### PR TITLE
ZyAura CO2 / Temperature / Humidity Sensor

### DIFF
--- a/esphome/components/zyaura/sensor.py
+++ b/esphome/components/zyaura/sensor.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import sensor
-from esphome.const import CONF_ID, CONF_CLOCK_PIN, CONF_DATA_PIN, CONF_UPDATE_INTERVAL, \
+from esphome.const import CONF_ID, CONF_CLOCK_PIN, CONF_DATA_PIN, \
     CONF_CO2, CONF_TEMPERATURE, CONF_HUMIDITY, \
     UNIT_PARTS_PER_MILLION, UNIT_CELSIUS, UNIT_PERCENT, \
     ICON_PERIODIC_TABLE_CO2, ICON_THERMOMETER, ICON_WATER_PERCENT
@@ -13,8 +13,8 @@ ZyAuraSensor = zyaura_ns.class_('ZyAuraSensor', cg.PollingComponent)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(ZyAuraSensor),
-    cv.Required(CONF_CLOCK_PIN): pins.gpio_input_pin_schema,
-    cv.Required(CONF_DATA_PIN): pins.gpio_input_pin_schema,
+    cv.Required(CONF_CLOCK_PIN): cv.All(pins.internal_gpio_input_pin_schema, pins.validate_has_interrupt),
+    cv.Required(CONF_DATA_PIN): cv.All(pins.internal_gpio_input_pin_schema, pins.validate_has_interrupt),
     cv.Optional(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_PERIODIC_TABLE_CO2, 0),
     cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
     cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),

--- a/esphome/components/zyaura/sensor.py
+++ b/esphome/components/zyaura/sensor.py
@@ -13,8 +13,10 @@ ZyAuraSensor = zyaura_ns.class_('ZyAuraSensor', cg.PollingComponent)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(ZyAuraSensor),
-    cv.Required(CONF_CLOCK_PIN): cv.All(pins.internal_gpio_input_pin_schema, pins.validate_has_interrupt),
-    cv.Required(CONF_DATA_PIN): cv.All(pins.internal_gpio_input_pin_schema, pins.validate_has_interrupt),
+    cv.Required(CONF_CLOCK_PIN): cv.All(pins.internal_gpio_input_pin_schema,
+                                        pins.validate_has_interrupt),
+    cv.Required(CONF_DATA_PIN): cv.All(pins.internal_gpio_input_pin_schema,
+                                       pins.validate_has_interrupt),
     cv.Optional(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_PERIODIC_TABLE_CO2, 0),
     cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
     cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),

--- a/esphome/components/zyaura/sensor.py
+++ b/esphome/components/zyaura/sensor.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import sensor
+from esphome.const import CONF_ID, CONF_CLOCK_PIN, CONF_DATA_PIN, CONF_UPDATE_INTERVAL, \
+    CONF_CO2, CONF_TEMPERATURE, CONF_HUMIDITY, \
+    UNIT_PARTS_PER_MILLION, UNIT_CELSIUS, UNIT_PERCENT, \
+    ICON_PERIODIC_TABLE_CO2, ICON_THERMOMETER, ICON_WATER_PERCENT
+from esphome.cpp_helpers import gpio_pin_expression
+
+zyaura_ns = cg.esphome_ns.namespace('zyaura')
+ZyAura = zyaura_ns.class_('ZyAura', cg.PollingComponent)
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(ZyAura),
+    cv.Required(CONF_CLOCK_PIN): pins.gpio_input_pin_schema,
+    cv.Required(CONF_DATA_PIN): pins.gpio_input_pin_schema,
+    cv.Optional(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_PERIODIC_TABLE_CO2, 0),
+    cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
+    cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),
+    cv.Optional(CONF_UPDATE_INTERVAL, default='20s'): cv.update_interval,
+}).extend(cv.polling_component_schema('20s'))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+
+    pin_clock = yield gpio_pin_expression(config[CONF_CLOCK_PIN])
+    cg.add(var.set_pin_clock(pin_clock))
+    pin_data = yield gpio_pin_expression(config[CONF_DATA_PIN])
+    cg.add(var.set_pin_data(pin_data))
+
+    if CONF_CO2 in config:
+        sens = yield sensor.new_sensor(config[CONF_CO2])
+        cg.add(var.set_co2_sensor(sens))
+    if CONF_TEMPERATURE in config:
+        sens = yield sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature_sensor(sens))
+    if CONF_HUMIDITY in config:
+        sens = yield sensor.new_sensor(config[CONF_HUMIDITY])
+        cg.add(var.set_humidity_sensor(sens))

--- a/esphome/components/zyaura/sensor.py
+++ b/esphome/components/zyaura/sensor.py
@@ -9,10 +9,10 @@ from esphome.const import CONF_ID, CONF_CLOCK_PIN, CONF_DATA_PIN, CONF_UPDATE_IN
 from esphome.cpp_helpers import gpio_pin_expression
 
 zyaura_ns = cg.esphome_ns.namespace('zyaura')
-ZyAura = zyaura_ns.class_('ZyAura', cg.PollingComponent)
+ZyAuraSensor = zyaura_ns.class_('ZyAuraSensor', cg.PollingComponent)
 
 CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(): cv.declare_id(ZyAura),
+    cv.GenerateID(): cv.declare_id(ZyAuraSensor),
     cv.Required(CONF_CLOCK_PIN): pins.gpio_input_pin_schema,
     cv.Required(CONF_DATA_PIN): pins.gpio_input_pin_schema,
     cv.Optional(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_PERIODIC_TABLE_CO2, 0),

--- a/esphome/components/zyaura/sensor.py
+++ b/esphome/components/zyaura/sensor.py
@@ -18,8 +18,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_PERIODIC_TABLE_CO2, 0),
     cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
     cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),
-    cv.Optional(CONF_UPDATE_INTERVAL, default='20s'): cv.update_interval,
-}).extend(cv.polling_component_schema('20s'))
+}).extend(cv.polling_component_schema('60s'))
 
 
 def to_code(config):

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -93,8 +93,8 @@ bool ZaSensorStore::set_value_(ZaMessage *message) {
   return true;
 }
 
-void ZyAura::dump_config() {
-  ESP_LOGCONFIG(TAG, "ZyAura:");
+void ZyAuraSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "ZyAuraSensor:");
   LOG_PIN("  Pin Clock: ", this->pin_clock_);
   LOG_PIN("  Pin Data: ", this->pin_data_);
   LOG_UPDATE_INTERVAL(this);
@@ -104,7 +104,7 @@ void ZyAura::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-void ZyAura::update() {
+void ZyAuraSensor::update() {
   this->temperature_sensor_->publish_state(this->store_.temperature);
   this->co2_sensor_->publish_state(this->store_.co2);
   this->humidity_sensor_->publish_state(this->store_.humidity);

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -69,7 +69,7 @@ bool ZaSensorStore::set_value_(ZaMessage *message) {
       if (message->value > 9999) {
         return false;
       }
-      this->humidity = (double)message->value / 100;
+      this->humidity = message->value / 100.0f;
       break;
 
     case TEMPERATURE:

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -105,9 +105,12 @@ void ZyAuraSensor::dump_config() {
 }
 
 void ZyAuraSensor::update() {
-  this->temperature_sensor_->publish_state(this->store_.temperature);
-  this->co2_sensor_->publish_state(this->store_.co2);
-  this->humidity_sensor_->publish_state(this->store_.humidity);
+  if (this->co2_sensor_ != nullptr)
+    this->co2_sensor_->publish_state(this->store_.co2);
+  if (this->temperature_sensor_ != nullptr)
+    this->temperature_sensor_->publish_state(this->store_.temperature);
+  if (this->humidity_sensor_ != nullptr)
+    this->humidity_sensor_->publish_state(this->store_.humidity);
 }
 
 }  // namespace zyaura

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -1,0 +1,106 @@
+#include "zyaura.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace zyaura {
+
+static const char *TAG = "zyaura";
+
+ZaMessage* ZaDataProcessor::process(unsigned long ms, bool data) {
+  // check if a new message has started, based on time since previous bit
+  if ((ms - this->prev_ms_) > ZA_MAX_MS) {
+    this->num_bits_ = 0;
+  }
+  this->prev_ms_ = ms;
+
+  // number of bits received is basically the "state"
+  if (this->num_bits_ < ZA_FRAME_SIZE) {
+    // store it while it fits
+    int idx = this->num_bits_ / ZA_BITS_IN_BYTE;
+    this->buffer_[idx] = (this->buffer_[idx] << 1) | (data ? 1 : 0);
+    // are we done yet?
+    this->num_bits_++;
+    if (this->num_bits_ == ZA_FRAME_SIZE) {
+      this->decode_();
+      return this->msg_;
+    }
+  }
+
+  return nullptr;
+}
+
+void ZaDataProcessor::decode_() {
+  uint8_t checksum = this->buffer_[ZA_BYTE_TYPE] + this->buffer_[ZA_BYTE_HIGH] + this->buffer_[ZA_BYTE_LOW];
+  this->msg_->checksumIsValid = (checksum == this->buffer_[ZA_BYTE_SUM] && this->buffer_[ZA_BYTE_END] == ZA_MSG_DELIMETER);
+  if (!this->msg_->checksumIsValid) {
+    return;
+  }
+
+  this->msg_->type = (ZaDataType)this->buffer_[ZA_BYTE_TYPE];
+  this->msg_->value = this->buffer_[ZA_BYTE_HIGH] << ZA_BITS_IN_BYTE | this->buffer_[ZA_BYTE_LOW];
+  this->msg_->inBoot = (this->msg_->type == CO2 && this->msg_->value > 10000);
+}
+
+void ZaSensorStore::setup(GPIOPin *pin_clock, GPIOPin *pin_data) {
+  pin_clock->setup();
+  pin_data->setup();
+  this->pin_clock_ = pin_clock;
+  this->pin_data_ = pin_data;
+  pin_clock->attach_interrupt(ZaSensorStore::interrupt, this, FALLING);
+}
+
+void ZaSensorStore::interrupt(ZaSensorStore *arg) {
+  unsigned long now = millis();
+  bool dataBit = arg->pin_data_->digital_read();
+  ZaMessage *message = arg->processor_.process(now, dataBit);
+
+  if (message) {
+    if (!message->checksumIsValid) {
+      ESP_LOGW(TAG, "Checksum validation error");
+    } else if (message->inBoot) {
+      ESP_LOGW(TAG, "Sensor reported invalid data. Is the update interval too small?");
+    } else {
+      arg->process_(message);
+    }
+  }
+}
+
+void ZaSensorStore::process_(ZaMessage *message) {
+  switch (message->type) {
+    case HUMIDITY:
+      this->humidity = (double)message->value / 100;
+      break;
+
+    case TEMPERATURE:
+      this->temperature = (double)message->value / 16 - 273.15;
+      break;
+
+    case CO2:
+      this->co2 = message->value;
+      break;
+
+    default:
+      break;
+  }
+}
+
+void ZyAura::dump_config() {
+  ESP_LOGCONFIG(TAG, "ZyAura:");
+  LOG_PIN("  Pin Clock: ", this->pin_clock_);
+  LOG_PIN("  Pin Data: ", this->pin_data_);
+  LOG_UPDATE_INTERVAL(this);
+
+  LOG_SENSOR("  ", "CO2", this->co2_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
+}
+
+void ZyAura::update() {
+  this->temperature_sensor_->publish_state(this->store_.temperature);
+  this->co2_sensor_->publish_state(this->store_.co2);
+  this->humidity_sensor_->publish_state(this->store_.humidity);
+}
+
+}  // namespace zyaura
+}  // namespace esphome

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -1,6 +1,5 @@
 #include "zyaura.h"
 #include "esphome/core/log.h"
-#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace zyaura {
@@ -44,12 +43,12 @@ void ZaDataProcessor::decode_() {
 void ZaSensorStore::setup(GPIOPin *pin_clock, GPIOPin *pin_data) {
   pin_clock->setup();
   pin_data->setup();
-  this->pin_clock_ = pin_clock;
-  this->pin_data_ = pin_data;
+  this->pin_clock_ = pin_clock->to_isr();
+  this->pin_data_ = pin_data->to_isr();
   pin_clock->attach_interrupt(ZaSensorStore::interrupt, this, FALLING);
 }
 
-void ZaSensorStore::interrupt(ZaSensorStore *arg) {
+void ICACHE_RAM_ATTR ZaSensorStore::interrupt(ZaSensorStore *arg) {
   uint32_t now = millis();
   bool dataBit = arg->pin_data_->digital_read();
   ZaMessage *message = arg->processor_.process(now, dataBit);

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -6,7 +6,7 @@ namespace zyaura {
 
 static const char *TAG = "zyaura";
 
-ZaMessage* ZaDataProcessor::process(unsigned long ms, bool data) {
+ZaMessage* ICACHE_RAM_ATTR ZaDataProcessor::process(unsigned long ms, bool data) {
   // check if a new message has started, based on time since previous bit
   if ((ms - this->prev_ms_) > ZA_MAX_MS) {
     this->num_bits_ = 0;
@@ -29,7 +29,7 @@ ZaMessage* ZaDataProcessor::process(unsigned long ms, bool data) {
   return nullptr;
 }
 
-void ZaDataProcessor::decode_() {
+void ICACHE_RAM_ATTR ZaDataProcessor::decode_() {
   uint8_t checksum = this->buffer_[ZA_BYTE_TYPE] + this->buffer_[ZA_BYTE_HIGH] + this->buffer_[ZA_BYTE_LOW];
   this->msg_->checksumIsValid = (checksum == this->buffer_[ZA_BYTE_SUM] && this->buffer_[ZA_BYTE_END] == ZA_MSG_DELIMETER);
   if (!this->msg_->checksumIsValid) {
@@ -58,7 +58,7 @@ void ICACHE_RAM_ATTR ZaSensorStore::interrupt(ZaSensorStore *arg) {
   }
 }
 
-void ZaSensorStore::set_data_(ZaMessage *message) {
+void ICACHE_RAM_ATTR ZaSensorStore::set_data_(ZaMessage *message) {
   if (!message->checksumIsValid) {
     this->isValid = false;
     return;

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -17,7 +17,7 @@ ZaMessage* ZaDataProcessor::process(unsigned long ms, bool data) {
   // number of bits received is basically the "state"
   if (this->num_bits_ < ZA_FRAME_SIZE) {
     // store it while it fits
-    int idx = this->num_bits_ / ZA_BITS_IN_BYTE;
+    int idx = this->num_bits_ / 8;
     this->buffer_[idx] = (this->buffer_[idx] << 1) | (data ? 1 : 0);
     // are we done yet?
     this->num_bits_++;

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -76,7 +76,7 @@ bool ZaSensorStore::set_value_(ZaMessage *message) {
       if (message->value > 5970) {
         return false;
       }
-      this->temperature = (double)message->value / 16 - 273.15;
+      this->temperature = message->value / 16.0f - 273.15f;
       break;
 
     case CO2:

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -6,7 +6,7 @@ namespace zyaura {
 
 static const char *TAG = "zyaura";
 
-ZaMessage* ICACHE_RAM_ATTR ZaDataProcessor::process(unsigned long ms, bool data) {
+ZaMessage * ICACHE_RAM_ATTR ZaDataProcessor::process(unsigned long ms, bool data) {
   // check if a new message has started, based on time since previous bit
   if ((ms - this->prev_ms_) > ZA_MAX_MS) {
     this->num_bits_ = 0;
@@ -31,12 +31,13 @@ ZaMessage* ICACHE_RAM_ATTR ZaDataProcessor::process(unsigned long ms, bool data)
 
 void ICACHE_RAM_ATTR ZaDataProcessor::decode_() {
   uint8_t checksum = this->buffer_[ZA_BYTE_TYPE] + this->buffer_[ZA_BYTE_HIGH] + this->buffer_[ZA_BYTE_LOW];
-  this->msg_->checksumIsValid = (checksum == this->buffer_[ZA_BYTE_SUM] && this->buffer_[ZA_BYTE_END] == ZA_MSG_DELIMETER);
+  this->msg_->checksumIsValid =
+      (checksum == this->buffer_[ZA_BYTE_SUM] && this->buffer_[ZA_BYTE_END] == ZA_MSG_DELIMETER);
   if (!this->msg_->checksumIsValid) {
     return;
   }
 
-  this->msg_->type = (ZaDataType)this->buffer_[ZA_BYTE_TYPE];
+  this->msg_->type = (ZaDataType) this->buffer_[ZA_BYTE_TYPE];
   this->msg_->value = this->buffer_[ZA_BYTE_HIGH] << 8 | this->buffer_[ZA_BYTE_LOW];
 }
 
@@ -50,8 +51,8 @@ void ZaSensorStore::setup(GPIOPin *pin_clock, GPIOPin *pin_data) {
 
 void ICACHE_RAM_ATTR ZaSensorStore::interrupt(ZaSensorStore *arg) {
   uint32_t now = millis();
-  bool dataBit = arg->pin_data_->digital_read();
-  ZaMessage *message = arg->processor_.process(now, dataBit);
+  bool data_bit = arg->pin_data_->digital_read();
+  ZaMessage *message = arg->processor_.process(now, data_bit);
 
   if (message && message->checksumIsValid) {
     arg->set_data_(message);

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -50,7 +50,7 @@ void ZaSensorStore::setup(GPIOPin *pin_clock, GPIOPin *pin_data) {
 }
 
 void ZaSensorStore::interrupt(ZaSensorStore *arg) {
-  unsigned long now = millis();
+  uint32_t now = millis();
   bool dataBit = arg->pin_data_->digital_read();
   ZaMessage *message = arg->processor_.process(now, dataBit);
 

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -38,12 +38,9 @@ class ZaDataProcessor {
   uint8_t buffer_[ZA_MSG_LEN];
   int num_bits_ = 0;
   unsigned long prev_ms_;
-  ZaMessage *msg_ = &_msg;
+  ZaMessage *msg_ = new ZaMessage;
 
   void decode_();
-
- private:
-  ZaMessage _msg;
 };
 
 class ZaSensorStore {

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -7,9 +7,8 @@ namespace esphome {
 namespace zyaura {
 
 #define ZA_MAX_MS         2
-#define ZA_BITS_IN_BYTE   8
 #define ZA_MSG_LEN        5
-#define ZA_FRAME_SIZE     ZA_BITS_IN_BYTE * ZA_MSG_LEN
+#define ZA_FRAME_SIZE     40
 #define ZA_MSG_DELIMETER  0x0D
 
 #define ZA_BYTE_TYPE      0
@@ -48,9 +47,9 @@ class ZaDataProcessor {
 
 class ZaSensorStore {
  public:
-  double temperature = 0;
-  uint16_t co2 = 0;
-  double humidity = 0;
+  float temperature = NAN;
+  uint16_t co2 = NAN;
+  float humidity = NAN;
 
   void setup(GPIOPin *pin_clock, GPIOPin *pin_data);
   static void interrupt(ZaSensorStore *arg);

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome {
+namespace zyaura {
+
+#define ZA_MAX_MS         2
+#define ZA_BITS_IN_BYTE   8
+#define ZA_MSG_LEN        5
+#define ZA_FRAME_SIZE     ZA_BITS_IN_BYTE * ZA_MSG_LEN
+#define ZA_MSG_DELIMETER  0x0D
+
+#define ZA_BYTE_TYPE      0
+#define ZA_BYTE_HIGH      1
+#define ZA_BYTE_LOW       2
+#define ZA_BYTE_SUM       3
+#define ZA_BYTE_END       4
+
+typedef enum {
+  HUMIDITY = 0x41,
+  TEMPERATURE = 0x42,
+  CO2 = 0x50,
+} ZaDataType;
+
+typedef struct {
+  ZaDataType type;
+  uint16_t value;
+  bool checksumIsValid;
+  bool inBoot;
+} ZaMessage;
+
+class ZaDataProcessor {
+ public:
+  ZaMessage* process(unsigned long ms, bool data);
+
+ protected:
+  uint8_t buffer_[ZA_MSG_LEN];
+  int num_bits_ = 0;
+  unsigned long prev_ms_;
+  ZaMessage *msg_ = &_msg;
+
+  void decode_();
+
+ private:
+  ZaMessage _msg;
+};
+
+class ZaSensorStore {
+ public:
+  double temperature = 0;
+  uint16_t co2 = 0;
+  double humidity = 0;
+
+  void setup(GPIOPin *pin_clock, GPIOPin *pin_data);
+  static void interrupt(ZaSensorStore *arg);
+
+ protected:
+  GPIOPin *pin_clock_;
+  GPIOPin *pin_data_;
+  ZaDataProcessor processor_;
+
+  void process_(ZaMessage *message);
+};
+
+/// Component for reading temperature/co2/humidity measurements from ZyAura sensors.
+class ZyAura : public PollingComponent {
+ public:
+  void set_pin_clock(GPIOPin *pin) { pin_clock_ = pin; }
+  void set_pin_data(GPIOPin *pin) { pin_data_ = pin; }
+  void set_co2_sensor(sensor::Sensor *co2_sensor) { co2_sensor_ = co2_sensor; }
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
+
+  void setup() override { this->store_.setup(this->pin_clock_, this->pin_data_); }
+  void dump_config() override;
+  void update() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  ZaSensorStore store_;
+  GPIOPin *pin_clock_;
+  GPIOPin *pin_data_;
+  sensor::Sensor *co2_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
+};
+
+}  // namespace zyaura
+}  // namespace esphome

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -32,7 +32,7 @@ struct ZaMessage {
 
 class ZaDataProcessor {
  public:
-  ZaMessage* process(unsigned long ms, bool data);
+  ZaMessage * process(unsigned long ms, bool data);
 
  protected:
   uint8_t buffer_[ZA_MSG_LEN];

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -64,7 +64,7 @@ class ZaSensorStore {
 };
 
 /// Component for reading temperature/co2/humidity measurements from ZyAura sensors.
-class ZyAura : public PollingComponent {
+class ZyAuraSensor : public PollingComponent {
  public:
   void set_pin_clock(GPIOPin *pin) { pin_clock_ = pin; }
   void set_pin_data(GPIOPin *pin) { pin_data_ = pin; }

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -18,17 +18,17 @@ static const uint8_t ZA_BYTE_LOW = 2;
 static const uint8_t ZA_BYTE_SUM = 3;
 static const uint8_t ZA_BYTE_END = 4;
 
-typedef enum {
+enum ZaDataType {
   HUMIDITY = 0x41,
   TEMPERATURE = 0x42,
   CO2 = 0x50,
-} ZaDataType;
+};
 
-typedef struct {
+struct ZaMessage {
   ZaDataType type;
   uint16_t value;
   bool checksumIsValid;
-} ZaMessage;
+};
 
 class ZaDataProcessor {
  public:

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -7,16 +7,16 @@
 namespace esphome {
 namespace zyaura {
 
-#define ZA_MAX_MS         2
-#define ZA_MSG_LEN        5
-#define ZA_FRAME_SIZE     40
-#define ZA_MSG_DELIMETER  0x0D
+static const uint8_t ZA_MAX_MS = 2;
+static const uint8_t ZA_MSG_LEN = 5;
+static const uint8_t ZA_FRAME_SIZE = 40;
+static const uint8_t ZA_MSG_DELIMETER = 0x0D;
 
-#define ZA_BYTE_TYPE      0
-#define ZA_BYTE_HIGH      1
-#define ZA_BYTE_LOW       2
-#define ZA_BYTE_SUM       3
-#define ZA_BYTE_END       4
+static const uint8_t ZA_BYTE_TYPE = 0;
+static const uint8_t ZA_BYTE_HIGH = 1;
+static const uint8_t ZA_BYTE_LOW = 2;
+static const uint8_t ZA_BYTE_SUM = 3;
+static const uint8_t ZA_BYTE_END = 4;
 
 typedef enum {
   HUMIDITY = 0x41,

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -27,20 +27,17 @@ enum ZaDataType {
 struct ZaMessage {
   ZaDataType type;
   uint16_t value;
-  bool checksumIsValid;
 };
 
 class ZaDataProcessor {
  public:
-  ZaMessage * process(unsigned long ms, bool data);
+  bool decode(unsigned long ms, bool data);
+  ZaMessage *message = new ZaMessage;
 
  protected:
   uint8_t buffer_[ZA_MSG_LEN];
   int num_bits_ = 0;
   unsigned long prev_ms_;
-  ZaMessage *msg_ = new ZaMessage;
-
-  void decode_();
 };
 
 class ZaSensorStore {

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -48,9 +48,10 @@ class ZaDataProcessor {
 
 class ZaSensorStore {
  public:
+  float co2 = NAN;
   float temperature = NAN;
-  uint16_t co2 = NAN;
   float humidity = NAN;
+  bool isValid = false;
 
   void setup(GPIOPin *pin_clock, GPIOPin *pin_data);
   static void interrupt(ZaSensorStore *arg);
@@ -60,7 +61,7 @@ class ZaSensorStore {
   ISRInternalGPIOPin *pin_data_;
   ZaDataProcessor processor_;
 
-  bool set_value_(ZaMessage *message);
+  void set_data_(ZaMessage *message);
 };
 
 /// Component for reading temperature/co2/humidity measurements from ZyAura sensors.
@@ -84,6 +85,8 @@ class ZyAuraSensor : public PollingComponent {
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
+
+  bool publish_state_(sensor::Sensor *sensor, float value);
 };
 
 }  // namespace zyaura

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/sensor/sensor.h"
 
 namespace esphome {
@@ -55,8 +56,8 @@ class ZaSensorStore {
   static void interrupt(ZaSensorStore *arg);
 
  protected:
-  GPIOPin *pin_clock_;
-  GPIOPin *pin_data_;
+  ISRInternalGPIOPin *pin_clock_;
+  ISRInternalGPIOPin *pin_data_;
   ZaDataProcessor processor_;
 
   bool set_value_(ZaMessage *message);

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -28,7 +28,6 @@ typedef struct {
   ZaDataType type;
   uint16_t value;
   bool checksumIsValid;
-  bool inBoot;
 } ZaMessage;
 
 class ZaDataProcessor {
@@ -61,7 +60,7 @@ class ZaSensorStore {
   GPIOPin *pin_data_;
   ZaDataProcessor processor_;
 
-  void process_(ZaMessage *message);
+  bool set_value_(ZaMessage *message);
 };
 
 /// Component for reading temperature/co2/humidity measurements from ZyAura sensors.

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -48,7 +48,6 @@ class ZaSensorStore {
   float co2 = NAN;
   float temperature = NAN;
   float humidity = NAN;
-  bool isValid = false;
 
   void setup(GPIOPin *pin_clock, GPIOPin *pin_data);
   static void interrupt(ZaSensorStore *arg);
@@ -83,7 +82,7 @@ class ZyAuraSensor : public PollingComponent {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
 
-  bool publish_state_(sensor::Sensor *sensor, float value);
+  bool publish_state_(sensor::Sensor *sensor, float *value);
 };
 
 }  // namespace zyaura

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -564,6 +564,15 @@ sensor:
       name: CCS811 TVOC
     update_interval: 30s
     baseline: 0x4242
+  - platform: zyaura
+    clock_pin: GPIO5
+    data_pin: GPIO4
+    co2:
+      name: "ZyAura CO2"
+    temperature:
+      name: "ZyAura Temperature"
+    humidity:
+      name: "ZyAura Humidity"
 
 
 esp32_touch:


### PR DESCRIPTION
## Description:
The ZyAura CO2 & Temperature & Humidity sensor allows you to use your [ZGm05(3)(U)](http://www.zyaura.com/products/ZGm05.asp) ([MT8057](https://masterkit.ru/shop/1266110), [MT8057S](https://medgadgets.ru/shop/kit-mt8057.html)), [ZG1683R(U)](http://www.zyaura.com/products/ZG1683R.asp) ([MT8060](https://masterkit.ru/shop/1921398)), [ZG1583RUD](http://www.zyaura.com/products/ZG1583RUD.asp) monitors with ESPHome.

```
# Example configuration entry
sensor:
  - platform: zyaura
    clock_pin: D1
    data_pin: D2
    co2:
      name: "ZyAura CO2"
    temperature:
      name: "ZyAura Temperature"
    humidity:
      name: "ZyAura Humidity"
```

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#281

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
