### PR TITLE
Optimize application loop speed

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -416,8 +416,6 @@ LightColorValues LightCall::validate_() {
   if (this->brightness_.has_value())
     v.set_brightness(*this->brightness_);
 
-  if (this->brightness_.has_value())
-    v.set_brightness(*this->brightness_);
   if (this->red_.has_value())
     v.set_red(*this->red_);
   if (this->green_.has_value())

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -57,13 +57,14 @@ void Application::setup() {
 
   ESP_LOGI(TAG, "setup() finished successfully!");
   this->schedule_dump_config();
+  this->calculate_looping_components_();
 }
 void Application::loop() {
   uint32_t new_app_state = 0;
   const uint32_t start = millis();
 
   this->scheduler.call();
-  for (Component *component : this->components_) {
+  for (Component *component : this->looping_components_) {
     component->call();
     new_app_state |= component->get_component_state();
     this->app_state_ |= new_app_state;
@@ -143,6 +144,14 @@ void Application::safe_reboot() {
   // restart() doesn't always end execution
   while (true) {
     yield();
+  }
+}
+
+void Application::calculate_looping_components_() {
+  for (auto *obj : this->components_) {
+    if ((void*)(obj->*(&Component::loop)) != (void*)(&Component::loop)) {
+      this->looping_components_.push_back(obj);
+    }
   }
 }
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -149,10 +149,8 @@ void Application::safe_reboot() {
 
 void Application::calculate_looping_components_() {
   for (auto *obj : this->components_) {
-    if ((void*)(obj->*(&Component::loop)) != (void*)(&Component::loop) ||
-        (void*)(obj->*(&Component::call_loop)) != (void*)(&Component::call_loop) ||) {
+    if (obj->has_overridden_loop())
       this->looping_components_.push_back(obj);
-    }
   }
 }
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -149,7 +149,8 @@ void Application::safe_reboot() {
 
 void Application::calculate_looping_components_() {
   for (auto *obj : this->components_) {
-    if ((void*)(obj->*(&Component::loop)) != (void*)(&Component::loop)) {
+    if ((void*)(obj->*(&Component::loop)) != (void*)(&Component::loop) ||
+        (void*)(obj->*(&Component::call_loop)) != (void*)(&Component::call_loop) ||) {
       this->looping_components_.push_back(obj);
     }
   }

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -209,7 +209,10 @@ class Application {
 
   void register_component_(Component *comp);
 
+  void calculate_looping_components_();
+
   std::vector<Component *> components_{};
+  std::vector<Component *> looping_components_{};
 
 #ifdef USE_BINARY_SENSOR
   std::vector<binary_sensor::BinarySensor *> binary_sensors_{};

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -138,6 +138,16 @@ float Component::get_actual_setup_priority() const {
   return this->setup_priority_override_;
 }
 void Component::set_setup_priority(float priority) { this->setup_priority_override_ = priority; }
+bool Component::has_overridden_loop() const {
+#ifdef CLANG_TIDY
+  bool loop_overridden = true;
+  bool call_loop_overridden = true;
+#else
+  bool loop_overridden = (void *) (this->*(&Component::loop)) != (void *) (&Component::loop);
+  bool call_loop_overridden = (void *) (this->*(&Component::call_loop)) != (void *) (&Component::call_loop);
+#endif
+  return loop_overridden || call_loop_overridden;
+}
 
 PollingComponent::PollingComponent(uint32_t update_interval) : Component(), update_interval_(update_interval) {}
 

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -126,6 +126,8 @@ class Component {
 
   void status_momentary_error(const std::string &name, uint32_t length = 5000);
 
+  bool has_overridden_loop() const;
+
  protected:
   virtual void call_loop();
   virtual void call_setup();


### PR DESCRIPTION
## Description:

While working on other C++ stuff, I had a realization about our core loop.

I've long suspected the main loop is less efficient than it could be - in App.loop() we're calling loop() for *any* Component, even if the function is empty. This call is expensive because it's an indirect jump (virtual method).

The "clean" fix would be to use some of C++'s features: either 

 - use dynamic_cast; needs RTTI, expensive size-wise
 - use templates; makes the Component class hard to use for beginners
 - have to different Component classes: one looping and one not; makes the class harder to use for beginners and python generator

There's an interesting fix for that: We know if the resolved (bound) function pointer to the loop() method equals Component::loop(), then it can't do anything interesting.

Fortunately, GCC has a C++ extension to get a bound function pointer of a virtual member function. We take advantage of that to calculate ahead of time what components do useful stuff in loop(), and store them in a separate data structure.

Very much a WIP. Needs:
 - benchmarking - if speed doesn't increase much there's no need for this hack
 - fix compiler warnings - this is non-standard C++ and compilers are not happy about it, but accept it (clang and gcc work)
 - document it in Component

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
