### PR TITLE
Provide the lights current color to the addressable_lambda_effect.

### DIFF
--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -50,7 +50,8 @@ class AddressableLightEffect : public LightEffect {
 
 class AddressableLambdaLightEffect : public AddressableLightEffect {
  public:
-  AddressableLambdaLightEffect(const std::string &name, const std::function<void(AddressableLight &, const ESPColor &)> &f,
+  AddressableLambdaLightEffect(const std::string &name,
+                               const std::function<void(AddressableLight &, const ESPColor &)> &f,
                                uint32_t update_interval)
       : AddressableLightEffect(name), f_(f), update_interval_(update_interval) {}
   void apply(AddressableLight &it, const ESPColor &current_color) override {

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -50,8 +50,7 @@ class AddressableLightEffect : public LightEffect {
 
 class AddressableLambdaLightEffect : public AddressableLightEffect {
  public:
-  AddressableLambdaLightEffect(const std::string &name,
-                               const std::function<void(AddressableLight &, ESPColor)> &f,
+  AddressableLambdaLightEffect(const std::string &name, const std::function<void(AddressableLight &, ESPColor)> &f,
                                uint32_t update_interval)
       : AddressableLightEffect(name), f_(f), update_interval_(update_interval) {}
   void apply(AddressableLight &it, const ESPColor &current_color) override {

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -50,19 +50,19 @@ class AddressableLightEffect : public LightEffect {
 
 class AddressableLambdaLightEffect : public AddressableLightEffect {
  public:
-  AddressableLambdaLightEffect(const std::string &name, const std::function<void(AddressableLight &)> &f,
+  AddressableLambdaLightEffect(const std::string &name, const std::function<void(AddressableLight &, const ESPColor &)> &f,
                                uint32_t update_interval)
       : AddressableLightEffect(name), f_(f), update_interval_(update_interval) {}
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     const uint32_t now = millis();
     if (now - this->last_run_ >= this->update_interval_) {
       this->last_run_ = now;
-      this->f_(it);
+      this->f_(it, current_color);
     }
   }
 
  protected:
-  std::function<void(AddressableLight &)> f_;
+  std::function<void(AddressableLight &, const ESPColor &)> f_;
   uint32_t update_interval_;
   uint32_t last_run_{0};
 };

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -51,7 +51,7 @@ class AddressableLightEffect : public LightEffect {
 class AddressableLambdaLightEffect : public AddressableLightEffect {
  public:
   AddressableLambdaLightEffect(const std::string &name,
-                               const std::function<void(AddressableLight &, const ESPColor &)> &f,
+                               const std::function<void(AddressableLight &, ESPColor)> &f,
                                uint32_t update_interval)
       : AddressableLightEffect(name), f_(f), update_interval_(update_interval) {}
   void apply(AddressableLight &it, const ESPColor &current_color) override {
@@ -63,7 +63,7 @@ class AddressableLambdaLightEffect : public AddressableLightEffect {
   }
 
  protected:
-  std::function<void(AddressableLight &, const ESPColor &)> f_;
+  std::function<void(AddressableLight &, ESPColor)> f_;
   uint32_t update_interval_;
   uint32_t last_run_{0};
 };

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -7,7 +7,7 @@ from esphome.const import CONF_NAME, CONF_LAMBDA, CONF_UPDATE_INTERVAL, CONF_TRA
     CONF_SEQUENCE
 from esphome.util import Registry
 from .types import LambdaLightEffect, RandomLightEffect, StrobeLightEffect, \
-    StrobeLightEffectColor, LightColorValues, AddressableLightRef, AddressableLambdaLightEffect, \
+    StrobeLightEffectColor, LightColorValues, AddressableLightRef, AddressableLambdaLightEffect, ESPColorConstRef,\
     FlickerLightEffect, AddressableRainbowLightEffect, AddressableColorWipeEffect, \
     AddressableColorWipeEffectColor, AddressableScanEffect, AddressableTwinkleEffect, \
     AddressableRandomTwinkleEffect, AddressableFireworksEffect, AddressableFlickerEffect, \
@@ -129,7 +129,7 @@ def flicker_effect_to_code(config, effect_id):
     cv.Optional(CONF_UPDATE_INTERVAL, default='0ms'): cv.positive_time_period_milliseconds,
 })
 def addressable_lambda_effect_to_code(config, effect_id):
-    args = [(AddressableLightRef, 'it')]
+    args = [(AddressableLightRef, 'it'), (ESPColorConstRef, 'current_color')]
     lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], args, return_type=cg.void)
     var = cg.new_Pvariable(effect_id, config[CONF_NAME], lambda_,
                            config[CONF_UPDATE_INTERVAL])

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -11,7 +11,7 @@ from .types import LambdaLightEffect, RandomLightEffect, StrobeLightEffect, \
     FlickerLightEffect, AddressableRainbowLightEffect, AddressableColorWipeEffect, \
     AddressableColorWipeEffectColor, AddressableScanEffect, AddressableTwinkleEffect, \
     AddressableRandomTwinkleEffect, AddressableFireworksEffect, AddressableFlickerEffect, \
-    AutomationLightEffect, ESPColorConstRef
+    AutomationLightEffect, ESPColor
 
 CONF_ADD_LED_INTERVAL = 'add_led_interval'
 CONF_REVERSE = 'reverse'
@@ -129,7 +129,7 @@ def flicker_effect_to_code(config, effect_id):
     cv.Optional(CONF_UPDATE_INTERVAL, default='0ms'): cv.positive_time_period_milliseconds,
 })
 def addressable_lambda_effect_to_code(config, effect_id):
-    args = [(AddressableLightRef, 'it'), (ESPColorConstRef, 'current_color')]
+    args = [(AddressableLightRef, 'it'), (ESPColor, 'current_color')]
     lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], args, return_type=cg.void)
     var = cg.new_Pvariable(effect_id, config[CONF_NAME], lambda_,
                            config[CONF_UPDATE_INTERVAL])

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -7,11 +7,11 @@ from esphome.const import CONF_NAME, CONF_LAMBDA, CONF_UPDATE_INTERVAL, CONF_TRA
     CONF_SEQUENCE
 from esphome.util import Registry
 from .types import LambdaLightEffect, RandomLightEffect, StrobeLightEffect, \
-    StrobeLightEffectColor, LightColorValues, AddressableLightRef, AddressableLambdaLightEffect, ESPColorConstRef,\
+    StrobeLightEffectColor, LightColorValues, AddressableLightRef, AddressableLambdaLightEffect, \
     FlickerLightEffect, AddressableRainbowLightEffect, AddressableColorWipeEffect, \
     AddressableColorWipeEffectColor, AddressableScanEffect, AddressableTwinkleEffect, \
     AddressableRandomTwinkleEffect, AddressableFireworksEffect, AddressableFlickerEffect, \
-    AutomationLightEffect
+    AutomationLightEffect, ESPColorConstRef
 
 CONF_ADD_LED_INTERVAL = 'add_led_interval'
 CONF_REVERSE = 'reverse'

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -11,8 +11,6 @@ AddressableLight = light_ns.class_('AddressableLight', cg.Component)
 AddressableLightRef = AddressableLight.operator('ref')
 
 ESPColor = light_ns.class_('ESPColor')
-ESPColorConstRef = ESPColor.operator('const').operator('ref')
-
 LightColorValues = light_ns.class_('LightColorValues')
 
 # Actions

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -9,6 +9,10 @@ AddressableLightState = light_ns.class_('LightState', LightState)
 LightOutput = light_ns.class_('LightOutput')
 AddressableLight = light_ns.class_('AddressableLight', cg.Component)
 AddressableLightRef = AddressableLight.operator('ref')
+
+ESPColor = light_ns.class_('ESPColor')
+ESPColorConstRef = ESPColor.operator('const').operator('ref')
+
 LightColorValues = light_ns.class_('LightColorValues')
 
 # Actions

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -893,6 +893,11 @@ light:
         name: Flicker Effect With Custom Values
         update_interval: 16ms
         intensity: 5%
+    - addressable_lambda:
+          name: "Test For Custom Lambda Effect"
+          lambda: |-
+            it[0] = current_color;
+                
     - automation:
         name: Custom Effect
         sequence:


### PR DESCRIPTION
The current color of the addressable light is a parameter to the internal effect functions, but it was not exposed to the addressable_lambda_effect. This patch fixes that.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
