### PR TITLE
Expose mac address via discovery (mDNS)

### DIFF
--- a/esphome/core/util.cpp
+++ b/esphome/core/util.cpp
@@ -62,6 +62,7 @@ void network_setup_mdns(IPAddress address, int interface) {
       // DNS-SD (!=mDNS !) requires at least one TXT record for service discovery - let's add version
       MDNS.addServiceTxt("esphomelib", "tcp", "version", ESPHOME_VERSION);
       MDNS.addServiceTxt("esphomelib", "tcp", "address", network_get_address().c_str());
+      MDNS.addServiceTxt("esphomelib", "tcp", "mac", get_mac_address().c_str());
     } else {
 #endif
       // Publish "http" service if not using native API.


### PR DESCRIPTION
## Description:

HA config flows should offer an unique id to allow users to ignore discovered devices.

This exposes the mac address via "mac" DNS-SD property.

https://github.com/home-assistant/core/pull/34724#issuecomment-619625519

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
