### PR TITLE
Correctly set warm white variables

### DIFF
--- a/esphome/components/cwww/cwww_light_output.h
+++ b/esphome/components/cwww/cwww_light_output.h
@@ -20,7 +20,7 @@ class CWWWLightOutput : public light::LightOutput {
     traits.set_supports_rgb_white_value(false);
     traits.set_supports_color_temperature(true);
     traits.set_min_mireds(this->cold_white_temperature_);
-    traits.set_min_mireds(this->warm_white_temperature_);
+    traits.set_max_mireds(this->warm_white_temperature_);
     return traits;
   }
   void write_state(light::LightState *state) override {

--- a/esphome/components/rgbww/light.py
+++ b/esphome/components/rgbww/light.py
@@ -37,4 +37,4 @@ def to_code(config):
 
     wwhite = yield cg.get_variable(config[CONF_WARM_WHITE])
     cg.add(var.set_warm_white(wwhite))
-    cg.add(var.set_warm_white_temperature(config[CONF_COLD_WHITE_COLOR_TEMPERATURE]))
+    cg.add(var.set_warm_white_temperature(config[CONF_WARM_WHITE_COLOR_TEMPERATURE]))

--- a/esphome/components/rgbww/rgbww_light_output.h
+++ b/esphome/components/rgbww/rgbww_light_output.h
@@ -23,7 +23,7 @@ class RGBWWLightOutput : public light::LightOutput {
     traits.set_supports_rgb_white_value(true);
     traits.set_supports_color_temperature(true);
     traits.set_min_mireds(this->cold_white_temperature_);
-    traits.set_min_mireds(this->warm_white_temperature_);
+    traits.set_max_mireds(this->warm_white_temperature_);
     return traits;
   }
   void write_state(light::LightState *state) override {


### PR DESCRIPTION
## Description:
Correctly sets the max_mireds (warm white) color for cwww and rgbwww lights

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
