### PR TITLE
Addressing first install issue noted by #580, #666, others.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-voluptuous>=0.11.5,<0.12
+voluptuous==0.11.5
 PyYAML>=5.1,<6
 paho-mqtt>=1.4,<2
 colorlog>=4.0.2


### PR DESCRIPTION
Voluptuous 0.11.7 appears to be explodey with the current live version of esphome.

## Description:


**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/580
https://github.com/esphome/issues/issues/666
https://github.com/esphome/issues/issues/728
https://github.com/esphome/issues/issues/693
https://github.com/esphome/issues/issues/687
https://github.com/esphome/issues/issues/679
https://github.com/esphome/issues/issues/647
https://github.com/esphome/issues/issues/644
https://github.com/esphome/issues/issues/621
https://github.com/esphome/issues/issues/591
https://github.com/esphome/issues/issues/579
https://github.com/esphome/issues/issues/578

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
