### PR TITLE
Move CI/CD to GitHub Actions

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -1,0 +1,59 @@
+name: PR testing
+
+on: [pull_request]
+
+jobs:
+  lint-custom:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Custom
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/ci-custom.py
+  lint-python:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Python
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/lint-python
+  lint-tidy:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Tidy
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: script/setup
+    - run: pio init --ide atom
+    - run: script/clang-tidy --all-headers --fix
+    - run: script/ci-suggest-changes
+  lint-format:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Format
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: script/setup
+    - run: script/clang-format -i
+    - run: script/ci-suggest-changes
+
+  test:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    strategy:
+      matrix:
+        test:
+        - test1
+        - test2
+        - test3
+        - test4
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: esphome tests/${{ matrix.test }}.yaml compile

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,0 +1,124 @@
+name: Release dev
+
+on:
+  push:
+    branches:
+    - dev
+
+jobs:
+  lint-custom:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Custom
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/ci-custom.py
+  lint-python:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Python
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/lint-python
+  lint-tidy:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Tidy
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: pio init --ide atom
+    - run: script/clang-tidy --all-headers --fix
+    - run: script/ci-suggest-changes
+  lint-format:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Format
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/clang-format -i
+    - run: script/ci-suggest-changes
+
+  test:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    strategy:
+      matrix:
+        test:
+        - test1
+        - test2
+        - test3
+        - test4
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: esphome tests/${{ matrix.test }}.yaml compile
+
+  deploy-docker:
+    runs-on: ubuntu-latest
+    needs: [lint-custom, lint-python, lint-tidy, lint-format, test]
+    strategy:
+      matrix:
+        arch: [aarch64, amd64, armv7, i386]
+        build-type: [hassio, docker]
+    steps:
+    - uses: actions/checkout@v2
+    - run: docker info
+    - run: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+    - env:
+        BASE_VERSION: 2.1.1
+      run: |
+        if [[ "${{ matrix.build-type }}" == "hassio" ]]; then
+          BUILD_FROM=esphome/esphome-hassio-base-${{ matrix.arch }}:${BASE_VERSION}
+          BUILD_TO=${{ github.repository }}-hassio-${{ matrix.arch }}
+          DOCKERFILE=docker/Dockerfile.hassio
+        else
+          BUILD_FROM=esphome/esphome-base-${{ matrix.arch }}:${BASE_VERSION}
+          BUILD_TO=${{ github.repository }}-${{ matrix.arch }}
+          DOCKERFILE=docker/Dockerfile
+        fi
+
+        TAG=${{ github.sha }}
+        TAG=${TAG:0:7}
+
+        echo "Building tag: ${TAG}"
+
+        docker build \
+          --build-arg BUILD_FROM=${BUILD_FROM} \
+          --build-arg BUILD_VERSION=${TAG} \
+          --tag ${BUILD_TO}:dev \
+          --file ${DOCKERFILE} \
+          .
+
+        echo "Pushing to ${BUILD_TO}:dev"
+        docker push ${BUILD_TO}:dev
+
+  deploy-docker-manifest-version:
+    runs-on: ubuntu-latest
+    needs: [deploy-docker]
+    steps:
+    - run: mkdir -p ~/.docker
+    - run: |
+        echo "{\"experimental\": \"enabled\"}" > ~/.docker/config.json
+    - run: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - run: |
+        REPO=${{ github.repository }}
+
+        docker manifest create ${REPO}:dev \
+          ${REPO}-aarch64:dev \
+          ${REPO}-amd64:dev \
+          ${REPO}-armv7:dev \
+          ${REPO}-i386:dev
+
+        echo "Pushing to ${REPO}:dev"
+        docker manifest push ${REPO}:dev

--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -1,0 +1,180 @@
+name: Release a version
+
+on:
+  push:
+    tags:
+    - "*"
+
+jobs:
+  lint-custom:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Custom
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/ci-custom.py
+  lint-python:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Python
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/lint-python
+  lint-tidy:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Tidy
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: pio init --ide atom
+    - run: script/clang-tidy --all-headers --fix
+    - run: script/ci-suggest-changes
+  lint-format:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    name: Lint Format
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: script/clang-format -i
+    - run: script/ci-suggest-changes
+
+  test:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    strategy:
+      matrix:
+        test:
+        - test1
+        - test2
+        - test3
+        - test4
+    steps:
+    - uses: actions/checkout@v2
+    - run: script/setup
+    - run: esphome tests/${{ matrix.test }}.yaml compile
+
+  deploy-pypi:
+    runs-on: ubuntu-latest
+    container: jesserockz/esphome-lint
+    needs: [lint-custom, lint-python, lint-tidy, lint-format, test]
+    steps:
+    - run: pip install twine wheel
+    - run: python setup.py sdist bdist_wheel
+    - run: twine upload dist/*
+      env:
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+
+  deploy-docker:
+    runs-on: ubuntu-latest
+    needs: [lint-custom, lint-python, lint-tidy, lint-format, test]
+    strategy:
+      matrix:
+        arch: [aarch64, amd64, armv7, i386]
+        build-type: [hassio, docker]
+    steps:
+    - uses: actions/checkout@v2
+    - run: docker info
+    - run: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+    - env:
+        BASE_VERSION: 2.1.1
+      run: |
+        if [[ "${{ matrix.build-type }}" == "hassio" ]]; then
+          BUILD_FROM=esphome/esphome-hassio-base-${{ matrix.arch }}:${BASE_VERSION}
+          BUILD_TO=${{ github.repository }}-hassio-${{ matrix.arch }}
+          DOCKERFILE=docker/Dockerfile.hassio
+        else
+          BUILD_FROM=esphome/esphome-base-${{ matrix.arch }}:${BASE_VERSION}
+          BUILD_TO=${{ github.repository }}-${{ matrix.arch }}
+          DOCKERFILE=docker/Dockerfile
+        fi
+
+        TAG=${{ github.ref }}
+        TAG=${TAG#refs/tags/v}
+
+        echo "Building tag: ${TAG}"
+
+        docker build \
+          --build-arg BUILD_FROM=${BUILD_FROM} \
+          --build-arg BUILD_VERSION=${TAG} \
+          --tag ${BUILD_TO}:${TAG} \
+          --file ${DOCKERFILE} \
+          .
+
+        echo "Pushing to ${BUILD_TO}:${TAG}"
+        docker push ${BUILD_TO}:${TAG}
+
+        beta_tag="^v\d+\.\d+\.\d+b\d+$"
+        if [[ "${TAG}" ~= "${beta_tag}" ]]; then
+          echo "Pushing to ${BUILD_TO}:beta"
+          docker tag ${BUILD_TO}:${TAG} ${BUILD_TO}:beta
+          docker push ${BUILD_TO}:beta
+        else
+          echo "Pushing to ${BUILD_TO}:latest"
+          docker tag ${BUILD_TO}:${TAG} ${BUILD_TO}:latest
+          docker push ${BUILD_TO}:latest
+        fi
+
+  deploy-docker-manifest-version:
+    runs-on: ubuntu-latest
+    steps:
+    - run: mkdir -p ~/.docker
+    - run: |
+        echo "{\"experimental\": \"enabled\"}" > ~/.docker/config.json
+    - run: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - run: |
+        REPO=${{ github.repository }}
+
+        TAG=${{ github.ref }}
+        TAG=${TAG#refs/tags/v}
+
+        docker manifest create ${REPO}:${TAG} \
+          ${REPO}-aarch64:${TAG} \
+          ${REPO}-amd64:${TAG} \
+          ${REPO}-armv7:${TAG} \
+          ${REPO}-i386:${TAG}
+
+        echo "Pushing to ${REPO}:${TAG}"
+        docker push ${REPO}:${TAG}
+
+  deploy-docker-manifest:
+    runs-on: ubuntu-latest
+    steps:
+    - run: mkdir -p ~/.docker
+    - run: |
+        echo "{\"experimental\": \"enabled\"}" > ~/.docker/config.json
+    - run: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - run: |
+        REPO=${{ github.repository }}
+
+        TAG=${{ github.ref }}
+        TAG=${TAG#refs/tags/v}
+
+        beta_tag="^v\d+\.\d+\.\d+b\d+$"
+        if [[ "${TAG}" ~= "${beta_tag}" ]]; then
+          TAG=beta
+        else
+          TAG=latest
+        fi
+        docker manifest create ${REPO}:${TAG} \
+          ${REPO}-aarch64:${TAG} \
+          ${REPO}-amd64:${TAG} \
+          ${REPO}-armv7:${TAG} \
+          ${REPO}-i386:${TAG}
+
+        echo "Pushing to ${REPO}:${TAG}"
+        docker push ${REPO}:${TAG}

--- a/script/setup
+++ b/script/setup
@@ -4,5 +4,5 @@
 set -e
 
 cd "$(dirname "$0")/.."
-pip install -r requirements_test.txt
-pip install -e .
+pip3 install -r requirements_test.txt
+pip3 install -e .


### PR DESCRIPTION
## Description:
Moves linting, testing and deploying to github actions.

The way this is set up allows forks to deploy their own images too.

This will require dockerhub user and pypi user credentials set up in secrets in the repository [settings](https://github.com/esphome/esphome/settings/secrets):

- `DOCKER_USER` 
- `DOCKER_PASSWORD`
- `TWINE_USERNAME`
- `TWINE_PASSWORD`


See workflow results [here](https://github.com/jesserockz/esphome/actions).



**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
