### PR TITLE
Add magic value REPLACEME

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -385,19 +385,17 @@ def recursive_check_replaceme(value):
 
     if isinstance(value, list):
         return cv.Schema([recursive_check_replaceme])(value)
-    elif isinstance(value, dict):
+    if isinstance(value, dict):
         return cv.Schema({cv.valid: recursive_check_replaceme})(value)
-    elif isinstance(value, ESPForceValue):
+    if isinstance(value, ESPForceValue):
         pass
-    elif isinstance(value, string_types):
-        if value != 'REPLACEME':
-            return
-
+    if isinstance(value, string_types) and value == 'REPLACEME':
         raise cv.Invalid("Found 'REPLACEME' in configuration, this is most likely an error. "
                          "Please make sure you have replaced all fields from the sample "
                          "configuration.\n"
                          "If you want to use the literal REPLACEME string, "
                          "please use \"!force REPLACEME\"")
+    return value
 
 
 def validate_config(config):

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -18,12 +18,12 @@ from esphome.components.substitutions import CONF_SUBSTITUTIONS
 from esphome.const import CONF_ESPHOME, CONF_PLATFORM, ESP_PLATFORMS
 from esphome.core import CORE, EsphomeError  # noqa
 from esphome.helpers import color, indent
-from esphome.py_compat import text_type, IS_PY2, decode_text
+from esphome.py_compat import text_type, IS_PY2, decode_text, string_types
 from esphome.util import safe_print, OrderedDict
 
 from typing import List, Optional, Tuple, Union  # noqa
 from esphome.core import ConfigType  # noqa
-from esphome.yaml_util import is_secret, ESPHomeDataBase
+from esphome.yaml_util import is_secret, ESPHomeDataBase, ESPForceValue
 from esphome.voluptuous_schema import ExtraKeysInvalid
 
 _LOGGER = logging.getLogger(__name__)
@@ -380,6 +380,26 @@ def do_id_pass(result):  # type: (Config) -> None
                 result.add_str_error("Couldn't resolve ID for type '{}'".format(id.type), path)
 
 
+def recursive_check_replaceme(value):
+    import esphome.config_validation as cv
+
+    if isinstance(value, list):
+        return cv.Schema([recursive_check_replaceme])(value)
+    elif isinstance(value, dict):
+        return cv.Schema({cv.valid: recursive_check_replaceme})(value)
+    elif isinstance(value, ESPForceValue):
+        pass
+    elif isinstance(value, string_types):
+        if value != 'REPLACEME':
+            return
+
+        raise cv.Invalid("Found 'REPLACEME' in configuration, this is most likely an error. "
+                         "Please make sure you have replaced all fields from the sample "
+                         "configuration.\n"
+                         "If you want to use the literal REPLACEME string, "
+                         "please use \"!force REPLACEME\"")
+
+
 def validate_config(config):
     result = Config()
 
@@ -392,6 +412,12 @@ def validate_config(config):
         except vol.Invalid as err:
             result.add_error(err)
             return result
+
+    # 1.1. Check for REPLACEME special value
+    try:
+        recursive_check_replaceme(config)
+    except vol.Invalid as err:
+        result.add_error(err)
 
     if 'esphomeyaml' in config:
         _LOGGER.warning("The esphomeyaml section has been renamed to esphome in 1.11.0. "
@@ -588,7 +614,7 @@ def _nested_getitem(data, path):
 
 def humanize_error(config, validation_error):
     validation_error = text_type(validation_error)
-    m = re.match(r'^(.*?)\s*(?:for dictionary value )?@ data\[.*$', validation_error)
+    m = re.match(r'^(.*?)\s*(?:for dictionary value )?@ data\[.*$', validation_error, re.DOTALL)
     if m is not None:
         validation_error = m.group(1)
     validation_error = validation_error.strip()

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -19,7 +19,7 @@ from esphome.const import CONF_AVAILABILITY, CONF_COMMAND_TOPIC, CONF_DISCOVERY,
     CONF_HOUR, CONF_MINUTE, CONF_SECOND, CONF_VALUE, CONF_UPDATE_INTERVAL, CONF_TYPE_ID, CONF_TYPE
 from esphome.core import CORE, HexInt, IPAddress, Lambda, TimePeriod, TimePeriodMicroseconds, \
     TimePeriodMilliseconds, TimePeriodSeconds, TimePeriodMinutes
-from esphome.helpers import list_starts_with
+from esphome.helpers import list_starts_with, add_class_to_obj
 from esphome.py_compat import integer_types, string_types, text_type, IS_PY2, decode_text
 from esphome.voluptuous_schema import _Schema
 
@@ -964,11 +964,8 @@ def enum(mapping, **kwargs):
     one_of_validator = one_of(*mapping, **kwargs)
 
     def validator(value):
-        from esphome.yaml_util import make_data_base
-
-        value = make_data_base(one_of_validator(value))
-        cls = value.__class__
-        value.__class__ = cls.__class__(cls.__name__ + "Enum", (cls, core.EnumValue), {})
+        value = one_of_validator(value)
+        value = add_class_to_obj(value, core.EnumValue)
         value.enum_value = mapping[value]
         return value
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -306,6 +306,6 @@ def add_class_to_obj(value, cls):
         for type_, func in _TYPE_OVERLOADS.items():
             # Use type() here, we only need to trigger if it's the exact type,
             # as otherwise we don't need to overload the class
-            if type(value) is type_:
+            if type(value) is type_:  # pylint: disable=unidiomatic-typecheck
                 return add_class_to_obj(func(value), cls)
         raise

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -261,3 +261,51 @@ def file_compare(path1, path2):
             if not blob1:
                 # Reached end
                 return True
+
+
+# A dict of types that need to be converted to heaptypes before a class can be added
+# to the object
+_TYPE_OVERLOADS = {
+    int: type('int', (int,), dict()),
+    float: type('float', (float,), dict()),
+    str: type('str', (str,), dict()),
+    dict: type('dict', (str,), dict()),
+    list: type('list', (list,), dict()),
+}
+
+if IS_PY2:
+    _TYPE_OVERLOADS[long] = type('long', (long,), dict())
+    _TYPE_OVERLOADS[unicode] = type('unicode', (unicode,), dict())
+
+# cache created classes here
+_CLASS_LOOKUP = {}
+
+
+def add_class_to_obj(value, cls):
+    """Add a class to a python type.
+
+    This function modifies value so that it has cls as a basetype.
+    The value itself may be modified by this action! You must use the return
+    value of this function however, since some types need to be copied first (heaptypes).
+    """
+    if isinstance(value, cls):
+        # If already is instance, do not add
+        return value
+
+    try:
+        orig_cls = value.__class__
+        key = (orig_cls, cls)
+        new_cls = _CLASS_LOOKUP.get(key)
+        if new_cls is None:
+            new_cls = orig_cls.__class__(orig_cls.__name__, (orig_cls, cls), {})
+            _CLASS_LOOKUP[key] = new_cls
+        value.__class__ = new_cls
+        return value
+    except TypeError:
+        # Non heap type, look in overloads dict
+        for type_, func in _TYPE_OVERLOADS.items():
+            # Use type() here, we only need to trigger if it's the exact type,
+            # as otherwise we don't need to overload the class
+            if type(value) is type_:
+                return add_class_to_obj(func(value), cls)
+        raise


### PR DESCRIPTION
## Description:

A lot of docs have fields that the user must replace (especially full device sample configurations). Usually the fields the user must replace have some string like "REPLACEME" or similar.

That is just asking for trouble - if you flash a device with a WiFi AP that does not exist you'll be in trouble (unless you have captive portal enabled).

Another option is to use `!secret` in the docs, but that's potentially too complicated for users (or you have to link to what !secret means in every document).

This PR adds a magic value "REPLACEME". Before validating, the entire config is scanned for the REPLACEME string. If found, the user is shown an error:

 - where the string they have to replace is and
 - how to force REPLACEME (probably will never be used, but you never know)

To facilitate this, the "add class to object" used in ESPHomeDataBase and Enum are cleaned up a bit.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
