### PR TITLE
fix esphome better error out

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -189,7 +189,8 @@ def upload_program(config, args, host):
     from esphome import espota2
 
     if not CONF_OTA in config:
-        raise EsphomeError("Cannot upload Over the Air as the config does not include the ota: component")
+        raise EsphomeError("Cannot upload Over the Air as the config does not include the ota: "
+                           "component")
 
     ota_conf = config[CONF_OTA]
     remote_port = ota_conf[CONF_PORT]

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -188,6 +188,9 @@ def upload_program(config, args, host):
 
     from esphome import espota2
 
+    if not CONF_OTA in config:
+        raise EsphomeError("Cannot upload Over the Air as the config does not include the ota: component")
+
     ota_conf = config[CONF_OTA]
     remote_port = ota_conf[CONF_PORT]
     password = ota_conf[CONF_PASSWORD]

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -188,7 +188,7 @@ def upload_program(config, args, host):
 
     from esphome import espota2
 
-    if not CONF_OTA in config:
+    if CONF_OTA not in config:
         raise EsphomeError("Cannot upload Over the Air as the config does not include the ota: "
                            "component")
 


### PR DESCRIPTION
## Description:

The thing is I just ran

`esphome file.yaml run --upload-port OTA`

and got a stack exception, because my config file did not have the `ota: ` there

now the menu to select how I'd like to upload did not show up as I explicitly said ota, and it did try to uplaod ota, but it fails because it tries to bring up the port (defaults 8266 or 3232) and the password and it crashes retrieving the ota from config).

this is just a heads up message showing what the problem is for better user experience.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
