### PR TITLE
SHTC3: Wake up the sensor during setup

### DIFF
--- a/esphome/components/shtcx/shtcx.cpp
+++ b/esphome/components/shtcx/shtcx.cpp
@@ -25,6 +25,7 @@ inline const char *to_string(SHTCXType type) {
 
 void SHTCXComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SHTCx...");
+  this->wake_up();
   this->soft_reset();
 
   if (!this->write_command_(SHTCX_COMMAND_READ_ID_REGISTER)) {


### PR DESCRIPTION
## Description:

ESPHome puts SHTC3 sensors to sleep between measurements.  While asleep the sensor will only respond to a wake up command.  All other commands, including a soft reset are ignored (it even ignores an I2C general call reset).  This is problematic if ESPHome is rebooted between measurements, since the sensor will still be asleep when it tries to set it up again after the reboot.  For example, doing an OTA update will usually cause the sensor to remain "failed" until power is cycled, because the OTA process will reboot while the sensor is still asleep.

So the trivial fix to this is to send a wake up command during `setup()` before anything else to make sure it's awake.  For me, this fixes SHTC3 sensors "failing" after most OTA updates.

## Checklist:
  - [x] The code change is tested and works locally.
