### PR TITLE
Fix web server transition length truncated

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -416,11 +416,15 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, UrlMatch ma
       if (request->hasParam("color_temp"))
         call.set_color_temperature(request->getParam("color_temp")->value().toFloat());
 
-      if (request->hasParam("flash"))
-        call.set_flash_length((uint32_t) request->getParam("flash")->value().toFloat() * 1000);
+      if (request->hasParam("flash")) {
+        float length_s = request->getParam("flash")->value().toFloat();
+        call.set_flash_length(static_cast<uint32_t>(length_s * 1000));
+      }
 
-      if (request->hasParam("transition"))
-        call.set_transition_length((uint32_t) request->getParam("transition")->value().toFloat() * 1000);
+      if (request->hasParam("transition")) {
+        float length_s = request->getParam("transition")->value().toFloat();
+        call.set_transition_length(static_cast<uint32_t>(length_s * 1000));
+      }
 
       if (request->hasParam("effect")) {
         const char *effect = request->getParam("effect")->value().c_str();


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/772

The value was cast to uint32_t *before* the multiplication by 1000.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
