### PR TITLE
Add E1.31 support

### DIFF
--- a/esphome/components/e131/__init__.py
+++ b/esphome/components/e131/__init__.py
@@ -1,0 +1,52 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components.light.types import AddressableLightEffect
+from esphome.components.light.effects import register_addressable_effect
+from esphome.const import CONF_ID, CONF_NAME, CONF_METHOD, CONF_CHANNELS
+
+e131_ns = cg.esphome_ns.namespace('e131')
+E131AddressableLightEffect = e131_ns.class_('E131AddressableLightEffect', AddressableLightEffect)
+E131Component = e131_ns.class_('E131Component', cg.Component)
+
+METHODS = {
+    'UNICAST': cg.global_ns.E131_UNICAST,
+    'MULTICAST': cg.global_ns.E131_MULTICAST
+}
+
+CHANNELS = {
+    'MONO': e131_ns.E131_MONO,
+    'RGB': e131_ns.E131_RGB,
+    'RGBW': e131_ns.E131_RGBW
+}
+
+CONF_UNIVERSE = 'universe'
+CONF_E131_ID = 'e131_id'
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(E131Component),
+    cv.Optional(CONF_METHOD, default='MULTICAST'): cv.one_of(*METHODS, upper=True),
+})
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    cg.add(var.set_method(METHODS[config[CONF_METHOD]]))
+
+
+@register_addressable_effect('e131', E131AddressableLightEffect, "E1.31", {
+    cv.GenerateID(CONF_E131_ID): cv.use_id(E131Component),
+    cv.Required(CONF_UNIVERSE): cv.int_range(min=1, max=512),
+    cv.Optional(CONF_CHANNELS, default='RGB'): cv.one_of(*CHANNELS, upper=True)
+})
+def e131_light_effect_to_code(config, effect_id):
+    parent = yield cg.get_variable(config[CONF_E131_ID])
+
+    effect = cg.new_Pvariable(effect_id, config[CONF_NAME])
+    cg.add(effect.set_first_universe(config[CONF_UNIVERSE]))
+    cg.add(effect.set_channels(CHANNELS[config[CONF_CHANNELS]]))
+    cg.add(effect.set_e131(parent))
+
+    # https://github.com/forkineye/ESPAsyncE131/blob/master/library.json
+    cg.add_library('ESPAsyncE131', '1.0.1')
+    yield effect

--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -1,0 +1,91 @@
+#include "e131.h"
+#include "e131_addressable_light_effect.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace e131 {
+
+static const char *TAG = "e131";
+static const int MAX_UNIVERSES = 512;
+
+void E131Component::add_effect(E131AddressableLightEffect *light_effect) {
+  ESP_LOGD(TAG, "Registering '%s' for universes %d-%d.", light_effect->get_name().c_str(),
+           light_effect->get_first_universe(), light_effect->get_last_universe());
+
+  light_effects_.insert(light_effect);
+  should_rebind_ = true;
+}
+
+void E131Component::remove_effect(E131AddressableLightEffect *light_effect) {
+  ESP_LOGD(TAG, "Unregistering '%s' for universes %d-%d.", light_effect->get_name().c_str(),
+           light_effect->get_first_universe(), light_effect->get_last_universe());
+
+  light_effects_.erase(light_effect);
+  should_rebind_ = true;
+}
+
+void E131Component::loop() {
+  if (should_rebind_) {
+    should_rebind_ = false;
+    rebind_();
+  }
+
+  if (!e131_client_) {
+    return;
+  }
+
+  while (!e131_client_->isEmpty()) {
+    e131_packet_t packet;
+    e131_client_->pull(&packet);  // Pull packet from ring buffer
+    auto universe = htons(packet.universe);
+    auto handled = process_(universe, packet);
+
+    if (!handled) {
+      ESP_LOGV(TAG, "Ignored packet for %d universe of size %d.", universe, packet.property_value_count);
+    }
+  }
+}
+
+void E131Component::rebind_() {
+  e131_client_.reset();
+
+  int first_universe = MAX_UNIVERSES;
+  int last_universe = 0;
+  int universe_count = 0;
+
+  for (auto light_effect : light_effects_) {
+    first_universe = std::min(first_universe, light_effect->get_first_universe());
+    last_universe = std::max(last_universe, light_effect->get_last_universe());
+    universe_count += light_effect->get_universe_count();
+  }
+
+  if (!universe_count) {
+    ESP_LOGI(TAG, "Stopped E1.31.");
+    return;
+  }
+
+  e131_client_.reset(new ESPAsyncE131(universe_count));
+
+  bool success = e131_client_->begin(listen_method_, first_universe, last_universe - first_universe + 1);
+
+  if (success) {
+    ESP_LOGI(TAG, "Started E1.31 for universes %d-%d", first_universe, last_universe);
+  } else {
+    ESP_LOGW(TAG, "Failed to start E1.31 for universes %d-%d", first_universe, last_universe);
+  }
+}
+
+bool E131Component::process_(int universe, const e131_packet_t &packet) {
+  bool handled = false;
+
+  ESP_LOGV(TAG, "Received E1.31 packet for %d universe, with %d bytes", universe, packet.property_value_count);
+
+  for (auto light_effect : light_effects_) {
+    handled = light_effect->process_(universe, packet) || handled;
+  }
+
+  return handled;
+}
+
+}  // namespace e131
+}  // namespace esphome

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esphome/core/component.h"
+
+#include "ESPAsyncE131.h"
+
+#include <memory>
+#include <set>
+
+namespace esphome {
+namespace e131 {
+
+class E131AddressableLightEffect;
+
+class E131Component : public esphome::Component {
+ public:
+  void loop() override;
+
+ public:
+  void add_effect(E131AddressableLightEffect *light_effect);
+  void remove_effect(E131AddressableLightEffect *light_effect);
+
+ public:
+  void set_method(e131_listen_t listen_method) { this->listen_method_ = listen_method; }
+
+ protected:
+  void rebind_();
+  bool process_(int universe, const e131_packet_t &packet);
+
+ protected:
+  e131_listen_t listen_method_{E131_MULTICAST};
+  std::unique_ptr<ESPAsyncE131> e131_client_;
+  std::set<E131AddressableLightEffect *> light_effects_;
+  bool should_rebind_{false};
+};
+
+}  // namespace e131
+}  // namespace esphome

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -1,0 +1,89 @@
+#include "e131.h"
+#include "e131_addressable_light_effect.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace e131 {
+
+static const char *TAG = "e131_addressable_light_effect";
+static const int MAX_DATA_SIZE = (sizeof(e131_packet_t::property_values) - 1);
+
+E131AddressableLightEffect::E131AddressableLightEffect(const std::string &name) : AddressableLightEffect(name) {}
+
+int E131AddressableLightEffect::get_data_per_universe() const { return get_lights_per_universe() * channels_; }
+
+int E131AddressableLightEffect::get_lights_per_universe() const { return MAX_DATA_SIZE / channels_; }
+
+int E131AddressableLightEffect::get_first_universe() const { return first_universe_; }
+
+int E131AddressableLightEffect::get_last_universe() const { return first_universe_ + get_universe_count() - 1; }
+
+int E131AddressableLightEffect::get_universe_count() const {
+  // Round up to lights_per_universe
+  auto lights = get_lights_per_universe();
+  return (get_addressable_()->size() + lights - 1) / lights;
+}
+
+void E131AddressableLightEffect::start() {
+  AddressableLightEffect::start();
+
+  if (this->e131_) {
+    this->e131_->add_effect(this);
+  }
+}
+
+void E131AddressableLightEffect::stop() {
+  if (this->e131_) {
+    this->e131_->remove_effect(this);
+  }
+
+  AddressableLightEffect::stop();
+}
+
+void E131AddressableLightEffect::apply(light::AddressableLight &it, const light::ESPColor &current_color) {
+  // ignore, it is run by `E131Component::update()`
+}
+
+bool E131AddressableLightEffect::process_(int universe, const e131_packet_t &packet) {
+  auto it = get_addressable_();
+
+  // check if this is our universe and data are valid
+  if (universe < first_universe_ || universe > get_last_universe())
+    return false;
+
+  int output_offset = (universe - first_universe_) * get_lights_per_universe();
+  int output_end = std::min(output_offset + get_lights_per_universe(), it->size());
+  auto input_data = packet.property_values + 1;
+
+  ESP_LOGV(TAG, "Applying data for '%s' on %d universe, for %d-%d.", get_name().c_str(), universe, output_offset,
+           output_end);
+
+  switch (channels_) {
+    case E131_MONO:
+      for (; output_offset < output_end; output_offset++, input_data++) {
+        auto output = (*it)[output_offset];
+        output.set(light::ESPColor(input_data[0], input_data[0], input_data[0], input_data[0]));
+      }
+      break;
+
+    case E131_RGB:
+      for (; output_offset < output_end; output_offset++, input_data += 3) {
+        auto output = (*it)[output_offset];
+        output.set(light::ESPColor(input_data[0], input_data[1], input_data[2],
+                                   (input_data[0] + input_data[1] + input_data[2]) / 3));
+      }
+      break;
+
+    case E131_RGBW:
+      for (; output_offset < output_end; output_offset++, input_data += 4) {
+        auto output = (*it)[output_offset];
+        output.set(light::ESPColor(input_data[0], input_data[1], input_data[2], input_data[3]));
+      }
+      break;
+  }
+
+  return true;
+}
+
+}  // namespace e131
+}  // namespace esphome

--- a/esphome/components/e131/e131_addressable_light_effect.h
+++ b/esphome/components/e131/e131_addressable_light_effect.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/light/addressable_light_effect.h"
+
+#include "ESPAsyncE131.h"
+
+namespace esphome {
+namespace e131 {
+
+class E131Component;
+
+enum E131LightChannels { E131_MONO = 1, E131_RGB = 3, E131_RGBW = 4 };
+
+class E131AddressableLightEffect : public light::AddressableLightEffect {
+ public:
+  E131AddressableLightEffect(const std::string &name);
+
+ public:
+  void start() override;
+  void stop() override;
+  void apply(light::AddressableLight &it, const light::ESPColor &current_color) override;
+
+ public:
+  int get_data_per_universe() const;
+  int get_lights_per_universe() const;
+  int get_first_universe() const;
+  int get_last_universe() const;
+  int get_universe_count() const;
+
+ public:
+  void set_first_universe(int universe) { this->first_universe_ = universe; }
+  void set_channels(E131LightChannels channels) { this->channels_ = channels; }
+  void set_e131(E131Component *e131) { this->e131_ = e131; }
+
+ protected:
+  bool process_(int universe, const e131_packet_t &packet);
+
+ protected:
+  int first_universe_{0};
+  int last_universe_{0};
+  E131LightChannels channels_{E131_RGB};
+  E131Component *e131_{nullptr};
+
+  friend class E131Component;
+};
+
+}  // namespace e131
+}  // namespace esphome

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ lib_deps =
     FastLED@3.2.9
     NeoPixelBus-esphome@2.5.2
     ESPAsyncTCP-esphome@1.2.2
+    ESPAsyncE131@1.0.1
     1655@1.0.2  ; TinyGPSPlus (has name conflict)
     6865@1.0.0  ; TM1651 Battery Display
 build_flags =

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -627,6 +627,8 @@ mcp23017:
 mcp23008:
   id: mcp23008_hub
 
+e131:
+
 light:
   - platform: neopixelbus
     name: Neopixelbus Light
@@ -635,6 +637,9 @@ light:
     variant: SK6812
     method: ESP8266_UART0
     num_leds: 100
+    effects:
+      - e131:
+          universe: 1
 
 servo:
   id: my_servo


### PR DESCRIPTION
## Description:

This is based on https://github.com/esphome/esphome/pull/947.
 
This adds a `e131` component that allows to register `e131` addressable light effect.

The usage (also described here https://github.com/ayufan/esphome-components#23-e131):

```yaml
e131:
  method: multicast # Register E1.31 to Multicast group
  # method: unicast # Listen only on port

light:
  - platform: neopixelbus
    pin: D4
    method: ESP8266_UART1
    num_leds: 189
    name: LEDs
    effects:
      - e131:
          universe: 1
          channels: RGB
          # channels: RGBW: to support additional W-channel
          # channels: MONO: to support only luminance
```

If there's more LEDs than allowed per-universe, additional universe will be used. In the above example of 189 LEDs, first 170 LEDs will be assigned to 1 universe, the rest of 19 LEDs will be automatically assigned to 2 universe.

It is possible to enable multiple light platforms to listen to the same universe concurrently, allowing to replicate the behaviour on multiple strips.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#TBD

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
