### PR TITLE
Add Pulse Counter sensor absolute_count_mode

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -45,6 +45,7 @@ struct PulseCounterStorage {
   PulseCounterCountMode rising_edge_mode{PULSE_COUNTER_INCREMENT};
   PulseCounterCountMode falling_edge_mode{PULSE_COUNTER_DISABLE};
   uint32_t filter_us{0};
+  bool  absolute_count_mode{false};
   pulse_counter_t last_value{0};
 };
 
@@ -54,6 +55,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   void set_rising_edge_mode(PulseCounterCountMode mode) { storage_.rising_edge_mode = mode; }
   void set_falling_edge_mode(PulseCounterCountMode mode) { storage_.falling_edge_mode = mode; }
   void set_filter_us(uint32_t filter) { storage_.filter_us = filter; }
+  void set_absolute_count_mode(bool value) { storage_.absolute_count_mode = value; }
 
   /// Unit of measurement is "pulses/min".
   void setup() override;

--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -4,7 +4,7 @@ from esphome import pins
 from esphome.components import sensor
 from esphome.const import CONF_COUNT_MODE, CONF_FALLING_EDGE, CONF_ID, CONF_INTERNAL_FILTER, \
     CONF_PIN, CONF_RISING_EDGE, CONF_NUMBER, \
-    ICON_PULSE, UNIT_PULSES_PER_MINUTE
+    ICON_PULSE, UNIT_PULSES_PER_MINUTE, CONF_ABSOLUTE_COUNT_MODE
 from esphome.core import CORE
 
 pulse_counter_ns = cg.esphome_ns.namespace('pulse_counter')
@@ -58,6 +58,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(UNIT_PULSES_PER_MINUTE, ICON_PULSE, 2).exte
         cv.Required(CONF_FALLING_EDGE): COUNT_MODE_SCHEMA,
     }), validate_count_mode),
     cv.Optional(CONF_INTERNAL_FILTER, default='13us'): validate_internal_filter,
+    cv.Optional(CONF_ABSOLUTE_COUNT_MODE, default=False): cv.boolean,
 }).extend(cv.polling_component_schema('60s'))
 
 
@@ -72,3 +73,4 @@ def to_code(config):
     cg.add(var.set_rising_edge_mode(count[CONF_RISING_EDGE]))
     cg.add(var.set_falling_edge_mode(count[CONF_FALLING_EDGE]))
     cg.add(var.set_filter_us(config[CONF_INTERNAL_FILTER]))
+    cg.add(var.set_absolute_count_mode(config[CONF_ABSOLUTE_COUNT_MODE]))

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -27,6 +27,7 @@ SOURCE_FILE_EXTENSIONS = {'.cpp', '.hpp', '.h', '.c', '.tcc', '.ino'}
 HEADER_FILE_EXTENSIONS = {'.h', '.hpp', '.tcc'}
 
 CONF_ABOVE = 'above'
+CONF_ABSOLUTE_COUNT_MODE = 'absolute_count_mode'
 CONF_ACCELERATION = 'acceleration'
 CONF_ACCELERATION_X = 'acceleration_x'
 CONF_ACCELERATION_Y = 'acceleration_y'


### PR DESCRIPTION

## Description:
Add Pulse Counter sensor absolute_count_mode
This boolean exposes the raw counter value instead of applying an average.

This allows for a LCD display to immediately show the updated count value.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [/ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
