### PR TITLE
Revert ESP32 default scan parameters

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -82,7 +82,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_SCAN_PARAMETERS, default={}): cv.All(cv.Schema({
         cv.Optional(CONF_DURATION, default='5min'): cv.positive_time_period_seconds,
         cv.Optional(CONF_INTERVAL, default='320ms'): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_WINDOW, default='200ms'): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_WINDOW, default='30ms'): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
     }), validate_scan_parameters),
 


### PR DESCRIPTION
A bit of history:

ESP32 BLE Tracker has had some problems with scan parameters before. If the ratio between scan_window and interval is too high, wifi packets get dropped and the device gets unstable

In https://github.com/esphome/issues/issues/824, we experimented with new defaults because maybe the newer esp-idf made the BLE+WiFi coexistence better.

As seen in https://github.com/esphome/issues/issues/837 and https://github.com/esphome/issues/issues/824 however, that does not appear to be true with all devices.

This patch reverts to the old scan parameter defaults from 1.13.x - docs will be updated to note the 1.14.0 defaults as an alternative if more BLE packets are required.

Fixes https://github.com/esphome/issues/issues/837, fixes https://github.com/esphome/issues/issues/824

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
