### PR TITLE
Bump minimum Python version to 3.7

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -525,9 +525,9 @@ def run_esphome(argv):
         _LOGGER.error("Missing configuration parameter, see esphome --help.")
         return 1
 
-    if sys.version_info < (3, 6, 0):
-        _LOGGER.error("You're running ESPHome with Python <3.6. ESPHome is no longer compatible "
-                      "with this Python version. Please reinstall ESPHome with Python 3.6+")
+    if sys.version_info < (3, 7, 0):
+        _LOGGER.error("You're running ESPHome with Python <3.7. ESPHome is no longer compatible "
+                      "with this Python version. Please reinstall ESPHome with Python 3.7+")
         return 1
 
     if args.command in PRE_CONFIG_ACTIONS:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     zip_safe=False,
     platforms='any',
     test_suite='tests',
-    python_requires='>=3.6,<4.0',
+    python_requires='>=3.7,<4.0',
     install_requires=REQUIRES,
     keywords=['home', 'automation'],
     entry_points={


### PR DESCRIPTION
## Description:

It's been quite some time since python 3.6 was set as the minimum and all distributions I know have py >3.7 already. So this should not be a problem.

New features:
 - dataclasses
 - stable dict insertion order guaranteed

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
