### PR TITLE
Fix some binary_sensor not having an initial state

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -23,6 +23,7 @@ IS_PLATFORM_COMPONENT = True
 
 binary_sensor_ns = cg.esphome_ns.namespace('binary_sensor')
 BinarySensor = binary_sensor_ns.class_('BinarySensor', cg.Nameable)
+BinarySensorInitiallyOff = binary_sensor_ns.class_('BinarySensorInitiallyOff', BinarySensor)
 BinarySensorPtr = BinarySensor.operator('ptr')
 
 # Triggers

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -67,7 +67,7 @@ class BinarySensor : public Nameable {
   void send_state_internal(bool state, bool is_initial);
 
   /// Return whether this binary sensor has outputted a state.
-  bool has_state() const;
+  virtual bool has_state() const;
 
   virtual bool is_status_binary_sensor() const;
 
@@ -84,6 +84,11 @@ class BinarySensor : public Nameable {
   Filter *filter_list_{nullptr};
   bool has_state_{false};
   Deduplicator<bool> publish_dedup_;
+};
+
+class BinarySensorInitiallyOff : public BinarySensor {
+ public:
+  bool has_state() const override { return true; }
 };
 
 }  // namespace binary_sensor

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace ble_presence {
 
-class BLEPresenceDevice : public binary_sensor::BinarySensor,
+class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
                           public esp32_ble_tracker::ESPBTDeviceListener,
                           public Component {
  public:

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -394,7 +394,7 @@ class Nextion : public PollingComponent, public uart::UARTDevice {
   bool wait_for_ack_{true};
 };
 
-class NextionTouchComponent : public binary_sensor::BinarySensor {
+class NextionTouchComponent : public binary_sensor::BinarySensorInitiallyOff {
  public:
   void set_page_id(uint8_t page_id) { page_id_ = page_id; }
   void set_component_id(uint8_t component_id) { component_id_ = component_id; }

--- a/esphome/components/rdm6300/rdm6300.h
+++ b/esphome/components/rdm6300/rdm6300.h
@@ -28,7 +28,7 @@ class RDM6300Component : public Component, public uart::UARTDevice {
   uint32_t last_id_{0};
 };
 
-class RDM6300BinarySensor : public binary_sensor::BinarySensor {
+class RDM6300BinarySensor : public binary_sensor::BinarySensorInitiallyOff {
  public:
   void set_id(uint32_t id) { id_ = id; }
 

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -267,11 +267,11 @@ class RemoteReceiverBase : public RemoteComponentBase {
   uint8_t tolerance_{25};
 };
 
-class RemoteReceiverBinarySensorBase : public binary_sensor::BinarySensor,
+class RemoteReceiverBinarySensorBase : public binary_sensor::BinarySensorInitiallyOff,
                                        public Component,
                                        public RemoteReceiverListener {
  public:
-  explicit RemoteReceiverBinarySensorBase() : BinarySensor() {}
+  explicit RemoteReceiverBinarySensorBase() : BinarySensorInitiallyOff() {}
   void dump_config() override;
   virtual bool matches(RemoteReceiveData src) = 0;
   bool on_receive(RemoteReceiveData src) override {

--- a/esphome/components/status/status_binary_sensor.cpp
+++ b/esphome/components/status/status_binary_sensor.cpp
@@ -30,7 +30,7 @@ void StatusBinarySensor::loop() {
 
   this->publish_state(status);
 }
-void StatusBinarySensor::setup() { this->publish_state(false); }
+void StatusBinarySensor::setup() { this->publish_initial_state(false); }
 void StatusBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Status Binary Sensor", this); }
 
 }  // namespace status


### PR DESCRIPTION
## Description:

Fixes https://github.com/home-assistant/home-assistant/issues/28384

The changes in HA which made components not publish empty states has had the issue that some components that were not publishing an initial state now have a `unknown` state in the frontend.

Fixing this by fixing it where the actual error is: this codebase. These components should publish an initial state.

Todo: maybe also consider fixing this in the HA codebase as a hotfix - like "if remote version is below x, assume that binary_sensors have a state". Depends on how fast I can get things fixed and writing the changelog.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
