### PR TITLE
Allow float values for font size

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -70,7 +70,7 @@ FONT_SCHEMA = cv.Schema({
     cv.Required(CONF_ID): cv.declare_id(Font),
     cv.Required(CONF_FILE): validate_truetype_file,
     cv.Optional(CONF_GLYPHS, default=DEFAULT_GLYPHS): validate_glyphs,
-    cv.Optional(CONF_SIZE, default=20): cv.int_range(min=1),
+    cv.Optional(CONF_SIZE, default=20): cv.float_range(min=1),
     cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
 })
 


### PR DESCRIPTION
## Description:
Currently only integer font sizes are allowed. This will allow float values.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/501

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
