### PR TITLE
add repeat log time

### DIFF
--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -251,7 +251,7 @@ bool RCSwitchDumper::dump(RemoteReceiveData src) {
       uint32_t m = millis();
       uint32_t delta_time = m - LAST_MILLIS;
       if (delta_time < 1000 && LAST_RECEIVED_DATA == out_data && LAST_RECEIVED_NBITS == out_nbits) {
-        ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s' Repeat: %dms", i, buffer, delta_time);
+        ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s' Repeat: %ums", i, buffer, delta_time);
       } else {
         ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s'", i, buffer);
       }

--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -234,9 +234,9 @@ bool RCSwitchRawReceiver::matches(RemoteReceiveData src) {
   return decoded_nbits == this->nbits_ && (decoded_code & this->mask_) == (this->code_ & this->mask_);
 }
 bool RCSwitchDumper::dump(RemoteReceiveData src) {
-  static uint32_t last_received_data = 0;
-  static uint8_t last_received_nbits;
-  static uint32_t last_millis = 0;
+  static uint32_t LAST_RECEIVED_DATA = 0;
+  static uint8_t LAST_RECEIVED_NBITS;
+  static uint32_t LAST_MILLIS = 0;
   for (uint8_t i = 1; i <= 7; i++) {
     src.reset();
     uint32_t out_data;
@@ -249,15 +249,15 @@ bool RCSwitchDumper::dump(RemoteReceiveData src) {
 
       buffer[out_nbits] = '\0';
       uint32_t m = millis();
-      uint32_t delta_time = m - last_millis;
-      if (delta_time < 1000 && last_received_data == out_data && last_received_nbits == out_nbits) {
+      uint32_t delta_time = m - LAST_MILLIS;
+      if (delta_time < 1000 && LAST_RECEIVED_DATA == out_data && LAST_RECEIVED_NBITS == out_nbits) {
         ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s' Repeat: %dms", i, buffer, delta_time);
       } else {
         ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s'", i, buffer);
       }
-      last_received_data = out_data;
-      last_received_nbits = out_nbits;
-      last_millis = m;
+      LAST_RECEIVED_DATA = out_data;
+      LAST_RECEIVED_NBITS = out_nbits;
+      LAST_MILLIS = m;
 
       // only send first decoded protocol
       return true;


### PR DESCRIPTION
## Description:
Adds repeat time information on rc-switch dump

Example:
````
[21:51:18][D][remote.rc_switch:256]: Received RCSwitch Raw: protocol=1 data='110100000011110100110000'
[21:51:18][D][remote.rc_switch:254]: Received RCSwitch Raw: protocol=1 data='110100000011110100110000' Repeat: 34ms
[21:51:18][D][remote.rc_switch:254]: Received RCSwitch Raw: protocol=1 data='110100000011110100110000' Repeat: 33ms
[21:51:18][D][remote.rc_switch:254]: Received RCSwitch Raw: protocol=1 data='110100000011110100110000' Repeat: 34ms
````
The idea is to give user additional information to setup their rc-switch, adding in docs
````yaml
   repat: 
    times: 5
    time: 30ms
```` 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
