### PR TITLE
Allow use of arduino core v2.5.0 on ESP8266

### DIFF
--- a/esphome/const.py
+++ b/esphome/const.py
@@ -415,5 +415,7 @@ CONF_SEGMENTS = 'segments'
 
 ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git#feature/stage'
+ARDUINO_VERSION_ESP32_1_0_1 = 'espressif32@1.5.0'
 ARDUINO_VERSION_ESP8266_DEV = 'https://github.com/platformio/platform-espressif8266.git#feature' \
                               '/stage'
+ARDUINO_VERSION_ESP8266_2_5_0 = 'espressif8266@2.0.0'

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -415,7 +415,7 @@ CONF_SEGMENTS = 'segments'
 
 ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git#feature/stage'
-ARDUINO_VERSION_ESP32_1_0_1 = 'espressif32@1.5.0'
+ARDUINO_VERSION_ESP32_1_0_1 = 'espressif32@1.6.0'
 ARDUINO_VERSION_ESP8266_DEV = 'https://github.com/platformio/platform-espressif8266.git#feature' \
                               '/stage'
 ARDUINO_VERSION_ESP8266_2_5_0 = 'espressif8266@2.0.0'

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -126,7 +126,7 @@ PLATFORMIO_ESP8266_LUT = {
 
 PLATFORMIO_ESP32_LUT = {
     '1.0.0': 'espressif32@1.4.0',
-    '1.0.1': 'espressif32@1.5.0',
+    '1.0.1': 'espressif32@1.6.0',
     'RECOMMENDED': 'espressif32@1.5.0',
     'LATEST': 'espressif32',
     'DEV': ARDUINO_VERSION_ESP32_DEV,

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -114,6 +114,7 @@ def validate_platform(value):
 
 
 PLATFORMIO_ESP8266_LUT = {
+    '2.5.0': 'espressif8266@2.0.0',
     '2.4.2': 'espressif8266@1.8.0',
     '2.4.1': 'espressif8266@1.7.3',
     '2.4.0': 'espressif8266@1.6.0',
@@ -125,6 +126,7 @@ PLATFORMIO_ESP8266_LUT = {
 
 PLATFORMIO_ESP32_LUT = {
     '1.0.0': 'espressif32@1.4.0',
+    '1.0.1': 'espressif32@1.5.0',
     'RECOMMENDED': 'espressif32@1.5.0',
     'LATEST': 'espressif32',
     'DEV': ARDUINO_VERSION_ESP32_DEV,

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -10,8 +10,8 @@ import shutil
 from esphome.config import iter_components
 from esphome.const import ARDUINO_VERSION_ESP32_DEV, ARDUINO_VERSION_ESP8266_DEV, \
     CONF_ARDUINO_VERSION, CONF_BOARD_FLASH_MODE, CONF_BRANCH, CONF_COMMIT, CONF_ESPHOME, \
-    CONF_LOCAL, \
-    CONF_PLATFORMIO_OPTIONS, CONF_REPOSITORY, CONF_TAG, CONF_USE_CUSTOM_CODE
+    CONF_LOCAL, CONF_PLATFORMIO_OPTIONS, CONF_REPOSITORY, CONF_TAG, CONF_USE_CUSTOM_CODE, \
+    ARDUINO_VERSION_ESP32_1_0_1, ARDUINO_VERSION_ESP8266_2_5_0
 from esphome.core import CORE, EsphomeError
 from esphome.core_config import GITHUB_ARCHIVE_ZIP, LIBRARY_URI_REPO, VERSION_REGEX
 from esphome.helpers import mkdir_p, run_system_command
@@ -285,7 +285,7 @@ def gather_lib_deps():
         lib_deps.discard('AsyncTCP@1.0.3')
 
         # Manual fix for AsyncTCP
-        if CORE.config[CONF_ESPHOME].get(CONF_ARDUINO_VERSION) == ARDUINO_VERSION_ESP32_DEV:
+        if CORE.arduino_version in (ARDUINO_VERSION_ESP32_DEV, ARDUINO_VERSION_ESP32_1_0_1):
             lib_deps.add('AsyncTCP@1.0.3')
             lib_deps.discard('AsyncTCP@1.0.1')
     elif CORE.is_esp8266:
@@ -356,7 +356,7 @@ def get_ini_content():
         if CORE.arduino_version in ('espressif8266@1.8.0', 'espressif8266@1.7.3',
                                     'espressif8266@1.6.0', 'espressif8266@1.5.0'):
             ld_script = ld_scripts[0]
-        elif CORE.arduino_version == ARDUINO_VERSION_ESP8266_DEV:
+        elif CORE.arduino_version in (ARDUINO_VERSION_ESP8266_DEV, ARDUINO_VERSION_ESP8266_2_5_0):
             ld_script = ld_scripts[1]
 
         if ld_script is not None:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -8,10 +8,10 @@ import re
 import shutil
 
 from esphome.config import iter_components
-from esphome.const import ARDUINO_VERSION_ESP32_DEV, ARDUINO_VERSION_ESP8266_DEV, \
-    CONF_ARDUINO_VERSION, CONF_BOARD_FLASH_MODE, CONF_BRANCH, CONF_COMMIT, CONF_ESPHOME, \
-    CONF_LOCAL, CONF_PLATFORMIO_OPTIONS, CONF_REPOSITORY, CONF_TAG, CONF_USE_CUSTOM_CODE, \
-    ARDUINO_VERSION_ESP32_1_0_1, ARDUINO_VERSION_ESP8266_2_5_0
+from esphome.const import ARDUINO_VERSION_ESP32_1_0_1, ARDUINO_VERSION_ESP32_DEV, \
+    ARDUINO_VERSION_ESP8266_2_5_0, ARDUINO_VERSION_ESP8266_DEV, CONF_BOARD_FLASH_MODE, \
+    CONF_BRANCH, CONF_COMMIT, CONF_ESPHOME, CONF_LOCAL, CONF_PLATFORMIO_OPTIONS, CONF_REPOSITORY, \
+    CONF_TAG, CONF_USE_CUSTOM_CODE
 from esphome.core import CORE, EsphomeError
 from esphome.core_config import GITHUB_ARCHIVE_ZIP, LIBRARY_URI_REPO, VERSION_REGEX
 from esphome.helpers import mkdir_p, run_system_command
@@ -363,7 +363,7 @@ def get_ini_content():
             build_flags.append('-Wl,-T{}'.format(ld_script))
 
     data = {
-        'platform': CORE.config[CONF_ESPHOME][CONF_ARDUINO_VERSION],
+        'platform': CORE.arduino_version,
         'board': CORE.board,
         'framework': 'arduino',
         'lib_deps': lib_deps + ['${common.lib_deps}'],


### PR DESCRIPTION
## Description:

It's very unstable, but you can try if you want

Ref https://github.com/esphome/feature-requests/issues/69

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
