### PR TITLE
Turn off PN532 RF field when not expecting a tag

### DIFF
--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -161,7 +161,11 @@ void PN532::loop() {
 
 void PN532::turn_off_rf_() {
   ESP_LOGVV(TAG, "Turning RF field OFF");
-  this->pn532_write_command_check_ack_({0x32, 0x1, 0x0});
+  this->pn532_write_command_check_ack_({
+      0x32,  // RFConfiguration
+      0x1,   // RF Field
+      0x0    // Off
+  });
 }
 
 float PN532::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -87,7 +87,7 @@ void PN532::setup() {
     return;
   }
 
-  this->turnOffRF();
+  this->turn_off_rf_();
 }
 
 void PN532::update() {
@@ -116,14 +116,14 @@ void PN532::loop() {
 
   if (read.size() <= 2 || read[0] != 0x4B) {
     // Something failed
-    this->turnOffRF();
+    this->turn_off_rf_();
     return;
   }
 
   uint8_t num_targets = read[1];
   if (num_targets != 1) {
     // no tags found or too many
-    this->turnOffRF();
+    this->turn_off_rf_();
     return;
   }
 
@@ -156,10 +156,10 @@ void PN532::loop() {
     ESP_LOGD(TAG, "Found new tag '%s'", buf);
   }
 
-  this->turnOffRF();
+  this->turn_off_rf_();
 }
 
-void PN532::turnOffRF() {
+void PN532::turn_off_rf_() {
   ESP_LOGVV(TAG, "Turning RF field OFF");
   this->pn532_write_command_check_ack_({0x32, 0x1, 0x0});
 }

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -55,7 +55,7 @@ class PN532 : public PollingComponent,
 
   bool read_ack_();
 
-  void turnOffRF();
+  void turn_off_rf_();
 
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -55,6 +55,8 @@ class PN532 : public PollingComponent,
 
   bool read_ack_();
 
+  void turnOffRF();
+
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;
   std::vector<PN532Trigger *> triggers_;


### PR DESCRIPTION
Avoids interference with Wifi connectivity of nearby devices.

## Description:

The PN532 has a very significant negative impact on the Wifi connectivity of nearby devices (a few centimeter away). In my particular case I get many access point association errors and timeouts of the Wemos D1 running esphome, even close to said access point.

This PR disables the RF field when not abolutely necessary. Instead of listening for tags for the duration of `update_interval`, it now checks for a tag every `update_interval`.

I welcome all feedback to improve this PR or suggestions for a better approach.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
