### PR TITLE
Fix unit test warning for hypothesis deprecation

### DIFF
--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1,7 +1,7 @@
 import pytest
 
 from hypothesis import given
-from hypothesis.provisional import ip4_addr_strings
+from hypothesis.provisional import ip_addresses
 from strategies import mac_addr_strings
 
 from esphome import core, const
@@ -24,7 +24,7 @@ class TestHexInt:
 
 
 class TestIPAddress:
-    @given(value=ip4_addr_strings())
+    @given(value=ip_addresses(v=4).map(str))
     def test_init__valid(self, value):
         core.IPAddress(*value.split("."))
 
@@ -33,7 +33,7 @@ class TestIPAddress:
         with pytest.raises(ValueError, match="IPAddress must consist of 4 items"):
             core.IPAddress(*value.split("."))
 
-    @given(value=ip4_addr_strings())
+    @given(value=ip_addresses(v=4).map(str))
     def test_str(self, value):
         target = core.IPAddress(*value.split("."))
 

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1,7 +1,7 @@
 import pytest
 
 from hypothesis import given
-from hypothesis.provisional import ip4_addr_strings
+from hypothesis.provisional import ip_addresses
 
 from esphome import helpers
 
@@ -75,7 +75,7 @@ def test_is_ip_address__invalid(host):
     assert actual is False
 
 
-@given(value=ip4_addr_strings())
+@given(value=ip_addresses(v=4).map(str))
 def test_is_ip_address__valid(value):
     actual = helpers.is_ip_address(value)
 


### PR DESCRIPTION
## Description:
The unit test output shows a deprecation warning from `hypothesis`:
>  C:\Development\esphome\venv\lib\site-packages\hypothesis\provisional.py:169: HypothesisDeprecationWarning: Use `ip_addresses(v=4).map(str)` instead of `ip4_addr_strings()`; the provisional strategy is less flexible and will be removed.
    since="2020-01-21",

This PR addresses that and there are no other warnings.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
