### PR TITLE
Add missing include - fixes missing GPIOPin definition

### DIFF
--- a/esphome/components/sm16716/sm16716.h
+++ b/esphome/components/sm16716/sm16716.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/output/float_output.h"
 
 namespace esphome {


### PR DESCRIPTION
## Description:  Using the SM16716 component causes a build failure such as:

In file included from src/esphome/components/sm16716/sm16716.cpp:1:0:
src/esphome/components/sm16716/sm16716.h:13:21: error: 'GPIOPin' has not been declared
   void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }

This PR adds the necessary include so that it compiles

**Related issue (if applicable):** fixes build failure

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Checklist:
  - [X] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [-] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
