### PR TITLE
Fix  current / power reading in INA219

### DIFF
--- a/esphome/components/ina219/ina219.cpp
+++ b/esphome/components/ina219/ina219.cpp
@@ -120,7 +120,7 @@ void INA219Component::setup() {
   }
 
   this->calibration_lsb_ = lsb;
-  auto calibration = uint32_t(0.04096f / (0.0001 * lsb * this->shunt_resistance_ohm_));
+  auto calibration = uint32_t(0.04096f / (0.000001 * lsb * this->shunt_resistance_ohm_));
   ESP_LOGV(TAG, "    Using LSB=%u calibration=%u", lsb, calibration);
   if (!this->write_byte_16(INA219_REGISTER_CALIBRATION, calibration)) {
     this->mark_failed();


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

https://github.com/esphome/issues/issues/116

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

No doc update necessary

Fix wrong calibration calculation, this will cause the current and power value to be 100 times smaller than correct value.

## Checklist:
  - [x] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).

Do not need new tests.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
