### PR TITLE
Use default average mode in INA3221

### DIFF
--- a/esphome/components/ina3221/ina3221.cpp
+++ b/esphome/components/ina3221/ina3221.cpp
@@ -42,7 +42,7 @@ void INA3221Component::setup() {
     config |= 0b0001000000000000;
   }
   // 0b0000xxx000000000 << 9 Averaging Mode (0 -> 1 sample, 111 -> 1024 samples)
-  config |= 0b0000111000000000;
+  config |= 0b0000000000000000;
   // 0b0000000xxx000000 << 6 Bus Voltage Conversion time (100 -> 1.1ms, 111 -> 8.244 ms)
   config |= 0b0000000111000000;
   // 0b0000000000xxx000 << 3 Shunt Voltage Conversion time (same as above)


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

https://github.com/esphome/issues/issues/1177

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

No doc update necessary

Use default average mode instead of 1024 samples, too many samples in average mode will cause the measured value changes slowly.

## Checklist:
  - [x] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).

Do not need new tests.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
