### PR TITLE
Print error messages

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -601,6 +601,8 @@ def read_config(verbose):
             res = strip_default_ids(res)
 
         safe_print(color('bold_red', u"Failed config"))
+        for msg, path in res.errors:
+            safe_print(color('bold_red', msg))
         safe_print('')
         for path, domain in res.domains:
             if not res.is_in_error_path(path):


### PR DESCRIPTION
## Description:
Previously, the error message only stated "Failed config". Now the underlying exception message is also logged.

**Related issue (if applicable):** fixes 
https://github.com/esphome/issues/issues/186

## Checklist:
  - [x] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
