### PR TITLE
added download, edit and retry buttons to upload modal

### DIFF
--- a/esphome/dashboard/static/esphome.js
+++ b/esphome/dashboard/static/esphome.js
@@ -412,21 +412,21 @@ const downloadAfterUploadButton = document.querySelector('.download-after-upload
 const uploadModal = new LogModalElem({
   name: 'upload',
   onPrepare: (modalElem, config) => {
-    retryUploadButton.setAttribute('data-node', uploadModal.activeConfig);
-    retryUploadButton.classList.add('hide');
-    editAfterUploadButton.setAttribute('data-node', uploadModal.activeConfig);
-    downloadAfterUploadButton.classList.remove('hide');
     downloadAfterUploadButton.classList.add('disabled');
+    retryUploadButton.setAttribute('data-node', uploadModal.activeConfig);
+    retryUploadButton.classList.add('disabled');
+    editAfterUploadButton.setAttribute('data-node', uploadModal.activeConfig);
     modalElem.querySelector(".stop-logs").innerHTML = "Stop";
   },
   onProcessExit: (modalElem, code) => {
     if (code === 0) {
       M.toast({html: "Program exited successfully."});
+      // if compilation succeeds but OTA fails, you can still download the binary and upload manually
       downloadAfterUploadButton.classList.remove('disabled');
     } else {
       M.toast({html: `Program failed with code ${code}`});
-      downloadAfterUploadButton.classList.add('hide');
-      retryUploadButton.classList.remove('hide');
+      downloadAfterUploadButton.classList.add('disabled');
+      retryUploadButton.classList.remove('disabled');
     }
     modalElem.querySelector(".stop-logs").innerHTML = "Close";
   },

--- a/esphome/dashboard/static/esphome.js
+++ b/esphome/dashboard/static/esphome.js
@@ -606,6 +606,12 @@ const startAceWebsocket = () => {
 
         editor.session.setAnnotations(arr);
 
+        if(arr.length) {
+          saveUploadButton.classList.add('disabled');
+        } else {
+          saveUploadButton.classList.remove('disabled');
+        }
+
         aceValidationRunning = false;
       } else if (msg.type === "read_file") {
         sendAceStdin({
@@ -640,7 +646,7 @@ editor.session.setOption('tabSize', 2);
 editor.session.setOption('useWorker', false);
 
 const saveButton = editModalElem.querySelector(".save-button");
-const saveValidateButton = editModalElem.querySelector(".save-validate-button");
+const saveUploadButton = editModalElem.querySelector(".save-upload-button");
 const saveEditor = () => {
   fetch(`./edit?configuration=${activeEditorConfig}`, {
       credentials: "same-origin",
@@ -692,14 +698,14 @@ setInterval(() => {
 }, 100);
 
 saveButton.addEventListener('click', saveEditor);
-saveValidateButton.addEventListener('click', saveEditor);
+saveUploadButton.addEventListener('click', saveEditor);
 
 document.querySelectorAll(".action-edit").forEach((btn) => {
   btn.addEventListener('click', (e) => {
     activeEditorConfig = e.target.getAttribute('data-node');
     const modalInstance = M.Modal.getInstance(editModalElem);
     const filenameField = editModalElem.querySelector('.filename');
-    editModalElem.querySelector(".save-validate-button").setAttribute('data-node', activeEditorConfig);
+    editModalElem.querySelector(".save-upload-button").setAttribute('data-node', activeEditorConfig);
     filenameField.innerHTML = activeEditorConfig;
 
     fetch(`./edit?configuration=${activeEditorConfig}`, {credentials: "same-origin"})

--- a/esphome/dashboard/static/esphome.js
+++ b/esphome/dashboard/static/esphome.js
@@ -406,16 +406,27 @@ const logsModal = new LogModalElem({
 });
 logsModal.setup();
 
+const retryUploadButton = document.querySelector('.retry-upload');
+const editAfterUploadButton = document.querySelector('.edit-after-upload');
+const downloadAfterUploadButton = document.querySelector('.download-after-upload');
 const uploadModal = new LogModalElem({
   name: 'upload',
   onPrepare: (modalElem, config) => {
+    retryUploadButton.setAttribute('data-node', uploadModal.activeConfig);
+    retryUploadButton.classList.add('hide');
+    editAfterUploadButton.setAttribute('data-node', uploadModal.activeConfig);
+    downloadAfterUploadButton.classList.remove('hide');
+    downloadAfterUploadButton.classList.add('disabled');
     modalElem.querySelector(".stop-logs").innerHTML = "Stop";
   },
   onProcessExit: (modalElem, code) => {
     if (code === 0) {
       M.toast({html: "Program exited successfully."});
+      downloadAfterUploadButton.classList.remove('disabled');
     } else {
       M.toast({html: `Program failed with code ${code}`});
+      downloadAfterUploadButton.classList.add('hide');
+      retryUploadButton.classList.remove('hide');
     }
     modalElem.querySelector(".stop-logs").innerHTML = "Close";
   },
@@ -425,6 +436,14 @@ const uploadModal = new LogModalElem({
   dismissible: false,
 });
 uploadModal.setup();
+downloadAfterUploadButton.addEventListener('click', () => {
+  const link = document.createElement("a");
+  link.download = name;
+  link.href = `./download.bin?configuration=${encodeURIComponent(uploadModal.activeConfig)}`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+});
 
 const validateModal = new LogModalElem({
   name: 'validate',

--- a/esphome/dashboard/templates/index.html
+++ b/esphome/dashboard/templates/index.html
@@ -121,11 +121,14 @@
        class="tooltipped" data-position="left" data-tooltip="Flash using esphomeflasher" rel="noreferrer">
       <i class="material-icons flash-using-esphomeflasher">help_outline</i>
     </a>
-    <a class="modal-close waves-effect waves-green btn-flat disabled download-after-upload">Download Binary</a>
-    <a class="waves-effect waves-green btn-flat disabled action-upload retry-upload">Retry</a>
-    <a class="modal-close waves-effect waves-green btn-flat action-edit edit-after-upload">Edit</a>
     <a class="modal-close waves-effect waves-green btn-flat stop-logs">Stop</a>
+    <div class="btn-flat"><i class="material-icons dropdown-trigger" data-target="dropdown-upload-actions">more_vert</i></div>
   </div>
+  <ul id="dropdown-upload-actions" class="select-action dropdown-content card-dropdown-action">
+    <li><a class="modal-close waves-effect waves-green btn-flat action-edit edit-after-upload">Edit</a></li>
+    <li><a class="modal-close waves-effect waves-green btn-flat disabled download-after-upload">Download Binary</a></li>
+    <li><a class="waves-effect waves-green btn-flat disabled action-upload retry-upload">Retry</a></li>
+  </ul>
 </div>
 
 <div id="modal-compile" class="modal modal-fixed-footer">

--- a/esphome/dashboard/templates/index.html
+++ b/esphome/dashboard/templates/index.html
@@ -121,6 +121,9 @@
        class="tooltipped" data-position="left" data-tooltip="Flash using esphomeflasher" rel="noreferrer">
       <i class="material-icons flash-using-esphomeflasher">help_outline</i>
     </a>
+    <a class="modal-close waves-effect waves-green btn-flat disabled download-after-upload">Download Binary</a>
+    <a class="modal-close waves-effect waves-green btn-flat action-edit edit-after-upload">Edit</a>
+    <a class="waves-effect waves-green btn-flat hide action-upload retry-upload">Retry</a>
     <a class="modal-close waves-effect waves-green btn-flat stop-logs">Stop</a>
   </div>
 </div>

--- a/esphome/dashboard/templates/index.html
+++ b/esphome/dashboard/templates/index.html
@@ -121,11 +121,11 @@
        class="tooltipped" data-position="left" data-tooltip="Flash using esphomeflasher" rel="noreferrer">
       <i class="material-icons flash-using-esphomeflasher">help_outline</i>
     </a>
+    <a class="modal-close waves-effect waves-green btn-flat action-edit edit-after-upload">Edit</a>
     <a class="modal-close waves-effect waves-green btn-flat stop-logs">Stop</a>
     <div class="btn-flat"><i class="material-icons dropdown-trigger" data-target="dropdown-upload-actions">more_vert</i></div>
   </div>
   <ul id="dropdown-upload-actions" class="select-action dropdown-content card-dropdown-action">
-    <li><a class="modal-close waves-effect waves-green btn-flat action-edit edit-after-upload">Edit</a></li>
     <li><a class="modal-close waves-effect waves-green btn-flat disabled download-after-upload">Download Binary</a></li>
     <li><a class="waves-effect waves-green btn-flat disabled action-upload retry-upload">Retry</a></li>
   </ul>
@@ -437,7 +437,7 @@
   </div>
   <div class="modal-footer">
     <a class="waves-effect waves-green btn-flat save-button">Save</a>
-    <a class="modal-close waves-effect waves-green btn-flat action-validate save-validate-button">Save &amp; Validate</a>
+    <a class="modal-close waves-effect waves-green btn-flat action-upload save-upload-button">Save &amp; Upload</a>
     <a class="modal-close waves-effect waves-green btn-flat">Close</a>
   </div>
 </div>

--- a/esphome/dashboard/templates/index.html
+++ b/esphome/dashboard/templates/index.html
@@ -122,8 +122,8 @@
       <i class="material-icons flash-using-esphomeflasher">help_outline</i>
     </a>
     <a class="modal-close waves-effect waves-green btn-flat disabled download-after-upload">Download Binary</a>
+    <a class="waves-effect waves-green btn-flat disabled action-upload retry-upload">Retry</a>
     <a class="modal-close waves-effect waves-green btn-flat action-edit edit-after-upload">Edit</a>
-    <a class="waves-effect waves-green btn-flat hide action-upload retry-upload">Retry</a>
     <a class="modal-close waves-effect waves-green btn-flat stop-logs">Stop</a>
   </div>
 </div>


### PR DESCRIPTION
## Description:
After a failed upload, the following options are usually taken:
- Download the bin file and upload it manually (OTA not possible, network issues, ...)
- Edit the config yaml
- Retry upload
I added buttons for these options to the upload modal. On thing to note is that, when checking if the upload succeeded, only compilation is taken into consideration at the moment, not the actual upload. I think this could be improved, then also button display can be finetuned to the error that actually occurred.

**Related issue (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).