### PR TITLE
Allow gamma correction in light partition

### DIFF
--- a/esphome/components/light/partition.py
+++ b/esphome/components/light/partition.py
@@ -3,8 +3,8 @@ import voluptuous as vol
 from esphome.components import light
 from esphome.components.light import AddressableLight
 import esphome.config_validation as cv
-from esphome.const import CONF_DEFAULT_TRANSITION_LENGTH, CONF_EFFECTS, CONF_FROM, CONF_ID, \
-    CONF_MAKE_ID, CONF_NAME, CONF_SEGMENTS, CONF_TO
+from esphome.const import CONF_DEFAULT_TRANSITION_LENGTH, CONF_EFFECTS, CONF_FROM, \
+    CONF_GAMMA_CORRECT, CONF_ID, CONF_MAKE_ID, CONF_NAME, CONF_SEGMENTS, CONF_TO
 from esphome.cpp_generator import get_variable, variable
 from esphome.cpp_types import App, Application
 
@@ -30,6 +30,7 @@ PLATFORM_SCHEMA = cv.nameable(light.LIGHT_PLATFORM_SCHEMA.extend({
         vol.Required(CONF_TO): cv.positive_int,
     }, validate_from_to), vol.Length(min=1)),
 
+    vol.Optional(CONF_GAMMA_CORRECT): cv.positive_float,
     vol.Optional(CONF_DEFAULT_TRANSITION_LENGTH): cv.positive_time_period_milliseconds,
     vol.Optional(CONF_EFFECTS): light.validate_effects(light.ADDRESSABLE_EFFECTS),
 }))


### PR DESCRIPTION
## Description:
For some reason gamma correction configuration is missing in light partition.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#201
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
