### PR TITLE
Integration sensor use double precision

### DIFF
--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -45,14 +45,14 @@ std::string IntegrationSensor::unit_of_measurement() {
 }
 void IntegrationSensor::process_sensor_value_(float value) {
   const uint32_t now = millis();
-  const float old_value = this->last_value_;
-  const float new_value = value;
+  const double old_value = this->last_value_;
+  const double new_value = value;
   const uint32_t dt_ms = now - this->last_update_;
-  const float dt = dt_ms * this->get_time_factor_();
-  float area = 0.0f;
+  const double dt = dt_ms * this->get_time_factor_();
+  double area = 0.0f;
   switch (this->method_) {
     case INTEGRATION_METHOD_TRAPEZOID:
-      area = dt * (old_value + new_value) / 2.0f;
+      area = dt * (old_value + new_value) / 2.0;
       break;
     case INTEGRATION_METHOD_LEFT:
       area = dt * old_value;

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -51,10 +51,11 @@ class IntegrationSensor : public sensor::Sensor, public Component {
         return 0.0f;
     }
   }
-  void publish_and_save_(float result) {
+  void publish_and_save_(double result) {
     this->result_ = result;
     this->publish_state(result);
-    this->rtc_.save(&result);
+    float result_f = result;
+    this->rtc_.save(&result_f);
   }
   std::string unit_of_measurement() override;
   std::string icon() override { return this->sensor_->get_icon(); }
@@ -67,7 +68,7 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   ESPPreferenceObject rtc_;
 
   uint32_t last_update_;
-  float result_{0.0f};
+  double result_{0.0f};
   float last_value_{0.0f};
 };
 


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/534

Kept the RTC value as a float in order not to introduce a breaking preferences change.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
