### PR TITLE
Suggested fix for empty domain

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -452,6 +452,8 @@ def validate_config(config):
         # Ensure conf is a list
         if not isinstance(conf, list) and conf:
             result[domain] = conf = [conf]
+        elif not conf:
+            result[domain] = conf = []
 
         for i, p_config in enumerate(conf):
             path = [domain, i]

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -450,10 +450,10 @@ def validate_config(config):
         result.remove_output_path([domain], domain)
 
         # Ensure conf is a list
-        if not isinstance(conf, list) and conf:
-            result[domain] = conf = [conf]
-        elif not conf:
+        if not conf:
             result[domain] = conf = []
+        elif not isinstance(conf, list):
+            result[domain] = conf = [conf]
 
         for i, p_config in enumerate(conf):
             path = [domain, i]

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -238,3 +238,6 @@ interval:
   interval: 5s
   then:
     - logger.log: "Interval Run"
+
+display:
+


### PR DESCRIPTION
**Operating environment/Installation (Hass.io/Docker/pip/etc.):**
Any

**ESP (ESP32/ESP8266, Board/Sonoff):**
Any

**Affected component:**
Config validation 

**Description of problem:**
If an empty platform is supplied via config, esphome crashes with the following error. This PR fixes that and adds a test to check this wont happen again.

**Problem-relevant YAML-configuration entries:**
```yaml
# ...
display:
  # empty

custom_component:
  - # irrelevant
# ...
```

**Traceback (if applicable):**
```
INFO Reading configuration...
display None
ERROR Unexpected exception while reading configuration:
Traceback (most recent call last):
  File "/REDACTED/bin/esphome", line 10, in <module>
    sys.exit(main())
  File "/REDACTED/lib/python2.7/site-packages/esphome/__main__.py", line 480, in main
    return run_esphome(sys.argv)
  File "/REDACTED/lib/python2.7/site-packages/esphome/__main__.py", line 463, in run_esphome
    config = read_config(args.verbose)
  File "/REDACTED/lib/python2.7/site-packages/esphome/config.py", line 791, in read_config
    res = load_config()
  File "/REDACTED/lib/python2.7/site-packages/esphome/config.py", line 651, in load_config
    return _load_config()
  File "/REDACTED/lib/python2.7/site-packages/esphome/config.py", line 639, in _load_config
    result = validate_config(config)
  File "/REDACTED/lib/python2.7/site-packages/esphome/config.py", line 456, in validate_config
    for i, p_config in enumerate(conf):
TypeError: 'NoneType' object is not iterable
```

**Additional information and things you've tried:**
The `display None` thing in the log is addition is my debug print.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
