### PR TITLE
Fix esp8266_restore_from_flash

### DIFF
--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -7,6 +7,7 @@
 #endif
 
 #include "esphome/core/esphal.h"
+#include "esphome/core/defines.h"
 
 namespace esphome {
 


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/424

## Description:

Creating directly against master because of merge conflicts

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
