### PR TITLE
Ble scanner

### DIFF
--- a/esphome/components/ble_scanner/ble_scanner.cpp
+++ b/esphome/components/ble_scanner/ble_scanner.cpp
@@ -1,0 +1,16 @@
+#include "ble_scanner.h"
+#include "esphome/core/log.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+namespace esphome {
+namespace ble_scanner {
+
+static const char *TAG = "ble_scanner";
+
+void BLEScanner::dump_config() { LOG_TEXT_SENSOR("", "BLE Scanner", this); }
+
+}  // namespace ble_scanner
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <time.h>
+
+#include <string>
+
+#include "esphome/core/component.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+namespace esphome {
+namespace ble_scanner {
+
+class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
+ public:
+  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
+    this->publish_state(
+      "{\"timestamp\":" + to_string(::time(NULL)) + ","
+      "\"address\":\"" + device.address_str() + "\","
+      "\"rssi\":" + to_string(device.get_rssi()) + ","
+      "\"name\":\"" + device.get_name() + "\"}");
+
+    return true;
+  }
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+};
+
+}  // namespace ble_scanner
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -15,11 +15,16 @@ namespace ble_scanner {
 class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
-    this->publish_state(
-      "{\"timestamp\":" + to_string(::time(NULL)) + ","
-      "\"address\":\"" + device.address_str() + "\","
-      "\"rssi\":" + to_string(device.get_rssi()) + ","
-      "\"name\":\"" + device.get_name() + "\"}");
+    this->publish_state("{\"timestamp\":" + to_string(::time(NULL)) +
+                        ","
+                        "\"address\":\"" +
+                        device.address_str() +
+                        "\","
+                        "\"rssi\":" +
+                        to_string(device.get_rssi()) +
+                        ","
+                        "\"name\":\"" +
+                        device.get_name() + "\"}");
 
     return true;
   }

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <time.h>
-
+#include <ctime>
 #include <string>
 
 #include "esphome/core/component.h"

--- a/esphome/components/ble_scanner/text_sensor.py
+++ b/esphome/components/ble_scanner/text_sensor.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor, esp32_ble_tracker
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ['esp32_ble_tracker']
+
+ble_scanner_ns = cg.esphome_ns.namespace('ble_scanner')
+BLEScanner = ble_scanner_ns.class_('BLEScanner', text_sensor.TextSensor, cg.Component,
+                                   esp32_ble_tracker.ESPBTDeviceListener)
+
+CONFIG_SCHEMA = cv.All(text_sensor.TEXT_SENSOR_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(BLEScanner),
+}).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA).extend(
+    cv.COMPONENT_SCHEMA))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield esp32_ble_tracker.register_ble_device(var, config)
+    yield text_sensor.register_text_sensor(var, config)

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -104,39 +104,6 @@ sensor:
       name: "Xiaomi CGG1 Humidity"
     battery_level:
       name: "Xiaomi CGG1 Battery Level"
-  - platform: pmsx003
-    type: PMSX003
-    pm_1_0:
-      name: "PM 1.0 Concentration"
-    pm_2_5:
-      name: "PM 2.5 Concentration"
-    pm_10_0:
-      name: "PM 10.0 Concentration"
-  - platform: pmsx003
-    type: PMS5003T
-    pm_2_5:
-      name: "PM 2.5 Concentration"
-    temperature:
-      name: "PMS Temperature"
-    humidity:
-      name: "PMS Humidity"
-  - platform: pmsx003
-    type: PMS5003ST
-    pm_2_5:
-      name: "PM 2.5 Concentration"
-    temperature:
-      name: "PMS Temperature"
-    humidity:
-      name: "PMS Humidity"
-    formaldehyde:
-      name: "PMS Formaldehyde Concentration"
-  - platform: cse7766
-    voltage:
-      name: "CSE7766 Voltage"
-    current:
-      name: "CSE7766 Current"
-    power:
-      name: "CSE776 Power"
   - platform: homeassistant
     entity_id: sensor.hello_world
     id: ha_hello_world
@@ -145,28 +112,6 @@ sensor:
       name: "Lightning Energy"
     distance:
       name: "Distance Storm"
-  - platform: ruuvitag
-    mac_address: FF:56:D3:2F:7D:E8
-    humidity:
-      name: "RuuviTag Humidity"
-    temperature:
-      name: "RuuviTag Temperature"
-    pressure:
-      name: "RuuviTag Pressure"
-    acceleration_x:
-      name: "RuuviTag Acceleration X"
-    acceleration_y:
-      name: "RuuviTag Acceleration Y"
-    acceleration_z:
-      name: "RuuviTag Acceleration Z"
-    battery_voltage:
-      name: "RuuviTag Battery Voltage"
-    tx_power:
-      name: "RuuviTag TX Power"
-    movement_counter:
-      name: "RuuviTag Movement Counter"
-    measurement_sequence_number:
-      name: "RuuviTag Measurement Sequence Number"
 
 time:
 - platform: homeassistant

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -137,21 +137,6 @@ sensor:
       name: "CSE7766 Current"
     power:
       name: "CSE776 Power"
-  - platform: apds9960
-    type: proximity
-    name: APDS9960 Proximity
-  - platform: apds9960
-    type: clear
-    name: APDS9960 Clear
-  - platform: apds9960
-    type: red
-    name: APDS9960 Red
-  - platform: apds9960
-    type: green
-    name: APDS9960 Green
-  - platform: apds9960
-    type: blue
-    name: APDS9960 Blue
   - platform: homeassistant
     entity_id: sensor.hello_world
     id: ha_hello_world
@@ -271,21 +256,6 @@ script:
   - id: my_script
     then:
       - lambda: 'ESP_LOGD("main", "Hello World!");'
-
-stepper:
-  - platform: uln2003
-    id: my_stepper
-    pin_a: GPIO23
-    pin_b: GPIO27
-    pin_c: GPIO25
-    pin_d: GPIO26
-    sleep_when_done: no
-    step_mode: HALF_STEP
-    max_speed: 250 steps/s
-
-    # Optional:
-    acceleration: inf
-    deceleration: inf
 
 interval:
   interval: 5s

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -257,6 +257,21 @@ script:
     then:
       - lambda: 'ESP_LOGD("main", "Hello World!");'
 
+stepper:
+  - platform: uln2003
+    id: my_stepper
+    pin_a: GPIO23
+    pin_b: GPIO27
+    pin_c: GPIO25
+    pin_d: GPIO26
+    sleep_when_done: no
+    step_mode: HALF_STEP
+    max_speed: 250 steps/s
+
+    # Optional:
+    acceleration: inf
+    deceleration: inf
+
 interval:
   interval: 5s
   then:

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -276,6 +276,8 @@ text_sensor:
   - platform: homeassistant
     entity_id: sensor.hello_world2
     id: ha_hello_world2
+  - platform: ble_scanner
+    name: Scanner
 
 script:
   - id: my_script

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -142,10 +142,6 @@ time:
       then:
         - logger.log: It's 16:00
 
-apds9960:
-  address: 0x20
-  update_interval: 60s
-
 esp32_touch:
   setup_mode: True
 

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -104,6 +104,28 @@ sensor:
       name: "Xiaomi CGG1 Humidity"
     battery_level:
       name: "Xiaomi CGG1 Battery Level"
+  - platform: ruuvitag
+    mac_address: FF:56:D3:2F:7D:E8
+    humidity:
+      name: "RuuviTag Humidity"
+    temperature:
+      name: "RuuviTag Temperature"
+    pressure:
+      name: "RuuviTag Pressure"
+    acceleration_x:
+      name: "RuuviTag Acceleration X"
+    acceleration_y:
+      name: "RuuviTag Acceleration Y"
+    acceleration_z:
+      name: "RuuviTag Acceleration Z"
+    battery_voltage:
+      name: "RuuviTag Battery Voltage"
+    tx_power:
+      name: "RuuviTag TX Power"
+    movement_counter:
+      name: "RuuviTag Movement Counter"
+    measurement_sequence_number:
+      name: "RuuviTag Measurement Sequence Number"
   - platform: homeassistant
     entity_id: sensor.hello_world
     id: ha_hello_world

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -214,18 +214,6 @@ binary_sensor:
     name: "ESP32 Touch Pad GPIO27"
     pin: GPIO27
     threshold: 1000
-  - platform: apds9960
-    direction: up
-    name: APDS9960 Up
-  - platform: apds9960
-    direction: down
-    name: APDS9960 Down
-  - platform: apds9960
-    direction: left
-    name: APDS9960 Left
-  - platform: apds9960
-    direction: right
-    name: APDS9960 Right
   - platform: homeassistant
     entity_id: binary_sensor.hello_world
     id: ha_hello_world_binary

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -531,6 +531,8 @@ stepper:
     sleep_when_done: no
     step_mode: HALF_STEP
     max_speed: 250 steps/s
+
+    # Optional:
     acceleration: inf
     deceleration: inf
   - platform: a4988
@@ -540,19 +542,6 @@ stepper:
     max_speed: 0.1 steps/s
     acceleration: 10 steps/s^2
     deceleration: 10 steps/s^2
-  - platform: uln2003
-    id: my_stepper
-    pin_a: GPIO23
-    pin_b: GPIO27
-    pin_c: GPIO25
-    pin_d: GPIO26
-    sleep_when_done: no
-    step_mode: HALF_STEP
-    max_speed: 250 steps/s
-
-    # Optional:
-    acceleration: inf
-    deceleration: inf
 
 interval:
   interval: 5s

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -393,28 +393,6 @@ sensor:
       name: "CSE7766 Current"
     power:
       name: "CSE776 Power"
-  - platform: ruuvitag
-    mac_address: FF:56:D3:2F:7D:E8
-    humidity:
-      name: "RuuviTag Humidity"
-    temperature:
-      name: "RuuviTag Temperature"
-    pressure:
-      name: "RuuviTag Pressure"
-    acceleration_x:
-      name: "RuuviTag Acceleration X"
-    acceleration_y:
-      name: "RuuviTag Acceleration Y"
-    acceleration_z:
-      name: "RuuviTag Acceleration Z"
-    battery_voltage:
-      name: "RuuviTag Battery Voltage"
-    tx_power:
-      name: "RuuviTag TX Power"
-    movement_counter:
-      name: "RuuviTag Movement Counter"
-    measurement_sequence_number:
-      name: "RuuviTag Measurement Sequence Number"
 
 time:
 - platform: homeassistant

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -221,7 +221,7 @@ sensor:
   - platform: homeassistant
     entity_id: sensor.hello_world
     id: ha_hello_world
-  - platform: aht10  
+  - platform: aht10
     temperature:
       name: "Temperature"
     humidity:
@@ -540,6 +540,19 @@ stepper:
     max_speed: 0.1 steps/s
     acceleration: 10 steps/s^2
     deceleration: 10 steps/s^2
+  - platform: uln2003
+    id: my_stepper
+    pin_a: GPIO23
+    pin_b: GPIO27
+    pin_c: GPIO25
+    pin_d: GPIO26
+    sleep_when_done: no
+    step_mode: HALF_STEP
+    max_speed: 250 steps/s
+
+    # Optional:
+    acceleration: inf
+    deceleration: inf
 
 interval:
   interval: 5s

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -360,6 +360,61 @@ sensor:
       name: "PM2.5"
     pm_10_0:
       name: "PM10.0"
+  - platform: pmsx003
+    type: PMSX003
+    pm_1_0:
+      name: "PM 1.0 Concentration"
+    pm_2_5:
+      name: "PM 2.5 Concentration"
+    pm_10_0:
+      name: "PM 10.0 Concentration"
+  - platform: pmsx003
+    type: PMS5003T
+    pm_2_5:
+      name: "PM 2.5 Concentration"
+    temperature:
+      name: "PMS Temperature"
+    humidity:
+      name: "PMS Humidity"
+  - platform: pmsx003
+    type: PMS5003ST
+    pm_2_5:
+      name: "PM 2.5 Concentration"
+    temperature:
+      name: "PMS Temperature"
+    humidity:
+      name: "PMS Humidity"
+    formaldehyde:
+      name: "PMS Formaldehyde Concentration"
+  - platform: cse7766
+    voltage:
+      name: "CSE7766 Voltage"
+    current:
+      name: "CSE7766 Current"
+    power:
+      name: "CSE776 Power"
+  - platform: ruuvitag
+    mac_address: FF:56:D3:2F:7D:E8
+    humidity:
+      name: "RuuviTag Humidity"
+    temperature:
+      name: "RuuviTag Temperature"
+    pressure:
+      name: "RuuviTag Pressure"
+    acceleration_x:
+      name: "RuuviTag Acceleration X"
+    acceleration_y:
+      name: "RuuviTag Acceleration Y"
+    acceleration_z:
+      name: "RuuviTag Acceleration Z"
+    battery_voltage:
+      name: "RuuviTag Battery Voltage"
+    tx_power:
+      name: "RuuviTag TX Power"
+    movement_counter:
+      name: "RuuviTag Movement Counter"
+    measurement_sequence_number:
+      name: "RuuviTag Measurement Sequence Number"
 
 time:
 - platform: homeassistant
@@ -531,8 +586,6 @@ stepper:
     sleep_when_done: no
     step_mode: HALF_STEP
     max_speed: 250 steps/s
-
-    # Optional:
     acceleration: inf
     deceleration: inf
   - platform: a4988


### PR DESCRIPTION
## Description:
Added a ble_scanner component that scans reachable BLE devices using [text_sensor](https://esphome.io/components/text_sensor/index.html) and [esp32_ble_tracker](https://esphome.io/components/esp32_ble_tracker.html). Implemented together with @jozhalaj.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation:** esphome/esphome-docs#611

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

## Example log:
| Address | RSSI | Name | Timestamp |
|---|---|---|---|
|62:E1:67:95:71:AA | -91 |   | Mon, 06 Jan 2020 13:08:50 GMT|
|62:E1:67:95:71:AA | -88 |   | Mon, 06 Jan 2020 13:08:50 GMT|
|62:E1:67:95:71:AA | -88 |   | Mon, 06 Jan 2020 13:08:47 GMT|
|62:E1:67:95:71:AA | -92 |   | Mon, 06 Jan 2020 13:08:46 GMT|
|62:E1:67:95:71:AA | -87 |   | Mon, 06 Jan 2020 13:08:45 GMT|
|62:E1:67:95:71:AA | -90 |   | Mon, 06 Jan 2020 13:08:43 GMT|
|2C:41:A1:87:CC:E5 | -80 | LE-Bose QC35 II | Mon, 06 Jan 2020 13:08:43 GMT|
|62:E1:67:95:71:AA | -94 |   | Mon, 06 Jan 2020 13:08:42 GMT|
|E7:F2:42:2D:7C:E7 | -93 | Amazfit Bip Watch | Mon, 06 Jan 2020 13:08:42 GMT|
|62:E1:67:95:71:AA | -90 |   | Mon, 06 Jan 2020 13:08:41 GMT|
|D7:E7:E7:6B:D6:3F | -82 | MI Band 2 | Mon, 06 Jan 2020 13:08:41 GMT|

