### PR TITLE
Install updated git version in lint image

### DIFF
--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -6,6 +6,10 @@ RUN \
         clang-format-7 \
         clang-tidy-7 \
         patch \
+        software-properties-common \
+    && apt-add-repository ppa:git-core/ppa \
+    && apt-get install -y --no-install-recommends \
+        git \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \


### PR DESCRIPTION
## Description:
Updates the git version installed in the lint container.

Looking to (re)create the gitlab-ci & travis in github actions completely but the git version needs to be updated.
This could be done in the workflow step, but it means adding more wait time there.

I am not sure where this docker image is built though and might be a manual build and upload to docker hub.


jesserockz/esphome#1



**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
