### PR TITLE
Use more layer caching for esphome/esphome Dockerfile

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -165,7 +165,7 @@ jobs:
           echo "::set-env name=TAG::${TAG}"
       - name: Set up env variables
         run: |
-          base_version="2.3.1"
+          base_version="2.3.3"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
           echo "::set-env name=TAG::${TAG}"
       - name: Set up env variables
         run: |
-          base_version="2.3.1"
+          base_version="2.3.3"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ${BUILD_FROM}
 
 # First install requirements to leverage caching when requirements don't change
 COPY requirements.txt /
-RUN pip3 install -r /requirements.txt
+RUN pip3 install --no-cache-dir -r /requirements.txt
 
 # Then copy esphome and install
 COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,21 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:2.3.1
+ARG BUILD_FROM=esphome/esphome-base-amd64:2.3.3
 FROM ${BUILD_FROM}
 
+# First install requirements to leverage caching when requirements don't change
+COPY requirements.txt /
+RUN pip3 install -r /requirements.txt
+
+# Then copy esphome and install
 COPY . .
 RUN pip3 install --no-cache-dir -e .
 
-ENV USERNAME=""
-ENV PASSWORD=""
+# Settings for dashboard
+ENV USERNAME="" PASSWORD=""
 
+# The directory the user should mount their configuration files to
 WORKDIR /config
+# Set entrypoint to esphome so that the user doesn't have to type 'esphome'
+# in every docker command twice
 ENTRYPOINT ["esphome"]
+# When no arguments given, start the dashboard in the workdir
 CMD ["/config", "dashboard"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:2.3.1
+FROM esphome/esphome-base-amd64:2.3.3
 
 COPY . .
 

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM esphome/esphome-lint-base:2.3.1
+FROM esphome/esphome-lint-base:2.3.3
 
 COPY requirements.txt requirements_test.txt /
 RUN pip3 install --no-cache-dir -r /requirements.txt -r /requirements_test.txt


### PR DESCRIPTION
## Description:

Main change is that `esphome/esphome:dev` will be faster to pull/generate because build dependencies are not re-written each time.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
