### PR TITLE
typing is only required for python < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     'colorlog>=3.1.2',
     'tornado>=5.0.0',
     'esptool>=2.3.1',
-    'typing>=3.0.0',
+    'typing>=3.0.0;python_version<"3.5"',
     'protobuf>=3.4',
     'tzlocal>=1.4',
 ]


### PR DESCRIPTION
Since 3.5, it is included in the standard library.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
