### PR TITLE
fix missing schedule call

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -122,6 +122,7 @@ template<typename... Ts> class AddressableSet : public Action<Ts...> {
       range.set_blue(this->blue_.value(x...));
     if (this->white_.has_value())
       range.set_white(this->white_.value(x...));
+    out->schedule_show();
   }
 
  protected:


### PR DESCRIPTION
## Description:
light.addressable_set should call schedule?

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/568

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
