### PR TITLE
Add coolix climate ❄ 🔥

### DIFF
--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -6,7 +6,7 @@ from esphome.const import CONF_ID, CONF_NAME, CONF_SENSOR
 AUTO_LOAD = ['sensor']
 
 coolix_ns = cg.esphome_ns.namespace('coolix')
-CoolixClimate = coolix_ns.class_('CoolixClimate', climate.ClimateDevice, cg.Component)
+CoolixClimate = coolix_ns.class_('CoolixClimate', climate.Climate, cg.Component)
 
 CONF_TRANSMITTER_ID = 'transmitter_id'
 CONF_SUPPORTS_HEAT = 'supports_heat'

--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate, remote_transmitter, sensor
-from esphome.const import CONF_ID, CONF_NAME, CONF_SENSOR
+from esphome.const import CONF_ID, CONF_SENSOR
 
 AUTO_LOAD = ['sensor']
 
@@ -22,7 +22,7 @@ CONFIG_SCHEMA = cv.All(climate.CLIMATE_SCHEMA.extend({
 
 
 def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID], config[CONF_NAME])
+    var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     yield climate.register_climate(var, config)
 

--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -1,0 +1,32 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import climate, remote_transmitter
+from esphome.const import CONF_ID, CONF_NAME
+
+coolix_ns = cg.esphome_ns.namespace('coolix')
+CoolixClimate = coolix_ns.class_('CoolixClimate', climate.ClimateDevice)
+
+CONF_TRANSMITTER_ID = 'transmitter_id'
+CONF_SUPPORTS_HEAT = 'supports_heat'
+CONF_SUPPORTS_COOL = 'supports_cool'
+
+CONFIG_SCHEMA = cv.All(climate.CLIMATE_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(CoolixClimate),
+    cv.GenerateID(CONF_TRANSMITTER_ID): cv.use_id(remote_transmitter.RemoteTransmitterComponent),
+    cv.Optional(CONF_SUPPORTS_COOL, default=True): cv.boolean,
+    cv.Optional(CONF_SUPPORTS_HEAT, default=True): cv.boolean,
+}).extend(cv.COMPONENT_SCHEMA))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID], config[CONF_NAME])
+    yield cg.register_component(var, config)
+    yield climate.register_climate(var, config)
+
+    if CONF_SUPPORTS_COOL in config:
+        cg.add(var.set_supports_cool(config[CONF_SUPPORTS_COOL]))
+    if CONF_SUPPORTS_HEAT in config:
+        cg.add(var.set_supports_heat(config[CONF_SUPPORTS_HEAT]))
+
+    transmitter = yield cg.get_variable(config[CONF_TRANSMITTER_ID])
+    cg.add(var.set_transmitter(transmitter))

--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -6,7 +6,7 @@ from esphome.const import CONF_ID, CONF_NAME, CONF_SENSOR
 AUTO_LOAD = ['sensor']
 
 coolix_ns = cg.esphome_ns.namespace('coolix')
-CoolixClimate = coolix_ns.class_('CoolixClimate', climate.ClimateDevice)
+CoolixClimate = coolix_ns.class_('CoolixClimate', climate.ClimateDevice, cg.Component)
 
 CONF_TRANSMITTER_ID = 'transmitter_id'
 CONF_SUPPORTS_HEAT = 'supports_heat'
@@ -26,10 +26,8 @@ def to_code(config):
     yield cg.register_component(var, config)
     yield climate.register_climate(var, config)
 
-    if CONF_SUPPORTS_COOL in config:
-        cg.add(var.set_supports_cool(config[CONF_SUPPORTS_COOL]))
-    if CONF_SUPPORTS_HEAT in config:
-        cg.add(var.set_supports_heat(config[CONF_SUPPORTS_HEAT]))
+    cg.add(var.set_supports_cool(config[CONF_SUPPORTS_COOL]))
+    cg.add(var.set_supports_heat(config[CONF_SUPPORTS_HEAT]))
     if CONF_SENSOR in config:
         sens = yield cg.get_variable(config[CONF_SENSOR])
         cg.add(var.set_sensor(sens))

--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -3,6 +3,8 @@ import esphome.config_validation as cv
 from esphome.components import climate, remote_transmitter, sensor
 from esphome.const import CONF_ID, CONF_NAME, CONF_SENSOR
 
+AUTO_LOAD = ['sensor']
+
 coolix_ns = cg.esphome_ns.namespace('coolix')
 CoolixClimate = coolix_ns.class_('CoolixClimate', climate.ClimateDevice)
 

--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, remote_transmitter
-from esphome.const import CONF_ID, CONF_NAME
+from esphome.components import climate, remote_transmitter, sensor
+from esphome.const import CONF_ID, CONF_NAME, CONF_SENSOR
 
 coolix_ns = cg.esphome_ns.namespace('coolix')
 CoolixClimate = coolix_ns.class_('CoolixClimate', climate.ClimateDevice)
@@ -15,6 +15,7 @@ CONFIG_SCHEMA = cv.All(climate.CLIMATE_SCHEMA.extend({
     cv.GenerateID(CONF_TRANSMITTER_ID): cv.use_id(remote_transmitter.RemoteTransmitterComponent),
     cv.Optional(CONF_SUPPORTS_COOL, default=True): cv.boolean,
     cv.Optional(CONF_SUPPORTS_HEAT, default=True): cv.boolean,
+    cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
 }).extend(cv.COMPONENT_SCHEMA))
 
 
@@ -27,6 +28,9 @@ def to_code(config):
         cg.add(var.set_supports_cool(config[CONF_SUPPORTS_COOL]))
     if CONF_SUPPORTS_HEAT in config:
         cg.add(var.set_supports_heat(config[CONF_SUPPORTS_HEAT]))
+    if CONF_SENSOR in config:
+        sens = yield cg.get_variable(config[CONF_SENSOR])
+        cg.add(var.set_sensor(sens))
 
     transmitter = yield cg.get_variable(config[CONF_TRANSMITTER_ID])
     cg.add(var.set_transmitter(transmitter))

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -8,22 +8,22 @@ static const char *TAG = "coolix.climate";
 
 const uint32_t COOLIX_OFF = 0xB27BE0;
 // On, 25C, Mode: Auto, Fan: Auto, Zone Follow: Off, Sensor Temp: Ignore.
-const uint32_t COOLIX_DEFAULT_STATE =  0xB2BFC8; 
-const uint32_t COOLIX_DEFAULT_STATE_AUTO_FAN = 0xB21FC8;
+const uint32_t COOLIX_DEFAULT_STATE = 0xB2BFC8; 
+const uint32_t COOLIX_DEFAULT_STATE_AUTO_24_FAN = 0xB21F48;
 const uint8_t COOLIX_COOL = 0b00;
-const uint8_t kCoolixDry = 0b01;
-const uint8_t kCoolixAuto = 0b10;
+const uint8_t COOLIX_DRY = 0b01;
+const uint8_t COOLIX_AUTO = 0b10;
 const uint8_t COOLIX_HEAT = 0b11;
-const uint8_t kCoolixFan = 4;                                 // Synthetic.
+const uint8_t COOLIX_FAN = 4;                                  // Synthetic.
 const uint32_t COOLIX_MODE_MASK = 0b000000000000000000001100;  // 0xC
 
 // Temperature
 const uint8_t COOLIX_TEMP_MIN = 17;  // Celsius
 const uint8_t COOLIX_TEMP_MAX = 30;  // Celsius
-const uint8_t kCoolixTempRange = COOLIX_TEMP_MAX - COOLIX_TEMP_MIN + 1;
-const uint8_t kCoolixFanTempCode = 0b1110;  // Part of Fan Mode.
+const uint8_t COOLIX_TEMP_RANGE = COOLIX_TEMP_MAX - COOLIX_TEMP_MIN + 1;
+const uint8_t COOLIX_FAN_TEMP_CODE = 0b1110;  // Part of Fan Mode.
 const uint32_t COOLIX_TEMP_MASK = 0b11110000;
-const uint8_t COOLIX_TEMP_MAP[kCoolixTempRange] = {
+const uint8_t COOLIX_TEMP_MAP[COOLIX_TEMP_RANGE] = {
     0b0000,  // 17C
     0b0001,  // 18c
     0b0011,  // 19C
@@ -44,40 +44,53 @@ const uint8_t COOLIX_TEMP_MAP[kCoolixTempRange] = {
 // Pulse parms are *50-100 for the Mark and *50+100 for the space
 // First MARK is the one after the long gap
 // pulse parameters in usec
-const uint16_t COLLIX_TICK = 560;  // Approximately 21 cycles at 38kHz
-const uint16_t COOLIX_BIT_MARKTicks = 1;
-const uint16_t COOLIX_BIT_MARK = COOLIX_BIT_MARKTicks * COLLIX_TICK;
-const uint16_t COOLIX_ONE_SPACETicks = 3;
-const uint16_t COOLIX_ONE_SPACE = COOLIX_ONE_SPACETicks * COLLIX_TICK;
-const uint16_t COOLIX_ZERO_SPACETicks = 1;
-const uint16_t COOLIX_ZERO_SPACE = COOLIX_ZERO_SPACETicks * COLLIX_TICK;
+const uint16_t COOLIX_TICK = 560;  // Approximately 21 cycles at 38kHz
+const uint16_t COOLIX_BIT_MARK_TICKS = 1;
+const uint16_t COOLIX_BIT_MARK = COOLIX_BIT_MARK_TICKS * COOLIX_TICK;
+const uint16_t COOLIX_ONE_SPACE_TICKS = 3;
+const uint16_t COOLIX_ONE_SPACE = COOLIX_ONE_SPACE_TICKS * COOLIX_TICK;
+const uint16_t COOLIX_ZERO_SPACE_TICKS = 1;
+const uint16_t COOLIX_ZERO_SPACE = COOLIX_ZERO_SPACE_TICKS * COOLIX_TICK;
 const uint16_t COOLIX_HEADER_MARK_TICKS = 8;
-const uint16_t COOLIX_HEADER_MARK = COOLIX_HEADER_MARK_TICKS * COLLIX_TICK;
-const uint16_t COOLIX_HEADER_SPACETicks = 8;
-const uint16_t COOLIX_HEADER_SPACE = COOLIX_HEADER_SPACETicks * COLLIX_TICK;
-const uint16_t COOLIX_MIN_GAP_TICKS = COOLIX_HEADER_MARK_TICKS + COOLIX_ZERO_SPACETicks;
-const uint16_t COOLIX_MIN_GAP = COOLIX_MIN_GAP_TICKS * COLLIX_TICK;
+const uint16_t COOLIX_HEADER_MARK = COOLIX_HEADER_MARK_TICKS * COOLIX_TICK;
+const uint16_t COOLIX_HEADER_SPACE_TICKS = 8;
+const uint16_t COOLIX_HEADER_SPACE = COOLIX_HEADER_SPACE_TICKS * COOLIX_TICK;
+const uint16_t COOLIX_MIN_GAP_TICKS = COOLIX_HEADER_MARK_TICKS + COOLIX_ZERO_SPACE_TICKS;
+const uint16_t COOLIX_MIN_GAP = COOLIX_MIN_GAP_TICKS * COOLIX_TICK;
 
 const uint16_t COOLIX_BITS = 24;
 
 climate::ClimateTraits CoolixClimate::traits() {
   auto traits = climate::ClimateTraits();
-  traits.set_supports_current_temperature(true);
+  traits.set_supports_current_temperature(this->sensor_ != nullptr);
   traits.set_supports_auto_mode(true);
   traits.set_supports_cool_mode(this->supports_cool_);
   traits.set_supports_heat_mode(this->supports_heat_);
   traits.set_supports_two_point_target_temperature(false);
   traits.set_supports_away(false);
+  traits.set_visual_min_temperature(17);
+  traits.set_visual_max_temperature(30);
+  traits.set_visual_temperature_step(1);
   return traits;
 }
 
 void CoolixClimate::setup() {
+  if (this->sensor_)
+  {
+    this->sensor_->add_on_state_callback([this](float state) {
+      this->current_temperature = state;
+      // current temperature changed, publish state
+      this->publish_state();
+    });
+    this->current_temperature = this->sensor_->state;
+  }
+  else this->current_temperature = NAN;
   // restore set points
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->to_call(this).perform();
   } else {
-    // restore from defaults, change_away handles those for us
+    // restore from defaults
     this->mode = climate::CLIMATE_MODE_AUTO;
   }
 }
@@ -88,7 +101,6 @@ void CoolixClimate::control(const climate::ClimateCall &call) {
   if (call.get_target_temperature().has_value())
     this->target_temperature = *call.get_target_temperature();
 
-  this->current_temperature = NAN;
   this->transmit_state_();
   this->publish_state();
 }
@@ -104,17 +116,16 @@ void CoolixClimate::transmit_state_() {
       remote_state = (COOLIX_DEFAULT_STATE & ~COOLIX_MODE_MASK) | (COOLIX_HEAT << 2);
       break;
     case climate::CLIMATE_MODE_AUTO:
-      remote_state = COOLIX_DEFAULT_STATE_AUTO_FAN;
+      remote_state = COOLIX_DEFAULT_STATE_AUTO_24_FAN;
       break;
     case climate::CLIMATE_MODE_OFF:
     default:
       remote_state = COOLIX_OFF;
       break;
   }
-  if (this->mode != climate::CLIMATE_MODE_OFF)
-  {
-    uint8_t temp = std::min((uint8_t)this->target_temperature, COOLIX_TEMP_MAX);
-    temp = std::max((uint8_t)this->target_temperature, COOLIX_TEMP_MIN);
+  if (this->mode != climate::CLIMATE_MODE_OFF) {
+    uint8_t temp = std::min((uint8_t) this->target_temperature, COOLIX_TEMP_MAX);
+    temp = std::max((uint8_t) this->target_temperature, COOLIX_TEMP_MIN);
     remote_state &= ~COOLIX_TEMP_MASK;  // Clear the old temp.
     remote_state |= (COOLIX_TEMP_MAP[temp - COOLIX_TEMP_MIN] << 4);
   }
@@ -138,11 +149,9 @@ void CoolixClimate::transmit_state_() {
       // Grab a bytes worth of data.
       uint8_t segment = (remote_state >> (COOLIX_BITS - i)) & 0xFF;
       // Normal
-      send_data_(data, COOLIX_BIT_MARK, COOLIX_ONE_SPACE, COOLIX_BIT_MARK,
-                 COOLIX_ZERO_SPACE, segment, 8, true);
+      send_data_(data, COOLIX_BIT_MARK, COOLIX_ONE_SPACE, COOLIX_BIT_MARK, COOLIX_ZERO_SPACE, segment, 8, true);
       // Inverted.
-      send_data_(data, COOLIX_BIT_MARK, COOLIX_ONE_SPACE, COOLIX_BIT_MARK,
-                 COOLIX_ZERO_SPACE, segment ^ 0xFF, 8, true);
+      send_data_(data, COOLIX_BIT_MARK, COOLIX_ONE_SPACE, COOLIX_BIT_MARK, COOLIX_ZERO_SPACE, segment ^ 0xFF, 8, true);
     }
 
     // Footer
@@ -164,11 +173,9 @@ void CoolixClimate::transmit_state_() {
 //   zerospace:  Nr. of usecs for the led to be fully off for a '0' bit.
 //   data:       The data to be transmitted.
 //   nbits:      Nr. of bits of data to be sent.
-//   MSBfirst:   Flag for bit transmission order. Defaults to MSB->LSB order.
-void CoolixClimate::send_data_(remote_base::RemoteTransmitData *transmit_data, 
-                                        uint16_t onemark, uint32_t onespace, uint16_t zeromark,
-                                        uint32_t zerospace, uint64_t data, uint16_t nbits,
-                                        bool msb_first) {
+//   msb_first:  Flag for bit transmission order. Defaults to MSB->LSB order.
+void CoolixClimate::send_data_(remote_base::RemoteTransmitData *transmit_data, uint16_t onemark, uint32_t onespace,
+                               uint16_t zeromark, uint32_t zerospace, uint64_t data, uint16_t nbits, bool msb_first) {
   if (nbits == 0)  // If we are asked to send nothing, just return.
     return;
   if (msb_first) {  // Send the MSB first.
@@ -199,5 +206,5 @@ void CoolixClimate::send_data_(remote_base::RemoteTransmitData *transmit_data,
   }
 }
 
-}  // namespace climate
+}  // namespace coolix
 }  // namespace esphome

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -125,7 +125,7 @@ void CoolixClimate::transmit_state_() {
   }
   if (this->mode != climate::CLIMATE_MODE_OFF) {
     uint8_t temp = std::min((uint8_t) this->target_temperature, COOLIX_TEMP_MAX);
-    temp = std::max((uint8_t) this->target_temperature, COOLIX_TEMP_MIN);
+    temp = std::max(temp, COOLIX_TEMP_MIN);
     remote_state &= ~COOLIX_TEMP_MASK;  // Clear the old temp.
     remote_state |= (COOLIX_TEMP_MAP[temp - COOLIX_TEMP_MIN] << 4);
   }

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -125,8 +125,7 @@ void CoolixClimate::transmit_state_() {
       break;
   }
   if (this->mode != climate::CLIMATE_MODE_OFF) {
-    uint8_t temp = std::min((uint8_t) this->target_temperature, COOLIX_TEMP_MAX);
-    temp = std::max(temp, COOLIX_TEMP_MIN);
+    auto temp = (uint8_t) roundf(clamp(this->target_temperature, COOLIX_TEMP_MIN, COOLIX_TEMP_MAX));
     remote_state &= ~COOLIX_TEMP_MASK;  // Clear the old temp.
     remote_state |= (COOLIX_TEMP_MAP[temp - COOLIX_TEMP_MIN] << 4);
   }

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -1,0 +1,203 @@
+#include "coolix.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace coolix {
+
+static const char *TAG = "coolix.climate";
+
+const uint32_t COOLIX_OFF = 0xB27BE0;
+// On, 25C, Mode: Auto, Fan: Auto, Zone Follow: Off, Sensor Temp: Ignore.
+const uint32_t COOLIX_DEFAULT_STATE =  0xB2BFC8; 
+const uint32_t COOLIX_DEFAULT_STATE_AUTO_FAN = 0xB21FC8;
+const uint8_t COOLIX_COOL = 0b00;
+const uint8_t kCoolixDry = 0b01;
+const uint8_t kCoolixAuto = 0b10;
+const uint8_t COOLIX_HEAT = 0b11;
+const uint8_t kCoolixFan = 4;                                 // Synthetic.
+const uint32_t COOLIX_MODE_MASK = 0b000000000000000000001100;  // 0xC
+
+// Temperature
+const uint8_t COOLIX_TEMP_MIN = 17;  // Celsius
+const uint8_t COOLIX_TEMP_MAX = 30;  // Celsius
+const uint8_t kCoolixTempRange = COOLIX_TEMP_MAX - COOLIX_TEMP_MIN + 1;
+const uint8_t kCoolixFanTempCode = 0b1110;  // Part of Fan Mode.
+const uint32_t COOLIX_TEMP_MASK = 0b11110000;
+const uint8_t COOLIX_TEMP_MAP[kCoolixTempRange] = {
+    0b0000,  // 17C
+    0b0001,  // 18c
+    0b0011,  // 19C
+    0b0010,  // 20C
+    0b0110,  // 21C
+    0b0111,  // 22C
+    0b0101,  // 23C
+    0b0100,  // 24C
+    0b1100,  // 25C
+    0b1101,  // 26C
+    0b1001,  // 27C
+    0b1000,  // 28C
+    0b1010,  // 29C
+    0b1011   // 30C
+};
+
+// Constants
+// Pulse parms are *50-100 for the Mark and *50+100 for the space
+// First MARK is the one after the long gap
+// pulse parameters in usec
+const uint16_t COLLIX_TICK = 560;  // Approximately 21 cycles at 38kHz
+const uint16_t COOLIX_BIT_MARKTicks = 1;
+const uint16_t COOLIX_BIT_MARK = COOLIX_BIT_MARKTicks * COLLIX_TICK;
+const uint16_t COOLIX_ONE_SPACETicks = 3;
+const uint16_t COOLIX_ONE_SPACE = COOLIX_ONE_SPACETicks * COLLIX_TICK;
+const uint16_t COOLIX_ZERO_SPACETicks = 1;
+const uint16_t COOLIX_ZERO_SPACE = COOLIX_ZERO_SPACETicks * COLLIX_TICK;
+const uint16_t COOLIX_HEADER_MARK_TICKS = 8;
+const uint16_t COOLIX_HEADER_MARK = COOLIX_HEADER_MARK_TICKS * COLLIX_TICK;
+const uint16_t COOLIX_HEADER_SPACETicks = 8;
+const uint16_t COOLIX_HEADER_SPACE = COOLIX_HEADER_SPACETicks * COLLIX_TICK;
+const uint16_t COOLIX_MIN_GAP_TICKS = COOLIX_HEADER_MARK_TICKS + COOLIX_ZERO_SPACETicks;
+const uint16_t COOLIX_MIN_GAP = COOLIX_MIN_GAP_TICKS * COLLIX_TICK;
+
+const uint16_t COOLIX_BITS = 24;
+
+climate::ClimateTraits CoolixClimate::traits() {
+  auto traits = climate::ClimateTraits();
+  traits.set_supports_current_temperature(true);
+  traits.set_supports_auto_mode(true);
+  traits.set_supports_cool_mode(this->supports_cool_);
+  traits.set_supports_heat_mode(this->supports_heat_);
+  traits.set_supports_two_point_target_temperature(false);
+  traits.set_supports_away(false);
+  return traits;
+}
+
+void CoolixClimate::setup() {
+  // restore set points
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->to_call(this).perform();
+  } else {
+    // restore from defaults, change_away handles those for us
+    this->mode = climate::CLIMATE_MODE_AUTO;
+  }
+}
+
+void CoolixClimate::control(const climate::ClimateCall &call) {
+  if (call.get_mode().has_value())
+    this->mode = *call.get_mode();
+  if (call.get_target_temperature().has_value())
+    this->target_temperature = *call.get_target_temperature();
+
+  this->current_temperature = NAN;
+  this->transmit_state_();
+  this->publish_state();
+}
+
+void CoolixClimate::transmit_state_() {
+  uint32_t remote_state;
+
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_COOL:
+      remote_state = (COOLIX_DEFAULT_STATE & ~COOLIX_MODE_MASK) | (COOLIX_COOL << 2);
+      break;
+    case climate::CLIMATE_MODE_HEAT:
+      remote_state = (COOLIX_DEFAULT_STATE & ~COOLIX_MODE_MASK) | (COOLIX_HEAT << 2);
+      break;
+    case climate::CLIMATE_MODE_AUTO:
+      remote_state = COOLIX_DEFAULT_STATE_AUTO_FAN;
+      break;
+    case climate::CLIMATE_MODE_OFF:
+    default:
+      remote_state = COOLIX_OFF;
+      break;
+  }
+  if (this->mode != climate::CLIMATE_MODE_OFF)
+  {
+    uint8_t temp = std::min((uint8_t)this->target_temperature, COOLIX_TEMP_MAX);
+    temp = std::max((uint8_t)this->target_temperature, COOLIX_TEMP_MIN);
+    remote_state &= ~COOLIX_TEMP_MASK;  // Clear the old temp.
+    remote_state |= (COOLIX_TEMP_MAP[temp - COOLIX_TEMP_MIN] << 4);
+  }
+
+  ESP_LOGD(TAG, "Sending coolix code: %u", remote_state);
+
+  auto transmit = this->transmitter_->transmit();
+  auto data = transmit.get_data();
+
+  data->set_carrier_frequency(38000);
+  uint16_t repeat = 1;
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Header
+    data->mark(COOLIX_HEADER_MARK);
+    data->space(COOLIX_HEADER_SPACE);
+
+    // Data
+    //   Break data into byte segments, starting at the Most Significant
+    //   Byte. Each byte then being sent normal, then followed inverted.
+    for (uint16_t i = 8; i <= COOLIX_BITS; i += 8) {
+      // Grab a bytes worth of data.
+      uint8_t segment = (remote_state >> (COOLIX_BITS - i)) & 0xFF;
+      // Normal
+      send_data_(data, COOLIX_BIT_MARK, COOLIX_ONE_SPACE, COOLIX_BIT_MARK,
+                 COOLIX_ZERO_SPACE, segment, 8, true);
+      // Inverted.
+      send_data_(data, COOLIX_BIT_MARK, COOLIX_ONE_SPACE, COOLIX_BIT_MARK,
+                 COOLIX_ZERO_SPACE, segment ^ 0xFF, 8, true);
+    }
+
+    // Footer
+    data->mark(COOLIX_BIT_MARK);
+    data->space(COOLIX_MIN_GAP);  // Pause before repeating
+  }
+
+  transmit.perform();
+}
+
+// Generic method for sending data that is common to most protocols.
+// Will send leading or trailing 0's if the nbits is larger than the number
+// of bits in data.
+//
+// Args:
+//   onemark:    Nr. of usecs for the led to be pulsed for a '1' bit.
+//   onespace:   Nr. of usecs for the led to be fully off for a '1' bit.
+//   zeromark:   Nr. of usecs for the led to be pulsed for a '0' bit.
+//   zerospace:  Nr. of usecs for the led to be fully off for a '0' bit.
+//   data:       The data to be transmitted.
+//   nbits:      Nr. of bits of data to be sent.
+//   MSBfirst:   Flag for bit transmission order. Defaults to MSB->LSB order.
+void CoolixClimate::send_data_(remote_base::RemoteTransmitData *transmit_data, 
+                                        uint16_t onemark, uint32_t onespace, uint16_t zeromark,
+                                        uint32_t zerospace, uint64_t data, uint16_t nbits,
+                                        bool msb_first) {
+  if (nbits == 0)  // If we are asked to send nothing, just return.
+    return;
+  if (msb_first) {  // Send the MSB first.
+    // Send 0's until we get down to a bit size we can actually manage.
+    while (nbits > sizeof(data) * 8) {
+      transmit_data->mark(zeromark);
+      transmit_data->space(zerospace);
+      nbits--;
+    }
+    // Send the supplied data.
+    for (uint64_t mask = 1ULL << (nbits - 1); mask; mask >>= 1)
+      if (data & mask) {  // Send a 1
+        transmit_data->mark(onemark);
+        transmit_data->space(onespace);
+      } else {  // Send a 0
+        transmit_data->mark(zeromark);
+        transmit_data->space(zerospace);
+      }
+  } else {  // Send the Least Significant Bit (LSB) first / MSB last.
+    for (uint16_t bit = 0; bit < nbits; bit++, data >>= 1)
+      if (data & 1) {  // Send a 1
+        transmit_data->mark(onemark);
+        transmit_data->space(onespace);
+      } else {  // Send a 0
+        transmit_data->mark(zeromark);
+        transmit_data->space(zerospace);
+      }
+  }
+}
+
+}  // namespace climate
+}  // namespace esphome

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -130,7 +130,7 @@ void CoolixClimate::transmit_state_() {
     remote_state |= (COOLIX_TEMP_MAP[temp - COOLIX_TEMP_MIN] << 4);
   }
 
-  ESP_LOGD(TAG, "Sending coolix code: %u", remote_state);
+  ESP_LOGV(TAG, "Sending coolix code: %u", remote_state);
 
   auto transmit = this->transmitter_->transmit();
   auto data = transmit.get_data();

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -91,6 +91,8 @@ void CoolixClimate::setup() {
   } else {
     // restore from defaults
     this->mode = climate::CLIMATE_MODE_AUTO;
+    // initialize target temperature to some value so that it's not NAN
+    this->target_temperature = roundf(this->current_temperature);
   }
 }
 

--- a/esphome/components/coolix/coolix.h
+++ b/esphome/components/coolix/coolix.h
@@ -15,7 +15,7 @@ class CoolixClimate : public climate::Climate, public Component {
   CoolixClimate(const std::string &name) : climate::Climate(name) {}
 
   void setup() override;
-  void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) { 
+  void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) {
     this->transmitter_ = transmitter;
   }
   void set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }

--- a/esphome/components/coolix/coolix.h
+++ b/esphome/components/coolix/coolix.h
@@ -31,9 +31,6 @@ class CoolixClimate : public climate::Climate, public Component {
   /// Transmit via IR the state of this climate controller.
   void transmit_state_();
 
-  void send_data_(remote_base::RemoteTransmitData * transmit_data, uint16_t onemark, uint32_t onespace,
-                  uint16_t zeromark, uint32_t zerospace, uint64_t data, uint16_t nbits, bool msb_first = true);
-
   bool supports_cool_{true};
   bool supports_heat_{true};
 

--- a/esphome/components/coolix/coolix.h
+++ b/esphome/components/coolix/coolix.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/remote_base/remote_base.h"
+#include "esphome/components/remote_transmitter/remote_transmitter.h"
+
+namespace esphome {
+namespace coolix {
+
+class CoolixClimate : public climate::Climate, public Component {
+ public:
+  CoolixClimate(const std::string &name) : climate::Climate(name) {}
+
+  void setup() override;
+  void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) { this->transmitter_ = transmitter; }
+  void set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
+  void set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat_; }
+
+ protected:
+  /// Override control to change settings of the climate device.
+  void control(const climate::ClimateCall &call) override;
+  /// Return the traits of this controller.
+  climate::ClimateTraits traits() override;
+
+  /// Transmit via IR the state of this climate controller.
+  void transmit_state_();
+
+  void send_data_(remote_base::RemoteTransmitData * transmit_data, uint16_t onemark, uint32_t onespace, uint16_t zeromark,
+                  uint32_t zerospace, uint64_t data, uint16_t nbits,
+                  bool msb_first = true);
+
+  bool supports_cool_{true};
+  bool supports_heat_{true};
+  
+  remote_transmitter::RemoteTransmitterComponent *transmitter_;
+};
+
+}  // namespace coolix
+}  // namespace esphome

--- a/esphome/components/coolix/coolix.h
+++ b/esphome/components/coolix/coolix.h
@@ -5,6 +5,7 @@
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/remote_base/remote_base.h"
 #include "esphome/components/remote_transmitter/remote_transmitter.h"
+#include "esphome/components/sensor/sensor.h"
 
 namespace esphome {
 namespace coolix {
@@ -14,9 +15,12 @@ class CoolixClimate : public climate::Climate, public Component {
   CoolixClimate(const std::string &name) : climate::Climate(name) {}
 
   void setup() override;
-  void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) { this->transmitter_ = transmitter; }
+  void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) { 
+    this->transmitter_ = transmitter;
+  }
   void set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
-  void set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat_; }
+  void set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }
+  void set_sensor(sensor::Sensor *sensor) { this->sensor_ = sensor; }
 
  protected:
   /// Override control to change settings of the climate device.
@@ -27,14 +31,14 @@ class CoolixClimate : public climate::Climate, public Component {
   /// Transmit via IR the state of this climate controller.
   void transmit_state_();
 
-  void send_data_(remote_base::RemoteTransmitData * transmit_data, uint16_t onemark, uint32_t onespace, uint16_t zeromark,
-                  uint32_t zerospace, uint64_t data, uint16_t nbits,
-                  bool msb_first = true);
+  void send_data_(remote_base::RemoteTransmitData * transmit_data, uint16_t onemark, uint32_t onespace,
+                  uint16_t zeromark, uint32_t zerospace, uint64_t data, uint16_t nbits, bool msb_first = true);
 
   bool supports_cool_{true};
   bool supports_heat_{true};
-  
+
   remote_transmitter::RemoteTransmitterComponent *transmitter_;
+  sensor::Sensor *sensor_{nullptr};
 };
 
 }  // namespace coolix

--- a/esphome/components/coolix/coolix.h
+++ b/esphome/components/coolix/coolix.h
@@ -12,8 +12,6 @@ namespace coolix {
 
 class CoolixClimate : public climate::Climate, public Component {
  public:
-  CoolixClimate(const std::string &name) : climate::Climate(name) {}
-
   void setup() override;
   void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) {
     this->transmitter_ = transmitter;

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -881,6 +881,15 @@ remote_transmitter:
   - pin: 32
     carrier_duty_percent: 100%
 
+climate:
+  - platform: coolix
+    name: Coolix Climate With Sensor
+    supports_heat: True
+    supports_cool: True
+    sensor: my_sensor
+  - platform: coolix
+    name: Coolix Climate
+
 switch:
   - platform: gpio
     pin: GPIO25


### PR DESCRIPTION
## Description:
Climate Coolix Infrared remote controller.
I am pushing this one alone, I'll definitely do two more (Tcl and Whirlpool from IRRemoteESP8266) but doing this alone first so I learn more on code styles, get the code reviewed, etc.

Tested functions 
  * OFF / AUTO / COOL, setting temperature from 17 to 30
  * accepts **optional** temperature sensor to display in thermostat card

Sample use:
````yaml
sensor:
  - platform: dht
    pin: D2
    model: DHT22
    temperature:
      name: "Estudio Test Temperature"
      id: estudio_test_dht_temp
    humidity:
      name: "Estudio Test Humidity"
    update_interval: 5s

remote_transmitter:
  carrier_duty_percent: 50%
  pin: D5

climate:
  platform: coolix
  name: 'AC Estudio'
  #sensor: estudio_test_dht_temp
````

**Related issue (if applicable):** 
feature: https://github.com/esphome/feature-requests/issues/24
old PR: https://github.com/esphome/esphome/pull/518

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
