### PR TITLE
Include common components for compiles

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -141,6 +141,9 @@ def migrate_src_version_0_to_1():
     with codecs.open(main_cpp, 'r', encoding='utf-8') as f_handle:
         content = orig_content = f_handle.read()
 
+    if CPP_INCLUDE_BEGIN in content:
+        return
+
     content, count = replace_file_content(content, r'\s*delay\((?:16|20)\);', '')
     if count != 0:
         _LOGGER.info("Migration: Removed %s occurrence of 'delay(16);' in %s", count, main_cpp)
@@ -311,6 +314,30 @@ def gather_build_flags():
         build_flags.add("-Wno-sign-compare")
     build_flags |= get_build_flags('required_build_flags')
     build_flags |= get_build_flags('REQUIRED_BUILD_FLAGS')
+
+    if not CORE.config[CONF_ESPHOME][CONF_USE_CUSTOM_CODE]:
+        # For new users, include common components out of the box.
+        # So that first impression is improved and user doesn't need to wait
+        # an eternity.
+        # It's not a perfect solution but shouldn't cause any issues I think
+        # Common components determined through Google Analytics page views
+        # and only components that are lightweight (e.g. not lights because they
+        # take up memory)
+        build_flags |= {
+            '-DUSE_BINARY_SENSOR',
+            '-DUSE_DALLAS_SENSOR',
+            '-DUSE_DHT_SENSOR',
+            '-DUSE_GPIO_BINARY_SENSOR',
+            '-DUSE_GPIO_SWITCH',
+            '-DUSE_SENSOR',
+            '-DUSE_STATUS_BINARY_SENSOR',
+            '-DUSE_STATUS_LED',
+            '-DUSE_SWITCH',
+            '-DUSE_TEMPLATE_BINARY_SENSOR',
+            '-DUSE_TEMPLATE_SENSOR',
+            '-DUSE_TEMPLATE_SWITCH',
+            '-DUSE_WIFI_SIGNAL_SENSOR',
+        }
 
     # avoid changing build flags order
     return list(sorted(list(build_flags)))


### PR DESCRIPTION
## Description:

Reduces compile time for new users by including commonly used components by default. When user then goes to enable it they won't have to rebuild the entire project because it is already compiled.

Only for components that are often used and that have little overhead.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
