### PR TITLE
ms5611 fix

### DIFF
--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -19,7 +19,7 @@ void MS5611Component::setup() {
     this->mark_failed();
     return;
   }
-  delay(100);  // NOLINT
+  delay(3);  // NOLINT trug, change from 100 to 3
   for (uint8_t offset = 0; offset < 6; offset++) {
     if (!this->read_byte_16(MS5611_CMD_READ_PROM + (offset * 2), &this->prom_[offset])) {
       this->mark_failed();


### PR DESCRIPTION
## Description:
ESPhome ms5611 library results in errors in pressure readings (jump up/down by 30hpa randomly). This is likely due to a problem with reading the prom calibration values. I have used another library successfully on other projects for several years straight. This ms5xxx library is found here:
https://github.com/Schm1tz1/arduino-ms5xxx

The only related difference between the libraries that I found so far is a different delay bewteen the reset command and prom read command. ESPhome uses 100ms, ms5xxx uses 3ms. This very well could be the cause of the problem!

ms5xxx also variable delays between readings and conversions that depend on resolution. Esphome uses 10ms for these delays, which is the same as the ms5xxx delay for 4k resolution. Since I'm not sure which res esphome uses, I left those at 10ms for now.

A link to the original discussion with some troubleshooting, and the issue report:
https://community.home-assistant.io/t/esphome-ms5611-issue/164240/2
https://github.com/esphome/issues/issues/1004

[update: The erroneous measurements still occer with this change.]

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).