### PR TITLE
Fix MAX31865 edge case.

### DIFF
--- a/esphome/components/max31865/max31865.h
+++ b/esphome/components/max31865/max31865.h
@@ -43,10 +43,12 @@ class MAX31865Sensor : public sensor::Sensor,
   float rtd_nominal_resistance_;
   MAX31865ConfigFilter filter_;
   uint8_t rtd_wires_;
+  uint8_t base_config_;
   bool has_fault_ = false;
   bool has_warn_ = false;
   void read_data_();
-  void write_register_(uint8_t reg, uint8_t mask, uint8_t bits, uint8_t start_position = 0);
+  void write_config_(uint8_t mask, uint8_t bits, uint8_t start_position = 0);
+  void write_register_(uint8_t reg, uint8_t value);
   const uint8_t read_register_(uint8_t reg);
   const uint16_t read_register_16_(uint8_t reg);
   float calc_temperature_(const float& rtd_ratio);


### PR DESCRIPTION
## Description:

In a heavy EMI environment, reading the current config from the MAX31865 can fail, such as switching from a 4-wire sensor to a 3-wire sensor. This causes the temperature value to be off wildly, but still technically valid, so it doesn't get reported as a sensor failure.

Since we know what configuration we want, rather than send it to the MAX31865 on setup and ask for it over and over (propagating any error as we write it back), instead store the base configuration and work from that to change modes. This not only avoids propagating any error, it also saves a lot of unnecessary reads from the MAX31865.

I ran into this issue after a week or so of uptime on my EPS32+MAX31865 setup. I have been running this update for a week now, and it has been working perfectly.

**Related issue (if applicable):** N/A (can make one if desired)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** No docs changes

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
