### PR TITLE
MQTT climate features

### DIFF
--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -14,12 +14,13 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
   auto traits = this->device_->get_traits();
   // current_temperature_topic
   if (traits.get_supports_current_temperature()) {
-    root["current_temperature_topic"] = this->get_current_temperature_state_topic();
+    // current_temperature_topic
+    root["curr_temp_t"] = this->get_current_temperature_state_topic();
   }
   // mode_command_topic
-  root["mode_command_topic"] = this->get_mode_command_topic();
+  root["mode_cmd_t"] = this->get_mode_command_topic();
   // mode_state_topic
-  root["mode_state_topic"] = this->get_mode_state_topic();
+  root["mode_stat_t"] = this->get_mode_state_topic();
   // modes
   JsonArray &modes = root.createNestedArray("modes");
   // sort array for nice UI in HA
@@ -37,18 +38,18 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
 
   if (traits.get_supports_two_point_target_temperature()) {
     // temperature_low_command_topic
-    root["temperature_low_command_topic"] = this->get_target_temperature_low_command_topic();
+    root["temp_lo_cmd_t"] = this->get_target_temperature_low_command_topic();
     // temperature_low_state_topic
-    root["temperature_low_state_topic"] = this->get_target_temperature_low_state_topic();
+    root["temp_lo_stat_t"] = this->get_target_temperature_low_state_topic();
     // temperature_high_command_topic
-    root["temperature_high_command_topic"] = this->get_target_temperature_high_command_topic();
+    root["temp_hi_cmd_t"] = this->get_target_temperature_high_command_topic();
     // temperature_high_state_topic
-    root["temperature_high_state_topic"] = this->get_target_temperature_high_state_topic();
+    root["temp_hi_stat_t"] = this->get_target_temperature_high_state_topic();
   } else {
     // temperature_command_topic
-    root["temperature_command_topic"] = this->get_target_temperature_command_topic();
+    root["temp_cmd_t"] = this->get_target_temperature_command_topic();
     // temperature_state_topic
-    root["temperature_state_topic"] = this->get_target_temperature_state_topic();
+    root["temp_stat_t"] = this->get_target_temperature_state_topic();
   }
 
   // min_temp
@@ -60,20 +61,20 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
 
   if (traits.get_supports_away()) {
     // away_mode_command_topic
-    root["away_mode_command_topic"] = this->get_away_command_topic();
+    root["away_mode_cmd_t"] = this->get_away_command_topic();
     // away_mode_state_topic
-    root["away_mode_state_topic"] = this->get_away_state_topic();
+    root["away_mode_stat_t"] = this->get_away_state_topic();
   }
   if (traits.get_supports_action()) {
     // action_topic
-    root["action_topic"] = this->get_action_state_topic();
+    root["act_t"] = this->get_action_state_topic();
   }
 
   if (traits.get_supports_fan_modes()) {
     // fan_mode_command_topic
-    root["fan_mode_command_topic"] = this->get_fan_mode_command_topic();
+    root["fan_mode_cmd_t"] = this->get_fan_mode_command_topic();
     // fan_mode_state_topic
-    root["fan_mode_state_topic"] = this->get_fan_mode_state_topic();
+    root["fan_mode_stat_t"] = this->get_fan_mode_state_topic();
     // fan_modes
     JsonArray &fan_modes = root.createNestedArray("fan_modes");
     if (traits.supports_fan_mode(CLIMATE_FAN_ON))
@@ -98,9 +99,9 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
 
   if (traits.get_supports_swing_modes()) {
     // swing_mode_command_topic
-    root["swing_mode_command_topic"] = this->get_swing_mode_command_topic();
+    root["swing_mode_cmd_t"] = this->get_swing_mode_command_topic();
     // swing_mode_state_topic
-    root["swing_mode_state_topic"] = this->get_swing_mode_state_topic();
+    root["swing_mode_stat_t"] = this->get_swing_mode_state_topic();
     // swing_modes
     JsonArray &swing_modes = root.createNestedArray("swing_modes");
     if (traits.supports_swing_mode(CLIMATE_SWING_OFF))

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -64,6 +64,10 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
     // away_mode_state_topic
     root["away_mode_state_topic"] = this->get_away_state_topic();
   }
+  if (traits.get_supports_action()) {
+    // action_topic
+    root["action_topic"] = this->get_action_state_topic();
+  }
   config.state_topic = false;
   config.command_topic = false;
 }
@@ -191,6 +195,31 @@ bool MQTTClimateComponent::publish_state_() {
   if (traits.get_supports_away()) {
     std::string payload = ONOFF(this->device_->away);
     if (!this->publish(this->get_away_state_topic(), payload))
+      success = false;
+  }
+  if (traits.get_supports_action()) {
+    const char *payload = "unknown";
+    switch (this->device_->action) {
+      case CLIMATE_ACTION_OFF:
+        payload = "off";
+        break;
+      case CLIMATE_ACTION_COOLING:
+        payload = "cooling";
+        break;
+      case CLIMATE_ACTION_HEATING:
+        payload = "heating";
+        break;
+      case CLIMATE_ACTION_IDLE:
+        payload = "idle";
+        break;
+      case CLIMATE_ACTION_DRYING:
+        payload = "drying";
+        break;
+      case CLIMATE_ACTION_FAN:
+        payload = "fan";
+        break;
+    }
+    if (!this->publish(this->get_action_state_topic(), payload))
       success = false;
   }
 

--- a/esphome/components/mqtt/mqtt_climate.h
+++ b/esphome/components/mqtt/mqtt_climate.h
@@ -30,6 +30,7 @@ class MQTTClimateComponent : public mqtt::MQTTComponent {
   MQTT_COMPONENT_CUSTOM_TOPIC(target_temperature_high, command)
   MQTT_COMPONENT_CUSTOM_TOPIC(away, state)
   MQTT_COMPONENT_CUSTOM_TOPIC(away, command)
+  MQTT_COMPONENT_CUSTOM_TOPIC(action, state)
 
  protected:
   std::string friendly_name() const override;

--- a/esphome/components/mqtt/mqtt_climate.h
+++ b/esphome/components/mqtt/mqtt_climate.h
@@ -31,6 +31,10 @@ class MQTTClimateComponent : public mqtt::MQTTComponent {
   MQTT_COMPONENT_CUSTOM_TOPIC(away, state)
   MQTT_COMPONENT_CUSTOM_TOPIC(away, command)
   MQTT_COMPONENT_CUSTOM_TOPIC(action, state)
+  MQTT_COMPONENT_CUSTOM_TOPIC(fan_mode, state)
+  MQTT_COMPONENT_CUSTOM_TOPIC(fan_mode, command)
+  MQTT_COMPONENT_CUSTOM_TOPIC(swing_mode, state)
+  MQTT_COMPONENT_CUSTOM_TOPIC(swing_mode, command)
 
  protected:
   std::string friendly_name() const override;


### PR DESCRIPTION
## Description:
This activates the new features (actions, fan mode and swing mode) for the `mqtt_climate` component.
Unfortunately, the discovery payload is very long and is not always transmitted (also depending on the component name). Therefore, abbreviations were introduced in the last commit. An alternative could be to increase the allowed MQTT payload size.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
