### PR TITLE
Brightness ssd1306

### DIFF
--- a/esphome/components/ssd1306_base/__init__.py
+++ b/esphome/components/ssd1306_base/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import display
-from esphome.const import CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, CONF_RESET_PIN
+from esphome.const import CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, CONF_RESET_PIN, CONF_BRIGHTNESS
 from esphome.core import coroutine
 
 ssd1306_base_ns = cg.esphome_ns.namespace('ssd1306_base')
@@ -25,6 +25,7 @@ SSD1306_MODEL = cv.enum(MODELS, upper=True, space="_")
 SSD1306_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend({
     cv.Required(CONF_MODEL): SSD1306_MODEL,
     cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+    cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
     cv.Optional(CONF_EXTERNAL_VCC): cv.boolean,
 }).extend(cv.polling_component_schema('1s'))
 
@@ -38,6 +39,8 @@ def setup_ssd1036(var, config):
     if CONF_RESET_PIN in config:
         reset = yield cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(reset))
+    if CONF_BRIGHTNESS in config:
+        cg.add(var.set_brightness_(config[CONF_BRIGHTNESS]))
     if CONF_EXTERNAL_VCC in config:
         cg.add(var.set_external_vcc(config[CONF_EXTERNAL_VCC]))
     if CONF_LAMBDA in config:

--- a/esphome/components/ssd1306_base/__init__.py
+++ b/esphome/components/ssd1306_base/__init__.py
@@ -2,7 +2,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import display
-from esphome.const import CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, CONF_RESET_PIN, CONF_BRIGHTNESS
+from esphome.const import CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, CONF_RESET_PIN, \
+    CONF_BRIGHTNESS
 from esphome.core import coroutine
 
 ssd1306_base_ns = cg.esphome_ns.namespace('ssd1306_base')
@@ -40,7 +41,7 @@ def setup_ssd1036(var, config):
         reset = yield cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(reset))
     if CONF_BRIGHTNESS in config:
-        cg.add(var.set_brightness_(config[CONF_BRIGHTNESS]))
+        cg.add(var.set_brightness(config[CONF_BRIGHTNESS]))
     if CONF_EXTERNAL_VCC in config:
         cg.add(var.set_external_vcc(config[CONF_EXTERNAL_VCC]))
     if CONF_LAMBDA in config:

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -79,8 +79,8 @@ void SSD1306::setup() {
     case SH1106_MODEL_128_64:
     case SSD1306_MODEL_64_48:
     case SH1106_MODEL_64_48:
-        this->command(int(255 * (this->brightness_)));
-        break;
+      this->command(int(255 * (this->brightness_)));
+      break;
     case SSD1306_MODEL_96_16:
     case SH1106_MODEL_96_16:
       if (this->external_vcc_)

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -79,11 +79,8 @@ void SSD1306::setup() {
     case SH1106_MODEL_128_64:
     case SSD1306_MODEL_64_48:
     case SH1106_MODEL_64_48:
-      if (this->external_vcc_)
-        this->command(0x9F);
-      else
-        this->command(0xCF);
-      break;
+        this->command(int(255 * (this->brightness_)));
+        break;
     case SSD1306_MODEL_96_16:
     case SH1106_MODEL_96_16:
       if (this->external_vcc_)
@@ -100,7 +97,7 @@ void SSD1306::setup() {
     this->command(0xF1);
 
   this->command(SSD1306_COMMAND_SET_VCOM_DETECT);
-  this->command(0x40);
+  this->command(0x00);
 
   this->command(SSD1306_COMMAND_DISPLAY_ALL_ON_RESUME);
   this->command(SSD1306_NORMAL_DISPLAY);

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -29,8 +29,7 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void set_model(SSD1306Model model) { this->model_ = model; }
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
-  void set_brightness_(float brightness) { this->brightness_ = brightness; }
-//  void set_brightness_(optional<float> brightness) { this->brightness_ = brightness; }
+  void set_brightness(float brightness) { this->brightness_ = brightness; }
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(int color) override;
@@ -53,7 +52,6 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   GPIOPin *reset_pin_{nullptr};
   bool external_vcc_{false};
   float brightness_{1.0};
-
 };
 
 }  // namespace ssd1306_base

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -29,6 +29,8 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void set_model(SSD1306Model model) { this->model_ = model; }
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
+  void set_brightness_(float brightness) { this->brightness_ = brightness; }
+//  void set_brightness_(optional<float> brightness) { this->brightness_ = brightness; }
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(int color) override;
@@ -50,6 +52,8 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   SSD1306Model model_{SSD1306_MODEL_128_64};
   GPIOPin *reset_pin_{nullptr};
   bool external_vcc_{false};
+  float brightness_{1.0};
+
 };
 
 }  // namespace ssd1306_base

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1215,10 +1215,11 @@ display:
     it.set_component_value("gauge", 50);
     it.set_component_text("textview", "Hello World!");
 - platform: ssd1306_i2c
-  model: "SSD1306 128x64"
+  model: "SSD1306_128X64"
   reset_pin: GPIO23
   address: 0x3C
   id: display1
+  brightness: 60%
   pages:
     - id: page1
       lambda: |-


### PR DESCRIPTION
## Description:

AS @waiet seems idle I created this PR with his changes and linted it.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/pull/681

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
Docs to do. Usage:

````yaml
display:
  - id: blue_display
    platform: ssd1306_i2c
    model: "SSD1306 128x64"
    reset_pin: D0
    update_interval: 500ms
    address: 0x3C
    brightness: 10%
````

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
