### PR TITLE
Fix Non-ASCII characters being escaped if in wrong locale

### DIFF
--- a/esphomeyaml/util.py
+++ b/esphomeyaml/util.py
@@ -42,9 +42,12 @@ def safe_print(message=""):
         pass
 
     try:
-        print(message.encode('ascii', 'backslashreplace'))
+        print(message.encode('utf-8', 'backslashreplace'))
     except UnicodeEncodeError:
-        print("Cannot print line because of invalid locale!")
+        try:
+            print(message.encode('ascii', 'backslashreplace'))
+        except UnicodeEncodeError:
+            print("Cannot print line because of invalid locale!")
 
 
 def shlex_quote(s):


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
