### PR TITLE
Remove deep sleep run_cycles

### DIFF
--- a/esphomeyaml/components/deep_sleep.py
+++ b/esphomeyaml/components/deep_sleep.py
@@ -49,8 +49,11 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_PINS): cv.ensure_list(pins.shorthand_input_pin, validate_pin_number),
         vol.Required(CONF_MODE): cv.one_of(*EXT1_WAKEUP_MODES, upper=True),
     })),
-    vol.Optional(CONF_RUN_CYCLES): cv.positive_int,
     vol.Optional(CONF_RUN_DURATION): cv.positive_time_period_milliseconds,
+
+    vol.Optional(CONF_RUN_CYCLES): cv.invalid("The run_cycles option has been removed in 1.11.0 as "
+                                              "it was essentially the same as a run_duration of 0s."
+                                              "Please use run_duration now.")
 }).extend(cv.COMPONENT_SCHEMA.schema)
 
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -137,7 +137,6 @@ power_supply:
 
 deep_sleep:
   run_duration: 20s
-  run_cycles: 500
   sleep_duration: 50s
   wakeup_pin: GPIO39
   wakeup_pin_mode: INVERT_WAKEUP


### PR DESCRIPTION
## Description:

It didn't do much in recent releases - essentially the same as 0s run_duration

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
