### PR TITLE
Fix compilation of automations

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -55,7 +55,7 @@ template<typename... Ts> class Trigger {
   bool is_running() {
     if (this->automation_parent_ == nullptr)
       return false;
-    return this->automation_parent_.is_running();
+    return this->automation_parent_->is_running();
   }
 
  protected:


### PR DESCRIPTION
## Description:

Automations did not compile due to a missing pointer dereference

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/268 and https://github.com/esphome/issues/issues/266, fixes https://github.com/esphome/issues/issues/300

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
