### PR TITLE
ESP8266 remove default opmode check

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -410,19 +410,6 @@ bool WiFiComponent::wifi_sta_pre_setup_() {
 
 void WiFiComponent::wifi_pre_setup_() {
   wifi_set_event_handler_cb(&WiFiComponent::wifi_event_callback);
-  // Make sure the default opmode is OFF
-  uint8_t default_opmode = wifi_get_opmode_default();
-  if (default_opmode != 0) {
-    ESP_LOGV(TAG, "Setting default WiFi Mode to 0 (was %u)", default_opmode);
-
-    ETS_UART_INTR_DISABLE();
-    bool ret = wifi_set_opmode(0);
-    ETS_UART_INTR_ENABLE();
-
-    if (!ret) {
-      ESP_LOGW(TAG, "Setting default WiFi mode failed!");
-    }
-  }
 
   // Make sure WiFi is in clean state before anything starts
   this->wifi_mode_(false, false);


### PR DESCRIPTION
## Description:

Related https://github.com/esphome/issues/issues/804

Reverting some stuff I committed for 1.14.

This check is not strictly necessary (it only affects what wifi mode the ESP boots up in). The line below resets the ESP to have all interfaces disabled anyway.

This check may have nothing to do with the crashes, but I'm leaving it out anyway in case it does.

Tried to reproduce the error with 1.14.0 and writing random data to an ESP8266 and then writing ESPHome FW without erasing flash, but it worked fine with 3 different random datas. It might have to do with something else (maybe that flash area is used up for some devices?)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
