### PR TITLE
Change buffer sending process for waveshare_epaper (2.70in)

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -425,20 +425,22 @@ void WaveshareEPaper2P7In::initialize() {
     this->data(i);
 }
 void HOT WaveshareEPaper2P7In::display() {
+  uint32_t bufLen = this->get_buffer_length_();
+
   // COMMAND DATA START TRANSMISSION 1
   this->command(0x10);
   delay(2);
-  this->start_data_();
-  this->write_array(this->buffer_, this->get_buffer_length_());
-  this->end_data_();
+  for (uint32_t i = 0; i < bufLen; i++) {
+    this->data(this->buffer_[i]);
+  }
   delay(2);
 
   // COMMAND DATA START TRANSMISSION 2
   this->command(0x13);
   delay(2);
-  this->start_data_();
-  this->write_array(this->buffer_, this->get_buffer_length_());
-  this->end_data_();
+  for (uint32_t i = 0; i < bufLen; i++) {
+    this->data(this->buffer_[i]);
+  }
 
   // COMMAND DISPLAY REFRESH
   this->command(0x12);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -425,12 +425,12 @@ void WaveshareEPaper2P7In::initialize() {
     this->data(i);
 }
 void HOT WaveshareEPaper2P7In::display() {
-  uint32_t bufLen = this->get_buffer_length_();
+  uint32_t buf_len = this->get_buffer_length_();
 
   // COMMAND DATA START TRANSMISSION 1
   this->command(0x10);
   delay(2);
-  for (uint32_t i = 0; i < bufLen; i++) {
+  for (uint32_t i = 0; i < buf_len; i++) {
     this->data(this->buffer_[i]);
   }
   delay(2);
@@ -438,7 +438,7 @@ void HOT WaveshareEPaper2P7In::display() {
   // COMMAND DATA START TRANSMISSION 2
   this->command(0x13);
   delay(2);
-  for (uint32_t i = 0; i < bufLen; i++) {
+  for (uint32_t i = 0; i < buf_len; i++) {
     this->data(this->buffer_[i]);
   }
 


### PR DESCRIPTION

## Description:
The current way ESPhome sending buffer to WaveshareEPaper2P7In does not show the expected content on the display, this commit is changing the data transferring process so the content is showing as expected.

The process is adapted from the demo code provided by Waveshare, manufacturer of the E-paper display.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1159

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  N/A

## Checklist:
  - [x ] The code change is tested and works locally.