### PR TITLE
Restore sending "None" effect type

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -318,6 +318,7 @@ bool APIConnection::send_light_info(light::LightState *light) {
     msg.max_mireds = traits.get_max_mireds();
   }
   if (light->supports_effects()) {
+    msg.effects.push_back("None");
     for (auto *effect : light->get_effects())
       msg.effects.push_back(effect->get_name());
   }


### PR DESCRIPTION
## Description:

This is a regression from 369d175694dcde3545bfc3b04711bd8dca81b2e5.

With current `dev`, the "None" effect is not sent and therefore effects cannot be turned off via the UI in home-assistant.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
