### PR TITLE
SSD1325 grayscale support

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -7,8 +7,8 @@ namespace display {
 
 static const char *TAG = "display";
 
-const Color COLOR_OFF = 0;
-const Color COLOR_ON = 1;
+const Color COLOR_OFF(0, 0, 0, 0);
+const Color COLOR_ON(1, 1, 1, 1);
 
 void DisplayBuffer::init_internal_(uint32_t buffer_length) {
   this->buffer_ = new uint8_t[buffer_length];
@@ -214,10 +214,10 @@ void DisplayBuffer::image(int x, int y, Color color, Image *image, bool invert) 
           this->draw_pixel_at(x + img_x, y + img_y, image->get_pixel(img_x, img_y) ? color : COLOR_OFF);
       }
     }
-  } else if (image->get_type() == GRAYSCALE4) {
+  } else if (image->get_type() == GRAYSCALE) {
     for (int img_x = 0; img_x < image->get_width(); img_x++) {
       for (int img_y = 0; img_y < image->get_height(); img_y++) {
-        this->draw_pixel_at(x + img_x, y + img_y, image->get_grayscale4_pixel(img_x, img_y));
+        this->draw_pixel_at(x + img_x, y + img_y, image->get_grayscale_pixel(img_x, img_y));
       }
     }
   } else if (image->get_type() == RGB565) {
@@ -457,14 +457,11 @@ int Image::get_color_pixel(int x, int y) const {
   int color = (pgm_read_byte(this->data_start_ + pos) << 8) + (pgm_read_byte(this->data_start_ + pos + 1));
   return color;
 }
-int Image::get_grayscale4_pixel(int x, int y) const {
+Color Image::get_grayscale_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return 0;
-  const uint32_t pos = (x + y * this->width_) / 2;
-  // 2 = number of pixels per byte, 4 = pixel shift
-  uint8_t shift = (x % 2) * 4;
-  int color = (pgm_read_byte(this->data_start_ + pos) >> shift) & 0x0f;
-  return color;
+  const uint32_t pos = (x + y * this->width_);
+  return Color(pgm_read_byte(this->data_start_ + pos) << 24);
 }
 int Image::get_width() const { return this->width_; }
 int Image::get_height() const { return this->height_; }

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -70,6 +70,11 @@ extern const Color COLOR_ON;
 
 enum ImageType { BINARY = 0, GRAYSCALE4 = 1, RGB565 = 2 };
 
+enum ImageType {
+  BINARY = 0,
+  GRAYSCALE4 = 1,
+};
+
 enum DisplayRotation {
   DISPLAY_ROTATION_0_DEGREES = 0,
   DISPLAY_ROTATION_90_DEGREES = 90,

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -68,12 +68,7 @@ extern const Color COLOR_OFF;
 /// Turn the pixel ON.
 extern const Color COLOR_ON;
 
-enum ImageType { BINARY = 0, GRAYSCALE4 = 1, RGB565 = 2 };
-
-enum ImageType {
-  BINARY = 0,
-  GRAYSCALE4 = 1,
-};
+enum ImageType { BINARY = 0, GRAYSCALE = 1, RGB565 = 2 };
 
 enum DisplayRotation {
   DISPLAY_ROTATION_0_DEGREES = 0,
@@ -390,7 +385,7 @@ class Image {
   Image(const uint8_t *data_start, int width, int height, int type);
   bool get_pixel(int x, int y) const;
   int get_color_pixel(int x, int y) const;
-  int get_grayscale4_pixel(int x, int y) const;
+  Color get_grayscale_pixel(int x, int y) const;
   int get_width() const;
   int get_height() const;
   ImageType get_type() const;

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['display']
 MULTI_CONF = True
 
-ImageType = {'binary': 0, 'grayscale4': 1, 'rgb565': 2}
+ImageType = {'binary': 0, 'grayscale': 1, 'rgb565': 2}
 
 Image_ = display.display_ns.class_('Image')
 
@@ -41,20 +41,18 @@ def to_code(config):
         image.thumbnail(config[CONF_RESIZE])
 
     if CONF_TYPE in config:
-        if config[CONF_TYPE].startswith('GRAYSCALE4'):
+        if config[CONF_TYPE].startswith('GRAYSCALE'):
             width, height = image.size
             image = image.convert('L', dither=Image.NONE)
             pixels = list(image.getdata())
-            data = [0 for _ in range(height * width // 2)]
+            data = [0 for _ in range(height * width)]
             pos = 0
-            for pixnum, pix in enumerate(pixels):
-                pixshift = (pixnum % 2) * 4
-                data[pos] |= (pix >> 4) << pixshift
-                if pixshift != 0:
-                    pos += 1
+            for pix in pixels:
+                data[pos] = pix
+                pos += 1
             rhs = [HexInt(x) for x in data]
             prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
-            cg.new_Pvariable(config[CONF_ID], prog_arr, width, height, ImageType['grayscale4'])
+            cg.new_Pvariable(config[CONF_ID], prog_arr, width, height, ImageType['grayscale'])
         elif config[CONF_TYPE].startswith('RGB565'):
             width, height = image.size
             image = image.convert('RGB')

--- a/esphome/components/ssd1325_base/__init__.py
+++ b/esphome/components/ssd1325_base/__init__.py
@@ -2,7 +2,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import display
-from esphome.const import CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, CONF_RESET_PIN
+from esphome.const import CONF_BRIGHTNESS, CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, \
+                          CONF_RESET_PIN
 from esphome.core import coroutine
 
 ssd1325_base_ns = cg.esphome_ns.namespace('ssd1325_base')
@@ -22,12 +23,13 @@ SSD1325_MODEL = cv.enum(MODELS, upper=True, space="_")
 SSD1325_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend({
     cv.Required(CONF_MODEL): SSD1325_MODEL,
     cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+    cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
     cv.Optional(CONF_EXTERNAL_VCC): cv.boolean,
 }).extend(cv.polling_component_schema('1s'))
 
 
 @coroutine
-def setup_ssd1036(var, config):
+def setup_ssd1325(var, config):
     yield cg.register_component(var, config)
     yield display.register_display(var, config)
 
@@ -35,6 +37,8 @@ def setup_ssd1036(var, config):
     if CONF_RESET_PIN in config:
         reset = yield cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(reset))
+    if CONF_BRIGHTNESS in config:
+        cg.add(var.init_brightness(config[CONF_BRIGHTNESS]))
     if CONF_EXTERNAL_VCC in config:
         cg.add(var.set_external_vcc(config[CONF_EXTERNAL_VCC]))
     if CONF_LAMBDA in config:

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -37,6 +37,7 @@ static const uint8_t SSD1325_SETROWPERIOD = 0xB2;
 static const uint8_t SSD1325_SETCLOCK = 0xB3;
 static const uint8_t SSD1325_SETPRECHARGECOMP = 0xB4;
 static const uint8_t SSD1325_SETGRAYTABLE = 0xB8;
+static const uint8_t SSD1325_SETDEFAULTGRAYTABLE = 0xB9;
 static const uint8_t SSD1325_SETPRECHARGEVOLTAGE = 0xBC;
 static const uint8_t SSD1325_SETVCOMLEVEL = 0xBE;
 static const uint8_t SSD1325_SETVSL = 0xBF;
@@ -72,14 +73,33 @@ void SSD1325::setup() {
     this->command(0x50);                    // COM bottom-up, split odd/even
   this->command(SSD1325_SETCURRENT + 0x2);  // Set Full Current Range
   this->command(SSD1325_SETGRAYTABLE);
-  this->command(0x01);
-  this->command(0x11);
-  this->command(0x22);
-  this->command(0x32);
-  this->command(0x43);
-  this->command(0x54);
-  this->command(0x65);
-  this->command(0x76);
+  // gamma ~2.2
+  if (this->model_ == SSD1327_MODEL_128_128) {
+    this->command(0);
+    this->command(1);
+    this->command(2);
+    this->command(3);
+    this->command(6);
+    this->command(8);
+    this->command(12);
+    this->command(16);
+    this->command(20);
+    this->command(26);
+    this->command(32);
+    this->command(39);
+    this->command(46);
+    this->command(54);
+    this->command(63);
+  } else {
+    this->command(0x01);
+    this->command(0x11);
+    this->command(0x22);
+    this->command(0x32);
+    this->command(0x43);
+    this->command(0x54);
+    this->command(0x65);
+    this->command(0x76);
+  }
   this->command(SSD1325_SETROWPERIOD);
   this->command(0x51);
   this->command(SSD1325_SETPHASELEN);

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -80,7 +80,6 @@ void SSD1325::setup() {
   this->command(0x54);
   this->command(0x65);
   this->command(0x76);
-  set_brightness(this->brightness_);
   this->command(SSD1325_SETROWPERIOD);
   this->command(0x51);
   this->command(SSD1325_SETPHASELEN);
@@ -94,9 +93,10 @@ void SSD1325::setup() {
   this->command(SSD1325_SETVSL);  // set Low Voltage Level of SEG Pin
   this->command(0x0D | 0x02);
   this->command(SSD1325_NORMALDISPLAY);  // set display mode
-  this->fill(BLACK);                     // clear display - ensures we do not see garbage at power-on
-  this->display();                       // ...write buffer, which actually clears the display's memory
-  this->command(SSD1325_DISPLAYON);      // display ON
+  set_brightness(this->brightness_);
+  this->fill(BLACK);                 // clear display - ensures we do not see garbage at power-on
+  this->display();                   // ...write buffer, which actually clears the display's memory
+  this->command(SSD1325_DISPLAYON);  // display ON
 }
 void SSD1325::display() {
   this->command(SSD1325_SETCOLADDR);  // set column address

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -79,8 +79,7 @@ void SSD1325::setup() {
   this->command(0x54);
   this->command(0x65);
   this->command(0x76);
-  this->command(SSD1325_SETCONTRAST);  // set contrast current
-  this->command(0x7F);                 // max!
+  set_brightness(this->brightness_);
   this->command(SSD1325_SETROWPERIOD);
   this->command(0x51);
   this->command(SSD1325_SETPHASELEN);
@@ -90,8 +89,8 @@ void SSD1325::setup() {
   this->command(SSD1325_SETPRECHARGECOMPENABLE);
   this->command(0x28);
   this->command(SSD1325_SETVCOMLEVEL);  // Set High Voltage Level of COM Pin
-  this->command(0x1C);                  // ?
-  this->command(SSD1325_SETVSL);        // set Low Voltage Level of SEG Pin
+  this->command(0x1C);
+  this->command(SSD1325_SETVSL);  // set Low Voltage Level of SEG Pin
   this->command(0x0D | 0x02);
   this->command(SSD1325_NORMALDISPLAY);  // set display mode
   this->fill(BLACK);                     // clear display - ensures we do not see garbage at power-on
@@ -99,21 +98,33 @@ void SSD1325::setup() {
   this->command(SSD1325_DISPLAYON);      // display ON
 }
 void SSD1325::display() {
-  this->command(SSD1325_SETCOLADDR); /* set column address */
-  this->command(0x00);               /* set column start address */
-  this->command(0x3F);               /* set column end address */
-  this->command(SSD1325_SETROWADDR); /* set row address */
-  this->command(0x00);               /* set row start address */
+  this->command(SSD1325_SETCOLADDR);  // set column address
+  this->command(0x00);                // set column start address
+  this->command(0x3F);                // set column end address
+  this->command(SSD1325_SETROWADDR);  // set row address
+  this->command(0x00);                // set row start address
   if (this->model_ == SSD1327_MODEL_128_128)
-    this->command(0x7F);  // 127 is last row
+    this->command(127);  // set last row
   else
-    this->command(0x3F);  // 63 is last row
+    this->command(63);  // set last row
 
   this->write_display_data();
 }
 void SSD1325::update() {
   this->do_update_();
   this->display();
+}
+void SSD1325::set_brightness(float brightness) {
+  // validation
+  if (brightness > 1)
+    this->brightness_ = 1.0;
+  else if (brightness < 0)
+    this->brightness_ = 0;
+  else
+    this->brightness_ = brightness;
+  // now write the new brightness level to the display
+  this->command(SSD1325_SETCONTRAST);
+  this->command(int(127 * (this->brightness_)));
 }
 int SSD1325::get_height_internal() {
   switch (this->model_) {

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -66,7 +66,7 @@ void SSD1325::setup() {
   this->command(0x02);
   this->command(SSD1325_SETREMAP);  // set segment remapping
   if (this->model_ == SSD1327_MODEL_128_128)
-    this->command(0x51);  //  COM bottom-up, split odd/even, enable column swap
+    this->command(0x53);  //  COM bottom-up, split odd/even, enable column and nibble remapping
   else
     this->command(0x50);                    // COM bottom-up, split odd/even
   this->command(SSD1325_SETCURRENT + 0x2);  // Set Full Current Range

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -64,13 +64,11 @@ void SSD1325::setup() {
   this->command(0x00);                 /* ------ */
   this->command(SSD1325_MASTERCONFIG); /*Set Master Config DC/DC Converter*/
   this->command(0x02);
-<<<<<<< HEAD
   this->command(SSD1325_SETREMAP);         /* set segment remapping */
   if (this->model_ == SSD1327_MODEL_128_128)
-    this->command(0x55);  // 0x56 is flipped horizontally: enable column swap, disable nibble remap
+    this->command(0x51);  // 0x56 is flipped horizontally: enable column swap, disable nibble remap
   else
     this->command(0x50);                 /* ...just like so... */
->>>>>>> Linted
   this->command(SSD1325_SETCURRENT + 0x2); /* Set Full Current Range */
   this->command(SSD1325_SETGRAYTABLE);
   this->command(0x01);

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -9,6 +9,7 @@ static const char *TAG = "ssd1325";
 
 static const uint8_t BLACK = 0;
 static const uint8_t WHITE = 15;
+static const uint8_t SSD1325_MAX_CONTRAST = 127;
 static const uint8_t SSD1325_COLORMASK = 0x0f;
 static const uint8_t SSD1325_COLORSHIFT = 4;
 static const uint8_t SSD1325_PIXELSPERBYTE = 2;
@@ -124,8 +125,10 @@ void SSD1325::set_brightness(float brightness) {
     this->brightness_ = brightness;
   // now write the new brightness level to the display
   this->command(SSD1325_SETCONTRAST);
-  this->command(int(127 * (this->brightness_)));
+  this->command(int(SSD1325_MAX_CONTRAST * (this->brightness_)));
 }
+void SSD1325::turn_on() { this->command(SSD1325_DISPLAYON); }
+void SSD1325::turn_off() { this->command(SSD1325_DISPLAYOFF); }
 int SSD1325::get_height_internal() {
   switch (this->model_) {
     case SSD1325_MODEL_128_32:

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -94,9 +94,9 @@ void SSD1325::setup() {
   this->command(0x0D | 0x02);
   this->command(SSD1325_NORMALDISPLAY);  // set display mode
   set_brightness(this->brightness_);
-  this->fill(BLACK);                 // clear display - ensures we do not see garbage at power-on
-  this->display();                   // ...write buffer, which actually clears the display's memory
-  this->command(SSD1325_DISPLAYON);  // display ON
+  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
+  this->display();    // ...write buffer, which actually clears the display's memory
+  this->turn_on();    // display ON
 }
 void SSD1325::display() {
   this->command(SSD1325_SETCOLADDR);  // set column address
@@ -127,8 +127,15 @@ void SSD1325::set_brightness(float brightness) {
   this->command(SSD1325_SETCONTRAST);
   this->command(int(SSD1325_MAX_CONTRAST * (this->brightness_)));
 }
-void SSD1325::turn_on() { this->command(SSD1325_DISPLAYON); }
-void SSD1325::turn_off() { this->command(SSD1325_DISPLAYOFF); }
+bool SSD1325::is_on() { return this->is_on_; }
+void SSD1325::turn_on() {
+  this->command(SSD1325_DISPLAYON);
+  this->is_on_ = true;
+}
+void SSD1325::turn_off() {
+  this->command(SSD1325_DISPLAYOFF);
+  this->is_on_ = false;
+}
 int SSD1325::get_height_internal() {
   switch (this->model_) {
     case SSD1325_MODEL_128_32:

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -92,11 +92,13 @@ void SSD1325::setup() {
   this->command(SSD1325_SETPRECHARGECOMPENABLE);
   this->command(0x28);
   this->command(SSD1325_SETVCOMLEVEL);  // Set High Voltage Level of COM Pin
-  this->command(0x1C);                  //?
+  this->command(0x1C);                  // ?
   this->command(SSD1325_SETVSL);        // set Low Voltage Level of SEG Pin
   this->command(0x0D | 0x02);
-  this->command(SSD1325_NORMALDISPLAY); /* set display mode */
-  this->command(SSD1325_DISPLAYON);     /* display ON */
+  this->command(SSD1325_NORMALDISPLAY);  // set display mode
+  this->fill(BLACK);                     // clear display - ensures we do not see garbage at power-on
+  this->display();                       // ...write buffer, which actually clears the display's memory
+  this->command(SSD1325_DISPLAYON);      // display ON
 }
 void SSD1325::display() {
   this->command(SSD1325_SETCOLADDR); /* set column address */
@@ -146,7 +148,7 @@ int SSD1325::get_width_internal() {
   }
 }
 size_t SSD1325::get_buffer_length_() {
-  return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 2u;
+  return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / SSD1325_PIXELSPERBYTE;
 }
 void HOT SSD1325::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -64,11 +64,13 @@ void SSD1325::setup() {
   this->command(0x00);                 /* ------ */
   this->command(SSD1325_MASTERCONFIG); /*Set Master Config DC/DC Converter*/
   this->command(0x02);
-  this->command(SSD1325_SETREMAP);     /* set segment remaping */
+<<<<<<< HEAD
+  this->command(SSD1325_SETREMAP);         /* set segment remapping */
   if (this->model_ == SSD1327_MODEL_128_128)
     this->command(0x55);  // 0x56 is flipped horizontally: enable column swap, disable nibble remap
   else
     this->command(0x50);                 /* ...just like so... */
+>>>>>>> Linted
   this->command(SSD1325_SETCURRENT + 0x2); /* Set Full Current Range */
   this->command(SSD1325_SETGRAYTABLE);
   this->command(0x01);

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -47,29 +47,29 @@ static const uint8_t SSD1325_COPY = 0x25;
 void SSD1325::setup() {
   this->init_internal_(this->get_buffer_length_());
 
-  this->command(SSD1325_DISPLAYOFF);   /* display off */
-  this->command(SSD1325_SETCLOCK);     /* set osc division */
-  this->command(0xF1);                 /* 145 */
-  this->command(SSD1325_SETMULTIPLEX); /* multiplex ratio */
+  this->command(SSD1325_DISPLAYOFF);    // display off
+  this->command(SSD1325_SETCLOCK);      // set osc division
+  this->command(0xF1);                  // 145
+  this->command(SSD1325_SETMULTIPLEX);  // multiplex ratio
   if (this->model_ == SSD1327_MODEL_128_128)
     this->command(0x7f);  // duty = height - 1
   else
-    this->command(0x3f);            // duty = 1/64
-  this->command(SSD1325_SETOFFSET); /* set display offset --- */
+    this->command(0x3f);             // duty = 1/64
+  this->command(SSD1325_SETOFFSET);  // set display offset
   if (this->model_ == SSD1327_MODEL_128_128)
     this->command(0x00);  // 0
   else
-    this->command(0x4C);               // 76
-  this->command(SSD1325_SETSTARTLINE); /*set start line */
-  this->command(0x00);                 /* ------ */
-  this->command(SSD1325_MASTERCONFIG); /*Set Master Config DC/DC Converter*/
+    this->command(0x4C);                // 76
+  this->command(SSD1325_SETSTARTLINE);  // set start line
+  this->command(0x00);                  // ...
+  this->command(SSD1325_MASTERCONFIG);  // Set Master Config DC/DC Converter
   this->command(0x02);
-  this->command(SSD1325_SETREMAP);         /* set segment remapping */
+  this->command(SSD1325_SETREMAP);  // set segment remapping
   if (this->model_ == SSD1327_MODEL_128_128)
-    this->command(0x51);  // 0x56 is flipped horizontally: enable column swap, disable nibble remap
+    this->command(0x51);  //  COM bottom-up, split odd/even, enable column swap
   else
-    this->command(0x50);                 /* ...just like so... */
-  this->command(SSD1325_SETCURRENT + 0x2); /* Set Full Current Range */
+    this->command(0x50);                    // COM bottom-up, split odd/even
+  this->command(SSD1325_SETCURRENT + 0x2);  // Set Full Current Range
   this->command(SSD1325_SETGRAYTABLE);
   this->command(0x01);
   this->command(0x11);
@@ -79,8 +79,8 @@ void SSD1325::setup() {
   this->command(0x54);
   this->command(0x65);
   this->command(0x76);
-  this->command(SSD1325_SETCONTRAST); /* set contrast current */
-  this->command(0x7F);                // max!
+  this->command(SSD1325_SETCONTRAST);  // set contrast current
+  this->command(0x7F);                 // max!
   this->command(SSD1325_SETROWPERIOD);
   this->command(0x51);
   this->command(SSD1325_SETPHASELEN);

--- a/esphome/components/ssd1325_base/ssd1325_base.h
+++ b/esphome/components/ssd1325_base/ssd1325_base.h
@@ -28,6 +28,8 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
   void init_brightness(float brightness) { this->brightness_ = brightness; }
   void set_brightness(float brightness);
+  void turn_on();
+  void turn_off();
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;

--- a/esphome/components/ssd1325_base/ssd1325_base.h
+++ b/esphome/components/ssd1325_base/ssd1325_base.h
@@ -28,6 +28,7 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
   void init_brightness(float brightness) { this->brightness_ = brightness; }
   void set_brightness(float brightness);
+  bool is_on();
   void turn_on();
   void turn_off();
 
@@ -49,6 +50,7 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   SSD1325Model model_{SSD1325_MODEL_128_64};
   GPIOPin *reset_pin_{nullptr};
   bool external_vcc_{false};
+  bool is_on_{false};
   float brightness_{1.0};
 };
 

--- a/esphome/components/ssd1325_base/ssd1325_base.h
+++ b/esphome/components/ssd1325_base/ssd1325_base.h
@@ -26,6 +26,8 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   void set_model(SSD1325Model model) { this->model_ = model; }
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
+  void init_brightness(float brightness) { this->brightness_ = brightness; }
+  void set_brightness(float brightness);
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
@@ -45,6 +47,7 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   SSD1325Model model_{SSD1325_MODEL_128_64};
   GPIOPin *reset_pin_{nullptr};
   bool external_vcc_{false};
+  float brightness_{1.0};
 };
 
 }  // namespace ssd1325_base

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = cv.All(ssd1325_base.SSD1325_SCHEMA.extend({
 
 def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    yield ssd1325_base.setup_ssd1036(var, config)
+    yield ssd1325_base.setup_ssd1325(var, config)
     yield spi.register_spi_device(var, config)
 
     dc = yield cg.gpio_pin_expression(config[CONF_DC_PIN])

--- a/esphome/components/ssd1325_spi/ssd1325_spi.cpp
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.cpp
@@ -11,8 +11,7 @@ void SPISSD1325::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SPI SSD1325...");
   this->spi_setup();
   this->dc_pin_->setup();  // OUTPUT
-  if (this->cs_)
-    this->cs_->setup();  // OUTPUT
+  this->cs_->setup();      // OUTPUT
 
   this->init_reset_();
   delay(500);  // NOLINT
@@ -28,30 +27,22 @@ void SPISSD1325::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 void SPISSD1325::command(uint8_t value) {
-  if (this->cs_)
-    this->cs_->digital_write(true);
+  this->cs_->digital_write(true);
   this->dc_pin_->digital_write(false);
   delay(1);
   this->enable();
-  if (this->cs_)
-    this->cs_->digital_write(false);
+  this->cs_->digital_write(false);
   this->write_byte(value);
-  if (this->cs_)
-    this->cs_->digital_write(true);
+  this->cs_->digital_write(true);
   this->disable();
 }
 void HOT SPISSD1325::write_display_data() {
-  if (this->cs_)
-    this->cs_->digital_write(true);
+  this->cs_->digital_write(true);
   this->dc_pin_->digital_write(true);
-  if (this->cs_)
-    this->cs_->digital_write(false);
+  this->cs_->digital_write(false);
   delay(1);
   this->enable();
-  for (uint32_t b = 0; b < this->get_buffer_length_(); b++)
-  {
-    this->write_byte(this->buffer_[b]);
-  }
+  this->write_array(this->buffer_, this->get_buffer_length_());
   if (this->cs_)
     this->cs_->digital_write(true);
   this->disable();

--- a/esphome/components/ssd1325_spi/ssd1325_spi.cpp
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.cpp
@@ -11,7 +11,8 @@ void SPISSD1325::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SPI SSD1325...");
   this->spi_setup();
   this->dc_pin_->setup();  // OUTPUT
-  this->cs_->setup();      // OUTPUT
+  if (this->cs_)
+    this->cs_->setup();  // OUTPUT
 
   this->init_reset_();
   delay(500);  // NOLINT
@@ -20,26 +21,32 @@ void SPISSD1325::setup() {
 void SPISSD1325::dump_config() {
   LOG_DISPLAY("", "SPI SSD1325", this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
-  LOG_PIN("  CS Pin: ", this->cs_);
+  if (this->cs_)
+    LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   ESP_LOGCONFIG(TAG, "  External VCC: %s", YESNO(this->external_vcc_));
   LOG_UPDATE_INTERVAL(this);
 }
 void SPISSD1325::command(uint8_t value) {
-  this->cs_->digital_write(true);
+  if (this->cs_)
+    this->cs_->digital_write(true);
   this->dc_pin_->digital_write(false);
   delay(1);
   this->enable();
-  this->cs_->digital_write(false);
+  if (this->cs_)
+    this->cs_->digital_write(false);
   this->write_byte(value);
-  this->cs_->digital_write(true);
+  if (this->cs_)
+    this->cs_->digital_write(true);
   this->disable();
 }
 void HOT SPISSD1325::write_display_data() {
-  this->cs_->digital_write(true);
+  if (this->cs_)
+    this->cs_->digital_write(true);
   this->dc_pin_->digital_write(true);
-  this->cs_->digital_write(false);
+  if (this->cs_)
+    this->cs_->digital_write(false);
   delay(1);
   this->enable();
   this->write_array(this->buffer_, this->get_buffer_length_());

--- a/esphome/components/ssd1325_spi/ssd1325_spi.cpp
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.cpp
@@ -48,19 +48,9 @@ void HOT SPISSD1325::write_display_data() {
     this->cs_->digital_write(false);
   delay(1);
   this->enable();
-  for (uint16_t x = 0; x < this->get_width_internal(); x += 2) {
-    for (uint16_t y = 0; y < this->get_height_internal(); y += 8) {  // we write 8 pixels at once
-      uint8_t left8 = this->buffer_[y * 16 + x];
-      uint8_t right8 = this->buffer_[y * 16 + x + 1];
-      for (uint8_t p = 0; p < 8; p++) {
-        uint8_t d = 0;
-        if (left8 & (1 << p))
-          d |= 0xF0;
-        if (right8 & (1 << p))
-          d |= 0x0F;
-        this->write_byte(d);
-      }
-    }
+  for (uint32_t b = 0; b < this->get_buffer_length_(); b++)
+  {
+    this->write_byte(this->buffer_[b]);
   }
   if (this->cs_)
     this->cs_->digital_write(true);

--- a/esphome/components/ssd1325_spi/ssd1325_spi.cpp
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.cpp
@@ -25,6 +25,7 @@ void SPISSD1325::dump_config() {
     LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  ESP_LOGCONFIG(TAG, "  Initial Brightness: %.2f", this->brightness_);
   ESP_LOGCONFIG(TAG, "  External VCC: %s", YESNO(this->external_vcc_));
   LOG_UPDATE_INTERVAL(this);
 }


### PR DESCRIPTION
## Description:

Small patch to add grayscale support to the SSD1325 display component.

**Related issue (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#596

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
