### PR TITLE
http_request: version validation fix

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -4,7 +4,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.const import CONF_ID, CONF_TIMEOUT, CONF_ESPHOME, CONF_METHOD, \
-    CONF_ARDUINO_VERSION, ARDUINO_VERSION_ESP8266_2_5_0
+    CONF_ARDUINO_VERSION, ARDUINO_VERSION_ESP8266_2_5_1
 from esphome.core import CORE, Lambda
 from esphome.core_config import PLATFORMIO_ESP8266_LUT
 
@@ -35,8 +35,8 @@ def validate_framework(config):
         return config
 
     framework = PLATFORMIO_ESP8266_LUT[version] if version in PLATFORMIO_ESP8266_LUT else version
-    if framework < ARDUINO_VERSION_ESP8266_2_5_0:
-        raise cv.Invalid('This component is not supported on arduino framework version below 2.5.0')
+    if framework < ARDUINO_VERSION_ESP8266_2_5_1:
+        raise cv.Invalid('This component is not supported on arduino framework version below 2.5.1')
     return config
 
 


### PR DESCRIPTION
## Description:
There are no methods `setFollowRedirects` and `setRedirectLimit` in 2.5.0

```
src/esphome/components/http_request/http_request.cpp: In member function 'void esphome::http_request::HttpRequestComponent::send()':
src/esphome/components/http_request/http_request.cpp:23:17: error: 'class HTTPClient' has no member named 'setFollowRedirects'
   this->client_.setFollowRedirects(true);
                 ^
src/esphome/components/http_request/http_request.cpp:24:17: error: 'class HTTPClient' has no member named 'setRedirectLimit'
   this->client_.setRedirectLimit(3);
                 ^
*** [.pioenvs/http/src/esphome/components/http_request/http_request.cpp.o] Error 1
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
