### PR TITLE
Fix decode and encode for RC5-protocol

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -420,7 +420,7 @@ def raw_action(var, config, args):
 RC5Data, RC5BinarySensor, RC5Trigger, RC5Action, RC5Dumper = declare_protocol('RC5')
 RC5_SCHEMA = cv.Schema({
     cv.Required(CONF_ADDRESS): cv.All(cv.hex_int, cv.Range(min=0, max=0x1F)),
-    cv.Required(CONF_COMMAND): cv.All(cv.hex_int, cv.Range(min=0, max=0x3F)),
+    cv.Required(CONF_COMMAND): cv.All(cv.hex_int, cv.Range(min=0, max=0x7F)),
 })
 
 

--- a/esphome/components/remote_base/rc5_protocol.cpp
+++ b/esphome/components/remote_base/rc5_protocol.cpp
@@ -14,10 +14,16 @@ void RC5Protocol::encode(RemoteTransmitData *dst, const RC5Data &data) {
   dst->set_carrier_frequency(36000);
 
   uint64_t out_data = 0;
-  out_data |= 0b11 << 12;
+  uint8_t command = data.command;
+  if (data.command >= 64) {
+    out_data |= 0b10 << 12;
+    command = command - 64;
+  } else {
+    out_data |= 0b11 << 12;
+  }
   out_data |= TOGGLE << 11;
   out_data |= data.address << 6;
-  out_data |= data.command;
+  out_data |= command;
 
   for (uint64_t mask = 1UL << (NBITS - 1); mask != 0; mask >>= 1) {
     if (out_data & mask) {
@@ -35,22 +41,41 @@ optional<RC5Data> RC5Protocol::decode(RemoteReceiveData src) {
       .address = 0,
       .command = 0,
   };
-  src.expect_space(BIT_TIME_US);
-  if (!src.expect_mark(BIT_TIME_US) || !src.expect_space(BIT_TIME_US) || !src.expect_mark(BIT_TIME_US))
+  int field_bit = 0;
+
+  if (src.expect_space(BIT_TIME_US) && src.expect_mark(BIT_TIME_US)) {
+    field_bit = 1;
+  } else if (src.expect_space(2*BIT_TIME_US)) {
+    field_bit = 0;
+  } else {
     return {};
+  }
+
+  if (!(((src.expect_space(BIT_TIME_US) || src.peek_space(2*BIT_TIME_US)) ||
+  (src.expect_mark(BIT_TIME_US) || src.peek_mark(2*BIT_TIME_US))) &&
+  (((src.expect_mark(BIT_TIME_US) || src.expect_mark(2*BIT_TIME_US)) &&
+  (src.expect_space(BIT_TIME_US) || src.peek_space(2*BIT_TIME_US))) ||
+  ((src.expect_space(BIT_TIME_US) || src.expect_space(2*BIT_TIME_US)) &&
+  (src.expect_mark(BIT_TIME_US) || src.peek_mark(2*BIT_TIME_US)))))) {
+    return {};
+  }
 
   uint64_t out_data = 0;
-  for (int bit = NBITS - 3; bit >= 0; bit--) {
-    if (src.expect_space(BIT_TIME_US) && src.expect_mark(BIT_TIME_US)) {
-      out_data |= 1 << bit;
-    } else if (src.expect_mark(BIT_TIME_US) && src.expect_space(BIT_TIME_US)) {
+  for (int bit = NBITS - 4; bit >= 1; bit--) {
+    if ((src.expect_space(BIT_TIME_US) || src.expect_space(2*BIT_TIME_US)) && (src.expect_mark(BIT_TIME_US) || src.peek_mark(2*BIT_TIME_US))) {
       out_data |= 0 << bit;
+    } else if ((src.expect_mark(BIT_TIME_US) || src.expect_mark(2*BIT_TIME_US)) && (src.expect_space(BIT_TIME_US) || src.peek_space(2*BIT_TIME_US))) {
+      out_data |= 1 << bit;
     } else {
       return {};
     }
   }
+  if (src.expect_space(BIT_TIME_US) || src.expect_space(2*BIT_TIME_US))
+    out_data |= 0;
+  if (src.expect_mark(BIT_TIME_US) || src.expect_mark(2*BIT_TIME_US))
+    out_data |= 1;
 
-  out.command = out_data & 0x3F;
+  out.command = (out_data & 0x3F) + (1 - field_bit) * 64;
   out.address = (out_data >> 6) & 0x1F;
   return out;
 }

--- a/esphome/components/remote_base/rc5_protocol.cpp
+++ b/esphome/components/remote_base/rc5_protocol.cpp
@@ -45,35 +45,38 @@ optional<RC5Data> RC5Protocol::decode(RemoteReceiveData src) {
 
   if (src.expect_space(BIT_TIME_US) && src.expect_mark(BIT_TIME_US)) {
     field_bit = 1;
-  } else if (src.expect_space(2*BIT_TIME_US)) {
+  } else if (src.expect_space(2 * BIT_TIME_US)) {
     field_bit = 0;
   } else {
     return {};
   }
 
-  if (!(((src.expect_space(BIT_TIME_US) || src.peek_space(2*BIT_TIME_US)) ||
-  (src.expect_mark(BIT_TIME_US) || src.peek_mark(2*BIT_TIME_US))) &&
-  (((src.expect_mark(BIT_TIME_US) || src.expect_mark(2*BIT_TIME_US)) &&
-  (src.expect_space(BIT_TIME_US) || src.peek_space(2*BIT_TIME_US))) ||
-  ((src.expect_space(BIT_TIME_US) || src.expect_space(2*BIT_TIME_US)) &&
-  (src.expect_mark(BIT_TIME_US) || src.peek_mark(2*BIT_TIME_US)))))) {
+  if (!(((src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US)) ||
+         (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) &&
+        (((src.expect_mark(BIT_TIME_US) || src.expect_mark(2 * BIT_TIME_US)) &&
+          (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) ||
+         ((src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) &&
+          (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US)))))) {
     return {};
   }
 
   uint64_t out_data = 0;
   for (int bit = NBITS - 4; bit >= 1; bit--) {
-    if ((src.expect_space(BIT_TIME_US) || src.expect_space(2*BIT_TIME_US)) && (src.expect_mark(BIT_TIME_US) || src.peek_mark(2*BIT_TIME_US))) {
+    if ((src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) &&
+        (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
       out_data |= 0 << bit;
-    } else if ((src.expect_mark(BIT_TIME_US) || src.expect_mark(2*BIT_TIME_US)) && (src.expect_space(BIT_TIME_US) || src.peek_space(2*BIT_TIME_US))) {
+    } else if ((src.expect_mark(BIT_TIME_US) || src.expect_mark(2 * BIT_TIME_US)) &&
+               (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) {
       out_data |= 1 << bit;
     } else {
       return {};
     }
   }
-  if (src.expect_space(BIT_TIME_US) || src.expect_space(2*BIT_TIME_US))
+  if (src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) {
     out_data |= 0;
-  if (src.expect_mark(BIT_TIME_US) || src.expect_mark(2*BIT_TIME_US))
+  } else if (src.expect_mark(BIT_TIME_US) || src.expect_mark(2 * BIT_TIME_US)) {
     out_data |= 1;
+  }
 
   out.command = (out_data & 0x3F) + (1 - field_bit) * 64;
   out.address = (out_data >> 6) & 0x1F;


### PR DESCRIPTION
## Description:
Decoding RC5 codes did not work, as each bit is represented as two pulses: either high -> low (1) or low -> high (0). In case of two unequahl bits (e.g. 0 1), the code low -> high -> high -> low will be detected as one short low pulse, one long high pulse and one short low pulse. This behaviour breaks the decoding.
Additionally, the second bit sent is interpreted as the field bit, extending the protocols command range to 0-127. This field bit is now also respected both in encoding and decoding.

**Related issue (if applicable):** fixes <https://github.com/esphome/issues/issues/674>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
