### PR TITLE
Allow TimePeriod for time_period_str_unit

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -461,6 +461,8 @@ def time_period_str_unit(value):
     if isinstance(value, int):
         raise Invalid("Don't know what '{0}' means as it has no time *unit*! Did you mean "
                       "'{0}s'?".format(value))
+    if isinstance(value, TimePeriod):
+        value = str(value)
     if not isinstance(value, string_types):
         raise Invalid("Expected string for time period with unit.")
 


### PR DESCRIPTION
## Description:

Before, passing the result of positive_time_period_x to the function again failed.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
