### PR TITLE
Add Integral Reset Action to PIDClimate

### DIFF
--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -7,6 +7,7 @@ from esphome.const import CONF_ID, CONF_SENSOR
 pid_ns = cg.esphome_ns.namespace('pid')
 PIDClimate = pid_ns.class_('PIDClimate', climate.Climate, cg.Component)
 PIDAutotuneAction = pid_ns.class_('PIDAutotuneAction', automation.Action)
+PIDResetIntegralTermAction = pid_ns.class_('PIDResetIntegralTermAction', automation.Action)
 
 CONF_DEFAULT_TARGET_TEMPERATURE = 'default_target_temperature'
 
@@ -62,6 +63,18 @@ def to_code(config):
         cg.add(var.set_max_integral(params[CONF_MAX_INTEGRAL]))
 
     cg.add(var.set_default_target_temperature(config[CONF_DEFAULT_TARGET_TEMPERATURE]))
+
+
+@automation.register_action(
+    'climate.pid.reset_integral_term',
+    PIDResetIntegralTermAction,
+    automation.maybe_simple_id({
+        cv.Required(CONF_ID): cv.use_id(PIDClimate),
+    })
+)
+def pid_reset_integral_term(config, action_id, template_arg, args):
+    paren = yield cg.get_variable(config[CONF_ID])
+    yield cg.new_Pvariable(action_id, template_arg, paren)
 
 
 @automation.register_action('climate.pid.autotune', PIDAutotuneAction, automation.maybe_simple_id({

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -148,5 +148,7 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
   });
 }
 
+void PIDClimate::reset_integral_term() { this->controller_.reset_accumulated_integral(); }
+
 }  // namespace pid
 }  // namespace esphome

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -39,6 +39,7 @@ class PIDClimate : public climate::Climate, public Component {
     default_target_temperature_ = default_target_temperature;
   }
   void start_autotune(std::unique_ptr<PIDAutotuner> &&autotune);
+  void reset_integral_term();
 
  protected:
   /// Override control to change settings of the climate device.
@@ -87,6 +88,16 @@ template<typename... Ts> class PIDAutotuneAction : public Action<Ts...> {
   float noiseband_;
   float positive_output_;
   float negative_output_;
+  PIDClimate *parent_;
+};
+
+template<typename... Ts> class PIDResetIntegralTermAction : public Action<Ts...> {
+ public:
+  PIDResetIntegralTermAction(PIDClimate *parent) : parent_(parent) {}
+
+  void play(Ts... x) { this->parent_->reset_integral_term(); }
+
+ protected:
   PIDClimate *parent_;
 };
 

--- a/esphome/components/pid/pid_controller.h
+++ b/esphome/components/pid/pid_controller.h
@@ -40,6 +40,8 @@ struct PIDController {
     return proportional_term + integral_term + derivative_term;
   }
 
+  void reset_accumulated_integral() { accumulated_integral_ = 0; }
+
   /// Proportional gain K_p.
   float kp = 0;
   /// Integral gain K_i.


### PR DESCRIPTION
## Description:
This action allows the user to reset the integral term which might be necessary under certain control circumstances

**Related issue (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#660

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
