### PR TITLE
Add servo missing restore option to codegen

### DIFF
--- a/esphome/components/servo/__init__.py
+++ b/esphome/components/servo/__init__.py
@@ -4,7 +4,7 @@ from esphome import automation
 from esphome.automation import maybe_simple_id
 from esphome.components.output import FloatOutput
 from esphome.const import CONF_ID, CONF_IDLE_LEVEL, CONF_MAX_LEVEL, CONF_MIN_LEVEL, CONF_OUTPUT, \
-    CONF_LEVEL
+    CONF_LEVEL, CONF_RESTORE
 
 servo_ns = cg.esphome_ns.namespace('servo')
 Servo = servo_ns.class_('Servo', cg.Component)
@@ -18,6 +18,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_MIN_LEVEL, default='3%'): cv.percentage,
     cv.Optional(CONF_IDLE_LEVEL, default='7.5%'): cv.percentage,
     cv.Optional(CONF_MAX_LEVEL, default='12%'): cv.percentage,
+    cv.Optional(CONF_RESTORE, default=False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 
 
@@ -30,6 +31,7 @@ def to_code(config):
     cg.add(var.set_min_level(config[CONF_MIN_LEVEL]))
     cg.add(var.set_idle_level(config[CONF_IDLE_LEVEL]))
     cg.add(var.set_max_level(config[CONF_MAX_LEVEL]))
+    cg.add(var.set_restore(config[CONF_RESTORE]))
 
 
 @automation.register_action('servo.write', ServoWriteAction, cv.Schema({

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -47,6 +47,7 @@ class Servo : public Component {
   void set_min_level(float min_level) { min_level_ = min_level; }
   void set_idle_level(float idle_level) { idle_level_ = idle_level; }
   void set_max_level(float max_level) { max_level_ = max_level; }
+  void set_restore(bool restore) { restore_ = restore; }
 
  protected:
   void save_level_(float v) { this->rtc_.save(&v); }

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -620,6 +620,7 @@ light:
 servo:
   id: my_servo
   output: out
+  restore: true
 
 ttp229_lsf:
 


### PR DESCRIPTION
See also https://github.com/esphome/issues/issues/609

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
