### PR TITLE
MPU6050 fix temperature reading (wrong datatype)

### DIFF
--- a/esphome/components/mpu6050/mpu6050.cpp
+++ b/esphome/components/mpu6050/mpu6050.cpp
@@ -110,7 +110,7 @@ void MPU6050Component::update() {
   float accel_y = data[1] * MPU6050_RANGE_PER_DIGIT_2G * GRAVITY_EARTH;
   float accel_z = data[2] * MPU6050_RANGE_PER_DIGIT_2G * GRAVITY_EARTH;
 
-  float temperature = raw_data[3] / 340.0f + 36.53f;
+  float temperature = data[3] / 340.0f + 36.53f;
 
   float gyro_x = data[4] * MPU6050_SCALE_DPS_PER_DIGIT_2000;
   float gyro_y = data[5] * MPU6050_SCALE_DPS_PER_DIGIT_2000;


### PR DESCRIPTION

## Description:
changed the temperature values to int16_t like the other values in order to get correct readings https://github.com/esphome/issues/issues/265

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
No added tests because as far as I understand it we don't have tests for subroutines/integrations (yet).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
