### PR TITLE
Fix missing yield in ESP32 UART timeout code causing watchdog resets when blocking for serial data.

### DIFF
--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -96,6 +96,7 @@ bool UARTComponent::check_read_timeout_(size_t len) {
       ESP_LOGE(TAG, "Reading from UART timed out at byte %u!", this->available());
       return false;
     }
+    yield();
   }
   return true;
 }


### PR DESCRIPTION
## Description:

I'm working on a project that uses a nextion display with a LOT of widgets, and it therefore takes a fairly long time to update the display in some cases. I've been running into fairly irregular watchdog timer resets with this.

I suspected there was a issue with some operation blocking long enough to cause the watchdog to trip, and looking around to see if I could find anything suspicious, the fact that the esp8266 variant of the uart functions has an explicit yield in the read timeout, while the esp32 version doesn't seems kind of suspicious. AS far as I know, both run the same FreeRTOS stack and mostly the same code in the ESP-IDF, so I can't see any reason that only the esp32 would not need to handle yielding to FreeRTOS in the timeout loop.

Really, I think there's some value in considering replacing the `yield()` call with a `vTaskDelay(1)`, since you're trying to delay, why not let the rtos handle delaying for you, but I've gone with just matching the other implementation at the moment.

**Related issue (if applicable):** fixes `<None>`

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** `<None>`

## Checklist:
  - [x] The code change is tested and works locally.


