### PR TITLE
Add wifi output_power setting

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -110,6 +110,7 @@ def validate(config):
     return config
 
 
+CONF_OUTPUT_POWER = 'output_power'
 CONFIG_SCHEMA = cv.All(cv.Schema({
     cv.GenerateID(): cv.declare_id(WiFiComponent),
     cv.Optional(CONF_NETWORKS): cv.ensure_list(WIFI_NETWORK_STA),
@@ -125,6 +126,7 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
         cv.enum(WIFI_POWER_SAVE_MODES, upper=True),
     cv.Optional(CONF_FAST_CONNECT, default=False): cv.boolean,
     cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
+    cv.Optional(CONF_OUTPUT_POWER): cv.All(cv.decibel, cv.float_range(min=10.0, max=20.5)),
 
     cv.Optional('hostname'): cv.invalid("The hostname option has been removed in 1.11.0"),
 }), validate)
@@ -186,6 +188,8 @@ def to_code(config):
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
     cg.add(var.set_power_save_mode(config[CONF_POWER_SAVE_MODE]))
     cg.add(var.set_fast_connect(config[CONF_FAST_CONNECT]))
+    if CONF_OUTPUT_POWER in config:
+        cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
 
     if CORE.is_esp8266:
         cg.add_library('ESP8266WiFi', None)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -36,6 +36,9 @@ void WiFiComponent::setup() {
 
   if (this->has_sta()) {
     this->wifi_sta_pre_setup_();
+    if (this->output_power_.has_value() && !this->wifi_apply_output_power_(*this->output_power_)) {
+      ESP_LOGV(TAG, "Setting Power Save Option failed!");
+    }
 
     if (!this->wifi_apply_power_save_()) {
       ESP_LOGV(TAG, "Setting Power Save Option failed!");
@@ -49,6 +52,9 @@ void WiFiComponent::setup() {
     }
   } else if (this->has_ap()) {
     this->setup_ap_config_();
+    if (this->output_power_.has_value() && !this->wifi_apply_output_power_(*this->output_power_)) {
+      ESP_LOGV(TAG, "Setting Power Save Option failed!");
+    }
 #ifdef USE_CAPTIVE_PORTAL
     if (captive_portal::global_captive_portal != nullptr)
       captive_portal::global_captive_portal->start();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -162,6 +162,7 @@ class WiFiComponent : public Component {
   bool is_connected();
 
   void set_power_save_mode(WiFiPowerSaveMode power_save);
+  void set_output_power(float output_power) { output_power_ = output_power; }
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -217,6 +218,7 @@ class WiFiComponent : public Component {
 
   bool wifi_mode_(optional<bool> sta, optional<bool> ap);
   bool wifi_sta_pre_setup_();
+  bool wifi_apply_output_power_(float output_power);
   bool wifi_apply_power_save_();
   bool wifi_sta_ip_config_(optional<ManualIP> manual_ip);
   IPAddress wifi_sta_ip_();
@@ -260,6 +262,7 @@ class WiFiComponent : public Component {
   std::vector<WiFiScanResult> scan_result_;
   bool scan_done_{false};
   bool ap_setup_{false};
+  optional<float> output_power_;
 };
 
 extern WiFiComponent *global_wifi_component;

--- a/esphome/components/wifi/wifi_component_esp32.cpp
+++ b/esphome/components/wifi/wifi_component_esp32.cpp
@@ -54,7 +54,7 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   return ret;
 }
 bool WiFiComponent::wifi_apply_output_power_(float output_power) {
-  int8_t val = *this->output_power_ * 4;
+  int8_t val = static_cast<uint8_t>(output_power * 4);
   return esp_wifi_set_max_tx_power(val) == ESP_OK;
 }
 bool WiFiComponent::wifi_sta_pre_setup_() {

--- a/esphome/components/wifi/wifi_component_esp32.cpp
+++ b/esphome/components/wifi/wifi_component_esp32.cpp
@@ -53,6 +53,10 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
 
   return ret;
 }
+bool WiFiComponent::wifi_apply_output_power_(float output_power) {
+  int8_t val = *this->output_power_ * 4;
+  return esp_wifi_set_max_tx_power(val) == ESP_OK;
+}
 bool WiFiComponent::wifi_sta_pre_setup_() {
   if (!this->wifi_mode_(true, {}))
     return false;

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -390,6 +390,11 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
   WiFiMockClass::_event_callback(event);
 }
 
+bool WiFiComponent::wifi_apply_output_power_(float output_power) {
+  uint8_t val = output_power * 4;
+  system_phy_set_max_tpw(val);
+  return true;
+}
 bool WiFiComponent::wifi_sta_pre_setup_() {
   if (!this->wifi_mode_(true, {}))
     return false;

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -391,7 +391,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
 }
 
 bool WiFiComponent::wifi_apply_output_power_(float output_power) {
-  uint8_t val = output_power * 4;
+  uint8_t val = static_cast<uint8_t>(output_power * 4);
   system_phy_set_max_tpw(val);
   return true;
 }

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -616,6 +616,7 @@ angle = float_with_unit("angle", u"(°|deg)", optional_unit=True)
 _temperature_c = float_with_unit("temperature", u"(°C|° C|°|C)?")
 _temperature_k = float_with_unit("temperature", u"(° K|° K|K)?")
 _temperature_f = float_with_unit("temperature", u"(°F|° F|F)?")
+decibel = float_with_unit("decibel", u"(dB|dBm|db|dbm)", optional_unit=True)
 
 if IS_PY2:
     # Override voluptuous invalid to unicode for py2


### PR DESCRIPTION
See also:
 - https://github.com/esphome/feature-requests/issues/471#issuecomment-552350467
 - https://github.com/esp8266/Arduino/issues/6366
 - https://github.com/esp8266/Arduino/issues/6471
 - https://github.com/xoseperez/espurna/blob/849f8cf920096fa4b804e70913dab0917ee18ad9/code/espurna/config/general.h#L593-L599
 - https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/network/esp_wifi.html#_CPPv425esp_wifi_set_max_tx_power6int8_t

Default output powers:
 - Tasmota: [17dB](https://github.com/arendst/Tasmota/blob/c7a74b82d0651465220fdd9bc542d47035249476/tasmota/settings.ino#L665)
 - ESPurna: [20dB](https://github.com/xoseperez/espurna/blob/849f8cf920096fa4b804e70913dab0917ee18ad9/code/espurna/config/general.h#L593-L599)
 - ESP SDK: 20.5dB (from looking at decompiled .elf with ghidra)

This patch does not set a new default yet - it's here to validate if output_power is in fact part of the problem.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
