### PR TITLE
Use default format to render FloatLiteral

### DIFF
--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -250,7 +250,7 @@ class FloatLiteral(Literal):
     def __str__(self):
         if math.isnan(self.float_):
             return u"NAN"
-        return u"{:f}f".format(self.float_)
+        return u"{}f".format(self.float_)
 
 
 # pylint: disable=bad-continuation


### PR DESCRIPTION
## Description:

FloatLiterals are rendered to fixed-point representation by the current code generator.  This can result in significant loss of accuracy in some situations (e.g. Steinhart-Hart coefficients for NTC thermistors, where in the motivating case accuracy was affected by greater than 11°C.)

This change switches from fixed-point rendering to default (full-precision exponential) when rendering floating point literals during code generation.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/557

**~Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):~** n/a
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] ~Tests have been added to verify that the new code works (under `tests/` folder).~ Covered by existing tests.

If user exposed functionality or configuration variables are added/changed:
  - [x] ~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~ n/a
