### PR TITLE
Bug/fix internal flag in binary sensor

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -131,11 +131,11 @@ def wrap_to_code(name, comp):
 
 
 def write_cpp(config):
-    assemble_cpp_file(config)
-    write_cpp_file()
+    generate_cpp_contents(config)
+    return write_cpp_file()
 
 
-def assemble_cpp_file(config):
+def generate_cpp_contents(config):
     _LOGGER.info("Generating C++ source...")
 
     for name, component, conf in iter_components(CORE.config):

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -131,6 +131,11 @@ def wrap_to_code(name, comp):
 
 
 def write_cpp(config):
+    assemble_cpp_file(config)
+    write_cpp_file()
+
+
+def assemble_cpp_file(config):
     _LOGGER.info("Generating C++ source...")
 
     for name, component, conf in iter_components(CORE.config):
@@ -140,6 +145,8 @@ def write_cpp(config):
 
     CORE.flush_tasks()
 
+
+def write_cpp_file():
     writer.write_platformio_project()
 
     code_s = indent(CORE.cpp_main_section)

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -224,7 +224,7 @@ BINARY_SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend({
 def setup_binary_sensor_core_(var, config):
     cg.add(var.set_name(config[CONF_NAME]))
     if CONF_INTERNAL in config:
-        cg.add(var.set_internal(CONF_INTERNAL))
+        cg.add(var.set_internal(config[CONF_INTERNAL]))
     if CONF_DEVICE_CLASS in config:
         cg.add(var.set_device_class(config[CONF_DEVICE_CLASS]))
     if CONF_INVERTED in config:

--- a/tests/component_tests/binary_sensor/test_binary_sensor.py
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.py
@@ -20,3 +20,5 @@ def test_binary_sensor_config_value_internal_set():
     # Then
     assert "bs_1->set_internal(true);" in CORE.cpp_main_section
     assert "bs_2->set_internal(false);" in CORE.cpp_main_section
+
+    CORE.reset()

--- a/tests/component_tests/binary_sensor/test_binary_sensor.py
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.py
@@ -1,0 +1,22 @@
+""" Tests for the binary sensor component """
+
+from esphome.core import CORE
+from esphome.config import read_config
+from esphome.__main__ import assemble_cpp_file
+
+
+def test_binary_sensor_config_value_internal_set():
+    """
+    Test that the "internal" config value is correctly set
+    """
+    # Given
+    CORE.config_path = "tests/component_tests/binary_sensor/test_binary_sensor.yaml"
+    CORE.config = read_config({})
+
+    # When
+    assemble_cpp_file(CORE.config)
+    # print(CORE.cpp_main_section)
+
+    # Then
+    assert "bs_1->set_internal(true);" in CORE.cpp_main_section
+    assert "bs_2->set_internal(false);" in CORE.cpp_main_section

--- a/tests/component_tests/binary_sensor/test_binary_sensor.py
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.py
@@ -2,7 +2,7 @@
 
 from esphome.core import CORE
 from esphome.config import read_config
-from esphome.__main__ import assemble_cpp_file
+from esphome.__main__ import generate_cpp_contents
 
 
 def test_binary_sensor_config_value_internal_set():
@@ -14,7 +14,7 @@ def test_binary_sensor_config_value_internal_set():
     CORE.config = read_config({})
 
     # When
-    assemble_cpp_file(CORE.config)
+    generate_cpp_contents(CORE.config)
     # print(CORE.cpp_main_section)
 
     # Then

--- a/tests/component_tests/binary_sensor/test_binary_sensor.yaml
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.yaml
@@ -1,0 +1,18 @@
+esphome:
+  name: test
+  platform: ESP8266
+  board: d1_mini_lite
+
+binary_sensor:
+  - platform: gpio
+    id: bs_1
+    name: "test bs1"
+    internal: true
+    pin:
+      number: D0
+  - platform: gpio
+    id: bs_2
+    name: "test bs2"
+    internal: false
+    pin:
+      number: D1


### PR DESCRIPTION
## Description:

The `internal` flag on binary sensors isn't set correctly. This is because the _name_ of the flag is used when generating the code instead of the _value_. This works correctly now.

Additionally, I took the liberty of creating a test to ensure that this will continue to work. The test reads a config file, let's the `core` component do all the assembly of the C++ code and then validates that the expected statements are in that code. To do this without having to write out all the C++ code to disk, I had to split the `write_cpp` function in `__main__.py` into two. One to assemble the C++ statements inside `CORE` and the other to write them to disk.

The test setup is very simple and could even be abstracted into a fixture like this:
```python
def test_setup_function(generate_main):
    maincpp = generate_main("test.yaml")

    assert "void setup() {" in maincpp
```

This would then ensure that the only code that is actually generated can be properly tested. I can do that in this PR if that would be useful.

**Related issue (if applicable):** fixes esphome/issues#1224

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
