### PR TITLE
fix for ESP32 'Association Leave'

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -98,6 +98,7 @@ void WiFiComponent::loop() {
       case WIFI_COMPONENT_STATE_STA_CONNECTED: {
         if (!this->is_connected()) {
           ESP_LOGW(TAG, "WiFi Connection lost... Reconnecting...");
+          this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTING;
           this->retry_connect();
         } else {
           this->status_clear_warning();


### PR DESCRIPTION
## Description:
Fixes "Association Leave" STA Error, because this happens after STA_CONNECTED state, before reconnent the state has to been set to STA_CONNECTING, otherwise the STATE_COOLDOWN reinits the scan after 5 seconds and disables to get connected

**Related issue (if applicable):** fixes <link to issue>
[#1248](https://github.com/esphome/issues/issues/1248)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
