### PR TITLE
fix servo bug restoring state and starting servo detached

### DIFF
--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -36,11 +36,11 @@ class Servo : public Component {
       this->rtc_ = global_preferences.make_preference<float>(global_servo_id);
       global_servo_id++;
       if (this->rtc_.load(&v)) {
-        this->write(v);
+        this->output_->set_level(v);
         return;
       }
     }
-    this->write(0.0f);
+    this->detach();
   }
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }


### PR DESCRIPTION
## Description:

Fixes as small bug which caused the restore option to actually not work.
Also servo by default now starts detached (I think this was the intended behavior), so I'm flagging this as breaking change (before the servo will start as centered and you would have to override this value with some nasty on_boot)

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/964

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
