### PR TITLE
Add rotary encoder min/max value

### DIFF
--- a/esphome/components/sensor/rotary_encoder.py
+++ b/esphome/components/sensor/rotary_encoder.py
@@ -3,16 +3,16 @@ import voluptuous as vol
 from esphome import pins
 from esphome.components import sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_NAME, CONF_RESOLUTION
+from esphome.const import CONF_ID, CONF_NAME, CONF_RESOLUTION, CONF_MIN_VALUE, CONF_MAX_VALUE
 from esphome.cpp_generator import Pvariable, add
 from esphome.cpp_helpers import gpio_input_pin_expression, setup_component
 from esphome.cpp_types import App, Component
 
 RotaryEncoderResolution = sensor.sensor_ns.enum('RotaryEncoderResolution')
 RESOLUTIONS = {
-    '1': RotaryEncoderResolution.ROTARY_ENCODER_1_PULSE_PER_CYCLE,
-    '2': RotaryEncoderResolution.ROTARY_ENCODER_2_PULSES_PER_CYCLE,
-    '4': RotaryEncoderResolution.ROTARY_ENCODER_4_PULSES_PER_CYCLE,
+    1: RotaryEncoderResolution.ROTARY_ENCODER_1_PULSE_PER_CYCLE,
+    2: RotaryEncoderResolution.ROTARY_ENCODER_2_PULSES_PER_CYCLE,
+    4: RotaryEncoderResolution.ROTARY_ENCODER_4_PULSES_PER_CYCLE,
 }
 
 CONF_PIN_A = 'pin_a'
@@ -21,13 +21,26 @@ CONF_PIN_RESET = 'pin_reset'
 
 RotaryEncoderSensor = sensor.sensor_ns.class_('RotaryEncoderSensor', sensor.Sensor, Component)
 
+
+def validate_min_max_value(config):
+    if CONF_MIN_VALUE in config and CONF_MAX_VALUE in config:
+        min_val = config[CONF_MIN_VALUE]
+        max_val = config[CONF_MAX_VALUE]
+        if min_val >= max_val:
+            raise vol.Invalid("Max value {} must be smaller than min value {}"
+                              "".format(max_val, min_val))
+    return config
+
+
 PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
     cv.GenerateID(): cv.declare_variable_id(RotaryEncoderSensor),
     vol.Required(CONF_PIN_A): pins.internal_gpio_input_pin_schema,
     vol.Required(CONF_PIN_B): pins.internal_gpio_input_pin_schema,
     vol.Optional(CONF_PIN_RESET): pins.internal_gpio_input_pin_schema,
-    vol.Optional(CONF_RESOLUTION): cv.one_of(*RESOLUTIONS, string=True),
-}).extend(cv.COMPONENT_SCHEMA.schema))
+    vol.Optional(CONF_RESOLUTION): cv.one_of(*RESOLUTIONS, int=True),
+    vol.Optional(CONF_MIN_VALUE): cv.int_,
+    vol.Optional(CONF_MAX_VALUE): cv.int_,
+}).extend(cv.COMPONENT_SCHEMA.schema), validate_min_max_value)
 
 
 def to_code(config):
@@ -45,6 +58,10 @@ def to_code(config):
     if CONF_RESOLUTION in config:
         resolution = RESOLUTIONS[config[CONF_RESOLUTION]]
         add(encoder.set_resolution(resolution))
+    if CONF_MIN_VALUE in config:
+        add(encoder.set_min_value(config[CONF_MIN_VALUE]))
+    if CONF_MAX_VALUE in config:
+        add(encoder.set_min_value(config[CONF_MAX_VALUE]))
 
     sensor.setup_sensor(encoder, config)
     setup_component(encoder, config)

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -416,6 +416,9 @@ CONF_FROM = 'from'
 CONF_TO = 'to'
 CONF_SEGMENTS = 'segments'
 CONF_MIN_POWER = 'min_power'
+CONF_MIN_VALUE = 'min_value'
+CONF_MAX_VALUE = 'max_value'
+
 
 ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git#feature/stage'

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -430,6 +430,9 @@ sensor:
       - or:
         - debounce: 0.1s
         - delta: 10
+    resolution: 4
+    min_value: -10
+    max_value: 30
   - platform: sht3xd
     temperature:
       name: "Living Room Temperature 8"


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#534

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
