### PR TITLE
Revert default ESP32 upload baud rate

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -190,7 +190,7 @@ def get_ini_content():
         'framework': 'arduino',
         'lib_deps': lib_deps + ['${common.lib_deps}'],
         'build_flags': build_flags + ['${common.build_flags}'],
-        'upload_speed': UPLOAD_SPEED_OVERRIDE.get(CORE.board, 460800),
+        'upload_speed': UPLOAD_SPEED_OVERRIDE.get(CORE.board, 115200),
     }
 
     if CORE.is_esp32:


### PR DESCRIPTION
On ESP8266, we already have a system to revert to 115200 baud rate when the faster one fails. On ESP32 that does not exist because we don't call esptool directly (for complex reasons).

I couldn't find a good solution for ESP32 (since updating baud rate requires updating platformio.ini, which will make the whole project re-compile). So for ESP32s, the default baud rate is now back to 115200.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).