### PR TITLE
More accurate measurement in pulse_counter and hlw8012 

### DIFF
--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -11,7 +11,7 @@ static const float HLW8012_REFERENCE_VOLTAGE = 2.43f;
 
 void HLW8012Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up HLW8012...");
-  last_update_ = millis();
+  last_update_ = micros();
 
   this->sel_pin_->setup();
   this->sel_pin_->digital_write(this->current_mode_);
@@ -33,7 +33,7 @@ void HLW8012Component::dump_config() {
 }
 float HLW8012Component::get_setup_priority() const { return setup_priority::DATA; }
 void HLW8012Component::update() {
-  uint32_t now = millis();
+  uint32_t now = micros();
   uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
   if (cycle_duration == 0) {
@@ -42,12 +42,12 @@ void HLW8012Component::update() {
   // HLW8012 has 50% duty cycle
   pulse_counter::pulse_counter_t raw_cf = this->cf_store_.read_raw_value();
   pulse_counter::pulse_counter_t raw_cf1 = this->cf1_store_.read_raw_value();
-  float cf_hz = raw_cf / (cycle_duration / 1000.0f);
+  float cf_hz = raw_cf / (cycle_duration / 1000000.0f);
   if (raw_cf <= 1) {
     // don't count single pulse as power
     cf_hz = 0.0f;
   }
-  float cf1_hz = raw_cf1 / (cycle_duration / 1000.0f);
+  float cf1_hz = raw_cf1 / (cycle_duration / 1000000.0f);
   if (raw_cf1 <= 1) {
     // don't count single pulse as anything
     cf1_hz = 0.0f;

--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -33,23 +33,21 @@ void HLW8012Component::dump_config() {
 }
 float HLW8012Component::get_setup_priority() const { return setup_priority::DATA; }
 void HLW8012Component::update() {
-
   uint32_t now = millis();
-  uint32_t cycleDuration = now - last_update_;
+  uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
-  if (cycleDuration == 0) {
+  if (cycle_duration == 0) {
     return;
   }
-
   // HLW8012 has 50% duty cycle
   pulse_counter::pulse_counter_t raw_cf = this->cf_store_.read_raw_value();
   pulse_counter::pulse_counter_t raw_cf1 = this->cf1_store_.read_raw_value();
-  float cf_hz = raw_cf / (cycleDuration / 1000.0f);
+  float cf_hz = raw_cf / (cycle_duration / 1000.0f);
   if (raw_cf <= 1) {
     // don't count single pulse as power
     cf_hz = 0.0f;
   }
-  float cf1_hz = raw_cf1 / (cycleDuration / 1000.0f); 
+  float cf1_hz = raw_cf1 / (cycle_duration / 1000.0f);
   if (raw_cf1 <= 1) {
     // don't count single pulse as anything
     cf1_hz = 0.0f;

--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -11,6 +11,8 @@ static const float HLW8012_REFERENCE_VOLTAGE = 2.43f;
 
 void HLW8012Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up HLW8012...");
+  last_update_ = millis();
+
   this->sel_pin_->setup();
   this->sel_pin_->digital_write(this->current_mode_);
   this->cf_store_.pulse_counter_setup(this->cf_pin_);
@@ -31,15 +33,23 @@ void HLW8012Component::dump_config() {
 }
 float HLW8012Component::get_setup_priority() const { return setup_priority::DATA; }
 void HLW8012Component::update() {
+
+  uint32_t now = millis();
+  uint32_t cycleDuration = now - last_update_;
+  last_update_ = now;
+  if (cycleDuration == 0) {
+    return;
+  }
+
   // HLW8012 has 50% duty cycle
   pulse_counter::pulse_counter_t raw_cf = this->cf_store_.read_raw_value();
   pulse_counter::pulse_counter_t raw_cf1 = this->cf1_store_.read_raw_value();
-  float cf_hz = raw_cf / (this->get_update_interval() / 1000.0f);
+  float cf_hz = raw_cf / (cycleDuration / 1000.0f);
   if (raw_cf <= 1) {
     // don't count single pulse as power
     cf_hz = 0.0f;
   }
-  float cf1_hz = raw_cf1 / (this->get_update_interval() / 1000.0f);
+  float cf1_hz = raw_cf1 / (cycleDuration / 1000.0f); 
   if (raw_cf1 <= 1) {
     // don't count single pulse as anything
     cf1_hz = 0.0f;

--- a/esphome/components/hlw8012/hlw8012.h
+++ b/esphome/components/hlw8012/hlw8012.h
@@ -37,6 +37,7 @@ class HLW8012Component : public PollingComponent {
   uint32_t change_mode_every_{8};
   float current_resistor_{0.001};
   float voltage_divider_{2351};
+  uint32_t last_update_;
   GPIOPin *sel_pin_;
   GPIOPin *cf_pin_;
   pulse_counter::PulseCounterStorage cf_store_;

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -156,7 +156,7 @@ void PulseCounterSensor::dump_config() {
 void PulseCounterSensor::update() {
   pulse_counter_t raw = this->storage_.read_raw_value();
 
-  uint32_t now = this->storage_.last_pulse;
+  uint32_t now = micros();
   uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
   if (cycle_duration == 0) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -156,7 +156,12 @@ void PulseCounterSensor::dump_config() {
 void PulseCounterSensor::update() {
   pulse_counter_t raw = this->storage_.read_raw_value();
 
+#ifdef ARDUINO_ARCH_ESP8266
   uint32_t now = this->storage_.last_pulse;
+#else
+// on the ESP32 we do not keep the last pulse time
+  uint32_t now = micros();
+#endif
   uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
   if (cycle_duration == 0) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -156,12 +156,7 @@ void PulseCounterSensor::dump_config() {
 void PulseCounterSensor::update() {
   pulse_counter_t raw = this->storage_.read_raw_value();
 
-#ifdef ARDUINO_ARCH_ESP8266
   uint32_t now = this->storage_.last_pulse;
-#else
-// on the ESP32 we do not keep the last pulse time
-  uint32_t now = micros();
-#endif
   uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
   if (cycle_duration == 0) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -156,7 +156,7 @@ void PulseCounterSensor::dump_config() {
 void PulseCounterSensor::update() {
   pulse_counter_t raw = this->storage_.read_raw_value();
 
-  uint32_t now = micros();
+  uint32_t now = this->storage_.last_pulse;
   uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
   if (cycle_duration == 0) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -154,17 +154,16 @@ void PulseCounterSensor::dump_config() {
 }
 
 void PulseCounterSensor::update() {
-
   pulse_counter_t raw = this->storage_.read_raw_value();
 
   uint32_t now = millis();
-  uint32_t cycleDuration = now - last_update_;
+  uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
-  if (cycleDuration == 0) {
+  if (cycle_duration == 0) {
     return;
   }
 
-  float value = (60000.0f * raw) / float(cycleDuration ));  // per minute
+  float value = (60000.0f * raw) / float(cycle_duration);  // per minute
 
   ESP_LOGD(TAG, "'%s': Retrieved counter: %0.2f pulses/min", this->get_name().c_str(), value);
   this->publish_state(value);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -137,7 +137,7 @@ pulse_counter_t PulseCounterStorage::read_raw_value() {
 
 void PulseCounterSensor::setup() {
   ESP_LOGCONFIG(TAG, "Setting up pulse counter '%s'...", this->name_.c_str());
-  last_update_ = millis();
+  last_update_ = micros();
   if (!this->storage_.pulse_counter_setup(this->pin_)) {
     this->mark_failed();
     return;
@@ -156,14 +156,14 @@ void PulseCounterSensor::dump_config() {
 void PulseCounterSensor::update() {
   pulse_counter_t raw = this->storage_.read_raw_value();
 
-  uint32_t now = millis();
+  uint32_t now = micros();
   uint32_t cycle_duration = now - last_update_;
   last_update_ = now;
   if (cycle_duration == 0) {
     return;
   }
 
-  float value = (60000.0f * raw) / float(cycle_duration);  // per minute
+  float value = (60000000.0f * raw) / float(cycle_duration);  // per minute
 
   ESP_LOGD(TAG, "'%s': Retrieved counter: %0.2f pulses/min", this->get_name().c_str(), value);
   this->publish_state(value);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -64,6 +64,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
  protected:
   GPIOPin *pin_;
   PulseCounterStorage storage_;
+  uint32_t last_update_;
 };
 
 #ifdef ARDUINO_ARCH_ESP32


### PR DESCRIPTION
## Description:
More accurate measurement in pulse_counter and hlw8012 by using actual cycle duration instead of configured update interval. Also prevent division by zero in rare cases. 

I think this will fix the problem I described in #1333 and also make the pulse counting more accurate. I have implemented something similar in a custom component. I have not been able to this specific PR as I do not fully understand how to do a compule of my projects from my own esphome branch. So maybe this is best seen as a 'sugessted sulution'

**Related issue (if applicable):** fixes <link to issue>
#1333

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
