### PR TITLE
Fix stack trace decode for latest platformio

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -101,12 +101,14 @@ def run_idedata(config):
     args = ['-t', 'idedata']
     stdout = run_platformio_cli_run(config, False, *args, capture_stdout=True)
     stdout = decode_text(stdout)
-    match = re.search(r'{.*}', stdout)
+    match = re.search(r'{\s*".*}', stdout)
     if match is None:
+        _LOGGER.debug("Could not match IDEData for %s", stdout)
         return IDEData(None)
     try:
         return IDEData(json.loads(match.group()))
     except ValueError:
+        _LOGGER.debug("Could not load IDEData for %s", stdout, exc_info=1)
         return IDEData(None)
 
 
@@ -165,11 +167,13 @@ ESP8266_EXCEPTION_CODES = {
 def _decode_pc(config, addr):
     idedata = get_idedata(config)
     if not idedata.addr2line_path or not idedata.firmware_elf_path:
+        _LOGGER.debug("decode_pc no addr2line")
         return
     command = [idedata.addr2line_path, '-pfiaC', '-e', idedata.firmware_elf_path, addr]
     try:
-        translation = subprocess.check_output(command).strip()
+        translation = decode_text(subprocess.check_output(command)).strip()
     except Exception:  # pylint: disable=broad-except
+        _LOGGER.debug("Caught exception for command %s", command, exc_info=1)
         return
 
     if "?? ??:0" in translation:


### PR DESCRIPTION
## Description:

Found out that latest platformio has different format for the idedata command - this PR fixes that

Manually merging it into 1.14.1 tag.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
