### PR TITLE
Daikin climate ir component

### DIFF
--- a/esphome/components/daikin/climate.py
+++ b/esphome/components/daikin/climate.py
@@ -1,0 +1,18 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import climate_ir
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ['climate_ir']
+
+daikin_ns = cg.esphome_ns.namespace('daikin')
+DaikinClimate = daikin_ns.class_('DaikinClimate', climate_ir.ClimateIR)
+
+CONFIG_SCHEMA = climate_ir.CLIMATE_IR_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(DaikinClimate),
+})
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield climate_ir.register_climate_ir(var, config)

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -1,0 +1,130 @@
+#include "daikin.h"
+#include "esphome/components/remote_base/remote_base.h"
+
+namespace esphome {
+namespace daikin {
+
+static const char *TAG = "daikin.climate";
+
+void DaikinClimate::transmit_state() {
+  uint8_t remote_state[35] = {
+    0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
+    0x11, 0xDA, 0x27, 0x00, 0x42, 0x49, 0x05, 0xA2,
+    0x11, 0xDA, 0x27, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00
+  };
+
+  remote_state[21] = this->operation_mode_();
+  remote_state[24] = this->fan_speed_();
+  remote_state[22] = this->temperature_();
+
+  // Calculate checksum
+  for (int i=16; i<34; i++) {
+    remote_state[34] += remote_state[i];
+  }
+  
+  auto transmit = this->transmitter_->transmit();
+  auto data = transmit.get_data();
+  data->set_carrier_frequency(DAIKIN_IR_FREQUENCY);
+  
+  data->mark(DAIKIN_HEADER_MARK);
+  data->space(DAIKIN_HEADER_SPACE);
+  for (int i=0; i<8; i++) {
+    for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
+      data->mark(DAIKIN_BIT_MARK);
+      bool bit = remote_state[i] & mask;
+      data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
+    }
+  }
+  data->mark(DAIKIN_BIT_MARK);
+  data->space(DAIKIN_MESSAGE_SPACE);
+  data->mark(DAIKIN_HEADER_MARK);
+  data->space(DAIKIN_HEADER_SPACE);
+
+  for (int i=8; i<16; i++) {
+    for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
+      data->mark(DAIKIN_BIT_MARK);
+      bool bit = remote_state[i] & mask;
+      data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
+    }
+  }
+  data->mark(DAIKIN_BIT_MARK);
+  data->space(DAIKIN_MESSAGE_SPACE);
+  data->mark(DAIKIN_HEADER_MARK);
+  data->space(DAIKIN_HEADER_SPACE);
+
+  for (int i=16; i<35; i++) {
+    for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
+      data->mark(DAIKIN_BIT_MARK);
+      bool bit = remote_state[i] & mask;
+      data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
+    }
+  }
+  data->mark(DAIKIN_BIT_MARK);
+  data->space(0);
+
+  transmit.perform();
+}
+
+uint8_t DaikinClimate::operation_mode_() {
+  uint8_t operating_mode = DAIKIN_MODE_ON;
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_COOL:
+      operating_mode |= DAIKIN_MODE_COOL;
+      break;
+    case climate::CLIMATE_MODE_DRY:
+      operating_mode |= DAIKIN_MODE_DRY;
+      break;
+    case climate::CLIMATE_MODE_HEAT:
+      operating_mode |= DAIKIN_MODE_HEAT;
+      break;
+    case climate::CLIMATE_MODE_AUTO:
+      operating_mode |= DAIKIN_MODE_AUTO;
+      break;
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      operating_mode |= DAIKIN_MODE_FAN;
+      break;
+    case climate::CLIMATE_MODE_OFF:
+    default:
+      operating_mode = DAIKIN_MODE_OFF;
+      break;
+  }
+
+  return operating_mode;
+}
+
+uint8_t DaikinClimate::fan_speed_() {
+  uint8_t fan_speed;
+  switch(this->fan_mode) {
+    case climate::CLIMATE_FAN_LOW:
+      fan_speed = DAIKIN_FAN_1;
+      break;
+    case climate::CLIMATE_FAN_MEDIUM:
+      fan_speed = DAIKIN_FAN_3;
+      break;
+    case climate::CLIMATE_FAN_HIGH:
+      fan_speed = DAIKIN_FAN_5;
+      break;
+    case climate::CLIMATE_FAN_AUTO:
+    default:
+      fan_speed = DAIKIN_FAN_AUTO;
+  }
+  
+  // If swing is enabled switch first 4 bits to 1111
+  return this->swing_mode == climate::CLIMATE_SWING_VERTICAL ? fan_speed | 0xF : fan_speed;
+}
+
+uint8_t DaikinClimate::temperature_() {
+  // Force special temperatures depending on the mode
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      return 25;
+    case climate::CLIMATE_MODE_DRY:
+      return 0xc0;
+    default:
+      uint8_t temperature = this->target_temperature;
+      return temperature << 1;
+  }
+}
+
+}  // namespace daikin
+}  // namespace esphome

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -119,7 +119,7 @@ uint8_t DaikinClimate::temperature_() {
     case climate::CLIMATE_MODE_DRY:
       return 0xc0;
     default:
-      uint8_t temperature = static_cast<uint8_t>(this->target_temperature);
+      uint8_t temperature = (uint8_t) roundf(clamp(this->target_temperature, DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX));
       return temperature << 1;
   }
 }

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -38,15 +38,12 @@ const uint32_t DAIKIN_MESSAGE_SPACE = 32300;
 
 class DaikinClimate : public climate_ir::ClimateIR {
  public:
-  DaikinClimate() : climate_ir::ClimateIR(
-    DAIKIN_TEMP_MIN,
-    DAIKIN_TEMP_MAX,
-    1.0f,
-    true,
-    true,
-    std::vector<climate::ClimateFanMode>{climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
-    std::vector<climate::ClimateSwingMode>{climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}
-  ) {}
+  DaikinClimate()
+      : climate_ir::ClimateIR(
+            DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,
+            std::vector<climate::ClimateFanMode>{climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
+                                                 climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
+            std::vector<climate::ClimateSwingMode>{climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
 
  protected:
   // Transmit via IR the state of this climate controller.
@@ -54,7 +51,6 @@ class DaikinClimate : public climate_ir::ClimateIR {
   uint8_t operation_mode_();
   uint8_t fan_speed_();
   uint8_t temperature_();
-
 };
 
 }  // namespace daikin

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "esphome/components/climate_ir/climate_ir.h"
+
+namespace esphome {
+namespace daikin {
+
+// Values for Daikin ARC43XXX IR Controllers
+// Temperature
+const uint8_t DAIKIN_TEMP_MIN = 10;  // Celsius
+const uint8_t DAIKIN_TEMP_MAX = 30;  // Celsius
+
+// Modes
+const uint8_t DAIKIN_MODE_AUTO = 0x00;
+const uint8_t DAIKIN_MODE_COOL = 0x30;
+const uint8_t DAIKIN_MODE_HEAT = 0x40;
+const uint8_t DAIKIN_MODE_DRY = 0x20;
+const uint8_t DAIKIN_MODE_FAN = 0x60;
+const uint8_t DAIKIN_MODE_OFF = 0x00;
+const uint8_t DAIKIN_MODE_ON = 0x01;
+
+// Fan Speed
+const uint8_t DAIKIN_FAN_AUTO = 0xA0;
+const uint8_t DAIKIN_FAN_1 = 0x30;
+const uint8_t DAIKIN_FAN_2 = 0x40;
+const uint8_t DAIKIN_FAN_3 = 0x50;
+const uint8_t DAIKIN_FAN_4 = 0x60;
+const uint8_t DAIKIN_FAN_5 = 0x70;
+
+// IR Transmission
+const uint32_t DAIKIN_IR_FREQUENCY = 38000;
+const uint32_t DAIKIN_HEADER_MARK = 3360;
+const uint32_t DAIKIN_HEADER_SPACE = 1760;
+const uint32_t DAIKIN_BIT_MARK = 360;
+const uint32_t DAIKIN_ONE_SPACE = 1370;
+const uint32_t DAIKIN_ZERO_SPACE = 520;
+const uint32_t DAIKIN_MESSAGE_SPACE = 32300;
+
+class DaikinClimate : public climate_ir::ClimateIR {
+ public:
+  DaikinClimate() : climate_ir::ClimateIR(
+    DAIKIN_TEMP_MIN,
+    DAIKIN_TEMP_MAX,
+    1.0f,
+    true,
+    true,
+    std::vector<climate::ClimateFanMode>{climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
+    std::vector<climate::ClimateSwingMode>{climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}
+  ) {}
+
+ protected:
+  // Transmit via IR the state of this climate controller.
+  void transmit_state() override;
+  uint8_t operation_mode_();
+  uint8_t fan_speed_();
+  uint8_t temperature_();
+
+};
+
+}  // namespace daikin
+}  // namespace esphome

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1190,6 +1190,8 @@ climate:
     name: Coolix Climate
   - platform: fujitsu_general
     name: Fujitsu General Climate
+  - platform: daikin
+    name: Daikin Climate
   - platform: yashima
     name: Yashima Climate
   - platform: mitsubishi


### PR DESCRIPTION
## Description: This MR adds support for Daikin climate IR controller models based on ARC43XXX (most typical one).
I followed the same structure as other climate controllers like the mitsubishi one, but I don't see how this "component" directory will scale in a future: "mitsubishi" or "daikin" component directories sounds too generic for me, are not talking about a "climate ir controller for daikin", and maybe other functionalities for Mitsubishi could be added in a future, even not related to "climate", where should they go?

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#476

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
