### PR TITLE
Add send_first_at option to sliding window sensor filter

### DIFF
--- a/esphomeyaml/components/sensor/__init__.py
+++ b/esphomeyaml/components/sensor/__init__.py
@@ -21,7 +21,7 @@ def validate_recursive_filter(value):
     return FILTERS_SCHEMA(value)
 
 
-def validate_first_at_less_than_send_every(value):
+def validate_send_first_at(value):
     send_first_at = value.get(CONF_SEND_FIRST_AT)
     send_every = value[CONF_SEND_EVERY]
     if send_first_at is not None and send_first_at > send_every:
@@ -43,7 +43,7 @@ FILTERS_SCHEMA = vol.All(cv.ensure_list, [vol.All({
         vol.Required(CONF_WINDOW_SIZE): cv.positive_not_null_int,
         vol.Required(CONF_SEND_EVERY): cv.positive_not_null_int,
         vol.Optional(CONF_SEND_FIRST_AT): cv.positive_not_null_int,
-    }), validate_first_at_less_than_send_every),
+    }), validate_send_first_at),
     vol.Optional(CONF_EXPONENTIAL_MOVING_AVERAGE): vol.Schema({
         vol.Required(CONF_ALPHA): cv.positive_float,
         vol.Required(CONF_SEND_EVERY): cv.positive_not_null_int,

--- a/esphomeyaml/const.py
+++ b/esphomeyaml/const.py
@@ -358,6 +358,7 @@ CONF_POSITION = 'position'
 CONF_STEP_PIN = 'step_pin'
 CONF_DIR_PIN = 'dir_pin'
 CONF_SLEEP_PIN = 'sleep_pin'
+CONF_SEND_FIRST_AT = 'send_first_at'
 
 ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git#feature/stage'

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -165,6 +165,7 @@ sensor:
       - sliding_window_moving_average:
           window_size: 15
           send_every: 15
+          send_first_at: 15
       - exponential_moving_average:
           alpha: 0.1
           send_every: 15


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/OttoWinter/esphomelib/issues/216

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#69
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#207

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
