### PR TITLE
ct_clamp: Check sample() return value is not NaN

### DIFF
--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -64,6 +64,8 @@ void CTClampSensor::loop() {
 
   // Perform a single sample
   float value = this->source_->sample();
+  if (isnan(value))
+    return;
 
   if (this->is_calibrating_offset_) {
     this->sample_sum_ += value;


### PR DESCRIPTION
Don't try to update CT clamp's state with NaN values returned from the
underlaying sensor.  A single IO error in the sensor code will cause a
NaN to be returned and if we use that in CTClampSensor's floating point
maths both sample_sum_ and offset_ will become NaN and from there every
future calculation will use the NaN offset_ and return NaN too.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
