### PR TITLE
Scan length for AddressableScanEffect

### DIFF
--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -143,12 +143,11 @@ class AddressableScanEffect : public AddressableLightEffect {
  public:
   explicit AddressableScanEffect(const std::string &name) : AddressableLightEffect(name) {}
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
-  void set_scan_length(uint32_t scan_length) { this->scan_length_ = scan_length; }
+  void set_scan_width(uint32_t scan_width) { this->scan_width_ = scan_width; }
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     it.all() = ESPColor::BLACK;
 
-    const uint32_t scan_length_limited = (scan_length_ < it.size()) ? scan_length_ : it.size();
-    for (auto i = 0; i < scan_length_limited; i++) {
+    for (auto i = 0; i < this->scan_width_; i++) {
         it[this->at_led_ + i] = current_color;
     }
 
@@ -156,7 +155,7 @@ class AddressableScanEffect : public AddressableLightEffect {
     if (now - this->last_move_ > this->move_interval_) {
       if (direction_) {
         this->at_led_++;
-        if (this->at_led_ == it.size() - scan_length_limited)
+        if (this->at_led_ == it.size() - this->scan_width_)
           this->direction_ = false;
       } else {
         this->at_led_--;
@@ -169,7 +168,7 @@ class AddressableScanEffect : public AddressableLightEffect {
 
  protected:
   uint32_t move_interval_{};
-  uint32_t scan_length_{1};
+  uint32_t scan_width_{1};
   uint32_t last_move_{0};
   int at_led_{0};
   bool direction_{true};

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -148,7 +148,7 @@ class AddressableScanEffect : public AddressableLightEffect {
     it.all() = ESPColor::BLACK;
 
     for (auto i = 0; i < this->scan_width_; i++) {
-        it[this->at_led_ + i] = current_color;
+      it[this->at_led_ + i] = current_color;
     }
 
     const uint32_t now = millis();

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -143,6 +143,7 @@ class AddressableScanEffect : public AddressableLightEffect {
  public:
   explicit AddressableScanEffect(const std::string &name) : AddressableLightEffect(name) {}
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
+  void set_scan_length(uint32_t scan_length) { this->scan_length_ = scan_length; }
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     it.all() = ESPColor::BLACK;
 
@@ -168,7 +169,7 @@ class AddressableScanEffect : public AddressableLightEffect {
 
  protected:
   uint32_t move_interval_{};
-  uint32_t scan_length_{10};
+  uint32_t scan_length_{1};
   uint32_t last_move_{0};
   int at_led_{0};
   bool direction_{true};

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -146,7 +146,8 @@ class AddressableScanEffect : public AddressableLightEffect {
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     it.all() = ESPColor::BLACK;
 
-    for (auto i = 0; i < this->scan_length_; i++) {
+    const uint32_t scan_length_limited = (scan_length_ < it.size()) ? scan_length_ : it.size();
+    for (auto i = 0; i < scan_length_limited; i++) {
         it[this->at_led_ + i] = current_color;
     }
 
@@ -154,7 +155,7 @@ class AddressableScanEffect : public AddressableLightEffect {
     if (now - this->last_move_ > this->move_interval_) {
       if (direction_) {
         this->at_led_++;
-        if (this->at_led_ == it.size() - scan_length_)
+        if (this->at_led_ == it.size() - scan_length_limited)
           this->direction_ = false;
       } else {
         this->at_led_--;
@@ -167,7 +168,7 @@ class AddressableScanEffect : public AddressableLightEffect {
 
  protected:
   uint32_t move_interval_{};
-  uint32_t scan_length_{10};    //TODO check less than it.size()
+  uint32_t scan_length_{10};
   uint32_t last_move_{0};
   int at_led_{0};
   bool direction_{true};

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -145,12 +145,16 @@ class AddressableScanEffect : public AddressableLightEffect {
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     it.all() = ESPColor::BLACK;
-    it[this->at_led_] = current_color;
+
+    for (auto i = 0; i < this->scan_length_; i++) {
+        it[this->at_led_ + i] = current_color;
+    }
+
     const uint32_t now = millis();
     if (now - this->last_move_ > this->move_interval_) {
       if (direction_) {
         this->at_led_++;
-        if (this->at_led_ == it.size() - 1)
+        if (this->at_led_ == it.size() - scan_length_)
           this->direction_ = false;
       } else {
         this->at_led_--;
@@ -163,6 +167,7 @@ class AddressableScanEffect : public AddressableLightEffect {
 
  protected:
   uint32_t move_interval_{};
+  uint32_t scan_length_{10};    //TODO check less than it.size()
   uint32_t last_move_{0};
   int at_led_{0};
   bool direction_{true};

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -16,7 +16,7 @@ from .types import LambdaLightEffect, RandomLightEffect, StrobeLightEffect, \
 CONF_ADD_LED_INTERVAL = 'add_led_interval'
 CONF_REVERSE = 'reverse'
 CONF_MOVE_INTERVAL = 'move_interval'
-CONF_SCAN_LENGTH = 'scan_length'
+CONF_SCAN_WIDTH = 'scan_width'
 CONF_TWINKLE_PROBABILITY = 'twinkle_probability'
 CONF_PROGRESS_INTERVAL = 'progress_interval'
 CONF_SPARK_PROBABILITY = 'spark_probability'
@@ -180,12 +180,12 @@ def addressable_color_wipe_effect_to_code(config, effect_id):
 
 @register_effect('addressable_scan', AddressableScanEffect, "Scan", {
     cv.Optional(CONF_MOVE_INTERVAL, default='0.1s'): cv.positive_time_period_milliseconds,
-    cv.Optional(CONF_SCAN_LENGTH, default=1): cv.All(cv.uint32_t, cv.Range(min=1))
+    cv.Optional(CONF_SCAN_WIDTH, default=1): cv.int_range(min=1),
 })
 def addressable_scan_effect_to_code(config, effect_id):
     var = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(var.set_move_interval(config[CONF_MOVE_INTERVAL]))
-    cg.add(var.set_scan_length(config[CONF_SCAN_LENGTH]))
+    cg.add(var.set_scan_width(config[CONF_SCAN_WIDTH]))
     yield var
 
 

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -16,6 +16,7 @@ from .types import LambdaLightEffect, RandomLightEffect, StrobeLightEffect, \
 CONF_ADD_LED_INTERVAL = 'add_led_interval'
 CONF_REVERSE = 'reverse'
 CONF_MOVE_INTERVAL = 'move_interval'
+CONF_SCAN_LENGTH = 'scan_length'
 CONF_TWINKLE_PROBABILITY = 'twinkle_probability'
 CONF_PROGRESS_INTERVAL = 'progress_interval'
 CONF_SPARK_PROBABILITY = 'spark_probability'
@@ -179,10 +180,12 @@ def addressable_color_wipe_effect_to_code(config, effect_id):
 
 @register_effect('addressable_scan', AddressableScanEffect, "Scan", {
     cv.Optional(CONF_MOVE_INTERVAL, default='0.1s'): cv.positive_time_period_milliseconds,
+    cv.Optional(CONF_SCAN_LENGTH, default=1): cv.All(cv.uint32_t, cv.Range(min=1))
 })
 def addressable_scan_effect_to_code(config, effect_id):
     var = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(var.set_move_interval(config[CONF_MOVE_INTERVAL]))
+    cg.add(var.set_scan_length(config[CONF_SCAN_LENGTH]))
     yield var
 
 


### PR DESCRIPTION
## Description:

Adds 'scan_length' option to Addressable Scan effect, so that it uses a range of LED's instead of just the one.

**Related issue (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#264

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
