### PR TITLE
✨ support iBeacon uuid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2.4'
+services:
+  esphome:
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile
+    ports:
+      - 6052:6052
+    volumes:
+      - ./:/usr/src/app
+      - ./config:/config

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -42,6 +42,27 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
         return true;
       }
     } else {
+      if (this->uuid_.get_uuid().len == ESP_UUID_LEN_128) {
+        auto ibeacon = device.get_ibeacon();
+        if (ibeacon.has_value()) {
+          auto uuid = ibeacon.value().get_uuid();
+          if (uuid.get_uuid().len == ESP_UUID_LEN_128) {
+            bool found = true;
+            for (int i = 0; i < ESP_UUID_LEN_128; i++) {
+              if (this->uuid_.get_uuid().uuid.uuid128[i] != uuid.get_uuid().uuid.uuid128[i]) {
+                found = false;
+                break;
+              }
+            }
+            if (found) {
+              this->publish_state(true);
+              this->found_ = true;
+              return true;
+            }
+          }
+        }
+      }
+
       for (auto uuid : device.get_service_uuids()) {
         switch (this->uuid_.get_uuid().len) {
           case ESP_UUID_LEN_16:

--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -40,6 +40,27 @@ class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDevi
         return true;
       }
     } else {
+      if (this->uuid_.get_uuid().len == ESP_UUID_LEN_128) {
+        auto ibeacon = device.get_ibeacon();
+        if (ibeacon.has_value()) {
+          auto uuid = ibeacon.value().get_uuid();
+          if (uuid.get_uuid().len == ESP_UUID_LEN_128) {
+            bool found = true;
+            for (int i = 0; i < ESP_UUID_LEN_128; i++) {
+              if (this->uuid_.get_uuid().uuid.uuid128[i] != uuid.get_uuid().uuid.uuid128[i]) {
+                found = false;
+                break;
+              }
+            }
+            if (found) {
+              this->publish_state(device.get_rssi());
+              this->found_ = true;
+              return true;
+            }
+          }
+        }
+      }
+
       for (auto uuid : device.get_service_uuids()) {
         switch (this->uuid_.get_uuid().len) {
           case ESP_UUID_LEN_16:

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -49,7 +49,12 @@ class ESPBLEiBeacon {
   uint16_t get_major() { return ((this->beacon_data_.major & 0xFF) << 8) | (this->beacon_data_.major >> 8); }
   uint16_t get_minor() { return ((this->beacon_data_.minor & 0xFF) << 8) | (this->beacon_data_.minor >> 8); }
   int8_t get_signal_power() { return this->beacon_data_.signal_power; }
-  ESPBTUUID get_uuid() { return ESPBTUUID::from_raw(this->beacon_data_.proximity_uuid); }
+  ESPBTUUID get_uuid() {
+    const int size = sizeof(this->beacon_data_.proximity_uuid) / sizeof(uint8_t);
+    uint8_t reversed[size];
+    std::reverse_copy(this->beacon_data_.proximity_uuid, this->beacon_data_.proximity_uuid + size, reversed);
+    return ESPBTUUID::from_raw(reversed);
+  }
 
  protected:
   struct {


### PR DESCRIPTION
## Description:
This is an enhancement to the UUID support added in #800. This brings support for detecting if a found device is an iBeacon with a given UUID.

Forewarning: I'm not a C++ or even Python developer (i'm a node/javascript and java developer), so definitely out of wheelhouse with this change, so any constructive criticism is welcome :)

I also included the `docker-compose.yml` that I used to run esphome in a way that made it relatively easy to test changes. Just create the `config` folder in the project root directory, run a `docker-compose up` from the project root directory then go to http://localhost:6052 and start flashing devices...make changes to the code and flash again. Maybe there's an easier way...idk, but I found this easy and didn't require anything other than docker on my machine. But if preferred I can leave it out...just lemme know.

Unless I was missing something, I couldn't figure out a good way to setup an advertisement from android device with a given service UUID. Only way I found to easily even do that was with [nRF Connect](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en_US), but found that it would periodically die and it doesn't come back up after automatically restarting your phone. There is another app, [Beacon Simulator](https://play.google.com/store/apps/details?id=net.alea.beaconsimulator&hl=en_US) which allows you to simulate an iBeacon and there is an option for "Broadcast Resilience" which is supposed to start-up the broadcast when the phone reboots.

**Related issue (if applicable):** Enhances #800 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
