### PR TITLE
[WIP] Allow hyphen in node name (do not merge)

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -43,7 +43,7 @@ ALLOW_EXTRA = vol.ALLOW_EXTRA
 UNDEFINED = vol.UNDEFINED
 RequiredFieldInvalid = vol.RequiredFieldInvalid
 
-ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_'
+ALLOWED_NAME_CHARS = u'abcdefghijklmnopqrstuvwxyz0123456789_-'
 
 RESERVED_IDS = [
     # C++ keywords http://en.cppreference.com/w/cpp/keyword


### PR DESCRIPTION
Add hyphen to allowed characters in node name.

## Description:
Update list of allowed characters in node names to include hyphen.
TODO: figure out if it's necessary to add a translation layer to convert between "hostname with arbitrary chars" and "valid C++ variable name" or if node name and "contact this name" hostname are cleanly separated

**Related issue (if applicable):** fixes esphome/feature-requests#418

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#350

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
