### PR TITLE
Fix os.symlink on Windows

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -132,3 +132,16 @@ def resolve_ip_address(host):
             raise EsphomeError("Error resolving IP address: {}".format(err))
 
     return ip
+
+
+def symlink(src, dst):
+    if hasattr(os, 'symlink'):
+        os.symlink(src, dst)
+    else:
+        import ctypes
+        csl = ctypes.windll.kernel32.CreateSymbolicLinkW
+        csl.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
+        csl.restype = ctypes.c_ubyte
+        flags = 1 if os.path.isdir(src) else 0
+        if csl(dst, src, flags) == 0:
+            raise ctypes.WinError()

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -14,7 +14,7 @@ from esphome.const import ARDUINO_VERSION_ESP32_1_0_1, ARDUINO_VERSION_ESP32_DEV
     CONF_TAG, CONF_USE_CUSTOM_CODE
 from esphome.core import CORE, EsphomeError
 from esphome.core_config import GITHUB_ARCHIVE_ZIP, LIBRARY_URI_REPO, VERSION_REGEX
-from esphome.helpers import mkdir_p, run_system_command
+from esphome.helpers import mkdir_p, run_system_command, symlink
 from esphome.pins import ESP8266_FLASH_SIZES, ESP8266_LD_SCRIPTS
 from esphome.py_compat import IS_PY3, string_types
 from esphome.storage_json import StorageJSON, storage_path
@@ -229,7 +229,7 @@ def symlink_esphome_core_version(esphome_core_version):
                 do_write = False
         if do_write:
             mkdir_p(lib_path)
-            os.symlink(src_path, dst_path)
+            symlink(src_path, dst_path)
     else:
         # Remove symlink when changing back from local version
         if os.path.islink(dst_path):


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
