### PR TITLE
Update dependencies

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import CONF_DATA, CONF_DATA_TEMPLATE, CONF_ID, CONF_PASSWORD,
 from esphome.core import CORE, coroutine_with_priority
 
 DEPENDENCIES = ['network']
+AUTO_LOAD = ['async_tcp']
 
 api_ns = cg.esphome_ns.namespace('api')
 APIServer = api_ns.class_('APIServer', cg.Component, cg.Controller)
@@ -67,10 +68,6 @@ def to_code(config):
 
     cg.add_define('USE_API')
     cg.add_global(api_ns.using)
-    if CORE.is_esp32:
-        cg.add_library('AsyncTCP', '1.0.3')
-    elif CORE.is_esp8266:
-        cg.add_library('ESPAsyncTCP', '1.2.0')
 
 
 KEY_VALUE_SCHEMA = cv.Schema({cv.string: cv.templatable(cv.string)})

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -4,7 +4,7 @@ from esphome import automation
 from esphome.automation import Condition
 from esphome.const import CONF_DATA, CONF_DATA_TEMPLATE, CONF_ID, CONF_PASSWORD, CONF_PORT, \
     CONF_REBOOT_TIMEOUT, CONF_SERVICE, CONF_VARIABLES, CONF_SERVICES, CONF_TRIGGER_ID, CONF_EVENT
-from esphome.core import CORE, coroutine_with_priority
+from esphome.core import coroutine_with_priority
 
 DEPENDENCIES = ['network']
 AUTO_LOAD = ['async_tcp']

--- a/esphome/components/async_tcp/__init__.py
+++ b/esphome/components/async_tcp/__init__.py
@@ -1,0 +1,13 @@
+# Dummy integration to allow relying on AsyncTCP
+from esphome.core import CORE, coroutine_with_priority
+import esphome.codegen as cg
+
+
+@coroutine_with_priority(200.0)
+def to_code(config):
+    if CORE.is_esp32:
+        # https://github.com/me-no-dev/AsyncTCP/blob/master/library.json
+        cg.add_library('AsyncTCP', '1.0.3')
+    elif CORE.is_esp8266:
+        # https://github.com/me-no-dev/ESPAsyncTCP/blob/master/library.json
+        cg.add_library('ESPAsyncTCP', '1.2.0')

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -34,5 +34,6 @@ def new_fastled_light(config):
         cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))
 
     yield light.register_light(var, config)
-    cg.add_library('FastLED', '3.2.0')
+    # https://github.com/FastLED/FastLED/blob/master/library.json
+    cg.add_library('FastLED', '3.2.9')
     yield var

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -6,7 +6,7 @@
 
 #define FASTLED_ESP8266_RAW_PIN_ORDER
 #define FASTLED_ESP32_RAW_PIN_ORDER
-#define FASTLED_RMT_BUILTIN_DRIVER
+#define FASTLED_RMT_BUILTIN_DRIVER true
 
 // Avoid annoying compiler messages
 #define FASTLED_INTERNAL

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -6,7 +6,7 @@
 
 #define FASTLED_ESP8266_RAW_PIN_ORDER
 #define FASTLED_ESP32_RAW_PIN_ORDER
-#define FASTLED_RMT_BUILTIN_DRIVER true
+#define FASTLED_RMT_BUILTIN_DRIVER
 
 // Avoid annoying compiler messages
 #define FASTLED_INTERNAL

--- a/esphome/components/gps/__init__.py
+++ b/esphome/components/gps/__init__.py
@@ -20,4 +20,6 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     yield uart.register_uart_device(var, config)
+
+    # https://platformio.org/lib/show/1655/TinyGPSPlus
     cg.add_library('TinyGPSPlus', '1.0.2')

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -15,7 +15,7 @@ from esphome.const import CONF_AVAILABILITY, CONF_BIRTH_MESSAGE, CONF_BROKER, CO
 from esphome.core import coroutine_with_priority, coroutine, CORE
 
 DEPENDENCIES = ['network']
-AUTO_LOAD = ['json']
+AUTO_LOAD = ['json', 'async_tcp']
 
 
 def validate_message_just_topic(value):
@@ -154,6 +154,7 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
 
+    # https://github.com/marvinroger/async-mqtt-client/blob/master/library.json
     cg.add_library('AsyncMqttClient', '0.8.2')
     cg.add_define('USE_MQTT')
     cg.add_global(mqtt_ns.using)

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -101,6 +101,14 @@ ESP8266_METHODS = {
 ESP32_METHODS = {
     'ESP32_I2S_0': 'NeoEsp32I2s0{}Method',
     'ESP32_I2S_1': 'NeoEsp32I2s1{}Method',
+    'ESP32_RMT_0': 'NeoEsp32Rmt0{}Method',
+    'ESP32_RMT_1': 'NeoEsp32Rmt1{}Method',
+    'ESP32_RMT_2': 'NeoEsp32Rmt2{}Method',
+    'ESP32_RMT_3': 'NeoEsp32Rmt3{}Method',
+    'ESP32_RMT_4': 'NeoEsp32Rmt4{}Method',
+    'ESP32_RMT_5': 'NeoEsp32Rmt5{}Method',
+    'ESP32_RMT_6': 'NeoEsp32Rmt6{}Method',
+    'ESP32_RMT_7': 'NeoEsp32Rmt7{}Method',
     'BIT_BANG': 'NeoEsp32BitBang{}Method',
 }
 
@@ -160,4 +168,5 @@ def to_code(config):
 
     cg.add(var.set_pixel_order(getattr(ESPNeoPixelOrder, config[CONF_TYPE])))
 
-    cg.add_library('NeoPixelBus', '2.4.1')
+    # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
+    cg.add_library('NeoPixelBus', '2.5.0')

--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 #ifdef ARDUINO_ARCH_ESP32
-#include "apps/sntp/sntp.h"
+#include "lwip/apps/sntp.h"
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
 #include "sntp.h"

--- a/esphome/components/sun/__init__.py
+++ b/esphome/components/sun/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import time
 from esphome.const import CONF_TIME_ID, CONF_ID, CONF_TRIGGER_ID
+from esphome.py_compat import string_types
 
 sun_ns = cg.esphome_ns.namespace('sun')
 
@@ -31,9 +32,9 @@ ELEVATION_MAP = {
 
 
 def elevation(value):
-    if isinstance(value, str):
+    if isinstance(value, string_types):
         try:
-            value = ELEVATION_MAP[cv.one_of(*ELEVATION_MAP, lower=True, space='_')]
+            value = ELEVATION_MAP[cv.one_of(*ELEVATION_MAP, lower=True, space='_')(value)]
         except cv.Invalid:
             pass
     value = cv.angle(value)

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -3,7 +3,7 @@ import esphome.codegen as cg
 from esphome.const import CONF_ID
 from esphome.core import coroutine_with_priority, CORE
 
-DEPENDENCIES = ['network']
+DEPENDENCIES = ['network', 'async_tcp']
 
 web_server_base_ns = cg.esphome_ns.namespace('web_server_base')
 WebServerBase = web_server_base_ns.class_('WebServerBase', cg.Component)
@@ -21,4 +21,5 @@ def to_code(config):
 
     if CORE.is_esp32:
         cg.add_library('FS', None)
-    cg.add_library('ESP Async WebServer', '1.1.1')
+    # https://github.com/me-no-dev/ESPAsyncWebServer/blob/master/library.json
+    cg.add_library('ESP Async WebServer', '1.2.2')

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -22,7 +22,7 @@ def patch_structhash():
     # removed/added. This might have unintended consequences, but this improves compile
     # times greatly when adding/removing components and a simple clean build solves
     # all issues
-    # pylint: disable=no-member,no-name-in-module
+    # pylint: disable=no-member,no-name-in-module,import-error
     from platformio.commands import run
     from platformio import util
     if is_platformio4():

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -171,9 +171,7 @@ def format_ini(data):
 
 
 def gather_lib_deps():
-    lib_deps_l = [x.as_lib_dep for x in CORE.libraries]
-    lib_deps_l.sort()
-    return lib_deps_l
+    return [x.as_lib_dep for x in CORE.libraries]
 
 
 def gather_build_flags():

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,9 +13,9 @@ lib_deps =
     AsyncTCP@1.0.3
     AsyncMqttClient@0.8.2
     ArduinoJson-esphomelib@5.13.3
-    ESP Async WebServer@1.1.1
-    FastLED@3.2.0
-    NeoPixelBus@2.4.1
+    ESP Async WebServer@1.2.2
+    FastLED@3.2.9
+    NeoPixelBus@2.5.0
     ESPAsyncTCP@1.2.0
     TinyGPSPlus@1.0.2
 build_flags =

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ tornado>=5.1.1,<6
 typing>=3.6.6;python_version<"3.5"
 protobuf>=3.7,<3.8
 tzlocal>=1.5.1
+pytz>=2019.1
 pyserial>=3.4,<4
 ifaddr>=0.1.6,<1
 platformio>=3.6.5 ; python_version<"3"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,9 +6,10 @@ tornado>=5.1.1,<6
 typing>=3.6.6 ; python_version<"3.5"
 protobuf>=3.7,<3.8
 tzlocal>=1.5.1
+pytz>=2019.1
 pyserial>=3.4,<4
 ifaddr>=0.1.6,<1
-platformio>=3.6.5 ; python_version<"3"
+platformio>=3.6.7 ; python_version<"3"
 https://github.com/platformio/platformio-core/archive/develop.zip ; python_version>"3"
 esptool>=2.6,<3
 pylint==1.9.4 ; python_version<"3"

--- a/script/.neopixelbus.patch
+++ b/script/.neopixelbus.patch
@@ -1,26 +1,35 @@
---- .piolibdeps/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h	2018-12-25 06:37:53.000000000 +0100
-+++ .piolibdeps/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h.2	2019-03-01 22:18:10.000000000 +0100
-@@ -169,7 +169,7 @@
+--- .piolibdeps/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h	2019-06-25 11:14:33.000000000 +0200
++++ .piolibdeps/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h.2	2019-06-25 11:14:40.000000000 +0200
+@@ -195,7 +195,12 @@
              _i2sBufDesc[indexDesc].sub_sof = 0;
              _i2sBufDesc[indexDesc].datalen = blockSize;
              _i2sBufDesc[indexDesc].blocksize = blockSize;
 -            _i2sBufDesc[indexDesc].buf_ptr = (uint32_t)is2Buffer;
-+            _i2sBufDesc[indexDesc].buf_ptr = is2Buffer;
++            union {
++                uint8_t *ptr;
++                uint32_t value;
++            } ptr;
++            ptr.ptr = is2Buffer;
++            _i2sBufDesc[indexDesc].buf_ptr = ptr.value;
              _i2sBufDesc[indexDesc].unused = 0;
              _i2sBufDesc[indexDesc].next_link_ptr = (uint32_t)&(_i2sBufDesc[indexDesc + 1]);
-
-@@ -329,11 +329,13 @@
+ 
+@@ -361,12 +366,15 @@
+ 
              case NeoDmaState_Sending:
                  {
-                     slc_queue_item* finished_item = (slc_queue_item*)SLCRXEDA;
-+                    uint32_t **ptr = reinterpret_cast<uint32_t **>(&finished_item);
-+                    uint32_t dat = *reinterpret_cast<uint32_t *>(ptr);
-
+-                    slc_queue_item* finished_item = (slc_queue_item*)SLCRXEDA;
+-
++                    union {
++                        slc_queue_item *ptr;
++                        uint32_t value;
++                    } ptr;
++                    ptr.value = SLCRXEDA;
                      // the data block had actual data sent
                      // point last state block to first state block thus
                      // just looping and not sending the data blocks
 -                    (finished_item + 1)->next_link_ptr = (uint32_t)(finished_item);
-+                    (finished_item + 1)->next_link_ptr = dat;
-
-                     s_this->_dmaState = NeoDmaState_Idle;
++                    (ptr.ptr + 1)->next_link_ptr = ptr.value;
+ 
+                     s_this->_dmaState = NeoDmaState_Zeroing;
                  }

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ REQUIRES = [
     'typing>=3.6.6;python_version<"3.5"',
     'protobuf>=3.7,<3.8',
     'tzlocal>=1.5.1',
+    'pytz>=2019.1',
     'pyserial>=3.4,<4',
     'ifaddr>=0.1.6,<1',
 ]


### PR DESCRIPTION
## Description:

- ESPAsyncWebServer: https://github.com/me-no-dev/ESPAsyncWebServer/compare/6edc4310348a54d14c44d2889dcf42e7ef2c0100...a0d5c618ffdf976890a18a5e05e8ccd5c1ea90ed (1.1.1 -> 1.2.2)
- FastLED: https://github.com/FastLED/FastLED/compare/3.2.0...3.2.9 (3.2.0 -> 3.2.9)
- NeoPixelBus: https://github.com/Makuna/NeoPixelBus/compare/2.4.1...2.5.0 (2.4.1 -> 2.5.0, adds ESP32 RMT methods)
- 🚫 AsyncTCP: 1.1.0 got released, but that's incompatible with our arduino-esp32 version (https://github.com/me-no-dev/AsyncTCP/compare/b193bebb278fbe9e68763fdbb6078cbaaa8ca02a...b5c6167a3fcbe7ea9d9dc10876f7873b99f6ca10#commitcomment-34066774), 1.0.4 was released too fast so it didn't propagate to platformio (https://platformio.org/lib/show/1826/AsyncTCP)

  - https://github.com/me-no-dev/AsyncTCP/compare/b193bebb278fbe9e68763fdbb6078cbaaa8ca02a...c9df7cdda6302f509db9c09d9a514a45f9392105 https://github.com/me-no-dev/AsyncTCP/compare/b193bebb278fbe9e68763fdbb6078cbaaa8ca02a...b5c6167a3fcbe7ea9d9dc10876f7873b99f6ca10#diff-5c977e380a3eb2cac7b8881fd6fd9dcbR205

- Platformio 4 support (WIP)

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/476

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
