### PR TITLE
Fix esphome/issues#947 - RGBW(W) white brightness

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -185,7 +185,7 @@ class LightColorValues {
   /// Convert these light color values to an RGBW representation and write them to red, green, blue, white.
   void as_rgbw(float *red, float *green, float *blue, float *white) const {
     this->as_rgb(red, green, blue);
-    *white = this->state_ * this->white_;
+    *white = this->state_ * this->brightness_ * this->white_;
   }
 
   /// Convert these light color values to an RGBWW representation with the given parameters.
@@ -196,8 +196,8 @@ class LightColorValues {
     const float ww_fraction = (color_temp - color_temperature_cw) / (color_temperature_ww - color_temperature_cw);
     const float cw_fraction = 1.0f - ww_fraction;
     const float max_cw_ww = std::max(ww_fraction, cw_fraction);
-    *cold_white = this->state_ * this->white_ * (cw_fraction / max_cw_ww);
-    *warm_white = this->state_ * this->white_ * (ww_fraction / max_cw_ww);
+    *cold_white = this->state_ * this->brightness_ * this->white_ * (cw_fraction / max_cw_ww);
+    *warm_white = this->state_ * this->brightness_ * this->white_ * (ww_fraction / max_cw_ww);
   }
 
   /// Convert these light color values to an CWWW representation with the given parameters.


### PR DESCRIPTION
## Description:
Updates the `as_rgbw()` and `as_rgbww()` calculations to factor in the brightness as well as the white level, so that the white channels dim as expected when the brightness is changed.

**Related issue (if applicable):** fixes [#947](https://github.com/esphome/issues/issues/947)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
