### PR TITLE
Add check if middle_text is too short

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -364,10 +364,7 @@ def command_update_all(args):
     def print_bar(middle_text):
         middle_text = " {} ".format(middle_text)
         width = len(click.unstyle(middle_text))
-        if width == 0:
-            half_line = "==="
-        else:
-            half_line = "=" * ((twidth - width) / 2)
+        half_line = "=" * ((twidth - width) // 2)
         click.echo("%s%s%s" % (half_line, middle_text, half_line))
 
     for f in files:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -364,7 +364,10 @@ def command_update_all(args):
     def print_bar(middle_text):
         middle_text = " {} ".format(middle_text)
         width = len(click.unstyle(middle_text))
-        half_line = "=" * ((twidth - width) / 2)
+        if width == 0:
+            half_line = "==="
+        else:
+            half_line = "=" * ((twidth - width) / 2)
         click.echo("%s%s%s" % (half_line, middle_text, half_line))
 
     for f in files:


### PR DESCRIPTION
## Description:

The `half_line` computation causes an error if the `middle_text` is too short in `update-all`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
