### PR TITLE
Generate variable for each custom component id

### DIFF
--- a/esphomeyaml/components/custom_component.py
+++ b/esphomeyaml/components/custom_component.py
@@ -25,8 +25,9 @@ def to_code(config):
 
     rhs = CustomComponentConstructor(template_)
     custom = variable(config[CONF_ID], rhs)
-    for i, comp in enumerate(config.get(CONF_COMPONENTS, [])):
-        setup_component(custom.get_component(i), comp)
+    for i, comp_config in enumerate(config.get(CONF_COMPONENTS, [])):
+        comp = variable(comp_config[CONF_ID], custom.get_component(i), ComponentPtr)
+        setup_component(comp, comp_config)
 
 
 BUILD_FLAGS = '-DUSE_CUSTOM_COMPONENT'

--- a/esphomeyaml/components/custom_component.py
+++ b/esphomeyaml/components/custom_component.py
@@ -2,7 +2,7 @@ import voluptuous as vol
 
 import esphomeyaml.config_validation as cv
 from esphomeyaml.const import CONF_ID, CONF_LAMBDA, CONF_COMPONENTS
-from esphomeyaml.cpp_generator import process_lambda, variable
+from esphomeyaml.cpp_generator import process_lambda, variable, Pvariable
 from esphomeyaml.cpp_helpers import setup_component
 from esphomeyaml.cpp_types import Component, ComponentPtr, esphomelib_ns, std_vector
 
@@ -26,7 +26,7 @@ def to_code(config):
     rhs = CustomComponentConstructor(template_)
     custom = variable(config[CONF_ID], rhs)
     for i, comp_config in enumerate(config.get(CONF_COMPONENTS, [])):
-        comp = variable(comp_config[CONF_ID], custom.get_component(i), ComponentPtr)
+        comp = Pvariable(comp_config[CONF_ID], custom.get_component(i))
         setup_component(comp, comp_config)
 
 


### PR DESCRIPTION
## Description:
Using following configuration:
```yaml
custom_component:
  - components:
      - id: foo
    lambda: |-
      return { /* some component initialisation code */ };
```
Before this change the generated code contained only the `CustomComponentConstructor`:
```C++
  CustomComponentConstructor customcomponentconstructor = CustomComponentConstructor([=]() -> std::vector<Component *> {
      return { /* some component initialisation code */ };
  });
```
After this change the generated code contains both the `CustomComponentConstructor`, as well as components constructed by it (as listed in the `components` list):
```C++
  CustomComponentConstructor customcomponentconstructor = CustomComponentConstructor([=]() -> std::vector<Component *> {
      return { /* some component initialisation code */ };
  });
  Component * foo = customcomponentconstructor.get_component(0);
```
which makes it possible to reference `foo` in other components or lambdas (eg `id(foo)`).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
