### PR TITLE
Fix issue that requires both heat and cool

### DIFF
--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -79,8 +79,8 @@ void BangBangClimate::compute_state_() {
       target_mode = climate::CLIMATE_MODE_OFF;
   } else {
     // neither too hot nor too cold -> in range
-    if (this->supports_cool_ && this->supports_heat_) {
-      // if supports both ends, go to idle mode
+    if (this->supports_cool_ || this->supports_heat_) {
+      // if supports either, go to idle mode
       target_mode = climate::CLIMATE_MODE_OFF;
     } else {
       // else use current mode and don't change (hysteresis)


### PR DESCRIPTION
## Description:
I've been working on an attic fan that gets turned on when the attic is too hot. However, unless you specify a `heat_action` the fan turns on, but never off. I think this is a simple bug in the code.

Here is my config which doesn't work as expected. Relay turns on, but never off (unless you reset).

```yaml
climate:
  - platform: bang_bang
    name: "Attic Fan"
    sensor: attic_fan_temp
    visual:
      min_temperature: -10
      max_temperature: 60
      temperature_step: 1
    default_target_temperature_low: 20
    default_target_temperature_high: 43
    cool_action:
      - switch.turn_on: attic_fan_relay
    idle_action:
      - switch.turn_off: attic_fan_relay```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
