### PR TITLE
set default to 50Hz, add register write read functions for debug with HA

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -71,7 +71,7 @@ void ATM90E32Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ATM90E32Component...");
   this->spi_setup();
 
-  uint16_t mmode0 = 0x185;
+  uint16_t mmode0 = 0x085;
   if (line_freq_ == 60) {
     mmode0 |= 1 << 12;
   }
@@ -145,6 +145,10 @@ uint16_t ATM90E32Component::read16_(uint16_t a_register) {
   ESP_LOGVV(TAG, "read16_ 0x%04X output 0x%04X", a_register, output);
   return output;
 }
+int ATM90E32Component::read16(int a_register) {
+  uint16_t rd = this->read16_((uint16_t)a_register);
+  return (int)rd;
+}
 
 int ATM90E32Component::read32_(uint16_t addr_h, uint16_t addr_l) {
   uint16_t val_h = this->read16_(addr_h);
@@ -170,6 +174,9 @@ void ATM90E32Component::write16_(uint16_t a_register, uint16_t val) {
   this->write_byte((val >> 8) & 0xff);
   this->write_byte(val & 0xFF);
   this->disable();
+}
+void ATM90E32Component::write16(int a_register, int val) {
+  this->write16_((uint16_t)a_register, (uint16_t)val);
 }
 
 float ATM90E32Component::get_line_voltage_a_() {

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -30,6 +30,8 @@ class ATM90E32Component : public PollingComponent,
   }
   void set_line_freq(int freq) { line_freq_ = freq; }
   void set_pga_gain(uint16_t gain) { pga_gain_ = gain; }
+  int read16(int a_register);
+  void write16(int a_register, int val);
 
  protected:
   uint16_t read16_(uint16_t a_register);


### PR DESCRIPTION
## Description:
Setting the line frequency did not work.
The code had the 60Hz bit set, then just set it again if line_frequency is set to 60Hz.  So it's was not possible to set to 50Hz.

Exposed register read and write functions for debugging.  That how this bug was discovered.

Issue has not been raised.  (yet)

## Checklist:
  - [ ] The code change is tested and works locally.
yes
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
no yet
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
not yet