### PR TITLE
Adding the espressif 2.6.3

### DIFF
--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -45,6 +45,7 @@ def validate_board(value):
 validate_platform = cv.one_of('ESP32', 'ESP8266', upper=True)
 
 PLATFORMIO_ESP8266_LUT = {
+    '2.6.3': 'espressif8266@2.3.2',
     '2.6.2': 'espressif8266@2.3.1',
     '2.6.1': 'espressif8266@2.3.0',
     '2.5.2': 'espressif8266@2.2.3',


### PR DESCRIPTION
## Description:
Adding support for the latest Arduino core 2.6.3 build

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
