### PR TITLE
BME280: fix typos, use forced mode constant

### DIFF
--- a/esphome/components/bme280/bme280.cpp
+++ b/esphome/components/bme280/bme280.cpp
@@ -146,7 +146,7 @@ void BME280Component::dump_config() {
       ESP_LOGE(TAG, "Communication with BME280 failed!");
       break;
     case WRONG_CHIP_ID:
-      ESP_LOGE(TAG, "BMP280 has wrong chip ID! Is it a BMP280?");
+      ESP_LOGE(TAG, "BME280 has wrong chip ID! Is it a BME280?");
       break;
     case NONE:
     default:

--- a/esphome/components/bme280/bme280.cpp
+++ b/esphome/components/bme280/bme280.cpp
@@ -172,7 +172,7 @@ void BME280Component::update() {
   uint8_t meas_register = 0;
   meas_register |= (this->temperature_oversampling_ & 0b111) << 5;
   meas_register |= (this->pressure_oversampling_ & 0b111) << 2;
-  meas_register |= 0b01;  // Forced mode
+  meas_register |= BME280_MODE_FORCED;
   if (!this->write_byte(BME280_REGISTER_CONTROL, meas_register)) {
     this->status_set_warning();
     return;


### PR DESCRIPTION
Two simple improvements for the BME280 component: fix two BMP typos and use a predefined constant instead of a literal for forced mode operation.