### PR TITLE
OTA don't error when upgrading from no password to password mode

### DIFF
--- a/esphomeyaml/espota2.py
+++ b/esphomeyaml/espota2.py
@@ -187,9 +187,6 @@ def perform_ota(sock, password, file_handle, filename):
 
         send_check(sock, result, 'auth result')
         receive_exactly(sock, 1, 'auth result', RESPONSE_AUTH_OK)
-    else:
-        if password:
-            raise OTAError("Password specified, but ESP doesn't accept password!")
 
     file_size_encoded = [
         (file_size >> 24) & 0xFF,


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
