### PR TITLE
ADE7953: Fix dereferencing of a null pointer

### DIFF
--- a/esphome/components/ade7953/ade7953.cpp
+++ b/esphome/components/ade7953/ade7953.cpp
@@ -18,7 +18,7 @@ void ADE7953::dump_config() {
 }
 
 #define ADE_PUBLISH_(name, factor) \
-  if (name) { \
+  if (name && this->name##_sensor_)  { \
     float value = *name / factor; \
     this->name##_sensor_->publish_state(value); \
   }

--- a/esphome/components/ade7953/ade7953.cpp
+++ b/esphome/components/ade7953/ade7953.cpp
@@ -18,7 +18,7 @@ void ADE7953::dump_config() {
 }
 
 #define ADE_PUBLISH_(name, factor) \
-  if (name && this->name##_sensor_)  { \
+  if (name && this->name##_sensor_) { \
     float value = *name / factor; \
     this->name##_sensor_->publish_state(value); \
   }


### PR DESCRIPTION
## Description:

The ade7953 driver dereferences a null pointer, when not all of
its sensors are used. This gives an exception like:

`
Fatal exception:29 flag:2 (EXCEPTION) epc1:0x4020c241 epc2:0x00000000 epc3:0x00000000 excvaddr:0x00000018 depc:0x00000000`


**Related issue (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** -

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).