### PR TITLE
Fixed iBeacon struct and major and minor parsing

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -46,14 +46,15 @@ class ESPBLEiBeacon {
   ESPBLEiBeacon(const uint8_t *data);
   static optional<ESPBLEiBeacon> from_manufacturer_data(const ServiceData &data);
 
-  uint16_t get_major() { return reverse_bits_16(this->beacon_data_.major); }
-  uint16_t get_minor() { return reverse_bits_16(this->beacon_data_.minor); }
+  uint16_t get_major() { return ((this->beacon_data_.major & 0xFF) << 8) | (this->beacon_data_.major >> 8); }
+  uint16_t get_minor() { return ((this->beacon_data_.minor & 0xFF) << 8) | (this->beacon_data_.minor >> 8); }
   int8_t get_signal_power() { return this->beacon_data_.signal_power; }
   ESPBTUUID get_uuid() { return ESPBTUUID::from_raw(this->beacon_data_.proximity_uuid); }
 
  protected:
   struct {
     uint8_t sub_type;
+    uint8_t length;
     uint8_t proximity_uuid[16];
     uint16_t major;
     uint16_t minor;


### PR DESCRIPTION
## Description:

iBeacon major and minor values are incorrectly parsed at the moment, this PR fixes it.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
