### PR TITLE
Add lambda to devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
     "terminal.integrated.shell.linux": "/bin/bash",
     "yaml.customTags": [
       "!secret scalar",
+      "!lambda scalar",
       "!include_dir_named scalar",
       "!include_dir_list scalar",
       "!include_dir_merge_list scalar",


### PR DESCRIPTION
## Description:
When using the devcontainer, vscode complains that lambda is not a valid yaml tag, this fixes that.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
