### PR TITLE
Allow pins 9&10 for PWM

### DIFF
--- a/esphomeyaml/components/output/esp8266_pwm.py
+++ b/esphomeyaml/components/output/esp8266_pwm.py
@@ -13,7 +13,7 @@ ESP_PLATFORMS = [ESP_PLATFORM_ESP8266]
 
 def valid_pwm_pin(value):
     num = value[CONF_NUMBER]
-    cv.one_of(0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16)(num)
+    cv.one_of(0, 1, 2, 3, 4, 5, 9, 10, 12, 13, 14, 15, 16)(num)
     return value
 
 


### PR DESCRIPTION
## Description:

Ref https://github.com/esp8266/Arduino/pull/5055 (requires latest arduino version)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
