### PR TITLE
WiFi AP apply manual ip settings

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -179,7 +179,8 @@ def to_code(config):
 
     if CONF_AP in config:
         conf = config[CONF_AP]
-        cg.add(var.set_ap(wifi_network(conf, config.get(CONF_MANUAL_IP))))
+        ip_config = conf.get(CONF_MANUAL_IP, config.get(CONF_MANUAL_IP))
+        cg.add(var.set_ap(wifi_network(conf, ip_config)))
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
 
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -579,7 +579,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
   strcpy(reinterpret_cast<char *>(conf.ssid), ap.get_ssid().c_str());
   conf.ssid_len = static_cast<uint8>(ap.get_ssid().size());
   conf.channel = ap.get_channel().value_or(1);
-  conf.ssid_hidden = 0;
+  conf.ssid_hidden = ap.get_hidden();
   conf.max_connection = 5;
   conf.beacon_interval = 100;
 


### PR DESCRIPTION
## Description:

Before, `manual_ip` settings from `ap:` sections were not used, but the global `wifi` value.

Also sets hidden property for AP mode.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
