### PR TITLE
SenseAir: flush input buffer on read error

### DIFF
--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -19,7 +19,7 @@ void SenseAirComponent::update() {
 
   if (response[0] != 0xFE || response[1] != 0x04) {
     ESP_LOGW(TAG, "Invalid preamble from SenseAir! %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x",
-             response[0], response[1], response[2], response[3], response[4], response[5], response[6], response[7], 
+             response[0], response[1], response[2], response[3], response[4], response[5], response[6], response[7],
              response[8], response[9], response[10], response[11], response[12]);
 
     this->status_set_warning();

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -28,7 +28,7 @@ void SenseAirComponent::update() {
       if(this->read_byte(&b)) {
         ESP_LOGW(TAG, "    ... %02x", b);
       } else {
-        ESP_LOGW(TAG, "    ... nothing read", b);
+        ESP_LOGW(TAG, "    ... nothing read");
       }
     }
     return;

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -26,7 +26,7 @@ void SenseAirComponent::update() {
     while (this->available()) {
       unsigned char b;
       if (this->read_byte(&b)) {
-        ESP_LOGW(TAG, "    ... %02x", b);
+        ESP_LOGD(TAG, "    ... %02x", b);
       } else {
         ESP_LOGD(TAG, "    ... nothing read");
       }

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -28,7 +28,7 @@ void SenseAirComponent::update() {
       if (this->read_byte(&b)) {
         ESP_LOGW(TAG, "    ... %02x", b);
       } else {
-        ESP_LOGW(TAG, "    ... nothing read");
+        ESP_LOGD(TAG, "    ... nothing read");
       }
     }
     return;

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -18,8 +18,19 @@ void SenseAirComponent::update() {
   }
 
   if (response[0] != 0xFE || response[1] != 0x04) {
-    ESP_LOGW(TAG, "Invalid preamble from SenseAir!");
+    ESP_LOGW(TAG, "Invalid preamble from SenseAir! %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x", response[0], response[1], response[2], response[3], 
+       response[4], response[5], response[6], response[7], 
+       response[8], response[9], response[10], response[11],     response[12]);
+
     this->status_set_warning();
+    while(this->available()) {
+      unsigned char b;
+      if(this->read_byte(&b)) {
+        ESP_LOGW(TAG, "    ... %02x", b);
+      } else {
+        ESP_LOGW(TAG, "    ... nothing read", b);
+      }
+    }
     return;
   }
 

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -18,14 +18,15 @@ void SenseAirComponent::update() {
   }
 
   if (response[0] != 0xFE || response[1] != 0x04) {
-    ESP_LOGW(TAG, "Invalid preamble from SenseAir! %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x", response[0], response[1], response[2], response[3], 
+    ESP_LOGW(TAG, "Invalid preamble from SenseAir! %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x",
+	   response[0], response[1], response[2], response[3], 
        response[4], response[5], response[6], response[7], 
        response[8], response[9], response[10], response[11],     response[12]);
 
     this->status_set_warning();
-    while(this->available()) {
+    while (this->available()) {
       unsigned char b;
-      if(this->read_byte(&b)) {
+      if (this->read_byte(&b)) {
         ESP_LOGW(TAG, "    ... %02x", b);
       } else {
         ESP_LOGW(TAG, "    ... nothing read");

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -19,8 +19,7 @@ void SenseAirComponent::update() {
 
   if (response[0] != 0xFE || response[1] != 0x04) {
     ESP_LOGW(TAG, "Invalid preamble from SenseAir! %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x",
-             response[0], response[1], response[2], response[3], 
-             response[4], response[5], response[6], response[7], 
+             response[0], response[1], response[2], response[3], response[4], response[5], response[6], response[7], 
              response[8], response[9], response[10], response[11], response[12]);
 
     this->status_set_warning();

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -19,9 +19,9 @@ void SenseAirComponent::update() {
 
   if (response[0] != 0xFE || response[1] != 0x04) {
     ESP_LOGW(TAG, "Invalid preamble from SenseAir! %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x",
-	   response[0], response[1], response[2], response[3], 
-       response[4], response[5], response[6], response[7], 
-       response[8], response[9], response[10], response[11],     response[12]);
+             response[0], response[1], response[2], response[3], 
+             response[4], response[5], response[6], response[7], 
+             response[8], response[9], response[10], response[11], response[12]);
 
     this->status_set_warning();
     while (this->available()) {


### PR DESCRIPTION
## Description:

If a read timeout occurs or a byte is dropped the read buffer isn't cleared and the bytes in the reply are shifted. This patch clears the input buffer if the header bytes are wrong.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
no doc update/no breaking changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
no doc update/no breaking changes
