### PR TITLE
Remove PCF8574 input_pullup mode and cleanup

### DIFF
--- a/esphome/components/pcf8574/__init__.py
+++ b/esphome/components/pcf8574/__init__.py
@@ -11,7 +11,6 @@ pcf8574_ns = cg.esphome_ns.namespace('pcf8574')
 PCF8574GPIOMode = pcf8574_ns.enum('PCF8574GPIOMode')
 PCF8674_GPIO_MODES = {
     'INPUT': PCF8574GPIOMode.PCF8574_INPUT,
-    'INPUT_PULLUP': PCF8574GPIOMode.PCF8574_INPUT_PULLUP,
     'OUTPUT': PCF8574GPIOMode.PCF8574_OUTPUT,
 }
 
@@ -33,16 +32,24 @@ def to_code(config):
     cg.add(var.set_pcf8575(config[CONF_PCF8575]))
 
 
+def validate_pcf8574_gpio_mode(value):
+    value = cv.string(value)
+    if value.upper() == 'INPUT_PULLUP':
+        raise cv.Invalid("INPUT_PULLUP mode has been removed in 1.14 and been combined into "
+                         "INPUT mode (they were the same thing). Please use INPUT instead.")
+    return cv.enum(PCF8674_GPIO_MODES, upper=True)(value)
+
+
 PCF8574_OUTPUT_PIN_SCHEMA = cv.Schema({
     cv.Required(CONF_PCF8574): cv.use_id(PCF8574Component),
     cv.Required(CONF_NUMBER): cv.int_,
-    cv.Optional(CONF_MODE, default="OUTPUT"): cv.enum(PCF8674_GPIO_MODES, upper=True),
+    cv.Optional(CONF_MODE, default="OUTPUT"): validate_pcf8574_gpio_mode,
     cv.Optional(CONF_INVERTED, default=False): cv.boolean,
 })
 PCF8574_INPUT_PIN_SCHEMA = cv.Schema({
     cv.Required(CONF_PCF8574): cv.use_id(PCF8574Component),
     cv.Required(CONF_NUMBER): cv.int_,
-    cv.Optional(CONF_MODE, default="INPUT"): cv.enum(PCF8674_GPIO_MODES, upper=True),
+    cv.Optional(CONF_MODE, default="INPUT"): validate_pcf8574_gpio_mode,
     cv.Optional(CONF_INVERTED, default=False): cv.boolean,
 })
 

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -10,7 +10,6 @@ namespace pcf8574 {
 /// Modes for PCF8574 pins
 enum PCF8574GPIOMode : uint8_t {
   PCF8574_INPUT = INPUT,
-  PCF8574_INPUT_PULLUP = INPUT_PULLUP,
   PCF8574_OUTPUT = OUTPUT,
 };
 
@@ -38,9 +37,12 @@ class PCF8574Component : public Component, public i2c::I2CDevice {
 
   bool write_gpio_();
 
-  uint16_t ddr_mask_{0x00};
+  /// Mask for the pin mode - 1 means output, 0 means input
+  uint16_t mode_mask_{0x00};
+  /// The mask to write as output state - 1 means HIGH, 0 means LOW
+  uint16_t output_mask_{0x00};
+  /// The state read in read_gpio_ - 1 means HIGH, 0 means LOW
   uint16_t input_mask_{0x00};
-  uint16_t port_mask_{0x00};
   bool pcf8575_;  ///< TRUE->16-channel PCF8575, FALSE->8-channel PCF8574
 };
 


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/755
Closes https://github.com/esphome/esphome/pull/822
Fixes https://github.com/esphome/issues/issues/667
Closes https://github.com/esphome/esphome/pull/808

Co-Authored-By: @amishv 
Co-Authored-By: @S-Przybylski

Merges all changes into one PR (otherwise merging will be hell) and cleans up the code a bit

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
