### PR TITLE
ESP32: Conditionally log on services to avoid OOM crashes

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -103,7 +103,13 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
   const char *msg = this->tx_buffer_ + offset;
   if (this->baud_rate_ > 0)
     this->hw_serial_->println(msg);
-  this->log_callback_.call(level, tag, msg);
+  // Suppress network-logging if memory constrained, but still log to serial
+  // ports. In some configurations (eg BLE enabled) there may be some transient
+  // memory exhaustion, and trying to log when OOM can lead to a crash. Skipping
+  // here usually allows the stack to recover instead.
+  // See issue #1234 for analysis.
+  if (xPortGetFreeHeapSize() > 2048)
+    this->log_callback_.call(level, tag, msg);
 }
 
 Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size, UARTSelection uart)

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -110,8 +110,10 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
   // here usually allows the stack to recover instead.
   // See issue #1234 for analysis.
   if (xPortGetFreeHeapSize() > 2048)
-#endif
     this->log_callback_.call(level, tag, msg);
+#else
+  this->log_callback_.call(level, tag, msg);
+#endif
 }
 
 Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size, UARTSelection uart)

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -103,12 +103,14 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
   const char *msg = this->tx_buffer_ + offset;
   if (this->baud_rate_ > 0)
     this->hw_serial_->println(msg);
+#ifdef ARDUINO_ARCH_ESP32
   // Suppress network-logging if memory constrained, but still log to serial
   // ports. In some configurations (eg BLE enabled) there may be some transient
   // memory exhaustion, and trying to log when OOM can lead to a crash. Skipping
   // here usually allows the stack to recover instead.
   // See issue #1234 for analysis.
   if (xPortGetFreeHeapSize() > 2048)
+#endif
     this->log_callback_.call(level, tag, msg);
 }
 

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -53,18 +53,7 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
   if (log == nullptr)
     return 0;
 
-  size_t len = strlen(format);
-  char *mFormat = (char *) malloc(len);
-  if (mFormat == NULL)
-    return 0;
-  memcpy(mFormat, format, len);
-
-  // Strip trailing newline - just overwrite with a null.
-  if (mFormat[len - 1] == '\n')
-    mFormat[len - 1] = '\0';
-
-  log->log_vprintf_(ESPHOME_LOG_LEVEL, "esp-idf", 0, mFormat, args);
-  free(mFormat);
+  log->log_vprintf_(ESPHOME_LOG_LEVEL, "esp-idf", 0, format, args);
 #endif
   return 0;
 }

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -55,7 +55,8 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
 
   size_t len = strlen(format);
   char *mFormat = (char *) malloc(len);
-  if (mFormat == NULL) return 0;
+  if (mFormat == NULL)
+    return 0;
   memcpy(mFormat, format, len);
 
   // Strip trailing newline - just overwrite with a null.

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -54,16 +54,16 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
     return 0;
 
   size_t len = strlen(format);
-  if (format[len - 1] == '\n') {
-    // Remove trailing newline from format
-    // Use locally stored
-    static std::string FORMAT_COPY;
-    FORMAT_COPY.clear();
-    FORMAT_COPY.insert(0, format, len - 1);
-    format = FORMAT_COPY.c_str();
-  }
+  char *mFormat = (char *) malloc(len);
+  if (mFormat == NULL) return 0;
+  memcpy(mFormat, format, len);
 
-  log->log_vprintf_(ESPHOME_LOG_LEVEL, "esp-idf", 0, format, args);
+  // Strip trailing newline - just overwrite with a null.
+  if (mFormat[len - 1] == '\n')
+    mFormat[len - 1] = '\0';
+
+  log->log_vprintf_(ESPHOME_LOG_LEVEL, "esp-idf", 0, mFormat, args);
+  free(mFormat);
 #endif
   return 0;
 }


### PR DESCRIPTION
Fixes a crash that sometimes occurs in this function.

The FORMAT_COPY variable is declared static, however it gets referenced across threads of the underlying freertos code. This is unsafe usage, leading to the type of crash shown below. Instead malloc space per call.


````
WARNING Decoded 0x40092094: invoke_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/panic.c:707
WARNING Decoded 0x400922c5: abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/panic.c:707
WARNING Decoded 0x4008e0c7: xQueueCreateCountingSemaphore at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/queue.c:2520
WARNING Decoded 0x4011d689: static_init_prepare() at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/cxx/cxx_guards.cpp:56
WARNING Decoded 0x4011d6d6: __cxa_guard_acquire at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/cxx/cxx_guards.cpp:134
WARNING Decoded 0x400ddc0c: esphome::esp_idf_log_vprintf_(char const*, __va_list_tag) at /config/esphome/atom1/src/esphome/core/log.cpp:59 (discriminator 1)
WARNING Decoded 0x4008453e: esp_log_write at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/log/log.c:215
WARNING Decoded 0x400fb495: _mdns_send_rx_action at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mdns/mdns.c:4526
WARNING Decoded 0x400fd521: _udp_recv at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mdns/mdns_networking.c:169
WARNING Decoded 0x4013fb5d: udp_input at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/core/udp.c:401
WARNING Decoded 0x40144bd5: ip4_input at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/core/ipv4/ip4.c:740
WARNING Decoded 0x40149ebe: ethernet_input at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/netif/ethernet.c:184
WARNING Decoded 0x40135733: tcpip_thread at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/api/tcpip.c:483
WARNING Decoded 0x4008e7dd: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)
````