### PR TITLE
Add HW SPI support

### DIFF
--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -160,7 +160,7 @@ uint8_t HOT SPIComponent::transfer_(uint8_t data) {
   }
 #endif
 
-  // App.feed_wdt();
+  App.feed_wdt();
 
   return out_data;
 }

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -177,9 +177,7 @@ class SPIDevice {
     this->cs_->digital_write(true);
   }
 
-  void enable() {
-    this->parent_->template enable<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE, DATA_RATE>(this->cs_);
-  }
+  void enable() { this->parent_->template enable<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE, DATA_RATE>(this->cs_); }
 
   void disable() { this->parent_->disable(); }
 

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -97,7 +97,8 @@ class SPIComponent : public Component {
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
   void write_array(const uint8_t *data, size_t length) {
     if (this->hw_spi_ != nullptr) {
-      this->hw_spi_->writeBytes(data, length);
+      auto *data_c = const_cast<uint8_t *>(data);
+      this->hw_spi_->writeBytes(data_c, length);
       return;
     }
     for (size_t i = 0; i < length; i++) {

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/esphal.h"
+#include <SPI.h>
 
 namespace esphome {
 namespace spi {
@@ -67,11 +68,18 @@ class SPIComponent : public Component {
   void dump_config() override;
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE> uint8_t read_byte() {
+    if (this->hw_spi_ != nullptr) {
+      return this->hw_spi_->transfer(0x00);
+    }
     return this->transfer_<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE, true, false>(0x00);
   }
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
   void read_array(uint8_t *data, size_t length) {
+    if (this->hw_spi_ != nullptr) {
+      this->hw_spi_->transfer(data, length);
+      return;
+    }
     for (size_t i = 0; i < length; i++) {
       data[i] = this->read_byte<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>();
     }
@@ -79,11 +87,19 @@ class SPIComponent : public Component {
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
   void write_byte(uint8_t data) {
+    if (this->hw_spi_ != nullptr) {
+      this->hw_spi_->write(data);
+      return;
+    }
     this->transfer_<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE, false, true>(data);
   }
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
   void write_array(const uint8_t *data, size_t length) {
+    if (this->hw_spi_ != nullptr) {
+      this->hw_spi_->writeBytes(data, length);
+      return;
+    }
     for (size_t i = 0; i < length; i++) {
       this->write_byte<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data[i]);
     }
@@ -91,17 +107,39 @@ class SPIComponent : public Component {
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
   uint8_t transfer_byte(uint8_t data) {
+    if (this->hw_spi_ != nullptr) {
+      return this->hw_spi_->transfer(data);
+    }
     return this->transfer_<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE, true, true>(data);
   }
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
   void transfer_array(uint8_t *data, size_t length) {
+    if (this->hw_spi_ != nullptr) {
+      this->hw_spi_->transfer(data, length);
+      return;
+    }
     for (size_t i = 0; i < length; i++) {
       data[i] = this->transfer_byte<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data[i]);
     }
   }
 
-  template<SPIClockPolarity CLOCK_POLARITY> void enable(GPIOPin *cs, uint32_t wait_cycle);
+  template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE, uint32_t DATA_RATE>
+  void enable(GPIOPin *cs) {
+    SPIComponent::debug_enable(cs->get_pin());
+
+    if (this->hw_spi_ != nullptr) {
+      uint8_t data_mode = (uint8_t(CLOCK_POLARITY) << 1) | uint8_t(CLOCK_PHASE);
+      SPISettings settings(DATA_RATE, BIT_ORDER, data_mode);
+      this->hw_spi_->beginTransaction(settings);
+    } else {
+      this->clk_->digital_write(CLOCK_POLARITY);
+      this->wait_cycle_ = uint32_t(F_CPU) / DATA_RATE / 2ULL;
+    }
+
+    this->active_cs_ = cs;
+    this->active_cs_->digital_write(false);
+  }
 
   void disable();
 
@@ -121,6 +159,7 @@ class SPIComponent : public Component {
   GPIOPin *miso_{nullptr};
   GPIOPin *mosi_{nullptr};
   GPIOPin *active_cs_{nullptr};
+  SPIClass *hw_spi_{nullptr};
   uint32_t wait_cycle_;
 };
 
@@ -138,7 +177,9 @@ class SPIDevice {
     this->cs_->digital_write(true);
   }
 
-  void enable() { this->parent_->template enable<CLOCK_POLARITY>(this->cs_, uint32_t(F_CPU) / DATA_RATE / 2ULL); }
+  void enable() {
+    this->parent_->template enable<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE, DATA_RATE>(this->cs_);
+  }
 
   void disable() { this->parent_->disable(); }
 


### PR DESCRIPTION
## Description:

Max speed for SPI on ESP8266 is around ~30kHz - this increases that to ~1MHz (only on certain pins)

Speedup is probably bigger on ESP32 - but only with write_array method.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
