### PR TITLE
ESP32 GPIOs 33 to 38 can be used for deep sleep wakeup

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -6,7 +6,7 @@ from esphome.const import CONF_ID, CONF_MODE, CONF_NUMBER, CONF_PINS, CONF_RUN_C
 
 
 def validate_pin_number(value):
-    valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 39]
+    valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
     if value[CONF_NUMBER] not in valid_pins:
         raise cv.Invalid(u"Only pins {} support wakeup"
                          u"".format(', '.join(str(x) for x in valid_pins)))


### PR DESCRIPTION
All RTC GPIOs can be used as deep sleep wakeup sources. This PR adds ESP32 GPIOs 33 to 38 as allowable config values for the wakeup_pin parameter of the deep sleep component.