### PR TITLE
PCF8574 correct input handling if pin is set to gnd while starting

### DIFF
--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -42,11 +42,13 @@ void PCF8574Component::pin_mode(uint8_t pin, uint8_t mode) {
   switch (mode) {
     case PCF8574_INPUT:
       this->ddr_mask_ &= ~(1 << pin);
-      this->port_mask_ &= ~(1 << pin);
+      this->port_mask_ |= ~(1 << pin);
+      this->write_gpio_();
       break;
     case PCF8574_INPUT_PULLUP:
       this->ddr_mask_ &= ~(1 << pin);
       this->port_mask_ |= (1 << pin);
+      this->write_gpio_();
       break;
     case PCF8574_OUTPUT:
       this->ddr_mask_ |= (1 << pin);


### PR DESCRIPTION
PCF8574 correct input handling if pin is set to gnd while starting and correct input mode

## Description:
see https://github.com/esphome/issues/issues/755
and 
https://github.com/esphome/issues/issues/667

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
