### PR TITLE
fix: only decode when not str already

### DIFF
--- a/esphome/util.py
+++ b/esphome/util.py
@@ -118,10 +118,11 @@ class RedirectText:
         # str
         # If the conversion fails, we will create an exception, which is okay because we won't
         # be able to print it anyway.
-        text = s.decode()
+        if not isinstance(s, str):
+            s = s.decode()
 
         if self._filter_pattern is not None:
-            self._line_buffer += text
+            self._line_buffer += s
             lines = self._line_buffer.splitlines(True)
             for line in lines:
                 if '\n' not in line and '\r' not in line:
@@ -138,7 +139,7 @@ class RedirectText:
 
                 self._write_color_replace(line)
         else:
-            self._write_color_replace(text)
+            self._write_color_replace(s)
 
         # write() returns the number of characters written
         # Let's print the number of characters of the original string in order to not confuse


### PR DESCRIPTION
## Description:

No need to call decode when an object is already a str.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/918

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
