### PR TITLE
Limit upload speed to 115200

### DIFF
--- a/esphomeyaml/writer.py
+++ b/esphomeyaml/writer.py
@@ -7,9 +7,9 @@ import os
 
 from esphomeyaml import core
 from esphomeyaml.config import iter_components
-from esphomeyaml.const import CONF_ARDUINO_VERSION, CONF_BOARD, CONF_BOARD_FLASH_MODE, \
-    CONF_ESPHOMELIB_VERSION, CONF_ESPHOMEYAML, CONF_LOCAL, CONF_NAME, CONF_USE_CUSTOM_CODE, \
-    ESP_PLATFORM_ESP32, ARDUINO_VERSION_ESP32_DEV
+from esphomeyaml.const import ARDUINO_VERSION_ESP32_DEV, CONF_ARDUINO_VERSION, CONF_BOARD, \
+    CONF_BOARD_FLASH_MODE, CONF_ESPHOMELIB_VERSION, CONF_ESPHOMEYAML, CONF_LOCAL, CONF_NAME, \
+    CONF_USE_CUSTOM_CODE, ESP_PLATFORM_ESP32
 from esphomeyaml.core import ESPHomeYAMLError
 from esphomeyaml.core_config import VERSION_REGEX
 from esphomeyaml.helpers import relative_path
@@ -64,7 +64,7 @@ upload_speed = {upload_speed}
 """
 
 UPLOAD_SPEED_OVERRIDE = {
-  'esp210': 57600,
+    'esp210': 57600,
 }
 
 

--- a/esphomeyaml/writer.py
+++ b/esphomeyaml/writer.py
@@ -60,7 +60,12 @@ lib_deps =
 build_flags =
     {build_flags}
     ${{common.build_flags}}
+upload_speed = {upload_speed}
 """
+
+UPLOAD_SPEED_OVERRIDE = {
+  'esp210': 57600,
+}
 
 
 def get_build_flags(config, key):
@@ -86,6 +91,7 @@ def get_ini_content(config, path):
         u'platform': config[CONF_ESPHOMEYAML][CONF_ARDUINO_VERSION],
         u'board': config[CONF_ESPHOMEYAML][CONF_BOARD],
         u'build_flags': u'',
+        u'upload_speed': UPLOAD_SPEED_OVERRIDE.get(core.BOARD, 115200),
     }
     build_flags = set()
     if not config[CONF_ESPHOMEYAML][CONF_USE_CUSTOM_CODE]:


### PR DESCRIPTION
Limit upload speed to 115200 baud, the new platformio default of 921600 can cause issues.

Has a small override for the `esp210` board which apparently has an even lower upload speed.

Fixes #121 
