### PR TITLE
Fix HLW8012 Voltage Divider option not being added to source

### DIFF
--- a/esphomeyaml/components/sensor/hlw8012.py
+++ b/esphomeyaml/components/sensor/hlw8012.py
@@ -50,6 +50,8 @@ def to_code(config):
         sensor.register_sensor(hlw.make_power_sensor(conf[CONF_NAME]), conf)
     if CONF_CURRENT_RESISTOR in config:
         add(hlw.set_current_resistor(config[CONF_CURRENT_RESISTOR]))
+    if CONF_VOLTAGE_DIVIDER in config:
+        add(hlw.set_voltage_divider(config[CONF_VOLTAGE_DIVIDER]))
     if CONF_CHANGE_MODE_EVERY in config:
         add(hlw.set_change_mode_every(config[CONF_CHANGE_MODE_EVERY]))
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** https://github.com/OttoWinter/esphomelib/issues/252

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).
