### PR TITLE
Add set_threshold and get_value methods to ESP32TouchBinarySensor.

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -158,12 +158,8 @@ ESP32TouchBinarySensor::ESP32TouchBinarySensor(const std::string &name, touch_pa
     : BinarySensor(name), touch_pad_(touch_pad), threshold_(threshold) {}
 touch_pad_t ESP32TouchBinarySensor::get_touch_pad() const { return this->touch_pad_; }
 uint16_t ESP32TouchBinarySensor::get_threshold() const { return this->threshold_; }
-void ESP32TouchBinarySensor::set_threshold(uint16_t threshold) {
-  this->threshold_ = threshold;
-}
-uint16_t ESP32TouchBinarySensor::get_value () const {
-  return this->value_;
-}
+void ESP32TouchBinarySensor::set_threshold(uint16_t threshold) { this->threshold_ = threshold; }
+uint16_t ESP32TouchBinarySensor::get_value() const { return this->value_; }
 }  // namespace esp32_touch
 }  // namespace esphome
 

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -116,6 +116,7 @@ void ESP32TouchComponent::loop() {
       touch_pad_read(child->get_touch_pad(), &value);
     }
 
+    child->value_ = value;
     child->publish_state(value < child->get_threshold());
 
     if (this->setup_mode_) {
@@ -157,7 +158,12 @@ ESP32TouchBinarySensor::ESP32TouchBinarySensor(const std::string &name, touch_pa
     : BinarySensor(name), touch_pad_(touch_pad), threshold_(threshold) {}
 touch_pad_t ESP32TouchBinarySensor::get_touch_pad() const { return this->touch_pad_; }
 uint16_t ESP32TouchBinarySensor::get_threshold() const { return this->threshold_; }
-
+void ESP32TouchBinarySensor::set_threshold(uint16_t threshold) {
+  this->threshold_ = threshold;
+}
+uint16_t ESP32TouchBinarySensor::get_value () const {
+  return this->value_;
+}
 }  // namespace esp32_touch
 }  // namespace esphome
 

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -129,23 +129,7 @@ void ESP32TouchComponent::loop() {
     delay(250);
   }
 }
-void ESP32TouchComponent::register_touch_pad(ESP32TouchBinarySensor *pad) { this->children_.push_back(pad); }
-void ESP32TouchComponent::set_setup_mode(bool setup_mode) { this->setup_mode_ = setup_mode; }
-bool ESP32TouchComponent::iir_filter_enabled_() const { return this->iir_filter_ > 0; }
 
-void ESP32TouchComponent::set_iir_filter(uint32_t iir_filter) { this->iir_filter_ = iir_filter; }
-float ESP32TouchComponent::get_setup_priority() const { return setup_priority::DATA; }
-void ESP32TouchComponent::set_sleep_duration(uint16_t sleep_duration) { this->sleep_cycle_ = sleep_duration; }
-void ESP32TouchComponent::set_measurement_duration(uint16_t meas_cycle) { this->meas_cycle_ = meas_cycle; }
-void ESP32TouchComponent::set_low_voltage_reference(touch_low_volt_t low_voltage_reference) {
-  this->low_voltage_reference_ = low_voltage_reference;
-}
-void ESP32TouchComponent::set_high_voltage_reference(touch_high_volt_t high_voltage_reference) {
-  this->high_voltage_reference_ = high_voltage_reference;
-}
-void ESP32TouchComponent::set_voltage_attenuation(touch_volt_atten_t voltage_attenuation) {
-  this->voltage_attenuation_ = voltage_attenuation;
-}
 void ESP32TouchComponent::on_shutdown() {
   if (this->iir_filter_enabled_()) {
     touch_pad_filter_stop();
@@ -156,10 +140,7 @@ void ESP32TouchComponent::on_shutdown() {
 
 ESP32TouchBinarySensor::ESP32TouchBinarySensor(const std::string &name, touch_pad_t touch_pad, uint16_t threshold)
     : BinarySensor(name), touch_pad_(touch_pad), threshold_(threshold) {}
-touch_pad_t ESP32TouchBinarySensor::get_touch_pad() const { return this->touch_pad_; }
-uint16_t ESP32TouchBinarySensor::get_threshold() const { return this->threshold_; }
-void ESP32TouchBinarySensor::set_threshold(uint16_t threshold) { this->threshold_ = threshold; }
-uint16_t ESP32TouchBinarySensor::get_value() const { return this->value_; }
+
 }  // namespace esp32_touch
 }  // namespace esphome
 

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -30,7 +30,7 @@ class ESP32TouchComponent : public Component {
     high_voltage_reference_ = high_voltage_reference;
   }
 
-  void set_voltage_attenuation(touch_volt_atten_t voltage_attenuation) { voltage_attenuation_ = voltage_attenuation }
+  void set_voltage_attenuation(touch_volt_atten_t voltage_attenuation) { voltage_attenuation_ = voltage_attenuation; }
 
   void setup() override;
   void dump_config() override;

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -12,32 +12,36 @@ class ESP32TouchBinarySensor;
 
 class ESP32TouchComponent : public Component {
  public:
-  void register_touch_pad(ESP32TouchBinarySensor *pad);
+  void register_touch_pad(ESP32TouchBinarySensor *pad) { children_.push_back(pad); }
 
-  void set_setup_mode(bool setup_mode);
+  void set_setup_mode(bool setup_mode) { setup_mode_ = setup_mode; }
 
-  void set_iir_filter(uint32_t iir_filter);
+  void set_iir_filter(uint32_t iir_filter) { iir_filter_ = iir_filter; }
 
-  void set_sleep_duration(uint16_t sleep_duration);
+  void set_sleep_duration(uint16_t sleep_duration) { sleep_cycle_ = sleep_duration; }
 
-  void set_measurement_duration(uint16_t meas_cycle);
+  void set_measurement_duration(uint16_t meas_cycle) { meas_cycle_ = meas_cycle; }
 
-  void set_low_voltage_reference(touch_low_volt_t low_voltage_reference);
+  void set_low_voltage_reference(touch_low_volt_t low_voltage_reference) {
+    low_voltage_reference_ = low_voltage_reference;
+  }
 
-  void set_high_voltage_reference(touch_high_volt_t high_voltage_reference);
+  void set_high_voltage_reference(touch_high_volt_t high_voltage_reference) {
+    high_voltage_reference_ = high_voltage_reference;
+  }
 
-  void set_voltage_attenuation(touch_volt_atten_t voltage_attenuation);
+  void set_voltage_attenuation(touch_volt_atten_t voltage_attenuation) { voltage_attenuation_ = voltage_attenuation }
 
   void setup() override;
   void dump_config() override;
   void loop() override;
-  float get_setup_priority() const override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void on_shutdown() override;
 
  protected:
   /// Is the IIR filter enabled?
-  bool iir_filter_enabled_() const;
+  bool iir_filter_enabled_() const { return iir_filter_ > 0; }
 
   uint16_t sleep_cycle_{};
   uint16_t meas_cycle_{65535};
@@ -54,10 +58,10 @@ class ESP32TouchBinarySensor : public binary_sensor::BinarySensor {
  public:
   ESP32TouchBinarySensor(const std::string &name, touch_pad_t touch_pad, uint16_t threshold);
 
-  touch_pad_t get_touch_pad() const;
-  uint16_t get_threshold() const;
-  void set_threshold(uint16_t);
-  uint16_t get_value() const;
+  touch_pad_t get_touch_pad() const { return touch_pad_; }
+  uint16_t get_threshold() const { return threshold_; }
+  void set_threshold(uint16_t threshold) { threshold_ = threshold; }
+  uint16_t get_value() const { return value_; }
 
  protected:
   friend ESP32TouchComponent;

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -56,12 +56,15 @@ class ESP32TouchBinarySensor : public binary_sensor::BinarySensor {
 
   touch_pad_t get_touch_pad() const;
   uint16_t get_threshold() const;
+  void set_threshold(uint16_t);
+  uint16_t get_value() const;
 
  protected:
   friend ESP32TouchComponent;
 
   touch_pad_t touch_pad_;
   uint16_t threshold_;
+  uint16_t value_;
 };
 
 }  // namespace esp32_touch

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1122,7 +1122,7 @@ interval:
   - interval: 2s
     then:
       - lambda: |-
-            uint16_t btn_left_state = id(btn_left)->get_value();
+            static uint16_t btn_left_state = id(btn_left)->get_value();
 
             ESP_LOGD("adaptive touch", "___  Touch Pad '%s' (T%u): val: %u state: %u tres:%u", id(btn_left)->get_name().c_str(), id(btn_left)->get_touch_pad(), id(btn_left)->get_value(), btn_left_state, id(btn_left)->get_threshold());
             

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -618,6 +618,7 @@ binary_sensor:
     name: "ESP32 Touch Pad GPIO27"
     pin: GPIO27
     threshold: 1000
+    id: btn_left
   - platform: nextion
     page_id: 0
     component_id: 2
@@ -1118,6 +1119,16 @@ interval:
         if (true) return id(page1); else return id(page2);
     -  display.page.show_next: display1
     -  display.page.show_previous: display1
+  - interval: 2s
+    then:
+      - lambda: |-
+            static uint16_t btn_left_state = id(btn_left)->get_value();
+
+            ESP_LOGD("adaptive touch", "___  Touch Pad '%s' (T%u): val: %u state: %u tres:%u", id(btn_left)->get_name().c_str(), id(btn_left)->get_touch_pad(), id(btn_left)->get_value(), btn_left_state, id(btn_left)->get_threshold());
+            
+            btn_left_state = ((uint32_t) id(btn_left)->get_value()  +  63 * (uint32_t)btn_left_state) >> 6;
+
+            id(btn_left)->set_threshold(btn_left_state * 0.9);
 
 display:
 - platform: lcd_gpio

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1122,7 +1122,7 @@ interval:
   - interval: 2s
     then:
       - lambda: |-
-            static uint16_t btn_left_state = id(btn_left)->get_value();
+            uint16_t btn_left_state = id(btn_left)->get_value();
 
             ESP_LOGD("adaptive touch", "___  Touch Pad '%s' (T%u): val: %u state: %u tres:%u", id(btn_left)->get_name().c_str(), id(btn_left)->get_touch_pad(), id(btn_left)->get_value(), btn_left_state, id(btn_left)->get_threshold());
             


### PR DESCRIPTION
## Description:

This patch exposes a "set_threshold" and a "get_value" method to the class "ESP32TouchBinarySensor" and adds a test. This allows to access the last touch value of an sensor and set its theshold.
A usecase could be a making a the threshold of an touchpad aptive, so it can compensate for slow drifts in the measured capacity. The code below calculates a long term average of the sensors value and sets the threshold 10% below it.   


```
binary_sensor:
  - platform: esp32_touch
    name: "Button Left"
    pin: GPIO12
    threshold: 660
    id: btn_left

interval:
  - interval: 2s
    then:
      - lambda: |-
            static uint16_t btn_left_state = id(btn_left)->get_value();

            ESP_LOGD("adaptive touch", "___  Touch Pad '%s' (T%u): val: %u state: %u tres:%u", id(btn_left)->get_name().c_str(), id(btn_left)->get_touch_pad(), id(btn_left)->get_value(), btn_left_state, id(btn_left)->get_threshold());
            
            btn_left_state = ((uint32_t) id(btn_left)->get_value()  +  63 * (uint32_t)btn_left_state) >> 6;

            id(btn_left)->set_threshold(btn_left_state * 0.9);

```

**Related issue (if applicable):** ---

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
