### PR TITLE
Mhz 19 abc

### DIFF
--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -53,12 +53,12 @@ void MHZ19Component::update() {
 bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *response) {
   this->write_array(command, MHZ19_REQUEST_LENGTH);
   this->write_byte(mhz19_checksum(command));
+  this->flush();
 
   if (response == nullptr)
     return true;
 
   bool ret = this->read_array(response, MHZ19_RESPONSE_LENGTH);
-  this->flush();
   return ret;
 }
 float MHZ19Component::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -51,7 +51,6 @@ void MHZ19Component::update() {
 }
 
 bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *response) {
-  this->flush();
   this->write_array(command, MHZ19_REQUEST_LENGTH);
   this->write_byte(mhz19_checksum(command));
 

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -16,6 +16,15 @@ uint8_t mhz19_checksum(const uint8_t *command) {
   return 0xFF - sum + 0x01;
 }
 
+static char hex_buf[MHZ19_PDU_LENGTH * 3 + 1];
+const char *dump_data_buf(const uint8_t *data) {
+  memset(hex_buf, '\0', sizeof(hex_buf));
+  for (int i = 0; i < MHZ19_PDU_LENGTH; i++) {
+    sprintf(hex_buf, "%s%0x%s", hex_buf, data[i], i == MHZ19_PDU_LENGTH - 1 ? "" : " ");
+  }
+  return hex_buf;
+}
+
 void MHZ19Component::update() {
   uint8_t response[MHZ19_PDU_LENGTH];
   if (!this->mhz19_write_command_(MHZ19_COMMAND_GET_PPM, response)) {
@@ -50,6 +59,7 @@ void MHZ19Component::update() {
 }
 
 bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *response) {
+  ESP_LOGD(TAG, "cmd [%s]", dump_data_buf(command));
   this->write_array(command, MHZ19_PDU_LENGTH);
   this->flush();
 
@@ -57,6 +67,7 @@ bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *respo
     return true;
 
   bool ret = this->read_array(response, MHZ19_PDU_LENGTH);
+  ESP_LOGD(TAG, "resp [%s]", dump_data_buf(response));
   return ret;
 }
 float MHZ19Component::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -5,20 +5,19 @@ namespace esphome {
 namespace mhz19 {
 
 static const char *TAG = "mhz19";
-static const uint8_t MHZ19_REQUEST_LENGTH = 8;
-static const uint8_t MHZ19_RESPONSE_LENGTH = 9;
-static const uint8_t MHZ19_COMMAND_GET_PPM[] = {0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00};
+static const uint8_t MHZ19_PDU_LENGTH = 9;
+static const uint8_t MHZ19_COMMAND_GET_PPM[] = {0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79};
 
 uint8_t mhz19_checksum(const uint8_t *command) {
   uint8_t sum = 0;
-  for (uint8_t i = 1; i < MHZ19_REQUEST_LENGTH; i++) {
+  for (uint8_t i = 1; i < MHZ19_PDU_LENGTH - 1; i++) {
     sum += command[i];
   }
   return 0xFF - sum + 0x01;
 }
 
 void MHZ19Component::update() {
-  uint8_t response[MHZ19_RESPONSE_LENGTH];
+  uint8_t response[MHZ19_PDU_LENGTH];
   if (!this->mhz19_write_command_(MHZ19_COMMAND_GET_PPM, response)) {
     ESP_LOGW(TAG, "Reading data from MHZ19 failed!");
     this->status_set_warning();
@@ -51,14 +50,13 @@ void MHZ19Component::update() {
 }
 
 bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *response) {
-  this->write_array(command, MHZ19_REQUEST_LENGTH);
-  this->write_byte(mhz19_checksum(command));
+  this->write_array(command, MHZ19_PDU_LENGTH);
   this->flush();
 
   if (response == nullptr)
     return true;
 
-  bool ret = this->read_array(response, MHZ19_RESPONSE_LENGTH);
+  bool ret = this->read_array(response, MHZ19_PDU_LENGTH);
   return ret;
 }
 float MHZ19Component::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -39,6 +39,13 @@ void MHZ19Component::update() {
     return;
   }
 
+  /* Sensor reports U(15000) during boot, ingnore reported CO2 until it boots */
+  uint16_t u = (response[6] << 8) + response[7];
+  if (u == 15000) {
+    ESP_LOGD(TAG, "Sensor is booting");
+    return;
+  }
+
   this->status_clear_warning();
   const uint16_t ppm = (uint16_t(response[2]) << 8) | response[3];
   const int temp = int(response[4]) - 40;

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -34,7 +34,7 @@ void MHZ19Component::update() {
   }
 
   if (response[0] != 0xFF || response[1] != 0x86) {
-    ESP_LOGW(TAG, "Invalid preamble from MHZ19!");
+    ESP_LOGW(TAG, "Invalid response from MHZ19! [%s]", dump_data_buf(response));
     this->status_set_warning();
     return;
   }

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -11,6 +11,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
  public:
   float get_setup_priority() const override;
 
+  void setup() override;
   void update() override;
   void dump_config() override;
 
@@ -22,6 +23,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
 
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *co2_sensor_{nullptr};
+  bool model_b_;
 };
 
 }  // namespace mhz19

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -17,6 +17,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_co2_sensor(sensor::Sensor *co2_sensor) { co2_sensor_ = co2_sensor; }
+  void set_abc(bool enable_abc) { abc_enabled_ = enable_abc; }
 
  protected:
   bool mhz19_write_command_(const uint8_t *command, uint8_t *response);
@@ -24,6 +25,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *co2_sensor_{nullptr};
   bool model_b_;
+  bool abc_enabled_;
 };
 
 }  // namespace mhz19

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -26,6 +26,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *co2_sensor_{nullptr};
   bool model_b_;
   bool abc_enabled_;
+  bool setup_done;
 };
 
 }  // namespace mhz19

--- a/esphome/components/mhz19/sensor.py
+++ b/esphome/components/mhz19/sensor.py
@@ -2,11 +2,11 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, uart
 from esphome.const import CONF_CO2, CONF_ID, CONF_TEMPERATURE, ICON_PERIODIC_TABLE_CO2, \
-    UNIT_PARTS_PER_MILLION, UNIT_CELSIUS, ICON_THERMOMETER, UNIT_EMPTY, ICON_EMPTY
+    UNIT_PARTS_PER_MILLION, UNIT_CELSIUS, ICON_THERMOMETER
 
 DEPENDENCIES = ['uart']
 
-CONF_ABC = "automatic_baseline_calibration"
+CONF_AUTOMATIC_BASELINE_CALIBRATION = "automatic_baseline_calibration"
 mhz19_ns = cg.esphome_ns.namespace('mhz19')
 MHZ19Component = mhz19_ns.class_('MHZ19Component', cg.PollingComponent, uart.UARTDevice)
 
@@ -14,7 +14,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(MHZ19Component),
     cv.Required(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_PERIODIC_TABLE_CO2, 0),
     cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 0),
-    cv.Optional(CONF_ABC, default=False): cv.boolean,
+    cv.Optional(CONF_AUTOMATIC_BASELINE_CALIBRATION, default=False): cv.boolean,
 }).extend(cv.polling_component_schema('60s')).extend(uart.UART_DEVICE_SCHEMA)
 
 
@@ -31,4 +31,4 @@ def to_code(config):
         sens = yield sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature_sensor(sens))
 
-    cg.add(var.set_abc(config[CONF_ABC]))
+    cg.add(var.set_abc(config[CONF_AUTOMATIC_BASELINE_CALIBRATION]))

--- a/esphome/components/mhz19/sensor.py
+++ b/esphome/components/mhz19/sensor.py
@@ -2,10 +2,11 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, uart
 from esphome.const import CONF_CO2, CONF_ID, CONF_TEMPERATURE, ICON_PERIODIC_TABLE_CO2, \
-    UNIT_PARTS_PER_MILLION, UNIT_CELSIUS, ICON_THERMOMETER
+    UNIT_PARTS_PER_MILLION, UNIT_CELSIUS, ICON_THERMOMETER, UNIT_EMPTY, ICON_EMPTY
 
 DEPENDENCIES = ['uart']
 
+CONF_ABC = "automatic_baseline_calibration"
 mhz19_ns = cg.esphome_ns.namespace('mhz19')
 MHZ19Component = mhz19_ns.class_('MHZ19Component', cg.PollingComponent, uart.UARTDevice)
 
@@ -13,6 +14,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(MHZ19Component),
     cv.Required(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_PERIODIC_TABLE_CO2, 0),
     cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 0),
+    cv.Optional(CONF_ABC, default=False): cv.boolean,
 }).extend(cv.polling_component_schema('60s')).extend(uart.UART_DEVICE_SCHEMA)
 
 
@@ -28,3 +30,5 @@ def to_code(config):
     if CONF_TEMPERATURE in config:
         sens = yield sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature_sensor(sens))
+
+    cg.add(var.set_abc(config[CONF_ABC]))

--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -98,6 +98,14 @@ void UARTComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing...");
   this->hw_serial_->flush();
 }
+
+void UARTComponent::drain() {
+  for (int i = 0; this->available(); i++) {
+    uint8_t junk;
+    this->read_byte(&junk);
+    ESP_LOGVV(TAG, "Draining RX[%d]: %0x", i, junk);
+  }
+}
 #endif  // ESP32
 
 #ifdef ARDUINO_ARCH_ESP8266
@@ -235,6 +243,19 @@ void UARTComponent::flush() {
   }
 }
 
+void UARTComponent::drain() {
+  if (this->hw_serial_ != nullptr) {
+    for (int i = 0; this->available(); i++) {
+      uint8_t junk;
+      this->read_byte(&junk);
+      ESP_LOGVV(TAG, "Draining RX[%d]: %0x", i, junk);
+    }
+  } else {
+    this->sw_serial_->drain();
+  }
+}
+
+
 void ESP8266SoftwareSerial::setup(int8_t tx_pin, int8_t rx_pin, uint32_t baud_rate) {
   this->bit_time_ = F_CPU / baud_rate;
   if (tx_pin != -1) {
@@ -321,6 +342,14 @@ uint8_t ESP8266SoftwareSerial::peek_byte() {
   return this->rx_buffer_[this->rx_out_pos_];
 }
 void ESP8266SoftwareSerial::flush() { this->rx_in_pos_ = this->rx_out_pos_ = 0; }
+
+void ESP8266SoftwareSerial::drain() {
+  for (int i = 0; this->available(); i++) {
+    uint8_t junk = this->read_byte();
+    ESP_LOGVV(TAG, "Draining RX[%d]: %0x", i, junk);
+  }
+}
+
 int ESP8266SoftwareSerial::available() {
   int avail = int(this->rx_in_pos_) - int(this->rx_out_pos_);
   if (avail < 0)

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -16,6 +16,7 @@ class ESP8266SoftwareSerial {
   uint8_t peek_byte();
 
   void flush();
+  void drain();
 
   void write_byte(uint8_t data);
 
@@ -62,6 +63,8 @@ class UARTComponent : public Component, public Stream {
   int available() override;
 
   void flush() override;
+
+  void drain();
 
   float get_setup_priority() const override { return setup_priority::BUS; }
 
@@ -110,6 +113,8 @@ class UARTDevice : public Stream {
   int available() override { return this->parent_->available(); }
 
   void flush() override { return this->parent_->flush(); }
+
+  void drain() { return this->parent_->drain(); }
 
   size_t write(uint8_t data) override { return this->parent_->write(data); }
   int read() override { return this->parent_->read(); }

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -16,7 +16,6 @@ class ESP8266SoftwareSerial {
   uint8_t peek_byte();
 
   void flush();
-  void drain();
 
   void write_byte(uint8_t data);
 
@@ -63,8 +62,6 @@ class UARTComponent : public Component, public Stream {
   int available() override;
 
   void flush() override;
-
-  void drain();
 
   float get_setup_priority() const override { return setup_priority::BUS; }
 


### PR DESCRIPTION
this PR is only one commit on top https://github.com/esphome/esphome/pull/588
since author doesn't reply in original PR

## Description:
Adds detection of MH-Z19B sensor
Ignore sensor reported values until it's booted.
Disable auto-calibration as it makes reported CO2 values not reflecting real situation in not sufficiently ventilated environment.
Fix/workaround non-recoverable "Invalid preamble from MHZ19!" case, when sensor is connected to hardware UART.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
