### PR TITLE
Implement addressable_gradient effect

### DIFF
--- a/esphome/components/gradient/__init__.py
+++ b/esphome/components/gradient/__init__.py
@@ -1,0 +1,128 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.const import CONF_ID, CONF_NAME
+from esphome.core import ID
+
+MULTI_CONF = True
+
+gradient_ns = cg.esphome_ns.namespace('gradient')
+# Gradient = gradient_ns.class_('Gradient', cg.Component)
+Gradient = gradient_ns.class_('Gradient')
+GradientPtr = Gradient.operator('ptr')
+GradientPoint = gradient_ns.struct('GradientPoint')
+
+CONF_GRADIENT = 'gradient'
+CONF_GIMP_GRADIENT = 'gimp'
+CONF_RGB_GRADIENT = 'rgb'
+CONF_POS = "pos"
+CONF_RED = "r"
+CONF_GREEN = "g"
+CONF_BLUE = "b"
+CONF_GRADIENT_DATA = 'gradient_data'
+
+GRADIENT_RGB_SCHEMA = cv.Schema({
+    #cv.Required(CONF_POS): cv.zero_to_one_float,
+    cv.Optional(CONF_RED, default=0.0): cv.zero_to_one_float,
+    cv.Optional(CONF_GREEN, default=0.0): cv.zero_to_one_float,
+    cv.Optional(CONF_BLUE, default=0.0): cv.zero_to_one_float
+})
+
+CONFIG_SCHEMA = cv.All(cv.Schema({
+    # cv.Required(CONF_ID): cv.declare_id(Gradient),
+    cv.GenerateID(): cv.declare_id(Gradient),
+    cv.Optional(CONF_NAME): cv.string,
+    cv.Optional(CONF_GIMP_GRADIENT): cv.string,
+    cv.Optional(CONF_RGB_GRADIENT): cv.ensure_list(GRADIENT_RGB_SCHEMA),
+    cv.GenerateID(CONF_GRADIENT_DATA): cv.declare_id(GradientPoint),
+}),#.extend(cv.COMPONENT_SCHEMA),
+    cv.has_exactly_one_key(CONF_GIMP_GRADIENT, CONF_RGB_GRADIENT))
+
+
+def to_code(config):
+    #var = cg.new_Pvariable(config[CONF_ID])
+    cg.add_global(gradient_ns.using)
+    print("creating gradient: %s %s" %(config[CONF_ID], type(config[CONF_ID])))
+    var = cg.new_Pvariable(config[CONF_ID])
+    #yield cg.register_component(var, config)
+    
+    segments = []
+
+    if CONF_NAME in config:
+        name = config[CONF_NAME]
+        # set name
+
+    if CONF_RGB_GRADIENT in config:
+        le = len(config[CONF_RGB_GRADIENT])
+        if le >= 2:
+            segsize = 1.0/(le-1)
+        else:
+            segsize = 1.0
+        pos = 0.0
+        lst = list(config[CONF_RGB_GRADIENT])
+        for (i, seg) in enumerate(lst):
+            # l, m, r, rl, gl, bl, rr, gr, br, fn, space;
+            
+            segments.append(cg.StructInitializer(
+                    GradientPoint,
+                    ('l', pos),
+                    ('m', pos+(segsize/2.0)),
+                    ('r', pos+segsize),
+                    ('rl', seg["r"]),
+                    ('gl', seg["g"]),
+                    ('bl', seg["b"]),
+                    ('rr', lst[(i + 1) % le]["r"]),
+                    ('gr', lst[(i + 1) % le]["g"]),
+                    ('br', lst[(i + 1) % le]["b"]),
+                    ('fn', 0),
+                    ('space', 0),
+            ))
+            pos = segsize * i
+
+    if CONF_GIMP_GRADIENT in config:
+        from esphome import ggr
+        print("----")
+        print(config[CONF_GIMP_GRADIENT], type(config[CONF_GIMP_GRADIENT]))
+        print("---###5")
+        gg = ggr.GimpGradient(content=config[CONF_GIMP_GRADIENT])
+        # FIXME: does not work because validator compains first
+        # use the gimp gradient name if available and name is default
+        #if gg.name and  config[CONF_NAME] == "Gradient":
+        #    name = gg.name
+        
+        #grad = "AdressableGradient_%s" %effect_id
+        #grad.type = AddressableGradientEffectColor
+        # cg.progmem_array(grad, rhs)
+        for seg in gg.segs:
+            # l, m, r, rl, gl, bl, rr, gr, br, fn, space;
+            segments.append(cg.StructInitializer(
+                    GradientPoint,
+                    ('l', seg.l),
+                    ('m', seg.m),
+                    ('r', seg.r),
+                    ('rl', seg.rl),
+                    ('gl', seg.gl),
+                    ('bl', seg.bl),
+                    ('rr', seg.rr),
+                    ('gr', seg.gr),
+                    ('br', seg.br),
+                    ('fn', int(seg.fn)),
+                    ('space', int(seg.space)),
+            ))
+    # cg.add(var.set_gradient(segments))
+    #grad = "AdressableGradient_%s" %effect_id
+    #grad.type = AddressableGradientEffectColor
+    # cg.progmem_array(length, segments)
+    if len(segments):
+        #pg_array = ID("%s_points" % config[CONF_ID], is_declaration=True, type=GradientPoint, is_manual=True)
+        print("%s %s" %(config[CONF_ID], type(config[CONF_ID])))
+        #pgr = cg.progmem_array(pg_array, segments)
+        pgr = cg.progmem_array(config[CONF_GRADIENT_DATA], segments)
+        print(pgr)
+        cg.add(var.set_gradient(pgr, len(segments)))
+    
+    yield var
+    # pin = yield cg.gpio_pin_expression(config[CONF_PIN])
+    # one_wire = cg.new_Pvariable(config[CONF_ONE_WIRE_ID], pin)
+    # var = cg.new_Pvariable(config[CONF_ID], one_wire)
+    # yield cg.register_component(var, config)

--- a/esphome/components/gradient/gradient.h
+++ b/esphome/components/gradient/gradient.h
@@ -1,0 +1,205 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+//#include "light_output.h"
+#include "esphome/components/light/light_state.h"
+#include "esphome/components/light/addressable_light.h"
+
+namespace esphome {
+namespace gradient {
+using esphome::light::ESPColor;
+using esphome::light::ESPHSVColor;
+
+/* The GradientPoint as used in the gimp gradient format. See esphome/ggr.py */
+
+struct GradientPoint {
+  public:
+    float l, m, r, rl, gl, bl, rr, gr, br;
+    // uint8_t causes crash on access, alignment did not work
+    uint32_t fn, space;
+};
+
+class Gradient {
+
+public: 
+  void set_name(std::string name) { this->name_ = name;}
+
+  void set_gradient(const GradientPoint* start, uint32_t length) {
+    //   int i;
+    //   // the last entry 
+    //   for(i = 0, start[i].l != nullptr || start[i].r != nullptr, i++ ) {
+
+    //   }
+      ESP_LOGD("custom", "set gp: %p len:%d ", start, length);
+      this->length_ = length;
+      this->start_ = start;
+      ESP_LOGD("custom", "set gp: %p len:%d ", this->start_, length);
+  }
+  const GradientPoint* get_gradient() const { return (const GradientPoint*)this->length_; }
+  size_t get_length() const { return this->length_; }
+
+  /* returns the color at point x of the gradient. 0 <= x <= 1.0 */
+  ESPColor color(float x) const {
+        /* for seg in self.segs:
+            if seg.l <= x <= seg.r:
+                break
+        else:
+            # No segment applies! Return black I guess.
+            return (0,0,0)
+
+        # Normalize the segment geometry.
+        mid = (seg.m - seg.l)/(seg.r - seg.l)
+        pos = (x - seg.l)/(seg.r - seg.l)
+        
+        # Assume linear (most common, and needed by most others).
+        if pos <= mid:
+            f = pos/mid/2
+        else:
+            f = (pos - mid)/(1 - mid)/2 + 0.5
+
+        # Find the correct interpolation factor.
+        if seg.fn == 1:   # Curved
+            f = math.pow(pos, math.log(0.5) / math.log(mid));
+        elif seg.fn == 2:   # Sinusoidal
+            f = (math.sin((-math.pi/2) + math.pi*f) + 1)/2
+        elif seg.fn == 3:   # Spherical increasing
+            f -= 1
+            f = math.sqrt(1 - f*f)
+        elif seg.fn == 4:   # Spherical decreasing
+            f = 1 - math.sqrt(1 - f*f);
+
+        # Interpolate the colors
+        if seg.space == 0:
+            c = (
+                seg.rl + (seg.rr-seg.rl) * f,
+                seg.gl + (seg.gr-seg.gl) * f,
+                seg.bl + (seg.br-seg.bl) * f
+                )
+        elif seg.space in (1,2):
+            hl, sl, vl = colorsys.rgb_to_hsv(seg.rl, seg.gl, seg.bl)
+            hr, sr, vr = colorsys.rgb_to_hsv(seg.rr, seg.gr, seg.br)
+
+            if seg.space == 1 and hr < hl:
+                hr += 1
+            elif seg.space == 2 and hr > hl:
+                hr -= 1
+
+            c = colorsys.hsv_to_rgb(
+                (hl + (hr-hl) * f) % 1.0,
+                sl + (sr-sl) * f,
+                vl + (vr-vl) * f
+                )
+        return c
+         */
+    //ESP_LOGF("x point:", x);
+    // ESP_LOGD("custom", "Pos x:%f len:%d gp:%p", x, this->length_, this->start_);
+    const GradientPoint* seg;
+    ESPColor c = ESPColor(0,0,0);
+    bool ok = false;
+    int i=0;
+    for (i=0; i < this->length_; i++) {
+      //(*friends_ptrs)
+      seg = &(this->start_)[i];
+      //seg = this->start_ + (sizeof(GradientPoint) * i);
+      //break;
+      //ESP_LOGD("custom", "segpos %p", this->start_[i]);
+      //ESP_LOGD("custom", "Test i: %d (%p) l: %f r: %f", i, seg, seg->l, seg->r);
+      if(seg->l <= x && x <= seg->r) {
+        ok = true;
+        break;
+      }
+    }
+    // ESP_LOGD("custom", "i:%d ",i);
+
+    // for(auto seg: this->gradient_) {
+    //   if(seg.l <= x && x <= seg.r) {
+    //     ok = true;
+    //     break;
+    //   }
+    // }
+    if(!ok){
+      ESP_LOGD("custom", "No color point found in gradient");
+      return ESPColor::BLACK;
+    }
+    // ESP_LOGD("custom", "seg.rl: %f seg.gl: %f seg.bl: %f seg.rr: %f seg.gr: %f seg.br: %f",
+    //         seg->rl, seg->gl, seg->bl, seg->rr, seg->gr, seg->br);
+    // ESP_LOGD("custom", "seg.l: %f seg.m: %f seg.r: %f ",
+    //         seg->l, seg->m, seg->r);
+    // ESP_LOGD("custom", "seg.fn: %u",
+    //         seg->space);
+    // ESP_LOGD("custom", "x");
+    float mid = (seg->m - seg->l)/(seg->r - seg->l);
+    // ESP_LOGD("custom", "x");
+    float pos = (x - seg->l)/(seg->r - seg->l);
+    // ESP_LOGD("custom", "x");
+    float f;
+
+    // Assume linear (most common, and needed by most others).
+    if (pos <= mid) {
+      f = (pos/mid/2.0);
+    } else {
+      f = (pos - mid)/(1.0 - mid)/2.0 + 0.5;
+    }
+    // ESP_LOGD("custom", "x");
+
+    if(seg->fn == 1) {   // Curved
+      f = pow(pos,(log(0.5) / log(mid)));
+    } else if (seg->fn == 2) {  // Sinusoidal
+      f = (sin((-M_PI/2.0) + M_PI*f) + 1.0)/2.0;
+    } else if (seg->fn == 3) {   // Spherical increasing
+      f -= 1.0;
+      f = sqrt(1.0 - f*f);
+    } else if (seg->fn == 4) {   // Spherical decreasing
+      f = 1.0 - sqrt(1.0 - f*f);
+    }
+
+    // ESP_LOGD("custom", "i:%d x: %f mid:%f pos:%f f:%f",i, x, mid, pos, f);
+    // ESP_LOGD("custom", "seg.rl: %f seg.gl: %f seg.bl: %f seg.rr: %f seg.gr: %f seg.br: %f",
+            // seg->rl, seg->gl, seg->bl, seg->rr, seg->gr, seg->br);
+
+    
+    // ESP_LOGD("custom", "finish r:%d g:%d b:%d",
+    //     (uint8_t)((seg->rl + (seg->rr-seg->rl) * f)*255),
+    //     (uint8_t)((seg->gl + (seg->gr-seg->gl) * f)*255),
+    //     (uint8_t)((seg->bl + (seg->br-seg->bl) * f)*255));
+
+    if (seg->space == 0) {
+      c = ESPColor(
+        (uint8_t)((seg->rl + (seg->rr-seg->rl) * f)*255),
+        (uint8_t)((seg->gl + (seg->gr-seg->gl) * f)*255),
+        (uint8_t)((seg->bl + (seg->br-seg->bl) * f)*255)
+      );
+      
+    } else if (seg->space == 1 || seg->space == 2) {
+      float hl, sl, vl, hr, sr, vr;
+      ESPHSVColor::rgb2hsv(seg->rl, seg->gl, seg->bl, hl, sl, vl);
+      ESPHSVColor::rgb2hsv(seg->rr, seg->gr, seg->br, hr, sr, vr);
+
+      if (seg->space == 1 && hr < hl) {
+        hr += 1;
+      } else if ( seg->space == 2 and hr > hl) {
+        hr -= 1;
+      }
+      //float h = l.h + (r.h-l.h) * f;
+      // ESP_LOGD("custom", "xx %f %f %d", (hl + (hr-hl) * f), fmod(hl + (hr-hl) * f, 1.0), (uint8_t)(fmod(hl + (hr-hl) * f, 360)*(255.0/360.0)));
+      c = ESPHSVColor(
+            (uint8_t)(fmod(hl + (hr-hl) * f, 360.0)*(255.0/360.0)),
+            (uint8_t)((sl + (sr-sl) * f)*255),
+            (uint8_t)((vl + (vr-vl) * f)*255)
+            ).to_rgb();
+      
+    }
+    return c;
+  }
+ protected:
+  std::string name_;
+  // gets updated when GradienPoint is set
+  size_t length_{0};
+  // pointer to the start element of gradient
+  //const struct GradientPoint* start_;
+  const GradientPoint* start_;
+};
+
+} // namespace light
+} // namespace esphome

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -182,6 +182,9 @@ struct ESPHSVColor {
                                                                                      saturation(saturation),
                                                                                      value(value) {}
   ESPColor to_rgb() const;
+  static ESPHSVColor from_rgb(uint8_t ri, uint8_t gi, uint8_t bi);
+  static ESPHSVColor from_rgb(float r, float g, float b);
+  static void rgb2hsv(float r, float g, float b, float &h, float &s, float &v) ;
 };
 
 class ESPColorCorrection {

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -4,14 +4,15 @@ from esphome import automation
 from esphome.const import CONF_NAME, CONF_LAMBDA, CONF_UPDATE_INTERVAL, CONF_TRANSITION_LENGTH, \
     CONF_COLORS, CONF_STATE, CONF_DURATION, CONF_BRIGHTNESS, CONF_RED, CONF_GREEN, CONF_BLUE, \
     CONF_WHITE, CONF_ALPHA, CONF_INTENSITY, CONF_SPEED, CONF_WIDTH, CONF_NUM_LEDS, CONF_RANDOM, \
-    CONF_SEQUENCE
+    CONF_SEQUENCE, CONF_ID
 from esphome.util import Registry
 from .types import LambdaLightEffect, RandomLightEffect, StrobeLightEffect, \
     StrobeLightEffectColor, LightColorValues, AddressableLightRef, AddressableLambdaLightEffect, \
     FlickerLightEffect, AddressableRainbowLightEffect, AddressableColorWipeEffect, \
     AddressableColorWipeEffectColor, AddressableScanEffect, AddressableTwinkleEffect, \
     AddressableRandomTwinkleEffect, AddressableFireworksEffect, AddressableFlickerEffect, \
-    AddressableGradientEffect, AddressableGradientEffectColor, AutomationLightEffect, ESPColor
+    AddressableGradientEffect, AutomationLightEffect, ESPColor
+from esphome.components.gradient import Gradient, GradientPoint, CONF_GRADIENT
 from esphome.ggr import GimpGradient
 
 CONF_ADD_LED_INTERVAL = 'add_led_interval'
@@ -28,7 +29,6 @@ CONF_USE_WHITE = 'use_white'
 CONF_STROBE = 'strobe'
 CONF_FLICKER = 'flicker'
 CONF_LENGTH = 'length'
-CONF_GRADIENT = 'gradient'
 CONF_ADDRESSABLE_LAMBDA = 'addressable_lambda'
 CONF_ADDRESSABLE_RAINBOW = 'addressable_rainbow'
 CONF_ADDRESSABLE_COLOR_WIPE = 'addressable_color_wipe'
@@ -46,7 +46,6 @@ RGB_EFFECTS = []
 ADDRESSABLE_EFFECTS = []
 
 EFFECTS_REGISTRY = Registry()
-
 
 def register_effect(name, effect_type, default_name, schema, *extra_validators):
     schema = cv.Schema(schema).extend({
@@ -282,15 +281,18 @@ def addressable_flicker_effect_to_code(config, effect_id):
 
 @register_addressable_effect(
     'addressable_gradient', AddressableGradientEffect, "Gradient", {
+    # cv.GenerateID(): cv.declare_id(AddressableGradientEffectColor),
     cv.Optional(CONF_MOVE_INTERVAL, default='0.1s'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_USE_WHITE, default=False): cv.boolean,
     cv.Optional(CONF_REVERSE, default=False): cv.boolean,
     cv.Optional(CONF_FLIP, default=False): cv.boolean,
-    cv.Required(CONF_GRADIENT): cv.string,
+#    cv.Required(CONF_GRADIENT): cv.string
+    cv.Required(CONF_GRADIENT): cv.use_id(Gradient),
     cv.Required(CONF_LENGTH): cv.positive_int,
 })
+
 def addressable_gradient_effect_to_code(config, effect_id):
-    gg = GimpGradient(content=config[CONF_GRADIENT])
+    #gg = GimpGradient(content=config[CONF_GRADIENT])
     name = config[CONF_NAME]
     # FIXME: does not work because validator compains first
     # use the gimp gradient name if available and name is default
@@ -300,29 +302,35 @@ def addressable_gradient_effect_to_code(config, effect_id):
     cg.add(var.set_move_interval(config[CONF_MOVE_INTERVAL]))
     cg.add(var.set_reverse(config[CONF_REVERSE]))
     cg.add(var.set_flip(config[CONF_FLIP]))
-    colors = []
-    gg = GimpGradient(content=config[CONF_GRADIENT])
-    mp = 1.0/config[CONF_LENGTH]
-    for i in range(config[CONF_LENGTH]):
-        r,g,b = gg.color(i*mp)
-        if config[CONF_USE_WHITE]:
-            w = min(r, g, b)
-            r, g, b = r - w, g - w, b - w
-            colors.append(cg.StructInitializer(
-                AddressableGradientEffectColor,
-                ('r', int(round(r * 255))),
-                ('g', int(round(g * 255))),
-                ('b', int(round(b * 255))),
-                ('w', int(round(w * 255)))
-            ))
-        else:
-            colors.append(cg.StructInitializer(
-                AddressableGradientEffectColor,
-                ('r', int(round(r * 255))),
-                ('g', int(round(g * 255))),
-                ('b', int(round(b * 255)))
-            ))
-    cg.add(var.set_colors(colors))
+    cg.add(var.set_use_white(config[CONF_USE_WHITE]))
+    cg.add(var.set_length(config[CONF_LENGTH]))
+    print("xx:",config[CONF_GRADIENT], type(config[CONF_GRADIENT]))
+    grad = yield cg.get_variable(config[CONF_GRADIENT])
+    cg.add(var.set_gradient(grad))
+    #grad = "AdressableGradient_%s" %effect_id
+    #grad.type = AddressableGradientEffectColor
+    # cg.progmem_array(grad, rhs)
+    # segments = []
+    # for seg in gg.segs:
+    #     # l, m, r, rl, gl, bl, rr, gr, br, fn, space;
+    #     segments.append(cg.StructInitializer(
+    #             AddressableGradientEffectColor,
+    #             ('l', seg.l),
+    #             ('m', seg.m),
+    #             ('r', seg.r),
+    #             ('rl', seg.rl),
+    #             ('gl', seg.gl),
+    #             ('bl', seg.bl),
+    #             ('rr', seg.rr),
+    #             ('gr', seg.gr),
+    #             ('br', seg.br),
+    #             ('fn', int(seg.fn)),
+    #             ('space', int(seg.space)),
+    #     ))
+    # # cg.add(var.set_gradient(segments))
+    # #grad = "AdressableGradient_%s" %effect_id
+    # #grad.type = AddressableGradientEffectColor
+    # cg.progmem_array(config[CONF_ID], segments)
     yield var
 
 

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -11,7 +11,8 @@ from .types import LambdaLightEffect, RandomLightEffect, StrobeLightEffect, \
     FlickerLightEffect, AddressableRainbowLightEffect, AddressableColorWipeEffect, \
     AddressableColorWipeEffectColor, AddressableScanEffect, AddressableTwinkleEffect, \
     AddressableRandomTwinkleEffect, AddressableFireworksEffect, AddressableFlickerEffect, \
-    AutomationLightEffect, ESPColor
+    AddressableGradientEffect, AddressableGradientEffectColor, AutomationLightEffect, ESPColor
+from esphome.ggr import GimpGradient
 
 CONF_ADD_LED_INTERVAL = 'add_led_interval'
 CONF_REVERSE = 'reverse'
@@ -22,8 +23,12 @@ CONF_PROGRESS_INTERVAL = 'progress_interval'
 CONF_SPARK_PROBABILITY = 'spark_probability'
 CONF_USE_RANDOM_COLOR = 'use_random_color'
 CONF_FADE_OUT_RATE = 'fade_out_rate'
+CONF_FLIP = 'flip'
+CONF_USE_WHITE = 'use_white'
 CONF_STROBE = 'strobe'
 CONF_FLICKER = 'flicker'
+CONF_LENGTH = 'length'
+CONF_GRADIENT = 'gradient'
 CONF_ADDRESSABLE_LAMBDA = 'addressable_lambda'
 CONF_ADDRESSABLE_RAINBOW = 'addressable_rainbow'
 CONF_ADDRESSABLE_COLOR_WIPE = 'addressable_color_wipe'
@@ -32,6 +37,7 @@ CONF_ADDRESSABLE_TWINKLE = 'addressable_twinkle'
 CONF_ADDRESSABLE_RANDOM_TWINKLE = 'addressable_random_twinkle'
 CONF_ADDRESSABLE_FIREWORKS = 'addressable_fireworks'
 CONF_ADDRESSABLE_FLICKER = 'addressable_flicker'
+CONF_ADDRESSABLE_GRADIENT = 'addressable_gradient'
 CONF_AUTOMATION = 'automation'
 
 BINARY_EFFECTS = []
@@ -271,6 +277,52 @@ def addressable_flicker_effect_to_code(config, effect_id):
     var = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
+    yield var
+
+
+@register_addressable_effect(
+    'addressable_gradient', AddressableGradientEffect, "Gradient", {
+    cv.Optional(CONF_MOVE_INTERVAL, default='0.1s'): cv.positive_time_period_milliseconds,
+    cv.Optional(CONF_USE_WHITE, default=False): cv.boolean,
+    cv.Optional(CONF_REVERSE, default=False): cv.boolean,
+    cv.Optional(CONF_FLIP, default=False): cv.boolean,
+    cv.Required(CONF_GRADIENT): cv.string,
+    cv.Required(CONF_LENGTH): cv.positive_int,
+})
+def addressable_gradient_effect_to_code(config, effect_id):
+    gg = GimpGradient(content=config[CONF_GRADIENT])
+    name = config[CONF_NAME]
+    # FIXME: does not work because validator compains first
+    # use the gimp gradient name if available and name is default
+    #if gg.name and  config[CONF_NAME] == "Gradient":
+    #    name = gg.name
+    var = cg.new_Pvariable(effect_id, name)
+    cg.add(var.set_move_interval(config[CONF_MOVE_INTERVAL]))
+    cg.add(var.set_reverse(config[CONF_REVERSE]))
+    cg.add(var.set_flip(config[CONF_FLIP]))
+    colors = []
+    gg = GimpGradient(content=config[CONF_GRADIENT])
+    mp = 1.0/config[CONF_LENGTH]
+    for i in range(config[CONF_LENGTH]):
+        r,g,b = gg.color(i*mp)
+        if config[CONF_USE_WHITE]:
+            w = min(r, g, b)
+            r, g, b = r - w, g - w, b - w
+            colors.append(cg.StructInitializer(
+                AddressableGradientEffectColor,
+                ('r', int(round(r * 255))),
+                ('g', int(round(g * 255))),
+                ('b', int(round(b * 255))),
+                ('w', int(round(w * 255)))
+            ))
+        else:
+            colors.append(cg.StructInitializer(
+                AddressableGradientEffectColor,
+                ('r', int(round(r * 255))),
+                ('g', int(round(g * 255))),
+                ('b', int(round(b * 255)))
+            ))
+    cg.add(var.set_colors(colors))
     yield var
 
 

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -43,4 +43,3 @@ AddressableRandomTwinkleEffect = light_ns.class_('AddressableRandomTwinkleEffect
 AddressableFireworksEffect = light_ns.class_('AddressableFireworksEffect', AddressableLightEffect)
 AddressableFlickerEffect = light_ns.class_('AddressableFlickerEffect', AddressableLightEffect)
 AddressableGradientEffect = light_ns.class_('AddressableGradientEffect', AddressableLightEffect)
-AddressableGradientEffectColor = light_ns.struct('AddressableGradientEffectColor')

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -42,3 +42,5 @@ AddressableRandomTwinkleEffect = light_ns.class_('AddressableRandomTwinkleEffect
                                                  AddressableLightEffect)
 AddressableFireworksEffect = light_ns.class_('AddressableFireworksEffect', AddressableLightEffect)
 AddressableFlickerEffect = light_ns.class_('AddressableFlickerEffect', AddressableLightEffect)
+AddressableGradientEffect = light_ns.class_('AddressableGradientEffect', AddressableLightEffect)
+AddressableGradientEffectColor = light_ns.struct('AddressableGradientEffectColor')

--- a/esphome/ggr.py
+++ b/esphome/ggr.py
@@ -1,0 +1,192 @@
+""" Read Gimp .ggr gradient files.
+    Ned Batchelder, http://nedbatchelder.com
+    This code is in the public domain.
+
+    Adjusted for esphome by Daniel Poelzleithner <git@poelzi.org>
+"""
+
+__version__ = '1.0.20070915'
+
+import colorsys, math
+
+class GimpGradient(object):
+    """ Read and interpret a Gimp .ggr gradient file.
+    """
+    def __init__(self, f=None, content=None):
+        self.name = None
+        if content:
+            self.parse_content(content)
+        if f:
+            self.read(f)
+        
+    class _segment:
+        pass
+    
+    def read(self, f):
+        """ Read a .ggr file from f (either an open file or a file path).
+        """
+        if isinstance(f, basestring):
+            f = file(f)
+        if f.readline().strip() != "GIMP Gradient":
+            raise Exception("Not a GIMP gradient file")
+        content = []
+        for line in f.readline():
+            content.append(line)
+
+    def parse_content(self, data = None):
+        content = [x.strip() for x in data.splitlines() if x]
+        self.parse_lines(content)
+
+    def parse_lines(self, content=[]):
+        print(content)
+        i = 0
+        nseq = None
+        if content[i].startswith("GIMP Gradient"):
+            i += 1
+        if content[i].startswith("Name: "):
+            self.name = content[i].split(": ", 1)[1]
+            i += 1
+        try:
+            nsegs = int(content[i].strip())
+            i += 1
+        except ValueError as e:
+            pass
+        self.segs = []
+        for line in content[i:nseq and nseq + i or None]:
+            line = line.strip()
+            if not line:
+                continue
+            seg = self._segment()
+            (seg.l, seg.m, seg.r,
+                seg.rl, seg.gl, seg.bl, _,
+                seg.rr, seg.gr, seg.br, _,
+                seg.fn, seg.space) = map(float, line.split())
+            self.segs.append(seg)
+            
+    def color(self, x):
+        """ Get the color for the point x in the range [0..1).
+            The color is returned as an rgb triple, with all values in the range
+            [0..1).
+        """
+        # Find the segment.
+        for seg in self.segs:
+            if seg.l <= x <= seg.r:
+                break
+        else:
+            # No segment applies! Return black I guess.
+            return (0,0,0)
+
+        # Normalize the segment geometry.
+        mid = (seg.m - seg.l)/(seg.r - seg.l)
+        pos = (x - seg.l)/(seg.r - seg.l)
+        
+        # Assume linear (most common, and needed by most others).
+        if pos <= mid:
+            f = pos/mid/2
+        else:
+            f = (pos - mid)/(1 - mid)/2 + 0.5
+
+        # Find the correct interpolation factor.
+        if seg.fn == 1:   # Curved
+            f = math.pow(pos, math.log(0.5) / math.log(mid));
+        elif seg.fn == 2:   # Sinusoidal
+            f = (math.sin((-math.pi/2) + math.pi*f) + 1)/2
+        elif seg.fn == 3:   # Spherical increasing
+            f -= 1
+            f = math.sqrt(1 - f*f)
+        elif seg.fn == 4:   # Spherical decreasing
+            f = 1 - math.sqrt(1 - f*f);
+
+        # Interpolate the colors
+        if seg.space == 0:
+            c = (
+                seg.rl + (seg.rr-seg.rl) * f,
+                seg.gl + (seg.gr-seg.gl) * f,
+                seg.bl + (seg.br-seg.bl) * f
+                )
+        elif seg.space in (1,2):
+            hl, sl, vl = colorsys.rgb_to_hsv(seg.rl, seg.gl, seg.bl)
+            hr, sr, vr = colorsys.rgb_to_hsv(seg.rr, seg.gr, seg.br)
+
+            if seg.space == 1 and hr < hl:
+                hr += 1
+            elif seg.space == 2 and hr > hl:
+                hr -= 1
+
+            c = colorsys.hsv_to_rgb(
+                (hl + (hr-hl) * f) % 1.0,
+                sl + (sr-sl) * f,
+                vl + (vr-vl) * f
+                )
+        return c
+    
+if __name__ == '__main__':
+    
+    test = """
+    GIMP Gradient
+    Name: Tropical Colors
+    9
+    0.000000 0.055556 0.085142 0.036578 0.159091 0.015374 1.000000 0.007899 0.310606 0.000000 1.000000 0 0
+    0.085142 0.138564 0.193656 0.007899 0.310606 0.000000 1.000000 0.195893 0.575758 0.085655 1.000000 0 0
+    0.193656 0.233723 0.276572 0.195893 0.575758 0.085655 1.000000 0.924242 0.750598 0.192395 1.000000 0 0
+    0.276572 0.332128 0.387683 0.924242 0.750598 0.192395 1.000000 0.954545 0.239854 0.132221 1.000000 0 0
+    0.387683 0.510851 0.555556 0.954545 0.239854 0.132221 1.000000 0.530303 0.319349 0.236012 1.000000 0 0
+    0.555556 0.611111 0.666667 0.530303 0.319349 0.236012 1.000000 0.472649 0.295792 1.000000 1.000000 0 0
+    0.666667 0.772955 0.826377 0.472649 0.295792 1.000000 1.000000 0.644153 1.000000 0.957743 1.000000 0 0
+    0.826377 0.866444 0.884808 0.644153 1.000000 0.957743 1.000000 0.408723 0.870000 0.278400 1.000000 0 0
+    0.884808 0.953255 1.000000 0.408723 0.870000 0.278400 1.000000 0.363558 0.500000 0.000000 1.000000 1 0
+    """
+
+    gg1 = GimpGradient(content=test)
+    print(gg1.color(0))
+    print(gg1.color(0.5))
+    print(gg1.color(1.0))
+    
+    
+    #import sys, wx
+
+    # class GgrView(wx.Frame):
+    #     def __init__(self, ggr, chunks):
+    #         """ Display the ggr file as a strip of colors.
+    #             If chunks is non-zero, then also display the gradient quantized
+    #             into that many chunks.
+    #         """
+    #         super(GgrView, self).__init__(None, -1, 'Ggr: %s' % ggr.name)
+    #         self.ggr = ggr
+    #         self.chunks = chunks
+    #         self.SetSize((600, 100))
+    #         self.panel = wx.Panel(self)
+    #         self.panel.Bind(wx.EVT_PAINT, self.on_paint)
+    #         self.panel.Bind(wx.EVT_SIZE, self.on_size)
+
+    #     def on_paint(self, event):
+    #         dc = wx.PaintDC(self.panel)
+    #         cw, ch = self.GetClientSize()
+    #         if self.chunks:
+    #             self.paint_some(dc, 0, 0, ch/2)
+    #             self.paint_some(dc, self.chunks, ch/2, ch)
+    #         else:
+    #             self.paint_some(dc, 0, 0, ch)
+                
+    #     def paint_some(self, dc, chunks, y0, y1):
+    #         cw, ch = self.GetClientSize()
+    #         chunkw = 1
+    #         if chunks:
+    #             chunkw = (cw // chunks) or 1
+    #         for x in range(0, cw, chunkw):
+    #             c = map(lambda x:int(255*x), ggr.color(float(x)/cw))
+    #             dc.SetPen(wx.Pen(wx.Colour(*c), 1))
+    #             dc.SetBrush(wx.Brush(wx.Colour(*c), wx.SOLID))
+    #             dc.DrawRectangle(x, y0, chunkw, y1-y0)
+        
+    #     def on_size(self, event):
+    #         self.Refresh()
+
+    # app = wx.PySimpleApp()
+    # ggr = GimpGradient(sys.argv[1])
+    # chunks = 0
+    # if len(sys.argv) > 2:
+    #     chunks = int(sys.argv[2])
+    # f = GgrView(ggr, chunks)
+    # f.Show()
+    # app.MainLoop()

--- a/esphome/ggr.py
+++ b/esphome/ggr.py
@@ -38,7 +38,6 @@ class GimpGradient(object):
         self.parse_lines(content)
 
     def parse_lines(self, content=[]):
-        print(content)
         i = 0
         nseq = None
         if content[i].startswith("GIMP Gradient"):
@@ -54,13 +53,15 @@ class GimpGradient(object):
         self.segs = []
         for line in content[i:nseq and nseq + i or None]:
             line = line.strip()
+            if line.startswith("#"):
+                continue
             if not line:
                 continue
             seg = self._segment()
             (seg.l, seg.m, seg.r,
                 seg.rl, seg.gl, seg.bl, _,
                 seg.rr, seg.gr, seg.br, _,
-                seg.fn, seg.space) = map(float, line.split())
+                seg.fn, seg.space, *xtra) = map(float, line.split())
             self.segs.append(seg)
             
     def color(self, x):


### PR DESCRIPTION
# Description:

This effect allows user defined gradients which the effect shifts through.
The gradient is defined with the gimp gradient format and a user defined length,
which should be much larger then the number of pixels in the strip. Setting flip
to true, will cause the gradient to change direction on the end.


Example:
```
light:
  - platform: neopixelbus
    type: GRBW
    variant: SK6812
    pin: RX
    num_leds: 20
    name: "Test neopixel"
    effects:
      - addressable_gradient:
          length: 50
          name: Fuschia 6
          use_white: true
          gradient: |
            GIMP Gradient
            Name: Fuschia 6
            4
            0.000000 0.125000 0.250000 0.811765 0.192157 0.870588 1.000000 0.784314 0.388235 0.937255 1.000000 0 0
            0.250000 0.375000 0.500000 0.784314 0.388235 0.937255 1.000000 0.560784 0.207843 0.964706 1.000000 0 0
            0.500000 0.625000 0.750000 0.560784 0.207843 0.964706 1.000000 0.823678 0.190171 0.822934 1.000000 0 0
            0.750000 0.875000 1.000000 0.823678 0.190171 0.822934 1.000000 0.560784 0.207843 0.964706 1.000000 0 0
```

**Related issue (if applicable):** fixes <link to issue>

fixes https://github.com/esphome/feature-requests/issues/417

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

esphome/esphome-docs#471

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
