### PR TITLE
Mark python 3.5 support deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-python: '3.5'
+python: '3.6'
 install: script/setup
 cache:
   directories:
@@ -15,8 +15,8 @@ matrix:
         - script/ci-custom.py
         - flake8 esphome
         - pylint esphome
-    - python: "3.5"
-      env: TARGET=Test3.5
+    - python: "3.6"
+      env: TARGET=Test3.6
       script:
         - esphome tests/test1.yaml compile
         - esphome tests/test2.yaml compile

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -14,7 +14,7 @@ from esphome.const import CONF_BAUD_RATE, CONF_BROKER, CONF_LOGGER, CONF_OTA, \
     CONF_PASSWORD, CONF_PORT, CONF_ESPHOME, CONF_PLATFORMIO_OPTIONS
 from esphome.core import CORE, EsphomeError, coroutine, coroutine_with_priority
 from esphome.helpers import color, indent
-from esphome.py_compat import IS_PY2, safe_input
+from esphome.py_compat import IS_PY2, safe_input, IS_PY3
 from esphome.util import run_external_command, run_external_process, safe_print, list_yaml_files
 
 _LOGGER = logging.getLogger(__name__)
@@ -514,6 +514,10 @@ def run_esphome(argv):
         _LOGGER.warning("You're using ESPHome with python 2. Support for python 2 is deprecated "
                         "and will be removed in 1.15.0. Please reinstall ESPHome with python 3.6 "
                         "or higher.")
+    elif IS_PY3 and sys.version_info < (3, 6, 0):
+        _LOGGER.warning("You're using ESPHome with python 3.5. Support for python 3.5 is "
+                        "deprecated and will be removed in 1.15.0. Please reinstall ESPHome with "
+                        "python 3.6 or higher.")
 
     if args.command in PRE_CONFIG_ACTIONS:
         try:

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     zip_safe=False,
     platforms='any',
     test_suite='tests',
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<4.0',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<4.0',
     install_requires=REQUIRES,
     keywords=['home', 'automation'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIRES = [
     'paho-mqtt==1.4.0',
     'colorlog==4.0.2',
     'tornado==5.1.1',
-    'typing>=3.6.6;python_version<"3.5"',
+    'typing>=3.6.6;python_version<"3.6"',
     'protobuf==3.10.0',
     'tzlocal==2.0.0',
     'pytz==2019.3',
@@ -69,7 +69,7 @@ setup(
     zip_safe=False,
     platforms='any',
     test_suite='tests',
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<4.0',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<4.0',
     install_requires=REQUIRES,
     keywords=['home', 'automation'],
     entry_points={


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/831

Looks like esphome needs some newer typing features - so adding typing as an external dependency explicitly.

Also marking 3.5 as deprecated

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
