### PR TITLE
clear and disable editor while fetching contents

### DIFF
--- a/esphome/dashboard/static/esphome.js
+++ b/esphome/dashboard/static/esphome.js
@@ -709,9 +709,12 @@ document.querySelectorAll(".action-edit").forEach((btn) => {
     editorUploadButton.setAttribute('data-node', activeEditorConfig);
     filenameField.innerHTML = activeEditorConfig;
 
+    editor.setValue("Loading configuration yaml...");
+    editor.setOption('readOnly', true)
     fetch(`./edit?configuration=${activeEditorConfig}`, {credentials: "same-origin"})
       .then(res => res.text()).then(response => {
         editor.setValue(response, -1);
+        editor.setOption('readOnly', false)
     });
 
     modalInstance.open();

--- a/esphome/dashboard/static/esphome.js
+++ b/esphome/dashboard/static/esphome.js
@@ -710,7 +710,7 @@ document.querySelectorAll(".action-edit").forEach((btn) => {
     filenameField.innerHTML = activeEditorConfig;
 
     editor.setValue("Loading configuration yaml...");
-    editor.setOption('readOnly', true)
+    editor.setOption('readOnly', true);
     fetch(`./edit?configuration=${activeEditorConfig}`, {credentials: "same-origin"})
       .then(res => res.text()).then(response => {
         editor.setValue(response, -1);

--- a/esphome/dashboard/static/esphome.js
+++ b/esphome/dashboard/static/esphome.js
@@ -714,7 +714,7 @@ document.querySelectorAll(".action-edit").forEach((btn) => {
     fetch(`./edit?configuration=${activeEditorConfig}`, {credentials: "same-origin"})
       .then(res => res.text()).then(response => {
         editor.setValue(response, -1);
-        editor.setOption('readOnly', false)
+        editor.setOption('readOnly', false);
     });
 
     modalInstance.open();


### PR DESCRIPTION
## Description:
On slow connections, the editor modal shows up with old content before the correct yaml is loaded from backend. By clearing it's content and disabling input, unexpected behavior is avoided.

**Related issue (if applicable):** fixes n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
