### PR TITLE
Tuya: Fix init sequence and handle wifi test command

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -22,7 +22,7 @@ void Tuya::loop() {
 void Tuya::dump_config() {
   ESP_LOGCONFIG(TAG, "Tuya:");
   if (this->init_state_ != TuyaInitState::INIT_DONE) {
-    ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %d",
+    ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",
                   this->init_state_);
     ESP_LOGCONFIG(TAG, "  If no further output is received, confirm that this is a supported Tuya device.");
     return;
@@ -40,8 +40,8 @@ void Tuya::dump_config() {
       ESP_LOGCONFIG(TAG, "  Datapoint %d: unknown", info.id);
   }
   if ((this->gpio_status_ != -1) || (this->gpio_reset_ != -1)) {
-    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d (not supported)",
-                  this->gpio_status_, this->gpio_reset_);
+    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d (not supported)", this->gpio_status_,
+                  this->gpio_reset_);
   }
   ESP_LOGCONFIG(TAG, "  Product: '%s'", this->product_.c_str());
   this->check_uart_settings(9600);
@@ -175,7 +175,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
     case TuyaCommandType::DATAPOINT_REPORT:
       if (this->init_state_ == TuyaInitState::INIT_DATAPOINT) {
         this->init_state_ = TuyaInitState::INIT_DONE;
-        if (!this->dump_complete_){
+        if (!this->dump_complete_) {
           this->set_timeout("datapoint_dump", 1000, [this] { this->dump_config(); });
         }
       }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -22,7 +22,7 @@ void Tuya::loop() {
 void Tuya::dump_config() {
   ESP_LOGCONFIG(TAG, "Tuya:");
   if (this->init_state_ != TuyaInitState::INIT_DONE) {
-    ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",
+    ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",  // NOLINT
                   this->init_state_);
     ESP_LOGCONFIG(TAG, "  If no further output is received, confirm that this is a supported Tuya device.");
     return;
@@ -94,7 +94,7 @@ bool Tuya::validate_message_() {
 
   // valid message
   const uint8_t *message_data = data + 6;
-  ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,
+  ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
            hexencode(message_data, length).c_str(), this->init_state_);
   this->handle_command_(command, version, message_data, length);
 
@@ -257,7 +257,7 @@ void Tuya::send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_
   uint8_t len_lo = len >> 0;
   uint8_t version = 0;
 
-  ESP_LOGV(TAG, "Sending Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,
+  ESP_LOGV(TAG, "Sending Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
            hexencode(buffer, len).c_str(), this->init_state_);
 
   this->write_array({0x55, 0xAA, version, (uint8_t) command, len_hi, len_lo});

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -106,7 +106,6 @@ void Tuya::handle_char_(uint8_t c) {
 }
 
 void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buffer, size_t len) {
-  uint8_t c[] = {0x00, 0x00};
   switch ((TuyaCommandType) command) {
     case TuyaCommandType::HEARTBEAT:
       ESP_LOGV(TAG, "MCU Heartbeat (0x%02X)", buffer[0]);
@@ -139,21 +138,21 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       }
       break;
     }
-    case TuyaCommandType::CONF_QUERY:
+    case TuyaCommandType::CONF_QUERY: {
       if (len >= 2) {
         gpio_status_ = buffer[0];
         gpio_reset_ = buffer[1];
       }
       // set wifi state LED to off or on depending on the MCU firmware
       // but it shouldn't be blinking
-      c[0] = 0x03;
-      c[1] = 0x00;
+      uint8_t c[] = {0x03};
       this->send_command_(TuyaCommandType::WIFI_STATE, c, 1);
       if (this->init_state_ == TuyaInitState::INIT_CONF) {
         this->init_state_ = TuyaInitState::INIT_DATAPOINT;
         this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
       }
       break;
+    }
     case TuyaCommandType::WIFI_STATE:
       break;
     case TuyaCommandType::WIFI_RESET:
@@ -173,8 +172,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
     case TuyaCommandType::DATAPOINT_QUERY:
       break;
     case TuyaCommandType::WIFI_TEST: {
-      c[0] = 0x00;
-      c[1] = 0x00;
+      uint8_t c[] = {0x00, 0x00};
       this->send_command_(TuyaCommandType::WIFI_TEST, c, 2);
       break;
     }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -89,7 +89,7 @@ bool Tuya::validate_message_() {
 
   // valid message
   const uint8_t *message_data = data + 6;
-  ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] STATE=%d", command, version,
+  ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] STATE=%hhu", command, version,
            hexencode(message_data, length).c_str(), this->init_state_);
   this->handle_command_(command, version, message_data, length);
 
@@ -129,7 +129,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       if (valid) {
         this->product_ = std::string(reinterpret_cast<const char *>(buffer), len);
       } else {
-        this->product_ = "{\"p\":\"INVALID\"}";
+        this->product_ = R"({"p":"INVALID"})";
       }
       if (this->init_state_ == TuyaInitState::INIT_PRODUCT) {
         this->init_state_ = TuyaInitState::INIT_CONF;
@@ -251,7 +251,7 @@ void Tuya::send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_
   uint8_t len_lo = len >> 0;
   uint8_t version = 0;
 
-  ESP_LOGV(TAG, "Sending Tuya: CMD=0x%02X VERSION=%u DATA=[%s] STATE=%d", command, version,
+  ESP_LOGV(TAG, "Sending Tuya: CMD=0x%02hhX VERSION=%u DATA=[%s] STATE=%hhu", command, version,
            hexencode(buffer, len).c_str(), this->init_state_);
 
   this->write_array({0x55, 0xAA, version, (uint8_t) command, len_hi, len_lo});

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -123,7 +123,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       // check it is a valid string made up of printable characters
       bool valid = true;
       for (int i = 0; i < len; i++) {
-        if (! isprint(buffer[i])) {
+        if (!isprint(buffer[i])) {
           valid = false;
           break;
         }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -8,7 +8,6 @@ namespace tuya {
 static const char *TAG = "tuya";
 
 void Tuya::setup() {
-  this->send_empty_command_(TuyaCommandType::HEARTBEAT);
   this->set_interval("heartbeat", 1000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
 }
 

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -22,7 +22,7 @@ void Tuya::loop() {
 
 void Tuya::dump_config() {
   ESP_LOGCONFIG(TAG, "Tuya:");
-  ESP_LOGCONFIG(TAG, "  Product: %s", this->product_.c_str());
+  ESP_LOGCONFIG(TAG, "  Product: '%s'", this->product_.c_str());
   if ((gpio_status_ != -1) || (gpio_reset_ != -1))
     ESP_LOGCONFIG(TAG, "  GPIO MCU configuration not supported!");
   for (auto &info : this->datapoints_) {
@@ -123,7 +123,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       // check it is a valid string made up of printable characters
       bool valid = true;
       for (int i = 0; i < len; i++) {
-        if (!isprint(buffer[i])) {
+        if (!std::isprint(buffer[i])) {
           valid = false;
           break;
         }
@@ -150,8 +150,8 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       c[1] = 0x00;
       this->send_command_(TuyaCommandType::WIFI_STATE, c, 1);
       if (this->init_state_ == TuyaInitState::INIT_CONF) {
-        this->init_state_ = TuyaInitState::INIT_DP;
-        this->send_empty_command_(TuyaCommandType::DP_QUERY);
+        this->init_state_ = TuyaInitState::INIT_DATAPOINT;
+        this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
       }
       break;
     case TuyaCommandType::WIFI_STATE:
@@ -162,15 +162,15 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
     case TuyaCommandType::WIFI_SELECT:
       ESP_LOGE(TAG, "TUYA_CMD_WIFI_SELECT is not handled");
       break;
-    case TuyaCommandType::DP_DELIVER:
+    case TuyaCommandType::DATAPOINT_DELIVER:
       break;
-    case TuyaCommandType::DP_REPORT:
-      if (this->init_state_ == TuyaInitState::INIT_DP) {
+    case TuyaCommandType::DATAPOINT_REPORT:
+      if (this->init_state_ == TuyaInitState::INIT_DATAPOINT) {
         this->init_state_ = TuyaInitState::INIT_DONE;
       }
       this->handle_datapoint_(buffer, len);
       break;
-    case TuyaCommandType::DP_QUERY:
+    case TuyaCommandType::DATAPOINT_QUERY:
       break;
     case TuyaCommandType::WIFI_TEST: {
       c[0] = 0x00;
@@ -301,7 +301,7 @@ void Tuya::set_datapoint_value(TuyaDatapoint datapoint) {
   buffer.push_back(data.size() >> 8);
   buffer.push_back(data.size() >> 0);
   buffer.insert(buffer.end(), data.begin(), data.end());
-  this->send_command_(TuyaCommandType::DP_DELIVER, buffer.data(), buffer.size());
+  this->send_command_(TuyaCommandType::DATAPOINT_DELIVER, buffer.data(), buffer.size());
 }
 
 void Tuya::register_listener(uint8_t datapoint_id, const std::function<void(TuyaDatapoint)> &func) {

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -20,6 +20,10 @@ void Tuya::loop() {
 }
 
 void Tuya::dump_config() {
+  this->set_timeout("dump_config", 2000, [this] { this->dump_config_(); });
+}
+
+void Tuya::dump_config_() {
   ESP_LOGCONFIG(TAG, "Tuya:");
   ESP_LOGCONFIG(TAG, "  Product: '%s'", this->product_.c_str());
   if ((gpio_status_ != -1) || (gpio_reset_ != -1))

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -45,7 +45,6 @@ void Tuya::dump_config() {
   }
   ESP_LOGCONFIG(TAG, "  Product: '%s'", this->product_.c_str());
   this->check_uart_settings(9600);
-  this->dump_complete_ = true;
 }
 
 bool Tuya::validate_message_() {
@@ -175,9 +174,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
     case TuyaCommandType::DATAPOINT_REPORT:
       if (this->init_state_ == TuyaInitState::INIT_DATAPOINT) {
         this->init_state_ = TuyaInitState::INIT_DONE;
-        if (!this->dump_complete_) {
-          this->set_timeout("datapoint_dump", 1000, [this] { this->dump_config(); });
-        }
+        this->set_timeout("datapoint_dump", 1000, [this] { this->dump_config(); });
       }
       this->handle_datapoint_(buffer, len);
       break;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -67,7 +67,6 @@ class Tuya : public Component, public uart::UARTDevice {
   void handle_char_(uint8_t c);
   void handle_datapoint_(const uint8_t *buffer, size_t len);
   bool validate_message_();
-  void dump_config_();
 
   void handle_command_(uint8_t command, uint8_t version, const uint8_t *buffer, size_t len);
   void send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_t len);

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -39,9 +39,9 @@ enum class TuyaCommandType : uint8_t {
   WIFI_STATE = 0x03,
   WIFI_RESET = 0x04,
   WIFI_SELECT = 0x05,
-  DP_DELIVER = 0x06,
-  DP_REPORT = 0x07,
-  DP_QUERY = 0x08,
+  DATAPOINT_DELIVER = 0x06,
+  DATAPOINT_REPORT = 0x07,
+  DATAPOINT_QUERY = 0x08,
   WIFI_TEST = 0x0E,
 };
 
@@ -50,7 +50,7 @@ enum class TuyaInitState : uint8_t {
   INIT_PRODUCT,
   INIT_CONF,
   INIT_WIFI,
-  INIT_DP,
+  INIT_DATAPOINT,
   INIT_DONE,
 };
 

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -75,7 +75,6 @@ class Tuya : public Component, public uart::UARTDevice {
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;
-  bool dump_complete_ = false;
   std::string product_ = "";
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -56,7 +56,7 @@ enum class TuyaInitState : uint8_t {
 
 class Tuya : public Component, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  float get_setup_priority() const override { return setup_priority::LATE; }
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -75,6 +75,7 @@ class Tuya : public Component, public uart::UARTDevice {
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;
+  bool dump_complete_ = false;
   std::string product_ = "";
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -57,6 +57,7 @@ enum class TuyaInitState : uint8_t {
 class Tuya : public Component, public uart::UARTDevice {
  public:
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  bool can_proceed() override { return this->init_state_ == TuyaInitState::INIT_DONE; }
   void setup() override;
   void loop() override;
   void dump_config() override;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -57,7 +57,6 @@ enum class TuyaInitState : uint8_t {
 class Tuya : public Component, public uart::UARTDevice {
  public:
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
-  bool can_proceed() override { return this->init_state_ == TuyaInitState::INIT_DONE; }
   void setup() override;
   void loop() override;
   void dump_config() override;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -67,6 +67,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void handle_char_(uint8_t c);
   void handle_datapoint_(const uint8_t *buffer, size_t len);
   bool validate_message_();
+  void dump_config_();
 
   void handle_command_(uint8_t command, uint8_t version, const uint8_t *buffer, size_t len);
   void send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_t len);

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -34,15 +34,24 @@ struct TuyaDatapointListener {
 
 enum class TuyaCommandType : uint8_t {
   HEARTBEAT = 0x00,
-  QUERY_PRODUCT = 0x01,
-  MCU_CONF = 0x02,
+  PRODUCT_QUERY = 0x01,
+  CONF_QUERY = 0x02,
   WIFI_STATE = 0x03,
   WIFI_RESET = 0x04,
   WIFI_SELECT = 0x05,
   DP_DELIVER = 0x06,
   DP_REPORT = 0x07,
-  QUERY_STATE = 0x08,
+  DP_QUERY = 0x08,
   WIFI_TEST = 0x0E,
+};
+
+enum class TuyaInitState : uint8_t {
+  INIT_HEARTBEAT = 0x00,
+  INIT_PRODUCT,
+  INIT_CONF,
+  INIT_WIFI,
+  INIT_DP,
+  INIT_DONE,
 };
 
 class Tuya : public Component, public uart::UARTDevice {
@@ -63,8 +72,10 @@ class Tuya : public Component, public uart::UARTDevice {
   void send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_t len);
   void send_empty_command_(TuyaCommandType command) { this->send_command_(command, nullptr, 0); }
 
+  TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;
+  std::string product_ = "";
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;
   std::vector<uint8_t> rx_message_;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -39,9 +39,10 @@ enum class TuyaCommandType : uint8_t {
   WIFI_STATE = 0x03,
   WIFI_RESET = 0x04,
   WIFI_SELECT = 0x05,
-  SET_DATAPOINT = 0x06,
-  STATE = 0x07,
+  DP_DELIVER = 0x06,
+  DP_REPORT = 0x07,
   QUERY_STATE = 0x08,
+  WIFI_TEST = 0x0E,
 };
 
 class Tuya : public Component, public uart::UARTDevice {


### PR DESCRIPTION
## Description:
* Handle WiFi test command 0x0E
* Run through complete init process as per documentation (heartbeat -> query product -> query conf -> report wifi -> query data packet)
* Handle Product ID string properly, and report in config dump

Documentation ref: https://docs.tuya.com/docDetail?code=K8uhkesnz5mie

## Checklist:
  - [x] The code change is tested and works locally.
