### PR TITLE
add time based cover, has built in endstop

### DIFF
--- a/esphome/components/time_based/cover.py
+++ b/esphome/components/time_based/cover.py
@@ -8,6 +8,8 @@ from esphome.const import CONF_CLOSE_ACTION, CONF_CLOSE_DURATION, CONF_ID, CONF_
 time_based_ns = cg.esphome_ns.namespace('time_based')
 TimeBasedCover = time_based_ns.class_('TimeBasedCover', cover.Cover, cg.Component)
 
+CONF_HAS_BUILT_IN_ENDSTOP = 'has_built_in_endstop'
+
 CONFIG_SCHEMA = cover.COVER_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(TimeBasedCover),
     cv.Required(CONF_STOP_ACTION): automation.validate_automation(single=True),
@@ -17,6 +19,8 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend({
 
     cv.Required(CONF_CLOSE_ACTION): automation.validate_automation(single=True),
     cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
+
+    cv.Optional(CONF_HAS_BUILT_IN_ENDSTOP, default=False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 
 
@@ -32,3 +36,5 @@ def to_code(config):
 
     cg.add(var.set_close_duration(config[CONF_CLOSE_DURATION]))
     yield automation.build_automation(var.get_close_trigger(), [], config[CONF_CLOSE_ACTION])
+
+    cg.add(var.set_has_built_in_endstop(config[CONF_HAS_BUILT_IN_ENDSTOP]))

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -62,6 +62,12 @@ void TimeBasedCover::control(const CoverCall &call) {
     auto pos = *call.get_position();
     if (pos == this->position) {
       // already at target
+      // for covers with built in end stop, we should send the command again
+      if (this->has_built_in_endstop_ && (pos == 0.0f || pos == 1.0f)) {
+        auto op = pos == 0.0f ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+        this->target_position_ = pos;
+        this->start_direction_(op);
+      }
     } else {
       auto op = pos < this->position ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
       this->target_position_ = pos;

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -87,7 +87,7 @@ bool TimeBasedCover::is_at_target_() const {
   }
 }
 void TimeBasedCover::start_direction_(CoverOperation dir) {
-  if (dir == this->current_operation)
+  if (dir == this->current_operation && dir != COVER_OPERATION_IDLE)
     return;
 
   this->recompute_position_();

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -31,7 +31,7 @@ void TimeBasedCover::loop() {
   this->recompute_position_();
 
   if (this->is_at_target_()) {
-    if (this->has_built_in_endstop_ && (this->target_position_ == 0.0f || this->target_position_ == 1.0f)) {
+    if (this->has_built_in_endstop_ && (this->target_position_ == COVER_OPEN || this->target_position_ == COVER_CLOSED)) {
       // Don't trigger stop, let the cover stop by itself.
       this->current_operation = COVER_OPERATION_IDLE;
     } else {
@@ -63,8 +63,8 @@ void TimeBasedCover::control(const CoverCall &call) {
     if (pos == this->position) {
       // already at target
       // for covers with built in end stop, we should send the command again
-      if (this->has_built_in_endstop_ && (pos == 0.0f || pos == 1.0f)) {
-        auto op = pos == 0.0f ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+      if (this->has_built_in_endstop_ && (pos == COVER_OPEN || pos == COVER_CLOSED)) {
+        auto op = pos == COVER_CLOSED ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
         this->target_position_ = pos;
         this->start_direction_(op);
       }

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -50,6 +50,7 @@ CoverTraits TimeBasedCover::get_traits() {
 }
 void TimeBasedCover::control(const CoverCall &call) {
   if (call.get_stop()) {
+    this->target_position_ = this->position;
     this->start_direction_(COVER_OPERATION_IDLE);
     this->publish_state();
   }
@@ -104,7 +105,12 @@ void TimeBasedCover::start_direction_(CoverOperation dir) {
   this->current_operation = dir;
 
   this->stop_prev_trigger_();
-  trig->trigger();
+  if (dir == COVER_OPERATION_IDLE && this->has_built_in_endstop_
+    &&  (this->target_position_ == 0.0f || this->target_position_ == 1.0f)) {
+    // Don't trigger stop, let the cover stop by itself.
+  } else {
+    trig->trigger();
+  }
   this->prev_command_trigger_ = trig;
 
   const uint32_t now = millis();

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -31,8 +31,7 @@ void TimeBasedCover::loop() {
   this->recompute_position_();
 
   if (this->is_at_target_()) {
-    if (this->has_built_in_endstop_
-      && (this->target_position_ == 0.0f || this->target_position_ == 1.0f)) {
+    if (this->has_built_in_endstop_ && (this->target_position_ == 0.0f || this->target_position_ == 1.0f)) {
       // Don't trigger stop, let the cover stop by itself.
       this->current_operation = COVER_OPERATION_IDLE;
     } else {

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -42,7 +42,7 @@ class TimeBasedCover : public cover::Cover, public Component {
   uint32_t start_dir_time_{0};
   uint32_t last_publish_time_{0};
   float target_position_{0};
-  bool has_built_in_endstop_{0};
+  bool has_built_in_endstop_{false};
 };
 
 }  // namespace time_based

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -20,6 +20,7 @@ class TimeBasedCover : public cover::Cover, public Component {
   void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
   void set_close_duration(uint32_t close_duration) { this->close_duration_ = close_duration; }
   cover::CoverTraits get_traits() override;
+  void set_has_built_in_endstop(bool value) { this->has_built_in_endstop_ = value; }
 
  protected:
   void control(const cover::CoverCall &call) override;
@@ -41,6 +42,7 @@ class TimeBasedCover : public cover::Cover, public Component {
   uint32_t start_dir_time_{0};
   uint32_t last_publish_time_{0};
   float target_position_{0};
+  bool has_built_in_endstop_{0};
 };
 
 }  // namespace time_based


### PR DESCRIPTION
## Description:
As my blinds has built in end stops I had to add a way to prevent this component to stop the blinds before they fully open or they fully close.
The way my blinds works, they have a remote control (rc switch) with three buttons, up, down and stop. The blinds themselves have the end stop logic to stop on the limits but you can also stop in any position you'd like.
Without this the blinds gets out of sync with the estimated position of the component (it starts at 50% after cold boot) and would likely open only half way and then stay there and only solution is to use original remote controller.

I added the Optional `has_built_in_endstop:` which defaults to false so is backwards compatible, may be this could be an opportunity to individualize built in end stops at open or closed position only.

Off: why a 100% position means fully open cover? is this imposed by HA?
Cover 0% -> cover closed
Cover 100% -> cover open
this just seems awkward to me

**Related issue (if applicable):** fixes not really but somewhat related:  https://github.com/esphome/issues/issues/355

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs# https://github.com/esphome/esphome-docs/pull/302

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
