### PR TITLE
Added equal symbol for MAX7219 7-segment display

### DIFF
--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -44,7 +44,7 @@ const uint8_t MAX7219_ASCII_TO_RAW[95] PROGMEM = {
     0b01001000,            // ':', ord 0x3A
     0b01011000,            // ';', ord 0x3B
     MAX7219_UNKNOWN_CHAR,  // '<', ord 0x3C
-    MAX7219_UNKNOWN_CHAR,  // '=', ord 0x3D
+    0b00001001,            // '=', ord 0x3D
     MAX7219_UNKNOWN_CHAR,  // '>', ord 0x3E
     0b01100101,            // '?', ord 0x3F
     0b01101111,            // '@', ord 0x40


### PR DESCRIPTION
## Description:
Show the equal sign = on the max7219 display when the ascii code 0x3d is given.
Done by lighting segments d and g.

**Related issue (if applicable):** none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/503

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
