### PR TITLE
Add MQTT Subscribe sensor

### DIFF
--- a/esphomeyaml/components/sensor/mqtt_subscribe.py
+++ b/esphomeyaml/components/sensor/mqtt_subscribe.py
@@ -1,0 +1,29 @@
+import voluptuous as vol
+
+from esphomeyaml.components import sensor
+import esphomeyaml.config_validation as cv
+from esphomeyaml.const import CONF_MAKE_ID, CONF_NAME, CONF_QOS, CONF_TOPIC
+from esphomeyaml.helpers import App, Application, add, variable
+
+DEPENDENCIES = ['mqtt']
+
+MakeMQTTSubscribeSensor = Application.MakeMQTTSubscribeSensor
+
+PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
+    cv.GenerateID(CONF_MAKE_ID): cv.declare_variable_id(MakeMQTTSubscribeSensor),
+    vol.Required(CONF_TOPIC): cv.subscribe_topic,
+    vol.Optional(CONF_QOS): cv.mqtt_qos,
+}))
+
+
+def to_code(config):
+    rhs = App.make_mqtt_subscribe_sensor(config[CONF_NAME], config[CONF_TOPIC])
+    make = variable(config[CONF_MAKE_ID], rhs)
+
+    if CONF_QOS in config:
+        add(make.Psensor.set_qos(config[CONF_QOS]))
+
+    sensor.setup_sensor(make.Psensor, make.Pmqtt, config)
+
+
+BUILD_FLAGS = '-DUSE_MQTT_SUBSCRIBE_SENSOR'

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -1,5 +1,5 @@
 esphomeyaml:
-  name: test1
+  name: test2
   platform: ESP32
   board: nodemcu-32s
   # Use latest upstream esphomelib git version.
@@ -73,7 +73,10 @@ sensor:
       name: "Xiaomi MiJia Humidity"
     battery_level:
       name: "Xiaomi MiJia Battery Level"
-
+  - platform: mqtt_subscribe
+    name: "MQTT Subscribe Sensor 1"
+    topic: "mqtt/topic"
+    qos: 2
 
 esp32_touch:
   setup_mode: True


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#50
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#193

## Example entry for YAML configuration (if applicable):
```yaml
sensor:
- platform: mqtt_subscribe
  name: "The Value"
  topic: "the/topic"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
