### PR TITLE
Add Switch power_on_value option

### DIFF
--- a/esphomeyaml/components/output/gpio.py
+++ b/esphomeyaml/components/output/gpio.py
@@ -3,14 +3,15 @@ import voluptuous as vol
 from esphomeyaml import pins
 import esphomeyaml.config_validation as cv
 from esphomeyaml.components import output
-from esphomeyaml.const import CONF_ID, CONF_PIN
-from esphomeyaml.helpers import App, Pvariable, gpio_output_pin_expression
+from esphomeyaml.const import CONF_ID, CONF_PIN, CONF_POWER_ON_VALUE
+from esphomeyaml.helpers import App, Pvariable, gpio_output_pin_expression, add
 
 GPIOBinaryOutputComponent = output.output_ns.GPIOBinaryOutputComponent
 
 PLATFORM_SCHEMA = output.BINARY_OUTPUT_PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): cv.declare_variable_id(GPIOBinaryOutputComponent),
     vol.Required(CONF_PIN): pins.gpio_output_pin_schema,
+    vol.Optional(CONF_POWER_ON_VALUE): cv.boolean,
 })
 
 
@@ -20,6 +21,8 @@ def to_code(config):
         yield
     rhs = App.make_gpio_output(pin)
     gpio = Pvariable(config[CONF_ID], rhs)
+    if CONF_POWER_ON_VALUE in config:
+        add(gpio.set_power_on_value(config[CONF_POWER_ON_VALUE]))
     output.setup_output_platform(gpio, config)
 
 

--- a/esphomeyaml/components/switch/gpio.py
+++ b/esphomeyaml/components/switch/gpio.py
@@ -3,14 +3,15 @@ import voluptuous as vol
 import esphomeyaml.config_validation as cv
 from esphomeyaml import pins
 from esphomeyaml.components import switch
-from esphomeyaml.const import CONF_MAKE_ID, CONF_NAME, CONF_PIN
-from esphomeyaml.helpers import App, Application, gpio_output_pin_expression, variable
+from esphomeyaml.const import CONF_MAKE_ID, CONF_NAME, CONF_PIN, CONF_POWER_ON_VALUE
+from esphomeyaml.helpers import App, Application, gpio_output_pin_expression, variable, add
 
 MakeGPIOSwitch = Application.MakeGPIOSwitch
 
 PLATFORM_SCHEMA = cv.nameable(switch.SWITCH_PLATFORM_SCHEMA.extend({
     cv.GenerateID(CONF_MAKE_ID): cv.declare_variable_id(MakeGPIOSwitch),
     vol.Required(CONF_PIN): pins.gpio_output_pin_schema,
+    vol.Optional(CONF_POWER_ON_VALUE): cv.boolean,
 }))
 
 
@@ -20,6 +21,8 @@ def to_code(config):
         yield
     rhs = App.make_gpio_switch(config[CONF_NAME], pin)
     gpio = variable(config[CONF_MAKE_ID], rhs)
+    if CONF_POWER_ON_VALUE in config:
+        add(gpio.Pgpio.set_power_on_value(config[CONF_POWER_ON_VALUE]))
     switch.setup_switch(gpio.Pswitch_, gpio.Pmqtt, config)
 
 

--- a/esphomeyaml/const.py
+++ b/esphomeyaml/const.py
@@ -340,6 +340,7 @@ CONF_MONTHS = 'months'
 CONF_DAYS_OF_WEEK = 'days_of_week'
 CONF_CRON = 'cron'
 CONF_POWER_SAVE_MODE = 'power_save_mode'
+CONF_POWER_ON_VALUE = 'power_on_value'
 
 ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git#feature/stage'

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -522,6 +522,7 @@ output:
     id: gpio_26
     power_supply: atx_power_supply
     inverted: False
+    power_on_value: True
   - platform: ledc
     pin: 19
     id: gpio_19
@@ -688,6 +689,7 @@ switch:
     icon: "mdi:restart"
     inverted: True
     command_topic: custom_command_topic
+    power_on_value: True
   - platform: remote_transmitter
     name: "Panasonic TV Off"
     nec:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#TODO
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#207

## Example entry for YAML configuration (if applicable):
```yaml
switch:
- platform: gpio
  # ...
  power_on_value: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
