### PR TITLE
Make dout the default flash mode

### DIFF
--- a/esphomeyaml/core_config.py
+++ b/esphomeyaml/core_config.py
@@ -168,7 +168,7 @@ CONFIG_SCHEMA = vol.Schema({
         cv.string_strict: vol.Any([cv.string], cv.string),
     }),
 
-    vol.Optional(CONF_BOARD_FLASH_MODE): cv.one_of(*BUILD_FLASH_MODES, lower=True),
+    vol.Optional(CONF_BOARD_FLASH_MODE, default='dout'): cv.one_of(*BUILD_FLASH_MODES, lower=True),
     vol.Optional(CONF_ON_BOOT): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_variable_id(StartupTrigger),
         vol.Optional(CONF_PRIORITY): cv.float_,


### PR DESCRIPTION
## Description:

dout works best. If user selects a board that doesn't support the fast modes (like qio) the ESP will not boot. This PR makes dout the default flash mode, which seems to be lowest common denominator

It can be a bit slower when cache misses (should be up to 4x slower for cache misses). But on the other hand ESPHome isn't optimized for speed anyway and I've not seen any impact.

Todo: more testing - done

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
