### PR TITLE
Brightness support for Nextion display

### DIFF
--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import display, uart
-from esphome.const import CONF_ID, CONF_LAMBDA
+from esphome.const import CONF_ID, CONF_LAMBDA, CONF_BRIGHTNESS
 from . import nextion_ns
 
 DEPENDENCIES = ['uart']
@@ -12,6 +12,7 @@ NextionRef = Nextion.operator('ref')
 
 CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(Nextion),
+    cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
 }).extend(cv.polling_component_schema('5s')).extend(uart.UART_DEVICE_SCHEMA)
 
 
@@ -20,6 +21,8 @@ def to_code(config):
     yield cg.register_component(var, config)
     yield uart.register_uart_device(var, config)
 
+    if CONF_BRIGHTNESS in config:
+        cg.add(var.set_brightness(config[CONF_BRIGHTNESS]))
     if CONF_LAMBDA in config:
         lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], [(NextionRef, 'it')],
                                           return_type=cg.void)

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -9,6 +9,7 @@ static const char *TAG = "nextion";
 void Nextion::setup() {
   this->send_command_no_ack("");
   this->send_command_printf("bkcmd=3");
+  this->set_backlight_brightness(static_cast<uint8_t>(brightness_ * 100));
   this->goto_page("0");
 }
 float Nextion::get_setup_priority() const { return setup_priority::PROCESSOR; }

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -365,6 +365,7 @@ class Nextion : public PollingComponent, public uart::UARTDevice {
   // (In most use cases you won't need these)
   void register_touch_component(NextionTouchComponent *obj) { this->touch_.push_back(obj); }
   void setup() override;
+  void set_brightness(float brightness) { this->brightness_ = brightness; }
   float get_setup_priority() const override;
   void update() override;
   void loop() override;
@@ -392,6 +393,7 @@ class Nextion : public PollingComponent, public uart::UARTDevice {
   std::vector<NextionTouchComponent *> touch_;
   optional<nextion_writer_t> writer_;
   bool wait_for_ack_{true};
+  float brightness_{1.0};
 };
 
 class NextionTouchComponent : public binary_sensor::BinarySensorInitiallyOff {


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#668

Support setting Nextion brightness in the configuration file.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
