### PR TITLE
Add use_build_flags removal notice

### DIFF
--- a/esphomeyaml/core_config.py
+++ b/esphomeyaml/core_config.py
@@ -176,7 +176,9 @@ CONFIG_SCHEMA = vol.Schema({
     })]),
 
     vol.Optional('library_uri'): cv.invalid("The library_uri option has been removed in 1.8.0 and "
-                                            "was moved into the esphomelib_version option.")
+                                            "was moved into the esphomelib_version option."),
+    vol.Optional('use_build_flags'): cv.invalid("The use_build_flags option has been replaced by "
+                                                "use_custom_code option in 1.8.0."),
 })
 
 


### PR DESCRIPTION
## Description:

Add `use_build_flags` removal notice.

**Related issue (if applicable):** fixes https://github.com/OttoWinter/esphomeyaml/issues/170

## Example entry for YAML configuration (if applicable):
```yaml
esphomeyaml:
  use_custom_code: True
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - [ ] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
