### PR TITLE
Escape double quotes and backslashes in ssid and psk

### DIFF
--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -61,11 +61,16 @@ api:
 """
 
 
+def sanitize_double_quotes(str):
+    str = str.replace('\\', '\\\\').replace('"', '\\"')
+    return str
+
+
 def wizard_file(**kwargs):
     config = BASE_CONFIG.format(**kwargs)
 
     if kwargs['password']:
-        config += u"  password: '{0}'\n\nota:\n  password: '{0}'\n".format(kwargs['password'])
+        config += u"  password: \"{0}\"\n\nota:\n  password: \"{0}\"\n".format(kwargs['password'])
     else:
         config += u"\nota:\n"
 
@@ -75,6 +80,11 @@ def wizard_file(**kwargs):
 def wizard_write(path, **kwargs):
     name = kwargs['name']
     board = kwargs['board']
+
+    kwargs['ssid'] = sanitize_double_quotes(kwargs['ssid'])
+    kwargs['psk'] = sanitize_double_quotes(kwargs['psk'])
+    kwargs['password'] = sanitize_double_quotes(kwargs['password'])
+
     if 'platform' not in kwargs:
         kwargs['platform'] = 'ESP8266' if board in ESP8266_BOARD_PINS else 'ESP32'
     platform = kwargs['platform']
@@ -235,7 +245,6 @@ def wizard(path):
     safe_print(u"Thank you very much! You've just chosen \"{}\" as your SSID."
                u"".format(color('cyan', ssid)))
     safe_print()
-    ssid = ssid.replace('\\','\\\\').replace('"','\\"')
     sleep(0.75)
 
     safe_print("Now please state the " + color('green', 'password') +
@@ -245,7 +254,6 @@ def wizard(path):
     sleep(0.5)
     psk = safe_input(color('bold_white', '(PSK): '))
     safe_print("Perfect! WiFi is now set up (you can create static IPs and so on later).")
-    psk = psk.replace('\\','\\\\').replace('"','\\"')
     sleep(1.5)
 
     safe_print_step(4, OTA_BIG)

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -61,16 +61,15 @@ api:
 """
 
 
-def sanitize_double_quotes(str):
-    str = str.replace('\\', '\\\\').replace('"', '\\"')
-    return str
+def sanitize_double_quotes(value):
+    return value.replace('\\', '\\\\').replace('"', '\\"')
 
 
 def wizard_file(**kwargs):
     config = BASE_CONFIG.format(**kwargs)
 
     if kwargs['password']:
-        config += u"  password: \"{0}\"\n\nota:\n  password: \"{0}\"\n".format(kwargs['password'])
+        config += u'  password: "{0}"\n\nota:\n  password: "{0}"\n'.format(kwargs['password'])
     else:
         config += u"\nota:\n"
 

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -235,6 +235,7 @@ def wizard(path):
     safe_print(u"Thank you very much! You've just chosen \"{}\" as your SSID."
                u"".format(color('cyan', ssid)))
     safe_print()
+    ssid = ssid.replace('\\','\\\\').replace('"','\\"')
     sleep(0.75)
 
     safe_print("Now please state the " + color('green', 'password') +
@@ -244,6 +245,7 @@ def wizard(path):
     sleep(0.5)
     psk = safe_input(color('bold_white', '(PSK): '))
     safe_print("Perfect! WiFi is now set up (you can create static IPs and so on later).")
+    psk = psk.replace('\\','\\\\').replace('"','\\"')
     sleep(1.5)
 
     safe_print_step(4, OTA_BIG)


### PR DESCRIPTION
## Description:
Escape ssid and psk

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/81

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
