### PR TITLE
A few improvements on cleanup-dashboard branch

### DIFF
--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -8,6 +8,8 @@ from esphome.const import CONF_AWAY, CONF_ID, CONF_INTERNAL, CONF_MAX_TEMPERATUR
     CONF_MQTT_ID, CONF_NAME
 from esphome.core import CORE, coroutine
 
+IS_PLATFORM_COMPONENT = True
+
 climate_ns = cg.esphome_ns.namespace('climate')
 
 ClimateDevice = climate_ns.class_('Climate', cg.Nameable)

--- a/esphome/components/custom/binary_sensor/__init__.py
+++ b/esphome/components/custom/binary_sensor/__init__.py
@@ -15,7 +15,8 @@ CONFIG_SCHEMA = cv.Schema({
 
 def to_code(config):
     template_ = yield cg.process_lambda(
-        config[CONF_LAMBDA], [], return_type=cg.std_vector.template(binary_sensor.BinarySensorPtr))
+        config[CONF_LAMBDA], [], '=',
+        return_type=cg.std_vector.template(binary_sensor.BinarySensorPtr))
 
     rhs = CustomBinarySensorConstructor(template_)
     custom = cg.variable(config[CONF_ID], rhs)

--- a/esphome/components/custom/output/__init__.py
+++ b/esphome/components/custom/output/__init__.py
@@ -53,7 +53,7 @@ def to_code(config):
     else:
         ret_type = output.FloatOutputPtr
         klass = CustomFloatOutputConstructor
-    template_ = yield cg.process_lambda(config[CONF_LAMBDA], [],
+    template_ = yield cg.process_lambda(config[CONF_LAMBDA], [], '=',
                                         return_type=cg.std_vector.template(ret_type))
 
     rhs = klass(template_)

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -36,7 +36,6 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase, pu
   std::vector<rmt_item32_t> rmt_temp_;
 #endif
   uint8_t carrier_duty_percent_{50};
-  remote_base::RemoteTransmitData temp_;
 };
 
 }  // namespace remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -63,9 +63,11 @@ void RemoteTransmitterComponent::space_(uint32_t usec) {
   delay_microseconds_accurate(usec);
 }
 void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
-  ESP_LOGD(TAG, "Sending remote code...");
   uint32_t on_time, off_time;
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
+  ESP_LOGD(TAG, "Sending remote code with %d mark/spaces at %d Hz times: %d / %d...", 
+             this->temp_.get_data().size(), this->temp_.get_carrier_frequency(),
+             on_time, off_time);
   for (uint32_t i = 0; i < send_times; i++) {
     disable_interrupts();
     for (int32_t item : this->temp_.get_data()) {

--- a/esphome/core/preferences.cpp
+++ b/esphome/core/preferences.cpp
@@ -29,7 +29,7 @@ bool ESPPreferenceObject::load_() {
 
   bool valid = this->data_[this->length_words_] == this->calculate_crc_();
 
-  ESP_LOGVV(TAG, "LOAD %zu: valid=%s, 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_,  // NOLINT
+  ESP_LOGVV(TAG, "LOAD %u: valid=%s, 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_,  // NOLINT
             YESNO(valid), this->data_[0], this->data_[1], this->type_, this->calculate_crc_());
   return valid;
 }
@@ -42,7 +42,7 @@ bool ESPPreferenceObject::save_() {
   this->data_[this->length_words_] = this->calculate_crc_();
   if (!this->save_internal_())
     return false;
-  ESP_LOGVV(TAG, "SAVE %zu: 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_,  // NOLINT
+  ESP_LOGVV(TAG, "SAVE %u: 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_,  // NOLINT
             this->data_[0], this->data_[1], this->type_, this->calculate_crc_());
   return true;
 }


### PR DESCRIPTION
## Description:

Using this new bits found a few issues you might like to be aware of.

the one in remote_transmitter.h is because this `remote_base::RemoteTransmitData temp_` is shadowing the one defined in `RemoteTransmitterBase` thus an incorrect instance is used by the transmitter implementation.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
