### PR TITLE
making SPI CS optional

### DIFF
--- a/esphome/components/as3935_spi/__init__.py
+++ b/esphome/components/as3935_spi/__init__.py
@@ -12,8 +12,7 @@ SPIAS3935 = as3935_spi_ns.class_('SPIAS3935Component', as3935.AS3935, spi.SPIDev
 
 CONFIG_SCHEMA = cv.All(as3935.AS3935_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(SPIAS3935),
-    cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
-}).extend(cv.COMPONENT_SCHEMA).extend(spi.SPI_DEVICE_SCHEMA))
+}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema(CS_PIN_required=True)))
 
 
 def to_code(config):

--- a/esphome/components/as3935_spi/__init__.py
+++ b/esphome/components/as3935_spi/__init__.py
@@ -1,7 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import as3935, spi
-from esphome.const import CONF_ID
+from esphome import pins
+from esphome.const import CONF_ID, CONF_CS_PIN
 
 AUTO_LOAD = ['as3935']
 DEPENDENCIES = ['spi']
@@ -10,7 +11,8 @@ as3935_spi_ns = cg.esphome_ns.namespace('as3935_spi')
 SPIAS3935 = as3935_spi_ns.class_('SPIAS3935Component', as3935.AS3935, spi.SPIDevice)
 
 CONFIG_SCHEMA = cv.All(as3935.AS3935_SCHEMA.extend({
-    cv.GenerateID(): cv.declare_id(SPIAS3935)
+    cv.GenerateID(): cv.declare_id(SPIAS3935),
+    cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
 }).extend(cv.COMPONENT_SCHEMA).extend(spi.SPI_DEVICE_SCHEMA))
 
 

--- a/esphome/components/as3935_spi/__init__.py
+++ b/esphome/components/as3935_spi/__init__.py
@@ -1,8 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import as3935, spi
-from esphome import pins
-from esphome.const import CONF_ID, CONF_CS_PIN
+from esphome.const import CONF_ID
 
 AUTO_LOAD = ['as3935']
 DEPENDENCIES = ['spi']

--- a/esphome/components/atm90e32/sensor.py
+++ b/esphome/components/atm90e32/sensor.py
@@ -55,7 +55,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Required(CONF_LINE_FREQUENCY): cv.enum(LINE_FREQS, upper=True),
     cv.Optional(CONF_CURRENT_PHASES, default='3'): cv.enum(CURRENT_PHASES, upper=True),
     cv.Optional(CONF_GAIN_PGA, default='2X'): cv.enum(PGA_GAINS, upper=True),
-}).extend(cv.polling_component_schema('60s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('60s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/esphome/components/max31855/sensor.py
+++ b/esphome/components/max31855/sensor.py
@@ -11,7 +11,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1).extend({
     cv.GenerateID(): cv.declare_id(MAX31855Sensor),
     cv.Optional(CONF_REFERENCE_TEMPERATURE):
         sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 2),
-}).extend(cv.polling_component_schema('60s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('60s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/esphome/components/max31856/sensor.py
+++ b/esphome/components/max31856/sensor.py
@@ -16,7 +16,7 @@ FILTER = {
 CONFIG_SCHEMA = sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1).extend({
     cv.GenerateID(): cv.declare_id(MAX31856Sensor),
     cv.Optional(CONF_MAINS_FILTER, default='60HZ'): cv.enum(FILTER, upper=True, space=''),
-}).extend(cv.polling_component_schema('60s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('60s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/esphome/components/max31865/sensor.py
+++ b/esphome/components/max31865/sensor.py
@@ -20,7 +20,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 2).extend({
     cv.Required(CONF_RTD_NOMINAL_RESISTANCE): cv.All(cv.resistance, cv.Range(min=100, max=1000)),
     cv.Optional(CONF_MAINS_FILTER, default='60HZ'): cv.enum(FILTER, upper=True, space=''),
     cv.Optional(CONF_RTD_WIRES, default=4): cv.int_range(min=2, max=4),
-}).extend(cv.polling_component_schema('60s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('60s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/esphome/components/max6675/sensor.py
+++ b/esphome/components/max6675/sensor.py
@@ -9,7 +9,7 @@ MAX6675Sensor = max6675_ns.class_('MAX6675Sensor', sensor.Sensor, cg.PollingComp
 
 CONFIG_SCHEMA = sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1).extend({
     cv.GenerateID(): cv.declare_id(MAX6675Sensor),
-}).extend(cv.polling_component_schema('60s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('60s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -14,7 +14,7 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend({
 
     cv.Optional(CONF_NUM_CHIPS, default=1): cv.int_range(min=1, max=255),
     cv.Optional(CONF_INTENSITY, default=15): cv.int_range(min=0, max=15),
-}).extend(cv.polling_component_schema('1s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/esphome/components/pcd8544/display.py
+++ b/esphome/components/pcd8544/display.py
@@ -17,7 +17,7 @@ CONFIG_SCHEMA = cv.All(display.FULL_DISPLAY_SCHEMA.extend({
     cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
     cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
     cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,  # CE
-}).extend(cv.polling_component_schema('1s')).extend(spi.SPI_DEVICE_SCHEMA),
+}).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema()),
                        cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA))
 
 

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -2,8 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import spi
-from esphome import pins
-from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID, CONF_CS_PIN
+from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID
 
 DEPENDENCIES = ['spi']
 AUTO_LOAD = ['binary_sensor']
@@ -15,7 +14,6 @@ PN532Trigger = pn532_ns.class_('PN532Trigger', automation.Trigger.template(cg.st
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(PN532),
-    cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
     cv.Optional(CONF_ON_TAG): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PN532Trigger),
     }),

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_ON_TAG): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PN532Trigger),
     }),
-}).extend(cv.polling_component_schema('1s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -2,7 +2,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import spi
-from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID
+from esphome import pins
+from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID, CONF_CS_PIN
 
 DEPENDENCIES = ['spi']
 AUTO_LOAD = ['binary_sensor']
@@ -14,6 +15,7 @@ PN532Trigger = pn532_ns.class_('PN532Trigger', automation.Trigger.template(cg.st
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(PN532),
+    cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
     cv.Optional(CONF_ON_TAG): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PN532Trigger),
     }),

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -31,7 +31,8 @@ void PN532::setup() {
   //    (this may time out, but that's ok)
   // 3. Send SAM config command with normal mode without waiting for ready bit (IRQ not initialized yet)
   // 4. Probably optional, send SAM config again, this time checking ACK and return value
-  this->cs_->digital_write(false);
+  if (this->cs_)
+    this->cs_->digital_write(false);
   delay(10);
 
   // send dummy firmware version command to get synced up

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -36,7 +36,7 @@ def to_code(config):
 
 SPI_DEVICE_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_SPI_ID): cv.use_id(SPIComponent),
-    cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
+    cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
 })
 
 
@@ -44,5 +44,6 @@ SPI_DEVICE_SCHEMA = cv.Schema({
 def register_spi_device(var, config):
     parent = yield cg.get_variable(config[CONF_SPI_ID])
     cg.add(var.set_spi_parent(parent))
-    pin = yield cg.gpio_pin_expression(config[CONF_CS_PIN])
-    cg.add(var.set_cs_pin(pin))
+    if CONF_CS_PIN in config:
+        pin = yield cg.gpio_pin_expression(config[CONF_CS_PIN])
+        cg.add(var.set_cs_pin(pin))

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -36,7 +36,11 @@ def to_code(config):
 
 SPI_DEVICE_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_SPI_ID): cv.use_id(SPIComponent),
-    cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
+    # The CS_PIN should be declared as cv.Optional or cv.Required in
+    # CONFIG_SCHEMA for each device that uses SPI:
+    # cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
+    # or
+    # cv.Required (CONF_CS_PIN): pins.gpio_output_pin_schema,
 })
 
 

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -34,7 +34,7 @@ def to_code(config):
         cg.add(var.set_mosi(mosi))
 
 
-def spi_device_schema (CS_PIN_required = False):
+def spi_device_schema(CS_PIN_required=False):
     """Create a schema for an SPI device.
     :param CS_PIN_required: If true, make the CS_PIN required in the config.
     :return: The SPI device schema, `extend` this in your config schema.

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -34,14 +34,19 @@ def to_code(config):
         cg.add(var.set_mosi(mosi))
 
 
-SPI_DEVICE_SCHEMA = cv.Schema({
-    cv.GenerateID(CONF_SPI_ID): cv.use_id(SPIComponent),
-    # The CS_PIN should be declared as cv.Optional or cv.Required in
-    # CONFIG_SCHEMA for each device that uses SPI:
-    # cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
-    # or
-    # cv.Required (CONF_CS_PIN): pins.gpio_output_pin_schema,
-})
+def spi_device_schema (CS_PIN_required = False):
+    """Create a schema for an SPI device.
+    :param CS_PIN_required: If true, make the CS_PIN required in the config.
+    :return: The SPI device schema, `extend` this in your config schema.
+    """
+    schema = {
+        cv.GenerateID(CONF_SPI_ID): cv.use_id(SPIComponent),
+    }
+    if CS_PIN_required:
+        schema[cv.Required(CONF_CS_PIN)] = pins.gpio_output_pin_schema
+    else:
+        schema[cv.Optional(CONF_CS_PIN)] = pins.gpio_output_pin_schema
+    return cv.Schema(schema)
 
 
 @coroutine

--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -12,9 +12,11 @@ void ICACHE_RAM_ATTR HOT SPIComponent::disable() {
   if (this->hw_spi_ != nullptr) {
     this->hw_spi_->endTransaction();
   }
-  ESP_LOGVV(TAG, "Disabling SPI Chip on pin %u...", this->active_cs_->get_pin());
-  this->active_cs_->digital_write(true);
-  this->active_cs_ = nullptr;
+  if (this->active_cs_) {
+    ESP_LOGVV(TAG, "Disabling SPI Chip on pin %u...", this->active_cs_->get_pin());
+    this->active_cs_->digital_write(true);
+    this->active_cs_ = nullptr;
+  }
 }
 void SPIComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SPI bus...");

--- a/esphome/components/ssd1306_spi/display.py
+++ b/esphome/components/ssd1306_spi/display.py
@@ -13,7 +13,7 @@ SPISSD1306 = ssd1306_spi.class_('SPISSD1306', ssd1306_base.SSD1306, spi.SPIDevic
 CONFIG_SCHEMA = cv.All(ssd1306_base.SSD1306_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(SPISSD1306),
     cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
-}).extend(cv.COMPONENT_SCHEMA).extend(spi.SPI_DEVICE_SCHEMA),
+}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema()),
                        cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA))
 
 

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import spi, ssd1325_base
-from esphome.const import CONF_DC_PIN, CONF_ID, CONF_LAMBDA, CONF_PAGES
+from esphome.const import CONF_DC_PIN, CONF_ID, CONF_LAMBDA, CONF_PAGES, CONF_CS_PIN
 
 AUTO_LOAD = ['ssd1325_base']
 DEPENDENCIES = ['spi']
@@ -13,6 +13,7 @@ SPISSD1325 = ssd1325_spi.class_('SPISSD1325', ssd1325_base.SSD1325, spi.SPIDevic
 CONFIG_SCHEMA = cv.All(ssd1325_base.SSD1325_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(SPISSD1325),
     cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
+    cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
 }).extend(cv.COMPONENT_SCHEMA).extend(spi.SPI_DEVICE_SCHEMA),
                        cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA))
 

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import spi, ssd1325_base
-from esphome.const import CONF_DC_PIN, CONF_ID, CONF_LAMBDA, CONF_PAGES, CONF_CS_PIN
+from esphome.const import CONF_DC_PIN, CONF_ID, CONF_LAMBDA, CONF_PAGES
 
 AUTO_LOAD = ['ssd1325_base']
 DEPENDENCIES = ['spi']

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -13,8 +13,7 @@ SPISSD1325 = ssd1325_spi.class_('SPISSD1325', ssd1325_base.SSD1325, spi.SPIDevic
 CONFIG_SCHEMA = cv.All(ssd1325_base.SSD1325_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(SPISSD1325),
     cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
-    cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
-}).extend(cv.COMPONENT_SCHEMA).extend(spi.SPI_DEVICE_SCHEMA),
+}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema()),
                        cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA))
 
 

--- a/esphome/components/ssd1325_spi/ssd1325_spi.cpp
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.cpp
@@ -11,7 +11,8 @@ void SPISSD1325::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SPI SSD1325...");
   this->spi_setup();
   this->dc_pin_->setup();  // OUTPUT
-  this->cs_->setup();      // OUTPUT
+  if (this->cs_)
+    this->cs_->setup();  // OUTPUT
 
   this->init_reset_();
   delay(500);  // NOLINT
@@ -27,19 +28,24 @@ void SPISSD1325::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 void SPISSD1325::command(uint8_t value) {
-  this->cs_->digital_write(true);
+  if (this->cs_)
+    this->cs_->digital_write(true);
   this->dc_pin_->digital_write(false);
   delay(1);
   this->enable();
-  this->cs_->digital_write(false);
+  if (this->cs_)
+    this->cs_->digital_write(false);
   this->write_byte(value);
-  this->cs_->digital_write(true);
+  if (this->cs_)
+    this->cs_->digital_write(true);
   this->disable();
 }
 void HOT SPISSD1325::write_display_data() {
-  this->cs_->digital_write(true);
+  if (this->cs_)
+    this->cs_->digital_write(true);
   this->dc_pin_->digital_write(true);
-  this->cs_->digital_write(false);
+  if (this->cs_)
+    this->cs_->digital_write(false);
   delay(1);
   this->enable();
   for (uint16_t x = 0; x < this->get_width_internal(); x += 2) {
@@ -56,7 +62,8 @@ void HOT SPISSD1325::write_display_data() {
       }
     }
   }
-  this->cs_->digital_write(true);
+  if (this->cs_)
+    this->cs_->digital_write(true);
   this->disable();
 }
 

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -50,7 +50,7 @@ CONFIG_SCHEMA = cv.All(display.FULL_DISPLAY_SCHEMA.extend({
     cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
     cv.Optional(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
     cv.Optional(CONF_FULL_UPDATE_EVERY): cv.uint32_t,
-}).extend(cv.polling_component_schema('1s')).extend(spi.SPI_DEVICE_SCHEMA),
+}).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema()),
                        validate_full_update_every_only_type_a,
                        cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA))
 


### PR DESCRIPTION
## Description:
These changes make the `cs_pin` yaml entry optional for SPI peripherals.
The CS pin on the SPI peripheral can usually be tied to ground if there is only one peripheral on the SPI bus.

**Related issue (if applicable):** fixes esphome/issues#1071

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): esphome/esphome-docs#644

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Please note:
There are 3 peripherals that write to the cs pin (`this->cs_`):
  * ssd1325_spi
  * pn532
  * as3935_spi

The modifications address `ssd1325_spi`, which was locally tested with and without the CS pin configured, with it being wired to an ESP8266 pin and with it tied to ground. The `pn532` code only had one instance of writing to this pin and only setting it low. This was wrapped in an if statement to check if the cs_ pin was defined.

Lastly, the code for `as3935_spi` appears to require flogging the CS pin to indicate end of read. The CS pin is therefore required in the configuration for this component.
