### PR TITLE
ESP32 Use NVS directly

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -40,7 +40,7 @@ class Application {
   void pre_setup(const std::string &name, const char *compilation_time) {
     this->name_ = name;
     this->compilation_time_ = compilation_time;
-    global_preferences.begin(this->name_);
+    global_preferences.begin();
   }
 
 #ifdef USE_BINARY_SENSOR

--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -2,10 +2,6 @@
 
 #include <string>
 
-#ifdef ARDUINO_ARCH_ESP32
-#include <Preferences.h>
-#endif
-
 #include "esphome/core/esphal.h"
 #include "esphome/core/defines.h"
 
@@ -56,7 +52,7 @@ static bool DEFAULT_IN_FLASH = true;
 class ESPPreferences {
  public:
   ESPPreferences();
-  void begin(const std::string &name);
+  void begin();
   ESPPreferenceObject make_preference(size_t length, uint32_t type, bool in_flash = DEFAULT_IN_FLASH);
   template<typename T> ESPPreferenceObject make_preference(uint32_t type, bool in_flash = DEFAULT_IN_FLASH);
 
@@ -77,7 +73,7 @@ class ESPPreferences {
 
   uint32_t current_offset_;
 #ifdef ARDUINO_ARCH_ESP32
-  Preferences preferences_;
+  uint32_t nvs_handle_;
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
   void save_esp8266_flash_();

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -239,7 +239,6 @@ def to_code(config):
 
     # Libraries
     if CORE.is_esp32:
-        cg.add_library('Preferences', None)
         cg.add_library('ESPmDNS', None)
     elif CORE.is_esp8266:
         cg.add_library('ESP8266WiFi', None)


### PR DESCRIPTION
## Description:

I had some issues where a corrupt NVS partition would make an ESP32 totally unresponsive (even WiFi was not working because esp-idf also accesses NVS from wifi calls).

This hopefully fixes that by automatically purging the NVS partition if an error is detected. Also this uses the `nvs_` calls directly instead of through `Preferences`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
