### PR TITLE
Template Cover don't auto-set current_operation

### DIFF
--- a/esphome/components/template/cover/template_cover.cpp
+++ b/esphome/components/template/cover/template_cover.cpp
@@ -74,18 +74,11 @@ void TemplateCover::control(const CoverCall &call) {
     this->stop_prev_trigger_();
     this->stop_trigger_->trigger();
     this->prev_command_trigger_ = this->stop_trigger_;
-    this->current_operation = COVER_OPERATION_IDLE;
     this->publish_state();
   }
   if (call.get_position().has_value()) {
     auto pos = *call.get_position();
     this->stop_prev_trigger_();
-
-    if (pos < this->position) {
-      this->current_operation = COVER_OPERATION_CLOSING;
-    } else if (pos > this->position) {
-      this->current_operation = COVER_OPERATION_OPENING;
-    }
 
     if (pos == COVER_OPEN) {
       this->open_trigger_->trigger();


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/408

Template Cover should not auto-set anything.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
