### PR TITLE
Add delayed_on_off binary_sensor filter

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -41,6 +41,7 @@ BinarySensorCondition = binary_sensor_ns.class_('BinarySensorCondition', Conditi
 
 # Filters
 Filter = binary_sensor_ns.class_('Filter')
+DelayedOnOffFilter = binary_sensor_ns.class_('DelayedOnOffFilter', Filter, cg.Component)
 DelayedOnFilter = binary_sensor_ns.class_('DelayedOnFilter', Filter, cg.Component)
 DelayedOffFilter = binary_sensor_ns.class_('DelayedOffFilter', Filter, cg.Component)
 InvertFilter = binary_sensor_ns.class_('InvertFilter', Filter)
@@ -53,6 +54,13 @@ validate_filters = cv.validate_registry('filter', FILTER_REGISTRY)
 @FILTER_REGISTRY.register('invert', InvertFilter, {})
 def invert_filter_to_code(config, filter_id):
     yield cg.new_Pvariable(filter_id)
+
+@FILTER_REGISTRY.register('delayed_on_off', DelayedOnOffFilter,
+                          cv.positive_time_period_milliseconds)
+def delayed_on_off_filter_to_code(config, filter_id):
+    var = cg.new_Pvariable(filter_id, config)
+    yield cg.register_component(var, {})
+    yield var
 
 
 @FILTER_REGISTRY.register('delayed_on', DelayedOnFilter,

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -55,6 +55,7 @@ validate_filters = cv.validate_registry('filter', FILTER_REGISTRY)
 def invert_filter_to_code(config, filter_id):
     yield cg.new_Pvariable(filter_id)
 
+
 @FILTER_REGISTRY.register('delayed_on_off', DelayedOnOffFilter,
                           cv.positive_time_period_milliseconds)
 def delayed_on_off_filter_to_code(config, filter_id):

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -30,7 +30,11 @@ void BinarySensor::publish_initial_state(bool state) {
   }
 }
 void BinarySensor::send_state_internal(bool state, bool is_initial) {
-  ESP_LOGD(TAG, "'%s': Sending state %s", this->get_name().c_str(), state ? "ON" : "OFF");
+  if (is_initial) {
+    ESP_LOGD(TAG, "'%s': Sending initial state %s", this->get_name().c_str(), ONOFF(state));
+  } else {
+    ESP_LOGD(TAG, "'%s': Sending state %s", this->get_name().c_str(), ONOFF(state));
+  }
   this->has_state_ = true;
   this->state = state;
   if (!is_initial) {

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -30,11 +30,7 @@ void BinarySensor::publish_initial_state(bool state) {
   }
 }
 void BinarySensor::send_state_internal(bool state, bool is_initial) {
-  if (is_initial) {
-    ESP_LOGD(TAG, "'%s': Sending initial state %s", this->get_name().c_str(), ONOFF(state));
-  } else {
-    ESP_LOGD(TAG, "'%s': Sending state %s", this->get_name().c_str(), ONOFF(state));
-  }
+  ESP_LOGD(TAG, "'%s': Sending state %s", this->get_name().c_str(), state ? "ON" : "OFF");
   this->has_state_ = true;
   this->state = state;
   if (!is_initial) {

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -23,6 +23,18 @@ void Filter::input(bool value, bool is_initial) {
     this->output(*b, is_initial);
   }
 }
+
+DelayedOnOffFilter::DelayedOnOffFilter(uint32_t delay) : delay_(delay) {}
+optional<bool> DelayedOnOffFilter::new_value(bool value, bool is_initial) {
+  if (value) {
+    this->set_timeout("ON_OFF", this->delay_, [this, is_initial]() { this->output(true, is_initial); });
+  } else {
+    this->set_timeout("ON_OFF", this->delay_, [this, is_initial]() { this->output(false, is_initial); });
+  }
+  return {};
+}
+float DelayedOnOffFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
+
 DelayedOnFilter::DelayedOnFilter(uint32_t delay) : delay_(delay) {}
 optional<bool> DelayedOnFilter::new_value(bool value, bool is_initial) {
   if (value) {
@@ -33,7 +45,6 @@ optional<bool> DelayedOnFilter::new_value(bool value, bool is_initial) {
     return false;
   }
 }
-
 float DelayedOnFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 DelayedOffFilter::DelayedOffFilter(uint32_t delay) : delay_(delay) {}

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -33,6 +33,7 @@ optional<bool> DelayedOnOffFilter::new_value(bool value, bool is_initial) {
   }
   return {};
 }
+
 float DelayedOnOffFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 DelayedOnFilter::DelayedOnFilter(uint32_t delay) : delay_(delay) {}
@@ -45,6 +46,7 @@ optional<bool> DelayedOnFilter::new_value(bool value, bool is_initial) {
     return false;
   }
 }
+
 float DelayedOnFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 DelayedOffFilter::DelayedOffFilter(uint32_t delay) : delay_(delay) {}
@@ -57,6 +59,7 @@ optional<bool> DelayedOffFilter::new_value(bool value, bool is_initial) {
     return true;
   }
 }
+
 float DelayedOffFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 optional<bool> InvertFilter::new_value(bool value, bool is_initial) { return !value; }

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -25,6 +25,18 @@ class Filter {
   Deduplicator<bool> dedup_;
 };
 
+class DelayedOnOffFilter : public Filter, public Component {
+ public:
+  explicit DelayedOnOffFilter(uint32_t delay);
+
+  optional<bool> new_value(bool value, bool is_initial) override;
+
+  float get_setup_priority() const override;
+
+ protected:
+  uint32_t delay_;
+};
+
 class DelayedOnFilter : public Filter, public Component {
  public:
   explicit DelayedOnFilter(uint32_t delay);


### PR DESCRIPTION
## Description:
Add a new binary sensor filter which properly debounces both on and off transitions.
Such filter can be useful for binary state switches (not push buttons) like a regular wall switch used to turn lamps on and off. Based on the documentation, it seems like using `delayed_on` and `delayed_off` together would be enough to debounce switches in both directions but actually because of the pipeline nature of the filters, it doesn't work. See https://github.com/esphome/issues/issues/463 for more details.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/463

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#324

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
