### PR TITLE
Fix sun default elevation

### DIFF
--- a/esphome/components/sun/__init__.py
+++ b/esphome/components/sun/__init__.py
@@ -17,6 +17,10 @@ CONF_ELEVATION = 'elevation'
 CONF_ON_SUNRISE = 'on_sunrise'
 CONF_ON_SUNSET = 'on_sunset'
 
+# Default sun elevation is a bit below horizon because sunset
+# means time when the entire sun disk is below the horizon
+DEFAULT_ELEVATION = -0.883
+
 ELEVATION_MAP = {
     'sunrise': 0.0,
     'sunset': 0.0,
@@ -44,11 +48,11 @@ CONFIG_SCHEMA = cv.Schema({
 
     cv.Optional(CONF_ON_SUNRISE): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SunTrigger),
-        cv.Optional(CONF_ELEVATION, default=0.0): elevation,
+        cv.Optional(CONF_ELEVATION, default=DEFAULT_ELEVATION): elevation,
     }),
     cv.Optional(CONF_ON_SUNSET): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SunTrigger),
-        cv.Optional(CONF_ELEVATION, default=0.0): elevation,
+        cv.Optional(CONF_ELEVATION, default=DEFAULT_ELEVATION): elevation,
     }),
 })
 
@@ -79,7 +83,7 @@ def to_code(config):
 
 @automation.register_condition('sun.is_above_horizon', SunCondition, cv.Schema({
     cv.GenerateID(): cv.use_id(Sun),
-    cv.Optional(CONF_ELEVATION, default=0): cv.templatable(elevation),
+    cv.Optional(CONF_ELEVATION, default=DEFAULT_ELEVATION): cv.templatable(elevation),
 }))
 def sun_above_horizon_to_code(config, condition_id, template_arg, args):
     var = cg.new_Pvariable(condition_id, template_arg)
@@ -92,7 +96,7 @@ def sun_above_horizon_to_code(config, condition_id, template_arg, args):
 
 @automation.register_condition('sun.is_below_horizon', SunCondition, cv.Schema({
     cv.GenerateID(): cv.use_id(Sun),
-    cv.Optional(CONF_ELEVATION, default=0): cv.templatable(elevation),
+    cv.Optional(CONF_ELEVATION, default=DEFAULT_ELEVATION): cv.templatable(elevation),
 }))
 def sun_below_horizon_to_code(config, condition_id, template_arg, args):
     var = cg.new_Pvariable(condition_id, template_arg)

--- a/esphome/components/sun/text_sensor/__init__.py
+++ b/esphome/components/sun/text_sensor/__init__.py
@@ -3,7 +3,7 @@ import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import CONF_ICON, ICON_WEATHER_SUNSET_DOWN, ICON_WEATHER_SUNSET_UP, CONF_TYPE, \
     CONF_ID, CONF_FORMAT
-from .. import sun_ns, CONF_SUN_ID, Sun, CONF_ELEVATION, elevation
+from .. import sun_ns, CONF_SUN_ID, Sun, CONF_ELEVATION, elevation, DEFAULT_ELEVATION
 
 DEPENDENCIES = ['sun']
 
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = cv.All(text_sensor.TEXT_SENSOR_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(SunTextSensor),
     cv.GenerateID(CONF_SUN_ID): cv.use_id(Sun),
     cv.Required(CONF_TYPE): cv.one_of(*SUN_TYPES, lower=True),
-    cv.Optional(CONF_ELEVATION, default=0): elevation,
+    cv.Optional(CONF_ELEVATION, default=DEFAULT_ELEVATION): elevation,
     cv.Optional(CONF_FORMAT, default='%X'): cv.string_strict,
 }).extend(cv.polling_component_schema('60s')), validate_optional_icon)
 


### PR DESCRIPTION
## Description:

ESPHome's sunset/sunrise calculations were always a bit off - at first I thought it was just the model being a bit off, but now I know why: Sunset is defined as the time when the entire sun disk on the horizon is no longer visible. That is at roughly -0.883 degrees.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
