### PR TITLE
Fix checksum errors on Feit Wifi Smart Dimmer

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -263,7 +263,7 @@ void Tuya::send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_
   if (command_waiting_for_response_ == 0 || now - command_waiting_for_response_ > 50) {
     command_waiting_for_response_ = millis();
   } else {
-    delay( 50 - now + command_waiting_for_response_ );
+    delay(50 - now + command_waiting_for_response_ );
     command_waiting_for_response_ = millis();
   }
 

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -263,7 +263,7 @@ void Tuya::send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_
   if (command_waiting_for_response_ == 0 || now - command_waiting_for_response_ > 50) {
     command_waiting_for_response_ = millis();
   } else {
-    delay(50 - now + command_waiting_for_response_ );
+    delay(50 - now + command_waiting_for_response_);
     command_waiting_for_response_ = millis();
   }
 

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -75,6 +75,7 @@ class Tuya : public Component, public uart::UARTDevice {
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;
+  uint32_t command_waiting_for_response_ = 0;
   std::string product_ = "";
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;


### PR DESCRIPTION
## Description:

Feit Wi-Fi Smart Dimmers see checksum errors in some situations where a second command is sent to the MCU before the response is received for the first.  This update imposes a 50ms delay if there is an attempt to send a second command while a response is outstanding.  In testing there is a dramatic reduction in checksum errors, but a few still slip through.  Raising the delay to 250ms didn't eliminate them, so a more complicated patch to queue commands until the response is received is probably necessary to eliminate the issue.  It isn't clear that the bug is worth that level of effort.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/986

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
