### PR TITLE
Bump platformio-espressif32 to 1.4.0

### DIFF
--- a/esphomeyaml/core_config.py
+++ b/esphomeyaml/core_config.py
@@ -119,8 +119,8 @@ PLATFORMIO_ESP8266_LUT = {
 }
 
 PLATFORMIO_ESP32_LUT = {
-    '1.0.0': 'espressif32@1.3.0',
-    'RECOMMENDED': 'espressif32@>=1.3.0',
+    '1.0.0': 'espressif32@1.4.0',
+    'RECOMMENDED': 'espressif32@>=1.4.0',
     'LATEST': 'espressif32',
     'DEV': ARDUINO_VERSION_ESP32_DEV,
 }


### PR DESCRIPTION
https://github.com/platformio/platform-espressif32/releases/tag/v1.4.0