### PR TITLE
Add ibeacon rssi support

### DIFF
--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -82,8 +82,7 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
         auto ibeacon = device.get_ibeacon();
         if (ibeacon.has_value()) {
           for (int i = 0; i < ESP_UUID_LEN_128; i++) {
-            if (ibeacon->get_uuid().get_uuid().uuid.uuid128[i] !=
-                this->uuid_.get_uuid().uuid.uuid128[i]) {
+            if (ibeacon->get_uuid().get_uuid().uuid.uuid128[i] != this->uuid_.get_uuid().uuid.uuid128[i]) {
               return false;
             }
           }

--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -59,17 +59,35 @@ class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDevi
             }
             break;
           case ESP_UUID_LEN_128:
+            bool still_matching = true;
             if (uuid.get_uuid().len == ESP_UUID_LEN_128) {
               for (int i = 0; i < ESP_UUID_LEN_128; i++) {
                 if (uuid.get_uuid().uuid.uuid128[i] != this->uuid_.get_uuid().uuid.uuid128[i]) {
-                  return false;
+                  still_matching = false;
+                  break;
                 }
               }
-              this->publish_state(device.get_rssi());
-              this->found_ = true;
-              return true;
+              if (still_matching) {
+                this->publish_state(device.get_rssi());
+                this->found_ = true;
+                return true;
+              }
             }
             break;
+        }
+      }
+      if (this->uuid_.get_uuid().len == ESP_UUID_LEN_128) {
+        auto ibeacon = device.get_ibeacon();
+        if (ibeacon.has_value()) {
+          for (int i = 0; i < ESP_UUID_LEN_128; i++) {
+            if (ibeacon->get_uuid().get_uuid().uuid.uuid128[i] !=
+                this->uuid_.get_uuid().uuid.uuid128[i]) {
+              return false;
+            }
+          }
+          this->publish_state(device.get_rssi());
+          this->found_ = true;
+          return true;
         }
       }
     }

--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -80,8 +80,7 @@ class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDevi
         auto ibeacon = device.get_ibeacon();
         if (ibeacon.has_value()) {
           for (int i = 0; i < ESP_UUID_LEN_128; i++) {
-            if (ibeacon->get_uuid().get_uuid().uuid.uuid128[i] !=
-                this->uuid_.get_uuid().uuid.uuid128[i]) {
+            if (ibeacon->get_uuid().get_uuid().uuid.uuid128[i] != this->uuid_.get_uuid().uuid.uuid128[i]) {
               return false;
             }
           }

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -74,7 +74,7 @@ def as_hex_array(value):
     value = value.replace("-", "")
     cpp_array = [f'0x{part}' for part in [value[i:i+2] for i in range(0, len(value), 2)]]
     return cg.RawExpression(
-        '(uint8_t*)(const uint8_t[16]){{{}}}'.format(','.join(reversed(cpp_array))))
+        '(uint8_t*)(const uint8_t[16]){{{}}}'.format(','.join(cpp_array)))
 
 
 CONFIG_SCHEMA = cv.Schema({

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -52,8 +52,9 @@ class ESPBLEiBeacon {
   ESPBTUUID get_uuid() { return ESPBTUUID::from_raw(this->beacon_data_.proximity_uuid); }
 
  protected:
+  // See 'Artwork and Specifications' @ https://developer.apple.com/ibeacon/
   struct {
-    uint8_t sub_type;
+    uint16_t sub_type;
     uint8_t proximity_uuid[16];
     uint16_t major;
     uint16_t minor;


### PR DESCRIPTION
## Description:
Add support for RSSI/presence for ibeacons.

As someone who knows nothing about esphome, and nothing about bluetooth, please treat this with PR with significant skepticism. The original code (recently added) for esp32_ble_tracker has ibeacon support that appears unused -- this PR uses it to allow the ble_rssi and ble_presence components to function correctly with beacons. Specifically, if there are not service_data UUIDs that match, the beacon data is compared (pulled out of the manufacturer data). This has been tested with both an ibeacon simulator (on android) and real ibeacons (radbeacons). 

There are two things to highlight here that give cause for concern:
 - It appears that the original struct beacon_data_ contained an incorrect datatype size for subtype, which is 1 byte short of the spec -- and which was causing UUIDs to thus contain an extra erroneous leading byte.
 - I have no idea why the __init__.py reverse the hex array of the configured to-be-matched UUID. Without removing the 'reversed', UUIDs clearly won't match. But I feel like I may be missing some reason why it was added in the first place (and alternative would be to keep the reversed in `__init__.py`, but compare the UUID bytes reversed).

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
