### PR TITLE
Use inclusive terminology

### DIFF
--- a/esphome/components/dallas/esp_one_wire.cpp
+++ b/esphome/components/dallas/esp_one_wire.cpp
@@ -30,7 +30,7 @@ bool HOT ICACHE_RAM_ATTR ESPOneWire::reset() {
 
   // Switch into RX mode, letting the pin float
   this->pin_->pin_mode(INPUT_PULLUP);
-  // after 15µs-60µs wait time, slave pulls low for 60µs-240µs
+  // after 15µs-60µs wait time, responder pulls low for 60µs-240µs
   // let's have 70µs just in case
   delayMicroseconds(70);
 

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -280,8 +280,8 @@ def mqtt_publish_json_action_to_code(config, action_id, template_arg, args):
 
 
 def get_default_topic_for(data, component_type, name, suffix):
-    whitelist = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
-    sanitized_name = ''.join(x for x in name.lower().replace(' ', '_') if x in whitelist)
+    allowlist = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+    sanitized_name = ''.join(x for x in name.lower().replace(' ', '_') if x in allowlist)
     return '{}/{}/{}/{}'.format(data.topic_prefix, component_type,
                                 sanitized_name, suffix)
 

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -12,7 +12,7 @@ static const char *TAG = "mqtt.component";
 void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
-  std::string sanitized_name = sanitize_string_whitelist(App.get_name(), HOSTNAME_CHARACTER_WHITELIST);
+  std::string sanitized_name = sanitize_string_allowlist(App.get_name(), HOSTNAME_CHARACTER_ALLOWLIST);
   return discovery_info.prefix + "/" + this->component_type() + "/" + sanitized_name + "/" +
          this->get_default_object_id_() + "/config";
 }
@@ -117,7 +117,7 @@ bool MQTTComponent::is_discovery_enabled() const {
 }
 
 std::string MQTTComponent::get_default_object_id_() const {
-  return sanitize_string_whitelist(to_lowercase_underscore(this->friendly_name()), HOSTNAME_CHARACTER_WHITELIST);
+  return sanitize_string_allowlist(to_lowercase_underscore(this->friendly_name()), HOSTNAME_CHARACTER_ALLOWLIST);
 }
 
 void MQTTComponent::subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos) {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -177,7 +177,7 @@ const std::string &Nameable::get_object_id() { return this->object_id_; }
 bool Nameable::is_internal() const { return this->internal_; }
 void Nameable::set_internal(bool internal) { this->internal_ = internal; }
 void Nameable::calc_object_id_() {
-  this->object_id_ = sanitize_string_whitelist(to_lowercase_underscore(this->name_), HOSTNAME_CHARACTER_WHITELIST);
+  this->object_id_ = sanitize_string_allowlist(to_lowercase_underscore(this->name_), HOSTNAME_CHARACTER_ALLOWLIST);
   // FNV-1 hash
   this->object_id_hash_ = fnv1_hash(this->object_id_);
 }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -85,16 +85,16 @@ std::string to_lowercase_underscore(std::string s) {
   return s;
 }
 
-std::string sanitize_string_whitelist(const std::string &s, const std::string &whitelist) {
+std::string sanitize_string_allowlist(const std::string &s, const std::string &allowlist) {
   std::string out(s);
   out.erase(std::remove_if(out.begin(), out.end(),
-                           [&whitelist](const char &c) { return whitelist.find(c) == std::string::npos; }),
+                           [&allowlist](const char &c) { return allowlist.find(c) == std::string::npos; }),
             out.end());
   return out;
 }
 
 std::string sanitize_hostname(const std::string &hostname) {
-  std::string s = sanitize_string_whitelist(hostname, HOSTNAME_CHARACTER_WHITELIST);
+  std::string s = sanitize_string_allowlist(hostname, HOSTNAME_CHARACTER_ALLOWLIST);
   return truncate_string(s, 63);
 }
 
@@ -154,7 +154,7 @@ ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
   return PARSE_NONE;
 }
 
-const char *HOSTNAME_CHARACTER_WHITELIST = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+const char *HOSTNAME_CHARACTER_ALLOWLIST = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
 
 uint8_t crc8(uint8_t *data, uint8_t len) {
   uint8_t crc = 0;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -24,7 +24,7 @@
 namespace esphome {
 
 /// The characters that are allowed in a hostname.
-extern const char *HOSTNAME_CHARACTER_WHITELIST;
+extern const char *HOSTNAME_CHARACTER_ALLOWLIST;
 
 /// Gets the MAC address as a string, this can be used as way to identify this ESP.
 std::string get_mac_address();
@@ -43,7 +43,7 @@ std::string to_string(double val);
 std::string to_string(long double val);
 optional<float> parse_float(const std::string &str);
 
-/// Sanitize the hostname by removing characters that are not in the whitelist and truncating it to 63 chars.
+/// Sanitize the hostname by removing characters that are not in the allowlist and truncating it to 63 chars.
 std::string sanitize_hostname(const std::string &hostname);
 
 /// Truncate a string to a specific length
@@ -121,8 +121,8 @@ std::string uint64_to_string(uint64_t num);
 /// Convert a uint32_t to a hex string
 std::string uint32_to_string(uint32_t num);
 
-/// Sanitizes the input string with the whitelist.
-std::string sanitize_string_whitelist(const std::string &s, const std::string &whitelist);
+/// Sanitizes the input string with the allowlist.
+std::string sanitize_string_allowlist(const std::string &s, const std::string &allowlist);
 
 uint8_t reverse_bits_8(uint8_t x);
 uint16_t reverse_bits_16(uint16_t x);

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -91,7 +91,8 @@ def lint_post_check(func):
 
 
 def lint_re_check(regex, **kwargs):
-    prog = re.compile(regex, re.MULTILINE)
+    flags = kwargs.pop('flags', re.MULTILINE)
+    prog = re.compile(regex, flags)
     decor = lint_content_check(**kwargs)
 
     def decorator(func):
@@ -327,6 +328,24 @@ def lint_pragma_once(fname, content):
     return None
 
 
+@lint_re_check(r'(whitelist|blacklist|slave)', exclude=['script/ci-custom.py'], 
+               flags=re.IGNORECASE | re.MULTILINE)
+def lint_inclusive_language(fname, match):
+    # From https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=49decddd39e5f6132ccd7d9fdc3d7c470b0061bb
+    return ("Avoid the use of whitelist/blacklist/slave.\n"
+            "Recommended replacements for 'master / slave' are:\n"
+            "    '{primary,main} / {secondary,replica,subordinate}\n"
+            "    '{initiator,requester} / {target,responder}'\n"
+            "    '{controller,host} / {device,worker,proxy}'\n"
+            "    'leader / follower'\n"
+            "    'director / performer'\n"
+            "\n"
+            "Recommended replacements for 'blacklist/whitelist' are:\n"
+            "    'denylist / allowlist'\n"
+            "    'blocklist / passlist'")
+
+
+
 @lint_content_find_check('ESP_LOG', include=['*.h', '*.tcc'], exclude=[
     'esphome/components/binary_sensor/binary_sensor.h',
     'esphome/components/cover/cover.h',
@@ -365,7 +384,7 @@ def add_errors(fname, errs):
             lineno = 1
             col = 1
             msg = err
-        if not isinstance(err, str):
+        if not isinstance(msg, str):
             raise ValueError("Error is not instance of string!")
         if not isinstance(lineno, int):
             raise ValueError("Line number is not an int!")


### PR DESCRIPTION
## Description:

Sadly a bit late to this. 

This PR removes archaic language/adds inclusive terminology to the ESPHome codebase. Specifically, blacklist/whitelist and the word slave are now removed.

If you don't think this is necessary, please go read the discussions on this topic in a lot of other projects (linux, chromium, etc). I'll lock this PR if a discussion here gets out of hand.

Happy to see that there's very few usages of these words to begin with :)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
