### PR TITLE
Make UART flush function consistent

### DIFF
--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -77,16 +77,17 @@ void MHZ19Component::abc_disable() {
 }
 
 bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *response) {
-  this->flush();
+  // Empty RX Buffer
+  while (this->available())
+    this->read();
   this->write_array(command, MHZ19_REQUEST_LENGTH);
   this->write_byte(mhz19_checksum(command));
+  this->flush();
 
   if (response == nullptr)
     return true;
 
-  bool ret = this->read_array(response, MHZ19_RESPONSE_LENGTH);
-  this->flush();
-  return ret;
+  return this->read_array(response, MHZ19_RESPONSE_LENGTH);
 }
 float MHZ19Component::get_setup_priority() const { return setup_priority::DATA; }
 void MHZ19Component::dump_config() {

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -94,7 +94,6 @@ float SDS011Component::get_setup_priority() const { return setup_priority::DATA;
 void SDS011Component::set_rx_mode_only(bool rx_mode_only) { this->rx_mode_only_ = rx_mode_only; }
 
 void SDS011Component::sds011_write_command_(const uint8_t *command_data) {
-  this->flush();
   this->write_byte(SDS011_MSG_HEAD);
   this->write_byte(SDS011_COMMAND_ID_REQUEST);
   this->write_array(command_data, SDS011_DATA_REQUEST_LENGTH);

--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -316,7 +316,9 @@ uint8_t ESP8266SoftwareSerial::peek_byte() {
     return 0;
   return this->rx_buffer_[this->rx_out_pos_];
 }
-void ESP8266SoftwareSerial::flush() { this->rx_in_pos_ = this->rx_out_pos_ = 0; }
+void ESP8266SoftwareSerial::flush() {
+  // Flush is a NO-OP with software serial, all bytes are written immediately.
+}
 int ESP8266SoftwareSerial::available() {
   int avail = int(this->rx_in_pos_) - int(this->rx_out_pos_);
   if (avail < 0)

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -61,6 +61,7 @@ class UARTComponent : public Component, public Stream {
 
   int available() override;
 
+  /// Block until all bytes have been written to the UART bus.
   void flush() override;
 
   float get_setup_priority() const override { return setup_priority::BUS; }


### PR DESCRIPTION
See also https://github.com/esphome/esphome/commit/78be9d29376d5fdcff81874540c540eb80a338f6

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
