### PR TITLE
Make initial run variable available to addressable_lambda

### DIFF
--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -50,12 +50,11 @@ class AddressableLightEffect : public LightEffect {
 
 class AddressableLambdaLightEffect : public AddressableLightEffect {
  public:
-  AddressableLambdaLightEffect(const std::string &name, const std::function<void(AddressableLight &, ESPColor, bool initial_run)> &f,
+  AddressableLambdaLightEffect(const std::string &name,
+                               const std::function<void(AddressableLight &, ESPColor, bool initial_run)> &f,
                                uint32_t update_interval)
       : AddressableLightEffect(name), f_(f), update_interval_(update_interval) {}
-  void start() override {
-    this->initial_run_ = true;
-  }
+  void start() override { this->initial_run_ = true; }
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     const uint32_t now = millis();
     if (now - this->last_run_ >= this->update_interval_) {

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -60,9 +60,7 @@ class AddressableLambdaLightEffect : public AddressableLightEffect {
     if (now - this->last_run_ >= this->update_interval_) {
       this->last_run_ = now;
       this->f_(it, current_color, this->initial_run_);
-      if (this->initial_run_) {
-        this->initial_run_ = false;
-      }
+      this->initial_run_ = false;
     }
   }
 

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -50,21 +50,28 @@ class AddressableLightEffect : public LightEffect {
 
 class AddressableLambdaLightEffect : public AddressableLightEffect {
  public:
-  AddressableLambdaLightEffect(const std::string &name, const std::function<void(AddressableLight &, ESPColor)> &f,
+  AddressableLambdaLightEffect(const std::string &name, const std::function<void(AddressableLight &, ESPColor, bool initial_run)> &f,
                                uint32_t update_interval)
       : AddressableLightEffect(name), f_(f), update_interval_(update_interval) {}
+  void start() override {
+    this->initial_run_ = true;
+  }
   void apply(AddressableLight &it, const ESPColor &current_color) override {
     const uint32_t now = millis();
     if (now - this->last_run_ >= this->update_interval_) {
       this->last_run_ = now;
-      this->f_(it, current_color);
+      this->f_(it, current_color, this->initial_run_);
+      if (this->initial_run_) {
+        this->initial_run_ = false;
+      }
     }
   }
 
  protected:
-  std::function<void(AddressableLight &, ESPColor)> f_;
+  std::function<void(AddressableLight &, ESPColor, bool initial_run)> f_;
   uint32_t update_interval_;
   uint32_t last_run_{0};
+  bool initial_run_;
 };
 
 class AddressableRainbowLightEffect : public AddressableLightEffect {

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -162,7 +162,7 @@ def flicker_effect_to_code(config, effect_id):
     }
 )
 def addressable_lambda_effect_to_code(config, effect_id):
-    args = [(AddressableLightRef, 'it'), (ESPColor, 'current_color')]
+    args = [(AddressableLightRef, 'it'), (ESPColor, 'current_color'), (bool, 'initial_run')]
     lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], args, return_type=cg.void)
     var = cg.new_Pvariable(effect_id, config[CONF_NAME], lambda_,
                            config[CONF_UPDATE_INTERVAL])

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1147,7 +1147,9 @@ light:
     - addressable_lambda:
           name: "Test For Custom Lambda Effect"
           lambda: |-
-            it[0] = current_color;
+            if (initial_run) {
+              it[0] = current_color;
+            }
 
     - automation:
         name: Custom Effect


### PR DESCRIPTION
## Description:

This PR adds a new variable, called initial_run, for the addressable_lambda. This variable is especially useful when the addressable lambda effect has some variables which need to be resetted with each restart.


Example


```yaml

effects:
  - addressable_lambda:
      name: Sunrise
      lambda: |-
        static uint16_t middlePos = it.size() / 2;
        static uint16_t ambientSize;
        static uint8_t ambientProgress;
        if (initial_run) {
          it.all() = ESPColor::BLACK;
          ambientSize = 0;
          ambientProgress = 20;
          return;
        }

        if (ambientProgress < 250) {
           ambientProgress++;
        }
        if (ambientSize < middlePos) {
           ambientSize++;
        }
        it.range(middlePos-ambientSize, middlePos+ambientSize) = ESPColor(ambientProgress, 0, 0, ambientProgress/4);
```




**Related issue (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#558

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
