### PR TITLE
fix integration sensor

### DIFF
--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -61,7 +61,9 @@ void IntegrationSensor::process_sensor_value_(float value) {
       area = dt * new_value;
       break;
   }
-  this->publish_and_save_(this->last_value_ + area);
+  this->last_value_ = new_value;
+  this->last_update_ = now;
+  this->publish_and_save_(this->result_ + area);
 }
 
 }  // namespace integration

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -54,7 +54,9 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   void publish_and_save_(float result) {
     this->result_ = result;
     this->publish_state(result);
-    this->rtc_.save(&result);
+    if (this->restore_) {
+      this->rtc_.save(&result);
+    }
   }
   std::string unit_of_measurement() override;
   std::string icon() override { return this->sensor_->get_icon(); }

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -54,9 +54,7 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   void publish_and_save_(float result) {
     this->result_ = result;
     this->publish_state(result);
-    if (this->restore_) {
-      this->rtc_.save(&result);
-    }
+    this->rtc_.save(&result);
   }
   std::string unit_of_measurement() override;
   std::string icon() override { return this->sensor_->get_icon(); }


### PR DESCRIPTION
## Description:

Issue reported in #533 also I believe it is storing the value on rtc mem even when restore is not set.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/533

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
