### PR TITLE
Add backlight handling for lcd_pcf8574

### DIFF
--- a/esphome/components/lcd_base/__init__.py
+++ b/esphome/components/lcd_base/__init__.py
@@ -1,12 +1,11 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import display
-from esphome.const import CONF_DIMENSIONS, CONF_LAMBDA
+from esphome.const import CONF_DIMENSIONS
 from esphome.core import coroutine
 
 lcd_base_ns = cg.esphome_ns.namespace('lcd_base')
 LCDDisplay = lcd_base_ns.class_('LCDDisplay', cg.PollingComponent)
-LCDDisplayRef = LCDDisplay.operator('ref')
 
 
 def validate_lcd_dimensions(value):
@@ -28,8 +27,3 @@ def setup_lcd_display(var, config):
     yield cg.register_component(var, config)
     yield display.register_display(var, config)
     cg.add(var.set_dimensions(config[CONF_DIMENSIONS][0], config[CONF_DIMENSIONS][1]))
-
-    if CONF_LAMBDA in config:
-        lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], [(LCDDisplayRef, 'it')],
-                                          return_type=cg.void)
-        cg.add(var.set_writer(lambda_))

--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -107,7 +107,7 @@ void LCDDisplay::update() {
   for (uint8_t i = 0; i < this->rows_ * this->columns_; i++)
     this->buffer_[i] = ' ';
 
-  this->writer_(*this);
+  this->call_writer();
   this->display();
 }
 void LCDDisplay::command_(uint8_t value) { this->send(value, false); }

--- a/esphome/components/lcd_base/lcd_display.h
+++ b/esphome/components/lcd_base/lcd_display.h
@@ -12,11 +12,8 @@ namespace lcd_base {
 
 class LCDDisplay;
 
-using lcd_writer_t = std::function<void(LCDDisplay &)>;
-
 class LCDDisplay : public PollingComponent {
  public:
-  void set_writer(lcd_writer_t &&writer) { this->writer_ = std::move(writer); }
   void set_dimensions(uint8_t columns, uint8_t rows) {
     this->columns_ = columns;
     this->rows_ = rows;
@@ -54,11 +51,11 @@ class LCDDisplay : public PollingComponent {
   virtual void send(uint8_t value, bool rs) = 0;
 
   void command_(uint8_t value);
+  virtual void call_writer() = 0;
 
   uint8_t columns_;
   uint8_t rows_;
   uint8_t *buffer_{nullptr};
-  lcd_writer_t writer_;
 };
 
 }  // namespace lcd_base

--- a/esphome/components/lcd_gpio/display.py
+++ b/esphome/components/lcd_gpio/display.py
@@ -2,7 +2,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import lcd_base
-from esphome.const import CONF_DATA_PINS, CONF_ENABLE_PIN, CONF_RS_PIN, CONF_RW_PIN, CONF_ID
+from esphome.const import CONF_DATA_PINS, CONF_ENABLE_PIN, CONF_RS_PIN, CONF_RW_PIN, CONF_ID, \
+    CONF_LAMBDA
 
 AUTO_LOAD = ['lcd_base']
 
@@ -42,3 +43,9 @@ def to_code(config):
     if CONF_RW_PIN in config:
         rw = yield cg.gpio_pin_expression(config[CONF_RW_PIN])
         cg.add(var.set_rw_pin(rw))
+
+    if CONF_LAMBDA in config:
+        lambda_ = yield cg.process_lambda(config[CONF_LAMBDA],
+                                          [(GPIOLCDDisplay.operator('ref'), 'it')],
+                                          return_type=cg.void)
+        cg.add(var.set_writer(lambda_))

--- a/esphome/components/lcd_gpio/gpio_lcd_display.h
+++ b/esphome/components/lcd_gpio/gpio_lcd_display.h
@@ -8,6 +8,7 @@ namespace lcd_gpio {
 
 class GPIOLCDDisplay : public lcd_base::LCDDisplay {
  public:
+  void set_writer(std::function<void(GPIOLCDDisplay &)> &&writer) { this->writer_ = std::move(writer); }
   void setup() override;
   void set_data_pins(GPIOPin *d0, GPIOPin *d1, GPIOPin *d2, GPIOPin *d3) {
     this->data_pins_[0] = d0;
@@ -36,10 +37,13 @@ class GPIOLCDDisplay : public lcd_base::LCDDisplay {
   void write_n_bits(uint8_t value, uint8_t n) override;
   void send(uint8_t value, bool rs) override;
 
+  void call_writer() override { this->writer_(*this); }
+
   GPIOPin *rs_pin_{nullptr};
   GPIOPin *rw_pin_{nullptr};
   GPIOPin *enable_pin_{nullptr};
   GPIOPin *data_pins_[8]{nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  std::function<void(GPIOLCDDisplay &)> writer_;
 };
 
 }  // namespace lcd_gpio

--- a/esphome/components/lcd_pcf8574/display.py
+++ b/esphome/components/lcd_pcf8574/display.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import lcd_base, i2c
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_LAMBDA
 
 DEPENDENCIES = ['i2c']
 AUTO_LOAD = ['lcd_base']
@@ -18,3 +18,9 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield lcd_base.setup_lcd_display(var, config)
     yield i2c.register_i2c_device(var, config)
+
+    if CONF_LAMBDA in config:
+        lambda_ = yield cg.process_lambda(config[CONF_LAMBDA],
+                                          [(PCF8574LCDDisplay.operator('ref'), 'it')],
+                                          return_type=cg.void)
+        cg.add(var.set_writer(lambda_))

--- a/esphome/components/lcd_pcf8574/pcf8574_display.cpp
+++ b/esphome/components/lcd_pcf8574/pcf8574_display.cpp
@@ -6,9 +6,13 @@ namespace lcd_pcf8574 {
 
 static const char *TAG = "lcd_pcf8574";
 
+static const uint8_t LCD_DISPLAY_BACKLIGHT_ON = 0x08;
+static const uint8_t LCD_DISPLAY_BACKLIGHT_OFF = 0x00;
+
 void PCF8574LCDDisplay::setup() {
   ESP_LOGCONFIG(TAG, "Setting up PCF8574 LCD Display...");
-  if (!this->write_bytes(0x08, nullptr, 0)) {
+  this->backlight_value_ = LCD_DISPLAY_BACKLIGHT_ON;
+  if (!this->write_bytes(this->backlight_value_, nullptr, 0)) {
     this->mark_failed();
     return;
   }
@@ -29,7 +33,7 @@ void PCF8574LCDDisplay::write_n_bits(uint8_t value, uint8_t n) {
     // Ugly fix: in the super setup() with n == 4 value needs to be shifted left
     value <<= 4;
   }
-  uint8_t data = value | 0x08;  // Enable backlight
+  uint8_t data = value | this->backlight_value_;  // Set backlight state
   this->write_bytes(data, nullptr, 0);
   // Pulse ENABLE
   this->write_bytes(data | 0x04, nullptr, 0);
@@ -40,6 +44,14 @@ void PCF8574LCDDisplay::write_n_bits(uint8_t value, uint8_t n) {
 void PCF8574LCDDisplay::send(uint8_t value, bool rs) {
   this->write_n_bits((value & 0xF0) | rs, 0);
   this->write_n_bits(((value << 4) & 0xF0) | rs, 0);
+}
+void PCF8574LCDDisplay::backlight() {
+  this->backlight_value_ = LCD_DISPLAY_BACKLIGHT_ON;
+  this->write_bytes(this->backlight_value_, nullptr, 0);
+}
+void PCF8574LCDDisplay::no_backlight() {
+  this->backlight_value_ = LCD_DISPLAY_BACKLIGHT_OFF;
+  this->write_bytes(this->backlight_value_, nullptr, 0);
 }
 
 }  // namespace lcd_pcf8574

--- a/esphome/components/lcd_pcf8574/pcf8574_display.h
+++ b/esphome/components/lcd_pcf8574/pcf8574_display.h
@@ -11,11 +11,16 @@ class PCF8574LCDDisplay : public lcd_base::LCDDisplay, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
+  void backlight();
+  void no_backlight();
 
  protected:
   bool is_four_bit_mode() override { return true; }
   void write_n_bits(uint8_t value, uint8_t n) override;
   void send(uint8_t value, bool rs) override;
+
+  // Stores the current state of the backlight.
+  uint8_t backlight_value_;
 };
 
 }  // namespace lcd_pcf8574

--- a/esphome/components/lcd_pcf8574/pcf8574_display.h
+++ b/esphome/components/lcd_pcf8574/pcf8574_display.h
@@ -9,6 +9,7 @@ namespace lcd_pcf8574 {
 
 class PCF8574LCDDisplay : public lcd_base::LCDDisplay, public i2c::I2CDevice {
  public:
+  void set_writer(std::function<void(PCF8574LCDDisplay &)> &&writer) { this->writer_ = std::move(writer); }
   void setup() override;
   void dump_config() override;
   void backlight();
@@ -19,8 +20,11 @@ class PCF8574LCDDisplay : public lcd_base::LCDDisplay, public i2c::I2CDevice {
   void write_n_bits(uint8_t value, uint8_t n) override;
   void send(uint8_t value, bool rs) override;
 
+  void call_writer() override { this->writer_(*this); }
+
   // Stores the current state of the backlight.
   uint8_t backlight_value_;
+  std::function<void(PCF8574LCDDisplay &)> writer_;
 };
 
 }  // namespace lcd_pcf8574


### PR DESCRIPTION
Switch the backlight on or off in the display lambda with
it.backlight() and it.no_backlight().

## Description:

I moved my display node from my home brew firmware to ESPHome and this is a missing functionality for me. I also saw it requested by others (see related issue). This is my first pull request here, so please let me know if something doesn't look good.

I adopted the usual Arduino library function names of `backlight()` and `noBacklight()` (changed to `no_backlight()` to fit the coding style guide) that are used to control backlight in other LCD libraries.

Also I want to say thank you for the ESPHome project, it's super nice and well thought out, especially the integration with Home Assistant. I'm in awe how easy it was to re-implement most of my nodes with just a few lines of yaml.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/160

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** The lcd commands are not really documented in the [lcd_display](https://esphome.io/components/display/lcd_display.html) section, so I didn't want to start adding the backlight ones now.

## Checklist:
  - [x] The code change is tested and works locally. (I have a small yaml where I can trigger the backlight on/off with a button and the node keeps working after.)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). -- I'm not sure this is necessary, but let me know if I should add an `it.no_backlight();` [here](https://github.com/esphome/esphome/blob/1ce257c721f454d492bf60eb980f197f88fd7b06/tests/test1.yaml#L1130)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). https://github.com/esphome/esphome-docs/pull/261