### PR TITLE
Light transition

### DIFF
--- a/esphomeyaml/components/light/binary.py
+++ b/esphomeyaml/components/light/binary.py
@@ -2,12 +2,14 @@ import voluptuous as vol
 
 from esphomeyaml.components import light, output
 import esphomeyaml.config_validation as cv
-from esphomeyaml.const import CONF_EFFECTS, CONF_MAKE_ID, CONF_NAME, CONF_OUTPUT
+from esphomeyaml.const import CONF_DEFAULT_TRANSITION_LENGTH, CONF_EFFECTS, CONF_MAKE_ID, CONF_NAME, \
+    CONF_OUTPUT
 from esphomeyaml.helpers import App, get_variable, setup_component, variable
 
 PLATFORM_SCHEMA = cv.nameable(light.LIGHT_PLATFORM_SCHEMA.extend({
     cv.GenerateID(CONF_MAKE_ID): cv.declare_variable_id(light.MakeLight),
     vol.Required(CONF_OUTPUT): cv.use_variable_id(output.BinaryOutput),
+    vol.Optional(CONF_DEFAULT_TRANSITION_LENGTH): cv.positive_time_period_milliseconds,
     vol.Optional(CONF_EFFECTS): light.validate_effects(light.BINARY_EFFECTS),
 }).extend(cv.COMPONENT_SCHEMA.schema))
 


### PR DESCRIPTION
## Description:
Currently there is some kind of inconsistency. The binary light does not have the transition length attribute but uses it when switching.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - [ ] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
