### PR TITLE
Fixed rc_switch dump off by one bit

### DIFF
--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -115,11 +115,11 @@ bool RCSwitchBase::decode(RemoteReceiveData &src, uint32_t *out_data, uint8_t *o
   *out_data = 0;
   for (*out_nbits = 1; *out_nbits < 32; *out_nbits += 1) {
     if (this->expect_zero(src)) {
-      *out_data <<= 1;
       *out_data |= 0;
-    } else if (this->expect_one(src)) {
       *out_data <<= 1;
+    } else if (this->expect_one(src)) {
       *out_data |= 1;
+      *out_data <<= 1;
     } else {
       *out_nbits -= 1;
       return *out_nbits >= 8;

--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -113,15 +113,14 @@ bool RCSwitchBase::decode(RemoteReceiveData &src, uint32_t *out_data, uint8_t *o
   this->expect_sync(src);
 
   *out_data = 0;
-  for (*out_nbits = 1; *out_nbits < 32; *out_nbits += 1) {
+  for (*out_nbits = 0; *out_nbits < 32; *out_nbits += 1) {
     if (this->expect_zero(src)) {
+      *out_data <<= 1;
       *out_data |= 0;
-      *out_data <<= 1;
     } else if (this->expect_one(src)) {
-      *out_data |= 1;
       *out_data <<= 1;
+      *out_data |= 1;
     } else {
-      *out_nbits -= 1;
       return *out_nbits >= 8;
     }
   }


### PR DESCRIPTION
## Description:
Found that the rc_switch dump raw output is off by one bit, the logic just needed to be changed to push the next received bit first and then shift the result left.

**Related issue (if applicable):** fixes [RC Switch Raw Dump is one bit off #482 ](https://github.com/esphome/issues/issues/482)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
