### PR TITLE
pin ESPAsyncTCP to v1.2.1

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -74,7 +74,7 @@ def to_code(config):
     if CORE.is_esp32:
         cg.add_library('AsyncTCP', '1.0.3')
     elif CORE.is_esp8266:
-        cg.add_library('ESPAsyncTCP', '1.2.0')
+        cg.add_library('ESPAsyncTCP', '1.2.1')
 
 
 HOMEASSISTANT_SERVICE_ACTION_SCHEMA = cv.Schema({


### PR DESCRIPTION
## Description: Update Version Pin for ESPAsyncTCP dependency in ESPAsyncWeb library

`ESPAsyncWeb` had a hard version pin to version v1.2.0. when ESPAsyncTCP updated to v1.2.1, this caused duplicate library errors as some components automatically pull `latest` and some (such as this one) are pinned to v1.2.0 . Credit to @thoemy for finding the fix in https://github.com/esphome/issues/issues/683

I opened this against master as this appears to break if a recompile happens for a devices codebase. Please let me know if I should open this against dev and I am happy to do so.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/683

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

My tests were previously failing without the fix and are now (still failing but progressing farther*) working with the fix applied locally. If a further test case is required I am happy to add it!
