### PR TITLE
Disable default wait_time for rc_switch

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -505,7 +505,7 @@ RC_SWITCH_TYPE_D_SCHEMA = cv.Schema({
 RC_SWITCH_TRANSMITTER = cv.Schema({
     cv.Optional(CONF_REPEAT, default={CONF_TIMES: 5}): cv.Schema({
         cv.Required(CONF_TIMES): cv.templatable(cv.positive_int),
-        cv.Optional(CONF_WAIT_TIME, default='10ms'):
+        cv.Optional(CONF_WAIT_TIME, default='0us'):
             cv.templatable(cv.positive_time_period_microseconds),
     }),
 })


### PR DESCRIPTION
See also https://github.com/esphome/esphome/commit/82625a30808f4c914bb9e6a2b3e7ef229a451c99#commitcomment-36092052

## Description:

Technically a breaking change, but I doubt anybody got it to work with the default value anyway.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
