### PR TITLE
Update docker base image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@
 variables:
   DOCKER_DRIVER: overlay2
   DOCKER_HOST: tcp://docker:2375/
-  BASE_VERSION: '2.1.0'
+  BASE_VERSION: '2.1.1'
   TZ: UTC
 
 stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@
 variables:
   DOCKER_DRIVER: overlay2
   DOCKER_HOST: tcp://docker:2375/
-  BASE_VERSION: '2.0.1'
+  BASE_VERSION: '2.1.0'
   TZ: UTC
 
 stages:
@@ -33,7 +33,7 @@ stages:
     - docker info
     - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
   script:
-    - docker run --rm --privileged multiarch/qemu-user-static:4.1.0-1 --reset -p yes
+    - docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
     - TAG="${CI_COMMIT_TAG#v}"
     - TAG="${TAG:-${CI_COMMIT_SHA:0:7}}"
     - echo "Tag ${TAG}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:2.1.0
+ARG BUILD_FROM=esphome/esphome-base-amd64:2.1.1
 FROM ${BUILD_FROM}
 
 COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:2.0.1
+ARG BUILD_FROM=esphome/esphome-base-amd64:2.1.0
 FROM ${BUILD_FROM}
 
 COPY . .

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:2.1.0
+FROM esphome/esphome-base-amd64:2.1.1
 
 RUN \
     apt-get update \

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:2.0.1
+FROM esphome/esphome-base-amd64:2.1.0
 
 RUN \
     apt-get update \


### PR DESCRIPTION
Cherry Picking from the master branch. The new base image include the updated version of platformio so you don't have to update it every time you start a fresh container.