### PR TITLE
Add support for MAX31855 sensor

### DIFF
--- a/esphomeyaml/components/sensor/max31855.py
+++ b/esphomeyaml/components/sensor/max31855.py
@@ -6,14 +6,13 @@ from esphomeyaml.components import sensor, spi
 from esphomeyaml.components.spi import SPIComponent
 from esphomeyaml.const import CONF_CS_PIN, CONF_MAKE_ID, CONF_NAME, CONF_SPI_ID, \
     CONF_UPDATE_INTERVAL
-from esphomeyaml.cpp_helpers import gpio_output_pin_expression
-from esphomeyaml.cpp_generator import get_variable, variable, \
-    setup_component
+from esphomeyaml.cpp_helpers import gpio_output_pin_expression, setup_component
+from esphomeyaml.cpp_generator import get_variable, variable
 from esphomeyaml.cpp_types import Application, App
 
 MakeMAX31855Sensor = Application.struct('MakeMAX31855Sensor')
 MAX31855Sensor = sensor.sensor_ns.class_('MAX31855Sensor', sensor.PollingSensorComponent,
-                                        spi.SPIDevice)
+                                         spi.SPIDevice)
 
 PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
     cv.GenerateID(): cv.declare_variable_id(MAX31855Sensor),
@@ -30,7 +29,7 @@ def to_code(config):
     for cs in gpio_output_pin_expression(config[CONF_CS_PIN]):
         yield
     rhs = App.make_max31855_sensor(config[CONF_NAME], spi_, cs,
-                                  config.get(CONF_UPDATE_INTERVAL))
+                                   config.get(CONF_UPDATE_INTERVAL))
     make = variable(config[CONF_MAKE_ID], rhs)
     max31855 = make.Pmax31855
     sensor.setup_sensor(max31855, make.Pmqtt, config)

--- a/esphomeyaml/components/sensor/max31855.py
+++ b/esphomeyaml/components/sensor/max31855.py
@@ -6,8 +6,10 @@ from esphomeyaml.components import sensor, spi
 from esphomeyaml.components.spi import SPIComponent
 from esphomeyaml.const import CONF_CS_PIN, CONF_MAKE_ID, CONF_NAME, CONF_SPI_ID, \
     CONF_UPDATE_INTERVAL
-from esphomeyaml.helpers import App, Application, get_variable, gpio_output_pin_expression, \
-    variable, setup_component
+from esphomeyaml.cpp_helpers import gpio_output_pin_expression
+from esphomeyaml.cpp_generator import get_variable, variable, \
+    setup_component
+from esphomeyaml.cpp_types import Application, App
 
 MakeMAX31855Sensor = Application.struct('MakeMAX31855Sensor')
 MAX31855Sensor = sensor.sensor_ns.class_('MAX31855Sensor', sensor.PollingSensorComponent,

--- a/esphomeyaml/components/sensor/max31855.py
+++ b/esphomeyaml/components/sensor/max31855.py
@@ -1,0 +1,42 @@
+import voluptuous as vol
+
+import esphomeyaml.config_validation as cv
+from esphomeyaml import pins
+from esphomeyaml.components import sensor, spi
+from esphomeyaml.components.spi import SPIComponent
+from esphomeyaml.const import CONF_CS_PIN, CONF_MAKE_ID, CONF_NAME, CONF_SPI_ID, \
+    CONF_UPDATE_INTERVAL
+from esphomeyaml.helpers import App, Application, get_variable, gpio_output_pin_expression, \
+    variable, setup_component
+
+MakeMAX31855Sensor = Application.struct('MakeMAX31855Sensor')
+MAX31855Sensor = sensor.sensor_ns.class_('MAX31855Sensor', sensor.PollingSensorComponent,
+                                        spi.SPIDevice)
+
+PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_variable_id(MAX31855Sensor),
+    cv.GenerateID(CONF_MAKE_ID): cv.declare_variable_id(MakeMAX31855Sensor),
+    cv.GenerateID(CONF_SPI_ID): cv.use_variable_id(SPIComponent),
+    vol.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
+    vol.Optional(CONF_UPDATE_INTERVAL): cv.update_interval,
+}).extend(cv.COMPONENT_SCHEMA.schema))
+
+
+def to_code(config):
+    for spi_ in get_variable(config[CONF_SPI_ID]):
+        yield
+    for cs in gpio_output_pin_expression(config[CONF_CS_PIN]):
+        yield
+    rhs = App.make_max31855_sensor(config[CONF_NAME], spi_, cs,
+                                  config.get(CONF_UPDATE_INTERVAL))
+    make = variable(config[CONF_MAKE_ID], rhs)
+    max31855 = make.Pmax31855
+    sensor.setup_sensor(max31855, make.Pmqtt, config)
+    setup_component(max31855, config)
+
+
+BUILD_FLAGS = '-DUSE_MAX31855_SENSOR'
+
+
+def to_hass_config(data, config):
+    return sensor.core_to_hass_config(data, config)

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -371,6 +371,10 @@ sensor:
     name: "Living Room Temperature"
     cs_pin: GPIO23
     update_interval: 15s
+  - platform: max31855
+    name: "Den Temperature"
+    cs_pin: GPIO23
+    update_interval: 15s
   - platform: mhz19
     co2:
       name: "MH-Z19 CO2 Value"


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#97
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#310

## Example entry for YAML configuration (if applicable):
```yaml
spi:
  miso_pin: GPIO13
  clk_pin: GPIO14
sensor:
  - platform: max31855
    name: Test Temperature
    cs_pin: GPIO12
```

## Checklist:
  - [✓] The code change is tested and works locally.
  - [✓] Tests have been added to verify that the new code works (under `tests/` folder).
  - [✓] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomeyaml/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [✓] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
