### PR TITLE
Fix fan oscillation trait not being used

### DIFF
--- a/esphome/components/fan/fan_traits.h
+++ b/esphome/components/fan/fan_traits.h
@@ -6,7 +6,7 @@ namespace fan {
 class FanTraits {
  public:
   FanTraits() = default;
-  FanTraits(bool oscillation, bool speed) : oscillation_(false), speed_(speed) {}
+  FanTraits(bool oscillation, bool speed) : oscillation_(oscillation), speed_(speed) {}
 
   /// Return if this fan supports oscillation.
   bool supports_oscillation() const { return this->oscillation_; }


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** 
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
