### PR TITLE
TFT-LCD ST7789V of ESP32 TTGO.

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -204,9 +204,18 @@ void DisplayBuffer::vprintf_(int x, int y, Font *font, int color, TextAlign alig
     this->print(x, y, font, color, align, buffer);
 }
 void DisplayBuffer::image(int x, int y, Image *image) {
-  for (int img_x = 0; img_x < image->get_width(); img_x++) {
-    for (int img_y = 0; img_y < image->get_height(); img_y++) {
-      this->draw_pixel_at(x + img_x, y + img_y, image->get_pixel(img_x, img_y) ? COLOR_ON : COLOR_OFF);
+  if (image->get_type()==0) {
+    for (int img_x = 0; img_x < image->get_width(); img_x++) {
+      for (int img_y = 0; img_y < image->get_height(); img_y++) {
+        this->draw_pixel_at(x + img_x, y + img_y, image->get_pixel(img_x, img_y) ? COLOR_ON : COLOR_OFF);
+      }
+    }
+  }
+  else if (image->get_type()==1) {
+    for (int img_x = 0; img_x < image->get_width(); img_x++) {
+      for (int img_y = 0; img_y < image->get_height(); img_y++) {
+        this->draw_pixel_at(x + img_x, y + img_y, image->get_color_pixel(img_x, img_y));
+      }
     }
   }
 }
@@ -431,10 +440,22 @@ bool Image::get_pixel(int x, int y) const {
   const uint32_t pos = x + y * width_8;
   return pgm_read_byte(this->data_start_ + (pos / 8u)) & (0x80 >> (pos % 8u));
 }
+
+int Image::get_color_pixel(int x, int y) const {
+  if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
+    return 0;
+
+  const uint32_t pos = (x + y * this->width_)*2;
+  int color = (pgm_read_byte(this->data_start_ + pos)<<8) + (pgm_read_byte(this->data_start_ + pos + 1));
+  return color;
+}
 int Image::get_width() const { return this->width_; }
 int Image::get_height() const { return this->height_; }
+int Image::get_type() const { return this->type_; }
 Image::Image(const uint8_t *data_start, int width, int height)
     : width_(width), height_(height), data_start_(data_start) {}
+Image::Image(const uint8_t *data_start, int width, int height, int type)
+    : width_(width), height_(height), type_(type), data_start_(data_start) {}
 
 DisplayPage::DisplayPage(const display_writer_t &writer) : writer_(writer) {}
 void DisplayPage::show() { this->parent_->show_page(this); }

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -378,13 +378,17 @@ class Font {
 class Image {
  public:
   Image(const uint8_t *data_start, int width, int height);
+  Image(const uint8_t *data_start, int width, int height, int type);
   bool get_pixel(int x, int y) const;
+  int get_color_pixel(int x, int y) const;
   int get_width() const;
   int get_height() const;
+  int get_type() const;
 
  protected:
   int width_;
   int height_;
+  int type_=0;
   const uint8_t *data_start_;
 };
 

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -4,7 +4,7 @@ from esphome import core
 from esphome.components import display, font
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import CONF_FILE, CONF_ID, CONF_RESIZE
+from esphome.const import CONF_FILE, CONF_ID, CONF_RESIZE, CONF_TYPE
 from esphome.core import CORE, HexInt
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +19,7 @@ IMAGE_SCHEMA = cv.Schema({
     cv.Required(CONF_ID): cv.declare_id(Image_),
     cv.Required(CONF_FILE): cv.file_,
     cv.Optional(CONF_RESIZE): cv.dimensions,
+    cv.Optional(CONF_TYPE): cv.string,
     cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
 })
 
@@ -37,20 +38,40 @@ def to_code(config):
     if CONF_RESIZE in config:
         image.thumbnail(config[CONF_RESIZE])
 
-    image = image.convert('1', dither=Image.NONE)
-    width, height = image.size
-    if width > 500 or height > 500:
-        _LOGGER.warning("The image you requested is very big. Please consider using the resize "
-                        "parameter")
-    width8 = ((width + 7) // 8) * 8
-    data = [0 for _ in range(height * width8 // 8)]
-    for y in range(height):
-        for x in range(width):
-            if image.getpixel((x, y)):
-                continue
-            pos = x + y * width8
-            data[pos // 8] |= 0x80 >> (pos % 8)
+    if config[CONF_TYPE].startswith('RGB565'):
+        width, height = image.size
+        image = image.convert('RGB')
+        pixels = list(image.getdata())
+        data = [0 for _ in range(height * width * 2)]
+     
+        pos = 0
+        for pix in pixels:
+            r = (pix[0] >> 3) & 0x1F
+            g = (pix[1] >> 2) & 0x3F
+            b = (pix[2] >> 3) & 0x1F
+            p = (r << 11) + (g << 5) + b
+            data[pos] = (p >> 8) & 0xFF
+            pos += 1
+            data[pos] = p & 0xFF
+            pos += 1
+        rhs = [HexInt(x) for x in data]
+        prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
+        cg.new_Pvariable(config[CONF_ID], prog_arr, width, height, 1)
+    else:
+        image = image.convert('1', dither=Image.NONE)
+        width, height = image.size
+        if width > 500 or height > 500:
+            _LOGGER.warning("The image you requested is very big. Please consider using the resize "
+                            "parameter")
+        width8 = ((width + 7) // 8) * 8
+        data = [0 for _ in range(height * width8 // 8)]
+        for y in range(height):
+            for x in range(width):
+                if image.getpixel((x, y)):
+                    continue
+                pos = x + y * width8
+                data[pos // 8] |= 0x80 >> (pos % 8)
 
-    rhs = [HexInt(x) for x in data]
-    prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
-    cg.new_Pvariable(config[CONF_ID], prog_arr, width, height)
+        rhs = [HexInt(x) for x in data]
+        prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
+        cg.new_Pvariable(config[CONF_ID], prog_arr, width, height)

--- a/esphome/components/st7789v/__init__.py
+++ b/esphome/components/st7789v/__init__.py
@@ -1,0 +1,3 @@
+import esphome.codegen as cg
+
+st7789v_ns = cg.esphome_ns.namespace('st7789v')

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -1,0 +1,47 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import display, spi
+from esphome.const import CONF_ID, CONF_LAMBDA
+from esphome.const import CONF_DC_PIN, CONF_CS_PIN, CONF_ID, CONF_LAMBDA, CONF_PAGES
+from esphome.const import CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, CONF_RESET_PIN, \
+    CONF_BRIGHTNESS
+from . import st7789v_ns
+
+DEPENDENCIES = ['spi']
+
+CONF_BACKLIGHT_PIN = 'bl_pin'
+
+ST7789V = st7789v_ns.class_('ST7789V', cg.PollingComponent, spi.SPIDevice)
+ST7789VRef = ST7789V.operator('ref')
+
+CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(ST7789V),
+    cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+    cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
+    cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
+    cv.Required(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
+    cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
+}).extend(cv.polling_component_schema('1s')).extend(spi.SPI_DEVICE_SCHEMA)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield spi.register_spi_device(var, config)
+
+    dc = yield cg.gpio_pin_expression(config[CONF_DC_PIN])
+    cg.add(var.set_dc_pin(dc))
+
+    reset = yield cg.gpio_pin_expression(config[CONF_RESET_PIN])
+    cg.add(var.set_reset_pin(reset))
+
+    bl = yield cg.gpio_pin_expression(config[CONF_BACKLIGHT_PIN])
+    cg.add(var.set_bl_pin(bl))
+
+    if CONF_LAMBDA in config:
+        lambda_ = yield cg.process_lambda(
+            config[CONF_LAMBDA], [(display.DisplayBufferRef, 'it')], return_type=cg.void)
+        cg.add(var.set_writer(lambda_))
+
+    yield display.register_display(var, config)

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -1,0 +1,321 @@
+#include "st7789v.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace st7789v {
+
+static const char *TAG = "st7789v";
+
+void ST7789V::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up SPI ST7789V...");
+  this->spi_setup();
+  this->dc_pin_->setup();  // OUTPUT
+
+  this->init_reset_();
+  
+  this->writecommand(ST7789_SLPOUT);   // Sleep out
+  delay(120);
+
+  this->writecommand(ST7789_NORON);    // Normal display mode on
+
+  //------------------------------display and color format setting--------------------------------//
+  this->writecommand(ST7789_MADCTL);
+  //writedata(0x00);
+  this->writedata(TFT_MAD_COLOR_ORDER);
+
+  // JLX240 display datasheet
+  this->writecommand(0xB6);
+  this->writedata(0x0A);
+  this->writedata(0x82);
+
+  this->writecommand(ST7789_COLMOD);
+  this->writedata(0x55);
+  delay(10);
+
+  //--------------------------------ST7789V Frame rate setting----------------------------------//
+  this->writecommand(ST7789_PORCTRL);
+  this->writedata(0x0c);
+  this->writedata(0x0c);
+  this->writedata(0x00);
+  this->writedata(0x33);
+  this->writedata(0x33);
+
+  this->writecommand(ST7789_GCTRL);      // Voltages: VGH / VGL
+  this->writedata(0x35);
+
+  //---------------------------------ST7789V Power setting--------------------------------------//
+  this->writecommand(ST7789_VCOMS);
+  this->writedata(0x28);		// JLX240 display datasheet
+
+  this->writecommand(ST7789_LCMCTRL);
+  this->writedata(0x0C);
+
+  this->writecommand(ST7789_VDVVRHEN);
+  this->writedata(0x01);
+  this->writedata(0xFF);
+
+  this->writecommand(ST7789_VRHS);       // voltage VRHS
+  this->writedata(0x10);
+
+  this->writecommand(ST7789_VDVSET);
+  this->writedata(0x20);
+
+  this->writecommand(ST7789_FRCTR2);
+  this->writedata(0x0f);
+
+  this->writecommand(ST7789_PWCTRL1);
+  this->writedata(0xa4);
+  this->writedata(0xa1);
+
+  //--------------------------------ST7789V gamma setting---------------------------------------//
+  this->writecommand(ST7789_PVGAMCTRL);
+  this->writedata(0xd0);
+  this->writedata(0x00);
+  this->writedata(0x02);
+  this->writedata(0x07);
+  this->writedata(0x0a);
+  this->writedata(0x28);
+  this->writedata(0x32);
+  this->writedata(0x44);
+  this->writedata(0x42);
+  this->writedata(0x06);
+  this->writedata(0x0e);
+  this->writedata(0x12);
+  this->writedata(0x14);
+  this->writedata(0x17);
+
+  this->writecommand(ST7789_NVGAMCTRL);
+  this->writedata(0xd0);
+  this->writedata(0x00);
+  this->writedata(0x02);
+  this->writedata(0x07);
+  this->writedata(0x0a);
+  this->writedata(0x28);
+  this->writedata(0x31);
+  this->writedata(0x54);
+  this->writedata(0x47);
+  this->writedata(0x0e);
+  this->writedata(0x1c);
+  this->writedata(0x17);
+  this->writedata(0x1b);
+  this->writedata(0x1e);
+
+  this->writecommand(ST7789_INVON);
+
+  this->writecommand(ST7789_CASET);    // Column address set
+  this->writedata(0x00);
+  this->writedata(0x00);
+  this->writedata(0x00);
+  this->writedata(0xE5);    // 239
+
+  this->writecommand(ST7789_RASET);    // Row address set
+  this->writedata(0x00);
+  this->writedata(0x00);
+  this->writedata(0x01);
+  this->writedata(0x3F);    // 319
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  //this->disable();
+  delay(120);
+  //this->enable();
+
+  this->writecommand(ST7789_DISPON);    //Display on
+  delay(120);
+  
+  backlight(true);
+  
+  this->init_internal_(this->get_buffer_length_());
+  memset(this->buffer_, 0x00, this->get_buffer_length_());
+  
+  //this->lcdDrawFillRect(1,1,186,279, 0xF800);
+  //this->lcdDrawFillRect(1,1,186,279, 0x0000);
+  //delay(10);
+  //this->lcdDrawFillRect(0,39,186,40, 0x0FFF);
+  //this->lcdDrawFillRect(0,39,52,279, 0x0FF0);
+}
+
+void ST7789V::write_display_data() {
+	uint16_t x1 = 52;// +dev->_offsetx;
+	uint16_t x2 = 186;// + dev->_offsetx;
+	uint16_t y1 = 40;// + dev->_offsety;
+	uint16_t y2 = 279;// + dev->_offsety;
+	
+	this->enable();
+
+	// set column(x) address
+	this->dc_pin_->digital_write(false);
+	this->write_byte(0x2A);
+	this->dc_pin_->digital_write(true);
+	this->spi_master_write_addr(x1, x2);
+	
+	// set Page(y) address
+	this->dc_pin_->digital_write(false);
+	this->write_byte(0x2B);
+	this->dc_pin_->digital_write(true);
+	this->spi_master_write_addr(y1, y2);
+
+	//  Memory Write
+	this->dc_pin_->digital_write(false);
+	this->write_byte(0x2C);
+	this->dc_pin_->digital_write(true);
+
+	this->write_array(this->buffer_, this->get_buffer_length_());
+
+	this->disable();
+}
+
+// Draw rectangle of filling
+// x1:Start X coordinate
+// y1:Start Y coordinate
+// x2:End X coordinate
+// y2:End Y coordinate
+// color:color
+void ST7789V::lcdDrawFillRect(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color) {
+	//if (x1 >= dev->_width) return;
+	//if (x2 >= dev->_width) x2=dev->_width-1;
+	//if (y1 >= dev->_height) return;
+	//if (y2 >= dev->_height) y2=dev->_height-1;
+
+	//ESP_LOGD(TAG,"offset(x)=%d offset(y)=%d",dev->_offsetx,dev->_offsety);
+	uint16_t _x1 = x1;// +dev->_offsetx;
+	uint16_t _x2 = x2;// + dev->_offsetx;
+	uint16_t _y1 = y1;// + dev->_offsety;
+	uint16_t _y2 = y2;// + dev->_offsety;
+
+	this->enable();
+	//this->writecommand(0x2A);	// set column(x) address
+	this->dc_pin_->digital_write(false);
+	this->write_byte(0x2A);
+	this->dc_pin_->digital_write(true);
+	//spi_master_write_data_word(dev, _x1);
+	//spi_master_write_data_word(dev, _x2);
+	this->spi_master_write_addr(_x1, _x2);
+	
+	//this->writecommand(0x2B);	// set Page(y) address
+	this->dc_pin_->digital_write(false);
+	this->write_byte(0x2B);
+	this->dc_pin_->digital_write(true);
+	//spi_master_write_data_word(dev, _y1);
+	//spi_master_write_data_word(dev, _y2);
+	this->spi_master_write_addr(_y1, _y2);
+	//this->writecommand(0x2C);	//  Memory Write
+	this->dc_pin_->digital_write(false);
+	this->write_byte(0x2C);
+	this->dc_pin_->digital_write(true);
+	for(int i=_x1;i<=_x2;i++){
+		uint16_t size = _y2-_y1+1;
+		this->spi_master_write_color(color, size);
+	}
+	this->disable();
+}
+
+void ST7789V::spi_master_write_addr(uint16_t addr1, uint16_t addr2)
+{
+	static uint8_t Byte[4];
+	Byte[0] = (addr1 >> 8) & 0xFF;
+	Byte[1] = addr1 & 0xFF;
+	Byte[2] = (addr2 >> 8) & 0xFF;
+	Byte[3] = addr2 & 0xFF;
+
+	
+	this->dc_pin_->digital_write(true);
+	this->write_array(Byte, 4);
+	
+}
+
+void ST7789V::spi_master_write_color(uint16_t color, uint16_t size)
+{
+	static uint8_t Byte[1024];
+	int index = 0;
+	for(int i=0;i<size;i++) {
+		Byte[index++] = (color >> 8) & 0xFF;
+		Byte[index++] = color & 0xFF;
+	}
+
+	this->dc_pin_->digital_write(true);
+	return write_array(Byte, size*2);
+
+}
+
+
+void ST7789V::dump_config() {
+  LOG_DISPLAY("", "SPI ST7789V", this);
+  LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  B/L Pin: ", this->bl_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+float ST7789V::get_setup_priority() const { 
+	return setup_priority::PROCESSOR; 
+}
+
+void ST7789V::update() {
+  this->do_update_();
+  this->write_display_data();
+}
+
+void ST7789V::loop() {
+
+}
+
+int ST7789V::get_width_internal() {
+	return 135;//240;
+}
+
+int ST7789V::get_height_internal() {
+	return 240;//320;
+}
+
+size_t ST7789V::get_buffer_length_() {
+  return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) * 2;
+}
+
+void HOT ST7789V::draw_absolute_pixel_internal(int x, int y, int color) {
+	if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
+		return;
+
+	uint16_t pos = (x + y * this->get_width_internal())*2;
+	this->buffer_[pos++] |= (color>>8) & 0xff;
+	this->buffer_[pos] |= color & 0xff;
+}
+
+void ST7789V::init_reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();
+    this->reset_pin_->digital_write(true);
+    delay(1);
+    // Trigger Reset
+    this->reset_pin_->digital_write(false);
+    delay(10);
+    // Wake up
+    this->reset_pin_->digital_write(true);
+  }
+}
+
+void ST7789V::backlight(bool onoff){
+  if (this->bl_pin_ != nullptr) {
+    this->bl_pin_->setup();
+
+    this->bl_pin_->digital_write(onoff);
+  }
+}
+
+void ST7789V::writecommand(uint8_t value) {
+  this->enable();
+  this->dc_pin_->digital_write(false);
+  this->write_byte(value);
+  this->dc_pin_->digital_write(true);
+  this->disable();
+}
+
+void ST7789V::writedata(uint8_t value) {
+  this->dc_pin_->digital_write(true);
+  this->enable();
+  this->write_byte(value);
+  this->disable();
+}
+
+}  // namespace st7789v
+}  // namespace esphome

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -1,0 +1,190 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+#include "esphome/components/display/display_buffer.h"
+
+#ifndef TFT_WIDTH
+  #define TFT_WIDTH  240
+#endif
+#ifndef TFT_HEIGHT
+  #define TFT_HEIGHT 320
+#endif
+
+#define TFT_RGB_ORDER 0
+
+#if (TFT_HEIGHT == 240) && (TFT_WIDTH == 240)
+  #define CGRAM_OFFSET
+#endif
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
+
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
+
+#define TFT_SLPIN   0x10
+#define TFT_SLPOUT  0x11
+#define TFT_NORON   0x13
+
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
+#define TFT_DISPOFF 0x28
+#define TFT_DISPON  0x29
+#define TFT_CASET   0x2A
+#define TFT_PASET   0x2B
+#define TFT_RAMWR   0x2C
+#define TFT_RAMRD   0x2E
+#define TFT_MADCTL  0x36
+#define TFT_COLMOD  0x3A
+
+// Flags for TFT_MADCTL
+#define TFT_MAD_MY  0x80
+#define TFT_MAD_MX  0x40
+#define TFT_MAD_MV  0x20
+#define TFT_MAD_ML  0x10
+#define TFT_MAD_RGB 0x00
+#define TFT_MAD_BGR 0x08
+#define TFT_MAD_MH  0x04
+#define TFT_MAD_SS  0x02
+#define TFT_MAD_GS  0x01
+
+#ifdef TFT_RGB_ORDER
+  #if (TFT_RGB_ORDER == 1)
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_RGB
+  #else
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_BGR
+  #endif
+#else
+  #ifdef CGRAM_OFFSET
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_BGR
+  #else
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_RGB
+  #endif
+#endif
+
+#define TFT_IDXRD   0x00 // ILI9341 only, indexed control register read
+
+// ST7789 specific commands used in init
+#define ST7789_NOP			0x00
+#define ST7789_SWRESET		0x01
+#define ST7789_RDDID		0x04
+#define ST7789_RDDST		0x09
+
+#define ST7789_RDDPM		0x0A      // Read display power mode
+#define ST7789_RDD_MADCTL	0x0B      // Read display MADCTL
+#define ST7789_RDD_COLMOD	0x0C      // Read display pixel format
+#define ST7789_RDDIM		0x0D      // Read display image mode
+#define ST7789_RDDSM		0x0E      // Read display signal mode
+#define ST7789_RDDSR		0x0F      // Read display self-diagnostic result (ST7789V)
+
+#define ST7789_SLPIN		0x10
+#define ST7789_SLPOUT		0x11
+#define ST7789_PTLON		0x12
+#define ST7789_NORON		0x13
+
+#define ST7789_INVOFF		0x20
+#define ST7789_INVON		0x21
+#define ST7789_GAMSET		0x26      // Gamma set
+#define ST7789_DISPOFF		0x28
+#define ST7789_DISPON		0x29
+#define ST7789_CASET		0x2A
+#define ST7789_RASET		0x2B
+#define ST7789_RAMWR		0x2C
+#define ST7789_RGBSET		0x2D      // Color setting for 4096, 64K and 262K colors
+#define ST7789_RAMRD		0x2E
+
+#define ST7789_PTLAR		0x30
+#define ST7789_VSCRDEF		0x33      // Vertical scrolling definition (ST7789V)
+#define ST7789_TEOFF		0x34      // Tearing effect line off
+#define ST7789_TEON			0x35      // Tearing effect line on
+#define ST7789_MADCTL		0x36      // Memory data access control
+#define ST7789_IDMOFF		0x38      // Idle mode off
+#define ST7789_IDMON		0x39      // Idle mode on
+#define ST7789_RAMWRC		0x3C      // Memory write continue (ST7789V)
+#define ST7789_RAMRDC		0x3E      // Memory read continue (ST7789V)
+#define ST7789_COLMOD		0x3A
+
+#define ST7789_RAMCTRL		0xB0      // RAM control
+#define ST7789_RGBCTRL		0xB1      // RGB control
+#define ST7789_PORCTRL		0xB2      // Porch control
+#define ST7789_FRCTRL1		0xB3      // Frame rate control
+#define ST7789_PARCTRL		0xB5      // Partial mode control
+#define ST7789_GCTRL		0xB7      // Gate control
+#define ST7789_GTADJ		0xB8      // Gate on timing adjustment
+#define ST7789_DGMEN		0xBA      // Digital gamma enable
+#define ST7789_VCOMS		0xBB      // VCOMS setting
+#define ST7789_LCMCTRL		0xC0      // LCM control
+#define ST7789_IDSET		0xC1      // ID setting
+#define ST7789_VDVVRHEN		0xC2      // VDV and VRH command enable
+#define ST7789_VRHS			0xC3      // VRH set
+#define ST7789_VDVSET		0xC4      // VDV setting
+#define ST7789_VCMOFSET		0xC5      // VCOMS offset set
+#define ST7789_FRCTR2		0xC6      // FR Control 2
+#define ST7789_CABCCTRL		0xC7      // CABC control
+#define ST7789_REGSEL1		0xC8      // Register value section 1
+#define ST7789_REGSEL2		0xCA      // Register value section 2
+#define ST7789_PWMFRSEL		0xCC      // PWM frequency selection
+#define ST7789_PWCTRL1		0xD0      // Power control 1
+#define ST7789_VAPVANEN		0xD2      // Enable VAP/VAN signal output
+#define ST7789_CMD2EN		0xDF      // Command 2 enable
+#define ST7789_PVGAMCTRL	0xE0      // Positive voltage gamma control
+#define ST7789_NVGAMCTRL	0xE1      // Negative voltage gamma control
+#define ST7789_DGMLUTR		0xE2      // Digital gamma look-up table for red
+#define ST7789_DGMLUTB		0xE3      // Digital gamma look-up table for blue
+#define ST7789_GATECTRL		0xE4      // Gate control
+#define ST7789_SPI2EN		0xE7      // SPI2 enable
+#define ST7789_PWCTRL2		0xE8      // Power control 2
+#define ST7789_EQCTRL		0xE9      // Equalize time control
+#define ST7789_PROMCTRL		0xEC      // Program control
+#define ST7789_PROMEN		0xFA      // Program mode enable
+#define ST7789_NVMSET		0xFC      // NVM setting
+#define ST7789_PROMACT		0xFE      // Program action
+
+namespace esphome {
+namespace st7789v {
+
+class ST7789V : public PollingComponent, public display::DisplayBuffer, 
+                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
+                                         spi::DATA_RATE_8MHZ> {
+ public:
+  void set_dc_pin(GPIOPin *dc_pin) { this->dc_pin_ = dc_pin; }
+  void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
+  void set_bl_pin(GPIOPin *bl_pin) { this->bl_pin_ = bl_pin; }
+  
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  void update() override;
+  void loop() override;
+  
+  void write_display_data();
+  
+ protected:
+  GPIOPin *dc_pin_;
+  GPIOPin *reset_pin_{nullptr};
+  GPIOPin *bl_pin_{nullptr};
+  
+  void init_reset_();
+  void backlight(bool onoff);
+  void writecommand(uint8_t value);
+  void writedata(uint8_t value);
+  
+  void lcdDrawFillRect(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
+  void spi_master_write_addr(uint16_t addr1, uint16_t addr2);
+  void spi_master_write_color(uint16_t color, uint16_t size);
+  
+  void draw_absolute_pixel_internal(int x, int y, int color) override;
+
+  int get_height_internal() override;
+  int get_width_internal() override;
+  size_t get_buffer_length_();
+};
+
+
+}  // namespace st7789v
+}  // namespace esphome


### PR DESCRIPTION
This patch allows you to use TFT-LCD ST7789V of ESP32 TTGO

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
