### PR TITLE
Fix OTA updates getting killed by task_wdt

### DIFF
--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -241,6 +241,8 @@ void OTAComponent::handle_() {
       last_progress = now;
       float percentage = (total * 100.0f) / ota_size;
       ESP_LOGD(TAG, "OTA in progress: %0.1f%%", percentage);
+      // slow down OTA update to avoid getting killed by task watchdog (task_wdt)
+      delay(10);
     }
   }
 


### PR DESCRIPTION
## Description:

My ESP32 was unable to do OTA updates with ESPHome. After further investigations it turned out that the Task Watchdog kills the OTA process since it blocks all other processes for too long. The simple fix/workaround was to add a sleep of 10ms for every 1000ms (1s) so that other processes _could_ be completed within these 10ms. Therefor the watchdog doesn't kill the OTA anymore and doesn't reset the whole chip.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/857

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** -

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

@pauln could you test this fix with your ESP32s?
