### PR TITLE
Added degree symbol for MAX7219 7-segment display.

### DIFF
--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -14,7 +14,7 @@ static const uint8_t MAX7219_REGISTER_SCAN_LIMIT = 0x0B;
 static const uint8_t MAX7219_REGISTER_SHUTDOWN = 0x0C;
 static const uint8_t MAX7219_UNKNOWN_CHAR = 0b11111111;
 
-const uint8_t MAX7219_ASCII_TO_RAW[94] PROGMEM = {
+const uint8_t MAX7219_ASCII_TO_RAW[95] PROGMEM = {
     0b00000000,            // ' ', ord 0x20
     0b10110000,            // '!', ord 0x21
     0b00100010,            // '"', ord 0x22
@@ -109,6 +109,7 @@ const uint8_t MAX7219_ASCII_TO_RAW[94] PROGMEM = {
     0b00110001,            // '{', ord 0x7B
     0b00000110,            // '|', ord 0x7C
     0b00000111,            // '}', ord 0x7D
+    0b01100011,            // '~', ord 0x7E (degree symbol)
 };
 
 float MAX7219Component::get_setup_priority() const { return setup_priority::PROCESSOR; }
@@ -166,7 +167,7 @@ uint8_t MAX7219Component::print(uint8_t start_pos, const char *str) {
   uint8_t pos = start_pos;
   for (; *str != '\0'; str++) {
     uint8_t data = MAX7219_UNKNOWN_CHAR;
-    if (*str >= ' ' && *str <= '}')
+    if (*str >= ' ' && *str <= '~')
       data = pgm_read_byte(&MAX7219_ASCII_TO_RAW[*str - ' ']);
 
     if (data == MAX7219_UNKNOWN_CHAR) {


### PR DESCRIPTION
The ascii char to use it is "~" (0x7E).

## Description:
Added degree symbol for MAX7219 7 segments display.

Fixes https://github.com/esphome/feature-requests/issues/433

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
