### PR TITLE
Allow updating pid control params

### DIFF
--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -98,15 +98,21 @@ def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
     PIDSetControlParametersAction,
     automation.maybe_simple_id({
         cv.Required(CONF_ID): cv.use_id(PIDClimate),
-        cv.Required(CONF_KP): cv.float_,
-        cv.Optional(CONF_KI, default=0.0): cv.float_,
-        cv.Optional(CONF_KD, default=0.0): cv.float_,
+        cv.Required(CONF_KP): cv.templatable(cv.float_),
+        cv.Optional(CONF_KI, default=0.0): cv.templatable(cv.float_),
+        cv.Optional(CONF_KD, default=0.0): cv.templatable(cv.float_),
     })
 )
 def set_control_parameters(config, action_id, template_arg, args):
     paren = yield cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    cg.add(var.set_kp(config[CONF_KP]))
-    cg.add(var.set_ki(config[CONF_KI]))
-    cg.add(var.set_kd(config[CONF_KD]))
+
+    kp_template_ = yield cg.templatable(config[CONF_KP], args, float)
+    cg.add(var.set_kp(kp_template_))
+  
+    ki_template_ = yield cg.templatable(config[CONF_KI], args, float)
+    cg.add(var.set_ki(ki_template_))
+
+    kd_template_ = yield cg.templatable(config[CONF_KD], args, float)
+    cg.add(var.set_kd(kd_template_))
     yield var

--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -109,7 +109,7 @@ def set_control_parameters(config, action_id, template_arg, args):
 
     kp_template_ = yield cg.templatable(config[CONF_KP], args, float)
     cg.add(var.set_kp(kp_template_))
-  
+
     ki_template_ = yield cg.templatable(config[CONF_KI], args, float)
     cg.add(var.set_ki(ki_template_))
 

--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -8,6 +8,7 @@ pid_ns = cg.esphome_ns.namespace('pid')
 PIDClimate = pid_ns.class_('PIDClimate', climate.Climate, cg.Component)
 PIDAutotuneAction = pid_ns.class_('PIDAutotuneAction', automation.Action)
 PIDResetIntegralTermAction = pid_ns.class_('PIDResetIntegralTermAction', automation.Action)
+PIDSetControlParametersAction = pid_ns.class_('PIDSetControlParametersAction', automation.Action)
 
 CONF_DEFAULT_TARGET_TEMPERATURE = 'default_target_temperature'
 
@@ -89,4 +90,23 @@ def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
     cg.add(var.set_noiseband(config[CONF_NOISEBAND]))
     cg.add(var.set_positive_output(config[CONF_POSITIVE_OUTPUT]))
     cg.add(var.set_negative_output(config[CONF_NEGATIVE_OUTPUT]))
+    yield var
+
+
+@automation.register_action(
+    'climate.pid.set_control_parameters',
+    PIDSetControlParametersAction,
+    automation.maybe_simple_id({
+        cv.Required(CONF_ID): cv.use_id(PIDClimate),
+        cv.Required(CONF_KP): cv.float_,
+        cv.Optional(CONF_KI, default=0.0): cv.float_,
+        cv.Optional(CONF_KD, default=0.0): cv.float_,
+    })
+)
+def set_control_parameters(config, action_id, template_arg, args):
+    paren = yield cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    cg.add(var.set_kp(config[CONF_KP]))
+    cg.add(var.set_ki(config[CONF_KI]))
+    cg.add(var.set_kd(config[CONF_KD]))
     yield var

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -104,5 +104,26 @@ template<typename... Ts> class PIDResetIntegralTermAction : public Action<Ts...>
   PIDClimate *parent_;
 };
 
+template<typename... Ts> class PIDSetControlParametersAction : public Action<Ts...> {
+ public:
+  PIDSetControlParametersAction(PIDClimate *parent) : parent_(parent) {}
+
+  void set_kp(float kp) { kp_ = kp; }
+  void set_ki(float ki) { ki_ = ki; }
+  void set_kd(float kd) { kd_ = kd; }
+
+  void play(Ts... x) {
+    this->parent_->set_kp(this->kp_);
+    this->parent_->set_ki(this->ki_);
+    this->parent_->set_kd(this->kd_);
+  }
+
+ protected:
+  float kp_;
+  float ki_;
+  float kd_;
+  PIDClimate *parent_;
+};
+
 }  // namespace pid
 }  // namespace esphome

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -108,20 +108,21 @@ template<typename... Ts> class PIDSetControlParametersAction : public Action<Ts.
  public:
   PIDSetControlParametersAction(PIDClimate *parent) : parent_(parent) {}
 
-  void set_kp(float kp) { kp_ = kp; }
-  void set_ki(float ki) { ki_ = ki; }
-  void set_kd(float kd) { kd_ = kd; }
-
   void play(Ts... x) {
-    this->parent_->set_kp(this->kp_);
-    this->parent_->set_ki(this->ki_);
-    this->parent_->set_kd(this->kd_);
+    auto kp = this->kp_.value(x...);
+    auto ki = this->ki_.value(x...);
+    auto kd = this->kd_.value(x...);
+
+    this->parent_->set_kp(kp);
+    this->parent_->set_ki(ki);
+    this->parent_->set_kd(kd);
   }
 
  protected:
-  float kp_;
-  float ki_;
-  float kd_;
+  TEMPLATABLE_VALUE(float, kp)
+  TEMPLATABLE_VALUE(float, ki)
+  TEMPLATABLE_VALUE(float, kd)
+
   PIDClimate *parent_;
 };
 

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -29,6 +29,9 @@ class PIDClimate : public climate::Climate, public Component {
 
   float get_output_value() const { return output_value_; }
   float get_error_value() const { return controller_.error; }
+  float get_kp() { return controller_.kp; }
+  float get_ki() { return controller_.ki; }
+  float get_kd() { return controller_.kd; }
   float get_proportional_term() const { return controller_.proportional_term; }
   float get_integral_term() const { return controller_.integral_term; }
   float get_derivative_term() const { return controller_.derivative_term; }

--- a/esphome/components/pid/sensor/__init__.py
+++ b/esphome/components/pid/sensor/__init__.py
@@ -15,6 +15,9 @@ PID_CLIMATE_SENSOR_TYPES = {
     'DERIVATIVE': PIDClimateSensorType.PID_SENSOR_TYPE_DERIVATIVE,
     'HEAT': PIDClimateSensorType.PID_SENSOR_TYPE_HEAT,
     'COOL': PIDClimateSensorType.PID_SENSOR_TYPE_COOL,
+    'KP': PIDClimateSensorType.PID_SENSOR_TYPE_KP,
+    'KI': PIDClimateSensorType.PID_SENSOR_TYPE_KI,
+    'KD': PIDClimateSensorType.PID_SENSOR_TYPE_KD,
 }
 
 CONF_CLIMATE_ID = 'climate_id'

--- a/esphome/components/pid/sensor/pid_climate_sensor.cpp
+++ b/esphome/components/pid/sensor/pid_climate_sensor.cpp
@@ -35,6 +35,15 @@ void PIDClimateSensor::update_from_parent_() {
     case PID_SENSOR_TYPE_COOL:
       value = clamp(-this->parent_->get_output_value(), 0.0f, 1.0f);
       break;
+    case PID_SENSOR_TYPE_KP:
+      value = this->parent_->get_kp();
+      break;
+    case PID_SENSOR_TYPE_KI:
+      value = this->parent_->get_ki();
+      break;
+    case PID_SENSOR_TYPE_KD:
+      value = this->parent_->get_kd();
+      break;
     default:
       value = NAN;
       break;

--- a/esphome/components/pid/sensor/pid_climate_sensor.cpp
+++ b/esphome/components/pid/sensor/pid_climate_sensor.cpp
@@ -37,13 +37,16 @@ void PIDClimateSensor::update_from_parent_() {
       break;
     case PID_SENSOR_TYPE_KP:
       value = this->parent_->get_kp();
-      break;
+      this->publish_state(value);
+      return;
     case PID_SENSOR_TYPE_KI:
       value = this->parent_->get_ki();
-      break;
+      this->publish_state(value);
+      return;
     case PID_SENSOR_TYPE_KD:
       value = this->parent_->get_kd();
-      break;
+      this->publish_state(value);
+      return;
     default:
       value = NAN;
       break;

--- a/esphome/components/pid/sensor/pid_climate_sensor.h
+++ b/esphome/components/pid/sensor/pid_climate_sensor.h
@@ -14,6 +14,9 @@ enum PIDClimateSensorType {
   PID_SENSOR_TYPE_DERIVATIVE,
   PID_SENSOR_TYPE_HEAT,
   PID_SENSOR_TYPE_COOL,
+  PID_SENSOR_TYPE_KP,
+  PID_SENSOR_TYPE_KI,
+  PID_SENSOR_TYPE_KD,
 };
 
 class PIDClimateSensor : public sensor::Sensor, public Component {

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -169,6 +169,13 @@ api:
       then:
         - tm1651.turn_off:
             id: tm1651_battery
+    - service: pid_set_control_parameters
+      then:
+        - climate.pid.set_control_parameters:
+            id: pid_climate
+            kp: 1.0
+            kd: 1.0
+            ki: 1.0
 
 wifi:
   ssid: 'MySSID'
@@ -681,6 +688,17 @@ climate:
     away_config:
       default_target_temperature_low: 16°C
       default_target_temperature_high: 20°C
+  - platform: pid
+    id: pid_climate
+    name: "PID Climate Controller"
+    sensor: ha_hello_world
+    default_target_temperature: 21°C
+    heat_output: my_slow_pwm
+    control_parameters:
+      kp: 0.0
+      ki: 0.0
+      kd: 0.0
+    
 
 cover:
   - platform: endstop
@@ -761,6 +779,11 @@ output:
     id: dimmer1
     gate_pin: GPIO5
     zero_cross_pin: GPIO12
+  - platform: slow_pwm
+    pin: GPIO5
+    id: my_slow_pwm
+    period: 15s
+
 
 mcp23017:
   id: mcp23017_hub


### PR DESCRIPTION
## Description:
As part of manually tuning a PID controller, it is useful to have a way to update the control parameters without having to reflash the device.

**Related issue (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#674

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
