### PR TITLE
http_request: fix memory allocation

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -28,6 +28,7 @@ class HttpRequestComponent : public Component {
 #ifdef ARDUINO_ARCH_ESP8266
     this->wifi_client_ = new BearSSL::WiFiClientSecure();
     this->wifi_client_->setInsecure();
+    this->wifi_client_->setBufferSizes(512, 512);
 #endif
   }
   void dump_config() override;


### PR DESCRIPTION
## Description:
Before fix sometimes i had problem with memory allocation in BearSSL (only esp8266). See stacktrace:
```
[13:26:18][HTTP-Client][begin] url: https://api.telegram.org/botXXXXXX:XXXXX/sendMessage
[13:26:18][HTTP-Client][begin] host: api.telegram.org port: 443 url: /botXXXXXX:XXXXX/sendMessage
[13:26:18][HTTP-Client][sendRequest] type: 'POST' redirCount: 0
[13:26:18][hostByName] request IP for: api.telegram.org
[13:26:18][hostByName] Host: api.telegram.org IP: 149.154.167.220
[13:26:18]BSSL:_connectSSL: start connection
[13:26:20]
[13:26:20]Abort called
[13:26:20]
[13:26:20]>>>stack>>>
WARNING Found stack trace! Trying to decode it
[13:26:20]
[13:26:20]ctx: cont
[13:26:20]sp: 3ffffa20 end: 3fffffc0 offset: 01b0
[13:26:20]3ffffbd0:  c012c008 c00dc003 3fff4144 4021177f  
INFO Need to fetch platformio IDE-data, please stand by
INFO Running:  platformio run -d /config/http -t idedata
WARNING Decoded 0x4021177f: BearSSL::WiFiClientSecure::_installClientX509Validator()
[13:26:23]3ffffbe0:  00000000 00000000 3ffffc14 3fff5eec  
[13:26:23]3ffffbf0:  3ffffd10 3fff1904 3fff4144 4021227e  
WARNING Decoded 0x4021227e: BearSSL::WiFiClientSecure::_connectSSL(char const*)
[13:26:23]3ffffc00:  00000000 4023b700 3fff1b08 3fff1b08  
WARNING Decoded 0x4023b700: mem_malloc at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/mem.c:210
[13:26:23]3ffffc10:  00000000 00000000 3fff1ee4 4023ac20  
WARNING Decoded 0x4023ac20: ip4_output_if_opt_src at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/ipv4/ip4.c:1007
[13:26:23]3ffffc20:  3ffffcf0 3ffffcc0 00000008 3fff1b74  
[13:26:23]3ffffc30:  00000014 3fff6444 000000ff 00000000  
[13:26:23]3ffffc40:  00000006 3fff1ea4 3ffffcf0 00000038  
[13:26:23]3ffffc50:  0000001c 00000008 3fff1b08 3fff6444  
[13:26:23]3ffffc60:  3fff5ecc 3fff1ee4 00000000 4023ac68  
WARNING Decoded 0x4023ac68: ip4_output_if_opt at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/ipv4/ip4.c:820
[13:26:23]3ffffc70:  3fff1ee4 00000000 00000000 4023b700  
WARNING Decoded 0x4023b700: mem_malloc at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/mem.c:210
[13:26:23]3ffffc80:  0000005a 4023b700 00000080 4023ac8e  
WARNING Decoded 0x4023b700: mem_malloc at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/mem.c:210
WARNING Decoded 0x4023ac8e: ip4_output_if at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/ipv4/ip4.c:793
[13:26:23]3ffffc90:  3fff1ee4 00000000 00000000 4023b80b  
WARNING Decoded 0x4023b80b: ip_chksum_pseudo at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/inet_chksum.c:542
[13:26:23]3ffffca0:  2e373631 00000040 00000000 40237a6a  
WARNING Decoded 0x40237a6a: tcp_output at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/tcp_out.c:1361
[13:26:23]3ffffcb0:  3fff1ee4 3ffffcc0 00000008 40236d55  
WARNING Decoded 0x40236d55: tcp_create_segment at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/tcp_out.c:190
[13:26:23]3ffffcc0:  00000001 3fff6448 3fff64c8 00000000  
[13:26:23]3ffffcd0:  00000000 3ffffd68 3fff4144 3fff1ee4  
[13:26:23]3ffffce0:  40105018 003cb3ad 3fff1aa4 00000000  
WARNING Decoded 0x40105018: ets_timer_arm_new
[13:26:23]3ffffcf0:  3fff0fa0 3fff1aa4 3ffe85d0 3fff1aa4  
[13:26:23]3ffffd00:  00000000 3ffffd60 40221ff4 3fffefa0  
WARNING Decoded 0x40221ff4: esp_yield
[13:26:23]3ffffd10:  00000000 00001388 00001388 402225d3  
WARNING Decoded 0x402225d3: delay
[13:26:23]3ffffd20:  00000000 3fff6fd4 3fff4144 40210965  
WARNING Decoded 0x40210965: WiFiClient::connect(IPAddress, unsigned short)
[13:26:23]3ffffd30:  000001bb 00000000 00000d50 000001bb  
[13:26:23]3ffffd40:  3fff4144 3fff5eec 3fff2d00 000001bb  
[13:26:23]3ffffd50:  3fff4144 3fff5eec 00000001 402124ed  
WARNING Decoded 0x402124ed: BearSSL::WiFiClientSecure::connect(char const*, unsigned short)
[13:26:23]3ffffd60:  40226a28 dca79a95 40226a28 dca79a95  
WARNING Decoded 0x40226a28: int conststr::parseNthInteger<6u>(char const (&) [6u], unsigned int)
WARNING Decoded 0x40226a28: int conststr::parseNthInteger<6u>(char const (&) [6u], unsigned int)
[13:26:24]3ffffd70:  00ff0000 3ffea7a4 3fff2d00 000000fd  
[13:26:24]3ffffd80:  3fff1904 3fff4144 3fff2d00 4021e42c  
WARNING Decoded 0x4021e42c: HTTPClient::connect()
[13:26:24]3ffffd90:  3fff6ed4 3fff2d38 3ffffde4 000000fd  
[13:26:24]3ffffda0:  00000000 3ffea7a4 3fff2d00 4021f065  
WARNING Decoded 0x4021f065: HTTPClient::sendRequest(char const*, unsigned char*, unsigned int)
[13:26:24]3ffffdb0:  3fff2d00 ffffffff 3fff2d38 4021e363  
WARNING Decoded 0x4021e363: HTTPClient::addHeader(String const&, String const&, bool, bool)
[13:26:24]3ffffdc0:  00000000 00000000 fffffdf0 00000000  
[13:26:24]3ffffdd0:  00000000 ffff2d00 3fff66dc 3fff2d9c  
[13:26:24]3ffffde0:  3fff5a70 000000fd 3ffffe30 40220c9a  
WARNING Decoded 0x40220c9a: String::reserve(unsigned int)
[13:26:24]3ffffdf0:  3fff5cd4 3fff2d00 3ffffe30 3fff2d9c  
[13:26:24]3ffffe00:  3ffea7a4 3fff2d00 3fff66dc 4021f23c  
WARNING Decoded 0x4021f23c: HTTPClient::sendRequest(char const*, String)
[13:26:24]3ffffe10:  3ffea7a4 3fff2d00 3fff2cf4 40220b98  
WARNING Decoded 0x40220b98: String::~String()
[13:26:24]3ffffe20:  3fff5cd4 3fff2d00 3fff2cf4 40205006  
WARNING Decoded 0x40205006: esphome::http_request::HttpRequestComponent::send()
[13:26:24]3ffffe30:  3fff66dc 00fd00ff ffff5ee4 00000000  
[13:26:24]3ffffe40:  00000000 fffffe40 3ffffea8 402314ea  
WARNING Decoded 0x402314ea: operator delete(void*) at /workdir/arena/gcc/xtensa-lx106-elf/libstdc++-v3-nox/libsupc++/../../../../../dl/gcc-xtensa/libstdc++-v3/libsupc++/del_op.cc:48
[13:26:24]3ffffe50:  3ffffe70 3fff2cf4 3fff2ec4 3fff2cf4  
[13:26:24]3ffffe60:  3ffffea8 3ffffea8 3fff2ec4 4020f5de  
WARNING Decoded 0x4020f5de: esphome::http_request::HttpRequestSendAction<>::play()
[13:26:24]3ffffe70:  3fff5cb4 3fff5cb4 000003cd 00000000  
[13:26:24]3ffffe80:  00000000 3fff40bc 3fff2b44 4020db7c  
WARNING Decoded 0x4020db7c: esphome::esp_log_vprintf_(int, char const*, int, __FlashStringHelper const*, __va_list_tag)
[13:26:24]3ffffe90:  3ffffee0 3ffffed0 00000010 402314ea  
WARNING Decoded 0x402314ea: operator delete(void*) at /workdir/arena/gcc/xtensa-lx106-elf/libstdc++-v3-nox/libsupc++/../../../../../dl/gcc-xtensa/libstdc++-v3/libsupc++/del_op.cc:48
[13:26:24]3ffffea0:  3ffea7ba 3ffea7a9 3fff5eec 3fff5eec  
[13:26:24]3ffffeb0:  3ffffee0 3ffffed0 00000010 00000000  
[13:26:24]3ffffec0:  3fff63a4 00000001 3fff2ec4 40224f5a  
WARNING Decoded 0x40224f5a: esphome::Action<>::play_complex()
[13:26:24]3ffffed0:  00000000 3fff3e4c 3fff2b44 40224cfc  
WARNING Decoded 0x40224cfc: esphome::ActionList<>::play()
[13:26:24]3ffffee0:  3fff2de0 3ffe95df 3fff171c 40207979  
WARNING Decoded 0x40207979: esphome::template_::TemplateSwitch::write_state(bool)
[13:26:24]3ffffef0:  00000000 3fff40bc 3fff2b44 402074b1  
WARNING Decoded 0x402074b1: esphome::switch_::Switch::toggle()
[13:26:25]3fffff00:  3fffdad0 00000000 3fff171c 40207ba4  
WARNING Decoded 0x40207ba4: std::_Function_handler<void (), esphome::web_server::WebServer::handle_switch_request(AsyncWebServerRequest*, esphome::web_server::UrlMatch)::{lambda()#1}>::_M_invoke(std::_Any_data const&) at web_server.cpp
[13:26:25]3fffff10:  3fffdad0 00000000 3fff171c 401002f4  
WARNING Decoded 0x401002f4: esphome::Scheduler::call()
[13:26:25]3fffff20:  00000000 00000000 4bc6a7f0 00000000  
[13:26:25]3fffff30:  00001e0f 00001dd1 401004fa c5e353f7  
WARNING Decoded 0x401004fa: millis
[13:26:25]3fffff40:  00000000 00000010 00000010 00001e0f  
[13:26:25]3fffff50:  3fffdad0 00000000 3fff171c 4020c0fc  
WARNING Decoded 0x4020c0fc: esphome::Application::loop()
[13:26:25]3fffff60:  00000001 000016cd feefeffe 3fff2f9c  
[13:26:25]3fffff70:  3fff2be4 3fff582c feefeffe feefeffe  
[13:26:25]3fffff80:  3fff2ec4 3fff2ec4 00000084 3fff1a48  
[13:26:25]3fffff90:  3fffdad0 00000000 3fff1a18 4020e9a8  
WARNING Decoded 0x4020e9a8: loop
[13:26:25]3fffffa0:  3fffdad0 00000000 3fff1a18 402220a4  
WARNING Decoded 0x402220a4: loop_wrapper() at core_esp8266_main.cpp
[13:26:25]3fffffb0:  feefeffe feefeffe 3ffe85d0 4010087d  
WARNING Decoded 0x4010087d: cont_wrapper
[13:26:25]<<<stack<<<
[13:26:25]
[13:26:25]last failed alloc call: 4023155A(1492)
WARNING Memory allocation of 1492 bytes failed at 4023155A
WARNING Decoded 0x4023155a: operator new(unsigned int) at /workdir/arena/gcc/xtensa-lx106-elf/libstdc++-v3-nox/libsupc++/../../../../../dl/gcc-xtensa/libstdc++-v3/libsupc++/new_op.cc:52
[13:26:25]
[13:26:25] ets Jan  8 2013,rst cause:2, boot mode:(3,6)
[13:26:25]
[13:26:25]load 0x4010f000, len 1384, room 16 
[13:26:25]tail 8
[13:26:25]chksum 0x2d
[13:26:25]csum 0x2d
[13:26:25]v8b899c12
[13:26:25]~ld
[13:26:25]
[13:26:25]SDK:2.2.1(cfd48f3)/Core:2.5.2=20502000/lwIP:STABLE-2_1_2_RELEASE/glue:1.1-7-g82abda3/BearSSL:a143020
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
