### PR TITLE
Add restore state option to template switch

### DIFF
--- a/esphomeyaml/components/switch/template.py
+++ b/esphomeyaml/components/switch/template.py
@@ -4,18 +4,21 @@ import esphomeyaml.config_validation as cv
 from esphomeyaml import automation
 from esphomeyaml.components import switch
 from esphomeyaml.const import CONF_LAMBDA, CONF_MAKE_ID, CONF_NAME, CONF_TURN_OFF_ACTION, \
-    CONF_TURN_ON_ACTION, CONF_OPTIMISTIC
+    CONF_TURN_ON_ACTION, CONF_OPTIMISTIC, CONF_RESTORE_STATE
 from esphomeyaml.helpers import App, Application, process_lambda, variable, NoArg, add, bool_, \
     optional
 
 MakeTemplateSwitch = Application.MakeTemplateSwitch
+TemplateSwitch = switch.switch_ns.TemplateSwitch
 
 PLATFORM_SCHEMA = cv.nameable(switch.SWITCH_PLATFORM_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_variable_id(TemplateSwitch),
     cv.GenerateID(CONF_MAKE_ID): cv.declare_variable_id(MakeTemplateSwitch),
     vol.Optional(CONF_LAMBDA): cv.lambda_,
     vol.Optional(CONF_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_TURN_OFF_ACTION): automation.validate_automation(single=True),
     vol.Optional(CONF_TURN_ON_ACTION): automation.validate_automation(single=True),
+    vol.Optional(CONF_RESTORE_STATE): cv.boolean,
 }), cv.has_at_least_one_key(CONF_LAMBDA, CONF_OPTIMISTIC))
 
 
@@ -39,6 +42,9 @@ def to_code(config):
                                     config[CONF_TURN_ON_ACTION])
     if CONF_OPTIMISTIC in config:
         add(make.Ptemplate_.set_optimistic(config[CONF_OPTIMISTIC]))
+
+    if CONF_RESTORE_STATE in config:
+        add(make.Ptemplate_.set_restore_state(config[CONF_RESTORE_STATE]))
 
 
 BUILD_FLAGS = '-DUSE_TEMPLATE_SWITCH'

--- a/esphomeyaml/const.py
+++ b/esphomeyaml/const.py
@@ -359,6 +359,7 @@ CONF_STEP_PIN = 'step_pin'
 CONF_DIR_PIN = 'dir_pin'
 CONF_SLEEP_PIN = 'sleep_pin'
 CONF_SEND_FIRST_AT = 'send_first_at'
+CONF_RESTORE_STATE = 'restore_state'
 
 ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git#feature/stage'

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -806,6 +806,7 @@ switch:
         level: !lambda 'return 0.5;'
     turn_off_action:
     - switch.turn_on: living_room_lights_off
+    restore_state: False
   - platform: restart
     name: "Living Room Restart"
   - platform: shutdown
@@ -832,6 +833,7 @@ switch:
         // Switch is OFF, do something else here
       }
     optimistic: true
+    restore_state: True
   - platform: uart
     name: "UART String Output"
     data: 'DataToSend'


### PR DESCRIPTION
## Description:


**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** https://github.com/OttoWinter/esphomedocs/commit/fbf1e039e896fc49feed8559cec3bd34afb16d7d
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#258

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
