### PR TITLE
Fix platformio version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 install:
   - pip install -r requirements.txt
-  - pip install tornado esptool flake8==3.5.0 pylint==1.8.4 tzlocal pillow
+  - pip install tornado esptool flake8==3.5.0 pylint==1.9.3 tzlocal pillow
 script:
  - flake8 esphomeyaml
  - pylint esphomeyaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 install:
   - pip install -r requirements.txt
-  - pip install tornado esptool flake8==3.5.0 pylint==1.9.3 tzlocal pillow
+  - pip install flake8==3.5.0 pylint==1.9.3 tzlocal pillow
 script:
  - flake8 esphomeyaml
  - pylint esphomeyaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,13 @@ EXPOSE 6123
 VOLUME /config
 WORKDIR /usr/src/app
 
-COPY requirements.txt /usr/src/app/
-RUN pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir tornado esptool
-
 COPY docker/platformio.ini /usr/src/app/
 RUN platformio settings set enable_telemetry No && \
     platformio run -e espressif32 -e espressif8266; exit 0
 
 COPY . .
 RUN pip install --no-cache-dir -e . && \
-    pip install --no-cache-dir tzlocal
+    pip install --no-cache-dir tzlocal pillow
 
 WORKDIR /config
 ENTRYPOINT ["esphomeyaml"]

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -3,4 +3,4 @@ FROM python:2.7
 COPY requirements.txt /requirements.txt
 
 RUN pip install -r /requirements.txt && \
-    pip install flake8==3.5.0 pylint==1.8.4 tzlocal pillow
+    pip install flake8==3.5.0 pylint==1.9.3 tzlocal pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-voluptuous==0.11.1
-platformio==3.5.2
-pyyaml==3.12
-paho-mqtt==1.3.1
-colorlog==3.1.2
-tornado==5.0.2
-esptool==2.3.1
+voluptuous>=0.11.1
+platformio>=3.5.3
+pyyaml>=3.12
+paho-mqtt>=1.3.1
+colorlog>=3.1.2
+tornado>=5.0.0
+esptool>=2.3.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, const.__version__)
 
 REQUIRES = [
     'voluptuous>=0.11.1',
-    'platformio>=3.5.2',
+    'platformio>=3.5.3',
     'pyyaml>=3.12',
     'paho-mqtt>=1.3.1',
     'colorlog>=3.1.2',


### PR DESCRIPTION
The new espressif8266 framework versions don't work with an old platformio core. This was only affecting docker installs.

Fixes #123

See https://github.com/platformio/platform-espressif8266/issues/87