### PR TITLE
Work around ESP32 BLE issue

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -1,5 +1,6 @@
 #include "esp32_ble_tracker.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 #ifdef ARDUINO_ARCH_ESP32
 
@@ -162,6 +163,11 @@ void ESP32BLETracker::start_scan(bool first) {
 
   esp_ble_gap_set_scan_params(&this->scan_params_);
   esp_ble_gap_start_scanning(this->scan_interval_);
+
+  this->set_timeout("scan", this->scan_interval_ * 2000, [] () {
+    ESP_LOGW(TAG, "ESP-IDF BLE scan never terminated, rebooting to restore BLE stack...");
+    App.reboot();
+  });
 }
 
 void ESP32BLETracker::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {


### PR DESCRIPTION
## Description:

See https://github.com/esphome/issues/issues/317

Restart ESP chip if BLE scan does not terminate (bug in esp-idf)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
