### PR TITLE
Add clean build files command and auto-clean on version change

### DIFF
--- a/esphomeyaml/__main__.py
+++ b/esphomeyaml/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import random
+import shutil
 import sys
 from datetime import datetime
 
@@ -355,6 +356,17 @@ def command_version(args):
     return 0
 
 
+def command_clean(args, config):
+    build_path = relative_path(config[CONF_ESPHOMEYAML][CONF_BUILD_PATH])
+    try:
+        writer.clean_build(build_path)
+    except OSError as err:
+        _LOGGER.error("Error deleting build files: %s", err)
+        return 1
+    _LOGGER.info("Done!")
+    return 0
+
+
 def command_dashboard(args):
     from esphomeyaml.dashboard import dashboard
 
@@ -375,6 +387,7 @@ POST_CONFIG_ACTIONS = {
     'run': command_run,
     'clean-mqtt': command_clean_mqtt,
     'mqtt-fingerprint': command_mqtt_fingerprint,
+    'clean': command_clean,
 }
 
 
@@ -444,6 +457,8 @@ def parse_args(argv):
     subparsers.add_parser('mqtt-fingerprint', help="Get the SSL fingerprint from a MQTT broker.")
 
     subparsers.add_parser('version', help="Print the esphomeyaml version and exit.")
+
+    subparsers.add_parser('clean', help="Delete all temporary build files.")
 
     dashboard = subparsers.add_parser('dashboard',
                                       help="Create a simple webserver for a dashboard.")

--- a/esphomeyaml/__main__.py
+++ b/esphomeyaml/__main__.py
@@ -4,7 +4,6 @@ import argparse
 import logging
 import os
 import random
-import shutil
 import sys
 from datetime import datetime
 

--- a/esphomeyaml/dashboard/dashboard.py
+++ b/esphomeyaml/dashboard/dashboard.py
@@ -124,6 +124,13 @@ class EsphomeyamlCleanMqttHandler(EsphomeyamlCommandWebSocket):
         return ["esphomeyaml", config_file, "clean-mqtt"]
 
 
+class EsphomeyamlCleanHandler(EsphomeyamlCommandWebSocket):
+    def build_command(self, message):
+        js = json.loads(message)
+        config_file = os.path.join(CONFIG_DIR, js['configuration'])
+        return ["esphomeyaml", config_file, "clean"]
+
+
 class SerialPortRequestHandler(BaseHandler):
     def get(self):
         if not self.is_authenticated():
@@ -221,6 +228,7 @@ def make_app(debug=False):
         (r"/compile", EsphomeyamlCompileHandler),
         (r"/validate", EsphomeyamlValidateHandler),
         (r"/clean-mqtt", EsphomeyamlCleanMqttHandler),
+        (r"/clean", EsphomeyamlCleanHandler),
         (r"/download.bin", DownloadBinaryRequestHandler),
         (r"/serial-ports", SerialPortRequestHandler),
         (r"/wizard.html", WizardRequestHandler),

--- a/esphomeyaml/dashboard/templates/index.html
+++ b/esphomeyaml/dashboard/templates/index.html
@@ -220,6 +220,7 @@
           </div>
           <ul id="dropdown-{{ i }}" class="dropdown-content">
             <li><a href="#" class="action-clean-mqtt" data-node="{{ file }}">Clean MQTT</a></li>
+            <li><a href="#" class="action-clean" data-node="{{ file }}">Clean Build</a></li>
           </ul>
         </div>
       </div>
@@ -475,6 +476,18 @@
 <div id="modal-clean-mqtt" class="modal modal-fixed-footer">
   <div class="modal-content">
     <h4>Clean MQTT discovery <code class="inlinecode filename"></code></h4>
+    <div class="log-container">
+      <pre class="log"></pre>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <a class="modal-close waves-effect waves-green btn-flat stop-logs">Stop</a>
+  </div>
+</div>
+
+<div id="modal-clean" class="modal modal-fixed-footer">
+  <div class="modal-content">
+    <h4>Clean Build Files <code class="inlinecode filename"></code></h4>
     <div class="log-container">
       <pre class="log"></pre>
     </div>
@@ -830,6 +843,54 @@
           const msg = data.data;
           log.innerHTML += colorReplace(msg);
         } else if (data.event === "exit") {
+          stopLogsButton.innerHTML = "Close";
+          stopped = true;
+        }
+      });
+      logSocket.addEventListener('open', () => {
+        const msg = JSON.stringify({configuration: configuration});
+        logSocket.send(msg);
+      });
+      logSocket.addEventListener('close', () => {
+        if (!stopped) {
+          M.toast({html: 'Terminated process.'});
+        }
+      });
+      modalInstance.options.onCloseStart = () => {
+        logSocket.close();
+      };
+    });
+  });
+
+  const cleanModalElem = document.getElementById("modal-clean");
+
+  document.querySelectorAll(".action-clean").forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      configuration = e.target.getAttribute('data-node');
+      const modalInstance = M.Modal.getInstance(cleanModalElem);
+      const log = cleanModalElem.querySelector(".log");
+      log.innerHTML = "";
+      const stopLogsButton = cleanModalElem.querySelector(".stop-logs");
+      let stopped = false;
+      stopLogsButton.innerHTML = "Stop";
+      modalInstance.open();
+
+      const filenameField = cleanModalElem.querySelector('.filename');
+      filenameField.innerHTML = configuration;
+
+      const logSocket = new WebSocket(wsUrl + "/clean");
+      logSocket.addEventListener('message', (event) => {
+        const data = JSON.parse(event.data);
+        if (data.event === "line") {
+          const msg = data.data;
+          log.innerHTML += colorReplace(msg);
+        } else if (data.event === "exit") {
+          if (data.code === 0) {
+            M.toast({html: "Program exited successfully."});
+            downloadButton.classList.remove('disabled');
+          } else {
+            M.toast({html: `Program failed with code ${data.code}`});
+          }
           stopLogsButton.innerHTML = "Close";
           stopped = true;
         }


### PR DESCRIPTION
## Description:

Should get rid of any weird platformio dependency errors when upgrading esphomelib.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
