### PR TITLE
Adds support for climate integrations to support eco mode

### DIFF
--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -15,6 +15,7 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(float, target_temperature_low)
   TEMPLATABLE_VALUE(float, target_temperature_high)
   TEMPLATABLE_VALUE(bool, away)
+  TEMPLATABLE_VALUE(bool, eco_mode)
   TEMPLATABLE_VALUE(ClimateFanMode, fan_mode)
   TEMPLATABLE_VALUE(ClimateSwingMode, swing_mode)
 
@@ -25,6 +26,7 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
     call.set_target_temperature_low(this->target_temperature_low_.optional_value(x...));
     call.set_target_temperature_high(this->target_temperature_high_.optional_value(x...));
     call.set_away(this->away_.optional_value(x...));
+    call.set_eco_mode(this->eco_mode_.optional_value(x...));
     call.set_fan_mode(this->fan_mode_.optional_value(x...));
     call.set_swing_mode(this->swing_mode_.optional_value(x...));
     call.perform();

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -33,6 +33,9 @@ void ClimateCall::perform() {
   if (this->away_.has_value()) {
     ESP_LOGD(TAG, "  Away Mode: %s", ONOFF(*this->away_));
   }
+  if (this->eco_mode_.has_value()) {
+    ESP_LOGD(TAG, "  Eco Mode: %s", ONOFF(*this->eco_mode_));
+  }
   this->parent_->control(*this);
 }
 void ClimateCall::validate_() {
@@ -97,6 +100,12 @@ void ClimateCall::validate_() {
     if (!traits.get_supports_away()) {
       ESP_LOGW(TAG, "  Cannot set away mode for this device!");
       this->away_.reset();
+    }
+  }
+  if (this->eco_mode_.has_value()) {
+    if (!traits.get_supports_eco_mode()) {
+      ESP_LOGW(TAG, "  Cannot set eco mode for this device!");
+      this->eco_mode_.reset();
     }
   }
 }
@@ -187,6 +196,7 @@ const optional<float> &ClimateCall::get_target_temperature() const { return this
 const optional<float> &ClimateCall::get_target_temperature_low() const { return this->target_temperature_low_; }
 const optional<float> &ClimateCall::get_target_temperature_high() const { return this->target_temperature_high_; }
 const optional<bool> &ClimateCall::get_away() const { return this->away_; }
+const optional<bool> &ClimateCall::get_eco_mode() const { return this->eco_mode_; }
 const optional<ClimateFanMode> &ClimateCall::get_fan_mode() const { return this->fan_mode_; }
 const optional<ClimateSwingMode> &ClimateCall::get_swing_mode() const { return this->swing_mode_; }
 ClimateCall &ClimateCall::set_away(bool away) {
@@ -195,6 +205,14 @@ ClimateCall &ClimateCall::set_away(bool away) {
 }
 ClimateCall &ClimateCall::set_away(optional<bool> away) {
   this->away_ = away;
+  return *this;
+}
+ClimateCall &ClimateCall::set_eco_mode(bool eco_mode) {
+  this->eco_mode_ = eco_mode;
+  return *this;
+}
+ClimateCall &ClimateCall::set_eco_mode(optional<bool> eco_mode) {
+  this->eco_mode_ = eco_mode;
   return *this;
 }
 ClimateCall &ClimateCall::set_target_temperature_high(optional<float> target_temperature_high) {
@@ -249,6 +267,9 @@ void Climate::save_state_() {
   if (traits.get_supports_away()) {
     state.away = this->away;
   }
+  if (traits.get_supports_eco_mode()) {
+    state.eco_mode = this->eco_mode;
+  }
   if (traits.get_supports_fan_modes()) {
     state.fan_mode = this->fan_mode;
   }
@@ -283,6 +304,9 @@ void Climate::publish_state() {
   }
   if (traits.get_supports_away()) {
     ESP_LOGD(TAG, "  Away: %s", ONOFF(this->away));
+  }
+  if (traits.get_supports_eco_mode()) {
+    ESP_LOGD(TAG, "  Eco Mode: %s", ONOFF(this->eco_mode));
   }
 
   // Send state to frontend
@@ -332,6 +356,9 @@ ClimateCall ClimateDeviceRestoreState::to_call(Climate *climate) {
   if (traits.get_supports_away()) {
     call.set_away(this->away);
   }
+  if (traits.get_supports_eco_mode()) {
+    call.set_eco_mode(this->eco_mode);
+  }
   if (traits.get_supports_fan_modes()) {
     call.set_fan_mode(this->fan_mode);
   }
@@ -351,6 +378,9 @@ void ClimateDeviceRestoreState::apply(Climate *climate) {
   }
   if (traits.get_supports_away()) {
     climate->away = this->away;
+  }
+  if (traits.get_supports_eco_mode()) {
+    climate->eco_mode = this->eco_mode;
   }
   if (traits.get_supports_fan_modes()) {
     climate->fan_mode = this->fan_mode;

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -178,7 +178,6 @@ class Climate : public Nameable {
    */
   bool eco_mode{false};
 
-
   /// The active fan mode of the climate device.
   ClimateFanMode fan_mode;
 

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -64,6 +64,8 @@ class ClimateCall {
   ClimateCall &set_target_temperature_high(optional<float> target_temperature_high);
   ClimateCall &set_away(bool away);
   ClimateCall &set_away(optional<bool> away);
+  ClimateCall &set_eco_mode(bool eco_mode);
+  ClimateCall &set_eco_mode(optional<bool> eco_mode);
   /// Set the fan mode of the climate device.
   ClimateCall &set_fan_mode(ClimateFanMode fan_mode);
   /// Set the fan mode of the climate device.
@@ -84,6 +86,7 @@ class ClimateCall {
   const optional<float> &get_target_temperature_low() const;
   const optional<float> &get_target_temperature_high() const;
   const optional<bool> &get_away() const;
+  const optional<bool> &get_eco_mode() const;
   const optional<ClimateFanMode> &get_fan_mode() const;
   const optional<ClimateSwingMode> &get_swing_mode() const;
 
@@ -96,6 +99,7 @@ class ClimateCall {
   optional<float> target_temperature_low_;
   optional<float> target_temperature_high_;
   optional<bool> away_;
+  optional<bool> eco_mode_;
   optional<ClimateFanMode> fan_mode_;
   optional<ClimateSwingMode> swing_mode_;
 };
@@ -104,6 +108,7 @@ class ClimateCall {
 struct ClimateDeviceRestoreState {
   ClimateMode mode;
   bool away;
+  bool eco_mode;
   ClimateFanMode fan_mode;
   ClimateSwingMode swing_mode;
   union {
@@ -166,6 +171,13 @@ class Climate : public Nameable {
    * one for normal mode and one for away mode.
    */
   bool away{false};
+
+  /** Whether the climate device is in eco mode.
+   *
+   * Eco allows climate devices to output using less energy.
+   */
+  bool eco_mode{false};
+
 
   /// The active fan mode of the climate device.
   ClimateFanMode fan_mode;

--- a/esphome/components/climate/climate_traits.cpp
+++ b/esphome/components/climate/climate_traits.cpp
@@ -38,6 +38,7 @@ void ClimateTraits::set_supports_fan_only_mode(bool supports_fan_only_mode) {
 }
 void ClimateTraits::set_supports_dry_mode(bool supports_dry_mode) { supports_dry_mode_ = supports_dry_mode; }
 void ClimateTraits::set_supports_away(bool supports_away) { supports_away_ = supports_away; }
+void ClimateTraits::set_supports_eco_mode(bool supports_eco_mode) { supports_eco_mode_ = supports_eco_mode; }
 void ClimateTraits::set_supports_action(bool supports_action) { supports_action_ = supports_action; }
 float ClimateTraits::get_visual_min_temperature() const { return visual_min_temperature_; }
 void ClimateTraits::set_visual_min_temperature(float visual_min_temperature) {
@@ -61,6 +62,7 @@ int8_t ClimateTraits::get_temperature_accuracy_decimals() const {
 }
 void ClimateTraits::set_visual_temperature_step(float temperature_step) { visual_temperature_step_ = temperature_step; }
 bool ClimateTraits::get_supports_away() const { return supports_away_; }
+bool ClimateTraits::get_supports_eco_mode() const { return supports_eco_mode_; }
 bool ClimateTraits::get_supports_action() const { return supports_action_; }
 
 void ClimateTraits::set_supports_fan_mode_on(bool supports_fan_mode_on) {

--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -25,6 +25,7 @@ namespace climate {
  *    - fan mode (only turns on fan)
  *  - supports away - away mode means that the climate device supports two different
  *      target temperature settings: one target temp setting for "away" mode and one for non-away mode.
+ *  - supports eco mode - eco mode means that the climate device supports outputting less energy.
  *  - supports action - if the climate device supports reporting the active
  *    current action of the device with the action property.
  *  - supports fan modes - optionally, if it has a fan which can be configured in different ways:
@@ -51,6 +52,8 @@ class ClimateTraits {
   void set_supports_dry_mode(bool supports_dry_mode);
   void set_supports_away(bool supports_away);
   bool get_supports_away() const;
+  void set_supports_eco_mode(bool supports_eco_mode);
+  bool get_supports_eco_mode() const;
   void set_supports_action(bool supports_action);
   bool get_supports_action() const;
   bool supports_mode(ClimateMode mode) const;
@@ -89,6 +92,7 @@ class ClimateTraits {
   bool supports_fan_only_mode_{false};
   bool supports_dry_mode_{false};
   bool supports_away_{false};
+  bool supports_eco_mode_{false};
   bool supports_action_{false};
   bool supports_fan_mode_on_{false};
   bool supports_fan_mode_off_{false};


### PR DESCRIPTION
## Description:
Add support for climate devices to set eco_mode on or off.
To be used this would need to be implemented also in API clients such as homeassistant as a `preset` mode for the climate entity.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#627

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
