### PR TITLE
List the correct boards when building for ESP32

### DIFF
--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -38,7 +38,7 @@ def validate_board(value):
 
     if value not in board_pins:
         raise cv.Invalid(u"Could not find board '{}'. Valid boards are {}".format(
-            value, u', '.join(board_pins.keys())))
+            value, u', '.join(sorted(board_pins.keys()))))
     return value
 
 

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -38,7 +38,7 @@ def validate_board(value):
 
     if value not in board_pins:
         raise cv.Invalid(u"Could not find board '{}'. Valid boards are {}".format(
-            value, u', '.join(pins.ESP8266_BOARD_PINS.keys())))
+            value, u', '.join(board_pins.keys())))
     return value
 
 


### PR DESCRIPTION
## Description:
The error message shown listing the valid boards only shows the ESP8266 boards, which is incorrect when building for ESP32. This also sorts the list of boards.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).
    => does not apply, this only changes an error message

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
