### PR TITLE
Add support for DS1307 real time clock

### DIFF
--- a/esphomeyaml/components/time/ds1307.py
+++ b/esphomeyaml/components/time/ds1307.py
@@ -1,0 +1,24 @@
+import voluptuous as vol
+
+from esphomeyaml.components import time as time_
+import esphomeyaml.config_validation as cv
+from esphomeyaml.const import CONF_ID
+from esphomeyaml.cpp_generator import Pvariable, add
+from esphomeyaml.cpp_helpers import setup_component
+from esphomeyaml.cpp_types import App
+
+DS1307Time = time_.time_ns.class_('DS1307Time', time_.RealTimeClockComponent)
+
+PLATFORM_SCHEMA = time_.TIME_PLATFORM_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_variable_id(DS1307Time)
+}).extend(cv.COMPONENT_SCHEMA.schema)
+
+
+def to_code(config):
+    rhs = App.make_ds1307_time_component()
+    ds1307 = Pvariable(config[CONF_ID], rhs)
+    time_.setup_time(ds1307, config)
+    setup_component(ds1307, config)
+
+
+BUILD_FLAGS = '-DUSE_DS1307_TIME'

--- a/esphomeyaml/components/time/ds1307.py
+++ b/esphomeyaml/components/time/ds1307.py
@@ -1,9 +1,7 @@
-import voluptuous as vol
-
 from esphomeyaml.components import time as time_
 import esphomeyaml.config_validation as cv
 from esphomeyaml.const import CONF_ID
-from esphomeyaml.cpp_generator import Pvariable, add
+from esphomeyaml.cpp_generator import Pvariable
 from esphomeyaml.cpp_helpers import setup_component
 from esphomeyaml.cpp_types import App
 

--- a/esphomeyaml/components/time/ds1307.py
+++ b/esphomeyaml/components/time/ds1307.py
@@ -1,11 +1,13 @@
-from esphomeyaml.components import time as time_
+from esphomeyaml.components import i2c, time as time_
 import esphomeyaml.config_validation as cv
 from esphomeyaml.const import CONF_ID
 from esphomeyaml.cpp_generator import Pvariable
 from esphomeyaml.cpp_helpers import setup_component
 from esphomeyaml.cpp_types import App
 
-DS1307Time = time_.time_ns.class_('DS1307Time', time_.RealTimeClockComponent)
+DEPENDENCIES = ['i2c']
+
+DS1307Time = time_.time_ns.class_('DS1307Time', time_.RealTimeClockComponent, i2c.I2CDevice)
 
 PLATFORM_SCHEMA = time_.TIME_PLATFORM_SCHEMA.extend({
     cv.GenerateID(): cv.declare_variable_id(DS1307Time)


### PR DESCRIPTION
## Description:

Add initial support for DS1307 (I2C) real time clock chips.

**Pull request in [ESPHome-Core](https://github.com/esphome/ESPHome-Core) with C++ framework changes (if applicable):** esphome/ESPHome-Core#457
**Pull request in [ESPHome-Docs](https://github.com/esphome/ESPHome-Docs) with C++ framework changes (if applicable):** esphome/ESPHome-Docs#144

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [ESPHome-Docs](https://github.com/esphome/ESPHome-Docs).
