### PR TITLE
Fix mqtt_text_sensor to honor unique_id when set.

### DIFF
--- a/esphome/components/mqtt/mqtt_text_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_text_sensor.cpp
@@ -15,9 +15,6 @@ void MQTTTextSensor::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig 
   if (!this->sensor_->get_icon().empty())
     root["icon"] = this->sensor_->get_icon();
 
-  if (!this->sensor_->unique_id().empty())
-    root["unique_id"] = this->sensor_->unique_id();
-
   config.command_topic = false;
 }
 void MQTTTextSensor::setup() {
@@ -40,6 +37,7 @@ bool MQTTTextSensor::send_initial_state() {
 bool MQTTTextSensor::is_internal() { return this->sensor_->is_internal(); }
 std::string MQTTTextSensor::component_type() const { return "sensor"; }
 std::string MQTTTextSensor::friendly_name() const { return this->sensor_->get_name(); }
+std::string MQTTTextSensor::unique_id() { return this->sensor_->unique_id(); }
 
 }  // namespace mqtt
 }  // namespace esphome

--- a/esphome/components/mqtt/mqtt_text_sensor.h
+++ b/esphome/components/mqtt/mqtt_text_sensor.h
@@ -31,6 +31,8 @@ class MQTTTextSensor : public mqtt::MQTTComponent {
 
   std::string friendly_name() const override;
 
+  std::string unique_id() override;
+
   text_sensor::TextSensor *sensor_;
 };
 

--- a/esphome/components/wifi_info/wifi_info_text_sensor.h
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.h
@@ -7,6 +7,8 @@
 namespace esphome {
 namespace wifi_info {
 
+static const char TAG[] = "wifi_info.text_sensor";
+
 class IPAddressWiFiInfo : public Component, public text_sensor::TextSensor {
  public:
   void loop() override {
@@ -16,7 +18,9 @@ class IPAddressWiFiInfo : public Component, public text_sensor::TextSensor {
       this->publish_state(ip.toString().c_str());
     }
   }
+  void dump_config() override { LOG_TEXT_SENSOR("", "WifiInfo IPAddress Text Sensor", this); }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  std::string unique_id() override { return get_mac_address() + "-wifiinfo-ip"; }
 
  protected:
   IPAddress last_ip_;
@@ -31,7 +35,9 @@ class SSIDWiFiInfo : public Component, public text_sensor::TextSensor {
       this->publish_state(this->last_ssid_);
     }
   }
+  void dump_config() override { LOG_TEXT_SENSOR("", "WifiInfo SSDID Text Sensor", this); }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  std::string unique_id() override { return get_mac_address() + "-wifiinfo-ssid"; }
 
  protected:
   std::string last_ssid_;
@@ -48,7 +54,9 @@ class BSSIDWiFiInfo : public Component, public text_sensor::TextSensor {
       this->publish_state(buf);
     }
   }
+  void dump_config() override { LOG_TEXT_SENSOR("", "WifiInfo BSSID Text Sensor", this); }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  std::string unique_id() override { return get_mac_address() + "-wifiinfo-bssid"; }
 
  protected:
   wifi::bssid_t last_bssid_;


### PR DESCRIPTION
## Description:
Fix mqtt_text_sensor to honor unique_id when set.
 - Remove setting of unique_id in json tree, as the mqtt_component already does this, and in fact overrides what we do here.

 - Add unqiue_id() and dump_config() to the wifi_info sensors.

**Related issue (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
