### PR TITLE
GPIO Switch Fix restore_mode validator

### DIFF
--- a/esphomeyaml/components/switch/gpio.py
+++ b/esphomeyaml/components/switch/gpio.py
@@ -23,7 +23,7 @@ PLATFORM_SCHEMA = cv.nameable(switch.SWITCH_PLATFORM_SCHEMA.extend({
     cv.GenerateID(): cv.declare_variable_id(GPIOSwitch),
     cv.GenerateID(CONF_MAKE_ID): cv.declare_variable_id(MakeGPIOSwitch),
     vol.Required(CONF_PIN): pins.gpio_output_pin_schema,
-    vol.Optional(CONF_RESTORE_MODE): cv.one_of(RESTORE_MODES, upper=True, space='_'),
+    vol.Optional(CONF_RESTORE_MODE): cv.one_of(*RESTORE_MODES, upper=True, space='_'),
 }).extend(cv.COMPONENT_SCHEMA.schema))
 
 


### PR DESCRIPTION
## Description:

`restore_mode: ALWAYS_OFF` is throwing an Exception (re: https://github.com/OttoWinter/esphomeyaml/pull/287)

    Unknown value 'ALWAYS_OFF', must be one of '{'RESTORE_DEFAULT_ON': <esphomeyaml.cpp_generator.MockObj object at 0x10939df90>, 'ALWAYS_OFF': <esphomeyaml.cpp_generator.MockObj object at 0x1093e3050>, 'ALWAYS_ON': <esphomeyaml.cpp_generator.MockObj object at 0x1093e30d0>, 'RESTORE_DEFAULT_OFF': <esphomeyaml.cpp_generator.MockObj object at 0x10939df50>}'. Got 'ALWAYS_OFF'

## Checklist:
  - [x] The code change is tested and works locally.