### PR TITLE
fix shunt voltage / current / power reading in INA3221

### DIFF
--- a/esphome/components/ina3221/ina3221.cpp
+++ b/esphome/components/ina3221/ina3221.cpp
@@ -100,7 +100,7 @@ void INA3221Component::update() {
         this->status_set_warning();
         return;
       }
-      const float shunt_voltage_v = int16_t(raw) * 40.0f / 1000000.0f;
+      const float shunt_voltage_v = int16_t(raw >> 3) * 40.0f / 1000000.0f;
       if (channel.shunt_voltage_sensor_ != nullptr)
         channel.shunt_voltage_sensor_->publish_state(shunt_voltage_v);
       current_a = shunt_voltage_v / channel.shunt_resistance_;

--- a/esphome/components/ina3221/ina3221.cpp
+++ b/esphome/components/ina3221/ina3221.cpp
@@ -100,7 +100,7 @@ void INA3221Component::update() {
         this->status_set_warning();
         return;
       }
-      const float shunt_voltage_v = int16_t(raw) / 8 * 40.0f / 1000000.0f;
+      const float shunt_voltage_v = int16_t(raw) * 40.0f / 8.0f / 1000000.0f;
       if (channel.shunt_voltage_sensor_ != nullptr)
         channel.shunt_voltage_sensor_->publish_state(shunt_voltage_v);
       current_a = shunt_voltage_v / channel.shunt_resistance_;

--- a/esphome/components/ina3221/ina3221.cpp
+++ b/esphome/components/ina3221/ina3221.cpp
@@ -100,7 +100,7 @@ void INA3221Component::update() {
         this->status_set_warning();
         return;
       }
-      const float shunt_voltage_v = int16_t(raw >> 3) * 40.0f / 1000000.0f;
+      const float shunt_voltage_v = int16_t(raw) / 8 * 40.0f / 1000000.0f;
       if (channel.shunt_voltage_sensor_ != nullptr)
         channel.shunt_voltage_sensor_->publish_state(shunt_voltage_v);
       current_a = shunt_voltage_v / channel.shunt_resistance_;


### PR DESCRIPTION
## Description:


**Related issue (if applicable):**
[#1206](https://github.com/esphome/issues/issues/1206)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** No doc update necessary

Fix wrong shunt voltage calculation, this will also cause wrong current/power calculation.

According to the official datasheet 8.6.2.2, the last three bits should be discarded before the calculation.

## Checklist:
  - [x] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).

Do not need new tests.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).