### PR TITLE
Retry connecting if the connection is not valid

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -420,6 +420,12 @@ void WiFiComponent::check_connecting_finished() {
   wl_status_t status = this->wifi_sta_status_();
 
   if (status == WL_CONNECTED) {
+    if (WiFi.SSID().equals("")) {
+      ESP_LOGW(TAG, "Incomplete connection.");
+      this->retry_connect();
+      return;
+    }
+
     ESP_LOGI(TAG, "WiFi Connected!");
     this->print_connect_params_();
 


### PR DESCRIPTION
## Description:
It was frequent that the ESP will report as "connected", but no SSID/BSSID/IP were set. It will then disconnect immediately with "Association Leave".
This ensures that a reconnect is done, which fixes the issue and connects successfully.

This problem with the first connections may be related to this:
https://github.com/espressif/esp-idf/issues/2647

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
