### PR TITLE
Allow i2c on non-pullup pins

### DIFF
--- a/esphome/components/i2c.py
+++ b/esphome/components/i2c.py
@@ -13,8 +13,8 @@ I2CDevice = pins.I2CDevice
 
 CONFIG_SCHEMA = vol.Schema({
     cv.GenerateID(): cv.declare_variable_id(I2CComponent),
-    vol.Optional(CONF_SDA, default='SDA'): pins.input_pullup_pin,
-    vol.Optional(CONF_SCL, default='SCL'): pins.input_pullup_pin,
+    vol.Optional(CONF_SDA, default='SDA'): pins.input_pin,
+    vol.Optional(CONF_SCL, default='SCL'): pins.input_pin,
     vol.Optional(CONF_FREQUENCY): vol.All(cv.frequency, vol.Range(min=0, min_included=False)),
     vol.Optional(CONF_SCAN): cv.boolean,
 


### PR DESCRIPTION
## Description:

Pin GPIO0 does not have internal pullup, so i2c cannot function properly without external pullups.
But, if the user adds those manually it's not a problem.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/59#issuecomment-466057042

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
