### PR TITLE
Make Climate component work over mqtt

### DIFF
--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -207,11 +207,6 @@ ClimateTraits Climate::get_traits() {
   return traits;
 }
 
-#ifdef USE_MQTT_CLIMATE
-MQTTClimateComponent *Climate::get_mqtt() const { return this->mqtt_; }
-void Climate::set_mqtt(MQTTClimateComponent *mqtt) { this->mqtt_ = mqtt; }
-#endif
-
 void Climate::set_visual_min_temperature_override(float visual_min_temperature_override) {
   this->visual_min_temperature_override_ = visual_min_temperature_override;
 }

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -169,11 +169,6 @@ class Climate : public Nameable {
    */
   ClimateTraits get_traits();
 
-#ifdef USE_MQTT_CLIMATE
-  MQTTClimateComponent *get_mqtt() const;
-  void set_mqtt(MQTTClimateComponent *mqtt);
-#endif
-
   void set_visual_min_temperature_override(float visual_min_temperature_override);
   void set_visual_max_temperature_override(float visual_max_temperature_override);
   void set_visual_temperature_step_override(float visual_temperature_step_override);

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -169,7 +169,7 @@ class Climate : public Nameable {
    */
   ClimateTraits get_traits();
 
-#ifdef USE_MQTT_COVER
+#ifdef USE_MQTT_CLIMATE
   MQTTClimateComponent *get_mqtt() const;
   void set_mqtt(MQTTClimateComponent *mqtt);
 #endif

--- a/esphome/components/climate/climate_mode.cpp
+++ b/esphome/components/climate/climate_mode.cpp
@@ -6,13 +6,13 @@ namespace climate {
 const char *climate_mode_to_string(ClimateMode mode) {
   switch (mode) {
     case CLIMATE_MODE_OFF:
-      return "OFF";
+      return "off";
     case CLIMATE_MODE_AUTO:
-      return "AUTO";
+      return "auto";
     case CLIMATE_MODE_COOL:
-      return "COOL";
+      return "cool";
     case CLIMATE_MODE_HEAT:
-      return "HEAT";
+      return "heat";
     default:
       return "UNKNOWN";
   }

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -60,6 +60,8 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
     // away_mode_state_topic
     root["away_mode_state_topic"] = this->get_away_state_topic();
   }
+  config.state_topic = false;
+  config.command_topic = false;
 }
 void MQTTClimateComponent::setup() {
   auto traits = this->device_->get_traits();
@@ -144,7 +146,7 @@ bool MQTTClimateComponent::publish_state_() {
   if (!this->publish(this->get_mode_state_topic(), mode_s))
     success = false;
   int8_t accuracy = traits.get_temperature_accuracy_decimals();
-  if (traits.get_supports_current_temperature()) {
+  if (traits.get_supports_current_temperature() && !isnan(this->device_->current_temperature)) {
     std::string payload = value_accuracy_to_string(this->device_->current_temperature, accuracy);
     if (!this->publish(this->get_current_temperature_state_topic(), payload))
       success = false;

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -24,12 +24,12 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
   JsonArray &modes = root.createNestedArray("modes");
   // sort array for nice UI in HA
   if (traits.supports_mode(CLIMATE_MODE_AUTO))
-    modes.add("auto");
-  modes.add("off");
+    modes.add(climate_mode_to_string(CLIMATE_MODE_AUTO));
+  modes.add(climate_mode_to_string(CLIMATE_MODE_OFF));
   if (traits.supports_mode(CLIMATE_MODE_COOL))
-    modes.add("cool");
+    modes.add(climate_mode_to_string(CLIMATE_MODE_COOL));
   if (traits.supports_mode(CLIMATE_MODE_HEAT))
-    modes.add("heat");
+    modes.add(climate_mode_to_string(CLIMATE_MODE_HEAT));
 
   if (traits.get_supports_two_point_target_temperature()) {
     // temperature_low_command_topic


### PR DESCRIPTION
## Description:

Moved from esphome-core (esphome/esphome-core#584) to esphome.

HA require the same spelling case for mode (discovery and state).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
