### PR TITLE
Fix dump/tx of 64 bit codes

### DIFF
--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -56,7 +56,7 @@ void RCSwitchBase::sync(RemoteTransmitData *dst) const {
 void RCSwitchBase::transmit(RemoteTransmitData *dst, uint64_t code, uint8_t len) const {
   dst->set_carrier_frequency(0);
   for (int16_t i = len - 1; i >= 0; i--) {
-    if (code & ((uint64_t)1 << i))
+    if (code & ((uint64_t) 1 << i))
       this->one(dst);
     else
       this->zero(dst);
@@ -237,7 +237,7 @@ bool RCSwitchDumper::dump(RemoteReceiveData src) {
     if (protocol->decode(src, &out_data, &out_nbits) && out_nbits >= 3) {
       char buffer[65];
       for (uint8_t j = 0; j < out_nbits; j++)
-        buffer[j] = (out_data & ((uint64_t)1 << (out_nbits - j - 1))) ? '1' : '0';
+        buffer[j] = (out_data & ((uint64_t) 1 << (out_nbits - j - 1))) ? '1' : '0';
 
       buffer[out_nbits] = '\0';
       ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s'", i, buffer);

--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -56,7 +56,7 @@ void RCSwitchBase::sync(RemoteTransmitData *dst) const {
 void RCSwitchBase::transmit(RemoteTransmitData *dst, uint64_t code, uint8_t len) const {
   dst->set_carrier_frequency(0);
   for (int16_t i = len - 1; i >= 0; i--) {
-    if (code & (1 << i))
+    if (code & ((uint64_t)1 << i))
       this->one(dst);
     else
       this->zero(dst);
@@ -237,7 +237,7 @@ bool RCSwitchDumper::dump(RemoteReceiveData src) {
     if (protocol->decode(src, &out_data, &out_nbits) && out_nbits >= 3) {
       char buffer[65];
       for (uint8_t j = 0; j < out_nbits; j++)
-        buffer[j] = (out_data & (1 << (out_nbits - j - 1))) ? '1' : '0';
+        buffer[j] = (out_data & ((uint64_t)1 << (out_nbits - j - 1))) ? '1' : '0';
 
       buffer[out_nbits] = '\0';
       ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s'", i, buffer);


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** 
fixes missed errors in #662
partially fixes https://github.com/esphome/feature-requests/issues/283 
KaKu bits are looking like this:
0: h, L, h, l
1: h, l, h, L
(h=high, l=low short, L=low long)
Now, rcswitch can't handle this, but it can handle (h, l) and (h, L) - this is exactly what protocol8 does in #662 

Tx still won't work, I'll add a note in the ticket about the remaining problems.

## Checklist:
  - [x] The code change is tested and works locally. Tested with a coco remote and an intertechno relay (both seem to be variation of kaku)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

