### PR TITLE
fix the problem of missing part of advertising packet when activ…

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -325,13 +325,13 @@ void ESPBTDevice::parse_scan_rst(const esp_ble_gap_cb_param_t::ble_scan_result_e
   }
 
   ESP_LOGVV(TAG, "Adv data: %s",
-            hexencode_string(std::string(reinterpret_cast<const char *>(param.ble_adv), param.adv_data_len)).c_str());
+            hexencode_string(std::string(reinterpret_cast<const char *>(param.ble_adv), param.adv_data_len + param.scan_rsp_len)).c_str());
 #endif
 }
 void ESPBTDevice::parse_adv_(const esp_ble_gap_cb_param_t::ble_scan_result_evt_param &param) {
   size_t offset = 0;
   const uint8_t *payload = param.ble_adv;
-  uint8_t len = param.adv_data_len;
+  uint8_t len = param.adv_data_len + param.scan_rsp_len;
 
   while (offset + 2 < len) {
     const uint8_t field_length = payload[offset++];  // First byte is length of adv record

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -325,7 +325,9 @@ void ESPBTDevice::parse_scan_rst(const esp_ble_gap_cb_param_t::ble_scan_result_e
   }
 
   ESP_LOGVV(TAG, "Adv data: %s",
-            hexencode_string(std::string(reinterpret_cast<const char *>(param.ble_adv), param.adv_data_len + param.scan_rsp_len)).c_str());
+            hexencode_string(
+                std::string(reinterpret_cast<const char *>(param.ble_adv), param.adv_data_len + param.scan_rsp_len))
+                .c_str());
 #endif
 }
 void ESPBTDevice::parse_adv_(const esp_ble_gap_cb_param_t::ble_scan_result_evt_param &param) {


### PR DESCRIPTION
## Description:
When "active" is enabled in esp32_ble_tracker and BLE peripheral responds to us, additional data is stored after the first incoming data in ble_adv buffer.
So it needs to parse param.scan_rsp_len range in addition to adv_data_len.

(If "active" is disabled or BLE peripheral doesn't respond to active scan, 0 is stored in scan_rsp_len.)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentar tion (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
