### PR TITLE
Allow tm1637 to use pins from IO expanders

### DIFF
--- a/esphome/components/tm1637/display.py
+++ b/esphome/components/tm1637/display.py
@@ -12,8 +12,8 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(TM1637Display),
 
     cv.Optional(CONF_INTENSITY, default=7): cv.All(cv.uint8_t, cv.Range(min=0, max=7)),
-    cv.Required(CONF_CLK_PIN): pins.internal_gpio_output_pin_schema,
-    cv.Required(CONF_DIO_PIN): pins.internal_gpio_output_pin_schema,
+    cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
+    cv.Required(CONF_DIO_PIN): pins.gpio_output_pin_schema,
 }).extend(cv.polling_component_schema('1s'))
 
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1478,6 +1478,16 @@ display:
   intensity: 3
   lambda: |-
       it.print("1234");
+- platform: tm1637
+  clk_pin:
+    mcp23017: mcp23017_hub
+    number: 1
+  dio_pin:
+    mcp23017: mcp23017_hub
+    number: 2
+  intensity: 3
+  lambda: |-
+      it.print("1234");
 - platform: nextion
   lambda: |-
     it.set_component_value("gauge", 50);


### PR DESCRIPTION
## Description:
This allows the TM1637 7-segment display to use IO expander pins for DIO and CLK. I have tested this with an MCP23017 as that is all I have to use and there are no issues.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
