### PR TITLE
Add cryptography requirement to the setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ REQUIRES = [
     'pytz==2020.1',
     'pyserial==3.4',
     'ifaddr==0.1.6',
+    'cryptography==2.9.2',
 ]
 
 # If you have problems importing platformio and esptool as modules you can set


### PR DESCRIPTION
## Description:

#1080 introduced a new requirement but the docker builds do not install from the requirements file.

This adds the requirement to the setup.py file too

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
