### PR TITLE
Fixed upload to the static IP

### DIFF
--- a/esphomeyaml/__main__.py
+++ b/esphomeyaml/__main__.py
@@ -12,8 +12,8 @@ from esphomeyaml import const, core_config, mqtt, platformio_api, wizard, writer
 from esphomeyaml.api.client import run_logs
 from esphomeyaml.config import get_component, iter_components, read_config, strip_default_ids
 from esphomeyaml.const import CONF_BAUD_RATE, CONF_DOMAIN, CONF_ESPHOMEYAML, \
-    CONF_HOSTNAME, CONF_LOGGER, CONF_MANUAL_IP, CONF_NAME, CONF_STATIC_IP, CONF_USE_CUSTOM_CODE, \
-    CONF_WIFI
+    CONF_HOSTNAME, CONF_LOGGER, CONF_MANUAL_IP, CONF_NAME, CONF_NETWORKS, CONF_STATIC_IP, \
+    CONF_USE_CUSTOM_CODE, CONF_WIFI
 from esphomeyaml.core import CORE, EsphomeyamlError
 from esphomeyaml.cpp_generator import Expression, RawStatement, add, statement
 from esphomeyaml.helpers import color, indent
@@ -133,8 +133,10 @@ def compile_program(args, config):
 
 
 def get_upload_host(config):
-    if CONF_MANUAL_IP in config[CONF_WIFI]:
-        host = str(config[CONF_WIFI][CONF_MANUAL_IP][CONF_STATIC_IP])
+    if CONF_NETWORKS in config[CONF_WIFI]:
+        for network in config[CONF_WIFI][CONF_NETWORKS]:
+            if CONF_MANUAL_IP in network:
+                host = str(network[CONF_MANUAL_IP][CONF_STATIC_IP])
     elif CONF_HOSTNAME in config[CONF_WIFI]:
         host = config[CONF_WIFI][CONF_HOSTNAME] + config[CONF_WIFI][CONF_DOMAIN]
     else:


### PR DESCRIPTION
## Description:

mDNS discovery hasn't been used for uploading a firmware in the static IP configuration. Regression has been introduced in https://github.com/OttoWinter/esphomeyaml/commit/da2821ab3627c3be06f0a94eaaed2906dbb4dad6 with the refactoring of the `config[CONF_WIFI]`.

Test [config](https://github.com/yottatsa/yottatsa-home-assistant/commit/a09ab8a59175c554ec515188ef7e43d9bcc0baad#diff-d112cc5a279b2b1a7b277d5e4f773daa):

    wifi:
      ssid: !secret ssid
      password: !secret wifi_password
      power_save_mode: none
      manual_ip:
        static_ip: 192.168.1.237

Previous version:

    INFO Reading configuration...
    INFO Resolving IP address of heater.local

Fixed version:

    INFO Reading configuration...
    INFO Connecting to 192.168.1.237

*Issue hasn't been sumbitted yet*

## Checklist:
  - [x] The code change is tested and works locally.