### PR TITLE
Warn if expire_after used without MQTT

### DIFF
--- a/esphomeyaml/components/sensor/__init__.py
+++ b/esphomeyaml/components/sensor/__init__.py
@@ -100,7 +100,8 @@ SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend({
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string_strict,
     vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_ACCURACY_DECIMALS): vol.Coerce(int),
-    vol.Optional(CONF_EXPIRE_AFTER): vol.Any(None, cv.positive_time_period_milliseconds),
+    vol.Optional(CONF_EXPIRE_AFTER): vol.All(cv.requires_component('mqtt'),
+                                             vol.Any(None, cv.positive_time_period_milliseconds)),
     vol.Optional(CONF_FILTERS): FILTERS_SCHEMA,
     vol.Optional(CONF_ON_VALUE): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(SensorStateTrigger),


### PR DESCRIPTION
Fixes https://github.com/OttoWinter/esphomelib/issues/372

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
