### PR TITLE
Fix compilation of my9231 component

### DIFF
--- a/esphome/components/my9231/my9231.h
+++ b/esphome/components/my9231/my9231.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/output/float_output.h"
 
 namespace esphome {


### PR DESCRIPTION
## Description:

missing definition of GPIOPin:
```
In file included from src/esphome/components/my9231/my9231.cpp:1:0:
src/esphome/components/my9231/my9231.h:13:19: error: 'GPIOPin' has not been declared
void set_pin_di(GPIOPin *pin_di) { pin_di_ = pin_di; }
^
src/esphome/components/my9231/my9231.h:14:21: error: 'GPIOPin' has not been declared
void set_pin_dcki(GPIOPin *pin_dcki) { pin_dcki_ = pin_dcki; }
^
src/esphome/components/my9231/my9231.h:51:3: error: 'GPIOPin' does not name a type
GPIOPin *pin_di_;
^
src/esphome/components/my9231/my9231.h:52:3: error: 'GPIOPin' does not name a type
GPIOPin *pin_dcki_;
^
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
