### PR TITLE
Allow id() syntax for custom code

### DIFF
--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -65,8 +65,7 @@ template<class C, typename... Ts> class GlobalVarSetAction : public Action<Ts...
   C *parent_;
 };
 
-template<typename T>
-T &id(GlobalsComponent<T> *value) { return value->value(); }
+template<typename T> T &id(GlobalsComponent<T> *value) { return value->value(); }
 
 }  // namespace globals
 }  // namespace esphome

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace globals {
@@ -63,6 +64,9 @@ template<class C, typename... Ts> class GlobalVarSetAction : public Action<Ts...
  protected:
   C *parent_;
 };
+
+template<typename T>
+T &id(GlobalsComponent<T> *value) { return value->value(); }
 
 }  // namespace globals
 }  // namespace esphome

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <vector>
 #include <memory>
+#include <type_traits>
 
 #include "esphome/core/optional.h"
 #include "esphome/core/esphal.h"
@@ -160,6 +161,13 @@ template<int...> struct seq {};                                       // NOLINT
 template<int N, int... S> struct gens : gens<N - 1, N - 1, S...> {};  // NOLINT
 template<int... S> struct gens<0, S...> { using type = seq<S...>; };  // NOLINT
 
+template<bool B, class T = void> using enable_if_t = typename std::enable_if<B, T>::type;
+
+template<typename T, enable_if_t<!std::is_pointer<T>::value, int> = 0>
+T id(T value) { return value; }
+template<typename T, enable_if_t<std::is_pointer<T*>::value, int> = 0>
+T &id(T *value) { return *value; }
+
 template<typename... X> class CallbackManager;
 
 /** Simple helper class to allow having multiple subscribers to a signal.
@@ -191,8 +199,6 @@ struct is_callable  // NOLINT
 
   static constexpr auto value = decltype(test<T>(nullptr))::value;  // NOLINT
 };
-
-template<bool B, class T = void> using enable_if_t = typename std::enable_if<B, T>::type;
 
 template<typename T, typename... X> class TemplatableValue {
  public:

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -163,10 +163,8 @@ template<int... S> struct gens<0, S...> { using type = seq<S...>; };  // NOLINT
 
 template<bool B, class T = void> using enable_if_t = typename std::enable_if<B, T>::type;
 
-template<typename T, enable_if_t<!std::is_pointer<T>::value, int> = 0>
-T id(T value) { return value; }
-template<typename T, enable_if_t<std::is_pointer<T*>::value, int> = 0>
-T &id(T *value) { return *value; }
+template<typename T, enable_if_t<!std::is_pointer<T>::value, int> = 0> T id(T value) { return value; }
+template<typename T, enable_if_t<std::is_pointer<T *>::value, int> = 0> T &id(T *value) { return *value; }
 
 template<typename... X> class CallbackManager;
 

--- a/tests/custom.h
+++ b/tests/custom.h
@@ -3,7 +3,12 @@
 
 class CustomSensor : public Component, public Sensor {
  public:
-  void loop() override { publish_state(42.0); }
+  void loop() override {
+    // Test id() helper
+    float value = id(my_sensor).state;
+    id(my_global_string) = "Hello World";
+    publish_state(42.0);
+  }
 };
 
 class CustomTextSensor : public Component, public TextSensor {

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -246,6 +246,11 @@ binary_sensor:
       - id: custom_binary_sensor
         name: Custom Binary Sensor
 
+globals:
+  - id: my_global_string
+    type: std::string
+    initial_value: '""'
+
 remote_receiver:
   pin: GPIO12
   dump: []


### PR DESCRIPTION
## Description:

Custom code could previously not use the familiar id() syntax for accessing objects.

This PR adds that ability with some hacky template functions.

Basically, it does the same stuff as the ESPHome pre-processor with de-referencing pointers and a special globals spezialization.

In the future, we could probably also replace the pre-processing in codegen by this.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
