### PR TITLE
Allow custom lights to be addressable

### DIFF
--- a/esphome/components/custom/light/__init__.py
+++ b/esphome/components/custom/light/__init__.py
@@ -10,7 +10,7 @@ CONF_LIGHTS = 'lights'
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(CustomLightOutputConstructor),
     cv.Required(CONF_LAMBDA): cv.returning_lambda,
-    cv.Required(CONF_LIGHTS): cv.ensure_list(light.RGB_LIGHT_SCHEMA),
+    cv.Required(CONF_LIGHTS): cv.ensure_list(light.ADDRESSABLE_LIGHT_SCHEMA),
 })
 
 


### PR DESCRIPTION
## Description: Allow custom light components to use the full addressable schema. Most importantly, addressable effects.


**Related issue (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [X] The code change is tested and works locally.

