### PR TITLE
Enable i2c scanning by default

### DIFF
--- a/esphome/components/i2c.py
+++ b/esphome/components/i2c.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = cv.Schema({
     vol.Optional(CONF_SDA, default='SDA'): pins.input_pin,
     vol.Optional(CONF_SCL, default='SCL'): pins.input_pin,
     vol.Optional(CONF_FREQUENCY): vol.All(cv.frequency, vol.Range(min=0, min_included=False)),
-    vol.Optional(CONF_SCAN): cv.boolean,
+    vol.Optional(CONF_SCAN, default=True): cv.boolean,
 
     vol.Optional(CONF_RECEIVE_TIMEOUT): cv.invalid("The receive_timeout option has been removed "
                                                    "because timeouts are already handled by the "


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
