### PR TITLE
Automatically hide secrets in validation

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 from collections import OrderedDict
 import importlib
-import json
 import logging
 import re
 


### PR DESCRIPTION
## Description:

#streamer-mode :)

Hides all secrets defined as `!secret` during the validation and config dump passes.

Due to the architecture of the config validation, this will hide all secrets **by value**. So if you have some value that happens to have the same value as a secret, it will be `!secret`-ized.

I tried removing all options places where this could be printed, but you can probably still get to secrets if you really try to, for example by inducing a C++ compile error - I do not think that is possible without explicitly trying though.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/78

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
