### PR TITLE
Bugfix/1077 decode called on str fetching platformio stacktrace

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -1,4 +1,6 @@
 import json
+from typing import Union
+
 import logging
 import os
 import re
@@ -62,7 +64,7 @@ FILTER_PLATFORMIO_LINES = [
 ]
 
 
-def run_platformio_cli(*args, **kwargs):
+def run_platformio_cli(*args, **kwargs) -> Union[str, int]:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = os.path.abspath(CORE.relative_pioenvs_path())
     os.environ["PLATFORMIO_LIBDEPS_DIR"] = os.path.abspath(CORE.relative_piolibdeps_path())
@@ -80,7 +82,7 @@ def run_platformio_cli(*args, **kwargs):
                                 *cmd, **kwargs)
 
 
-def run_platformio_cli_run(config, verbose, *args, **kwargs):
+def run_platformio_cli_run(config, verbose, *args, **kwargs) -> Union[str, int]:
     command = ['run', '-d', CORE.build_path]
     if verbose:
         command += ['-v']
@@ -98,7 +100,7 @@ def run_upload(config, verbose, port):
 
 def run_idedata(config):
     args = ['-t', 'idedata']
-    stdout = run_platformio_cli_run(config, False, *args, capture_stdout=True).decode()
+    stdout = run_platformio_cli_run(config, False, *args, capture_stdout=True)
     match = re.search(r'{\s*".*}', stdout)
     if match is None:
         _LOGGER.debug("Could not match IDEData for %s", stdout)

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -153,7 +153,9 @@ class RedirectText:
         return True
 
 
-def run_external_command(func, *cmd, capture_stdout: bool = False, filter_lines: str = None) -> Union[int, str]:
+def run_external_command(func, *cmd,
+                         capture_stdout: bool = False,
+                         filter_lines: str = None) -> Union[int, str]:
     """
     Run a function from an external package that acts like a main method.
 

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import collections
 import io
 import logging
@@ -151,7 +153,19 @@ class RedirectText:
         return True
 
 
-def run_external_command(func, *cmd, **kwargs):
+def run_external_command(func, *cmd, capture_stdout: bool = False, filter_lines: str = None) -> Union[int, str]:
+    """
+    Run a function from an external package that acts like a main method.
+
+    Temporarily replaces stdin/stderr/stdout, sys.argv and sys.exit handler during the run.
+
+    :param func: Function to execute
+    :param cmd: Command to run as (eg first element of sys.argv)
+    :param capture_stdout: Capture text from stdout and return that.
+    :param filter_lines: Regular expression used to filter captured output.
+    :return: str if `capture_stdout` is set else int exit code.
+
+    """
     def mock_exit(return_code):
         raise SystemExit(return_code)
 
@@ -160,13 +174,11 @@ def run_external_command(func, *cmd, **kwargs):
     full_cmd = ' '.join(shlex_quote(x) for x in cmd)
     _LOGGER.info("Running:  %s", full_cmd)
 
-    filter_lines = kwargs.get('filter_lines')
     orig_stdout = sys.stdout
     sys.stdout = RedirectText(sys.stdout, filter_lines=filter_lines)
     orig_stderr = sys.stderr
     sys.stderr = RedirectText(sys.stderr, filter_lines=filter_lines)
 
-    capture_stdout = kwargs.get('capture_stdout', False)
     if capture_stdout:
         cap_stdout = sys.stdout = io.StringIO()
 


### PR DESCRIPTION
## Description:
Fixes an errant call decode call on a str. Added return-type annotations and docstring to help IDEs and static analysis tools identify this issue.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1077

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
