### PR TITLE
Add handling for min power output setting

### DIFF
--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -3,7 +3,7 @@ import voluptuous as vol
 from esphome.automation import ACTION_REGISTRY, maybe_simple_id
 from esphome.components.power_supply import PowerSupplyComponent
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_INVERTED, CONF_LEVEL, CONF_MAX_POWER, CONF_POWER_SUPPLY
+from esphome.const import CONF_ID, CONF_INVERTED, CONF_LEVEL, CONF_MAX_POWER, CONF_MIN_POWER, CONF_POWER_SUPPLY
 from esphome.core import CORE
 from esphome.cpp_generator import Pvariable, add, get_variable, templatable
 from esphome.cpp_types import Action, esphome_ns, float_
@@ -21,6 +21,7 @@ BINARY_OUTPUT_PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BINARY_OUTPUT_SCHEMA.sche
 
 FLOAT_OUTPUT_SCHEMA = BINARY_OUTPUT_SCHEMA.extend({
     vol.Optional(CONF_MAX_POWER): cv.percentage,
+    vol.Optional(CONF_MIN_POWER): cv.percentage,
 })
 
 FLOAT_OUTPUT_PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(FLOAT_OUTPUT_SCHEMA.schema)
@@ -47,6 +48,8 @@ def setup_output_platform_(obj, config, skip_power_supply=False):
         add(obj.set_power_supply(power_supply))
     if CONF_MAX_POWER in config:
         add(obj.set_max_power(config[CONF_MAX_POWER]))
+    if CONF_MIN_POWER in config:
+        add(obj.set_min_power(config[CONF_MIN_POWER]))
 
 
 def setup_output_platform(obj, config, skip_power_supply=False):

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -3,7 +3,8 @@ import voluptuous as vol
 from esphome.automation import ACTION_REGISTRY, maybe_simple_id
 from esphome.components.power_supply import PowerSupplyComponent
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_INVERTED, CONF_LEVEL, CONF_MAX_POWER, CONF_MIN_POWER, CONF_POWER_SUPPLY
+from esphome.const import CONF_ID, CONF_INVERTED, CONF_LEVEL, CONF_MAX_POWER, \
+    CONF_MIN_POWER, CONF_POWER_SUPPLY
 from esphome.core import CORE
 from esphome.cpp_generator import Pvariable, add, get_variable, templatable
 from esphome.cpp_types import Action, esphome_ns, float_

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -412,6 +412,7 @@ CONF_USE_ADDRESS = 'use_address'
 CONF_FROM = 'from'
 CONF_TO = 'to'
 CONF_SEGMENTS = 'segments'
+CONF_MIN_POWER = 'min_power'
 
 ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git#feature/stage'


### PR DESCRIPTION
## Description:
Adding ESPHome support of a min_power configuration to the output component, complementary to the max_power configuration already present. This setting will let the user clamp the output of any floating point variable component like [ESP8266 PWM](https://esphome.io/components/output/esp8266_pwm) to make the full range between min and max available to the frontend in HA. Servos especially will benefit from this, since many standard servos operate in a range between 10%-20% duty cycle.

**Related issue (if applicable):** fixes feature_requests/#64

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#516

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
