### PR TITLE
Simplify coroutine syntax

### DIFF
--- a/esphome/components/api.py
+++ b/esphome/components/api.py
@@ -108,8 +108,7 @@ HOMEASSISTANT_SERVIC_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_HOMEASSISTANT_SERVICE, HOMEASSISTANT_SERVIC_ACTION_SCHEMA)
 def homeassistant_service_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_home_assistant_service_call_action(template_arg)
     type = HomeAssistantServiceCallAction.template(template_arg)
     act = Pvariable(action_id, rhs, type=type)
@@ -123,8 +122,7 @@ def homeassistant_service_to_code(config, action_id, template_arg, args):
     if CONF_VARIABLES in config:
         datas = []
         for key, value in config[CONF_VARIABLES].items():
-            for value_ in process_lambda(value, []):
-                yield None
+            value_ = yield process_lambda(value, [])
             datas.append(TemplatableKeyValuePair(key, value_))
         add(act.set_variables(datas))
     yield act

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -205,9 +205,8 @@ def setup_filter(config):
     elif CONF_DELAYED_ON in config:
         yield App.register_component(DelayedOnFilter.new(config[CONF_DELAYED_ON]))
     elif CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA], [(bool_, 'x')],
-                                      return_type=optional.template(bool_)):
-            yield None
+        lambda_ = yield process_lambda(config[CONF_LAMBDA], [(bool_, 'x')],
+                                       return_type=optional.template(bool_))
         yield LambdaFilter.new(lambda_)
 
 

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -10,7 +10,7 @@ from esphome.const import CONF_DELAYED_OFF, CONF_DELAYED_ON, CONF_DEVICE_CLASS, 
     CONF_LAMBDA, CONF_MAX_LENGTH, CONF_MIN_LENGTH, CONF_MQTT_ID, CONF_ON_CLICK, \
     CONF_ON_DOUBLE_CLICK, CONF_ON_MULTI_CLICK, CONF_ON_PRESS, CONF_ON_RELEASE, CONF_ON_STATE, \
     CONF_STATE, CONF_TIMING, CONF_TRIGGER_ID, CONF_FOR
-from esphome.core import CORE
+from esphome.core import CORE, coroutine
 from esphome.cpp_generator import Pvariable, StructInitializer, add, get_variable, process_lambda
 from esphome.cpp_types import App, Component, Nameable, Trigger, bool_, esphome_ns, optional
 from esphome.py_compat import string_types
@@ -196,6 +196,7 @@ BINARY_SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend({
 BINARY_SENSOR_PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BINARY_SENSOR_SCHEMA.schema)
 
 
+@coroutine
 def setup_filter(config):
     if CONF_INVERT in config:
         yield InvertFilter.new()
@@ -210,15 +211,16 @@ def setup_filter(config):
         yield LambdaFilter.new(lambda_)
 
 
+@coroutine
 def setup_filters(config):
     filters = []
     for conf in config:
-        for filter in setup_filter(conf):
-            yield None
+        filter = yield setup_filter(conf)
         filters.append(filter)
     yield filters
 
 
+@coroutine
 def setup_binary_sensor_core_(binary_sensor_var, config):
     if CONF_INTERNAL in config:
         add(binary_sensor_var.set_internal(CONF_INTERNAL))
@@ -227,8 +229,7 @@ def setup_binary_sensor_core_(binary_sensor_var, config):
     if CONF_INVERTED in config:
         add(binary_sensor_var.set_inverted(config[CONF_INVERTED]))
     if CONF_FILTERS in config:
-        for filters in setup_filters(config[CONF_FILTERS]):
-            yield
+        filters = yield setup_filters(config[CONF_FILTERS])
         add(binary_sensor_var.add_filters(filters))
 
     for conf in config.get(CONF_ON_PRESS, []):
@@ -298,8 +299,7 @@ BINARY_SENSOR_IS_ON_CONDITION_SCHEMA = maybe_simple_id({
 
 @CONDITION_REGISTRY.register(CONF_BINARY_SENSOR_IS_ON, BINARY_SENSOR_IS_ON_CONDITION_SCHEMA)
 def binary_sensor_is_on_to_code(config, condition_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_binary_sensor_is_on_condition(template_arg, config.get(CONF_FOR))
     type = BinarySensorCondition.template(template_arg)
     yield Pvariable(condition_id, rhs, type=type)
@@ -314,8 +314,7 @@ BINARY_SENSOR_IS_OFF_CONDITION_SCHEMA = maybe_simple_id({
 
 @CONDITION_REGISTRY.register(CONF_BINARY_SENSOR_IS_OFF, BINARY_SENSOR_IS_OFF_CONDITION_SCHEMA)
 def binary_sensor_is_off_to_code(config, condition_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_binary_sensor_is_off_condition(template_arg, config.get(CONF_FOR))
     type = BinarySensorCondition.template(template_arg)
     yield Pvariable(condition_id, rhs, type=type)

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -214,8 +214,7 @@ def setup_filter(config):
 def setup_filters(config):
     filters = []
     for conf in config:
-        filter = yield setup_filter(conf)
-        filters.append(filter)
+        filters.append((yield setup_filter(conf)))
     yield filters
 
 

--- a/esphome/components/binary_sensor/apds9960.py
+++ b/esphome/components/binary_sensor/apds9960.py
@@ -25,8 +25,7 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_APDS9960_ID]):
-        yield
+    hub = yield get_variable(config[CONF_APDS9960_ID])
     func = getattr(hub, DIRECTIONS[config[CONF_DIRECTION]])
     rhs = func(config[CONF_NAME])
     binary_sensor.register_binary_sensor(rhs, config)

--- a/esphome/components/binary_sensor/custom.py
+++ b/esphome/components/binary_sensor/custom.py
@@ -20,9 +20,8 @@ PLATFORM_SCHEMA = binary_sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                    return_type=std_vector.template(binary_sensor.BinarySensorPtr)):
-        yield
+    template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                     return_type=std_vector.template(binary_sensor.BinarySensorPtr))
 
     rhs = CustomBinarySensorConstructor(template_)
     custom = variable(config[CONF_ID], rhs)

--- a/esphome/components/binary_sensor/esp32_ble_tracker.py
+++ b/esphome/components/binary_sensor/esp32_ble_tracker.py
@@ -19,7 +19,6 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_ESP32_BLE_ID]):
-        yield
+    hub = yield get_variable(config[CONF_ESP32_BLE_ID])
     rhs = hub.make_presence_sensor(config[CONF_NAME], make_address_array(config[CONF_MAC_ADDRESS]))
     binary_sensor.register_binary_sensor(rhs, config)

--- a/esphome/components/binary_sensor/esp32_touch.py
+++ b/esphome/components/binary_sensor/esp32_touch.py
@@ -47,7 +47,6 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    hub = None
     hub = yield get_variable(config[CONF_ESP32_TOUCH_ID])
     touch_pad = TOUCH_PADS[config[CONF_PIN]]
     rhs = hub.make_touch_pad(config[CONF_NAME], touch_pad, config[CONF_THRESHOLD])

--- a/esphome/components/binary_sensor/esp32_touch.py
+++ b/esphome/components/binary_sensor/esp32_touch.py
@@ -48,8 +48,7 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 def to_code(config):
     hub = None
-    for hub in get_variable(config[CONF_ESP32_TOUCH_ID]):
-        yield
+    hub = yield get_variable(config[CONF_ESP32_TOUCH_ID])
     touch_pad = TOUCH_PADS[config[CONF_PIN]]
     rhs = hub.make_touch_pad(config[CONF_NAME], touch_pad, config[CONF_THRESHOLD])
     binary_sensor.register_binary_sensor(rhs, config)

--- a/esphome/components/binary_sensor/gpio.py
+++ b/esphome/components/binary_sensor/gpio.py
@@ -19,7 +19,6 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    pin = None
     pin = yield gpio_input_pin_expression(config[CONF_PIN])
     rhs = App.make_gpio_binary_sensor(config[CONF_NAME], pin)
     gpio = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/binary_sensor/gpio.py
+++ b/esphome/components/binary_sensor/gpio.py
@@ -20,8 +20,7 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 def to_code(config):
     pin = None
-    for pin in gpio_input_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_input_pin_expression(config[CONF_PIN])
     rhs = App.make_gpio_binary_sensor(config[CONF_NAME], pin)
     gpio = Pvariable(config[CONF_ID], rhs)
     binary_sensor.setup_binary_sensor(gpio, config)

--- a/esphome/components/binary_sensor/mpr121.py
+++ b/esphome/components/binary_sensor/mpr121.py
@@ -18,7 +18,6 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_MPR121_ID]):
-        yield
+    hub = yield get_variable(config[CONF_MPR121_ID])
     rhs = MPR121Channel.new(config[CONF_NAME], config[CONF_CHANNEL])
     binary_sensor.register_binary_sensor(hub.add_channel(rhs), config)

--- a/esphome/components/binary_sensor/nextion.py
+++ b/esphome/components/binary_sensor/nextion.py
@@ -22,8 +22,7 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_NEXTION_ID]):
-        yield
+    hub = yield get_variable(config[CONF_NEXTION_ID])
     rhs = hub.make_touch_component(config[CONF_NAME], config[CONF_PAGE_ID],
                                    config[CONF_COMPONENT_ID])
     binary_sensor.register_binary_sensor(rhs, config)

--- a/esphome/components/binary_sensor/pn532.py
+++ b/esphome/components/binary_sensor/pn532.py
@@ -38,8 +38,7 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_PN532_ID]):
-        yield
+    hub = yield get_variable(config[CONF_PN532_ID])
     addr = [HexInt(int(x, 16)) for x in config[CONF_UID].split('-')]
     rhs = hub.make_tag(config[CONF_NAME], addr)
     binary_sensor.register_binary_sensor(rhs, config)

--- a/esphome/components/binary_sensor/rdm6300.py
+++ b/esphome/components/binary_sensor/rdm6300.py
@@ -20,7 +20,6 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_RDM6300_ID]):
-        yield
+    hub = yield get_variable(config[CONF_RDM6300_ID])
     rhs = hub.make_card(config[CONF_NAME], config[CONF_UID])
     binary_sensor.register_binary_sensor(rhs, config)

--- a/esphome/components/binary_sensor/remote_receiver.py
+++ b/esphome/components/binary_sensor/remote_receiver.py
@@ -136,8 +136,7 @@ def receiver_base(full_config):
 
 
 def to_code(config):
-    for remote in get_variable(config[CONF_REMOTE_RECEIVER_ID]):
-        yield
+    remote = yield get_variable(config[CONF_REMOTE_RECEIVER_ID])
     rhs = receiver_base(config)
     receiver = Pvariable(config[CONF_RECEIVER_ID], rhs)
 

--- a/esphome/components/binary_sensor/template.py
+++ b/esphome/components/binary_sensor/template.py
@@ -27,9 +27,8 @@ def to_code(config):
     setup_component(var, config)
 
     if CONF_LAMBDA in config:
-        for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                        return_type=optional.template(bool_)):
-            yield
+        template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                         return_type=optional.template(bool_))
         add(var.set_template(template_))
 
 
@@ -45,12 +44,10 @@ BINARY_SENSOR_TEMPLATE_PUBLISH_ACTION_SCHEMA = cv.Schema({
 @ACTION_REGISTRY.register(CONF_BINARY_SENSOR_TEMPLATE_PUBLISH,
                           BINARY_SENSOR_TEMPLATE_PUBLISH_ACTION_SCHEMA)
 def binary_sensor_template_publish_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_binary_sensor_publish_action(template_arg)
     type = BinarySensorPublishAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_STATE], args, bool_):
-        yield None
+    template_ = yield templatable(config[CONF_STATE], args, bool_)
     add(action.set_state(template_))
     yield action

--- a/esphome/components/binary_sensor/ttp229_lsf.py
+++ b/esphome/components/binary_sensor/ttp229_lsf.py
@@ -18,7 +18,6 @@ PLATFORM_SCHEMA = cv.nameable(binary_sensor.BINARY_SENSOR_PLATFORM_SCHEMA.extend
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_TTP229_ID]):
-        yield
+    hub = yield get_variable(config[CONF_TTP229_ID])
     rhs = TTP229Channel.new(config[CONF_NAME], config[CONF_CHANNEL])
     binary_sensor.register_binary_sensor(hub.add_channel(rhs), config)

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -84,32 +84,26 @@ CLIMATE_CONTROL_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_CLIMATE_CONTROL, CLIMATE_CONTROL_ACTION_SCHEMA)
 def climate_control_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     type = ControlAction.template(template_arg)
     rhs = type.new(var)
     action = Pvariable(action_id, rhs, type=type)
     if CONF_MODE in config:
         if isinstance(config[CONF_MODE], core.Lambda):
-            for template_ in templatable(config[CONF_MODE], args, ClimateMode):
-                yield None
+            template_ = yield templatable(config[CONF_MODE], args, ClimateMode)
             add(action.set_mode(template_))
         else:
             add(action.set_mode(CLIMATE_MODES[config[CONF_MODE]]))
     if CONF_TARGET_TEMPERATURE in config:
-        for template_ in templatable(config[CONF_TARGET_TEMPERATURE], args, float_):
-            yield None
+        template_ = yield templatable(config[CONF_TARGET_TEMPERATURE], args, float_)
         add(action.set_target_temperature(template_))
     if CONF_TARGET_TEMPERATURE_LOW in config:
-        for template_ in templatable(config[CONF_TARGET_TEMPERATURE_LOW], args, float_):
-            yield None
+        template_ = yield templatable(config[CONF_TARGET_TEMPERATURE_LOW], args, float_)
         add(action.set_target_temperature_low(template_))
     if CONF_TARGET_TEMPERATURE_HIGH in config:
-        for template_ in templatable(config[CONF_TARGET_TEMPERATURE_HIGH], args, float_):
-            yield None
+        template_ = yield templatable(config[CONF_TARGET_TEMPERATURE_HIGH], args, float_)
         add(action.set_target_temperature_high(template_))
     if CONF_AWAY in config:
-        for template_ in templatable(config[CONF_AWAY], args, bool_):
-            yield None
+        template_ = yield templatable(config[CONF_AWAY], args, bool_)
         add(action.set_away(template_))
     yield action

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -8,7 +8,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_AWAY, CONF_ID, CONF_INTERNAL, CONF_MAX_TEMPERATURE, \
     CONF_MIN_TEMPERATURE, CONF_MODE, CONF_MQTT_ID, CONF_TARGET_TEMPERATURE, \
     CONF_TARGET_TEMPERATURE_HIGH, CONF_TARGET_TEMPERATURE_LOW, CONF_TEMPERATURE_STEP, CONF_VISUAL
-from esphome.core import CORE
+from esphome.core import CORE, coroutine
 from esphome.cpp_generator import Pvariable, add, get_variable, templatable
 from esphome.cpp_types import Action, App, Nameable, bool_, esphome_ns, float_
 
@@ -49,6 +49,7 @@ CLIMATE_SCHEMA = cv.MQTT_COMMAND_COMPONENT_SCHEMA.extend({
 CLIMATE_PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(CLIMATE_SCHEMA.schema)
 
 
+@coroutine
 def setup_climate_core_(climate_var, config):
     if CONF_INTERNAL in config:
         add(climate_var.set_internal(config[CONF_INTERNAL]))
@@ -89,11 +90,9 @@ def climate_control_to_code(config, action_id, template_arg, args):
     rhs = type.new(var)
     action = Pvariable(action_id, rhs, type=type)
     if CONF_MODE in config:
-        if isinstance(config[CONF_MODE], core.Lambda):
-            template_ = yield templatable(config[CONF_MODE], args, ClimateMode)
-            add(action.set_mode(template_))
-        else:
-            add(action.set_mode(CLIMATE_MODES[config[CONF_MODE]]))
+        template_ = yield templatable(config[CONF_MODE], args, ClimateMode,
+                                      to_exp=CLIMATE_MODES)
+        add(action.set_mode(template_))
     if CONF_TARGET_TEMPERATURE in config:
         template_ = yield templatable(config[CONF_TARGET_TEMPERATURE], args, float_)
         add(action.set_target_temperature(template_))

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -1,6 +1,5 @@
 import voluptuous as vol
 
-from esphome import core
 from esphome.automation import ACTION_REGISTRY
 from esphome.components import mqtt
 from esphome.components.mqtt import setup_mqtt_component

--- a/esphome/components/climate/bang_bang.py
+++ b/esphome/components/climate/bang_bang.py
@@ -35,8 +35,7 @@ def to_code(config):
     climate.register_climate(control, config)
     setup_component(control, config)
 
-    for var in get_variable(config[CONF_SENSOR]):
-        yield
+    var = yield get_variable(config[CONF_SENSOR])
     add(control.set_sensor(var))
 
     normal_config = BangBangClimateTargetTempConfig(

--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -87,8 +87,7 @@ COVER_OPEN_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_COVER_OPEN, COVER_OPEN_ACTION_SCHEMA)
 def cover_open_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     type = OpenAction.template(template_arg)
     rhs = type.new(var)
     yield Pvariable(action_id, rhs, type=type)
@@ -102,8 +101,7 @@ COVER_CLOSE_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_COVER_CLOSE, COVER_CLOSE_ACTION_SCHEMA)
 def cover_close_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     type = CloseAction.template(template_arg)
     rhs = type.new(var)
     yield Pvariable(action_id, rhs, type=type)
@@ -117,8 +115,7 @@ COVER_STOP_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_COVER_STOP, COVER_STOP_ACTION_SCHEMA)
 def cover_stop_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     type = StopAction.template(template_arg)
     rhs = type.new(var)
     yield Pvariable(action_id, rhs, type=type)
@@ -136,14 +133,12 @@ COVER_CONTROL_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_COVER_CONTROL, COVER_CONTROL_ACTION_SCHEMA)
 def cover_control_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     type = StopAction.template(template_arg)
     rhs = type.new(var)
     action = Pvariable(action_id, rhs, type=type)
     if CONF_STOP in config:
-        for template_ in templatable(config[CONF_STOP], args, bool):
-            yield None
+        template_ = yield templatable(config[CONF_STOP], args, bool)
         add(action.set_stop(template_))
     if CONF_STATE in config:
         for template_ in templatable(config[CONF_STATE], args, float,
@@ -151,11 +146,9 @@ def cover_control_to_code(config, action_id, template_arg, args):
             yield None
         add(action.set_position(template_))
     if CONF_POSITION in config:
-        for template_ in templatable(config[CONF_POSITION], args, float):
-            yield None
+        template_ = yield templatable(config[CONF_POSITION], args, float)
         add(action.set_position(template_))
     if CONF_TILT in config:
-        for template_ in templatable(config[CONF_TILT], args, float):
-            yield None
+        template_ = yield templatable(config[CONF_TILT], args, float)
         add(action.set_tilt(template_))
     yield action

--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -141,9 +141,8 @@ def cover_control_to_code(config, action_id, template_arg, args):
         template_ = yield templatable(config[CONF_STOP], args, bool)
         add(action.set_stop(template_))
     if CONF_STATE in config:
-        for template_ in templatable(config[CONF_STATE], args, float,
-                                     to_exp=COVER_STATES):
-            yield None
+        template_ = yield templatable(config[CONF_STATE], args, float,
+                                      to_exp=COVER_STATES)
         add(action.set_position(template_))
     if CONF_POSITION in config:
         template_ = yield templatable(config[CONF_POSITION], args, float)

--- a/esphome/components/cover/endstop.py
+++ b/esphome/components/cover/endstop.py
@@ -36,15 +36,13 @@ def to_code(config):
     automation.build_automations(var.get_stop_trigger(), [],
                                  config[CONF_STOP_ACTION])
 
-    for bin in get_variable(config[CONF_OPEN_ENDSTOP]):
-        yield
+    bin = yield get_variable(config[CONF_OPEN_ENDSTOP])
     add(var.set_open_endstop(bin))
     add(var.set_open_duration(config[CONF_OPEN_DURATION]))
     automation.build_automations(var.get_open_trigger(), [],
                                  config[CONF_OPEN_ACTION])
 
-    for bin in get_variable(config[CONF_CLOSE_ENDSTOP]):
-        yield
+    bin = yield get_variable(config[CONF_CLOSE_ENDSTOP])
     add(var.set_close_endstop(bin))
     add(var.set_close_duration(config[CONF_CLOSE_DURATION]))
     automation.build_automations(var.get_close_trigger(), [],

--- a/esphome/components/cover/template.py
+++ b/esphome/components/cover/template.py
@@ -4,9 +4,9 @@ from esphome import automation
 from esphome.automation import ACTION_REGISTRY
 from esphome.components import cover
 import esphome.config_validation as cv
-from esphome.const import CONF_ASSUMED_STATE, CONF_CLOSE_ACTION, CONF_ID, CONF_LAMBDA, CONF_NAME, \
-    CONF_OPEN_ACTION, CONF_OPTIMISTIC, CONF_STATE, CONF_STOP_ACTION, CONF_POSITION, \
-    CONF_CURRENT_OPERATION, CONF_RESTORE_MODE
+from esphome.const import CONF_ASSUMED_STATE, CONF_CLOSE_ACTION, CONF_CURRENT_OPERATION, CONF_ID, \
+    CONF_LAMBDA, CONF_NAME, CONF_OPEN_ACTION, CONF_OPTIMISTIC, CONF_POSITION, CONF_RESTORE_MODE, \
+    CONF_STATE, CONF_STOP_ACTION
 from esphome.cpp_generator import Pvariable, add, get_variable, process_lambda, templatable
 from esphome.cpp_helpers import setup_component
 from esphome.cpp_types import Action, App, optional
@@ -40,9 +40,8 @@ def to_code(config):
     setup_component(var, config)
 
     if CONF_LAMBDA in config:
-        for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                        return_type=optional.template(float)):
-            yield
+        template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                         return_type=optional.template(float))
         add(var.set_state_lambda(template_))
     if CONF_OPEN_ACTION in config:
         automation.build_automations(var.get_open_trigger(), [],
@@ -75,8 +74,7 @@ COVER_TEMPLATE_PUBLISH_ACTION_SCHEMA = cv.Schema({
 @ACTION_REGISTRY.register(CONF_COVER_TEMPLATE_PUBLISH,
                           COVER_TEMPLATE_PUBLISH_ACTION_SCHEMA)
 def cover_template_publish_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     type = CoverPublishAction.template(template_arg)
     rhs = type.new(var)
     action = Pvariable(action_id, rhs, type=type)

--- a/esphome/components/cover/template.py
+++ b/esphome/components/cover/template.py
@@ -79,18 +79,15 @@ def cover_template_publish_to_code(config, action_id, template_arg, args):
     rhs = type.new(var)
     action = Pvariable(action_id, rhs, type=type)
     if CONF_STATE in config:
-        for template_ in templatable(config[CONF_STATE], args, float,
-                                     to_exp=cover.COVER_STATES):
-            yield None
+        template_ = yield templatable(config[CONF_STATE], args, float,
+                                      to_exp=cover.COVER_STATES)
         add(action.set_position(template_))
     if CONF_POSITION in config:
-        for template_ in templatable(config[CONF_POSITION], args, float,
-                                     to_exp=cover.COVER_STATES):
-            yield None
+        template_ = yield templatable(config[CONF_POSITION], args, float,
+                                      to_exp=cover.COVER_STATES)
         add(action.set_position(template_))
     if CONF_CURRENT_OPERATION in config:
-        for template_ in templatable(config[CONF_CURRENT_OPERATION], args, cover.CoverOperation,
-                                     to_exp=cover.COVER_OPERATIONS):
-            yield None
+        template_ = yield templatable(config[CONF_CURRENT_OPERATION], args, cover.CoverOperation,
+                                      to_exp=cover.COVER_OPERATIONS)
         add(action.set_current_operation(template_))
     yield action

--- a/esphome/components/custom_component.py
+++ b/esphome/components/custom_component.py
@@ -19,9 +19,8 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                    return_type=std_vector.template(ComponentPtr)):
-        yield
+    template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                     return_type=std_vector.template(ComponentPtr))
 
     rhs = CustomComponentConstructor(template_)
     custom = variable(config[CONF_ID], rhs)

--- a/esphome/components/deep_sleep.py
+++ b/esphome/components/deep_sleep.py
@@ -63,8 +63,7 @@ def to_code(config):
     if CONF_SLEEP_DURATION in config:
         add(deep_sleep.set_sleep_duration(config[CONF_SLEEP_DURATION]))
     if CONF_WAKEUP_PIN in config:
-        for pin in gpio_input_pin_expression(config[CONF_WAKEUP_PIN]):
-            yield
+        pin = yield gpio_input_pin_expression(config[CONF_WAKEUP_PIN])
         add(deep_sleep.set_wakeup_pin(pin))
     if CONF_WAKEUP_PIN_MODE in config:
         add(deep_sleep.set_wakeup_pin_mode(WAKEUP_PIN_MODES[config[CONF_WAKEUP_PIN_MODE]]))
@@ -96,8 +95,7 @@ DEEP_SLEEP_ENTER_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_DEEP_SLEEP_ENTER, DEEP_SLEEP_ENTER_ACTION_SCHEMA)
 def deep_sleep_enter_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_enter_deep_sleep_action(template_arg)
     type = EnterDeepSleepAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -111,8 +109,7 @@ DEEP_SLEEP_PREVENT_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_DEEP_SLEEP_PREVENT, DEEP_SLEEP_PREVENT_ACTION_SCHEMA)
 def deep_sleep_prevent_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_prevent_deep_sleep_action(template_arg)
     type = PreventDeepSleepAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)

--- a/esphome/components/display/lcd_gpio.py
+++ b/esphome/components/display/lcd_gpio.py
@@ -46,27 +46,22 @@ def to_code(config):
     lcd = Pvariable(config[CONF_ID], rhs)
     pins_ = []
     for conf in config[CONF_DATA_PINS]:
-        for pin in gpio_output_pin_expression(conf):
-            yield
+        pin = yield gpio_output_pin_expression(conf)
         pins_.append(pin)
     add(lcd.set_data_pins(*pins_))
-    for enable in gpio_output_pin_expression(config[CONF_ENABLE_PIN]):
-        yield
+    enable = yield gpio_output_pin_expression(config[CONF_ENABLE_PIN])
     add(lcd.set_enable_pin(enable))
 
-    for rs in gpio_output_pin_expression(config[CONF_RS_PIN]):
-        yield
+    rs = yield gpio_output_pin_expression(config[CONF_RS_PIN])
     add(lcd.set_rs_pin(rs))
 
     if CONF_RW_PIN in config:
-        for rw in gpio_output_pin_expression(config[CONF_RW_PIN]):
-            yield
+        rw = yield gpio_output_pin_expression(config[CONF_RW_PIN])
         add(lcd.set_rw_pin(rw))
 
     if CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA], [(LCDDisplayRef, 'it')],
-                                      return_type=void):
-            yield
+        lambda_ = yield process_lambda(config[CONF_LAMBDA], [(LCDDisplayRef, 'it')],
+                                       return_type=void)
         add(lcd.set_writer(lambda_))
 
     display.setup_display(lcd, config)

--- a/esphome/components/display/lcd_gpio.py
+++ b/esphome/components/display/lcd_gpio.py
@@ -46,8 +46,7 @@ def to_code(config):
     lcd = Pvariable(config[CONF_ID], rhs)
     pins_ = []
     for conf in config[CONF_DATA_PINS]:
-        pin = yield gpio_output_pin_expression(conf)
-        pins_.append(pin)
+        pins_.append((yield gpio_output_pin_expression(conf)))
     add(lcd.set_data_pins(*pins_))
     enable = yield gpio_output_pin_expression(config[CONF_ENABLE_PIN])
     add(lcd.set_enable_pin(enable))

--- a/esphome/components/display/lcd_pcf8574.py
+++ b/esphome/components/display/lcd_pcf8574.py
@@ -28,9 +28,8 @@ def to_code(config):
         add(lcd.set_address(config[CONF_ADDRESS]))
 
     if CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA], [(LCDDisplayRef, 'it')],
-                                      return_type=void):
-            yield
+        lambda_ = yield process_lambda(config[CONF_LAMBDA], [(LCDDisplayRef, 'it')],
+                                       return_type=void)
         add(lcd.set_writer(lambda_))
 
     display.setup_display(lcd, config)

--- a/esphome/components/display/max7219.py
+++ b/esphome/components/display/max7219.py
@@ -26,10 +26,8 @@ PLATFORM_SCHEMA = display.BASIC_DISPLAY_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for spi_ in get_variable(config[CONF_SPI_ID]):
-        yield
-    for cs in gpio_output_pin_expression(config[CONF_CS_PIN]):
-        yield
+    spi_ = yield get_variable(config[CONF_SPI_ID])
+    cs = yield gpio_output_pin_expression(config[CONF_CS_PIN])
     rhs = App.make_max7219(spi_, cs)
     max7219 = Pvariable(config[CONF_ID], rhs)
 
@@ -39,9 +37,8 @@ def to_code(config):
         add(max7219.set_intensity(config[CONF_INTENSITY]))
 
     if CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA], [(MAX7219ComponentRef, 'it')],
-                                      return_type=void):
-            yield
+        lambda_ = yield process_lambda(config[CONF_LAMBDA], [(MAX7219ComponentRef, 'it')],
+                                       return_type=void)
         add(max7219.set_writer(lambda_))
 
     display.setup_display(max7219, config)

--- a/esphome/components/display/nextion.py
+++ b/esphome/components/display/nextion.py
@@ -18,15 +18,13 @@ PLATFORM_SCHEMA = display.BASIC_DISPLAY_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for uart_ in get_variable(config[CONF_UART_ID]):
-        yield
+    uart_ = yield get_variable(config[CONF_UART_ID])
     rhs = App.make_nextion(uart_)
     nextion = Pvariable(config[CONF_ID], rhs)
 
     if CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA], [(NextionRef, 'it')],
-                                      return_type=void):
-            yield
+        lambda_ = yield process_lambda(config[CONF_LAMBDA], [(NextionRef, 'it')],
+                                       return_type=void)
         add(nextion.set_writer(lambda_))
 
     display.setup_display(nextion, config)

--- a/esphome/components/display/ssd1306_i2c.py
+++ b/esphome/components/display/ssd1306_i2c.py
@@ -28,17 +28,15 @@ def to_code(config):
     add(ssd.set_model(ssd1306_spi.MODELS[config[CONF_MODEL]]))
 
     if CONF_RESET_PIN in config:
-        for reset in gpio_output_pin_expression(config[CONF_RESET_PIN]):
-            yield
+        reset = yield gpio_output_pin_expression(config[CONF_RESET_PIN])
         add(ssd.set_reset_pin(reset))
     if CONF_EXTERNAL_VCC in config:
         add(ssd.set_external_vcc(config[CONF_EXTERNAL_VCC]))
     if CONF_ADDRESS in config:
         add(ssd.set_address(config[CONF_ADDRESS]))
     if CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA],
-                                      [(display.DisplayBufferRef, 'it')], return_type=void):
-            yield
+        lambda_ = yield process_lambda(config[CONF_LAMBDA],
+                                       [(display.DisplayBufferRef, 'it')], return_type=void)
         add(ssd.set_writer(lambda_))
 
     display.setup_display(ssd, config)

--- a/esphome/components/display/waveshare_epaper.py
+++ b/esphome/components/display/waveshare_epaper.py
@@ -53,12 +53,9 @@ PLATFORM_SCHEMA = vol.All(display.FULL_DISPLAY_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for spi_ in get_variable(config[CONF_SPI_ID]):
-        yield
-    for cs in gpio_output_pin_expression(config[CONF_CS_PIN]):
-        yield
-    for dc in gpio_output_pin_expression(config[CONF_DC_PIN]):
-        yield
+    spi_ = yield get_variable(config[CONF_SPI_ID])
+    cs = yield gpio_output_pin_expression(config[CONF_CS_PIN])
+    dc = yield gpio_output_pin_expression(config[CONF_DC_PIN])
 
     model_type, model = MODELS[config[CONF_MODEL]]
     if model_type == 'a':
@@ -71,17 +68,14 @@ def to_code(config):
         raise NotImplementedError()
 
     if CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA], [(display.DisplayBufferRef, 'it')],
-                                      return_type=void):
-            yield
+        lambda_ = yield process_lambda(config[CONF_LAMBDA], [(display.DisplayBufferRef, 'it')],
+                                       return_type=void)
         add(epaper.set_writer(lambda_))
     if CONF_RESET_PIN in config:
-        for reset in gpio_output_pin_expression(config[CONF_RESET_PIN]):
-            yield
+        reset = yield gpio_output_pin_expression(config[CONF_RESET_PIN])
         add(epaper.set_reset_pin(reset))
     if CONF_BUSY_PIN in config:
-        for reset in gpio_input_pin_expression(config[CONF_BUSY_PIN]):
-            yield
+        reset = yield gpio_input_pin_expression(config[CONF_BUSY_PIN])
         add(epaper.set_busy_pin(reset))
     if CONF_FULL_UPDATE_EVERY in config:
         add(epaper.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))

--- a/esphome/components/ethernet.py
+++ b/esphome/components/ethernet.py
@@ -74,8 +74,7 @@ def to_code(config):
     add(eth.set_use_address(config[CONF_USE_ADDRESS]))
 
     if CONF_POWER_PIN in config:
-        for pin in gpio_output_pin_expression(config[CONF_POWER_PIN]):
-            yield
+        pin = yield gpio_output_pin_expression(config[CONF_POWER_PIN])
         add(eth.set_power_pin(pin))
 
     if CONF_MANUAL_IP in config:

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -82,8 +82,7 @@ FAN_TOGGLE_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_FAN_TOGGLE, FAN_TOGGLE_ACTION_SCHEMA)
 def fan_toggle_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_toggle_action(template_arg)
     type = ToggleAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -97,8 +96,7 @@ FAN_TURN_OFF_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_FAN_TURN_OFF, FAN_TURN_OFF_ACTION_SCHEMA)
 def fan_turn_off_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_turn_off_action(template_arg)
     type = TurnOffAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -114,18 +112,15 @@ FAN_TURN_ON_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_FAN_TURN_ON, FAN_TURN_ON_ACTION_SCHEMA)
 def fan_turn_on_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_turn_on_action(template_arg)
     type = TurnOnAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
     if CONF_OSCILLATING in config:
-        for template_ in templatable(config[CONF_OSCILLATING], args, bool_):
-            yield None
+        template_ = yield templatable(config[CONF_OSCILLATING], args, bool_)
         add(action.set_oscillating(template_))
     if CONF_SPEED in config:
-        for template_ in templatable(config[CONF_SPEED], args, FanSpeed):
-            yield None
+        template_ = yield templatable(config[CONF_SPEED], args, FanSpeed)
         if isinstance(template_, string_types):
             template_ = FAN_SPEEDS[template_]
         add(action.set_speed(template_))

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -10,7 +10,6 @@ from esphome.const import CONF_ID, CONF_INTERNAL, CONF_MQTT_ID, CONF_OSCILLATING
 from esphome.core import CORE
 from esphome.cpp_generator import Pvariable, add, get_variable, templatable
 from esphome.cpp_types import Action, Application, Component, Nameable, bool_, esphome_ns
-from esphome.py_compat import string_types
 
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
 

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -120,8 +120,7 @@ def fan_turn_on_to_code(config, action_id, template_arg, args):
         template_ = yield templatable(config[CONF_OSCILLATING], args, bool_)
         add(action.set_oscillating(template_))
     if CONF_SPEED in config:
-        template_ = yield templatable(config[CONF_SPEED], args, FanSpeed)
-        if isinstance(template_, string_types):
-            template_ = FAN_SPEEDS[template_]
+        template_ = yield templatable(config[CONF_SPEED], args, FanSpeed,
+                                      to_exp=FAN_SPEEDS)
         add(action.set_speed(template_))
     yield action

--- a/esphome/components/fan/binary.py
+++ b/esphome/components/fan/binary.py
@@ -15,15 +15,13 @@ PLATFORM_SCHEMA = cv.nameable(fan.FAN_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for output_ in get_variable(config[CONF_OUTPUT]):
-        yield
+    output_ = yield get_variable(config[CONF_OUTPUT])
 
     rhs = App.make_fan(config[CONF_NAME])
     fan_struct = variable(config[CONF_MAKE_ID], rhs)
     add(fan_struct.Poutput.set_binary(output_))
     if CONF_OSCILLATION_OUTPUT in config:
-        for oscillation_output in get_variable(config[CONF_OSCILLATION_OUTPUT]):
-            yield
+        oscillation_output = yield get_variable(config[CONF_OSCILLATION_OUTPUT])
         add(fan_struct.Poutput.set_oscillation(oscillation_output))
 
     fan.setup_fan(fan_struct.Pstate, config)

--- a/esphome/components/fan/speed.py
+++ b/esphome/components/fan/speed.py
@@ -23,8 +23,7 @@ PLATFORM_SCHEMA = cv.nameable(fan.FAN_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for output_ in get_variable(config[CONF_OUTPUT]):
-        yield
+    output_ = yield get_variable(config[CONF_OUTPUT])
     rhs = App.make_fan(config[CONF_NAME])
     fan_struct = variable(config[CONF_MAKE_ID], rhs)
     if CONF_SPEED in config:
@@ -37,8 +36,7 @@ def to_code(config):
         add(fan_struct.Poutput.set_speed(output_))
 
     if CONF_OSCILLATION_OUTPUT in config:
-        for oscillation_output in get_variable(config[CONF_OSCILLATION_OUTPUT]):
-            yield
+        oscillation_output = yield get_variable(config[CONF_OSCILLATION_OUTPUT])
         add(fan_struct.Poutput.set_oscillation(oscillation_output))
 
     fan.setup_fan(fan_struct.Pstate, config)

--- a/esphome/components/light/binary.py
+++ b/esphome/components/light/binary.py
@@ -14,8 +14,7 @@ PLATFORM_SCHEMA = cv.nameable(light.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for output_ in get_variable(config[CONF_OUTPUT]):
-        yield
+    output_ = yield get_variable(config[CONF_OUTPUT])
     rhs = App.make_binary_light(config[CONF_NAME], output_)
     light_struct = variable(config[CONF_MAKE_ID], rhs)
     light.setup_light(light_struct.Pstate, light_struct.Poutput, config)

--- a/esphome/components/light/cwww.py
+++ b/esphome/components/light/cwww.py
@@ -20,10 +20,8 @@ PLATFORM_SCHEMA = cv.nameable(light.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for cold_white in get_variable(config[CONF_COLD_WHITE]):
-        yield
-    for warm_white in get_variable(config[CONF_WARM_WHITE]):
-        yield
+    cold_white = yield get_variable(config[CONF_COLD_WHITE])
+    warm_white = yield get_variable(config[CONF_WARM_WHITE])
     rhs = App.make_cwww_light(config[CONF_NAME], config[CONF_COLD_WHITE_COLOR_TEMPERATURE],
                               config[CONF_WARM_WHITE_COLOR_TEMPERATURE],
                               cold_white, warm_white)

--- a/esphome/components/light/fastled_clockless.py
+++ b/esphome/components/light/fastled_clockless.py
@@ -85,8 +85,7 @@ def to_code(config):
         add(fast_led.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))
 
     if CONF_POWER_SUPPLY in config:
-        for power_supply in get_variable(config[CONF_POWER_SUPPLY]):
-            yield
+        power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
         add(fast_led.set_power_supply(power_supply))
 
     light.setup_light(make.Pstate, make.Pfast_led, config)

--- a/esphome/components/light/fastled_spi.py
+++ b/esphome/components/light/fastled_spi.py
@@ -68,8 +68,7 @@ def to_code(config):
         add(fast_led.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))
 
     if CONF_POWER_SUPPLY in config:
-        for power_supply in get_variable(config[CONF_POWER_SUPPLY]):
-            yield
+        power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
         add(fast_led.set_power_supply(power_supply))
 
     light.setup_light(make.Pstate, make.Pfast_led, config)

--- a/esphome/components/light/monochromatic.py
+++ b/esphome/components/light/monochromatic.py
@@ -14,8 +14,7 @@ PLATFORM_SCHEMA = cv.nameable(light.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for output_ in get_variable(config[CONF_OUTPUT]):
-        yield
+    output_ = yield get_variable(config[CONF_OUTPUT])
     rhs = App.make_monochromatic_light(config[CONF_NAME], output_)
     light_struct = variable(config[CONF_MAKE_ID], rhs)
     light.setup_light(light_struct.Pstate, light_struct.Poutput, config)

--- a/esphome/components/light/neopixelbus.py
+++ b/esphome/components/light/neopixelbus.py
@@ -169,8 +169,7 @@ def to_code(config):
     add(output.set_pixel_order(getattr(ESPNeoPixelOrder, type_)))
 
     if CONF_POWER_SUPPLY in config:
-        for power_supply in get_variable(config[CONF_POWER_SUPPLY]):
-            yield
+        power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
         add(output.set_power_supply(power_supply))
 
     light.setup_light(make.Pstate, output, config)

--- a/esphome/components/light/partition.py
+++ b/esphome/components/light/partition.py
@@ -34,8 +34,7 @@ PLATFORM_SCHEMA = cv.nameable(light.PLATFORM_SCHEMA.extend({
 def to_code(config):
     segments = []
     for conf in config[CONF_SEGMENTS]:
-        for var in get_variable(conf[CONF_ID]):
-            yield
+        var = yield get_variable(conf[CONF_ID])
         segments.append(AddressableSegment(var, conf[CONF_FROM],
                                            conf[CONF_TO] - conf[CONF_FROM] + 1))
 

--- a/esphome/components/light/rgb.py
+++ b/esphome/components/light/rgb.py
@@ -16,12 +16,9 @@ PLATFORM_SCHEMA = cv.nameable(light.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for red in get_variable(config[CONF_RED]):
-        yield
-    for green in get_variable(config[CONF_GREEN]):
-        yield
-    for blue in get_variable(config[CONF_BLUE]):
-        yield
+    red = yield get_variable(config[CONF_RED])
+    green = yield get_variable(config[CONF_GREEN])
+    blue = yield get_variable(config[CONF_BLUE])
     rhs = App.make_rgb_light(config[CONF_NAME], red, green, blue)
     light_struct = variable(config[CONF_MAKE_ID], rhs)
     light.setup_light(light_struct.Pstate, light_struct.Poutput, config)

--- a/esphome/components/light/rgbw.py
+++ b/esphome/components/light/rgbw.py
@@ -17,14 +17,10 @@ PLATFORM_SCHEMA = cv.nameable(light.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for red in get_variable(config[CONF_RED]):
-        yield
-    for green in get_variable(config[CONF_GREEN]):
-        yield
-    for blue in get_variable(config[CONF_BLUE]):
-        yield
-    for white in get_variable(config[CONF_WHITE]):
-        yield
+    red = yield get_variable(config[CONF_RED])
+    green = yield get_variable(config[CONF_GREEN])
+    blue = yield get_variable(config[CONF_BLUE])
+    white = yield get_variable(config[CONF_WHITE])
     rhs = App.make_rgbw_light(config[CONF_NAME], red, green, blue, white)
     light_struct = variable(config[CONF_MAKE_ID], rhs)
     light.setup_light(light_struct.Pstate, light_struct.Poutput, config)

--- a/esphome/components/light/rgbww.py
+++ b/esphome/components/light/rgbww.py
@@ -34,16 +34,11 @@ PLATFORM_SCHEMA = cv.nameable(light.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for red in get_variable(config[CONF_RED]):
-        yield
-    for green in get_variable(config[CONF_GREEN]):
-        yield
-    for blue in get_variable(config[CONF_BLUE]):
-        yield
-    for cold_white in get_variable(config[CONF_COLD_WHITE]):
-        yield
-    for warm_white in get_variable(config[CONF_WARM_WHITE]):
-        yield
+    red = yield get_variable(config[CONF_RED])
+    green = yield get_variable(config[CONF_GREEN])
+    blue = yield get_variable(config[CONF_BLUE])
+    cold_white = yield get_variable(config[CONF_COLD_WHITE])
+    warm_white = yield get_variable(config[CONF_WARM_WHITE])
     rhs = App.make_rgbww_light(config[CONF_NAME], config[CONF_COLD_WHITE_COLOR_TEMPERATURE],
                                config[CONF_WARM_WHITE_COLOR_TEMPERATURE],
                                red, green, blue, cold_white, warm_white)

--- a/esphome/components/logger.py
+++ b/esphome/components/logger.py
@@ -177,8 +177,7 @@ def logger_log_action_to_code(config, action_id, template_arg, args):
 
     text = text_type(statement(esp_log(config[CONF_TAG], config[CONF_FORMAT], *args_)))
 
-    for lambda_ in process_lambda(Lambda(text), args, return_type=void):
-        yield None
+    lambda_ = yield process_lambda(Lambda(text), args, return_type=void)
     rhs = LambdaAction.new(template_arg, lambda_)
     type = LambdaAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)

--- a/esphome/components/mqtt.py
+++ b/esphome/components/mqtt.py
@@ -203,25 +203,20 @@ MQTT_PUBLISH_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_MQTT_PUBLISH, MQTT_PUBLISH_ACTION_SCHEMA)
 def mqtt_publish_action_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_publish_action(template_arg)
     type = MQTTPublishAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_TOPIC], args, std_string):
-        yield None
+    template_ = yield templatable(config[CONF_TOPIC], args, std_string)
     add(action.set_topic(template_))
 
-    for template_ in templatable(config[CONF_PAYLOAD], args, std_string):
-        yield None
+    template_ = yield templatable(config[CONF_PAYLOAD], args, std_string)
     add(action.set_payload(template_))
     if CONF_QOS in config:
-        for template_ in templatable(config[CONF_QOS], args, uint8):
-            yield
+        template_ = yield templatable(config[CONF_QOS], args, uint8)
         add(action.set_qos(template_))
     if CONF_RETAIN in config:
-        for template_ in templatable(config[CONF_RETAIN], args, bool_):
-            yield None
+        template_ = yield templatable(config[CONF_RETAIN], args, bool_)
         add(action.set_retain(template_))
     yield action
 
@@ -238,18 +233,15 @@ MQTT_PUBLISH_JSON_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_MQTT_PUBLISH_JSON, MQTT_PUBLISH_JSON_ACTION_SCHEMA)
 def mqtt_publish_json_action_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_publish_json_action(template_arg)
     type = MQTTPublishJsonAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_TOPIC], args, std_string):
-        yield None
+    template_ = yield templatable(config[CONF_TOPIC], args, std_string)
     add(action.set_topic(template_))
 
     args_ = args + [(JsonObjectRef, 'root')]
-    for lambda_ in process_lambda(config[CONF_PAYLOAD], args_, return_type=void):
-        yield None
+    lambda_ = yield process_lambda(config[CONF_PAYLOAD], args_, return_type=void)
     add(action.set_payload(lambda_))
     if CONF_QOS in config:
         add(action.set_qos(config[CONF_QOS]))

--- a/esphome/components/my9231.py
+++ b/esphome/components/my9231.py
@@ -26,10 +26,8 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for di in gpio_output_pin_expression(config[CONF_DATA_PIN]):
-        yield
-    for dcki in gpio_output_pin_expression(config[CONF_CLOCK_PIN]):
-        yield
+    di = yield gpio_output_pin_expression(config[CONF_DATA_PIN])
+    dcki = yield gpio_output_pin_expression(config[CONF_CLOCK_PIN])
     rhs = App.make_my9231_component(di, dcki)
     my9231 = Pvariable(config[CONF_ID], rhs)
     if CONF_NUM_CHANNELS in config:

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -43,7 +43,6 @@ def setup_output_platform_(obj, config, skip_power_supply=False):
     if CONF_INVERTED in config:
         add(obj.set_inverted(config[CONF_INVERTED]))
     if not skip_power_supply and CONF_POWER_SUPPLY in config:
-        power_supply = None
         power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
         add(obj.set_power_supply(power_supply))
     if CONF_MAX_POWER in config:

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -44,8 +44,7 @@ def setup_output_platform_(obj, config, skip_power_supply=False):
         add(obj.set_inverted(config[CONF_INVERTED]))
     if not skip_power_supply and CONF_POWER_SUPPLY in config:
         power_supply = None
-        for power_supply in get_variable(config[CONF_POWER_SUPPLY]):
-            yield
+        power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
         add(obj.set_power_supply(power_supply))
     if CONF_MAX_POWER in config:
         add(obj.set_max_power(config[CONF_MAX_POWER]))
@@ -72,8 +71,7 @@ OUTPUT_TURN_ON_ACTION = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_OUTPUT_TURN_ON, OUTPUT_TURN_ON_ACTION)
 def output_turn_on_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_turn_on_action(template_arg)
     type = TurnOnAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -87,8 +85,7 @@ OUTPUT_TURN_OFF_ACTION = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_OUTPUT_TURN_OFF, OUTPUT_TURN_OFF_ACTION)
 def output_turn_off_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_turn_off_action(template_arg)
     type = TurnOffAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -103,12 +100,10 @@ OUTPUT_SET_LEVEL_ACTION = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_OUTPUT_SET_LEVEL, OUTPUT_SET_LEVEL_ACTION)
 def output_set_level_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_set_level_action(template_arg)
     type = SetLevelAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_LEVEL], args, float_):
-        yield None
+    template_ = yield templatable(config[CONF_LEVEL], args, float_)
     add(action.set_level(template_))
     yield action

--- a/esphome/components/output/copy.py
+++ b/esphome/components/output/copy.py
@@ -40,8 +40,7 @@ PLATFORM_SCHEMA = validate_copy_output
 def to_code(config):
     outputs = []
     for out in config[CONF_OUTPUTS]:
-        var = yield get_variable(out)
-        outputs.append(var)
+        outputs.append((yield get_variable(out)))
 
     klass = {
         'binary': BinaryCopyOutput,

--- a/esphome/components/output/copy.py
+++ b/esphome/components/output/copy.py
@@ -40,8 +40,7 @@ PLATFORM_SCHEMA = validate_copy_output
 def to_code(config):
     outputs = []
     for out in config[CONF_OUTPUTS]:
-        for var in get_variable(out):
-            yield
+        var = yield get_variable(out)
         outputs.append(var)
 
     klass = {

--- a/esphome/components/output/custom.py
+++ b/esphome/components/output/custom.py
@@ -55,9 +55,8 @@ def to_code(config):
     else:
         ret_type = output.FloatOutputPtr
         klass = CustomFloatOutputConstructor
-    for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                    return_type=std_vector.template(ret_type)):
-        yield
+    template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                     return_type=std_vector.template(ret_type))
 
     rhs = klass(template_)
     custom = variable(config[CONF_ID], rhs)

--- a/esphome/components/output/esp8266_pwm.py
+++ b/esphome/components/output/esp8266_pwm.py
@@ -27,8 +27,7 @@ PLATFORM_SCHEMA = output.FLOAT_OUTPUT_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin in gpio_output_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_output_pin_expression(config[CONF_PIN])
     rhs = App.make_esp8266_pwm_output(pin)
     gpio = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/output/gpio.py
+++ b/esphome/components/output/gpio.py
@@ -18,8 +18,7 @@ PLATFORM_SCHEMA = output.BINARY_OUTPUT_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin in gpio_output_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_output_pin_expression(config[CONF_PIN])
     rhs = App.make_gpio_output(pin)
     gpio = Pvariable(config[CONF_ID], rhs)
     output.setup_output_platform(gpio, config)

--- a/esphome/components/output/my9231.py
+++ b/esphome/components/output/my9231.py
@@ -22,11 +22,9 @@ PLATFORM_SCHEMA = output.FLOAT_OUTPUT_PLATFORM_SCHEMA.extend({
 def to_code(config):
     power_supply = None
     if CONF_POWER_SUPPLY in config:
-        for power_supply in get_variable(config[CONF_POWER_SUPPLY]):
-            yield
+        power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
     my9231 = None
-    for my9231 in get_variable(config[CONF_MY9231_ID]):
-        yield
+    my9231 = yield get_variable(config[CONF_MY9231_ID])
     rhs = my9231.create_channel(config[CONF_CHANNEL], power_supply)
     out = Pvariable(config[CONF_ID], rhs)
     output.setup_output_platform(out, config, skip_power_supply=True)

--- a/esphome/components/output/my9231.py
+++ b/esphome/components/output/my9231.py
@@ -23,7 +23,6 @@ def to_code(config):
     power_supply = None
     if CONF_POWER_SUPPLY in config:
         power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
-    my9231 = None
     my9231 = yield get_variable(config[CONF_MY9231_ID])
     rhs = my9231.create_channel(config[CONF_CHANNEL], power_supply)
     out = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/output/pca9685.py
+++ b/esphome/components/output/pca9685.py
@@ -21,10 +21,8 @@ PLATFORM_SCHEMA = output.FLOAT_OUTPUT_PLATFORM_SCHEMA.extend({
 def to_code(config):
     power_supply = None
     if CONF_POWER_SUPPLY in config:
-        for power_supply in get_variable(config[CONF_POWER_SUPPLY]):
-            yield
-    for pca9685 in get_variable(config[CONF_PCA9685_ID]):
-        yield
+        power_supply = yield get_variable(config[CONF_POWER_SUPPLY])
+    pca9685 = yield get_variable(config[CONF_PCA9685_ID])
     rhs = pca9685.create_channel(config[CONF_CHANNEL], power_supply)
     out = Pvariable(config[CONF_ID], rhs)
     output.setup_output_platform(out, config, skip_power_supply=True)

--- a/esphome/components/pn532.py
+++ b/esphome/components/pn532.py
@@ -29,10 +29,8 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for spi_ in get_variable(config[CONF_SPI_ID]):
-        yield
-    for cs in gpio_output_pin_expression(config[CONF_CS_PIN]):
-        yield
+    spi_ = yield get_variable(config[CONF_SPI_ID])
+    cs = yield gpio_output_pin_expression(config[CONF_CS_PIN])
     rhs = App.make_pn532_component(spi_, cs, config.get(CONF_UPDATE_INTERVAL))
     pn532 = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/power_supply.py
+++ b/esphome/components/power_supply.py
@@ -20,8 +20,7 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for pin in gpio_output_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_output_pin_expression(config[CONF_PIN])
 
     rhs = App.make_power_supply(pin)
     psu = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/rdm6300.py
+++ b/esphome/components/rdm6300.py
@@ -17,8 +17,7 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for uart_ in get_variable(config[CONF_UART_ID]):
-        yield
+    uart_ = yield get_variable(config[CONF_UART_ID])
     rhs = App.make_rdm6300_component(uart_)
     var = Pvariable(config[CONF_ID], rhs)
     setup_component(var, config)

--- a/esphome/components/remote_receiver.py
+++ b/esphome/components/remote_receiver.py
@@ -54,8 +54,7 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for pin in gpio_input_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_input_pin_expression(config[CONF_PIN])
     rhs = App.make_remote_receiver_component(pin)
     receiver = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/remote_transmitter.py
+++ b/esphome/components/remote_transmitter.py
@@ -106,8 +106,7 @@ def binary_code(value):
 
 
 def to_code(config):
-    for pin in gpio_output_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_output_pin_expression(config[CONF_PIN])
     rhs = App.make_remote_transmitter_component(pin)
     transmitter = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/script.py
+++ b/esphome/components/script.py
@@ -30,8 +30,7 @@ SCRIPT_EXECUTE_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_SCRIPT_EXECUTE, SCRIPT_EXECUTE_ACTION_SCHEMA)
 def script_execute_action_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_execute_action(template_arg)
     type = ScriptExecuteAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -45,8 +44,7 @@ SCRIPT_STOP_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_SCRIPT_STOP, SCRIPT_STOP_ACTION_SCHEMA)
 def script_stop_action_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_stop_action(template_arg)
     type = ScriptStopAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -184,8 +184,7 @@ def setup_filter(config):
 def setup_filters(config):
     filters = []
     for conf in config:
-        filter = yield setup_filter(conf)
-        filters.append(filter)
+        filters.append((yield setup_filter(conf)))
     yield filters
 
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -159,9 +159,8 @@ def setup_filter(config):
         conf = config[CONF_EXPONENTIAL_MOVING_AVERAGE]
         yield ExponentialMovingAverageFilter.new(conf[CONF_ALPHA], conf[CONF_SEND_EVERY])
     elif CONF_LAMBDA in config:
-        for lambda_ in process_lambda(config[CONF_LAMBDA], [(float_, 'x')],
-                                      return_type=optional.template(float_)):
-            yield None
+        lambda_ = yield process_lambda(config[CONF_LAMBDA], [(float_, 'x')],
+                                       return_type=optional.template(float_))
         yield LambdaFilter.new(lambda_)
     elif CONF_THROTTLE in config:
         yield ThrottleFilter.new(config[CONF_THROTTLE])

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -15,7 +15,7 @@ from esphome.const import CONF_ABOVE, CONF_ACCURACY_DECIMALS, CONF_ALPHA, CONF_B
     CONF_SEND_EVERY, CONF_SEND_FIRST_AT, CONF_SLIDING_WINDOW_MOVING_AVERAGE, \
     CONF_THROTTLE, CONF_TO, CONF_TRIGGER_ID, CONF_UNIQUE, CONF_UNIT_OF_MEASUREMENT, \
     CONF_WINDOW_SIZE
-from esphome.core import CORE
+from esphome.core import CORE, coroutine
 from esphome.cpp_generator import Pvariable, add, get_variable, process_lambda, templatable
 from esphome.cpp_types import App, Component, Nameable, PollingComponent, Trigger, \
     esphome_ns, float_, optional
@@ -143,6 +143,7 @@ SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend({
 SENSOR_PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(SENSOR_SCHEMA.schema)
 
 
+@coroutine
 def setup_filter(config):
     if CONF_OFFSET in config:
         yield OffsetFilter.new(config[CONF_OFFSET])
@@ -167,8 +168,7 @@ def setup_filter(config):
     elif CONF_DELTA in config:
         yield DeltaFilter.new(config[CONF_DELTA])
     elif CONF_OR in config:
-        for filters in setup_filters(config[CONF_OR]):
-            yield None
+        filters = yield setup_filters(config[CONF_OR])
         yield OrFilter.new(filters)
     elif CONF_HEARTBEAT in config:
         yield App.register_component(HeartbeatFilter.new(config[CONF_HEARTBEAT]))
@@ -181,15 +181,16 @@ def setup_filter(config):
         yield CalibrateLinearFilter.new(k, b)
 
 
+@coroutine
 def setup_filters(config):
     filters = []
     for conf in config:
-        for filter in setup_filter(conf):
-            yield None
+        filter = yield setup_filter(conf)
         filters.append(filter)
     yield filters
 
 
+@coroutine
 def setup_sensor_core_(sensor_var, config):
     if CONF_INTERNAL in config:
         add(sensor_var.set_internal(config[CONF_INTERNAL]))
@@ -200,8 +201,7 @@ def setup_sensor_core_(sensor_var, config):
     if CONF_ACCURACY_DECIMALS in config:
         add(sensor_var.set_accuracy_decimals(config[CONF_ACCURACY_DECIMALS]))
     if CONF_FILTERS in config:
-        for filters in setup_filters(config[CONF_FILTERS]):
-            yield
+        filters = yield setup_filters(config[CONF_FILTERS])
         add(sensor_var.set_filters(filters))
 
     for conf in config.get(CONF_ON_VALUE, []):
@@ -217,12 +217,10 @@ def setup_sensor_core_(sensor_var, config):
         trigger = Pvariable(conf[CONF_TRIGGER_ID], rhs)
         add(App.register_component(trigger))
         if CONF_ABOVE in conf:
-            for template_ in templatable(conf[CONF_ABOVE], float_, float_):
-                yield
+            template_ = yield templatable(conf[CONF_ABOVE], float_, float_)
             add(trigger.set_min(template_))
         if CONF_BELOW in conf:
-            for template_ in templatable(conf[CONF_BELOW], float_, float_):
-                yield
+            template_ = yield templatable(conf[CONF_BELOW], float_, float_)
             add(trigger.set_max(template_))
         automation.build_automations(trigger, [(float_, 'x')], conf)
 
@@ -260,8 +258,7 @@ SENSOR_IN_RANGE_CONDITION_SCHEMA = vol.All({
 
 @CONDITION_REGISTRY.register(CONF_SENSOR_IN_RANGE, SENSOR_IN_RANGE_CONDITION_SCHEMA)
 def sensor_in_range_to_code(config, condition_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_sensor_in_range_condition(template_arg)
     type = SensorInRangeCondition.template(template_arg)
     cond = Pvariable(condition_id, rhs, type=type)

--- a/esphome/components/sensor/ads1115.py
+++ b/esphome/components/sensor/ads1115.py
@@ -60,8 +60,7 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_ADS1115_ID]):
-        yield
+    hub = yield get_variable(config[CONF_ADS1115_ID])
 
     mux = MUX[config[CONF_MULTIPLEXER]]
     gain = GAIN[config[CONF_GAIN]]

--- a/esphome/components/sensor/apds9960.py
+++ b/esphome/components/sensor/apds9960.py
@@ -24,8 +24,7 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_APDS9960_ID]):
-        yield
+    hub = yield get_variable(config[CONF_APDS9960_ID])
     func = getattr(hub, TYPES[config[CONF_TYPE]])
     rhs = func(config[CONF_NAME])
     sensor.register_sensor(rhs, config)

--- a/esphome/components/sensor/ble_rssi.py
+++ b/esphome/components/sensor/ble_rssi.py
@@ -20,7 +20,6 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_ESP32_BLE_ID]):
-        yield
+    hub = yield get_variable(config[CONF_ESP32_BLE_ID])
     rhs = hub.make_rssi_sensor(config[CONF_NAME], make_address_array(config[CONF_MAC_ADDRESS]))
     sensor.register_sensor(rhs, config)

--- a/esphome/components/sensor/cse7766.py
+++ b/esphome/components/sensor/cse7766.py
@@ -38,8 +38,7 @@ PLATFORM_SCHEMA = vol.All(sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for uart_ in get_variable(config[CONF_UART_ID]):
-        yield
+    uart_ = yield get_variable(config[CONF_UART_ID])
 
     rhs = App.make_cse7766(uart_, config.get(CONF_UPDATE_INTERVAL))
     cse = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/custom.py
+++ b/esphome/components/sensor/custom.py
@@ -18,9 +18,8 @@ PLATFORM_SCHEMA = sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                    return_type=std_vector.template(sensor.SensorPtr)):
-        yield
+    template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                     return_type=std_vector.template(sensor.SensorPtr))
 
     rhs = CustomSensorConstructor(template_)
     custom = variable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/dallas.py
+++ b/esphome/components/sensor/dallas.py
@@ -20,8 +20,7 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_DALLAS_ID]):
-        yield
+    hub = yield get_variable(config[CONF_DALLAS_ID])
     if CONF_ADDRESS in config:
         address = HexIntLiteral(config[CONF_ADDRESS])
         rhs = hub.Pget_sensor_by_address(config[CONF_NAME], address, config.get(CONF_RESOLUTION))

--- a/esphome/components/sensor/dht.py
+++ b/esphome/components/sensor/dht.py
@@ -40,8 +40,7 @@ PLATFORM_SCHEMA = sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin in gpio_output_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_output_pin_expression(config[CONF_PIN])
     rhs = App.make_dht_sensor(config[CONF_TEMPERATURE][CONF_NAME],
                               config[CONF_HUMIDITY][CONF_NAME],
                               pin, config.get(CONF_UPDATE_INTERVAL))

--- a/esphome/components/sensor/duty_cycle.py
+++ b/esphome/components/sensor/duty_cycle.py
@@ -19,8 +19,7 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin in gpio_input_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_input_pin_expression(config[CONF_PIN])
     rhs = App.make_duty_cycle_sensor(config[CONF_NAME], pin,
                                      config.get(CONF_UPDATE_INTERVAL))
     duty = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/hlw8012.py
+++ b/esphome/components/sensor/hlw8012.py
@@ -40,8 +40,7 @@ PLATFORM_SCHEMA = vol.All(sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for sel in gpio_output_pin_expression(config[CONF_SEL_PIN]):
-        yield
+    sel = yield gpio_output_pin_expression(config[CONF_SEL_PIN])
 
     rhs = App.make_hlw8012(sel, config[CONF_CF_PIN], config[CONF_CF1_PIN],
                            config.get(CONF_UPDATE_INTERVAL))

--- a/esphome/components/sensor/hx711.py
+++ b/esphome/components/sensor/hx711.py
@@ -30,10 +30,8 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for dout_pin in gpio_input_pin_expression(config[CONF_DOUT_PIN]):
-        yield
-    for sck_pin in gpio_input_pin_expression(config[CONF_CLK_PIN]):
-        yield
+    dout_pin = yield gpio_input_pin_expression(config[CONF_DOUT_PIN])
+    sck_pin = yield gpio_input_pin_expression(config[CONF_CLK_PIN])
 
     rhs = App.make_hx711_sensor(config[CONF_NAME], dout_pin, sck_pin,
                                 config.get(CONF_UPDATE_INTERVAL))

--- a/esphome/components/sensor/max31855.py
+++ b/esphome/components/sensor/max31855.py
@@ -21,10 +21,8 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for spi_ in get_variable(config[CONF_SPI_ID]):
-        yield
-    for cs in gpio_output_pin_expression(config[CONF_CS_PIN]):
-        yield
+    spi_ = yield get_variable(config[CONF_SPI_ID])
+    cs = yield gpio_output_pin_expression(config[CONF_CS_PIN])
     rhs = App.make_max31855_sensor(config[CONF_NAME], spi_, cs,
                                    config.get(CONF_UPDATE_INTERVAL))
     max31855 = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/max6675.py
+++ b/esphome/components/sensor/max6675.py
@@ -22,10 +22,8 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for spi_ in get_variable(config[CONF_SPI_ID]):
-        yield
-    for cs in gpio_output_pin_expression(config[CONF_CS_PIN]):
-        yield
+    spi_ = yield get_variable(config[CONF_SPI_ID])
+    cs = yield gpio_output_pin_expression(config[CONF_CS_PIN])
     rhs = App.make_max6675_sensor(config[CONF_NAME], spi_, cs,
                                   config.get(CONF_UPDATE_INTERVAL))
     max6675 = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/mhz19.py
+++ b/esphome/components/sensor/mhz19.py
@@ -30,8 +30,7 @@ PLATFORM_SCHEMA = sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for uart_ in get_variable(config[CONF_UART_ID]):
-        yield
+    uart_ = yield get_variable(config[CONF_UART_ID])
     rhs = App.make_mhz19_sensor(uart_, config[CONF_CO2][CONF_NAME],
                                 config.get(CONF_UPDATE_INTERVAL))
     mhz19 = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/pmsx003.py
+++ b/esphome/components/sensor/pmsx003.py
@@ -61,8 +61,7 @@ PLATFORM_SCHEMA = vol.All(sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for uart_ in get_variable(config[CONF_UART_ID]):
-        yield
+    uart_ = yield get_variable(config[CONF_UART_ID])
 
     rhs = App.make_pmsx003(uart_, PMSX003_TYPES[config[CONF_TYPE]])
     pms = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/pulse_counter.py
+++ b/esphome/components/sensor/pulse_counter.py
@@ -58,8 +58,7 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin in gpio_input_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_input_pin_expression(config[CONF_PIN])
     rhs = App.make_pulse_counter_sensor(config[CONF_NAME], pin,
                                         config.get(CONF_UPDATE_INTERVAL))
     pcnt = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/rotary_encoder.py
+++ b/esphome/components/sensor/rotary_encoder.py
@@ -46,16 +46,13 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin_a in gpio_input_pin_expression(config[CONF_PIN_A]):
-        yield
-    for pin_b in gpio_input_pin_expression(config[CONF_PIN_B]):
-        yield
+    pin_a = yield gpio_input_pin_expression(config[CONF_PIN_A])
+    pin_b = yield gpio_input_pin_expression(config[CONF_PIN_B])
     rhs = App.make_rotary_encoder_sensor(config[CONF_NAME], pin_a, pin_b)
     encoder = Pvariable(config[CONF_ID], rhs)
 
     if CONF_PIN_RESET in config:
-        for pin_i in gpio_input_pin_expression(config[CONF_PIN_RESET]):
-            yield
+        pin_i = yield gpio_input_pin_expression(config[CONF_PIN_RESET])
         add(encoder.set_reset_pin(pin_i))
     if CONF_RESOLUTION in config:
         resolution = RESOLUTIONS[config[CONF_RESOLUTION]]

--- a/esphome/components/sensor/sds011.py
+++ b/esphome/components/sensor/sds011.py
@@ -46,8 +46,7 @@ PLATFORM_SCHEMA = vol.All(sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for uart_ in get_variable(config[CONF_UART_ID]):
-        yield
+    uart_ = yield get_variable(config[CONF_UART_ID])
 
     rhs = App.make_sds011(uart_)
     sds011 = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/template.py
+++ b/esphome/components/sensor/template.py
@@ -26,9 +26,8 @@ def to_code(config):
     setup_component(template, config)
 
     if CONF_LAMBDA in config:
-        for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                        return_type=optional.template(float_)):
-            yield
+        template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                         return_type=optional.template(float_))
         add(template.set_template(template_))
 
 
@@ -43,12 +42,10 @@ SENSOR_TEMPLATE_PUBLISH_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_SENSOR_TEMPLATE_PUBLISH, SENSOR_TEMPLATE_PUBLISH_ACTION_SCHEMA)
 def sensor_template_publish_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_sensor_publish_action(template_arg)
     type = SensorPublishAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_STATE], args, float_):
-        yield None
+    template_ = yield templatable(config[CONF_STATE], args, float_)
     add(action.set_state(template_))
     yield action

--- a/esphome/components/sensor/total_daily_energy.py
+++ b/esphome/components/sensor/total_daily_energy.py
@@ -20,10 +20,8 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for time_ in get_variable(config[CONF_TIME_ID]):
-        yield
-    for sens in get_variable(config[CONF_POWER_ID]):
-        yield
+    time_ = yield get_variable(config[CONF_TIME_ID])
+    sens = yield get_variable(config[CONF_POWER_ID])
     rhs = App.make_total_daily_energy_sensor(config[CONF_NAME], time_, sens)
     total_energy = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/sensor/ultrasonic.py
+++ b/esphome/components/sensor/ultrasonic.py
@@ -33,10 +33,8 @@ PLATFORM_SCHEMA = cv.nameable(sensor.SENSOR_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for trigger in gpio_output_pin_expression(config[CONF_TRIGGER_PIN]):
-        yield
-    for echo in gpio_input_pin_expression(config[CONF_ECHO_PIN]):
-        yield
+    trigger = yield gpio_output_pin_expression(config[CONF_TRIGGER_PIN])
+    echo = yield gpio_input_pin_expression(config[CONF_ECHO_PIN])
     rhs = App.make_ultrasonic_sensor(config[CONF_NAME], trigger, echo,
                                      config.get(CONF_UPDATE_INTERVAL))
     ultrasonic = Pvariable(config[CONF_ID], rhs)

--- a/esphome/components/sensor/xiaomi_miflora.py
+++ b/esphome/components/sensor/xiaomi_miflora.py
@@ -23,8 +23,7 @@ PLATFORM_SCHEMA = sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_ESP32_BLE_ID]):
-        yield
+    hub = yield get_variable(config[CONF_ESP32_BLE_ID])
     rhs = hub.make_xiaomi_device(make_address_array(config[CONF_MAC_ADDRESS]))
     dev = Pvariable(config[CONF_ID], rhs)
     if CONF_TEMPERATURE in config:

--- a/esphome/components/sensor/xiaomi_mijia.py
+++ b/esphome/components/sensor/xiaomi_mijia.py
@@ -21,8 +21,7 @@ PLATFORM_SCHEMA = sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for hub in get_variable(config[CONF_ESP32_BLE_ID]):
-        yield
+    hub = yield get_variable(config[CONF_ESP32_BLE_ID])
     rhs = hub.make_xiaomi_device(make_address_array(config[CONF_MAC_ADDRESS]))
     dev = Pvariable(config[CONF_MAKE_ID], rhs)
     if CONF_TEMPERATURE in config:

--- a/esphome/components/servo.py
+++ b/esphome/components/servo.py
@@ -24,8 +24,7 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for out in get_variable(config[CONF_OUTPUT]):
-        yield
+    out = yield get_variable(config[CONF_OUTPUT])
 
     rhs = App.register_component(Servo.new(out))
     servo = Pvariable(config[CONF_ID], rhs)
@@ -48,12 +47,10 @@ SERVO_WRITE_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_SERVO_WRITE, SERVO_WRITE_ACTION_SCHEMA)
 def servo_write_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = ServoWriteAction.new(template_arg, var)
     type = ServoWriteAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_LEVEL], args, float_):
-        yield None
+    template_ = yield templatable(config[CONF_LEVEL], args, float_)
     add(action.set_value(template_))
     yield action

--- a/esphome/components/spi.py
+++ b/esphome/components/spi.py
@@ -21,17 +21,14 @@ CONFIG_SCHEMA = vol.All(cv.Schema({
 
 
 def to_code(config):
-    for clk in gpio_output_pin_expression(config[CONF_CLK_PIN]):
-        yield
+    clk = yield gpio_output_pin_expression(config[CONF_CLK_PIN])
     rhs = App.init_spi(clk)
     spi = Pvariable(config[CONF_ID], rhs)
     if CONF_MISO_PIN in config:
-        for miso in gpio_input_pin_expression(config[CONF_MISO_PIN]):
-            yield
+        miso = yield gpio_input_pin_expression(config[CONF_MISO_PIN])
         add(spi.set_miso(miso))
     if CONF_MOSI_PIN in config:
-        for mosi in gpio_input_pin_expression(config[CONF_MOSI_PIN]):
-            yield
+        mosi = yield gpio_input_pin_expression(config[CONF_MOSI_PIN])
         add(spi.set_mosi(mosi))
 
     setup_component(spi, config)

--- a/esphome/components/status_led.py
+++ b/esphome/components/status_led.py
@@ -15,8 +15,7 @@ CONFIG_SCHEMA = cv.Schema({
 
 
 def to_code(config):
-    for pin in gpio_output_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_output_pin_expression(config[CONF_PIN])
     rhs = App.make_status_led(pin)
     var = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -93,13 +93,11 @@ STEPPER_SET_TARGET_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_STEPPER_SET_TARGET, STEPPER_SET_TARGET_ACTION_SCHEMA)
 def stepper_set_target_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_set_target_action(template_arg)
     type = SetTargetAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_TARGET], args, int32):
-        yield None
+    template_ = yield templatable(config[CONF_TARGET], args, int32)
     add(action.set_target(template_))
     yield action
 
@@ -113,12 +111,10 @@ STEPPER_REPORT_POSITION_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_STEPPER_REPORT_POSITION, STEPPER_REPORT_POSITION_ACTION_SCHEMA)
 def stepper_report_position_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_report_position_action(template_arg)
     type = ReportPositionAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_POSITION], args, int32):
-        yield None
+    template_ = yield templatable(config[CONF_POSITION], args, int32)
     add(action.set_position(template_))
     yield action

--- a/esphome/components/stepper/a4988.py
+++ b/esphome/components/stepper/a4988.py
@@ -19,16 +19,13 @@ PLATFORM_SCHEMA = stepper.STEPPER_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for step_pin in gpio_output_pin_expression(config[CONF_STEP_PIN]):
-        yield
-    for dir_pin in gpio_output_pin_expression(config[CONF_DIR_PIN]):
-        yield
+    step_pin = yield gpio_output_pin_expression(config[CONF_STEP_PIN])
+    dir_pin = yield gpio_output_pin_expression(config[CONF_DIR_PIN])
     rhs = App.make_a4988(step_pin, dir_pin)
     a4988 = Pvariable(config[CONF_ID], rhs)
 
     if CONF_SLEEP_PIN in config:
-        for sleep_pin in gpio_output_pin_expression(config[CONF_SLEEP_PIN]):
-            yield
+        sleep_pin = yield gpio_output_pin_expression(config[CONF_SLEEP_PIN])
         add(a4988.set_sleep_pin(sleep_pin))
 
     stepper.setup_stepper(a4988, config)

--- a/esphome/components/stepper/uln2003.py
+++ b/esphome/components/stepper/uln2003.py
@@ -31,14 +31,10 @@ PLATFORM_SCHEMA = stepper.STEPPER_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin_a in gpio_output_pin_expression(config[CONF_PIN_A]):
-        yield
-    for pin_b in gpio_output_pin_expression(config[CONF_PIN_B]):
-        yield
-    for pin_c in gpio_output_pin_expression(config[CONF_PIN_C]):
-        yield
-    for pin_d in gpio_output_pin_expression(config[CONF_PIN_D]):
-        yield
+    pin_a = yield gpio_output_pin_expression(config[CONF_PIN_A])
+    pin_b = yield gpio_output_pin_expression(config[CONF_PIN_B])
+    pin_c = yield gpio_output_pin_expression(config[CONF_PIN_C])
+    pin_d = yield gpio_output_pin_expression(config[CONF_PIN_D])
     rhs = App.make_uln2003(pin_a, pin_b, pin_c, pin_d)
     uln = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -84,8 +84,7 @@ SWITCH_TOGGLE_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_SWITCH_TOGGLE, SWITCH_TOGGLE_ACTION_SCHEMA)
 def switch_toggle_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_toggle_action(template_arg)
     type = ToggleAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -99,8 +98,7 @@ SWITCH_TURN_OFF_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_SWITCH_TURN_OFF, SWITCH_TURN_OFF_ACTION_SCHEMA)
 def switch_turn_off_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_turn_off_action(template_arg)
     type = TurnOffAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -114,8 +112,7 @@ SWITCH_TURN_ON_ACTION_SCHEMA = maybe_simple_id({
 
 @ACTION_REGISTRY.register(CONF_SWITCH_TURN_ON, SWITCH_TURN_ON_ACTION_SCHEMA)
 def switch_turn_on_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_turn_on_action(template_arg)
     type = TurnOnAction.template(template_arg)
     yield Pvariable(action_id, rhs, type=type)
@@ -129,8 +126,7 @@ SWITCH_IS_ON_CONDITION_SCHEMA = maybe_simple_id({
 
 @CONDITION_REGISTRY.register(CONF_SWITCH_IS_ON, SWITCH_IS_ON_CONDITION_SCHEMA)
 def switch_is_on_to_code(config, condition_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_switch_is_on_condition(template_arg)
     type = SwitchCondition.template(template_arg)
     yield Pvariable(condition_id, rhs, type=type)
@@ -144,8 +140,7 @@ SWITCH_IS_OFF_CONDITION_SCHEMA = maybe_simple_id({
 
 @CONDITION_REGISTRY.register(CONF_SWITCH_IS_OFF, SWITCH_IS_OFF_CONDITION_SCHEMA)
 def switch_is_off_to_code(config, condition_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_switch_is_off_condition(template_arg)
     type = SwitchCondition.template(template_arg)
     yield Pvariable(condition_id, rhs, type=type)

--- a/esphome/components/switch/custom.py
+++ b/esphome/components/switch/custom.py
@@ -19,9 +19,8 @@ PLATFORM_SCHEMA = switch.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                    return_type=std_vector.template(switch.SwitchPtr)):
-        yield
+    template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                     return_type=std_vector.template(switch.SwitchPtr))
 
     rhs = CustomSwitchConstructor(template_)
     custom = variable(config[CONF_ID], rhs)

--- a/esphome/components/switch/gpio.py
+++ b/esphome/components/switch/gpio.py
@@ -27,8 +27,7 @@ PLATFORM_SCHEMA = cv.nameable(switch.SWITCH_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for pin in gpio_output_pin_expression(config[CONF_PIN]):
-        yield
+    pin = yield gpio_output_pin_expression(config[CONF_PIN])
     rhs = App.make_gpio_switch(config[CONF_NAME], pin)
     gpio = Pvariable(config[CONF_ID], rhs)
 
@@ -38,8 +37,7 @@ def to_code(config):
     if CONF_INTERLOCK in config:
         interlock = []
         for it in config[CONF_INTERLOCK]:
-            for lock in get_variable(it):
-                yield
+            lock = yield get_variable(it)
             interlock.append(lock)
         add(gpio.set_interlock(interlock))
 

--- a/esphome/components/switch/output.py
+++ b/esphome/components/switch/output.py
@@ -16,8 +16,7 @@ PLATFORM_SCHEMA = cv.nameable(switch.SWITCH_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for output_ in get_variable(config[CONF_OUTPUT]):
-        yield
+    output_ = yield get_variable(config[CONF_OUTPUT])
     rhs = App.make_output_switch(config[CONF_NAME], output_)
     switch_ = Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/switch/remote_transmitter.py
+++ b/esphome/components/switch/remote_transmitter.py
@@ -146,8 +146,7 @@ def transmitter_base(full_config):
 
 
 def to_code(config):
-    for remote in get_variable(config[CONF_REMOTE_TRANSMITTER_ID]):
-        yield
+    remote = yield get_variable(config[CONF_REMOTE_TRANSMITTER_ID])
     rhs = transmitter_base(config)
     transmitter = Pvariable(config[CONF_TRANSMITTER_ID], rhs)
 

--- a/esphome/components/switch/template.py
+++ b/esphome/components/switch/template.py
@@ -31,9 +31,8 @@ def to_code(config):
     switch.setup_switch(template, config)
 
     if CONF_LAMBDA in config:
-        for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                        return_type=optional.template(bool_)):
-            yield
+        template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                         return_type=optional.template(bool_))
         add(template.set_state_lambda(template_))
     if CONF_TURN_OFF_ACTION in config:
         automation.build_automations(template.get_turn_off_trigger(), [],
@@ -63,12 +62,10 @@ SWITCH_TEMPLATE_PUBLISH_ACTION_SCHEMA = cv.Schema({
 
 @ACTION_REGISTRY.register(CONF_SWITCH_TEMPLATE_PUBLISH, SWITCH_TEMPLATE_PUBLISH_ACTION_SCHEMA)
 def switch_template_publish_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_switch_publish_action(template_arg)
     type = SwitchPublishAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_STATE], args, bool_):
-        yield None
+    template_ = yield templatable(config[CONF_STATE], args, bool_)
     add(action.set_state(template_))
     yield action

--- a/esphome/components/switch/uart.py
+++ b/esphome/components/switch/uart.py
@@ -33,8 +33,7 @@ PLATFORM_SCHEMA = cv.nameable(switch.SWITCH_PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for uart_ in get_variable(config[CONF_UART_ID]):
-        yield
+    uart_ = yield get_variable(config[CONF_UART_ID])
     data = config[CONF_DATA]
     if isinstance(data, str):
         data = [HexInt(ord(x)) for x in data]

--- a/esphome/components/text_sensor/custom.py
+++ b/esphome/components/text_sensor/custom.py
@@ -19,9 +19,8 @@ PLATFORM_SCHEMA = text_sensor.PLATFORM_SCHEMA.extend({
 
 
 def to_code(config):
-    for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                    return_type=std_vector.template(text_sensor.TextSensorPtr)):
-        yield
+    template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                     return_type=std_vector.template(text_sensor.TextSensorPtr))
 
     rhs = CustomTextSensorConstructor(template_)
     custom = variable(config[CONF_ID], rhs)

--- a/esphome/components/text_sensor/template.py
+++ b/esphome/components/text_sensor/template.py
@@ -26,9 +26,8 @@ def to_code(config):
     setup_component(template, config)
 
     if CONF_LAMBDA in config:
-        for template_ in process_lambda(config[CONF_LAMBDA], [],
-                                        return_type=optional.template(std_string)):
-            yield
+        template_ = yield process_lambda(config[CONF_LAMBDA], [],
+                                         return_type=optional.template(std_string))
         add(template.set_template(template_))
 
 
@@ -44,12 +43,10 @@ TEXT_SENSOR_TEMPLATE_PUBLISH_ACTION_SCHEMA = cv.Schema({
 @ACTION_REGISTRY.register(CONF_TEXT_SENSOR_TEMPLATE_PUBLISH,
                           TEXT_SENSOR_TEMPLATE_PUBLISH_ACTION_SCHEMA)
 def text_sensor_template_publish_to_code(config, action_id, template_arg, args):
-    for var in get_variable(config[CONF_ID]):
-        yield None
+    var = yield get_variable(config[CONF_ID])
     rhs = var.make_text_sensor_publish_action(template_arg)
     type = TextSensorPublishAction.template(template_arg)
     action = Pvariable(action_id, rhs, type=type)
-    for template_ in templatable(config[CONF_STATE], args, std_string):
-        yield None
+    template_ = yield templatable(config[CONF_STATE], args, std_string)
     add(action.set_state(template_))
     yield action

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -483,7 +483,7 @@ if IS_PY2:
 def temperature(value):
     try:
         return _temperature_c(value)
-    except vol.Invalid as orig_err:
+    except vol.Invalid as orig_err:  # noqa
         pass
 
     try:
@@ -498,7 +498,7 @@ def temperature(value):
     except vol.Invalid:
         pass
 
-    raise orig_err
+    raise orig_err  # noqa
 
 
 _color_temperature_mireds = float_with_unit('Color Temperature', r'(mireds|Mireds)')

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -433,6 +433,7 @@ def process_lambda(value,  # type: Lambda
     yield LambdaExpression(parts, parameters, capture, return_type)
 
 
+@coroutine
 def templatable(value,  # type: Any
                 args,  # type: List[Tuple[SafeExpType, str]]
                 output_type,  # type: Optional[SafeExpType],

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -6,7 +6,7 @@ from typing import Any, Generator, List, Optional, Tuple, Type, Union, Dict, Cal
 
 from esphome.core import (  # noqa
     CORE, HexInt, ID, Lambda, TimePeriod, TimePeriodMicroseconds,
-    TimePeriodMilliseconds, TimePeriodMinutes, TimePeriodSeconds)
+    TimePeriodMilliseconds, TimePeriodMinutes, TimePeriodSeconds, coroutine)
 from esphome.helpers import cpp_string_escape, indent_all_but_first_and_last
 from esphome.py_compat import integer_types, string_types, text_type
 
@@ -399,12 +399,13 @@ def add(expression,  # type: Union[Expression, Statement]
     CORE.add(expression, require=require)
 
 
+@coroutine
 def get_variable(id):  # type: (ID) -> Generator[MockObj]
-    for var in CORE.get_variable(id):
-        yield None
+    var = yield CORE.get_variable(id)
     yield var
 
 
+@coroutine
 def process_lambda(value,  # type: Lambda
                    parameters,  # type: List[Tuple[Expression, str]]
                    capture='=',  # type: str
@@ -418,8 +419,7 @@ def process_lambda(value,  # type: Lambda
         return
     parts = value.parts[:]
     for i, id in enumerate(value.requires_ids):
-        for full_id, var in CORE.get_variable_with_full_id(id):
-            yield
+        full_id, var = yield CORE.get_variable_with_full_id(id)
         if full_id is not None and isinstance(full_id.type, MockObjClass) and \
                 full_id.type.inherits_from(GlobalVariableComponent):
             parts[i * 3 + 1] = var.value()
@@ -439,8 +439,7 @@ def templatable(value,  # type: Any
                 to_exp=None  # type: Optional[Any]
                 ):
     if isinstance(value, Lambda):
-        for lambda_ in process_lambda(value, args, return_type=output_type):
-            yield None
+        lambda_ = yield process_lambda(value, args, return_type=output_type)
         yield lambda_
     else:
         if to_exp is None:

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -1,10 +1,11 @@
 from esphome.const import CONF_INVERTED, CONF_MODE, CONF_NUMBER, CONF_PCF8574, \
     CONF_SETUP_PRIORITY, CONF_MCP23017
-from esphome.core import CORE, EsphomeError
+from esphome.core import CORE, EsphomeError, coroutine
 from esphome.cpp_generator import IntLiteral, RawExpression
 from esphome.cpp_types import GPIOInputPin, GPIOOutputPin
 
 
+@coroutine
 def generic_gpio_pin_expression_(conf, mock_obj, default_mode):
     if conf is None:
         return
@@ -13,8 +14,7 @@ def generic_gpio_pin_expression_(conf, mock_obj, default_mode):
     if CONF_PCF8574 in conf:
         from esphome.components import pcf8574
 
-        for hub in CORE.get_variable(conf[CONF_PCF8574]):
-            yield None
+        hub = yield CORE.get_variable(conf[CONF_PCF8574])
 
         if default_mode == u'INPUT':
             mode = pcf8574.PCF8675_GPIO_MODES[conf.get(CONF_MODE, u'INPUT')]
@@ -28,8 +28,7 @@ def generic_gpio_pin_expression_(conf, mock_obj, default_mode):
     if CONF_MCP23017 in conf:
         from esphome.components import mcp23017
 
-        for hub in CORE.get_variable(conf[CONF_MCP23017]):
-            yield None
+        hub = yield CORE.get_variable(conf[CONF_MCP23017])
 
         if default_mode == u'INPUT':
             mode = mcp23017.MCP23017_GPIO_MODES[conf.get(CONF_MODE, u'INPUT')]
@@ -47,16 +46,14 @@ def generic_gpio_pin_expression_(conf, mock_obj, default_mode):
     yield mock_obj(number, mode, inverted)
 
 
+@coroutine
 def gpio_output_pin_expression(conf):
-    for exp in generic_gpio_pin_expression_(conf, GPIOOutputPin, 'OUTPUT'):
-        yield None
-    yield exp
+    yield generic_gpio_pin_expression_(conf, GPIOOutputPin, 'OUTPUT')
 
 
+@coroutine
 def gpio_input_pin_expression(conf):
-    for exp in generic_gpio_pin_expression_(conf, GPIOInputPin, 'INPUT'):
-        yield None
-    yield exp
+    yield generic_gpio_pin_expression_(conf, GPIOInputPin, 'INPUT')
 
 
 def setup_component(obj, config):


### PR DESCRIPTION
## Description:

Until now, we always had to write
```python
for var in get_variable(config[CONF_ID]):
  yield None
# Use var
```

That was always ugly, but I thought something nicer was not possible due to the lack of `yield from` in py2.7 - until I took a closer look at tornado's coroutines.

This PR adds a new method decorator `@coroutine` (defined in core.py) that converts a coroutine of the style
```python
var = yield get_variable(config[CONF_ID])
# Use var
```
to the old style directly. It's 100% backwards compatible too! The way it works is by using `send` on the generator object. If the result is a generator itself, then `yield from` that generator, otherwise yield the object as before.

This decorator needs to be applied to all coroutine functions. However, some functions like `CORE.add_job` and `ACTION_REGISTRY` apply the decorator by default (because it's backwards and forwards compatible).
