### PR TITLE
Fix addressable effects

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -85,8 +85,46 @@ ESPColorView ESPRangeView::operator[](int32_t index) const {
   index = interpret_index(index, this->size());
   return (*this->parent_)[index];
 }
+ESPRangeIterator ESPRangeView::begin() { return {*this, this->begin_}; }
+ESPRangeIterator ESPRangeView::end() { return {*this, this->end_}; }
+void ESPRangeView::set_red(uint8_t red) {
+  for (auto c : *this)
+    c.set_red(red);
+}
+void ESPRangeView::set_green(uint8_t green) {
+  for (auto c : *this)
+    c.set_green(green);
+}
+void ESPRangeView::set_blue(uint8_t blue) {
+  for (auto c : *this)
+    c.set_blue(blue);
+}
+void ESPRangeView::set_white(uint8_t white) {
+  for (auto c : *this)
+    c.set_white(white);
+}
+void ESPRangeView::set_effect_data(uint8_t effect_data) {
+  for (auto c : *this)
+    c.set_effect_data(effect_data);
+}
+void ESPRangeView::fade_to_white(uint8_t amnt) {
+  for (auto c : *this)
+    c.fade_to_white(amnt);
+}
+void ESPRangeView::fade_to_black(uint8_t amnt) {
+  for (auto c : *this)
+    c.fade_to_white(amnt);
+}
+void ESPRangeView::lighten(uint8_t delta) {
+  for (auto c : *this)
+    c.lighten(delta);
+}
+void ESPRangeView::darken(uint8_t delta) {
+  for (auto c : *this)
+    c.darken(delta);
+}
 
-ESPColorView ESPRangeView::Iterator::operator*() const { return (*this->range_->parent_)[this->i_]; }
+ESPColorView ESPRangeIterator::operator*() const { return this->range_.parent_->get(this->i_); }
 
 int32_t HOT interpret_index(int32_t index, int32_t size) {
   if (index < 0)

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -308,14 +308,15 @@ class AddressableFlickerEffect : public AddressableLightEffect {
   explicit AddressableFlickerEffect(const std::string &name) : AddressableLightEffect(name) {}
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     const uint32_t now = millis();
-    const uint8_t delta_intensity = 255 - this->intensity_;
+    const uint8_t intensity = this->intensity_;
+    const uint8_t inv_intensity = 255 - intensity;
     if (now - this->last_update_ < this->update_interval_)
       return;
     this->last_update_ = now;
     fast_random_set_seed(random_uint32());
     for (auto var : it) {
-      const uint8_t flicker = fast_random_8() % this->intensity_;
-      var = (var.get() * delta_intensity) + (current_color * flicker);
+      const uint8_t flicker = fast_random_8() % intensity;
+      var = (var.get() * inv_intensity) + (current_color * flicker);
     }
   }
   void set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -476,6 +476,7 @@ void WiFiComponent::wifi_scan_done_callback_(void *arg, STATUS status) {
 
   if (status != OK) {
     ESP_LOGV(TAG, "Scan failed! %d", status);
+    this->retry_connect();
     return;
   }
   auto *head = reinterpret_cast<bss_info *>(arg);


### PR DESCRIPTION
## Description:

Issue was that the ESPRange Iterator was passed a pointer to the ESPRange. But of when using a C++ for-each loop the ESPRange gets destroyed and the iterator accesses the old memory.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/367

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
