### PR TITLE
(Daikin climate) Support for ARC432A14.

### DIFF
--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -5,17 +5,71 @@ namespace esphome {
 namespace daikin {
 
 static const char *TAG = "daikin.climate";
+// TODO: Make these inputs
+static bool ARC432A14 = true;
+static bool comfort_mode = false;
+static bool powerful_mode = false;
+static bool economy_mode = false;
+static const uint8_t FRAME_THREE_OFFSET = 16;
+static const uint8_t HEADER_ID = 3;
+static const uint8_t MESSAGE_ID = 4;
+static const uint8_t COMFORT_ID = 6;
+static const uint8_t SWING_VERTICAL_ID = (FRAME_THREE_OFFSET + 8);
+static const uint8_t SWING_HORIZONTAL_ID = (FRAME_THREE_OFFSET + 9);
+static const uint8_t TIMER_A_ID = (FRAME_THREE_OFFSET + 10);
+static const uint8_t TIMER_B_ID = (FRAME_THREE_OFFSET + 11);
+static const uint8_t TIMER_C_ID = (FRAME_THREE_OFFSET + 12);
+static const uint8_t POWERFUL_ID = (FRAME_THREE_OFFSET + 13);
+static const uint8_t ECONOMY_ID = (FRAME_THREE_OFFSET + 16);
 
 void DaikinClimate::transmit_state() {
-  uint8_t remote_state[35] = {0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7, 0x11, 0xDA, 0x27, 0x00,
+  uint8_t remote_state[35] = {0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0x00, 0x11, 0xDA, 0x27, 0x00,
                               0x42, 0x49, 0x05, 0xA2, 0x11, 0xDA, 0x27, 0x00, 0x00, 0x00, 0x00, 0x00,
-                              0x00, 0x00, 0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00};
+                              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00};
+  // Original author's setting. Untested.
+  if (!ARC432A14) {
+    remote_state[27] = 0x06;
+    remote_state[28] = 0x60;
+  }
+
+  // Frame #1
+  if (ARC432A14) {
+    remote_state[HEADER_ID] = 0xF0;
+    remote_state[MESSAGE_ID] = 0x00;
+  }
+  if (comfort_mode) {
+    remote_state[COMFORT_ID] = 0x10;
+  }
+  // Calculate checksum
+  for (int i = 0; i < 7; i++) {
+    remote_state[7] += remote_state[i];
+  }
+
+  // Calculations frame #3
+  if (this->swing_mode == climate::CLIMATE_SWING_HORIZONTAL) {
+    remote_state[SWING_HORIZONTAL_ID] |= 0xF0;
+  }
+  // FUTURE:
+#if 0
+  if (this->swing_mode == climate::CLIMATE_SWING_WIDE)
+  {
+     remote_state[SWING_HORIZONTAL_ID] &= 0x0F;
+     remote_state[SWING_HORIZONTAL_ID] |= 0xE0;
+  }
+#endif
 
   remote_state[21] = this->operation_mode_();
   remote_state[22] = this->temperature_();
+  // Vertical swing covered in fan speed.
   uint16_t fan_speed = this->fan_speed_();
   remote_state[24] = fan_speed >> 8;
   remote_state[25] = fan_speed & 0xff;
+  if (powerful_mode) {
+    remote_state[POWERFUL_ID] = 0x01;
+  }
+  if (economy_mode) {
+    remote_state[ECONOMY_ID] |= 0x04;
+  }
 
   // Calculate checksum
   for (int i = 16; i < 34; i++) {
@@ -40,17 +94,20 @@ void DaikinClimate::transmit_state() {
   data->mark(DAIKIN_HEADER_MARK);
   data->space(DAIKIN_HEADER_SPACE);
 
-  for (int i = 8; i < 16; i++) {
-    for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
-      data->mark(DAIKIN_BIT_MARK);
-      bool bit = remote_state[i] & mask;
-      data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
+  // Second frame not necessary for ARC432A14
+  if (!ARC432A14) {
+    for (int i = 8; i < 16; i++) {
+      for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
+        data->mark(DAIKIN_BIT_MARK);
+        bool bit = remote_state[i] & mask;
+        data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
+      }
     }
+    data->mark(DAIKIN_BIT_MARK);
+    data->space(DAIKIN_MESSAGE_SPACE);
+    data->mark(DAIKIN_HEADER_MARK);
+    data->space(DAIKIN_HEADER_SPACE);
   }
-  data->mark(DAIKIN_BIT_MARK);
-  data->space(DAIKIN_MESSAGE_SPACE);
-  data->mark(DAIKIN_HEADER_MARK);
-  data->space(DAIKIN_HEADER_SPACE);
 
   for (int i = 16; i < 35; i++) {
     for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
@@ -103,6 +160,9 @@ uint16_t DaikinClimate::fan_speed_() {
       break;
     case climate::CLIMATE_FAN_HIGH:
       fan_speed = DAIKIN_FAN_5 << 8;
+      break;
+    case climate::CLIMATE_FAN_FOCUS:
+      fan_speed = DAIKIN_FAN_SILENT;
       break;
     case climate::CLIMATE_FAN_AUTO:
     default:

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -36,6 +36,7 @@ const uint32_t DAIKIN_BIT_MARK = 520;
 const uint32_t DAIKIN_ONE_SPACE = 1370;
 const uint32_t DAIKIN_ZERO_SPACE = 360;
 const uint32_t DAIKIN_MESSAGE_SPACE = 32300;
+const uint32_t DAIKIN_MESSAGE_SHORT_SPACE = 25000;
 
 // State Frame size
 const uint8_t DAIKIN_STATE_FRAME_SIZE = 19;
@@ -46,9 +47,10 @@ class DaikinClimate : public climate_ir::ClimateIR {
       : climate_ir::ClimateIR(
             DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,
             std::vector<climate::ClimateFanMode>{climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
-                                                 climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
-            std::vector<climate::ClimateSwingMode>{climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
-                                                   climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH}) {}
+                                                 climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH,
+                                                 climate::CLIMATE_FAN_FOCUS},
+            std::vector<climate::ClimateSwingMode>{climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL,
+                                                   climate::CLIMATE_SWING_VERTICAL}) {}
 
  protected:
   // Transmit via IR the state of this climate controller.


### PR DESCRIPTION
## Description:

I added support for my remote ARC432A14 and I have been using it happily for a while at home now without upstreaming it. I think putting it up here might work as a good incentive to finish sharing it. The code needs some fixes though and is a very lazy patch. Specifically at least these items need to be taken care of:

* The messages are a bit different for my remote, so a configuration option needs to be introduced for ARC432A14.
* I added more functionality than I actually use myself, e.g., powerful mode. So one should decide what to do with this.
* I wanted silent mode, so I hijacked focus mode, and I am not sure these should the same.
* Testing so I do not break support for other already support remotes.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
