### PR TITLE
Release BT controller unused memory in the right place

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -99,13 +99,13 @@ bool ESP32BLETracker::ble_setup() {
     return false;
   }
 
+  esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+
   // Initialize the bluetooth controller with the default configuration
   if (!btStart()) {
     ESP_LOGE(TAG, "btStart failed: %d", esp_bt_controller_get_status());
     return false;
   }
-
-  esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
 
   err = esp_bluedroid_init();
   if (err != ESP_OK) {


### PR DESCRIPTION
## Description:

Frees unused BT memory at the correct state of initialisation. Espressif docs state that this call should be made prior to BT stack init, but it was being done afterwards.

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/bluetooth/controller_vhci.html#_CPPv429esp_bt_controller_mem_release13esp_bt_mode_t

This appears to have improved BT stability somewhat (for me).

**Related issue (if applicable):**  869

