### PR TITLE
Remove DNS1,DNS2 inclusive

### DIFF
--- a/esphomeyaml/components/wifi.py
+++ b/esphomeyaml/components/wifi.py
@@ -50,8 +50,8 @@ AP_MANUAL_IP_SCHEMA = vol.Schema({
 })
 
 STA_MANUAL_IP_SCHEMA = AP_MANUAL_IP_SCHEMA.extend({
-    vol.Inclusive(CONF_DNS1, 'dns'): cv.ipv4,
-    vol.Inclusive(CONF_DNS2, 'dns'): cv.ipv4,
+    vol.Optional(CONF_DNS1, default="1.1.1.1"): cv.ipv4,
+    vol.Optional(CONF_DNS2, default="1.0.0.1"): cv.ipv4,
 })
 
 WIFI_NETWORK_BASE = vol.Schema({


### PR DESCRIPTION
## Description:

Requirement on DNS2 was from the pre 1.10 days when we were still using Arduino's wifi lib. Now that we use our own, no need anymore.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
