### PR TITLE
SDS011: use minutes for set_update_interval_min()

### DIFF
--- a/esphome/components/sensor/sds011.py
+++ b/esphome/components/sensor/sds011.py
@@ -53,7 +53,7 @@ def to_code(config):
     sds011 = Pvariable(config[CONF_ID], rhs)
 
     if CONF_UPDATE_INTERVAL in config:
-        add(sds011.set_update_interval_min(config.get(CONF_UPDATE_INTERVAL)))
+        add(sds011.set_update_interval_min(config[CONF_UPDATE_INTERVAL].total_minutes))
     if CONF_RX_ONLY in config:
         add(sds011.set_rx_mode_only(config[CONF_RX_ONLY]))
 


### PR DESCRIPTION
## Description:

This fix the a bug we introduced by changing to `update_interval_min`.

**Related issue (if applicable):** fixes #467 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
