### PR TITLE
Fixes esphome/issues#1192 - Save on upload bug

### DIFF
--- a/esphome/dashboard/static/js/esphome.js
+++ b/esphome/dashboard/static/js/esphome.js
@@ -735,6 +735,7 @@ document.querySelectorAll("[data-action='edit']").forEach((button) => {
     const closeButton = document.querySelector("#js-editor-modal [data-action='close']");
     saveButton.setAttribute('data-filename', editorActiveFilename);
     uploadButton.setAttribute('data-filename', editorActiveFilename);
+    uploadButton.setAttribute('onClick', `saveFile("${editorActiveFilename}")`);
     if (editorActiveFilename === "secrets.yaml") {
       uploadButton.classList.add("disabled");
       editorActiveSecrets = true;


### PR DESCRIPTION
## Description:
Fixes bug whereby editor would not save prior to upload button being clicked.

**Related issue (if applicable):** 
Fixes esphome/issues#1192

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
