### PR TITLE
updated DHT22 delay time

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -93,7 +93,7 @@ bool HOT ICACHE_RAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, 
       this->pin_->digital_write(true);
       delayMicroseconds(40);
     } else {
-      delayMicroseconds(800);
+      delayMicroseconds(2000);
     }
     this->pin_->pin_mode(INPUT_PULLUP);
     delayMicroseconds(40);


### PR DESCRIPTION
## Description:

I had issues with DHT22 (+breakout board) that I just got (4 different DHTs). 4 different ESP8266 NodeMCU boards. All had the same problem, could never get any data from them.

Tested another DHT library, and they worked just fine.

https://github.com/beegee-tokyo/DHTesp

We (ssieb on discord) and I noticed the timing was the main difference between the two libraries. ESPHome uses 800 microseconds, and DHTesp uses 2000 microseconds (2 milliseconds).

I went in and setup a custom_component for the DHT library so we could edit the timing and I tested changing it to 2000 microseconds to match the other library and It works 100%.

`[17:14:05][D][dht:048]: Got Temperature=22.2°C Humidity=35.1%`

I tested various amounts of milliseconds. 0.8, 1, 1.2, 1.5, 2, 18

Only the 2+ milliseconds has worked for the DHT22. (note its milliseconds, not microseconds)

I also tested telling ESPHome it was a DHT11, but only ever got highly irregular results back.

It would be nice to see if we can get someone to test with a working setup, to see if it works for both systems, and that it does not break existing polling?

**Related issue (if applicable):** fixes #926 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
