### PR TITLE
Auto-Generate esphome.h

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -266,7 +266,7 @@ def write_platformio_project():
     write_platformio_ini(content)
 
 
-DEFINES_H_FORMAT = u"""\
+DEFINES_H_FORMAT = ESPHOME_H_FORMAT = u"""\
 #pragma once
 {}
 """
@@ -301,7 +301,7 @@ def copy_src_tree():
     source_files_l = [it for it in source_files.items()]
     source_files_l.sort()
 
-    # Build #include list for main.cpp
+    # Build #include list for esphome.h
     include_l = []
     for target, path in source_files_l:
         if os.path.splitext(path)[1] in HEADER_FILE_EXTENSIONS:
@@ -341,8 +341,8 @@ def copy_src_tree():
                           CORE.relative_src_path('esphome', 'core', 'defines.h'))
     write_file_if_changed(ESPHOME_README_TXT,
                           CORE.relative_src_path('esphome', 'README.txt'))
-
-    return include_s
+    write_file_if_changed(ESPHOME_H_FORMAT.format(include_s),
+                          CORE.relative_src_path('esphome.h'))
 
 
 def generate_defines_h():
@@ -361,8 +361,8 @@ def write_cpp(code_s):
     else:
         code_format = CPP_BASE_FORMAT
 
-    include_s = copy_src_tree()
-    global_s = include_s + u'\n'
+    copy_src_tree()
+    global_s = u'#include "esphome.h"\n'
     global_s += CORE.cpp_global_section
 
     full_file = code_format[0] + CPP_INCLUDE_BEGIN + u'\n' + global_s + CPP_INCLUDE_END

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -53,6 +53,13 @@ for f in files:
     if content and not content.endswith('\n'):
         errors[f].append("File does not end with a newline, please add an empty line at the end of "
                          "the file.")
+    _, ext = os.path.splitext(f)
+    if ext in ('.h', '.c', '.cpp', '.tcc'):
+        for line, col in find_all(content, '"esphome.h"'):
+            errors[f].append("File contains reference to 'esphome.h' - This file is "
+                             "auto-generated and should only be used for *custom* "
+                             "components. Please replace with references to the direct "
+                             "files.")
 
 for f, errs in errors.items():
     print("\033[0;32m************* File \033[1;32m{}\033[0m".format(f))

--- a/tests/custom.h
+++ b/tests/custom.h
@@ -1,3 +1,4 @@
+#include "esphome.h"
 
 class CustomSensor : public Component, public Sensor {
  public:


### PR DESCRIPTION
## Description:

For custom components - they can now include `esphome.h` for including everything in esphome.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
