### PR TITLE
fix missing checks of is_playing condition

### DIFF
--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -8,8 +8,10 @@ static const char* TAG = "dfplayer";
 
 void DFPlayer::play_folder(uint16_t folder, uint16_t file) {
   if (folder < 100 && file < 256) {
+    this->ack_set_is_playing_ = true;
     this->send_cmd_(0x0F, (uint8_t) folder, (uint8_t) file);
   } else if (folder <= 10 && file <= 1000) {
+    this->ack_set_is_playing_ = true;
     this->send_cmd_(0x14, (((uint16_t) folder) << 12) | file);
   } else {
     ESP_LOGE(TAG, "Cannot play folder %d file %d.", folder, file);
@@ -93,6 +95,10 @@ void DFPlayer::loop() {
               ESP_LOGI(TAG, "USB, TF Card available");
             }
             break;
+          case 0x40:
+            ESP_LOGV(TAG, "Nack");
+            this->ack_set_is_playing_ = false;
+            this->ack_reset_is_playing_ = false;
           case 0x41:
             ESP_LOGV(TAG, "Ack ok");
             this->is_playing_ |= this->ack_set_is_playing_;

--- a/esphome/components/dfplayer/dfplayer.h
+++ b/esphome/components/dfplayer/dfplayer.h
@@ -27,29 +27,56 @@ class DFPlayer : public uart::UARTDevice, public Component {
  public:
   void loop() override;
 
-  void next() { this->send_cmd_(0x01); }
-  void previous() { this->send_cmd_(0x02); }
+  void next() {
+    this->ack_set_is_playing_ = true;
+    this->send_cmd_(0x01);
+  }
+  void previous() {
+    this->ack_set_is_playing_ = true;
+    this->send_cmd_(0x02);
+  }
   void play_file(uint16_t file) {
     this->ack_set_is_playing_ = true;
     this->send_cmd_(0x03, file);
   }
-  void play_file_loop(uint16_t file) { this->send_cmd_(0x08, file); }
+  void play_file_loop(uint16_t file) {
+    this->ack_set_is_playing_ = true;
+    this->send_cmd_(0x08, file);
+  }
   void play_folder(uint16_t folder, uint16_t file);
-  void play_folder_loop(uint16_t folder) { this->send_cmd_(0x17, folder); }
+  void play_folder_loop(uint16_t folder) {
+    this->ack_set_is_playing_ = true;
+    this->send_cmd_(0x17, folder);
+  }
   void volume_up() { this->send_cmd_(0x04); }
   void volume_down() { this->send_cmd_(0x05); }
   void set_device(Device device) { this->send_cmd_(0x09, device); }
   void set_volume(uint8_t volume) { this->send_cmd_(0x06, volume); }
   void set_eq(EqPreset preset) { this->send_cmd_(0x07, preset); }
-  void sleep() { this->send_cmd_(0x0A); }
-  void reset() { this->send_cmd_(0x0C); }
-  void start() { this->send_cmd_(0x0D); }
+  void sleep() {
+    this->ack_reset_is_playing_ = true;
+    this->send_cmd_(0x0A);
+  }
+  void reset() {
+    this->ack_reset_is_playing_ = true;
+    this->send_cmd_(0x0C);
+  }
+  void start() {
+    this->ack_set_is_playing_ = true;
+    this->send_cmd_(0x0D);
+  }
   void pause() {
     this->ack_reset_is_playing_ = true;
     this->send_cmd_(0x0E);
   }
-  void stop() { this->send_cmd_(0x16); }
-  void random() { this->send_cmd_(0x18); }
+  void stop() {
+    this->ack_reset_is_playing_ = true;
+    this->send_cmd_(0x16);
+  }
+  void random() {
+    this->ack_set_is_playing_ = true;
+    this->send_cmd_(0x18);
+  }
 
   bool is_playing() { return is_playing_; }
   void dump_config() override;


### PR DESCRIPTION
## Description:

Is playing is not properly handled in some sitations.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/834#issuecomment-552543519

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
