### PR TITLE
Add pyserial to install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tornado>=5.0.0
 esptool>=2.3.1
 typing>=3.0.0
 protobuf>=3.4
+pyserial>=3.4,<4

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ REQUIRES = [
     'typing>=3.0.0;python_version<"3.5"',
     'protobuf>=3.4',
     'tzlocal>=1.4',
+    'pyserial>=3.4,<4',
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
It's used in https://github.com/OttoWinter/esphomeyaml/blob/e81338b4f586a2b5af18ace5abef813dcb2d3878/esphomeyaml/__main__.py#L32