### PR TITLE
Add on_rc_switch trigger

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -546,7 +546,9 @@ RC_SWITCH_TRANSMITTER = cv.Schema({
 })
 
 rc_switch_protocols = ns.rc_switch_protocols
+RCSwitchData = ns.struct('RCSwitchData')
 RCSwitchBase = ns.class_('RCSwitchBase')
+RCSwitchTrigger = ns.class_('RCSwitchTrigger', RemoteReceiverTrigger)
 RCSwitchDumper = ns.class_('RCSwitchDumper', RemoteTransmitterDumper)
 RCSwitchRawAction = ns.class_('RCSwitchRawAction', RemoteTransmitterActionBase)
 RCSwitchTypeAAction = ns.class_('RCSwitchTypeAAction', RemoteTransmitterActionBase)
@@ -640,6 +642,11 @@ def rc_switch_type_d_action(var, config, args):
     cg.add(var.set_group((yield cg.templatable(config[CONF_GROUP], args, cg.std_string))))
     cg.add(var.set_device((yield cg.templatable(config[CONF_DEVICE], args, cg.uint8))))
     cg.add(var.set_state((yield cg.templatable(config[CONF_STATE], args, bool))))
+
+
+@register_trigger('rc_switch', RCSwitchTrigger, RCSwitchData)
+def rc_switch_trigger(var, config):
+    pass
 
 
 @register_dumper('rc_switch', RCSwitchDumper)

--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -127,6 +127,19 @@ bool RCSwitchBase::decode(RemoteReceiveData &src, uint64_t *out_data, uint8_t *o
   }
   return true;
 }
+optional<RCSwitchData> RCSwitchBase::decode(RemoteReceiveData &src) const {
+  RCSwitchData out;
+  uint8_t out_nbits;
+  for (uint8_t i = 1; i <= 8; i++) {
+    src.reset();
+    RCSwitchBase *protocol = &rc_switch_protocols[i];
+    if (protocol->decode(src, &out.code, &out_nbits) && out_nbits >= 3) {
+      out.protocol = i;
+      return out;
+    }
+  }
+  return {};
+}
 
 void RCSwitchBase::simple_code_to_tristate(uint16_t code, uint8_t nbits, uint64_t *out_code) {
   *out_code = 0;

--- a/esphome/components/remote_base/rc_switch_protocol.h
+++ b/esphome/components/remote_base/rc_switch_protocol.h
@@ -6,6 +6,13 @@
 namespace esphome {
 namespace remote_base {
 
+struct RCSwitchData {
+  uint64_t code;
+  uint8_t protocol;
+
+  bool operator==(const RCSwitchData &rhs) const { return code == rhs.code && protocol == rhs.protocol; }
+};
+
 class RCSwitchBase {
  public:
   RCSwitchBase() = default;
@@ -27,6 +34,8 @@ class RCSwitchBase {
   bool expect_sync(RemoteReceiveData &src) const;
 
   bool decode(RemoteReceiveData &src, uint64_t *out_data, uint8_t *out_nbits) const;
+
+  optional<RCSwitchData> decode(RemoteReceiveData &src) const;
 
   static void simple_code_to_tristate(uint16_t code, uint8_t nbits, uint64_t *out_code);
 
@@ -203,6 +212,8 @@ class RCSwitchDumper : public RemoteReceiverDumperBase {
  public:
   bool dump(RemoteReceiveData src) override;
 };
+
+using RCSwitchTrigger = RemoteReceiverTrigger<RCSwitchBase, RCSwitchData>;
 
 }  // namespace remote_base
 }  // namespace esphome


### PR DESCRIPTION
## Description:
This adds the missing trigger for RCSwitch.

```yaml
remote_receiver:
  ...
  on_rc_switch:
    - logger.log:
        format: "on_rc_switch: %i %llu"
        args: [x.protocol, x.code]
```

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/550

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
