### PR TITLE
Fix logger uart conflict check

### DIFF
--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -32,6 +32,7 @@ class Logger : public Component {
   /// Manually set the baud rate for serial, set to 0 to disable.
   void set_baud_rate(uint32_t baud_rate);
   uint32_t get_baud_rate() const { return baud_rate_; }
+  HardwareSerial *get_hw_serial() const { return hw_serial_; }
 
   /// Get the UART used by the logger.
   UARTSelection get_uart() const;

--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -373,16 +373,7 @@ void UARTComponent::check_logger_conflict_() {
     return;
   }
 
-  auto logger_uart = logger::global_logger->get_uart();
-
-  if ((this->hw_serial_ == &Serial && logger_uart == logger::UARTSelection::UART_SELECTION_UART0) ||
-      (this->hw_serial_ == &Serial1 && logger_uart == logger::UARTSelection::UART_SELECTION_UART1) ||
-#ifdef ARDUINO_ARCH_ESP32
-      (this->hw_serial_ == &Serial2 && logger_uart == logger::UARTSelection::UART_SELECTION_UART2)) {
-#endif
-#ifdef ARDUINO_ARCH_ESP8266
-      (this->hw_serial_ == &Serial && logger_uart == logger::UARTSelection::UART_SELECTION_UART0_SWAP)) {
-#endif
+  if (this->hw_serial_ == logger::global_logger->get_hw_serial()) {
     ESP_LOGW(TAG, "  You're using the same serial port for logging and the UART component. Please "
                   "disable logging over the serial port by setting logger->baud_rate to 0.");
   }

--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -46,7 +46,7 @@ void UARTComponent::dump_config() {
   }
   ESP_LOGCONFIG(TAG, "  Baud Rate: %u baud", this->baud_rate_);
   ESP_LOGCONFIG(TAG, "  Stop bits: %u", this->stop_bits_);
-  this->check_logger_();
+  this->check_logger_conflict_();
 }
 
 void UARTComponent::write_byte(uint8_t data) {
@@ -151,7 +151,7 @@ void UARTComponent::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Using software serial");
   }
-  this->check_logger_();
+  this->check_logger_conflict_();
 }
 
 void UARTComponent::write_byte(uint8_t data) {
@@ -367,18 +367,7 @@ int UARTComponent::peek() {
   return data;
 }
 
-void UARTDevice::check_uart_settings(uint32_t baud_rate, uint8_t stop_bits) {
-  if (this->parent_->baud_rate_ != baud_rate) {
-    ESP_LOGE(TAG, "  Invalid baud_rate: Integration requested baud_rate %u but you have %u!", baud_rate,
-             this->parent_->baud_rate_);
-  }
-  if (this->parent_->stop_bits_ != stop_bits) {
-    ESP_LOGE(TAG, "  Invalid stop bits: Integration requested stop_bits %u but you have %u!", stop_bits,
-             this->parent_->stop_bits_);
-  }
-}
-
-void UARTDevice::check_logger(){
+void UARTComponent::check_logger_conflict_(){
 #ifdef USE_LOGGER
   if (this->hw_serial_ == nullptr || logger::global_logger->get_baud_rate() == 0)
     return
@@ -398,6 +387,17 @@ void UARTDevice::check_logger(){
 
   }
 #endif
+}
+
+void UARTDevice::check_uart_settings(uint32_t baud_rate, uint8_t stop_bits) {
+  if (this->parent_->baud_rate_ != baud_rate) {
+    ESP_LOGE(TAG, "  Invalid baud_rate: Integration requested baud_rate %u but you have %u!", baud_rate,
+             this->parent_->baud_rate_);
+  }
+  if (this->parent_->stop_bits_ != stop_bits) {
+    ESP_LOGE(TAG, "  Invalid stop bits: Integration requested stop_bits %u but you have %u!", stop_bits,
+             this->parent_->stop_bits_);
+  }
 }
 
 }  // namespace uart

--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -375,15 +375,14 @@ void UARTComponent::check_logger_conflict_() {
 
   auto logger_uart = logger::global_logger->get_uart();
 
-  if ((this->hw_serial_ == &Serial  && logger_uart == logger::UARTSelection::UART_SELECTION_UART0) ||
+  if ((this->hw_serial_ == &Serial && logger_uart == logger::UARTSelection::UART_SELECTION_UART0) ||
       (this->hw_serial_ == &Serial1 && logger_uart == logger::UARTSelection::UART_SELECTION_UART1) ||
 #ifdef ARDUINO_ARCH_ESP32
-      (this->hw_serial_ == &Serial2 && logger_uart == logger::UARTSelection::UART_SELECTION_UART2)
+      (this->hw_serial_ == &Serial2 && logger_uart == logger::UARTSelection::UART_SELECTION_UART2)) {
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
-      (this->hw_serial_ == &Serial && logger_uart == logger::UARTSelection::UART_SELECTION_UART0_SWAP)
+      (this->hw_serial_ == &Serial && logger_uart == logger::UARTSelection::UART_SELECTION_UART0_SWAP)) {
 #endif
-      ) {
     ESP_LOGW(TAG, "  You're using the same serial port for logging and the UART component. Please "
                   "disable logging over the serial port by setting logger->baud_rate to 0.");
   }

--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -367,24 +367,25 @@ int UARTComponent::peek() {
   return data;
 }
 
-void UARTComponent::check_logger_conflict_(){
+void UARTComponent::check_logger_conflict_() {
 #ifdef USE_LOGGER
-  if (this->hw_serial_ == nullptr || logger::global_logger->get_baud_rate() == 0)
-    return
+  if (this->hw_serial_ == nullptr || logger::global_logger->get_baud_rate() == 0) {
+    return;
+  }
 
   auto logger_uart = logger::global_logger->get_uart();
 
   if ((this->hw_serial_ == &Serial  && logger_uart == logger::UARTSelection::UART_SELECTION_UART0) ||
       (this->hw_serial_ == &Serial1 && logger_uart == logger::UARTSelection::UART_SELECTION_UART1) ||
 #ifdef ARDUINO_ARCH_ESP32
-      (this->hw_serial_ == &Serial2 && logger_uart == logger::UARTSelection::UART_SELECTION_UART2)){
+      (this->hw_serial_ == &Serial2 && logger_uart == logger::UARTSelection::UART_SELECTION_UART2)
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
-      (this->hw_serial_ == &Serial && logger_uart == logger::UARTSelection::UART_SELECTION_UART0_SWAP)){}
+      (this->hw_serial_ == &Serial && logger_uart == logger::UARTSelection::UART_SELECTION_UART0_SWAP)
 #endif
+      ) {
     ESP_LOGW(TAG, "  You're using the same serial port for logging and the UART component. Please "
                   "disable logging over the serial port by setting logger->baud_rate to 0.");
-
   }
 #endif
 }

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -76,6 +76,7 @@ class UARTComponent : public Component, public Stream {
   void set_stop_bits(uint8_t stop_bits) { this->stop_bits_ = stop_bits; }
 
  protected:
+  void check_logger_conflict_();
   bool check_read_timeout_(size_t len = 1);
   friend class UARTDevice;
 


### PR DESCRIPTION
## Description:
The logger/uart confict check warning didn't actually check for conflicts. It would simply warn any time the UART is configured to use hardware UART0 and the logger has a non-zero baud rate.

Fix this by actually checking to see if the logger is using the same hardware as the UART component.

**Related issue (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [ ] The code change is tested and works locally.