### PR TITLE
Revert HLW8012 to use pulse counter

### DIFF
--- a/esphome/components/hlw8012/hlw8012.h
+++ b/esphome/components/hlw8012/hlw8012.h
@@ -3,7 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/esphal.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/pulse_width/pulse_width.h"
+#include "esphome/components/pulse_counter/pulse_counter_sensor.h"
 
 namespace esphome {
 namespace hlw8012 {
@@ -34,9 +34,9 @@ class HLW8012Component : public PollingComponent {
   float voltage_divider_{2351};
   GPIOPin *sel_pin_;
   GPIOPin *cf_pin_;
-  pulse_width::PulseWidthSensorStore cf_store_;
+  pulse_counter::PulseCounterStorage cf_store_;
   GPIOPin *cf1_pin_;
-  pulse_width::PulseWidthSensorStore cf1_store_;
+  pulse_counter::PulseCounterStorage cf1_store_;
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};

--- a/esphome/components/hlw8012/sensor.py
+++ b/esphome/components/hlw8012/sensor.py
@@ -6,7 +6,7 @@ from esphome.const import CONF_CHANGE_MODE_EVERY, CONF_CURRENT, \
     CONF_CURRENT_RESISTOR, CONF_ID, CONF_POWER, CONF_SEL_PIN, CONF_VOLTAGE, CONF_VOLTAGE_DIVIDER, \
     ICON_FLASH, UNIT_VOLT, UNIT_AMPERE, UNIT_WATT
 
-AUTO_LOAD = ['pulse_width']
+AUTO_LOAD = ['pulse_counter']
 
 hlw8012_ns = cg.esphome_ns.namespace('hlw8012')
 HLW8012Component = hlw8012_ns.class_('HLW8012Component', cg.PollingComponent)

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -28,7 +28,9 @@ void ICACHE_RAM_ATTR PulseCounterStorage::gpio_intr(PulseCounterStorage *arg) {
       break;
   }
 }
-bool PulseCounterStorage::pulse_counter_setup() {
+bool PulseCounterStorage::pulse_counter_setup(GPIOPin *pin) {
+  this->pin = pin;
+  this->pin->setup();
   this->isr_pin = this->pin->to_isr();
   this->pin->attach_interrupt(PulseCounterStorage::gpio_intr, this, CHANGE);
   return true;
@@ -42,7 +44,9 @@ pulse_counter_t PulseCounterStorage::read_raw_value() {
 #endif
 
 #ifdef ARDUINO_ARCH_ESP32
-bool PulseCounterStorage::pulse_counter_setup() {
+bool PulseCounterStorage::pulse_counter_setup(GPIOPin *pin) {
+  this->pin = pin;
+  this->pin->setup();
   this->pcnt_unit = next_pcnt_unit;
   next_pcnt_unit = pcnt_unit_t(int(next_pcnt_unit) + 1);  // NOLINT
 
@@ -133,9 +137,7 @@ pulse_counter_t PulseCounterStorage::read_raw_value() {
 
 void PulseCounterSensor::setup() {
   ESP_LOGCONFIG(TAG, "Setting up pulse counter '%s'...", this->name_.c_str());
-  this->pin_->setup();
-  this->storage_.pin = this->pin_;
-  if (!this->storage_.pulse_counter_setup()) {
+  if (!this->storage_.pulse_counter_setup(this->pin_)) {
     this->mark_failed();
     return;
   }

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -25,7 +25,7 @@ using pulse_counter_t = int32_t;
 #endif
 
 struct PulseCounterStorage {
-  bool pulse_counter_setup();
+  bool pulse_counter_setup(GPIOPin *pin);
   pulse_counter_t read_raw_value();
 
   static void gpio_intr(PulseCounterStorage *arg);
@@ -42,9 +42,9 @@ struct PulseCounterStorage {
 #ifdef ARDUINO_ARCH_ESP8266
   ISRInternalGPIOPin *isr_pin;
 #endif
-  PulseCounterCountMode rising_edge_mode{};
-  PulseCounterCountMode falling_edge_mode{};
-  uint32_t filter_us{};
+  PulseCounterCountMode rising_edge_mode{PULSE_COUNTER_INCREMENT};
+  PulseCounterCountMode falling_edge_mode{PULSE_COUNTER_DISABLE};
+  uint32_t filter_us{0};
   pulse_counter_t last_value{0};
 };
 


### PR DESCRIPTION
## Description:

Pulse width didn't work for some reason - Idea was to get better accuracy over calculating via pulse width, but didn't work.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
