### PR TITLE
Support voluptuous 0.11.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ venv.bak/
 
 .pioenvs
 .piolibdeps
+.pio
 .vscode
 CMakeListsPrivate.txt
 CMakeLists.txt

--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -21,8 +21,8 @@ def ensure_multiple_invalid(err):
 # pylint: disable=protected-access, unidiomatic-typecheck
 class _Schema(vol.Schema):
     """Custom cv.Schema that prints similar keys on error."""
-    def __init__(self, schema, extra=vol.PREVENT_EXTRA, extra_schemas=None):
-        super(_Schema, self).__init__(schema, extra=extra)
+    def __init__(self, schema, required=False, extra=vol.PREVENT_EXTRA, extra_schemas=None):
+        super(_Schema, self).__init__(schema, required=required, extra=extra)
         # List of extra schemas to apply after validation
         # Should be used sparingly, as it's not a very voluptuous-way/clean way of
         # doing things.

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@
 ; It's *not* used during runtime.
 
 [platformio]
-env_default = livingroom8266
+default_envs = livingroom8266
 src_dir = .
 include_dir = include
 

--- a/script/.neopixelbus.patch
+++ b/script/.neopixelbus.patch
@@ -1,5 +1,5 @@
---- .piolibdeps/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h	2019-06-25 11:14:33.000000000 +0200
-+++ .piolibdeps/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h.2	2019-06-25 11:14:40.000000000 +0200
+--- .pio/libdeps/livingroom8266/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h	2019-06-25 11:14:33.000000000 +0200
++++ .pio/libdeps/livingroom8266/NeoPixelBus_ID547/src/internal/NeoEsp8266DmaMethod.h.2	2019-06-25 11:14:40.000000000 +0200
 @@ -195,7 +195,12 @@
              _i2sBufDesc[indexDesc].sub_sof = 0;
              _i2sBufDesc[indexDesc].datalen = blockSize;


### PR DESCRIPTION
## Description:

This adds support for voluptuous 0.11.7 (incompatibilities introduced by alecthomas/voluptuous#380). This change is verified to still work with voluptuous 0.11.5.

*This Pull Request also contains a fix for platformio 4 in travis-ci builds.*

**Related issue (if applicable):** fixes esphome/issues#580

## Checklist:
  - [x] The code change is tested and works locally.

