### PR TITLE
Feature/component test fixture

### DIFF
--- a/tests/component_tests/binary_sensor/test_binary_sensor.py
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.py
@@ -1,24 +1,15 @@
 """ Tests for the binary sensor component """
 
-from esphome.core import CORE
-from esphome.config import read_config
-from esphome.__main__ import generate_cpp_contents
 
-
-def test_binary_sensor_config_value_internal_set():
+def test_binary_sensor_config_value_internal_set(generate_main):
     """
     Test that the "internal" config value is correctly set
     """
     # Given
-    CORE.config_path = "tests/component_tests/binary_sensor/test_binary_sensor.yaml"
-    CORE.config = read_config({})
 
     # When
-    generate_cpp_contents(CORE.config)
-    # print(CORE.cpp_main_section)
+    main_cpp = generate_main("tests/component_tests/binary_sensor/test_binary_sensor.yaml")
 
     # Then
-    assert "bs_1->set_internal(true);" in CORE.cpp_main_section
-    assert "bs_2->set_internal(false);" in CORE.cpp_main_section
-
-    CORE.reset()
+    assert "bs_1->set_internal(true);" in main_cpp
+    assert "bs_2->set_internal(false);" in main_cpp

--- a/tests/component_tests/binary_sensor/test_binary_sensor.py
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.py
@@ -1,6 +1,34 @@
 """ Tests for the binary sensor component """
 
 
+def test_binary_sensor_is_setup(generate_main):
+    """
+    When the binary sensor is set in the yaml file, it should be registered in main
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main("tests/component_tests/binary_sensor/test_binary_sensor.yaml")
+
+    # Then
+    assert "new gpio::GPIOBinarySensor();" in main_cpp
+    assert "App.register_binary_sensor" in main_cpp
+
+
+def test_binary_sensor_sets_mandatory_fields(generate_main):
+    """
+    When the mandatory fields are set in the yaml, they should be set in main
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main("tests/component_tests/binary_sensor/test_binary_sensor.yaml")
+
+    # Then
+    assert "bs_1->set_name(\"test bs1\");" in main_cpp
+    assert "bs_1->set_pin(new GPIOPin" in main_cpp
+
+
 def test_binary_sensor_config_value_internal_set(generate_main):
     """
     Test that the "internal" config value is correctly set

--- a/tests/component_tests/conftest.py
+++ b/tests/component_tests/conftest.py
@@ -1,0 +1,23 @@
+""" Fixtures for component tests """
+
+import pytest
+
+from esphome.core import CORE
+from esphome.config import read_config
+from esphome.__main__ import generate_cpp_contents
+
+
+@pytest.fixture
+def generate_main():
+    """ Generates the C++ main.cpp file and returns it in string form """
+
+    def generator(path: str) -> str:
+        CORE.config_path = path
+        CORE.config = read_config({})
+        generate_cpp_contents(CORE.config)
+        # print(CORE.cpp_main_section)
+        return CORE.cpp_main_section
+
+    yield generator
+
+    CORE.reset()

--- a/tests/component_tests/conftest.py
+++ b/tests/component_tests/conftest.py
@@ -15,7 +15,7 @@ def generate_main():
         CORE.config_path = path
         CORE.config = read_config({})
         generate_cpp_contents(CORE.config)
-        # print(CORE.cpp_main_section)
+        print(CORE.cpp_main_section)
         return CORE.cpp_main_section
 
     yield generator


### PR DESCRIPTION
## Description:

* Move the main generation in the `component_test` folder to a new fixture, which ensures that `CORE` is always reset.
* Add a couple more tests to demonstrate how to test for components being set up correctly in `main.cpp`

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).