### PR TITLE
Fix deep sleep on_shutdown hooks

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -119,8 +119,12 @@ class Application {
   void safe_reboot();
 
   void run_safe_shutdown_hooks() {
-    for (auto *comp : this->components_)
+    for (auto *comp : this->components_) {
       comp->on_safe_shutdown();
+    }
+    for (auto *comp : this->components_) {
+      comp->on_shutdown();
+    }
   }
 
   uint32_t get_app_state() const { return this->app_state_; }


### PR DESCRIPTION
Fixes https://github.com/esphome/feature-requests/issues/294, fixes https://github.com/esphome/issues/issues/497

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
