### PR TITLE
Wio_link and wio_node pinout improvements

### DIFF
--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -54,8 +54,8 @@ ESP8266_BOARD_PINS = {
                   'D8': 12, 'D9': 13, 'D10': 15, 'D11': 13, 'D12': 12, 'D13': 14},
     'wifinfo': {'LED': 12, 'D0': 16, 'D1': 5, 'D2': 4, 'D3': 0, 'D4': 2, 'D5': 14, 'D6': 12,
                 'D7': 13, 'D8': 15, 'D9': 3, 'D10': 1},
-    'wio_link': {'LED': 2, 'GROVE': 15},
-    'wio_node': 'nodemcu',
+    'wio_link': {'LED': 2, 'GROVE': 15, 'D0': 14, 'D1': 12, 'D2': 13, 'BUTTON': 0},
+    'wio_node': {'LED': 2, 'GROVE': 15, 'D0': 3, 'D1': 5, 'BUTTON': 0},
     'xinabox_cw01': {'SDA': 2, 'SCL': 14, 'LED': 5, 'LED_RED': 12, 'LED_GREEN': 13}
 }
 


### PR DESCRIPTION
Makes configuring these boards easier thru improved definitions.
wio_node pointed to nodemcu base, which was incorrect
wio_link lacked D0, D1, D2, and BUTTON

## Description:
Playing with some WioLinks and ESPHome and discovered that the definition was lacking, figured a quick pull request is the best way to improve things.  Don't have a WioNode but since the documentation says that it's certainly not matching the nodemcu pinout, and more much like a WioLink, figured that's likely to save someone else in the future frustration when they have no luck making a wio_node work out of the box with ESPHome.

Sourced from: https://github.com/Seeed-Studio/Wio_Link/blob/master/boards.json

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphomedocs]
(https://github.com/OttoWinter/esphomedocs).

Might want to add a note somewhere for these boards that all of the connections are power linked to GPIO15 (Grove) and unless you do "mode: INPUT_PULLUP" that pin first, nothing works as expected.   Learned this the hard way.