### PR TITLE
Fix remote_transmitter type_a encoding

### DIFF
--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -140,19 +140,13 @@ void RCSwitchBase::simple_code_to_tristate(uint16_t code, uint8_t nbits, uint32_
 void RCSwitchBase::type_a_code(uint8_t switch_group, uint8_t switch_device, bool state, uint32_t *out_code,
                                uint8_t *out_nbits) {
   uint16_t code = 0;
-  code |= (switch_group & 0b0001) ? 0 : 0b1000;
-  code |= (switch_group & 0b0010) ? 0 : 0b0100;
-  code |= (switch_group & 0b0100) ? 0 : 0b0010;
-  code |= (switch_group & 0b1000) ? 0 : 0b0001;
-  code <<= 4;
-  code |= (switch_device & 0b0001) ? 0 : 0b1000;
-  code |= (switch_device & 0b0010) ? 0 : 0b0100;
-  code |= (switch_device & 0b0100) ? 0 : 0b0010;
-  code |= (switch_device & 0b1000) ? 0 : 0b0001;
+  code = switch_group ^ 0b11111;
+  code <<= 5;
+  code |= switch_device ^ 0b11111;
   code <<= 2;
   code |= state ? 0b01 : 0b10;
-  simple_code_to_tristate(code, 10, out_code);
-  *out_nbits = 20;
+  simple_code_to_tristate(code, 12, out_code);
+  *out_nbits = 24;
 }
 void RCSwitchBase::type_b_code(uint8_t address_code, uint8_t channel_code, bool state, uint32_t *out_code,
                                uint8_t *out_nbits) {


### PR DESCRIPTION
## Description:
The type_a protocol used in remote_transmitter for 433Mhz devices uses 5 bits for switch_group and 5 bits for switch_device. When encoding, a mask of 4 bits is applied for each, which means 2 bits are lost.

This fixes it by applying a 5 bits mask.

**Related issue (if applicable)**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
