### PR TITLE
Updated Color change commands

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -49,16 +49,16 @@ void Nextion::display_picture(int picture_id, int x_start, int y_start) {
   this->send_command_printf("pic %d %d %d", x_start, y_start, picture_id);
 }
 void Nextion::set_component_background_color(const char *component, const char *color) {
-  this->send_command_printf("%s.bco=\"%s\"", component, color);
+  this->send_command_printf("%s.bco=%s", component, color);
 }
 void Nextion::set_component_pressed_background_color(const char *component, const char *color) {
-  this->send_command_printf("%s.bco2=\"%s\"", component, color);
+  this->send_command_printf("%s.bco2=%s", component, color);
 }
 void Nextion::set_component_font_color(const char *component, const char *color) {
-  this->send_command_printf("%s.pco=\"%s\"", component, color);
+  this->send_command_printf("%s.pco=%s", component, color);
 }
 void Nextion::set_component_pressed_font_color(const char *component, const char *color) {
-  this->send_command_printf("%s.pco2=\"%s\"", component, color);
+  this->send_command_printf("%s.pco2=%s", component, color);
 }
 void Nextion::set_component_coordinates(const char *component, int x, int y) {
   this->send_command_printf("%s.xcen=%d", component, x);


### PR DESCRIPTION
The current syntax of the commands for changing color on Nextion Displays was wrong. It's not supposed to be submitted as a string, but as a number.

## Description:
The quoted strings in the command was wrong. This PR fixes that issue

**Related issue (if applicable):** fixes esphome/issues#915

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not Applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
