### PR TITLE
Output from platformio idedata command does not need to be decoded

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -98,7 +98,7 @@ def run_upload(config, verbose, port):
 
 def run_idedata(config):
     args = ['-t', 'idedata']
-    stdout = run_platformio_cli_run(config, False, *args, capture_stdout=True).decode()
+    stdout = run_platformio_cli_run(config, False, *args, capture_stdout=True)
     match = re.search(r'{\s*".*}', stdout)
     if match is None:
         _LOGGER.debug("Could not match IDEData for %s", stdout)


### PR DESCRIPTION
## Description: Don't try to decode output from platformio command; doing so fails on py3


**Related issue (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.

  _- [ ] Tests have been added to verify that the new code works (under `tests/` folder)._
I don't think we can test for this since it's triggered on reading a stack trace from the logs, but it would be nice.