### PR TITLE
Add CT Clamp Sensor code

### DIFF
--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -1,0 +1,64 @@
+#include "esphome/components/ct_clamp/ct_clamp_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ct_clamp {
+
+static const char *TAG = "ct_clamp";
+
+CTClampSensor::CTClampSensor(const std::string &name, uint8_t pin, uint32_t calibration,
+                            uint32_t sample_size, uint32_t supply_voltage, uint32_t update_interval)
+    : PollingSensorComponent(name, update_interval), pin_(pin),
+      calibration_(calibration), sample_size_(sample_size), supply_voltage_(supply_voltage) {}
+
+void CTClampSensor::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up CT Clamp '%s'...", this->get_name().c_str());
+  GPIOPin(this->pin_, INPUT).setup();
+
+  offsetI = ADC_COUNTS>>1;
+
+}
+
+void CTClampSensor::dump_config() {
+  LOG_SENSOR("", "CT Clamp Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+float CTClampSensor::get_setup_priority() const { return setup_priority::DATA; }
+
+void CTClampSensor::update() {
+
+  for (unsigned int n = 0; n < this->sample_size_; n++)
+  {
+    sampleI = analogRead(this->pin_);
+
+    // Digital low pass filter extracts the 1.65 V dc offset,
+    //  then subtract this - signal is now centered on 0 counts.
+    offsetI = (offsetI + (sampleI-offsetI)/(ADC_COUNTS));
+    filteredI = sampleI - offsetI;
+
+    // Root-mean-square method current
+    // 1) square current values
+    sqI = filteredI * filteredI;
+    // 2) sum
+    sumI += sqI;
+  }
+
+  double I_RATIO = this->calibration_ * ((supply_voltage_) / (ADC_COUNTS));
+  Irms = I_RATIO * sqrt(sumI / this->sample_size_);
+
+  //Reset accumulators
+  sumI = 0;
+
+  ESP_LOGD(TAG, "'%s': Got amps=%.2fA", this->get_name().c_str(), Irms);
+
+  this->publish_state(Irms);
+}
+
+#ifdef ARDUINO_ARCH_ESP8266
+std::string CTClampSensor::unique_id() { return get_mac_address() + "-ct_clamp"; }
+#endif
+
+}  // namespace ct_clamp
+}  // namespace esphome

--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome {
+namespace ct_clamp {
+
+/** This class allows reading the measured current from a CT clamp.
+ *
+ * It uses the existing `analogRead` methods for doing this.
+ *
+ * The ESP8266 only has one pin where this can be used: A0
+ *
+ * The ESP32 has multiple pins that can be used with this component: GPIO32-GPIO39
+ * Note you can't use the ADC2 here on the ESP32 because that's already used by WiFi internally.
+ * Additionally on the ESP32 you can set an using `set_attenuation`.
+ */
+class CTClampSensor : public sensor::PollingSensorComponent {
+ public:
+  explicit CTClampSensor(const std::string &name, uint8_t pin,
+    uint32_t calibration, uint32_t sample_size, uint32_t supply_voltage, uint32_t update_interval);
+
+  /// Update CT Clamp sensor values.
+  void update() override;
+  /// Setup CT Sensor
+  void setup() override;
+  void dump_config() override;
+  /// `HARDWARE_LATE` setup priority.
+  float get_setup_priority() const override;
+
+#ifdef ARDUINO_ARCH_ESP8266
+  std::string unique_id() override;
+#endif
+
+ protected:
+  uint8_t pin_;
+  uint32_t calibration_;
+  uint32_t sample_size_;
+  double supply_voltage_;
+
+  int sampleI;
+  double Irms,filteredI,offsetI,sumI,sqI;
+
+#ifdef ARDUINO_ARCH_ESP32
+#define ADC_BITS    12
+#endif
+#ifdef ARDUINO_ARCH_ESP8266
+#define ADC_BITS    10
+#endif
+#define ADC_COUNTS  (1<<ADC_BITS)
+};
+
+} // namespace ct_clamp
+} // namespace esphome

--- a/esphome/components/ct_clamp/sensor.py
+++ b/esphome/components/ct_clamp/sensor.py
@@ -1,0 +1,37 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import sensor
+from esphome.const import CONF_ID, CONF_NAME, CONF_PIN, CONF_UPDATE_INTERVAL, \
+    CONF_ICON, ICON_FLASH, CONF_UNIT_OF_MEASUREMENT, UNIT_AMPERE, CONF_ACCURACY_DECIMALS
+
+CONF_CALIBRATION = 'calibration'
+CONF_SAMPLE_SIZE = 'sample_size'
+CONF_SUPPLY_VOLTAGE = 'supply_voltage'
+
+ct_clamp_ns = cg.esphome_ns.namespace('ct_clamp')
+CTClampSensor = ct_clamp_ns.class_('CTClampSensor', sensor.PollingSensorComponent)
+
+CONFIG_SCHEMA = cv.nameable(sensor.SENSOR_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_variable_id(CTClampSensor),
+    cv.Required(CONF_PIN): pins.analog_pin,
+    cv.Required(CONF_CALIBRATION): cv.positive_int,
+
+    cv.Optional(CONF_SAMPLE_SIZE, default=1480): cv.positive_int,
+    cv.Optional(CONF_SUPPLY_VOLTAGE, default='1V'): cv.voltage,
+    cv.Optional(CONF_UPDATE_INTERVAL, default='60s'): cv.update_interval,
+    cv.Optional(CONF_ICON, default=ICON_FLASH): sensor.icon,
+    cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE): sensor.unit_of_measurement,
+    cv.Optional(CONF_ACCURACY_DECIMALS, default=2): sensor.accuracy_decimals,
+}).extend(cv.COMPONENT_SCHEMA))
+
+
+def to_code(config):
+    pin = config[CONF_PIN]
+
+    rhs = CTClampSensor.new(config[CONF_NAME], pin, config.get(CONF_CALIBRATION),
+                            config.get(CONF_SAMPLE_SIZE), config.get(CONF_SUPPLY_VOLTAGE),
+                            config.get(CONF_UPDATE_INTERVAL))
+    ct_clamp = cg.Pvariable(config[CONF_ID], rhs)
+    yield cg.register_component(ct_clamp, config)
+    yield sensor.register_sensor(ct_clamp, config)


### PR DESCRIPTION
## Description:
Adds sensor code for CT (Current Transformer) Clamps.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
