### PR TITLE
WiFi networks priority

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -5,7 +5,7 @@ from esphome.automation import Condition
 from esphome.const import CONF_AP, CONF_BSSID, CONF_CHANNEL, CONF_DNS1, CONF_DNS2, CONF_DOMAIN, \
     CONF_FAST_CONNECT, CONF_GATEWAY, CONF_HIDDEN, CONF_ID, CONF_MANUAL_IP, CONF_NETWORKS, \
     CONF_PASSWORD, CONF_POWER_SAVE_MODE, CONF_REBOOT_TIMEOUT, CONF_SSID, CONF_STATIC_IP, \
-    CONF_SUBNET, CONF_USE_ADDRESS
+    CONF_SUBNET, CONF_USE_ADDRESS, CONF_PRIORITY
 from esphome.core import CORE, HexInt, coroutine_with_priority
 
 AUTO_LOAD = ['network']
@@ -72,6 +72,7 @@ WIFI_NETWORK_AP = WIFI_NETWORK_BASE.extend({
 WIFI_NETWORK_STA = WIFI_NETWORK_BASE.extend({
     cv.Optional(CONF_BSSID): cv.mac_address,
     cv.Optional(CONF_HIDDEN): cv.boolean,
+    cv.Optional(CONF_PRIORITY, default=0.0): cv.float_,
 })
 
 
@@ -161,6 +162,8 @@ def wifi_network(config, static_ip):
         cg.add(ap.set_channel(config[CONF_CHANNEL]))
     if static_ip is not None:
         cg.add(ap.set_manual_ip(manual_ip(static_ip)))
+    if CONF_PRIORITY in config:
+        cg.add(ap.set_priority(config[CONF_PRIORITY]))
 
     return ap
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -273,6 +273,9 @@ void WiFiComponent::print_connect_params_() {
   int8_t rssi = WiFi.RSSI();
   print_signal_bars(rssi, signal_bars);
   ESP_LOGCONFIG(TAG, "  Signal strength: %d dB %s", rssi, signal_bars);
+  if (this->selected_ap_.get_bssid().has_value()) {
+    ESP_LOGV(TAG, "  Priority: %.1f", this->get_sta_priority(*this->selected_ap_.get_bssid()));
+  }
   ESP_LOGCONFIG(TAG, "  Channel: %d", WiFi.channel());
   ESP_LOGCONFIG(TAG, "  Subnet: %s", WiFi.subnetMask().toString().c_str());
   ESP_LOGCONFIG(TAG, "  Gateway: %s", WiFi.gatewayIP().toString().c_str());

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -66,12 +66,14 @@ class WiFiAP {
   void set_bssid(optional<bssid_t> bssid);
   void set_password(const std::string &password);
   void set_channel(optional<uint8_t> channel);
+  void set_priority(float priority) { priority_ = priority; }
   void set_manual_ip(optional<ManualIP> manual_ip);
   void set_hidden(bool hidden);
   const std::string &get_ssid() const;
   const optional<bssid_t> &get_bssid() const;
   const std::string &get_password() const;
   const optional<uint8_t> &get_channel() const;
+  float get_priority() const { return priority_; }
   const optional<ManualIP> &get_manual_ip() const;
   bool get_hidden() const;
 
@@ -80,6 +82,7 @@ class WiFiAP {
   optional<bssid_t> bssid_;
   std::string password_;
   optional<uint8_t> channel_;
+  float priority_{0};
   optional<ManualIP> manual_ip_;
   bool hidden_{false};
 };
@@ -99,6 +102,12 @@ class WiFiScanResult {
   int8_t get_rssi() const;
   bool get_with_auth() const;
   bool get_is_hidden() const;
+  float get_priority() const {
+    return priority_;
+  }
+  void set_priority(float priority) {
+    priority_ = priority;
+  }
 
  protected:
   bool matches_{false};
@@ -108,6 +117,12 @@ class WiFiScanResult {
   int8_t rssi_;
   bool with_auth_;
   bool is_hidden_;
+  float priority_{0.0f};
+};
+
+struct WiFiSTAPriority {
+  bssid_t bssid;
+  float priority;
 };
 
 enum WiFiPowerSaveMode {
@@ -175,6 +190,30 @@ class WiFiComponent : public Component {
 
   IPAddress wifi_soft_ap_ip();
 
+  bool has_sta_priority(const bssid_t &bssid) {
+    for (auto &it : this->sta_priorities_)
+      if (it.bssid == bssid)
+        return true;
+    return false;
+  }
+  float get_sta_priority(const bssid_t bssid) {
+    for (auto &it : this->sta_priorities_)
+      if (it.bssid == bssid)
+        return it.priority;
+    return 0.0f;
+  }
+  void set_sta_priority(const bssid_t bssid, float priority) {
+    for (auto &it : this->sta_priorities_)
+      if (it.bssid == bssid) {
+        it.priority = priority;
+        return;
+      }
+    this->sta_priorities_.push_back(WiFiSTAPriority{
+      .bssid = bssid,
+      .priority = priority,
+    });
+  }
+
  protected:
   static std::string format_mac_addr(const uint8_t mac[6]);
   void setup_ap_config_();
@@ -209,6 +248,7 @@ class WiFiComponent : public Component {
 
   std::string use_address_;
   std::vector<WiFiAP> sta_;
+  std::vector<WiFiSTAPriority> sta_priorities_;
   WiFiAP selected_ap_;
   bool fast_connect_{false};
 

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -102,12 +102,8 @@ class WiFiScanResult {
   int8_t get_rssi() const;
   bool get_with_auth() const;
   bool get_is_hidden() const;
-  float get_priority() const {
-    return priority_;
-  }
-  void set_priority(float priority) {
-    priority_ = priority;
-  }
+  float get_priority() const { return priority_; }
+  void set_priority(float priority) { priority_ = priority; }
 
  protected:
   bool matches_{false};
@@ -209,8 +205,8 @@ class WiFiComponent : public Component {
         return;
       }
     this->sta_priorities_.push_back(WiFiSTAPriority{
-      .bssid = bssid,
-      .priority = priority,
+        .bssid = bssid,
+        .priority = priority,
     });
   }
 


### PR DESCRIPTION
## Description:

Add priority setting to WiFi networks.

Priority is saved per-bssid and defaults to 0. Of all matching networks, the one with the highest current priority is chosen (if some share the same priority, RSSI is used). Each time connecting to a network fails or a connection is lost, the priority of the BSSID decreases by one.

- Allows users to force a network to be used with a higher priority (fixes https://github.com/esphome/feature-requests/issues/136)
- Adds some smartness to network selection - if for example a matching network exists that errors out when connecting, the ESP will automatically choose the next-best network until connecting works.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
