### PR TITLE
Fix for wizard via dashboard not decoding strings

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -325,7 +325,10 @@ class WizardRequestHandler(BaseHandler):
     def post(self):
         from esphome import wizard
 
-        kwargs = {k: ''.join(str(x) for x in v) for k, v in self.request.arguments.items()}
+        kwargs = {
+            k: ''.join(x.decode() for x in v)
+            for k, v in self.request.arguments.items()
+        }
         destination = settings.rel_path(kwargs['name'] + '.yaml')
         wizard.wizard_write(path=destination, **kwargs)
         self.redirect('./?begin=True')


### PR DESCRIPTION
In the change to drop python 2 code was changed to use str(b'')

## Description:
Handling of request arguments in WizardRequestHandler is not decoding
bytes and rather just doing a str conversion resulting in a value of
"b''" being supplied to the wizard code.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/945

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
