### PR TITLE
Adding SI7021 sensor to config validation

### DIFF
--- a/esphomeyaml/components/sensor/dht.py
+++ b/esphomeyaml/components/sensor/dht.py
@@ -16,6 +16,7 @@ DHT_MODELS = {
     'DHT22': DHTModel.DHT_MODEL_DHT22,
     'AM2302': DHTModel.DHT_MODEL_AM2302,
     'RHT03': DHTModel.DHT_MODEL_RHT03,
+    'SI7021': DHTModel.DHT_MODEL_SI7021,
 }
 
 MakeDHTSensor = Application.struct('MakeDHTSensor')


### PR DESCRIPTION
## Description:

Some one wire versions of SI7021 (distributed by Sonoff for their TH modules) requires a different initialization procedure to work. They use the same protocol as the DHT sensors.
I added the model to the header file and the conditional code to initialize these sensors.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#132
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#433

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
