### PR TITLE
Add MCP3008 I/O Expander

### DIFF
--- a/esphome/components/mcp3008/__init__.py
+++ b/esphome/components/mcp3008/__init__.py
@@ -14,7 +14,7 @@ MCP3008 = mcp3008_ns.class_('MCP3008', cg.Component, spi.SPIDevice)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(MCP3008),
-}).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(spi.spi_device_schema(CS_PIN_required=True))
 
 
 def to_code(config):

--- a/esphome/components/mcp3008/__init__.py
+++ b/esphome/components/mcp3008/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import spi, sensor
+from esphome.components import spi
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ['spi']

--- a/esphome/components/mcp3008/__init__.py
+++ b/esphome/components/mcp3008/__init__.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import spi, sensor
+from esphome.const import CONF_ID, CONF_NUMBER, CONF_MODE, CONF_INVERTED
+
+DEPENDENCIES = ['spi']
+AUTO_LOAD = ['sensor']
+MULTI_CONF = True
+
+CONF_MCP3008 = 'mcp3008'
+
+mcp3008_ns = cg.esphome_ns.namespace('mcp3008')
+MCP3008 = mcp3008_ns.class_('MCP3008', cg.Component, spi.SPIDevice)
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(MCP3008),
+}).extend(spi.SPI_DEVICE_SCHEMA)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield spi.register_spi_device(var, config)

--- a/esphome/components/mcp3008/__init__.py
+++ b/esphome/components/mcp3008/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import spi, sensor
-from esphome.const import CONF_ID, CONF_NUMBER, CONF_MODE, CONF_INVERTED
+from esphome.const import CONF_ID
 
 DEPENDENCIES = ['spi']
 AUTO_LOAD = ['sensor']

--- a/esphome/components/mcp3008/mcp3008.cpp
+++ b/esphome/components/mcp3008/mcp3008.cpp
@@ -1,0 +1,50 @@
+#include "mcp3008.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace mcp3008 {
+
+static const char *TAG = "mcp3008";
+
+float MCP3008::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+void MCP3008::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up mcp3008");
+  this->spi_setup();
+  ESP_LOGI(TAG, "SPI setup finished!");
+}
+
+void MCP3008::dump_config() { LOG_PIN("  CS Pin: ", this->cs_); }
+
+float MCP3008::readData(uint8_t pin) {
+  byte b0, b1, b2;
+
+  byte command = ((0x01 << 7) |          // start bit
+                  (0 << 6) |             // single or differential
+                  ((pin & 0x07) << 3));  // channel number
+
+  this->enable();
+
+  b0 = this->transfer_byte(command);
+  b1 = this->transfer_byte(0x00);
+  b2 = this->transfer_byte(0x00);
+
+  this->disable();
+
+  int data = 0x3FF & ((b0 & 0x01) << 9 | (b1 & 0xFF) << 1 | (b2 & 0x80) >> 7);
+
+  return data / 1024.0f;
+}
+
+MCP3008Sensor::MCP3008Sensor(MCP3008 *parent, std::string name, uint8_t pin)
+    : PollingComponent(1000), parent_(parent), _pin(pin) {
+  this->set_name(name);
+}
+void MCP3008Sensor::setup() { ESP_LOGCONFIG(TAG, "Setting up MCP3008 Sensor '%s'...", this->get_name().c_str()); }
+void MCP3008Sensor::update() {
+  float value_v = this->parent_->readData(_pin);
+  this->publish_state(value_v);
+}
+
+}  // namespace mcp3008
+}  // namespace esphome

--- a/esphome/components/mcp3008/mcp3008.cpp
+++ b/esphome/components/mcp3008/mcp3008.cpp
@@ -11,10 +11,12 @@ float MCP3008::get_setup_priority() const { return setup_priority::HARDWARE; }
 void MCP3008::setup() {
   ESP_LOGCONFIG(TAG, "Setting up mcp3008");
   this->spi_setup();
-  ESP_LOGI(TAG, "SPI setup finished!");
 }
 
-void MCP3008::dump_config() { LOG_PIN("  CS Pin: ", this->cs_); }
+void MCP3008::dump_config() {
+  ESP_LOGCONFIG(TAG, "MCP3008:");
+  LOG_PIN("  CS Pin: ", this->cs_);
+}
 
 float MCP3008::read_data(uint8_t pin) {
   byte b0, b1, b2;
@@ -40,7 +42,7 @@ MCP3008Sensor::MCP3008Sensor(MCP3008 *parent, std::string name, uint8_t pin)
     : PollingComponent(1000), parent_(parent), pin_(pin) {
   this->set_name(name);
 }
-void MCP3008Sensor::setup() { ESP_LOGCONFIG(TAG, "Setting up MCP3008 Sensor '%s'...", this->get_name().c_str()); }
+void MCP3008Sensor::setup() { LOG_SENSOR("", "Setting up MCP3008 Sensor '%s'...", this); }
 void MCP3008Sensor::update() {
   float value_v = this->parent_->read_data(pin_);
   this->publish_state(value_v);

--- a/esphome/components/mcp3008/mcp3008.cpp
+++ b/esphome/components/mcp3008/mcp3008.cpp
@@ -19,21 +19,21 @@ void MCP3008::dump_config() {
 }
 
 float MCP3008::read_data(uint8_t pin) {
-  byte b0, b1, b2;
+  byte data_msb = 0;
+  byte data_lsb = 0;
 
   byte command = ((0x01 << 7) |          // start bit
-                  (0 << 6) |             // single or differential
-                  ((pin & 0x07) << 3));  // channel number
+                  ((pin & 0x07) << 4));  // channel number
 
   this->enable();
 
-  b0 = this->transfer_byte(command);
-  b1 = this->transfer_byte(0x00);
-  b2 = this->transfer_byte(0x00);
+  this->transfer_byte(0x01);
+  data_msb = this->transfer_byte(command) & 0x03;
+  data_lsb = this->transfer_byte(0x00);
 
   this->disable();
 
-  int data = 0x3FF & ((b0 & 0x01) << 9 | (b1 & 0xFF) << 1 | (b2 & 0x80) >> 7);
+  int data = data_msb << 8 | data_lsb;
 
   return data / 1024.0f;
 }

--- a/esphome/components/mcp3008/mcp3008.cpp
+++ b/esphome/components/mcp3008/mcp3008.cpp
@@ -18,7 +18,7 @@ void MCP3008::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
 }
 
-float MCP3008::read_data(uint8_t pin) {
+float MCP3008::read_data_(uint8_t pin) {
   byte data_msb = 0;
   byte data_lsb = 0;
 
@@ -44,7 +44,7 @@ MCP3008Sensor::MCP3008Sensor(MCP3008 *parent, std::string name, uint8_t pin)
 }
 void MCP3008Sensor::setup() { LOG_SENSOR("", "Setting up MCP3008 Sensor '%s'...", this); }
 void MCP3008Sensor::update() {
-  float value_v = this->parent_->read_data(pin_);
+  float value_v = this->parent_->read_data_(pin_);
   this->publish_state(value_v);
 }
 

--- a/esphome/components/mcp3008/mcp3008.cpp
+++ b/esphome/components/mcp3008/mcp3008.cpp
@@ -16,7 +16,7 @@ void MCP3008::setup() {
 
 void MCP3008::dump_config() { LOG_PIN("  CS Pin: ", this->cs_); }
 
-float MCP3008::readData(uint8_t pin) {
+float MCP3008::read_data(uint8_t pin) {
   byte b0, b1, b2;
 
   byte command = ((0x01 << 7) |          // start bit
@@ -37,12 +37,12 @@ float MCP3008::readData(uint8_t pin) {
 }
 
 MCP3008Sensor::MCP3008Sensor(MCP3008 *parent, std::string name, uint8_t pin)
-    : PollingComponent(1000), parent_(parent), _pin(pin) {
+    : PollingComponent(1000), parent_(parent), pin_(pin) {
   this->set_name(name);
 }
 void MCP3008Sensor::setup() { ESP_LOGCONFIG(TAG, "Setting up MCP3008 Sensor '%s'...", this->get_name().c_str()); }
 void MCP3008Sensor::update() {
-  float value_v = this->parent_->readData(_pin);
+  float value_v = this->parent_->read_data(_pin);
   this->publish_state(value_v);
 }
 

--- a/esphome/components/mcp3008/mcp3008.cpp
+++ b/esphome/components/mcp3008/mcp3008.cpp
@@ -42,7 +42,7 @@ MCP3008Sensor::MCP3008Sensor(MCP3008 *parent, std::string name, uint8_t pin)
 }
 void MCP3008Sensor::setup() { ESP_LOGCONFIG(TAG, "Setting up MCP3008 Sensor '%s'...", this->get_name().c_str()); }
 void MCP3008Sensor::update() {
-  float value_v = this->parent_->read_data(_pin);
+  float value_v = this->parent_->read_data(pin_);
   this->publish_state(value_v);
 }
 

--- a/esphome/components/mcp3008/mcp3008.h
+++ b/esphome/components/mcp3008/mcp3008.h
@@ -8,6 +8,8 @@
 namespace esphome {
 namespace mcp3008 {
 
+class MCP3008Sensor;
+
 class MCP3008 : public Component,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                       spi::DATA_RATE_1MHZ> {  // At 3.3V 2MHz is too fast 1.35MHz is about right
@@ -17,9 +19,11 @@ class MCP3008 : public Component,
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  float read_data(uint8_t pin);
 
  protected:
+  float read_data(uint8_t pin);
+
+  friend class MCP3008Sensor;
 };
 
 class MCP3008Sensor : public PollingComponent, public sensor::Sensor {

--- a/esphome/components/mcp3008/mcp3008.h
+++ b/esphome/components/mcp3008/mcp3008.h
@@ -21,7 +21,7 @@ class MCP3008 : public Component,
   float get_setup_priority() const override;
 
  protected:
-  float read_data(uint8_t pin);
+  float read_data_(uint8_t pin);
 
   friend class MCP3008Sensor;
 };

--- a/esphome/components/mcp3008/mcp3008.h
+++ b/esphome/components/mcp3008/mcp3008.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome {
+namespace mcp3008 {
+
+class MCP3008 : public Component,
+                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                                      spi::DATA_RATE_1MHZ> {  // At 3.3V 2MHz is too fast 1.35MHz is about right
+ public:
+  MCP3008() = default;
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  float readData(uint8_t pin);
+
+ protected:
+};
+
+class MCP3008Sensor : public PollingComponent, public sensor::Sensor {
+ public:
+  MCP3008Sensor(MCP3008 *parent, std::string name, uint8_t pin);
+
+  void setup() override;
+  void update() override;
+
+ protected:
+  MCP3008 *parent_;
+  uint8_t _pin;
+};
+
+}  // namespace mcp3008
+}  // namespace esphome

--- a/esphome/components/mcp3008/mcp3008.h
+++ b/esphome/components/mcp3008/mcp3008.h
@@ -17,7 +17,7 @@ class MCP3008 : public Component,
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  float readData(uint8_t pin);
+  float read_data(uint8_t pin);
 
  protected:
 };
@@ -31,7 +31,7 @@ class MCP3008Sensor : public PollingComponent, public sensor::Sensor {
 
  protected:
   MCP3008 *parent_;
-  uint8_t _pin;
+  uint8_t pin_;
 };
 
 }  // namespace mcp3008

--- a/esphome/components/mcp3008/sensor.py
+++ b/esphome/components/mcp3008/sensor.py
@@ -2,20 +2,22 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import CONF_ID, CONF_NUMBER, CONF_NAME
-from . import mcp3008_ns, MCP3008, CONF_MCP3008
+from . import mcp3008_ns, MCP3008
 
 DEPENDENCIES = ['mcp3008']
 
 MCP3008Sensor = mcp3008_ns.class_('MCP3008Sensor', sensor.Sensor, cg.PollingComponent)
 
+CONF_MCP3008_ID = 'mcp3008_id'
+
 CONFIG_SCHEMA = sensor.SENSOR_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(MCP3008Sensor),
-    cv.Required(CONF_MCP3008): cv.use_id(MCP3008),
+    cv.GenerateID(CONF_MCP3008_ID): cv.use_id(MCP3008),
     cv.Required(CONF_NUMBER): cv.int_,
 }).extend(cv.polling_component_schema('1s'))
 
 
 def to_code(config):
-    parent = yield cg.get_variable(config[CONF_MCP3008])
+    parent = yield cg.get_variable(config[CONF_MCP3008_ID])
     var = cg.new_Pvariable(config[CONF_ID], parent, config[CONF_NAME], config[CONF_NUMBER])
     yield cg.register_component(var, config)

--- a/esphome/components/mcp3008/sensor.py
+++ b/esphome/components/mcp3008/sensor.py
@@ -1,0 +1,21 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import CONF_ID, CONF_NUMBER, CONF_NAME
+from . import mcp3008_ns, MCP3008, CONF_MCP3008
+
+DEPENDENCIES = ['mcp3008']
+
+MCP3008Sensor = mcp3008_ns.class_('MCP3008Sensor', sensor.Sensor, cg.PollingComponent)
+
+CONFIG_SCHEMA = sensor.SENSOR_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(MCP3008Sensor),
+    cv.Required(CONF_MCP3008): cv.use_id(MCP3008),
+    cv.Required(CONF_NUMBER): cv.int_,
+}).extend(cv.polling_component_schema('1s'))
+
+
+def to_code(config):
+    parent = yield cg.get_variable(config[CONF_MCP3008])
+    var = cg.new_Pvariable(config[CONF_ID], parent, config[CONF_NAME], config[CONF_NUMBER])
+    yield cg.register_component(var, config)


### PR DESCRIPTION
## Description:
Added support for MCP3008. There is a component for the SPI device and then the inputs are used as sensors. Example:

````yaml
spi:
  clk_pin: D5
  miso_pin: D6
  mosi_pin: D7
  
mcp3008:
  - id: 'mcp3008_hub'
    cs_pin: D8

sensor:
  - platform: mcp3008
    update_interval: 1s
    mcp3008: 'mcp3008_hub'
    id: freezer_temp_source
    name: "Freezer Temp"
    number: 0
  - platform: mcp3008
    update_interval: 1s
    mcp3008: 'mcp3008_hub'
    name: "FridgeTmep"
    number: 1
  - platform: resistance
    id: resistance_sensor
    sensor: freezer_temp_source
    configuration: DOWNSTREAM
    resistor: 10kOhm
    name: Resistance Sensor
  - platform: ntc
    id: freezer_temp
    sensor: resistance_sensor
    calibration:
      b_constant: 3950
      reference_temperature: 25°C
      reference_resistance: 10kOhm
    name: NTC Temperature
````

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#591

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
