### PR TITLE
BME280: Increase sensor timeout

### DIFF
--- a/esphome/components/bme280/bme280.cpp
+++ b/esphome/components/bme280/bme280.cpp
@@ -178,7 +178,7 @@ void BME280Component::update() {
     return;
   }
 
-  float meas_time = 1;
+  float meas_time = 1.5;
   meas_time += 2.3f * oversampling_to_time(this->temperature_oversampling_);
   meas_time += 2.3f * oversampling_to_time(this->pressure_oversampling_) + 0.575f;
   meas_time += 2.3f * oversampling_to_time(this->humidity_oversampling_) + 0.575f;


### PR DESCRIPTION
## Description:

I'm facing some occasional timeouts when reading BME280. 
Looking at Adafruit driver (that this code is based on), I see that base timeout is set to 1.25ms, increased by 2.3*oversampling  + 0.575ms for each value being read. 
I changed existing 1ms to 1.5ms as baseline, to be on the safe side.
Code has no user exposure so no documentation update needed.

## Checklist:
  - [X] The code change is tested and works locally.
