### PR TITLE
add time cover assumed_state option

### DIFF
--- a/esphome/components/time_based/cover.py
+++ b/esphome/components/time_based/cover.py
@@ -3,7 +3,7 @@ import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import cover
 from esphome.const import CONF_CLOSE_ACTION, CONF_CLOSE_DURATION, CONF_ID, CONF_OPEN_ACTION, \
-    CONF_OPEN_DURATION, CONF_STOP_ACTION
+    CONF_OPEN_DURATION, CONF_STOP_ACTION, CONF_ASSUMED_STATE
 
 time_based_ns = cg.esphome_ns.namespace('time_based')
 TimeBasedCover = time_based_ns.class_('TimeBasedCover', cover.Cover, cg.Component)
@@ -21,6 +21,7 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend({
     cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
 
     cv.Optional(CONF_HAS_BUILT_IN_ENDSTOP, default=False): cv.boolean,
+    cv.Optional(CONF_ASSUMED_STATE, default=True): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 
 
@@ -38,3 +39,4 @@ def to_code(config):
     yield automation.build_automation(var.get_close_trigger(), [], config[CONF_CLOSE_ACTION])
 
     cg.add(var.set_has_built_in_endstop(config[CONF_HAS_BUILT_IN_ENDSTOP]))
+    cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -51,7 +51,7 @@ float TimeBasedCover::get_setup_priority() const { return setup_priority::DATA; 
 CoverTraits TimeBasedCover::get_traits() {
   auto traits = CoverTraits();
   traits.set_supports_position(true);
-  traits.set_is_assumed_state(true);
+  traits.set_is_assumed_state(this->assumed_state_);
   return traits;
 }
 void TimeBasedCover::control(const CoverCall &call) {

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -21,6 +21,7 @@ class TimeBasedCover : public cover::Cover, public Component {
   void set_close_duration(uint32_t close_duration) { this->close_duration_ = close_duration; }
   cover::CoverTraits get_traits() override;
   void set_has_built_in_endstop(bool value) { this->has_built_in_endstop_ = value; }
+  void set_assumed_state(bool value) { this->assumed_state_ = value; }
 
  protected:
   void control(const cover::CoverCall &call) override;
@@ -43,6 +44,7 @@ class TimeBasedCover : public cover::Cover, public Component {
   uint32_t last_publish_time_{0};
   float target_position_{0};
   bool has_built_in_endstop_{false};
+  bool assumed_state_{false};
 };
 
 }  // namespace time_based


### PR DESCRIPTION
## Description:
adds the option of assumed_state so HA front end disables the buttons on the UI, defaults to true to keep old behavior.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/578

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/490

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
