### PR TITLE
Add support for Sensirion SCD30 CO2 sensors

### DIFF
--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -99,14 +99,14 @@ void SCD30Component::update() {
         return;
       }
       unsigned int temp_c_o2_u32, temp_temp_u32, temp_hum_u32;
-      temp_c_o2_u32 = (unsigned int) ((((unsigned int) raw_data[0]) << 16) | ((unsigned int) raw_data[1]));
-      float co2 = *(float *) &temp_c_o2_u32;
+      temp_c_o2_u32 = (((uint32_t(raw_data[0])) << 16) | (uint32_t(raw_data[1])));
+      float co2 = *reinterpret_cast<float *>(&temp_c_o2_u32);
 
-      temp_temp_u32 = (unsigned int) ((((unsigned int) raw_data[2]) << 16) | ((unsigned int) raw_data[3]));
-      float temperature = *(float *) &temp_temp_u32;
+      temp_temp_u32 = (((uint32_t(raw_data[2])) << 16) | (uint32_t(raw_data[3])));
+      float temperature = *reinterpret_cast<float *>(&temp_temp_u32);
 
-      temp_hum_u32 = (unsigned int) ((((unsigned int) raw_data[4]) << 16) | ((unsigned int) raw_data[5]));
-      float humidity = *(float *) &temp_hum_u32;
+      temp_hum_u32 = (((uint32_t(raw_data[4])) << 16) | (uint32_t(raw_data[5])));
+      float humidity = *reinterpret_cast<float *>(&temp_hum_u32);
 
       ESP_LOGD(TAG, "Got CO2=%.2fppm temperature=%.2f°C humidity=%.2f%%", co2, temperature, humidity);
       if (this->co2_sensor_ != nullptr)

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -20,7 +20,6 @@ static const uint16_t SCD30_CMD_TEMPERATURE_OFFSET = 0x5403;
 static const uint16_t SCD30_CMD_ALTITUDE_COMPENSATION = 0x5102;
 static const uint16_t SCD30_CMD_SOFT_RESET = 0xD304;
 
-
 void SCD30Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up scd30...");
 
@@ -47,7 +46,6 @@ void SCD30Component::setup() {
     this->mark_failed();
     return;
   }
-
 }
 
 void SCD30Component::dump_config() {

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -40,7 +40,7 @@ void SCD30Component::setup() {
   ESP_LOGD(TAG, "SCD30 Firmware v%0d.%02d", (uint16_t(raw_firmware_version[0]) >> 8),
            uint16_t(raw_firmware_version[0] & 0xFF));
 
-   /// Sensor initialization
+  /// Sensor initialization
   if (!this->write_command_(SCD30_CMD_START_CONTINUOUS_MEASUREMENTS)) {
     ESP_LOGE(TAG, "Sensor SCD30 error starting continuous measurements.");
     this->error_code_ = MEASUREMENT_INIT_FAILED;
@@ -101,23 +101,16 @@ void SCD30Component::update() {
         return;
       }
       unsigned int temp_c_o2_u32, temp_temp_u32, temp_hum_u32;
-      temp_c_o2_u32 = (unsigned int) (
-              (((unsigned int) raw_data[0]) << 16) | ((unsigned int) raw_data[1])
-              );
+      temp_c_o2_u32 = (unsigned int) ((((unsigned int) raw_data[0]) << 16) | ((unsigned int) raw_data[1]));
       float co2 = *(float *) &temp_c_o2_u32;
 
-      temp_temp_u32 = (unsigned int) (
-              (((unsigned int) raw_data[2]) << 16) | ((unsigned int) raw_data[3])
-              );
+      temp_temp_u32 = (unsigned int) ((((unsigned int) raw_data[2]) << 16) | ((unsigned int) raw_data[3]));
       float temperature = *(float *) &temp_temp_u32;
 
-      temp_hum_u32 = (unsigned int) (
-              (((unsigned int) raw_data[4]) << 16) | ((unsigned int) raw_data[5])
-              );
+      temp_hum_u32 = (unsigned int) ((((unsigned int) raw_data[4]) << 16) | ((unsigned int) raw_data[5]));
       float humidity = *(float *) &temp_hum_u32;
 
-      ESP_LOGD(TAG, "Got CO2=%.2fppm temperature=%.2f°C humidity=%.2f%%",
-              co2, temperature, humidity);
+      ESP_LOGD(TAG, "Got CO2=%.2fppm temperature=%.2f°C humidity=%.2f%%", co2, temperature, humidity);
       if (this->co2_sensor_ != nullptr)
         this->co2_sensor_->publish_state(co2);
       if (this->temperature_sensor_ != nullptr)

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -21,7 +21,7 @@ static const uint16_t SCD30_CMD_ALTITUDE_COMPENSATION = 0x5102;
 static const uint16_t SCD30_CMD_SOFT_RESET = 0xD304;
 
 
-void Scd30Component::setup() {
+void SCD30Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up scd30...");
 
   /// Firmware version identification
@@ -50,7 +50,7 @@ void Scd30Component::setup() {
 
 }
 
-void Scd30Component::dump_config() {
+void SCD30Component::dump_config() {
   ESP_LOGCONFIG(TAG, "scd30:");
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {
@@ -75,7 +75,7 @@ void Scd30Component::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-void Scd30Component::update() {
+void SCD30Component::update() {
   /// Check if measurement is ready before reading the value
   if (!this->write_command_(SCD30_CMD_GET_DATA_READY_STATUS)) {
     this->status_set_warning();
@@ -124,18 +124,18 @@ void Scd30Component::update() {
         this->temperature_sensor_->publish_state(temperature);
       if (this->humidity_sensor_ != nullptr)
         this->humidity_sensor_->publish_state(humidity);
-      
+
       this->status_clear_warning();
     });
   }
 }
 
-bool Scd30Component::write_command_(uint16_t command) {
+bool SCD30Component::write_command_(uint16_t command) {
   // Warning ugly, trick the I2Ccomponent base by setting register to the first 8 bit.
   return this->write_byte(command >> 8, command & 0xFF);
 }
 
-uint8_t Scd30Component::sht_crc_(uint8_t data1, uint8_t data2) {
+uint8_t SCD30Component::sht_crc_(uint8_t data1, uint8_t data2) {
   uint8_t bit;
   uint8_t crc = 0xFF;
 
@@ -158,7 +158,7 @@ uint8_t Scd30Component::sht_crc_(uint8_t data1, uint8_t data2) {
   return crc;
 }
 
-bool Scd30Component::read_data_(uint16_t *data, uint8_t len) {
+bool SCD30Component::read_data_(uint16_t *data, uint8_t len) {
   const uint8_t num_bytes = len * 3;
   auto *buf = new uint8_t[num_bytes];
 
@@ -169,7 +169,7 @@ bool Scd30Component::read_data_(uint16_t *data, uint8_t len) {
 
   for (uint8_t i = 0; i < len; i++) {
     const uint8_t j = 3 * i;
-    uint8_t crc = sht_crc(buf[j], buf[j + 1]);
+    uint8_t crc = sht_crc_(buf[j], buf[j + 1]);
     if (crc != buf[j + 2]) {
       ESP_LOGE(TAG, "CRC8 Checksum invalid! 0x%02X != 0x%02X", buf[j + 2], crc);
       delete[](buf);

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -1,0 +1,186 @@
+#include "scd30.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace scd30 {
+
+static const char *TAG = "scd30";
+
+static const uint16_t SCD30_CMD_GET_FIRMWARE_VERSION = 0xd100;
+static const uint16_t SCD30_CMD_START_CONTINUOUS_MEASUREMENTS = 0x0010;
+static const uint16_t SCD30_CMD_GET_DATA_READY_STATUS = 0x0202;
+static const uint16_t SCD30_CMD_READ_MEASUREMENT = 0x0300;
+
+///Commands for future use
+static const uint16_t SCD30_CMD_STOP_MEASUREMENTS = 0x0104;
+static const uint16_t SCD30_CMD_MEASUREMENT_INTERVAL = 0x4600;
+static const uint16_t SCD30_CMD_AUTOMATIC_SELF_CALIBRATION = 0x5306;
+static const uint16_t SCD30_CMD_FORCED_CALIBRATION = 0x5204;
+static const uint16_t SCD30_CMD_TEMPERATURE_OFFSET = 0x5403;
+static const uint16_t SCD30_CMD_ALTITUDE_COMPENSATION = 0x5102;
+static const uint16_t SCD30_CMD_SOFT_RESET = 0xD304;
+
+
+void scd30Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up scd30...");
+
+  ///Firmware version identification
+  if (!this->write_command_(SCD30_CMD_GET_FIRMWARE_VERSION)) {
+    this->error_code_ = COMMUNICATION_FAILED;
+    this->mark_failed();
+    return;
+  }
+  uint16_t raw_firmware_version[3];
+
+  if (!this->read_data_(raw_firmware_version, 3)) {
+    this->error_code_ = FIRMWARE_IDENTIFICATION_FAILED;
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGD(TAG, "SCD30 Firmware v%0d.%02d", (uint16_t(raw_firmware_version[0]) >> 8),
+          uint16_t(raw_firmware_version[0] & 0xFF));
+
+   ///Sensor initialization
+  if (!this->write_command_(SCD30_CMD_START_CONTINUOUS_MEASUREMENTS)) {
+    ESP_LOGE(TAG, "Sensor SCD30 error starting continuous measurements.");
+    this->error_code_ = MEASUREMENT_INIT_FAILED;
+    this->mark_failed();
+    return;
+  }
+
+}
+
+void scd30Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "scd30:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    switch (this->error_code_) {
+      case COMMUNICATION_FAILED:
+        ESP_LOGW(TAG, "Communication failed! Is the sensor connected?");
+        break;
+      case MEASUREMENT_INIT_FAILED:
+        ESP_LOGW(TAG, "Measurement Initialization failed!");
+        break;
+      case FIRMWARE_IDENTIFICATION_FAILED:
+        ESP_LOGW(TAG, "Unable to read sensor firmware version");
+        break;
+      default:
+        ESP_LOGW(TAG, "Unknown setup error!");
+        break;
+    }
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "CO2", this->co2_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
+}
+
+void scd30Component::update() {
+  /// Check if measurement is ready before reading the value
+  if (!this->write_command_(SCD30_CMD_GET_DATA_READY_STATUS)) {
+    this->status_set_warning();
+    return;
+  }
+
+  uint16_t raw_read_status[1];
+  if (!this->read_data_(raw_read_status, 1) || raw_read_status[0] == 0x00) {
+    this->status_set_warning();
+    ESP_LOGW(TAG, "Data not ready yet!");
+    return;
+  } else {
+    if (!this->write_command_(SCD30_CMD_READ_MEASUREMENT)) {
+      ESP_LOGW(TAG, "Error reading measurement!");
+      this->status_set_warning();
+      return;
+    }
+
+    this->set_timeout(50, [this]() {
+        uint16_t raw_data[6];
+        if (!this->read_data_(raw_data, 6)) {
+          this->status_set_warning();
+          return;
+        }
+        unsigned int tempCO2U32, tempTempU32, tempHumU32;
+        tempCO2U32 = (unsigned int) (
+                (((unsigned int) raw_data[0]) << 16) | ((unsigned int) raw_data[1])
+                );
+        float co2 = *(float *) &tempCO2U32;
+
+        tempTempU32 = (unsigned int) (
+                (((unsigned int) raw_data[2]) << 16) | ((unsigned int) raw_data[3])
+                );
+        float temperature = *(float *) &tempTempU32;
+
+        tempHumU32 = (unsigned int) (
+                (((unsigned int) raw_data[4]) << 16) | ((unsigned int) raw_data[5])
+                );
+        float humidity = *(float *) &tempHumU32;
+
+        ESP_LOGD(TAG, "Got CO2=%.2fppm temperature=%.2f°C humidity=%.2f%%",
+                co2, temperature, humidity);
+        if (this->co2_sensor_ != nullptr)
+          this->co2_sensor_->publish_state(co2);
+        if (this->temperature_sensor_ != nullptr)
+          this->temperature_sensor_->publish_state(temperature);
+        if (this->humidity_sensor_ != nullptr)
+          this->humidity_sensor_->publish_state(humidity);
+
+        this->status_clear_warning();
+    });
+  }
+}
+
+bool scd30Component::write_command_(uint16_t command) {
+  // Warning ugly, trick the I2Ccomponent base by setting register to the first 8 bit.
+  return this->write_byte(command >> 8, command & 0xFF);
+}
+
+uint8_t scd30Component::sht_crc(uint8_t data1, uint8_t data2) {
+  uint8_t bit;
+  uint8_t crc = 0xFF;
+
+  crc ^= data1;
+  for (bit = 8; bit > 0; --bit) {
+    if (crc & 0x80)
+      crc = (crc << 1) ^ 0x131;
+    else
+      crc = (crc << 1);
+  }
+
+  crc ^= data2;
+  for (bit = 8; bit > 0; --bit) {
+    if (crc & 0x80)
+      crc = (crc << 1) ^ 0x131;
+    else
+      crc = (crc << 1);
+  }
+
+  return crc;
+}
+
+bool scd30Component::read_data_(uint16_t *data, uint8_t len) {
+  const uint8_t num_bytes = len * 3;
+  auto *buf = new uint8_t[num_bytes];
+
+  if (!this->parent_->raw_receive(this->address_, buf, num_bytes)) {
+    delete[](buf);
+    return false;
+  }
+
+  for (uint8_t i = 0; i < len; i++) {
+    const uint8_t j = 3 * i;
+    uint8_t crc = sht_crc(buf[j], buf[j + 1]);
+    if (crc != buf[j + 2]) {
+      ESP_LOGE(TAG, "CRC8 Checksum invalid! 0x%02X != 0x%02X", buf[j + 2], crc);
+      delete[](buf);
+      return false;
+    }
+    data[i] = (buf[j] << 8) | buf[j + 1];
+  }
+
+  delete[](buf);
+  return true;
+}
+
+}  // namespace scd30
+}  // namespace esphome

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -8,7 +8,7 @@ namespace esphome {
 namespace scd30 {
 
 /// This class implements support for the Sensirion scd30 i2c GAS (VOC and CO2eq) sensors.
-class scd30Component : public PollingComponent, public i2c::I2CDevice {
+class Scd30Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
   void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
@@ -22,7 +22,7 @@ class scd30Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   bool write_command_(uint16_t command);
   bool read_data_(uint16_t *data, uint8_t len);
-  uint8_t sht_crc(uint8_t data1, uint8_t data2);
+  uint8_t sht_crc_(uint8_t data1, uint8_t data2);
 
   enum ErrorCode {
     COMMUNICATION_FAILED,

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace scd30 {
+
+/// This class implements support for the Sensirion scd30 i2c GAS (VOC and CO2eq) sensors.
+class scd30Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
+  void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
+  void set_temperature_sensor(sensor::Sensor *temperature) { temperature_sensor_ = temperature; }
+
+  void setup() override;
+  void update() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  bool write_command_(uint16_t command);
+  bool read_data_(uint16_t *data, uint8_t len);
+  uint8_t sht_crc(uint8_t data1, uint8_t data2);
+
+  enum ErrorCode {
+    COMMUNICATION_FAILED,
+    FIRMWARE_IDENTIFICATION_FAILED,
+    MEASUREMENT_INIT_FAILED,
+    UNKNOWN
+  } error_code_{UNKNOWN};
+
+  sensor::Sensor *co2_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+};
+
+}  // namespace scd30
+}  // namespace esphome

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -8,7 +8,7 @@ namespace esphome {
 namespace scd30 {
 
 /// This class implements support for the Sensirion scd30 i2c GAS (VOC and CO2eq) sensors.
-class Scd30Component : public PollingComponent, public i2c::I2CDevice {
+class SCD30Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
   void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -1,0 +1,39 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import CONF_ID, UNIT_PARTS_PER_MILLION, \
+    CONF_HUMIDITY, CONF_TEMPERATURE, ICON_PERIODIC_TABLE_CO2, \
+    UNIT_CELSIUS, ICON_THERMOMETER, ICON_WATER_PERCENT, UNIT_PERCENT
+
+DEPENDENCIES = ['i2c']
+
+scd30_ns = cg.esphome_ns.namespace('scd30')
+scd30Component = scd30_ns.class_('scd30Component', cg.PollingComponent, i2c.I2CDevice)
+
+CONF_CO2 = 'co2'
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(scd30Component),
+    cv.Required(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION,
+                                                ICON_PERIODIC_TABLE_CO2, 0),
+    cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
+    cv.Required(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),
+}).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x61))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield i2c.register_i2c_device(var, config)
+
+    if CONF_CO2 in config:
+        sens = yield sensor.new_sensor(config[CONF_CO2])
+        cg.add(var.set_co2_sensor(sens))
+
+    if CONF_HUMIDITY in config:
+        sens = yield sensor.new_sensor(config[CONF_HUMIDITY])
+        cg.add(var.set_humidity_sensor(sens))
+
+    if CONF_TEMPERATURE in config:
+        sens = yield sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature_sensor(sens))

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -8,12 +8,12 @@ from esphome.const import CONF_ID, UNIT_PARTS_PER_MILLION, \
 DEPENDENCIES = ['i2c']
 
 scd30_ns = cg.esphome_ns.namespace('scd30')
-scd30Component = scd30_ns.class_('scd30Component', cg.PollingComponent, i2c.I2CDevice)
+SCD30Component = scd30_ns.class_('SCD30Component', cg.PollingComponent, i2c.I2CDevice)
 
 CONF_CO2 = 'co2'
 
 CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(): cv.declare_id(scd30Component),
+    cv.GenerateID(): cv.declare_id(SCD30Component),
     cv.Required(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION,
                                                 ICON_PERIODIC_TABLE_CO2, 0),
     cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -502,6 +502,15 @@ sensor:
       name: "Living Room Humidity 8"
     address: 0x44
     update_interval: 15s
+  - platform: scd30
+    co2:
+      name: "Living Room CO2 9"
+    temperature:
+      name: "Living Room Temperature 9"
+    humidity:
+      name: "Living Room Humidity 9"
+    address: 0x61
+    update_interval: 15s
   - platform: template
     name: "Template Sensor"
     id: template_sensor


### PR DESCRIPTION
## Description:
Added support for the Sensirion SCD30 high-accuracy i2c CO2 sensors with built-in Temperature and Humidity sensors

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#333

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
