### PR TITLE
Explicitly set language to English

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -139,7 +139,7 @@ float WebServer::get_setup_priority() const { return setup_priority::WIFI - 1.0f
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
   AsyncResponseStream *stream = request->beginResponseStream("text/html");
   std::string title = App.get_name() + " Web Server";
-  stream->print(F("<!DOCTYPE html><html><head><meta charset=UTF-8><title>"));
+  stream->print(F("<!DOCTYPE html><html lang=\"en\"><head><meta charset=UTF-8><title>"));
   stream->print(title.c_str());
   stream->print(F("</title>"));
 #ifdef WEBSERVER_CSS_INCLUDE


### PR DESCRIPTION
## Description:

Google Chrome oftentimes auto-detects the language of ESPHome to be _Danish_ and annoys me with a translation popup. Explicitly stating the content to be English prevents this.

## Checklist:
  - [x] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
