### PR TITLE
Improve API naming convention consistency

### DIFF
--- a/esphomeyaml/components/fan/speed.py
+++ b/esphomeyaml/components/fan/speed.py
@@ -29,7 +29,7 @@ def to_code(config):
     fan_struct = variable(config[CONF_MAKE_ID], rhs)
     if CONF_SPEED in config:
         speeds = config[CONF_SPEED]
-        add(fan_struct.Poutput.set_speed(output, 0.0,
+        add(fan_struct.Poutput.set_speed(output,
                                          speeds[CONF_LOW],
                                          speeds[CONF_MEDIUM],
                                          speeds[CONF_HIGH]))

--- a/esphomeyaml/components/sensor/__init__.py
+++ b/esphomeyaml/components/sensor/__init__.py
@@ -64,8 +64,8 @@ HeartbeatFilter = sensor_ns.HeartbeatFilter
 DebounceFilter = sensor_ns.DebounceFilter
 UniqueFilter = sensor_ns.UniqueFilter
 
-SensorValueTrigger = sensor_ns.SensorValueTrigger
-RawSensorValueTrigger = sensor_ns.RawSensorValueTrigger
+SensorStateTrigger = sensor_ns.SensorStateTrigger
+SensorRawStateTrigger = sensor_ns.SensorRawStateTrigger
 ValueRangeTrigger = sensor_ns.ValueRangeTrigger
 
 SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend({
@@ -77,10 +77,10 @@ SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend({
     vol.Optional(CONF_EXPIRE_AFTER): vol.Any(None, cv.positive_time_period_milliseconds),
     vol.Optional(CONF_FILTERS): FILTERS_SCHEMA,
     vol.Optional(CONF_ON_VALUE): automation.validate_automation({
-        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(SensorValueTrigger),
+        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(SensorStateTrigger),
     }),
     vol.Optional(CONF_ON_RAW_VALUE): automation.validate_automation({
-        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(RawSensorValueTrigger),
+        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(SensorRawStateTrigger),
     }),
     vol.Optional(CONF_ON_VALUE_RANGE): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(ValueRangeTrigger),
@@ -155,11 +155,11 @@ def setup_sensor_core_(sensor_var, mqtt_var, config):
         add(sensor_var.set_filters(filters))
 
     for conf in config.get(CONF_ON_VALUE, []):
-        rhs = sensor_var.make_value_trigger()
+        rhs = sensor_var.make_state_trigger()
         trigger = Pvariable(conf[CONF_TRIGGER_ID], rhs)
         automation.build_automation(trigger, float_, conf)
     for conf in config.get(CONF_ON_RAW_VALUE, []):
-        rhs = sensor_var.make_raw_value_trigger()
+        rhs = sensor_var.make_raw_state_trigger()
         trigger = Pvariable(conf[CONF_TRIGGER_ID], rhs)
         automation.build_automation(trigger, float_, conf)
     for conf in config.get(CONF_ON_VALUE_RANGE, []):

--- a/esphomeyaml/components/text_sensor/__init__.py
+++ b/esphomeyaml/components/text_sensor/__init__.py
@@ -16,14 +16,14 @@ text_sensor_ns = esphomelib_ns.namespace('text_sensor')
 TextSensor = text_sensor_ns.TextSensor
 MQTTTextSensor = text_sensor_ns.MQTTTextSensor
 
-TextSensorValueTrigger = text_sensor_ns.TextSensorValueTrigger
+TextSensorStateTrigger = text_sensor_ns.TextSensorStateTrigger
 
 TEXT_SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend({
     cv.GenerateID(CONF_MQTT_ID): cv.declare_variable_id(MQTTTextSensor),
     cv.GenerateID(): cv.declare_variable_id(TextSensor),
     vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_ON_VALUE): automation.validate_automation({
-        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(TextSensorValueTrigger),
+        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(TextSensorStateTrigger),
     }),
 })
 
@@ -37,7 +37,7 @@ def setup_text_sensor_core_(text_sensor_var, mqtt_var, config):
         add(text_sensor_var.set_icon(config[CONF_ICON]))
 
     for conf in config.get(CONF_ON_VALUE, []):
-        rhs = text_sensor_var.make_value_trigger()
+        rhs = text_sensor_var.make_state_trigger()
         trigger = Pvariable(conf[CONF_TRIGGER_ID], rhs)
         automation.build_automation(trigger, std_string, conf)
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -181,9 +181,9 @@ sensor:
       then:
         - lambda: >-
             ESP_LOGD("main", "Got value %f", x);
-            id(my_sensor).push_new_value(42.0);
-            ESP_LOGI("main", "Value of my sensor: %f", id(my_sensor).value);
-            ESP_LOGI("main", "Raw Value of my sensor: %f", id(my_sensor).value);
+            id(my_sensor).publish_state(42.0);
+            ESP_LOGI("main", "Value of my sensor: %f", id(my_sensor).state);
+            ESP_LOGI("main", "Raw Value of my sensor: %f", id(my_sensor).state);
     on_value_range:
       above: 5
       below: 10
@@ -419,7 +419,7 @@ sensor:
   - platform: template
     name: "Template Sensor"
     lambda: >-
-      if (id(ultrasonic_sensor1).value > 1) {
+      if (id(ultrasonic_sensor1).state > 1) {
         return 42.0;
       } else {
         return {};
@@ -506,12 +506,12 @@ binary_sensor:
   - platform: template
     name: "Garage Door Open"
     lambda: >-
-      if (isnan(id(my_sensor).value)) {
+      if (isnan(id(my_sensor).state)) {
         // isnan checks if the ultrasonic sensor echo
         // has timed out, resulting in a NaN (not a number) state
         // in that case, return {} to indicate that we don't know.
         return {};
-      } else if (id(my_sensor).value > 30) {
+      } else if (id(my_sensor).state > 30) {
         // Garage Door is open.
         return true;
       } else {
@@ -805,17 +805,17 @@ switch:
     name: "Template Switch"
     id: my_switch
     lambda: |-
-      if (id(binary_sensor1).value) {
+      if (id(binary_sensor1).state) {
         return true;
       } else {
         return {};
       }
       id(my_switch).publish_state(false);
       id(my_switch).publish_state(true);
-      if (id(my_switch).value) {
+      if (id(my_switch).state) {
         // Switch is ON, do something here
-        id(my_switch).write_state(false);
-        id(my_switch).write_state(true);
+        id(my_switch).turn_off();
+        id(my_switch).turn_on();
       } else {
         // Switch is OFF, do something else here
       }
@@ -923,7 +923,7 @@ cover:
   - platform: template
     name: "Template Cover"
     lambda: >-
-      if (id(binary_sensor1).value) {
+      if (id(binary_sensor1).state) {
         return cover::COVER_OPEN;
       } else {
         return {};

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -150,8 +150,8 @@ text_sensor:
     icon: mdi:icon
     id: version_sensor
     on_value:
-      lambda: |-
-        ESP_LOGD("main", "The state is %s=%s", x.c_str(), id(version_sensor).state.c_str());
+      - lambda: |-
+          ESP_LOGD("main", "The state is %s=%s", x.c_str(), id(version_sensor).state.c_str());
       - script.execute: my_script
   - platform: mqtt_subscribe
     name: "MQTT Subscribe Text"

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -150,8 +150,8 @@ text_sensor:
     icon: mdi:icon
     id: version_sensor
     on_value:
-      - lambda: |-
-          ESP_LOGD("main", "The value is %s=%s", x.c_str(), id(version_sensor).value.c_str());
+      lambda: |-
+        ESP_LOGD("main", "The state is %s=%s", x.c_str(), id(version_sensor).state.c_str());
       - script.execute: my_script
   - platform: mqtt_subscribe
     name: "MQTT Subscribe Text"


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#62
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#231

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
