### PR TITLE
Use higher default baudrate for USB upload

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -166,7 +166,7 @@ def compile_program(args, config):
 def upload_using_esptool(config, port):
     path = CORE.firmware_bin
     cmd = ['esptool.py', '--before', 'default_reset', '--after', 'hard_reset',
-           '--baud', str(config[CONF_ESPHOME][CONF_PLATFORMIO_OPTIONS].get('upload_speed', 115200)),
+           '--baud', str(config[CONF_ESPHOME][CONF_PLATFORMIO_OPTIONS].get('upload_speed', 460800)),
            '--chip', 'esp8266', '--port', port, 'write_flash', '0x0', path]
 
     if os.environ.get('ESPHOME_USE_SUBPROCESS') is None:

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -31,7 +31,7 @@ def validate_rx_pin(value):
 
 CONFIG_SCHEMA = cv.All(cv.Schema({
     cv.GenerateID(): cv.declare_id(UARTComponent),
-    cv.Required(CONF_BAUD_RATE): cv.int_range(min=1, max=115200),
+    cv.Required(CONF_BAUD_RATE): cv.int_range(min=1),
     cv.Optional(CONF_TX_PIN): pins.output_pin,
     cv.Optional(CONF_RX_PIN): validate_rx_pin,
 }).extend(cv.COMPONENT_SCHEMA), cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN))

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -191,7 +191,7 @@ def get_ini_content():
         'framework': 'arduino',
         'lib_deps': lib_deps + ['${common.lib_deps}'],
         'build_flags': build_flags + ['${common.build_flags}'],
-        'upload_speed': UPLOAD_SPEED_OVERRIDE.get(CORE.board, 115200),
+        'upload_speed': UPLOAD_SPEED_OVERRIDE.get(CORE.board, 460800),
     }
 
     if CORE.is_esp32:


### PR DESCRIPTION
See also https://github.com/espressif/esptool/issues/435

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
