### PR TITLE
More changes for 1.12

### DIFF
--- a/esphome/components/esp32_ble_beacon.py
+++ b/esphome/components/esp32_ble_beacon.py
@@ -7,6 +7,7 @@ from esphome.cpp_helpers import setup_component
 from esphome.cpp_types import App, Component, esphome_ns
 
 ESP_PLATFORMS = [ESP_PLATFORM_ESP32]
+CONFLICTS_WITH = ['esp32_ble_tracker']
 
 ESP32BLEBeacon = esphome_ns.class_('ESP32BLEBeacon', Component)
 

--- a/esphome/components/esp32_camera.py
+++ b/esphome/components/esp32_camera.py
@@ -127,4 +127,4 @@ def to_code(config):
     add(cam.set_frame_size(FRAME_SIZES[config[CONF_RESOLUTION]]))
 
 
-BUILD_FLAGS = '-DUSE_ESP32_CAMERA'
+BUILD_FLAGS = ['-DUSE_ESP32_CAMERA', '-DBOARD_HAS_PSRAM']

--- a/esphome/components/esp32_camera.py
+++ b/esphome/components/esp32_camera.py
@@ -64,11 +64,11 @@ CONFIG_SCHEMA = cv.Schema({
     vol.Required(CONF_VSYNC_PIN): pins.input_pin,
     vol.Required(CONF_HREF_PIN): pins.input_pin,
     vol.Required(CONF_PIXEL_CLOCK_PIN): pins.input_pin,
-    vol.Required(CONF_EXTERNAL_CLOCK): vol.Schema({
+    vol.Required(CONF_EXTERNAL_CLOCK): cv.Schema({
         vol.Required(CONF_PIN): pins.output_pin,
         vol.Optional(CONF_FREQUENCY, default='20MHz'): vol.All(cv.frequency, vol.In([20e6, 10e6])),
     }),
-    vol.Required(CONF_I2C_PINS): vol.Schema({
+    vol.Required(CONF_I2C_PINS): cv.Schema({
         vol.Required(CONF_SDA): pins.output_pin,
         vol.Required(CONF_SCL): pins.output_pin,
     }),

--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -159,3 +159,7 @@ class _Schema(vol.Schema):
             return out
 
         return validate_mapping
+
+    def extend(self, schema, required=None, extra=None):
+        ret = vol.Schema.extend(self, schema, required=required, extra=extra)
+        return _Schema(ret.schema, required=ret.required, extra=ret.extra)

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -172,9 +172,9 @@ remote_receiver:
 esp32_ble_tracker:
   scan_interval: 300s
 
-esp32_ble_beacon:
-  type: iBeacon
-  uuid: 'c29ce823-e67a-4e71-bff2-abaa32e77a98'
+#esp32_ble_beacon:
+#  type: iBeacon
+#  uuid: 'c29ce823-e67a-4e71-bff2-abaa32e77a98'
 
 status_led:
   pin: GPIO2


### PR DESCRIPTION
## Description:

- Warn if BLE tracker used together with ble beacon
- Fixes CSE7766 not reading further when cycle outside of range. fixes https://github.com/esphome/issues/issues/134
- Enable PSRAM for ESP32 Cameras (https://github.com/esphome/issues/issues/127)
- Show similar keys on config validation error more often

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
