### PR TITLE
Fix scheduler first execution

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -259,7 +259,7 @@ def setup_sensor_core_(var, config):
     if CONF_ACCURACY_DECIMALS in config:
         cg.add(var.set_accuracy_decimals(config[CONF_ACCURACY_DECIMALS]))
     cg.add(var.set_force_update(config[CONF_FORCE_UPDATE]))
-    if CONF_FILTERS in config:
+    if config.get(CONF_FILTERS):  # must exist and not be empty
         filters = yield build_filters(config[CONF_FILTERS])
         cg.add(var.set_filters(filters))
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -57,7 +57,7 @@ void HOT Scheduler::set_interval(Component *component, const std::string &name, 
   item->name = name;
   item->type = SchedulerItem::INTERVAL;
   item->interval = interval;
-  item->last_execution = now - offset;
+  item->last_execution = now - offset - interval;
   item->last_execution_major = this->millis_major_;
   if (item->last_execution > now)
     item->last_execution_major--;
@@ -106,7 +106,7 @@ void ICACHE_RAM_ATTR HOT Scheduler::call() {
       // Not reached timeout yet, done for this call
       break;
     uint8_t major = item->last_execution_major;
-    if (item->last_execution + item->interval < item->last_execution)
+    if (item->last_execution > now)
       major++;
     if (major != this->millis_major_)
       break;


### PR DESCRIPTION
## Description:

The first execution of an interval should happen immediately on the next loop() call. This was fixed by subtracting `interval` in `set_interval`.

That exposed another error: the rollover checks can cause an interval to be executed in twice the normal interval during a rollover. The fix for that is on line 109. The new check works better.

The scheduler is awesome but quite hard to fully understand. Some more comments would probably be good.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
