### PR TITLE
Fix SSD1306 post-setup brightness control

### DIFF
--- a/esphome/components/ssd1306_base/__init__.py
+++ b/esphome/components/ssd1306_base/__init__.py
@@ -41,7 +41,7 @@ def setup_ssd1036(var, config):
         reset = yield cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(reset))
     if CONF_BRIGHTNESS in config:
-        cg.add(var.set_brightness(config[CONF_BRIGHTNESS]))
+        cg.add(var.init_brightness(config[CONF_BRIGHTNESS]))
     if CONF_EXTERNAL_VCC in config:
         cg.add(var.set_external_vcc(config[CONF_EXTERNAL_VCC]))
     if CONF_LAMBDA in config:

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -73,8 +73,6 @@ void SSD1306::setup() {
       break;
   }
 
-  set_brightness(this->brightness_);
-
   this->command(SSD1306_COMMAND_SET_PRE_CHARGE);
   if (this->external_vcc_)
     this->command(0x22);
@@ -89,10 +87,12 @@ void SSD1306::setup() {
 
   this->command(SSD1306_COMMAND_DEACTIVATE_SCROLL);
 
+  set_brightness(this->brightness_);
+
   this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
   this->display();    // ...write buffer, which actually clears the display's memory
 
-  this->command(SSD1306_COMMAND_DISPLAY_ON);
+  this->turn_on();
 }
 void SSD1306::display() {
   if (this->is_sh1106_()) {

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -140,8 +140,15 @@ void SSD1306::set_brightness(float brightness) {
   this->command(SSD1306_COMMAND_SET_CONTRAST);
   this->command(int(SSD1306_MAX_CONTRAST * (this->brightness_)));
 }
-void SSD1306::turn_on() { this->command(SSD1306_COMMAND_DISPLAY_ON); }
-void SSD1306::turn_off() { this->command(SSD1306_COMMAND_DISPLAY_OFF); }
+bool SSD1306::is_on() { return this->is_on_; }
+void SSD1306::turn_on() {
+  this->command(SSD1306_COMMAND_DISPLAY_ON);
+  this->is_on_ = true;
+}
+void SSD1306::turn_off() {
+  this->command(SSD1306_COMMAND_DISPLAY_OFF);
+  this->is_on_ = false;
+}
 int SSD1306::get_height_internal() {
   switch (this->model_) {
     case SSD1306_MODEL_128_32:

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -130,12 +130,7 @@ void SSD1306::update() {
 }
 void SSD1306::set_brightness(float brightness) {
   // validation
-  if (brightness > 1)
-    this->brightness_ = 1.0;
-  else if (brightness < 0)
-    this->brightness_ = 0;
-  else
-    this->brightness_ = brightness;
+  this->brightness_ = clamp(brightness, 0, 1);
   // now write the new brightness level to the display
   this->command(SSD1306_COMMAND_SET_CONTRAST);
   this->command(int(SSD1306_MAX_CONTRAST * (this->brightness_)));

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -9,6 +9,7 @@ static const char *TAG = "ssd1306";
 
 static const uint8_t BLACK = 0;
 static const uint8_t WHITE = 1;
+static const uint8_t SSD1306_MAX_CONTRAST = 255;
 
 static const uint8_t SSD1306_COMMAND_DISPLAY_OFF = 0xAE;
 static const uint8_t SSD1306_COMMAND_DISPLAY_ON = 0xAF;
@@ -137,8 +138,10 @@ void SSD1306::set_brightness(float brightness) {
     this->brightness_ = brightness;
   // now write the new brightness level to the display
   this->command(SSD1306_COMMAND_SET_CONTRAST);
-  this->command(int(255 * (this->brightness_)));
+  this->command(int(SSD1306_MAX_CONTRAST * (this->brightness_)));
 }
+void SSD1306::turn_on() { this->command(SSD1306_COMMAND_DISPLAY_ON); }
+void SSD1306::turn_off() { this->command(SSD1306_COMMAND_DISPLAY_OFF); }
 int SSD1306::get_height_internal() {
   switch (this->model_) {
     case SSD1306_MODEL_128_32:

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -31,6 +31,7 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
   void init_brightness(float brightness) { this->brightness_ = brightness; }
   void set_brightness(float brightness);
+  bool is_on();
   void turn_on();
   void turn_off();
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
@@ -53,6 +54,7 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   SSD1306Model model_{SSD1306_MODEL_128_64};
   GPIOPin *reset_pin_{nullptr};
   bool external_vcc_{false};
+  bool is_on_{false};
   float brightness_{1.0};
 };
 

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -29,7 +29,8 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void set_model(SSD1306Model model) { this->model_ = model; }
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
-  void set_brightness(float brightness) { this->brightness_ = brightness; }
+  void init_brightness(float brightness) { this->brightness_ = brightness; }
+  void set_brightness(float brightness);
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -31,7 +31,8 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
   void init_brightness(float brightness) { this->brightness_ = brightness; }
   void set_brightness(float brightness);
-
+  void turn_on();
+  void turn_off();
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
 


### PR DESCRIPTION
## Description:

Quick patch to fix post-setup brightness control on this display.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1235

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** No doc update necessary

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
