### PR TITLE
added energy reading for pzem004

### DIFF
--- a/esphome/components/pzem004t/pzem004t.cpp
+++ b/esphome/components/pzem004t/pzem004t.cpp
@@ -59,11 +59,19 @@ void PZEM004T::loop() {
         if (this->power_sensor_ != nullptr)
           this->power_sensor_->publish_state(power);
         ESP_LOGD(TAG, "Got Power %u W", power);
+        this->write_state_(READ_ENERGY);
+        break;
+      }
+
+      case 0xA3: {  // Energy Response
+        uint32_t energy = (uint32_t(resp[1]) << 16) | (uint32_t(resp[2]) << 8) | (uint32_t(resp[3]));
+        if (this->energy_sensor_ != nullptr)
+          this->energy_sensor_->publish_state(energy);
+        ESP_LOGD(TAG, "Got Energy %u Wh", energy);
         this->write_state_(DONE);
         break;
       }
 
-      case 0xA3:  // Energy Response
       case 0xA5:  // Set Power Alarm Response
       case 0xB0:  // Voltage Request
       case 0xB1:  // Current Request

--- a/esphome/components/pzem004t/pzem004t.h
+++ b/esphome/components/pzem004t/pzem004t.h
@@ -12,6 +12,7 @@ class PZEM004T : public PollingComponent, public uart::UARTDevice {
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }
   void set_power_sensor(sensor::Sensor *power_sensor) { power_sensor_ = power_sensor; }
+  void set_energy_sensor(sensor::Sensor *energy_sensor) { energy_sensor_ = energy_sensor; }
 
   void loop() override;
 
@@ -23,12 +24,14 @@ class PZEM004T : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *voltage_sensor_;
   sensor::Sensor *current_sensor_;
   sensor::Sensor *power_sensor_;
+  sensor::Sensor *energy_sensor_;
 
   enum PZEM004TReadState {
     SET_ADDRESS = 0xB4,
     READ_VOLTAGE = 0xB0,
     READ_CURRENT = 0xB1,
     READ_POWER = 0xB2,
+    READ_ENERGY = 0xB3,
     DONE = 0x00,
   } read_state_{DONE};
 

--- a/esphome/components/pzem004t/sensor.py
+++ b/esphome/components/pzem004t/sensor.py
@@ -2,7 +2,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, uart
 from esphome.const import CONF_CURRENT, CONF_ID, CONF_POWER, CONF_VOLTAGE, \
-    UNIT_VOLT, ICON_FLASH, UNIT_AMPERE, UNIT_WATT
+    CONF_ENERGY, UNIT_VOLT, ICON_FLASH, ICON_COUNTER, UNIT_AMPERE, UNIT_WATT, \
+    UNIT_WATT_HOURS
 
 DEPENDENCIES = ['uart']
 
@@ -15,6 +16,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(UNIT_VOLT, ICON_FLASH, 1),
     cv.Optional(CONF_CURRENT): sensor.sensor_schema(UNIT_AMPERE, ICON_FLASH, 2),
     cv.Optional(CONF_POWER): sensor.sensor_schema(UNIT_WATT, ICON_FLASH, 0),
+    cv.Optional(CONF_ENERGY): sensor.sensor_schema(UNIT_WATT_HOURS, ICON_COUNTER, 0)
 }).extend(cv.polling_component_schema('60s')).extend(uart.UART_DEVICE_SCHEMA)
 
 
@@ -35,3 +37,7 @@ def to_code(config):
         conf = config[CONF_POWER]
         sens = yield sensor.new_sensor(conf)
         cg.add(var.set_power_sensor(sens))
+    if CONF_ENERGY in config:
+        conf = config[CONF_ENERGY]
+        sens = yield sensor.new_sensor(conf)
+        cg.add(var.set_energy_sensor(sens))


### PR DESCRIPTION
## Description:

The pzem004t sensor (the old version, not v3) has energy metric (kWh). I've updated the code to also read the energy from the sensor, so the kWh consumption over time is known. 


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#547

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
