### PR TITLE
Update hdc1080.cpp

### DIFF
--- a/esphome/components/hdc1080/hdc1080.cpp
+++ b/esphome/components/hdc1080/hdc1080.cpp
@@ -19,7 +19,7 @@ void HDC1080Component::setup() {
       0b00000000   // reserved
   };
 
-  if (!this->write_bytes(HDC1080_CMD_CONFIGURATION, data, 2)) {
+  if (!this->write_bytes(HDC1080_CMD_CONFIGURATION, data, 20)) {
     this->mark_failed();
     return;
   }
@@ -36,7 +36,7 @@ void HDC1080Component::dump_config() {
 }
 void HDC1080Component::update() {
   uint16_t raw_temp;
-  if (!this->read_byte_16(HDC1080_CMD_TEMPERATURE, &raw_temp, 9)) {
+  if (!this->read_byte_16(HDC1080_CMD_TEMPERATURE, &raw_temp, 20)) {
     this->status_set_warning();
     return;
   }
@@ -44,7 +44,7 @@ void HDC1080Component::update() {
   this->temperature_->publish_state(temp);
 
   uint16_t raw_humidity;
-  if (!this->read_byte_16(HDC1080_CMD_HUMIDITY, &raw_humidity, 9)) {
+  if (!this->read_byte_16(HDC1080_CMD_HUMIDITY, &raw_humidity, 20)) {
     this->status_set_warning();
     return;
   }

--- a/esphome/components/hdc1080/hdc1080.cpp
+++ b/esphome/components/hdc1080/hdc1080.cpp
@@ -19,7 +19,7 @@ void HDC1080Component::setup() {
       0b00000000   // reserved
   };
 
-  if (!this->write_bytes(HDC1080_CMD_CONFIGURATION, data, 20)) {
+  if (!this->write_bytes(HDC1080_CMD_CONFIGURATION, data, 2)) {
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
increase waittime, to fix reading errors

## Description:
i recognized that the delaytime is not long enough for the hdc1080. 
like in the related issue i got my "broken" module working by increasing the waittime to 20 ms.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/504

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
