### PR TITLE
Remove double publish_state in ultrasonic sensor

### DIFF
--- a/esphome/components/ultrasonic/ultrasonic_sensor.cpp
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.cpp
@@ -26,7 +26,6 @@ void UltrasonicSensorComponent::update() {
     this->publish_state(NAN);
   } else {
     float result = UltrasonicSensorComponent::us_to_m(time);
-    this->publish_state(result);
     ESP_LOGD(TAG, "'%s' - Got distance: %.2f m", this->name_.c_str(), result);
     this->publish_state(result);
   }


### PR DESCRIPTION
## Description:
Remove double publish_state in ultrasonic sensor

**Related issue (if applicable):** Fixes https://github.com/esphome/issues/issues/589

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).