### PR TITLE
Fix home assistant binary sensor initial state

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -30,7 +30,11 @@ void BinarySensor::publish_initial_state(bool state) {
   }
 }
 void BinarySensor::send_state_internal(bool state, bool is_initial) {
-  ESP_LOGD(TAG, "'%s': Sending %s state %s", this->get_name().c_str(), is_initial ? "initial" : "", ONOFF(state));
+  if (is_initial) {
+    ESP_LOGD(TAG, "'%s': Sending initial state %s", this->get_name().c_str(), ONOFF(state));
+  } else {
+    ESP_LOGD(TAG, "'%s': Sending state %s", this->get_name().c_str(), ONOFF(state));
+  }
   this->has_state_ = true;
   this->state = state;
   if (!is_initial) {

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -30,7 +30,7 @@ void BinarySensor::publish_initial_state(bool state) {
   }
 }
 void BinarySensor::send_state_internal(bool state, bool is_initial) {
-  ESP_LOGD(TAG, "'%s': Sending state %s", this->get_name().c_str(), state ? "ON" : "OFF");
+  ESP_LOGD(TAG, "'%s': Sending %s state %s", this->get_name().c_str(), is_initial ? "initial" : "", ONOFF(state));
   this->has_state_ = true;
   this->state = state;
   if (!is_initial) {

--- a/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.cpp
+++ b/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.cpp
@@ -19,7 +19,7 @@ void HomeassistantBinarySensor::setup() {
       case PARSE_OFF:
         bool new_state = val == PARSE_ON;
         ESP_LOGD(TAG, "'%s': Got state %s", this->entity_id_.c_str(), ONOFF(new_state));
-        if (this->initial_) 
+        if (this->initial_)
           this->publish_initial_state(new_state);
         else
           this->publish_state(new_state);

--- a/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.cpp
+++ b/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.cpp
@@ -16,14 +16,16 @@ void HomeassistantBinarySensor::setup() {
         ESP_LOGW(TAG, "Can't convert '%s' to binary state!", state.c_str());
         break;
       case PARSE_ON:
-        ESP_LOGD(TAG, "'%s': Got state ON", this->entity_id_.c_str());
-        this->publish_state(true);
-        break;
       case PARSE_OFF:
-        ESP_LOGD(TAG, "'%s': Got state OFF", this->entity_id_.c_str());
-        this->publish_state(false);
+        bool newState = val == PARSE_ON;
+        ESP_LOGD(TAG, "'%s': Got state %s", this->entity_id_.c_str(), ONOFF(newState));
+        if (this->initial_) 
+          this->publish_initial_state(newState);
+        else
+          this->publish_state(newState);
         break;
     }
+    this->initial_ = false;
   });
 }
 void HomeassistantBinarySensor::dump_config() {

--- a/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.cpp
+++ b/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.cpp
@@ -17,12 +17,12 @@ void HomeassistantBinarySensor::setup() {
         break;
       case PARSE_ON:
       case PARSE_OFF:
-        bool newState = val == PARSE_ON;
-        ESP_LOGD(TAG, "'%s': Got state %s", this->entity_id_.c_str(), ONOFF(newState));
+        bool new_state = val == PARSE_ON;
+        ESP_LOGD(TAG, "'%s': Got state %s", this->entity_id_.c_str(), ONOFF(new_state));
         if (this->initial_) 
-          this->publish_initial_state(newState);
+          this->publish_initial_state(new_state);
         else
-          this->publish_state(newState);
+          this->publish_state(new_state);
         break;
     }
     this->initial_ = false;

--- a/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.h
+++ b/esphome/components/homeassistant/binary_sensor/homeassistant_binary_sensor.h
@@ -15,6 +15,7 @@ class HomeassistantBinarySensor : public binary_sensor::BinarySensor, public Com
 
  protected:
   std::string entity_id_;
+  bool initial_{true};
 };
 
 }  // namespace homeassistant


### PR DESCRIPTION
## Description:
So, I'm debugging why my lights sometimes turns on and off 

I'm mostly using `on_state` on many binary sensors (I have no push button but standard lights toggle buttons connected to GPIOs)

I found out that when ESPHome restarts it will toggle lights when it connects to Wifi and there is a binary sensor:
````yaml
- platform: homeassistant
  name: "Switch Este Test 1 from HA"
  entity_id: binary_sensor.switch_este_test_1
  on_state:
    then: 
      - light.toggle: luz_led_test_arduino
````

With this configuration I got the log that the binary sensor got a state (ON or OFF) and then it raises the events.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
