### PR TITLE
Fixes sim800l

### DIFF
--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -71,7 +71,8 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       // While we were waiting for update to check for messages, this notifies a message
       // is available.
       bool message_available = message.compare(0, 6, "+CMTI:") == 0;
-      if (!message_available) break;
+      if (!message_available)
+        break;
       // Else fall thru ...
     }
     case STATE_CHECK_SMS:

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -68,11 +68,15 @@ void Sim800LComponent::parse_cmd_(std::string message) {
 
   switch (this->state_) {
     case STATE_INIT:
-      if (message.compare(0, 6, "+CMTI:") == 0) {
-        // While we were waiting for update to check for messages, this notifies a message
-        // is available. Grab it quickly
-        this->state_ = STATE_CHECK_SMS;
-      }
+      // While we were waiting for update to check for messages, this notifies a message
+      // is available. 
+      bool message_available = message.compare(0, 6, "+CMTI:") == 0;
+      if (!message_available) break;
+      // Else fall thru ...
+    case STATE_CHECK_SMS:
+      send_cmd_("AT+CMGL=\"ALL\"");
+      this->state_ = STATE_PARSE_SMS;
+      this->parse_index_ = 0;
       break;
     case STATE_DISABLE_ECHO:
       send_cmd_("ATE0");
@@ -95,7 +99,6 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       if (registered) {
         if (!this->registered_)
           ESP_LOGD(TAG, "Registered OK");
-        send_cmd_("AT+CSQ");
         this->state_ = STATE_CSQ;
         this->expect_ack_ = true;
       } else {
@@ -113,6 +116,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       break;
     }
     case STATE_CSQ:
+      send_cmd_("AT+CSQ");
       this->state_ = STATE_CSQ_RESPONSE;
       break;
     case STATE_CSQ_RESPONSE:
@@ -123,6 +127,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
           ESP_LOGD(TAG, "RSSI: %d", this->rssi_);
         }
       }
+      this->expect_ack_ = true;
       this->state_ = STATE_CHECK_SMS;
       break;
     case STATE_PARSE_SMS:
@@ -208,12 +213,6 @@ void Sim800LComponent::parse_cmd_(std::string message) {
     default:
       ESP_LOGD(TAG, "Unhandled: %s - %d", message.c_str(), this->state_);
       break;
-  }
-  if (this->state_ == STATE_CHECK_SMS) {
-    send_cmd_("AT+CMGL=\"ALL\"");
-    this->state_ = STATE_PARSE_SMS;
-    this->parse_index_ = 0;
-    this->expect_ack_ = true;
   }
 }
 

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -67,12 +67,13 @@ void Sim800LComponent::parse_cmd_(std::string message) {
   }
 
   switch (this->state_) {
-    case STATE_INIT:
+    case STATE_INIT: {
       // While we were waiting for update to check for messages, this notifies a message
-      // is available. 
+      // is available.
       bool message_available = message.compare(0, 6, "+CMTI:") == 0;
       if (!message_available) break;
       // Else fall thru ...
+    }
     case STATE_CHECK_SMS:
       send_cmd_("AT+CMGL=\"ALL\"");
       this->state_ = STATE_PARSE_SMS;


### PR DESCRIPTION
## Description:

Some improvements after better debugging, sms are now received quickly as before there was a glitch which caused the protocol to timeout and later receive the sms on the retry.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
