### PR TITLE
sim800l: Add support of roaming-registered SIM cards

### DIFF
--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -97,7 +97,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
     case STATE_CREGWAIT: {
       // Response: "+CREG: 0,1" -- the one there means registered ok
       //           "+CREG: -,-" means not registered ok
-      bool registered = message.compare(0, 6, "+CREG:") == 0 && (message[9] == '1' or message[9] == '5');
+      bool registered = message.compare(0, 6, "+CREG:") == 0 && (message[9] == '1' || message[9] == '5');
       if (registered) {
         if (!this->registered_)
           ESP_LOGD(TAG, "Registered OK");

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -97,7 +97,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
     case STATE_CREGWAIT: {
       // Response: "+CREG: 0,1" -- the one there means registered ok
       //           "+CREG: -,-" means not registered ok
-      bool registered = message.compare(0, 6, "+CREG:") == 0 && message[9] == '1';
+      bool registered = message.compare(0, 6, "+CREG:") == 0 && (message[9] == '1' or message[9] == '5');
       if (registered) {
         if (!this->registered_)
           ESP_LOGD(TAG, "Registered OK");


### PR DESCRIPTION
## Description:
Library only accepted properly registered SIM cards with operator, not allowing to use roaming cards (like MVNO, shared infrastructure - internal roaming). This PR allows also those card to be properly detected and thus used in esphome.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1042

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs# n/a

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
