### PR TITLE
Fix bug in test temperature in manual (heat and cool). bang_bang_climate

### DIFF
--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -27,7 +27,7 @@ void BangBangClimate::setup() {
   }
 }
 void BangBangClimate::control(const climate::ClimateCall &call) {
-  if (call.get_mode().has_value()){
+  if (call.get_mode().has_value()) {
     auto valor_mode = this->mode;
     this->mode = *call.get_mode();
     change_mode = (this->mode != valor_mode) ? true : false;
@@ -65,67 +65,73 @@ void BangBangClimate::compute_state_() {
   climate::ClimateAction target_action;
   if (too_cold) {
     // too cold -> enable heating if possible ( auto or heat), else idle
-    if ((this->supports_heat_) && ((this->mode == climate::CLIMATE_MODE_AUTO) || (this->mode == climate::CLIMATE_MODE_HEAT)))
+    if ((this->supports_heat_) &&
+        ((this->mode == climate::CLIMATE_MODE_AUTO) || (this->mode == climate::CLIMATE_MODE_HEAT)))
       target_action = climate::CLIMATE_ACTION_HEATING;
     else
       target_action = climate::CLIMATE_ACTION_OFF;
   } else if (too_hot) {
     // too hot -> enable cooling if possible (auto or cool), else idle
-    if ((this->supports_cool_) && ((this->mode == climate::CLIMATE_MODE_AUTO) || (this->mode == climate::CLIMATE_MODE_COOL)))
+    if ((this->supports_cool_) &&
+        ((this->mode == climate::CLIMATE_MODE_AUTO) || (this->mode == climate::CLIMATE_MODE_COOL)))
       target_action = climate::CLIMATE_ACTION_COOLING;
     else
       target_action = climate::CLIMATE_ACTION_OFF;
   } else {
     switch (this->mode) {
-      case climate::CLIMATE_MODE_AUTO: //mode auto
+      case climate::CLIMATE_MODE_AUTO:  // mode auto
         if (this->supports_cool_ && this->supports_heat_) {
           // if supports both ends, go to idle mode
           target_action = climate::CLIMATE_ACTION_OFF;
         } else {
-         // else use current mode and not change (hysteresis)
+          // else use current mode and not change (hysteresis)
           target_action = this->action;
         }
-        break;        
+        break;
 
-       case climate::CLIMATE_MODE_HEAT: //mode heat
+      case climate::CLIMATE_MODE_HEAT:  // mode heat
         if (this->supports_heat_) {
-          if (this->action ==climate::CLIMATE_ACTION_HEATING) {//works until high temperature is reached
+          if (this->action == climate::CLIMATE_ACTION_HEATING) {  // works until high temperature
+                                                                  // is reached
             target_action = this->action;
             change_mode = false;
           } else {
-            if (change_mode) { //In manual mode, the operating mode has been changed and starts heating
-              target_action = climate::CLIMATE_ACTION_HEATING; 
+            if (change_mode) {  // In manual mode, the operating mode has been
+                                // changed and starts heating
+              target_action = climate::CLIMATE_ACTION_HEATING;
               change_mode = false;
-            } else {// hysteresic
+            } else {  // hysteresic
               target_action = climate::CLIMATE_ACTION_OFF;
             }
           }
-        } else { //not support_heat
+        } else {  // not support_heat
           target_action = climate::CLIMATE_ACTION_OFF;
         }
         break;
 
-      case climate::CLIMATE_MODE_COOL: //mode cool
+      case climate::CLIMATE_MODE_COOL:  // mode cool
         if (this->supports_cool_) {
-          if (this->action == climate::CLIMATE_ACTION_COOLING) { //works until low temperature is reached
+          if (this->action == climate::CLIMATE_ACTION_COOLING) {  // works until low temperature is
+                                                                  // reached
             target_action = this->action;
             change_mode = false;
           } else {
-            if (change_mode) {  //In manual mode, the operating mode has been changed and starts cooling
-              target_action = climate::CLIMATE_ACTION_COOLING; 
+            if (change_mode) {  // In manual mode, the operating mode has been
+                                // changed and starts cooling
+              target_action = climate::CLIMATE_ACTION_COOLING;
               change_mode = false;
-            } else {//hysteresic
+            } else {  // hysteresic
               target_action = climate::CLIMATE_ACTION_OFF;
             }
-          } 
-        } else { //not supports_cool
+          }
+        } else {  // not supports_cool
           target_action = climate::CLIMATE_ACTION_OFF;
         }
         break;
 
-      default :
+      default:
         // other mode
-        target_action = this->action;       
+        target_action = this->action;
     }
   }
 

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -30,7 +30,7 @@ void BangBangClimate::control(const climate::ClimateCall &call) {
   if (call.get_mode().has_value()) {
     auto valor_mode = this->mode;
     this->mode = *call.get_mode();
-    change_mode = (this->mode != valor_mode) ? true : false;
+    change_mode = (this->mode != valor_mode);
   }
   if (call.get_target_temperature_low().has_value())
     this->target_temperature_low = *call.get_target_temperature_low();

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -28,12 +28,10 @@ void BangBangClimate::setup() {
   change_mode = true;
 }
 void BangBangClimate::control(const climate::ClimateCall &call) {
-  uint8_t valor_mode;
-  if (call.get_mode().has_value()){
-    valor_mode = this->mode;
+ if (call.get_mode().has_value()){
+    auto valor_mode = this->mode;
     this->mode = *call.get_mode();
-    if (this->mode != valor_mode){
-      valor_mode = this->mode;     
+    if (this->mode != valor_mode){   
       change_mode = true;
     } else {
       change_mode = false;

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -5,7 +5,7 @@ namespace esphome {
 namespace bang_bang {
 
 static const char *TAG = "bang_bang.climate";
-bool change_mode;
+bool change_mode = true;
 
 void BangBangClimate::setup() {
   this->sensor_->add_on_state_callback([this](float state) {
@@ -25,7 +25,6 @@ void BangBangClimate::setup() {
     this->mode = climate::CLIMATE_MODE_AUTO;
     this->change_away_(false);
   }
-  change_mode = true;
 }
 void BangBangClimate::control(const climate::ClimateCall &call) {
   if (call.get_mode().has_value()){

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -30,11 +30,7 @@ void BangBangClimate::control(const climate::ClimateCall &call) {
   if (call.get_mode().has_value()){
     auto valor_mode = this->mode;
     this->mode = *call.get_mode();
-    if (this->mode != valor_mode){   
-      change_mode = true;
-    } else {
-      change_mode = false;
-    }
+    change_mode = (this->mode != valor_mode) ? true : false;
   }
   if (call.get_target_temperature_low().has_value())
     this->target_temperature_low = *call.get_target_temperature_low();

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -28,7 +28,7 @@ void BangBangClimate::setup() {
   change_mode = true;
 }
 void BangBangClimate::control(const climate::ClimateCall &call) {
- if (call.get_mode().has_value()){
+  if (call.get_mode().has_value()){
     auto valor_mode = this->mode;
     this->mode = *call.get_mode();
     if (this->mode != valor_mode){   

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -5,7 +5,7 @@ namespace esphome {
 namespace bang_bang {
 
 static const char *TAG = "bang_bang.climate";
-bool change_mode = true;
+static bool change_mode = true;
 
 void BangBangClimate::setup() {
   this->sensor_->add_on_state_callback([this](float state) {


### PR DESCRIPTION
## Description:

Fix bug in test temperature in manual (heat and cool).
If you change from operating mode to heat or cool (in manual mode).
And it is between high and low temperature. It starts working until it reaches the temperature that has to be deactivated

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1104

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#524

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
