### PR TITLE
Corrections to default register values of ATM90E32 component

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -80,7 +80,7 @@ void ATM90E32Component::setup() {
     mmode0 |= 1 << 8;  // sets 8th bit to 1, 3P3W
     mmode0 |= 0 << 1;  // sets 1st bit to 0, phase b is not counted into the all-phase sum energy/power (P/Q/S)
   }
-  
+
   this->write16_(ATM90E32_REGISTER_SOFTRESET, 0x789A);    // Perform soft reset
   this->write16_(ATM90E32_REGISTER_CFGREGACCEN, 0x55AA);  // enable register config access
   this->write16_(ATM90E32_REGISTER_METEREN, 0x0001);      // Enable Metering

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -71,7 +71,7 @@ void ATM90E32Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ATM90E32 Component...");
   this->spi_setup();
 
-  uint16_t mmode0 = 0x87; // 3P4W 50Hz
+  uint16_t mmode0 = 0x87;  // 3P4W 50Hz
   if (line_freq_ == 60) {
     mmode0 |= 1 << 12;  // sets 12th bit to 1, 60Hz
   }
@@ -89,15 +89,15 @@ void ATM90E32Component::setup() {
     return;
   }
   
-  this->write16_(ATM90E32_REGISTER_PLCONSTH, 0x0861);                    // PL Constant MSB (default) = 140625000
-  this->write16_(ATM90E32_REGISTER_PLCONSTL, 0xC468);                    // PL Constant LSB (default)
-  this->write16_(ATM90E32_REGISTER_ZXCONFIG, 0xD654);                    // ZX2, ZX1, ZX0 pin config
-  this->write16_(ATM90E32_REGISTER_MMODE0, mmode0);                      // Mode Config (frequency set in main program)
-  this->write16_(ATM90E32_REGISTER_MMODE1, pga_gain_);                   // PGA Gain Configuration for Current Channels
-  this->write16_(ATM90E32_REGISTER_PSTARTTH, 0x1D4C);                    // All Active Startup Power Threshold - 0.02A/0.00032 = 7500
-  this->write16_(ATM90E32_REGISTER_QSTARTTH, 0x1D4C);                    // All Reactive Startup Power Threshold - 50%
-  this->write16_(ATM90E32_REGISTER_PPHASETH, 0x02EE);                    // Each Phase Active Phase Threshold - 0.002A/0.00032 = 750
-  this->write16_(ATM90E32_REGISTER_QPHASETH, 0x02EE);                    // Each phase Reactive Phase Threshold - 10%
+  this->write16_(ATM90E32_REGISTER_PLCONSTH, 0x0861);   // PL Constant MSB (default) = 140625000
+  this->write16_(ATM90E32_REGISTER_PLCONSTL, 0xC468);   // PL Constant LSB (default)
+  this->write16_(ATM90E32_REGISTER_ZXCONFIG, 0xD654);   // ZX2, ZX1, ZX0 pin config
+  this->write16_(ATM90E32_REGISTER_MMODE0, mmode0);     // Mode Config (frequency set in main program)
+  this->write16_(ATM90E32_REGISTER_MMODE1, pga_gain_);  // PGA Gain Configuration for Current Channels
+  this->write16_(ATM90E32_REGISTER_PSTARTTH, 0x1D4C);   // All Active Startup Power Threshold - 0.02A/0.00032 = 7500
+  this->write16_(ATM90E32_REGISTER_QSTARTTH, 0x1D4C);   // All Reactive Startup Power Threshold - 50%
+  this->write16_(ATM90E32_REGISTER_PPHASETH, 0x02EE);   // Each Phase Active Phase Threshold - 0.002A/0.00032 = 750
+  this->write16_(ATM90E32_REGISTER_QPHASETH, 0x02EE);   // Each phase Reactive Phase Threshold - 10%
   this->write16_(ATM90E32_REGISTER_UGAINA, this->phase_[0].volt_gain_);  // A Voltage rms gain
   this->write16_(ATM90E32_REGISTER_IGAINA, this->phase_[0].ct_gain_);    // A line current gain
   this->write16_(ATM90E32_REGISTER_UGAINB, this->phase_[1].volt_gain_);  // B Voltage rms gain

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -75,6 +75,7 @@ void ATM90E32Component::setup() {
   if (line_freq_ == 60) {
     mmode0 |= 1 << 12;  // sets 12th bit to 1, 60Hz
   }
+
   if (current_phases_ == 2) {
     mmode0 |= 1 << 8;  // sets 8th bit to 1, 3P3W
     mmode0 |= 0 << 1;  // sets 1st bit to 0, phase b is not counted into the all-phase sum energy/power (P/Q/S)
@@ -88,7 +89,6 @@ void ATM90E32Component::setup() {
     this->mark_failed();
     return;
   }
-  
   this->write16_(ATM90E32_REGISTER_PLCONSTH, 0x0861);   // PL Constant MSB (default) = 140625000
   this->write16_(ATM90E32_REGISTER_PLCONSTL, 0xC468);   // PL Constant LSB (default)
   this->write16_(ATM90E32_REGISTER_ZXCONFIG, 0xD654);   // ZX2, ZX1, ZX0 pin config

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -68,14 +68,18 @@ void ATM90E32Component::update() {
 }
 
 void ATM90E32Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ATM90E32Component...");
+  ESP_LOGCONFIG(TAG, "Setting up ATM90E32 Component...");
   this->spi_setup();
 
-  uint16_t mmode0 = 0x185;
+  uint16_t mmode0 = 0x87; // 3P4W 50Hz
   if (line_freq_ == 60) {
-    mmode0 |= 1 << 12;
+    mmode0 |= 1 << 12; // sets 12th bit to 1, 60Hz
   }
-
+  if (current_phases_ == 2) {
+    mmode0 |= 1 << 8; // sets 8th bit to 1, 3P3W
+    mmode0 |= 0 << 1; // sets 1st bit to 0, phase b is not counted into the all-phase sum energy/power (P/Q/S)
+  }
+  
   this->write16_(ATM90E32_REGISTER_SOFTRESET, 0x789A);    // Perform soft reset
   this->write16_(ATM90E32_REGISTER_CFGREGACCEN, 0x55AA);  // enable register config access
   this->write16_(ATM90E32_REGISTER_METEREN, 0x0001);      // Enable Metering
@@ -84,13 +88,16 @@ void ATM90E32Component::setup() {
     this->mark_failed();
     return;
   }
-
-  this->write16_(ATM90E32_REGISTER_ZXCONFIG, 0x0A55);                    // ZX2, ZX1, ZX0 pin config
+  
+  this->write16_(ATM90E32_REGISTER_PLCONSTH, 0x0861);                    // PL Constant MSB (default) - Meter Constant = 3200 - PL Constant = 140625000
+  this->write16_(ATM90E32_REGISTER_PLCONSTL, 0xC468);                    // PL Constant LSB (default) - this is 4C68 in the application note, which is incorrect
+  this->write16_(ATM90E32_REGISTER_ZXCONFIG, 0xD654);                    // ZX2, ZX1, ZX0 pin config
   this->write16_(ATM90E32_REGISTER_MMODE0, mmode0);                      // Mode Config (frequency set in main program)
   this->write16_(ATM90E32_REGISTER_MMODE1, pga_gain_);                   // PGA Gain Configuration for Current Channels
-  this->write16_(ATM90E32_REGISTER_PSTARTTH, 0x0AFC);                    // Active Startup Power Threshold = 50%
-  this->write16_(ATM90E32_REGISTER_QSTARTTH, 0x0AEC);                    // Reactive Startup Power Threshold = 50%
-  this->write16_(ATM90E32_REGISTER_PPHASETH, 0x00BC);                    // Active Phase Threshold = 10%
+  this->write16_(ATM90E32_REGISTER_PSTARTTH, 0x1D4C);                    // All Phase Active Startup Power Threshold - 50% of startup current = 0.02A/0.00032 = 7500
+  this->write16_(ATM90E32_REGISTER_QSTARTTH, 0x1D4C);                    // All Phase Reactive Startup Power Threshold - 50%
+  this->write16_(ATM90E32_REGISTER_PPHASETH, 0x02EE);                    // Each Phase Active Phase Threshold - 10% of startup current = 0.002A/0.00032 = 750
+  this->write16_(ATM90E32_REGISTER_QPHASETH, 0x02EE);                    // Each phase Reactive Phase Threshold - 10%
   this->write16_(ATM90E32_REGISTER_UGAINA, this->phase_[0].volt_gain_);  // A Voltage rms gain
   this->write16_(ATM90E32_REGISTER_IGAINA, this->phase_[0].ct_gain_);    // A line current gain
   this->write16_(ATM90E32_REGISTER_UGAINB, this->phase_[1].volt_gain_);  // B Voltage rms gain

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -73,11 +73,11 @@ void ATM90E32Component::setup() {
 
   uint16_t mmode0 = 0x87; // 3P4W 50Hz
   if (line_freq_ == 60) {
-    mmode0 |= 1 << 12; // sets 12th bit to 1, 60Hz
+    mmode0 |= 1 << 12;  // sets 12th bit to 1, 60Hz
   }
   if (current_phases_ == 2) {
-    mmode0 |= 1 << 8; // sets 8th bit to 1, 3P3W
-    mmode0 |= 0 << 1; // sets 1st bit to 0, phase b is not counted into the all-phase sum energy/power (P/Q/S)
+    mmode0 |= 1 << 8;  // sets 8th bit to 1, 3P3W
+    mmode0 |= 0 << 1;  // sets 1st bit to 0, phase b is not counted into the all-phase sum energy/power (P/Q/S)
   }
   
   this->write16_(ATM90E32_REGISTER_SOFTRESET, 0x789A);    // Perform soft reset
@@ -89,14 +89,14 @@ void ATM90E32Component::setup() {
     return;
   }
   
-  this->write16_(ATM90E32_REGISTER_PLCONSTH, 0x0861);                    // PL Constant MSB (default) - Meter Constant = 3200 - PL Constant = 140625000
-  this->write16_(ATM90E32_REGISTER_PLCONSTL, 0xC468);                    // PL Constant LSB (default) - this is 4C68 in the application note, which is incorrect
+  this->write16_(ATM90E32_REGISTER_PLCONSTH, 0x0861);                    // PL Constant MSB (default) = 140625000
+  this->write16_(ATM90E32_REGISTER_PLCONSTL, 0xC468);                    // PL Constant LSB (default)
   this->write16_(ATM90E32_REGISTER_ZXCONFIG, 0xD654);                    // ZX2, ZX1, ZX0 pin config
   this->write16_(ATM90E32_REGISTER_MMODE0, mmode0);                      // Mode Config (frequency set in main program)
   this->write16_(ATM90E32_REGISTER_MMODE1, pga_gain_);                   // PGA Gain Configuration for Current Channels
-  this->write16_(ATM90E32_REGISTER_PSTARTTH, 0x1D4C);                    // All Phase Active Startup Power Threshold - 50% of startup current = 0.02A/0.00032 = 7500
-  this->write16_(ATM90E32_REGISTER_QSTARTTH, 0x1D4C);                    // All Phase Reactive Startup Power Threshold - 50%
-  this->write16_(ATM90E32_REGISTER_PPHASETH, 0x02EE);                    // Each Phase Active Phase Threshold - 10% of startup current = 0.002A/0.00032 = 750
+  this->write16_(ATM90E32_REGISTER_PSTARTTH, 0x1D4C);                    // All Active Startup Power Threshold - 0.02A/0.00032 = 7500
+  this->write16_(ATM90E32_REGISTER_QSTARTTH, 0x1D4C);                    // All Reactive Startup Power Threshold - 50%
+  this->write16_(ATM90E32_REGISTER_PPHASETH, 0x02EE);                    // Each Phase Active Phase Threshold - 0.002A/0.00032 = 750
   this->write16_(ATM90E32_REGISTER_QPHASETH, 0x02EE);                    // Each phase Reactive Phase Threshold - 10%
   this->write16_(ATM90E32_REGISTER_UGAINA, this->phase_[0].volt_gain_);  // A Voltage rms gain
   this->write16_(ATM90E32_REGISTER_IGAINA, this->phase_[0].ct_gain_);    // A line current gain

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -29,6 +29,7 @@ class ATM90E32Component : public PollingComponent,
     chip_temperature_sensor_ = chip_temperature_sensor;
   }
   void set_line_freq(int freq) { line_freq_ = freq; }
+  void set_current_phases(int phases) { current_phases_ = phases; }
   void set_pga_gain(uint16_t gain) { pga_gain_ = gain; }
 
  protected:
@@ -55,8 +56,8 @@ class ATM90E32Component : public PollingComponent,
   float get_chip_temperature_();
 
   struct ATM90E32Phase {
-    uint16_t volt_gain_{41820};
-    uint16_t ct_gain_{25498};
+    uint16_t volt_gain_{7305};
+    uint16_t ct_gain_{27961};
     sensor::Sensor *voltage_sensor_{nullptr};
     sensor::Sensor *current_sensor_{nullptr};
     sensor::Sensor *power_sensor_{nullptr};
@@ -67,6 +68,7 @@ class ATM90E32Component : public PollingComponent,
   sensor::Sensor *chip_temperature_sensor_{nullptr};
   uint16_t pga_gain_{0x15};
   int line_freq_{60};
+  int current_phases_{3};
 };
 
 }  // namespace atm90e32

--- a/esphome/components/atm90e32/atm90e32_reg.h
+++ b/esphome/components/atm90e32/atm90e32_reg.h
@@ -234,12 +234,12 @@ static const uint16_t ATM90E32_REGISTER_IRMSBLSB = 0xEE;    // Lower Word (B RMS
 static const uint16_t ATM90E32_REGISTER_IRMSCLSB = 0xEF;    // Lower Word (C RMS Current)
 
 /* THD, FREQUENCY, ANGLE & TEMPTEMP REGISTERS*/
-static const uint16_t ATM90E32_REGISTER_THDNUA = 0xF1;   // A Voltage THD+N
-static const uint16_t ATM90E32_REGISTER_THDNUB = 0xF2;   // B Voltage THD+N
-static const uint16_t ATM90E32_REGISTER_THDNUC = 0xF3;   // C Voltage THD+N
-static const uint16_t ATM90E32_REGISTER_THDNIA = 0xF5;   // A Current THD+N
-static const uint16_t ATM90E32_REGISTER_THDNIB = 0xF6;   // B Current THD+N
-static const uint16_t ATM90E32_REGISTER_THDNIC = 0xF7;   // C Current THD+N
+static const uint16_t ATM90E32_REGISTER_UPEAKA = 0xF1;   // A Voltage Peak
+static const uint16_t ATM90E32_REGISTER_UPEAKB = 0xF2;   // B Voltage Peak
+static const uint16_t ATM90E32_REGISTER_UPEAKC = 0xF3;   // C Voltage Peak
+static const uint16_t ATM90E32_REGISTER_IPEAKA = 0xF5;   // A Current Peak
+static const uint16_t ATM90E32_REGISTER_IPEAKB = 0xF6;   // B Current Peak
+static const uint16_t ATM90E32_REGISTER_IPEAKC = 0xF7;   // C Current Peak
 static const uint16_t ATM90E32_REGISTER_FREQ = 0xF8;     // Frequency
 static const uint16_t ATM90E32_REGISTER_PANGLEA = 0xF9;  // A Mean Phase Angle
 static const uint16_t ATM90E32_REGISTER_PANGLEB = 0xFA;  // B Mean Phase Angle

--- a/esphome/components/atm90e32/sensor.py
+++ b/esphome/components/atm90e32/sensor.py
@@ -14,6 +14,7 @@ CONF_REACTIVE_POWER = 'reactive_power'
 CONF_LINE_FREQUENCY = 'line_frequency'
 CONF_CHIP_TEMPERATURE = 'chip_temperature'
 CONF_GAIN_PGA = 'gain_pga'
+CONF_CURRENT_PHASES = 'current_phases'
 CONF_GAIN_VOLTAGE = 'gain_voltage'
 CONF_GAIN_CT = 'gain_ct'
 LINE_FREQS = {

--- a/esphome/components/atm90e32/sensor.py
+++ b/esphome/components/atm90e32/sensor.py
@@ -20,6 +20,10 @@ LINE_FREQS = {
     '50HZ': 50,
     '60HZ': 60,
 }
+CURRENT_PHASES = {
+    '2': 2,
+    '3': 3,
+}
 PGA_GAINS = {
     '1X': 0x0,
     '2X': 0x15,
@@ -36,8 +40,8 @@ ATM90E32_PHASE_SCHEMA = cv.Schema({
     cv.Optional(CONF_REACTIVE_POWER): sensor.sensor_schema(UNIT_VOLT_AMPS_REACTIVE,
                                                            ICON_LIGHTBULB, 2),
     cv.Optional(CONF_POWER_FACTOR): sensor.sensor_schema(UNIT_EMPTY, ICON_FLASH, 2),
-    cv.Optional(CONF_GAIN_VOLTAGE, default=41820): cv.uint16_t,
-    cv.Optional(CONF_GAIN_CT, default=25498): cv.uint16_t,
+    cv.Optional(CONF_GAIN_VOLTAGE, default=7305): cv.uint16_t,
+    cv.Optional(CONF_GAIN_CT, default=27961): cv.uint16_t,
 })
 
 CONFIG_SCHEMA = cv.Schema({
@@ -48,6 +52,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_FREQUENCY): sensor.sensor_schema(UNIT_HERTZ, ICON_CURRENT_AC, 1),
     cv.Optional(CONF_CHIP_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
     cv.Required(CONF_LINE_FREQUENCY): cv.enum(LINE_FREQS, upper=True),
+    cv.Optional(CONF_CURRENT_PHASES, default='3'): cv.enum(CURRENT_PHASES, upper=True),
     cv.Optional(CONF_GAIN_PGA, default='2X'): cv.enum(PGA_GAINS, upper=True),
 }).extend(cv.polling_component_schema('60s')).extend(spi.SPI_DEVICE_SCHEMA)
 
@@ -85,4 +90,5 @@ def to_code(config):
         sens = yield sensor.new_sensor(config[CONF_CHIP_TEMPERATURE])
         cg.add(var.set_chip_temperature_sensor(sens))
     cg.add(var.set_line_freq(config[CONF_LINE_FREQUENCY]))
+    cg.add(var.set_current_phases(config[CONF_CURRENT_PHASES]))
     cg.add(var.set_pga_gain(config[CONF_GAIN_PGA]))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -265,8 +265,8 @@ sensor:
         name: "EMON Reactive Power CT1"
       power_factor:
         name: "EMON Power Factor CT1"
-      gain_voltage: 47660
-      gain_ct: 12577
+      gain_voltage: 7305
+      gain_ct: 27961
     phase_b:
       current:
         name: "EMON CT2 Current"
@@ -276,8 +276,8 @@ sensor:
         name: "EMON Reactive Power CT2"
       power_factor:
         name: "EMON Power Factor CT2"
-      gain_voltage: 47660
-      gain_ct: 12577
+      gain_voltage: 7305
+      gain_ct: 27961
     phase_c:
       current:
         name: "EMON CT3 Current"
@@ -287,13 +287,14 @@ sensor:
         name: "EMON Reactive Power CT3"
       power_factor:
         name: "EMON Power Factor CT3"
-      gain_voltage: 47660
-      gain_ct: 12577
+      gain_voltage: 7305
+      gain_ct: 27961
     frequency:
       name: "EMON Line Frequency"
     chip_temperature:
       name: "EMON Chip Temp A"
-    line_frequency: 50Hz
+    line_frequency: 60Hz
+    current_phases: 3
     gain_pga: 2X
   - platform: bh1750
     name: "Living Room Brightness 3"


### PR DESCRIPTION
- Added values for default PL constant registers
- Added each phase reactive threshold register
- Corrected values for all phase active/reactive power startup thresholds & each phase active power threshold
- Corrected default mmode to 3P4W
- Added current_phases to config, which will set the correct bits in mmode for the 2 channel meter vs 6 channel meter (2x 3 channel). Default current_phases is set to 3
- Corrected default values for voltage and ct gain to correspond with current hardware
- Corrected register names for voltatge & current peak. They are different for the ATM90E32 vs the ATM90E36 (which these same registers are THD+N)

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
