### PR TITLE
web_server_base AUTO_LOAD includes ASYNC_TCP

### DIFF
--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -4,6 +4,7 @@ from esphome.const import CONF_ID
 from esphome.core import coroutine_with_priority, CORE
 
 DEPENDENCIES = ['network', 'async_tcp']
+AUTO_LOAD = ['async_tcp']
 
 web_server_base_ns = cg.esphome_ns.namespace('web_server_base')
 WebServerBase = web_server_base_ns.class_('WebServerBase', cg.Component)

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -3,7 +3,7 @@ import esphome.codegen as cg
 from esphome.const import CONF_ID
 from esphome.core import coroutine_with_priority, CORE
 
-DEPENDENCIES = ['network', 'async_tcp']
+DEPENDENCIES = ['network']
 AUTO_LOAD = ['async_tcp']
 
 web_server_base_ns = cg.esphome_ns.namespace('web_server_base')


### PR DESCRIPTION
fix AUTO_LOAD of web_server_base to include ASYNC_TCP

## Description:
web_server_base is missing the ASYNC_TCP in its autoload causing the config to fail with no error message.
You get 
`component async_tcp cannot be loaded via YAML (no CONFIG_SCHEMA).`
when manualy adding web_server_base: to the yaml

**Related issue (if applicable):** fixes   esphome/issues#760


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
