### PR TITLE
Bump ArduinoJson from 5.13.3 to 6.15.2

### DIFF
--- a/esphome/components/json/__init__.py
+++ b/esphome/components/json/__init__.py
@@ -6,6 +6,6 @@ json_ns = cg.esphome_ns.namespace('json')
 
 @coroutine_with_priority(1.0)
 def to_code(config):
-    cg.add_library('ArduinoJson-esphomelib', '5.13.3')
+    cg.add_library('ArduinoJson-esphomelib', '6.15.2')
     cg.add_define('USE_JSON')
     cg.add_global(json_ns.using)

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ include_dir = include
 lib_deps =
     AsyncTCP-esphome@1.1.1
     AsyncMqttClient-esphome@0.8.4
-    ArduinoJson-esphomelib@5.13.3
+    ArduinoJson-esphomelib@6.15.2
     ESPAsyncWebServer-esphome@1.2.6
     FastLED@3.2.9
     NeoPixelBus-esphome@2.5.2


### PR DESCRIPTION
## Description:

Will first have to wait for platformio library crawler to pick up the update from the fork.

URL: https://platformio.org/lib/show/3837/ArduinoJson-esphomelib

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
