### PR TITLE
Sort keys in dicts in output yaml for 'config' command

### DIFF
--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -338,7 +338,7 @@ class ESPHomeDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors
             self.represented_objects[self.alias_key] = node
         best_style = True
         if hasattr(mapping, 'items'):
-            mapping = list(mapping.items())
+            mapping = sorted(mapping.items(), key=lambda item: item[0])
         for item_key, item_value in mapping:
             node_key = self.represent_data(item_key)
             node_value = self.represent_data(item_value)


### PR DESCRIPTION
## Description:

Having different output each time due to random key order makes some
tasks harder (such as CI scripts). So, let's sort the keys to have same yaml output each time.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
