### PR TITLE
Fix for PCF8574 output chattering at the start/reboot

### DIFF
--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -56,7 +56,6 @@ void PCF8574Component::pin_mode(uint8_t pin, uint8_t mode) {
       break;
   }
 
-  this->write_gpio_();
 }
 bool PCF8574Component::read_gpio_() {
   if (this->is_failed())

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -55,7 +55,7 @@ void PCF8574Component::pin_mode(uint8_t pin, uint8_t mode) {
     default:
       break;
   }
-
+  return;
 }
 bool PCF8574Component::read_gpio_() {
   if (this->is_failed())

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -55,7 +55,6 @@ void PCF8574Component::pin_mode(uint8_t pin, uint8_t mode) {
     default:
       break;
   }
-  return;
 }
 bool PCF8574Component::read_gpio_() {
   if (this->is_failed())


### PR DESCRIPTION
## Description:
Fix for GPIO switch toggles ON and OFF (powercycle) at start and reset.

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/715
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
