### PR TITLE
extract and use current version of python 3

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,5 +2,5 @@ ports:
 - port: 6052
   onOpen: open-preview
 tasks:
-- before: script/setup
+- before: pyenv local $(pyenv version | grep '^3\.' | cut -d ' ' -f 1) && script/setup
   command: python -m esphome config dashboard


### PR DESCRIPTION
## Description:
After python 2 support was dropped, we need to tell Gitpod to use Python 3.

**Related issue (if applicable):** Regression from #793 

## Checklist:
  - [x] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
