### PR TITLE
First step to сustom networking implementations

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,6 +1,6 @@
 #include "api_connection.h"
 
-#include "../network/async_tcp.h"
+#include "esphome/components/network/async_tcp.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 #include "esphome/core/version.h"
@@ -17,13 +17,13 @@ namespace api {
 
 static const char *TAG = "api.connection";
 
-APIConnection::APIConnection(AsyncClient *client, APIServer *parent)
+APIConnection::APIConnection(network::AsyncClient *client, APIServer *parent)
     : client_(client), parent_(parent), initial_state_iterator_(parent, this), list_entities_iterator_(parent, this) {
-  this->client_->onError([](void *s, AsyncClient *c, int8_t error) { ((APIConnection *) s)->on_error_(error); }, this);
-  this->client_->onDisconnect([](void *s, AsyncClient *c) { ((APIConnection *) s)->on_disconnect_(); }, this);
-  this->client_->onTimeout([](void *s, AsyncClient *c, uint32_t time) { ((APIConnection *) s)->on_timeout_(time); },
+  this->client_->onError([](void *s, network::AsyncClient *c, int8_t error) { ((APIConnection *) s)->on_error_(error); }, this);
+  this->client_->onDisconnect([](void *s, network::AsyncClient *c) { ((APIConnection *) s)->on_disconnect_(); }, this);
+  this->client_->onTimeout([](void *s, network::AsyncClient *c, uint32_t time) { ((APIConnection *) s)->on_timeout_(time); },
                            this);
-  this->client_->onData([](void *s, AsyncClient *c, void *buf,
+  this->client_->onData([](void *s, network::AsyncClient *c, void *buf,
                            size_t len) { ((APIConnection *) s)->on_data_(reinterpret_cast<uint8_t *>(buf), len); },
                         this);
 

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,4 +1,6 @@
 #include "api_connection.h"
+
+#include "../network/async_tcp.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 #include "esphome/core/version.h"
@@ -79,6 +81,13 @@ void APIConnection::parse_recv_buffer_() {
     this->recv_buffer_.erase(this->recv_buffer_.begin(), this->recv_buffer_.begin() + total);
     this->last_traffic_ = millis();
   }
+}
+
+void APIConnection::set_nodelay(bool nodelay) {
+  if (nodelay == this->current_nodelay_)
+    return;
+  this->client_->setNoDelay(nodelay);
+  this->current_nodelay_ = nodelay;
 }
 
 void APIConnection::disconnect_client() {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -6,6 +6,10 @@
 #include "api_pb2_service.h"
 #include "api_server.h"
 
+namespace asynctcp {
+	class AsyncClient;
+}
+
 namespace esphome {
 namespace api {
 
@@ -138,12 +142,7 @@ class APIConnection : public APIServerConnection {
   void on_timeout_(uint32_t time);
   void on_data_(uint8_t *buf, size_t len);
   void parse_recv_buffer_();
-  void set_nodelay(bool nodelay) override {
-    if (nodelay == this->current_nodelay_)
-      return;
-    this->client_->setNoDelay(nodelay);
-    this->current_nodelay_ = nodelay;
-  }
+  void set_nodelay(bool nodelay) override;
 
   enum class ConnectionState {
     WAITING_FOR_HELLO,

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -6,16 +6,17 @@
 #include "api_pb2_service.h"
 #include "api_server.h"
 
-namespace asynctcp {
-	class AsyncClient;
+namespace esphome {
+
+namespace network {
+class AsyncClient;
 }
 
-namespace esphome {
 namespace api {
 
 class APIConnection : public APIServerConnection {
  public:
-  APIConnection(AsyncClient *client, APIServer *parent);
+  APIConnection(network::AsyncClient *client, APIServer *parent);
   virtual ~APIConnection();
 
   void disconnect_client();
@@ -167,7 +168,7 @@ class APIConnection : public APIServerConnection {
   bool service_call_subscription_{false};
   bool current_nodelay_{false};
   bool next_close_{false};
-  AsyncClient *client_;
+  network::AsyncClient *client_;
   APIServer *parent_;
   InitialStateIterator initial_state_iterator_;
   ListEntitiesIterator list_entities_iterator_;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -13,14 +13,13 @@
 
 #include <algorithm>
 
-asynctcp::AsyncServer *createAsyncServer(uint16_t port)
-{
-	// Here it would be possible to return any transport implementation.
-	return new esphome::network::AsyncTcpServerImpl(port);
-}
-
 namespace esphome {
 namespace api {
+
+network::AsyncServer *createAsyncServer(uint16_t port) {
+  // Here it would be possible to return any transport implementation.
+  return new esphome::network::AsyncTcpServerImpl(port);
+}
 
 static const char *TAG = "api";
 
@@ -32,7 +31,7 @@ void APIServer::setup() {
   this->server_->setNoDelay(false);
   this->server_->begin();
   this->server_->onClient(
-      [](void *s, asynctcp::AsyncClient *client) {
+      [](void *s, esphome::network::AsyncClient *client) {
         if (client == nullptr)
           return;
 

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -5,12 +5,19 @@
 #include "esphome/core/util.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/version.h"
+#include "esphome/components/network/async_tcp_server_impl.h"
 
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
 #endif
 
 #include <algorithm>
+
+asynctcp::AsyncServer *createAsyncServer(uint16_t port)
+{
+	// Here it would be possible to return any transport implementation.
+	return new esphome::network::AsyncTcpServerImpl(port);
+}
 
 namespace esphome {
 namespace api {
@@ -21,11 +28,11 @@ static const char *TAG = "api";
 void APIServer::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Home Assistant API server...");
   this->setup_controller();
-  this->server_ = AsyncServer(this->port_);
-  this->server_.setNoDelay(false);
-  this->server_.begin();
-  this->server_.onClient(
-      [](void *s, AsyncClient *client) {
+  this->server_.reset(createAsyncServer(this->port_));
+  this->server_->setNoDelay(false);
+  this->server_->begin();
+  this->server_->onClient(
+      [](void *s, asynctcp::AsyncClient *client) {
         if (client == nullptr)
           return;
 

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -12,15 +12,14 @@
 #include "homeassistant_service.h"
 #include "user_services.h"
 
-namespace asynctcp {
-	class AsyncServer;
-	class AsyncClient;
-}
-
 namespace esphome {
-namespace api {
 
-using namespace asynctcp;
+namespace network {
+class AsyncServer;
+class AsyncClient;
+}  // namespace network
+
+namespace api {
 
 class APIServer : public Component, public Controller {
  public:
@@ -79,7 +78,7 @@ class APIServer : public Component, public Controller {
   const std::vector<UserServiceDescriptor *> &get_user_services() const { return this->user_services_; }
 
  protected:
-  std::unique_ptr<AsyncServer> server_;
+  std::unique_ptr<network::AsyncServer> server_;
   uint16_t port_{6053};
   uint32_t reboot_timeout_{300000};
   uint32_t last_connected_{0};

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -12,15 +12,15 @@
 #include "homeassistant_service.h"
 #include "user_services.h"
 
-#ifdef ARDUINO_ARCH_ESP32
-#include <AsyncTCP.h>
-#endif
-#ifdef ARDUINO_ARCH_ESP8266
-#include <ESPAsyncTCP.h>
-#endif
+namespace asynctcp {
+	class AsyncServer;
+	class AsyncClient;
+}
 
 namespace esphome {
 namespace api {
+
+using namespace asynctcp;
 
 class APIServer : public Component, public Controller {
  public:
@@ -79,7 +79,7 @@ class APIServer : public Component, public Controller {
   const std::vector<UserServiceDescriptor *> &get_user_services() const { return this->user_services_; }
 
  protected:
-  AsyncServer server_{0};
+  std::unique_ptr<AsyncServer> server_;
   uint16_t port_{6053};
   uint32_t reboot_timeout_{300000};
   uint32_t last_connected_{0};

--- a/esphome/components/network/async_tcp.cpp
+++ b/esphome/components/network/async_tcp.cpp
@@ -1,0 +1,19 @@
+/*
+ * async_tcp.cpp
+ *
+ * Async Not Only TCP
+ *
+ *  Created on: Mar 5, 2020
+ *      Author: Oleksandr Omelchuk
+ */
+
+#include "async_tcp.h"
+
+
+namespace asynctcp {
+
+AsyncClient::AsyncClient() {}
+
+AsyncClient::~AsyncClient() {};
+
+} // namespace asynctcp

--- a/esphome/components/network/async_tcp.cpp
+++ b/esphome/components/network/async_tcp.cpp
@@ -9,11 +9,12 @@
 
 #include "async_tcp.h"
 
-
-namespace asynctcp {
+namespace esphome {
+namespace network {
 
 AsyncClient::AsyncClient() {}
 
-AsyncClient::~AsyncClient() {};
+AsyncClient::~AsyncClient(){};
 
-} // namespace asynctcp
+} /* namespace network */
+} /* namespace esphome */

--- a/esphome/components/network/async_tcp.h
+++ b/esphome/components/network/async_tcp.h
@@ -12,80 +12,80 @@
 #include "IPAddress.h"
 #include <functional>
 
-struct pbuf; // packet bufers from LwIp
+struct pbuf;  // packet bufers from LwIp
 
-namespace asynctcp {
+namespace esphome {
+namespace network {
 
 class AsyncClient;
 
 typedef std::function<void(void*, AsyncClient*)> AcConnectHandler;
 typedef std::function<void(void*, AsyncClient*, size_t len, uint32_t time)> AcAckHandler;
 typedef std::function<void(void*, AsyncClient*, int8_t error)> AcErrorHandler;
-typedef std::function<void(void*, AsyncClient*, void *data, size_t len)> AcDataHandler;
-typedef std::function<void(void*, AsyncClient*, pbuf *pb)> AcPacketHandler;
+typedef std::function<void(void*, AsyncClient*, void* data, size_t len)> AcDataHandler;
+typedef std::function<void(void*, AsyncClient*, pbuf* pb)> AcPacketHandler;
 typedef std::function<void(void*, AsyncClient*, uint32_t time)> AcTimeoutHandler;
 
 /**
  * Interface for dealing with network connections
  */
 class AsyncClient {
-  public:
-    AsyncClient();
-    virtual ~AsyncClient();
+ public:
+  AsyncClient();
+  virtual ~AsyncClient();
 
-    virtual bool connect(const char* host, uint16_t port) = 0;
-    virtual void close(bool now = false) = 0;
-    virtual void stop() = 0;
-    virtual int8_t abort() = 0;
-    virtual bool free() = 0;
+  virtual bool connect(const char* host, uint16_t port) = 0;
+  virtual void close(bool now = false) = 0;
+  virtual void stop() = 0;
+  virtual int8_t abort() = 0;
+  virtual bool free() = 0;
 
+  virtual bool canSend() const = 0;
+  virtual size_t space() const = 0;                       // space available in the TCP window
+  virtual size_t add(const char* data, size_t size) = 0;  // add for sending
+  virtual bool send() = 0;                                // send all data added with the method above
 
-    virtual bool canSend() const = 0;
-    virtual size_t space()const  = 0;                     //space available in the TCP window
-    virtual size_t add(const char* data, size_t size) = 0;//add for sending
-    virtual bool send() = 0;                              //send all data added with the method above
+  virtual size_t write(const char* data) = 0;
+  virtual size_t write(const char* data, size_t size) = 0;  // only when canSend() == true
 
-    virtual size_t write(const char* data) = 0;
-    virtual size_t write(const char* data, size_t size) = 0; //only when canSend() == true
+  virtual bool connecting() const = 0;
+  virtual bool connected() const = 0;
+  virtual bool disconnecting() const = 0;
+  virtual bool disconnected() const = 0;
+  virtual bool freeable() const = 0;  // disconnected or disconnecting
 
-    virtual bool connecting() const = 0;
-    virtual bool connected() const = 0;
-    virtual bool disconnecting() const = 0;
-    virtual bool disconnected() const = 0;
-    virtual bool freeable() const = 0; //disconnected or disconnecting
+  virtual void setNoDelay(bool nodelay) = 0;
+  virtual bool getNoDelay() const = 0;
 
-    virtual void setNoDelay(bool nodelay) = 0;
-    virtual bool getNoDelay() const = 0;
+  virtual IPAddress remoteIP() = 0;
 
-    virtual IPAddress remoteIP() = 0;
+  // Set Callbacks
+  virtual void onConnect(AcConnectHandler cb, void* arg) = 0;     // on successful connect
+  virtual void onDisconnect(AcConnectHandler cb, void* arg) = 0;  // disconnected
+  virtual void onAck(AcAckHandler cb, void* arg) = 0;             // ack received
+  virtual void onError(AcErrorHandler cb, void* arg) = 0;         // unsuccessful connect or error
+  virtual void onData(AcDataHandler cb, void* arg) = 0;           // data received (called if onPacket is not used)
+  virtual void onPacket(AcPacketHandler cb, void* arg) = 0;       // data received
+  virtual void onTimeout(AcTimeoutHandler cb, void* arg) = 0;     // ack timeout
+  virtual void onPoll(AcConnectHandler cb, void* arg) = 0;        // every 125ms when connected
 
-    // Set Callbacks
-	virtual void onConnect(asynctcp::AcConnectHandler cb, void* arg) = 0;     //on successful connect
-	virtual void onDisconnect(asynctcp::AcConnectHandler cb, void* arg) = 0;  //disconnected
-	virtual void onAck(asynctcp::AcAckHandler cb, void* arg) = 0;             //ack received
-	virtual void onError(asynctcp::AcErrorHandler cb, void* arg) = 0;         //unsuccessful connect or error
-	virtual void onData(asynctcp::AcDataHandler cb, void* arg) = 0;           //data received (called if onPacket is not used)
-	virtual void onPacket(asynctcp::AcPacketHandler cb, void* arg) = 0;       //data received
-	virtual void onTimeout(asynctcp::AcTimeoutHandler cb, void* arg) = 0;     //ack timeout
-	virtual void onPoll(asynctcp::AcConnectHandler cb, void* arg) = 0;        //every 125ms when connected
-
-  protected:
-    AsyncClient(const AsyncClient &other) {};
-
+ protected:
+  AsyncClient(const AsyncClient& other){};
 };
 
 /**
  * Interface for network server
  */
 class AsyncServer {
-  public:
-    virtual ~AsyncServer() {};
+ public:
+  virtual ~AsyncServer(){};
 
-    virtual void onClient(AcConnectHandler cb, void* arg) = 0;
-    virtual void begin() = 0;
-    virtual void end() = 0;
-    virtual void setNoDelay(bool nodelay) = 0;
-    virtual bool getNoDelay() const = 0;
+  virtual void onClient(AcConnectHandler cb, void* arg) = 0;
+  virtual void begin() = 0;
+  virtual void end() = 0;
+  virtual void setNoDelay(bool nodelay) = 0;
+  virtual bool getNoDelay() const = 0;
 };
 
-} // namespace asynctcp
+} /* namespace network */
+} /* namespace esphome */

--- a/esphome/components/network/async_tcp.h
+++ b/esphome/components/network/async_tcp.h
@@ -1,0 +1,91 @@
+/*
+ * async_tcp.h
+ *
+ * Async Not Only TCP
+ *
+ *  Created on: Mar 5, 2020
+ *      Author: Oleksandr Omelchuk
+ */
+
+#pragma once
+
+#include "IPAddress.h"
+#include <functional>
+
+struct pbuf; // packet bufers from LwIp
+
+namespace asynctcp {
+
+class AsyncClient;
+
+typedef std::function<void(void*, AsyncClient*)> AcConnectHandler;
+typedef std::function<void(void*, AsyncClient*, size_t len, uint32_t time)> AcAckHandler;
+typedef std::function<void(void*, AsyncClient*, int8_t error)> AcErrorHandler;
+typedef std::function<void(void*, AsyncClient*, void *data, size_t len)> AcDataHandler;
+typedef std::function<void(void*, AsyncClient*, pbuf *pb)> AcPacketHandler;
+typedef std::function<void(void*, AsyncClient*, uint32_t time)> AcTimeoutHandler;
+
+/**
+ * Interface for dealing with network connections
+ */
+class AsyncClient {
+  public:
+    AsyncClient();
+    virtual ~AsyncClient();
+
+    virtual bool connect(const char* host, uint16_t port) = 0;
+    virtual void close(bool now = false) = 0;
+    virtual void stop() = 0;
+    virtual int8_t abort() = 0;
+    virtual bool free() = 0;
+
+
+    virtual bool canSend() const = 0;
+    virtual size_t space()const  = 0;                     //space available in the TCP window
+    virtual size_t add(const char* data, size_t size) = 0;//add for sending
+    virtual bool send() = 0;                              //send all data added with the method above
+
+    virtual size_t write(const char* data) = 0;
+    virtual size_t write(const char* data, size_t size) = 0; //only when canSend() == true
+
+    virtual bool connecting() const = 0;
+    virtual bool connected() const = 0;
+    virtual bool disconnecting() const = 0;
+    virtual bool disconnected() const = 0;
+    virtual bool freeable() const = 0; //disconnected or disconnecting
+
+    virtual void setNoDelay(bool nodelay) = 0;
+    virtual bool getNoDelay() const = 0;
+
+    virtual IPAddress remoteIP() = 0;
+
+    // Set Callbacks
+	virtual void onConnect(asynctcp::AcConnectHandler cb, void* arg) = 0;     //on successful connect
+	virtual void onDisconnect(asynctcp::AcConnectHandler cb, void* arg) = 0;  //disconnected
+	virtual void onAck(asynctcp::AcAckHandler cb, void* arg) = 0;             //ack received
+	virtual void onError(asynctcp::AcErrorHandler cb, void* arg) = 0;         //unsuccessful connect or error
+	virtual void onData(asynctcp::AcDataHandler cb, void* arg) = 0;           //data received (called if onPacket is not used)
+	virtual void onPacket(asynctcp::AcPacketHandler cb, void* arg) = 0;       //data received
+	virtual void onTimeout(asynctcp::AcTimeoutHandler cb, void* arg) = 0;     //ack timeout
+	virtual void onPoll(asynctcp::AcConnectHandler cb, void* arg) = 0;        //every 125ms when connected
+
+  protected:
+    AsyncClient(const AsyncClient &other) {};
+
+};
+
+/**
+ * Interface for network server
+ */
+class AsyncServer {
+  public:
+    virtual ~AsyncServer() {};
+
+    virtual void onClient(AcConnectHandler cb, void* arg) = 0;
+    virtual void begin() = 0;
+    virtual void end() = 0;
+    virtual void setNoDelay(bool nodelay) = 0;
+    virtual bool getNoDelay() const = 0;
+};
+
+} // namespace asynctcp

--- a/esphome/components/network/async_tcp_client_impl.cpp
+++ b/esphome/components/network/async_tcp_client_impl.cpp
@@ -5,7 +5,6 @@
  *      Author: Oleksandr Omelchuk
  */
 
-
 #include "async_tcp_client_impl.h"
 #include "esphome/core/log.h"
 #ifdef ARDUINO_ARCH_ESP32
@@ -18,144 +17,82 @@
 namespace esphome {
 namespace network {
 
-AsyncTcpClientImpl::AsyncTcpClientImpl(::AsyncClient *wrapped)
-	: AsyncClient()
-	, impl_(wrapped)
-{
-}
+AsyncTcpClientImpl::AsyncTcpClientImpl(::AsyncClient* wrapped) : AsyncClient(), impl_(wrapped) {}
 
+AsyncTcpClientImpl::~AsyncTcpClientImpl() {}
 
-AsyncTcpClientImpl::~AsyncTcpClientImpl() {
+bool AsyncTcpClientImpl::connect(const char* host, uint16_t port) { return impl_->connect(host, port); }
 
-}
+void AsyncTcpClientImpl::close(bool now) { impl_->close(now); }
 
-bool AsyncTcpClientImpl::connect(const char* host, uint16_t port) {
-	return impl_->connect(host, port);
-}
+void AsyncTcpClientImpl::stop() { impl_->stop(); }
 
-void AsyncTcpClientImpl::close(bool now) {
-	impl_->close(now);
-}
+int8_t AsyncTcpClientImpl::abort() { return abort(); }
 
-void AsyncTcpClientImpl::stop() {
-	impl_->stop();
-}
+bool AsyncTcpClientImpl::free() { return impl_->free(); }
 
-int8_t AsyncTcpClientImpl::abort() {
-	return abort();
-}
+bool AsyncTcpClientImpl::canSend() const { return impl_->canSend(); }
 
-bool AsyncTcpClientImpl::free() {
-	return impl_->free();
-}
+size_t AsyncTcpClientImpl::space() const { return impl_->space(); }
 
-bool AsyncTcpClientImpl::canSend() const {
-	return impl_->canSend();
-}
+size_t AsyncTcpClientImpl::add(const char* data, size_t size) { return impl_->add(data, size); }
 
-size_t AsyncTcpClientImpl::space()const  {
-	return impl_->space();
-}
+bool AsyncTcpClientImpl::send() { return impl_->send(); }
 
-size_t AsyncTcpClientImpl::add(const char* data, size_t size) {
-	return impl_->add(data, size);
-}
+size_t AsyncTcpClientImpl::write(const char* data) { return impl_->write(data); }
 
-bool AsyncTcpClientImpl::send() {
-	return impl_->send();
-}
+size_t AsyncTcpClientImpl::write(const char* data, size_t size) { return impl_->write(data, size); }
 
-size_t AsyncTcpClientImpl::write(const char* data) {
-	return impl_->write(data);
-}
+bool AsyncTcpClientImpl::connecting() const { return impl_->connecting(); }
 
-size_t AsyncTcpClientImpl::write(const char* data, size_t size) {
-	return impl_->write(data, size);
-}
+bool AsyncTcpClientImpl::connected() const { return impl_->connected(); }
 
-bool AsyncTcpClientImpl::connecting() const {
-	return impl_->connecting();
-}
+bool AsyncTcpClientImpl::disconnecting() const { return impl_->disconnecting(); }
 
-bool AsyncTcpClientImpl::connected() const {
-	return impl_->connected();
-}
+bool AsyncTcpClientImpl::disconnected() const { return impl_->disconnected(); }
 
-bool AsyncTcpClientImpl::disconnecting() const {
-	return impl_->disconnecting();
-}
+bool AsyncTcpClientImpl::freeable() const { return impl_->freeable(); }
+// disconnected or disconnecting
 
-bool AsyncTcpClientImpl::disconnected() const {
-	return impl_->disconnected();
-}
+void AsyncTcpClientImpl::setNoDelay(bool nodelay) { impl_->setNoDelay(nodelay); }
 
-bool AsyncTcpClientImpl::freeable() const {
-	return impl_->freeable();
-}
-//disconnected or disconnecting
+bool AsyncTcpClientImpl::getNoDelay() const { return getNoDelay(); }
 
-void AsyncTcpClientImpl::setNoDelay(bool nodelay) {
-	impl_->setNoDelay(nodelay);
-}
-
-bool AsyncTcpClientImpl::getNoDelay() const {
-	return getNoDelay();
-}
-
-
-IPAddress AsyncTcpClientImpl::remoteIP()
-{
-	return impl_->remoteIP();
-}
+IPAddress AsyncTcpClientImpl::remoteIP() { return impl_->remoteIP(); }
 
 // Set Callbacks
 
-void AsyncTcpClientImpl::onConnect(asynctcp::AcConnectHandler cb, void* arg) {
-	impl_->onConnect([cb, this](void* arg, ::AsyncClient*client){
-		cb(arg, this);
-	}, arg);
+void AsyncTcpClientImpl::onConnect(AcConnectHandler cb, void* arg) {
+  impl_->onConnect([cb, this](void* arg, ::AsyncClient* client) { cb(arg, this); }, arg);
 }
 
-void AsyncTcpClientImpl::onDisconnect(asynctcp::AcConnectHandler cb, void* arg) {
-	impl_->onDisconnect([cb, this](void* arg, ::AsyncClient*client){
-		cb(arg, this);
-	}, arg);
+void AsyncTcpClientImpl::onDisconnect(AcConnectHandler cb, void* arg) {
+  impl_->onDisconnect([cb, this](void* arg, ::AsyncClient* client) { cb(arg, this); }, arg);
 }
 
-void AsyncTcpClientImpl::onAck(asynctcp::AcAckHandler cb, void* arg) {
-	impl_->onAck([cb, this](void *arg, ::AsyncClient*cli, size_t len, uint32_t time){
-		cb(arg, this, len, time);
-	}, arg);
+void AsyncTcpClientImpl::onAck(AcAckHandler cb, void* arg) {
+  impl_->onAck([cb, this](void* arg, ::AsyncClient* cli, size_t len, uint32_t time) { cb(arg, this, len, time); }, arg);
 }
 
-void AsyncTcpClientImpl::onError(asynctcp::AcErrorHandler cb, void* arg) {
-	impl_->onError([cb, this](void* arg, ::AsyncClient*client, int8_t error){
-		cb(arg, this, error);
-	}, arg);
+void AsyncTcpClientImpl::onError(AcErrorHandler cb, void* arg) {
+  impl_->onError([cb, this](void* arg, ::AsyncClient* client, int8_t error) { cb(arg, this, error); }, arg);
 }
 
-void AsyncTcpClientImpl::onData(asynctcp::AcDataHandler cb, void* arg) {
-	impl_->onData([cb, this](void* arg, ::AsyncClient*client, void *data, size_t len){
-		cb(arg, this, data, len);
-	}, arg);
+void AsyncTcpClientImpl::onData(AcDataHandler cb, void* arg) {
+  impl_->onData([cb, this](void* arg, ::AsyncClient* client, void* data, size_t len) { cb(arg, this, data, len); },
+                arg);
 }
 
-void AsyncTcpClientImpl::onPacket(asynctcp::AcPacketHandler cb, void* arg) {
-	impl_->onPacket([cb, this](void* arg, ::AsyncClient*client, struct pbuf *pb){
-		cb(arg, this, pb);
-	}, arg);
+void AsyncTcpClientImpl::onPacket(AcPacketHandler cb, void* arg) {
+  impl_->onPacket([cb, this](void* arg, ::AsyncClient* client, struct pbuf* pb) { cb(arg, this, pb); }, arg);
 }
 
-void AsyncTcpClientImpl::onTimeout(asynctcp::AcTimeoutHandler cb, void* arg) {
-	impl_->onTimeout([cb, this](void* arg, ::AsyncClient*client, uint32_t time){
-		cb(arg, this, time);
-	}, arg);
+void AsyncTcpClientImpl::onTimeout(AcTimeoutHandler cb, void* arg) {
+  impl_->onTimeout([cb, this](void* arg, ::AsyncClient* client, uint32_t time) { cb(arg, this, time); }, arg);
 }
 
-void AsyncTcpClientImpl::onPoll(asynctcp::AcConnectHandler cb, void* arg) {
-	impl_->onPoll([cb, this](void* arg, ::AsyncClient*client){
-		cb(arg, this);
-	}, arg);
+void AsyncTcpClientImpl::onPoll(AcConnectHandler cb, void* arg) {
+  impl_->onPoll([cb, this](void* arg, ::AsyncClient* client) { cb(arg, this); }, arg);
 }
 
 } /* namespace network */

--- a/esphome/components/network/async_tcp_client_impl.cpp
+++ b/esphome/components/network/async_tcp_client_impl.cpp
@@ -1,0 +1,162 @@
+/*
+ * async_tcp_client_impl.cpp
+ *
+ *  Created on: Mar 5, 2020
+ *      Author: Oleksandr Omelchuk
+ */
+
+
+#include "async_tcp_client_impl.h"
+#include "esphome/core/log.h"
+#ifdef ARDUINO_ARCH_ESP32
+#include <AsyncTCP.h>
+#endif
+#ifdef ARDUINO_ARCH_ESP8266
+#include <ESPAsyncTCP.h>
+#endif
+
+namespace esphome {
+namespace network {
+
+AsyncTcpClientImpl::AsyncTcpClientImpl(::AsyncClient *wrapped)
+	: AsyncClient()
+	, impl_(wrapped)
+{
+}
+
+
+AsyncTcpClientImpl::~AsyncTcpClientImpl() {
+
+}
+
+bool AsyncTcpClientImpl::connect(const char* host, uint16_t port) {
+	return impl_->connect(host, port);
+}
+
+void AsyncTcpClientImpl::close(bool now) {
+	impl_->close(now);
+}
+
+void AsyncTcpClientImpl::stop() {
+	impl_->stop();
+}
+
+int8_t AsyncTcpClientImpl::abort() {
+	return abort();
+}
+
+bool AsyncTcpClientImpl::free() {
+	return impl_->free();
+}
+
+bool AsyncTcpClientImpl::canSend() const {
+	return impl_->canSend();
+}
+
+size_t AsyncTcpClientImpl::space()const  {
+	return impl_->space();
+}
+
+size_t AsyncTcpClientImpl::add(const char* data, size_t size) {
+	return impl_->add(data, size);
+}
+
+bool AsyncTcpClientImpl::send() {
+	return impl_->send();
+}
+
+size_t AsyncTcpClientImpl::write(const char* data) {
+	return impl_->write(data);
+}
+
+size_t AsyncTcpClientImpl::write(const char* data, size_t size) {
+	return impl_->write(data, size);
+}
+
+bool AsyncTcpClientImpl::connecting() const {
+	return impl_->connecting();
+}
+
+bool AsyncTcpClientImpl::connected() const {
+	return impl_->connected();
+}
+
+bool AsyncTcpClientImpl::disconnecting() const {
+	return impl_->disconnecting();
+}
+
+bool AsyncTcpClientImpl::disconnected() const {
+	return impl_->disconnected();
+}
+
+bool AsyncTcpClientImpl::freeable() const {
+	return impl_->freeable();
+}
+//disconnected or disconnecting
+
+void AsyncTcpClientImpl::setNoDelay(bool nodelay) {
+	impl_->setNoDelay(nodelay);
+}
+
+bool AsyncTcpClientImpl::getNoDelay() const {
+	return getNoDelay();
+}
+
+
+IPAddress AsyncTcpClientImpl::remoteIP()
+{
+	return impl_->remoteIP();
+}
+
+// Set Callbacks
+
+void AsyncTcpClientImpl::onConnect(asynctcp::AcConnectHandler cb, void* arg) {
+	impl_->onConnect([cb, this](void* arg, ::AsyncClient*client){
+		cb(arg, this);
+	}, arg);
+}
+
+void AsyncTcpClientImpl::onDisconnect(asynctcp::AcConnectHandler cb, void* arg) {
+	impl_->onDisconnect([cb, this](void* arg, ::AsyncClient*client){
+		cb(arg, this);
+	}, arg);
+}
+
+void AsyncTcpClientImpl::onAck(asynctcp::AcAckHandler cb, void* arg) {
+	impl_->onAck([cb, this](void *arg, ::AsyncClient*cli, size_t len, uint32_t time){
+		cb(arg, this, len, time);
+	}, arg);
+}
+
+void AsyncTcpClientImpl::onError(asynctcp::AcErrorHandler cb, void* arg) {
+	impl_->onError([cb, this](void* arg, ::AsyncClient*client, int8_t error){
+		cb(arg, this, error);
+	}, arg);
+}
+
+void AsyncTcpClientImpl::onData(asynctcp::AcDataHandler cb, void* arg) {
+	impl_->onData([cb, this](void* arg, ::AsyncClient*client, void *data, size_t len){
+		cb(arg, this, data, len);
+	}, arg);
+}
+
+void AsyncTcpClientImpl::onPacket(asynctcp::AcPacketHandler cb, void* arg) {
+	impl_->onPacket([cb, this](void* arg, ::AsyncClient*client, struct pbuf *pb){
+		cb(arg, this, pb);
+	}, arg);
+}
+
+void AsyncTcpClientImpl::onTimeout(asynctcp::AcTimeoutHandler cb, void* arg) {
+	impl_->onTimeout([cb, this](void* arg, ::AsyncClient*client, uint32_t time){
+		cb(arg, this, time);
+	}, arg);
+}
+
+void AsyncTcpClientImpl::onPoll(asynctcp::AcConnectHandler cb, void* arg) {
+	impl_->onPoll([cb, this](void* arg, ::AsyncClient*client){
+		cb(arg, this);
+	}, arg);
+}
+
+} /* namespace network */
+} /* namespace esphome */

--- a/esphome/components/network/async_tcp_client_impl.h
+++ b/esphome/components/network/async_tcp_client_impl.h
@@ -1,0 +1,66 @@
+/*
+ * async_tcp_client_impl.h
+ *
+ *  Created on: Mar 5, 2020
+ *      Author: Oleksandr Omelchuk
+ */
+
+#pragma once
+
+#include <memory>
+#include "async_tcp.h"
+
+class AsyncClient;
+
+namespace esphome {
+namespace network {
+
+
+class AsyncTcpClientImpl: public asynctcp::AsyncClient {
+public:
+	AsyncTcpClientImpl(::AsyncClient *wrapped);
+	virtual ~AsyncTcpClientImpl();
+
+	virtual bool connect(const char* host, uint16_t port) override;
+	virtual void close(bool now = false) override;
+	virtual void stop() override;
+	virtual int8_t abort() override;
+	virtual bool free() override;
+
+
+	virtual bool canSend() const override;
+	virtual size_t space()const  override; //space available in the TCP window
+	virtual size_t add(const char* data, size_t size) override;//add for sending
+	virtual bool send() override;//send all data added with the method above
+
+	virtual size_t write(const char* data) override;
+	virtual size_t write(const char* data, size_t size) override; //only when canSend() == true
+
+	virtual bool connecting() const override;
+	virtual bool connected() const override;
+	virtual bool disconnecting() const override;
+	virtual bool disconnected() const override;
+	virtual bool freeable() const override;//disconnected or disconnecting
+
+	virtual void setNoDelay(bool nodelay) override;
+	virtual bool getNoDelay() const override;
+
+	virtual IPAddress remoteIP();
+
+	// Set Callbacks
+	virtual void onConnect(asynctcp::AcConnectHandler cb, void* arg) override;     //on successful connect
+	virtual void onDisconnect(asynctcp::AcConnectHandler cb, void* arg) override;  //disconnected
+	virtual void onAck(asynctcp::AcAckHandler cb, void* arg) override;             //ack received
+	virtual void onError(asynctcp::AcErrorHandler cb, void* arg) override;         //unsuccessful connect or error
+	virtual void onData(asynctcp::AcDataHandler cb, void* arg) override;           //data received (called if onPacket is not used)
+	virtual void onPacket(asynctcp::AcPacketHandler cb, void* arg) override;       //data received
+	virtual void onTimeout(asynctcp::AcTimeoutHandler cb, void* arg) override;     //ack timeout
+	virtual void onPoll(asynctcp::AcConnectHandler cb, void* arg) override;        //every 125ms when connected
+
+private:
+	std::unique_ptr<::AsyncClient> impl_;
+};
+
+} /* namespace network */
+} /* namespace esphome */
+

--- a/esphome/components/network/async_tcp_client_impl.h
+++ b/esphome/components/network/async_tcp_client_impl.h
@@ -15,52 +15,50 @@ class AsyncClient;
 namespace esphome {
 namespace network {
 
+class AsyncTcpClientImpl : public AsyncClient {
+ public:
+  AsyncTcpClientImpl(::AsyncClient* wrapped);
+  virtual ~AsyncTcpClientImpl();
 
-class AsyncTcpClientImpl: public asynctcp::AsyncClient {
-public:
-	AsyncTcpClientImpl(::AsyncClient *wrapped);
-	virtual ~AsyncTcpClientImpl();
+  virtual bool connect(const char* host, uint16_t port) override;
+  virtual void close(bool now = false) override;
+  virtual void stop() override;
+  virtual int8_t abort() override;
+  virtual bool free() override;
 
-	virtual bool connect(const char* host, uint16_t port) override;
-	virtual void close(bool now = false) override;
-	virtual void stop() override;
-	virtual int8_t abort() override;
-	virtual bool free() override;
+  virtual bool canSend() const override;
+  virtual size_t space() const override;                       // space available in the TCP window
+  virtual size_t add(const char* data, size_t size) override;  // add for sending
+  virtual bool send() override;                                // send all data added with the method above
 
+  virtual size_t write(const char* data) override;
+  virtual size_t write(const char* data, size_t size) override;  // only when canSend() == true
 
-	virtual bool canSend() const override;
-	virtual size_t space()const  override; //space available in the TCP window
-	virtual size_t add(const char* data, size_t size) override;//add for sending
-	virtual bool send() override;//send all data added with the method above
+  virtual bool connecting() const override;
+  virtual bool connected() const override;
+  virtual bool disconnecting() const override;
+  virtual bool disconnected() const override;
+  virtual bool freeable() const override;  // disconnected or disconnecting
 
-	virtual size_t write(const char* data) override;
-	virtual size_t write(const char* data, size_t size) override; //only when canSend() == true
+  virtual void setNoDelay(bool nodelay) override;
+  virtual bool getNoDelay() const override;
 
-	virtual bool connecting() const override;
-	virtual bool connected() const override;
-	virtual bool disconnecting() const override;
-	virtual bool disconnected() const override;
-	virtual bool freeable() const override;//disconnected or disconnecting
+  virtual IPAddress remoteIP();
 
-	virtual void setNoDelay(bool nodelay) override;
-	virtual bool getNoDelay() const override;
+  // Set Callbacks
+  virtual void onConnect(AcConnectHandler cb, void* arg) override;     // on successful connect
+  virtual void onDisconnect(AcConnectHandler cb, void* arg) override;  // disconnected
+  virtual void onAck(AcAckHandler cb, void* arg) override;             // ack received
+  virtual void onError(AcErrorHandler cb, void* arg) override;         // unsuccessful connect or error
+  virtual void onData(AcDataHandler cb, void* arg) override;           // data received (called if onPacket is not
+                                                                       // used)
+  virtual void onPacket(AcPacketHandler cb, void* arg) override;       // data received
+  virtual void onTimeout(AcTimeoutHandler cb, void* arg) override;     // ack timeout
+  virtual void onPoll(AcConnectHandler cb, void* arg) override;        // every 125ms when connected
 
-	virtual IPAddress remoteIP();
-
-	// Set Callbacks
-	virtual void onConnect(asynctcp::AcConnectHandler cb, void* arg) override;     //on successful connect
-	virtual void onDisconnect(asynctcp::AcConnectHandler cb, void* arg) override;  //disconnected
-	virtual void onAck(asynctcp::AcAckHandler cb, void* arg) override;             //ack received
-	virtual void onError(asynctcp::AcErrorHandler cb, void* arg) override;         //unsuccessful connect or error
-	virtual void onData(asynctcp::AcDataHandler cb, void* arg) override;           //data received (called if onPacket is not used)
-	virtual void onPacket(asynctcp::AcPacketHandler cb, void* arg) override;       //data received
-	virtual void onTimeout(asynctcp::AcTimeoutHandler cb, void* arg) override;     //ack timeout
-	virtual void onPoll(asynctcp::AcConnectHandler cb, void* arg) override;        //every 125ms when connected
-
-private:
-	std::unique_ptr<::AsyncClient> impl_;
+ private:
+  std::unique_ptr<::AsyncClient> impl_;
 };
 
 } /* namespace network */
 } /* namespace esphome */
-

--- a/esphome/components/network/async_tcp_server_impl.cpp
+++ b/esphome/components/network/async_tcp_server_impl.cpp
@@ -18,38 +18,26 @@
 namespace esphome {
 namespace network {
 
-AsyncTcpServerImpl::AsyncTcpServerImpl(uint16_t port)
-	:impl_(new ::AsyncServer(port))
-{
+AsyncTcpServerImpl::AsyncTcpServerImpl(uint16_t port) : impl_(new ::AsyncServer(port)) {}
 
+AsyncTcpServerImpl::~AsyncTcpServerImpl() { impl_->end(); }
+
+void AsyncTcpServerImpl::onClient(AcConnectHandler cb, void* arg) {
+  impl_->onClient(
+      [cb](void* arg, ::AsyncClient* connection) {
+        AsyncTcpClientImpl* client_wrapper = new AsyncTcpClientImpl(connection);
+        cb(arg, client_wrapper);
+      },
+      arg);
 }
 
-AsyncTcpServerImpl::~AsyncTcpServerImpl() {
-	impl_->end();
-}
+void AsyncTcpServerImpl::begin() { impl_->begin(); }
 
-void AsyncTcpServerImpl::onClient(asynctcp::AcConnectHandler cb, void* arg) {
-	impl_->onClient([cb](void* arg, ::AsyncClient *connection) {
-		AsyncTcpClientImpl *client_wrapper = new AsyncTcpClientImpl(connection);
-		cb(arg, client_wrapper);
-	}, arg);
-}
+void AsyncTcpServerImpl::end() { impl_->end(); }
 
-void AsyncTcpServerImpl::begin() {
-	impl_->begin();
-}
+void AsyncTcpServerImpl::setNoDelay(bool nodelay) { impl_->setNoDelay(nodelay); }
 
-void AsyncTcpServerImpl::end() {
-	impl_->end();
-}
-
-void AsyncTcpServerImpl::setNoDelay(bool nodelay) {
-	impl_->setNoDelay(nodelay);
-}
-
-bool AsyncTcpServerImpl::getNoDelay() const {
-	return impl_->getNoDelay();
-}
+bool AsyncTcpServerImpl::getNoDelay() const { return impl_->getNoDelay(); }
 
 } /* namespace network */
 } /* namespace esphome */

--- a/esphome/components/network/async_tcp_server_impl.cpp
+++ b/esphome/components/network/async_tcp_server_impl.cpp
@@ -1,0 +1,55 @@
+/*
+ * async_tcp_server_impl.cpp
+ *
+ *  Created on: Mar 5, 2020
+ *      Author: Oleksandr Omelchuk
+ */
+
+#include "async_tcp_server_impl.h"
+#include "async_tcp_client_impl.h"
+#include "esphome/core/log.h"
+#ifdef ARDUINO_ARCH_ESP32
+#include <AsyncTCP.h>
+#endif
+#ifdef ARDUINO_ARCH_ESP8266
+#include <ESPAsyncTCP.h>
+#endif
+
+namespace esphome {
+namespace network {
+
+AsyncTcpServerImpl::AsyncTcpServerImpl(uint16_t port)
+	:impl_(new ::AsyncServer(port))
+{
+
+}
+
+AsyncTcpServerImpl::~AsyncTcpServerImpl() {
+	impl_->end();
+}
+
+void AsyncTcpServerImpl::onClient(asynctcp::AcConnectHandler cb, void* arg) {
+	impl_->onClient([cb](void* arg, ::AsyncClient *connection) {
+		AsyncTcpClientImpl *client_wrapper = new AsyncTcpClientImpl(connection);
+		cb(arg, client_wrapper);
+	}, arg);
+}
+
+void AsyncTcpServerImpl::begin() {
+	impl_->begin();
+}
+
+void AsyncTcpServerImpl::end() {
+	impl_->end();
+}
+
+void AsyncTcpServerImpl::setNoDelay(bool nodelay) {
+	impl_->setNoDelay(nodelay);
+}
+
+bool AsyncTcpServerImpl::getNoDelay() const {
+	return impl_->getNoDelay();
+}
+
+} /* namespace network */
+} /* namespace esphome */

--- a/esphome/components/network/async_tcp_server_impl.h
+++ b/esphome/components/network/async_tcp_server_impl.h
@@ -15,20 +15,20 @@ class AsyncServer;
 namespace esphome {
 namespace network {
 
-class AsyncTcpServerImpl: public asynctcp::AsyncServer {
-public:
-	AsyncTcpServerImpl(uint16_t port);
-	virtual ~AsyncTcpServerImpl();
+class AsyncTcpServerImpl : public AsyncServer {
+ public:
+  AsyncTcpServerImpl(uint16_t port);
+  virtual ~AsyncTcpServerImpl();
 
-	virtual void onClient(asynctcp::AcConnectHandler cb, void* arg) override;
-	virtual void begin() override;
-	virtual void end() override;
-	virtual void setNoDelay(bool nodelay) override;
-	virtual bool getNoDelay() const override;
-protected:
-	std::unique_ptr<::AsyncServer> impl_;
+  virtual void onClient(AcConnectHandler cb, void* arg) override;
+  virtual void begin() override;
+  virtual void end() override;
+  virtual void setNoDelay(bool nodelay) override;
+  virtual bool getNoDelay() const override;
+
+ protected:
+  std::unique_ptr<::AsyncServer> impl_;
 };
 
 } /* namespace network */
 } /* namespace esphome */
-

--- a/esphome/components/network/async_tcp_server_impl.h
+++ b/esphome/components/network/async_tcp_server_impl.h
@@ -1,0 +1,34 @@
+/*
+ * async_tcp_server_impl.h
+ *
+ *  Created on: Mar 5, 2020
+ *      Author: Oleksandr Omelchuk
+ */
+
+#pragma once
+
+#include <memory>
+#include "async_tcp.h"
+
+class AsyncServer;
+
+namespace esphome {
+namespace network {
+
+class AsyncTcpServerImpl: public asynctcp::AsyncServer {
+public:
+	AsyncTcpServerImpl(uint16_t port);
+	virtual ~AsyncTcpServerImpl();
+
+	virtual void onClient(asynctcp::AcConnectHandler cb, void* arg) override;
+	virtual void begin() override;
+	virtual void end() override;
+	virtual void setNoDelay(bool nodelay) override;
+	virtual bool getNoDelay() const override;
+protected:
+	std::unique_ptr<::AsyncServer> impl_;
+};
+
+} /* namespace network */
+} /* namespace esphome */
+


### PR DESCRIPTION
## Description:
Extracted minimal AsyncServer and AsyncClient implementations for API server.
Only refactoring. 
This is the first step. We would need to define way to replace networking implementation. Possibly through yaml "platform" options.

Following things might become possible:
- usb attached devices
- networking with fallback support wifi/ethernet/etc
- one wire mesh
- LoRa long range radio connections
- vpn, proxyng
- mocked api clients for unit testing
- running esphome on arduino compatible devices without wifi.
- infrared networking

Initial idea described here: https://github.com/esphome/feature-requests/issues/627

This will fix feature requests for custom connectivity options.

No changes visible to user. No changes to documentation.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
