### PR TITLE
Don't run deploy job when repository is not esphome/esphome

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -158,7 +158,7 @@ jobs:
         run: script/setup
       - name: Install Github Actions annotator
         run: pip install pytest-github-actions-annotate-failures
-      
+
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/python.json"
@@ -172,6 +172,7 @@ jobs:
 
   deploy-docker:
     name: Build and publish docker containers
+    if: github.repository == "esphome/esphome"
     runs-on: ubuntu-latest
     needs: [lint-clang-format, lint-clang-tidy, lint-python, test, pytest]
     strategy:
@@ -231,6 +232,7 @@ jobs:
 
 
   deploy-docker-manifest:
+    if: github.repository == "esphome/esphome"
     runs-on: ubuntu-latest
     needs: [deploy-docker]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
           echo "::add-matcher::.github/workflows/matchers/python.json"
       - run: esphome tests/${{ matrix.test }}.yaml compile
-  
+
   pytest:
     runs-on: ubuntu-latest
     steps:
@@ -156,7 +156,7 @@ jobs:
         run: script/setup
       - name: Install Github Actions annotator
         run: pip install pytest-github-actions-annotate-failures
-      
+
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/python.json"
@@ -170,6 +170,7 @@ jobs:
 
   deploy-pypi:
     name: Build and publish to PyPi
+    if: github.repository == "esphome/esphome"
     needs: [lint-clang-format, lint-clang-tidy, lint-python, test, pytest]
     runs-on: ubuntu-latest
     steps:
@@ -192,6 +193,7 @@ jobs:
 
   deploy-docker:
     name: Build and publish docker containers
+    if: github.repository == "esphome/esphome"
     runs-on: ubuntu-latest
     needs: [lint-clang-format, lint-clang-tidy, lint-python, test, pytest]
     strategy:
@@ -259,6 +261,7 @@ jobs:
           docker push "${BUILD_TO}:latest"
 
   deploy-docker-manifest:
+    if: github.repository == "esphome/esphome"
     runs-on: ubuntu-latest
     needs: [deploy-docker]
     steps:


### PR DESCRIPTION
## Description:
This stops the GitHub Actions Workflows from trying to run the deploy steps on forks.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
