### PR TITLE
 rtttl player

### DIFF
--- a/esphome/components/esp8266_pwm/esp8266_pwm.h
+++ b/esphome/components/esp8266_pwm/esp8266_pwm.h
@@ -13,7 +13,7 @@ class ESP8266PWM : public output::FloatOutput, public Component {
   void set_pin(GPIOPin *pin) { pin_ = pin; }
   void set_frequency(float frequency) { this->frequency_ = frequency; }
   /// Dynamically update frequency
-  void update_frequency(float frequency) {
+  void update_frequency(float frequency) override {
     this->set_frequency(frequency);
     this->write_state(this->last_output_);
   }

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -22,7 +22,7 @@ void LEDCOutput::write_state(float state) {
 }
 
 void LEDCOutput::setup() {
-  this->apply_frequency(this->frequency_);
+  this->update_frequency(this->frequency_);
   this->turn_off();
   // Attach pin after setting default value
   ledcAttachPin(this->pin_->get_pin(), this->channel_);
@@ -50,7 +50,7 @@ optional<uint8_t> ledc_bit_depth_for_frequency(float frequency) {
   return {};
 }
 
-void LEDCOutput::apply_frequency(float frequency) {
+void LEDCOutput::update_frequency(float frequency) {
   auto bit_depth_opt = ledc_bit_depth_for_frequency(frequency);
   if (!bit_depth_opt.has_value()) {
     ESP_LOGW(TAG, "Frequency %f can't be achieved with any bit depth", frequency);

--- a/esphome/components/ledc/ledc_output.h
+++ b/esphome/components/ledc/ledc_output.h
@@ -19,7 +19,7 @@ class LEDCOutput : public output::FloatOutput, public Component {
   void set_channel(uint8_t channel) { this->channel_ = channel; }
   void set_frequency(float frequency) { this->frequency_ = frequency; }
   /// Dynamically change frequency at runtime
-  void apply_frequency(float frequency);
+  void update_frequency(float frequency) override;
 
   /// Setup LEDC.
   void setup() override;
@@ -45,7 +45,7 @@ template<typename... Ts> class SetFrequencyAction : public Action<Ts...> {
 
   void play(Ts... x) {
     float freq = this->frequency_.value(x...);
-    this->parent_->apply_frequency(freq);
+    this->parent_->update_frequency(freq);
   }
 
  protected:

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -49,6 +49,9 @@ class FloatOutput : public BinaryOutput {
   /// Set the level of this float output, this is called from the front-end.
   void set_level(float state);
 
+  /// Set the frequency of the output for PWM outputs
+  virtual void update_frequency(float frequency) {}
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
 

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -46,10 +46,18 @@ class FloatOutput : public BinaryOutput {
    */
   void set_min_power(float min_power);
 
-  /// Set the level of this float output, this is called from the front-end.
+  /** Set the level of this float output, this is called from the front-end.
+   *
+   * @param state The new state.
+   */
   void set_level(float state);
 
-  /// Set the frequency of the output for PWM outputs
+  /** Set the frequency of the output for PWM outputs.
+   *
+   * Implemented only by components which can set the output PWM frequency.
+   *
+   * @param frequence The new frequency.
+   */
   virtual void update_frequency(float frequency) {}
 
   // ========== INTERNAL METHODS ==========

--- a/esphome/components/rtttl/__init__.py
+++ b/esphome/components/rtttl/__init__.py
@@ -2,18 +2,28 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components.output import FloatOutput
-from esphome.const import CONF_ID, CONF_OUTPUT
-
-rtttl_ns = cg.esphome_ns.namespace('rtttl')
-Rtttl = rtttl_ns .class_('Rtttl', cg.Component)
-RtttlPlayAction = rtttl_ns.class_('RtttlPlayAction', automation.Action)
+from esphome.const import CONF_ID, CONF_OUTPUT, CONF_TRIGGER_ID
 
 CONF_RTTTL = 'rtttl'
+CONF_ON_FINISHED_PLAYBACK = 'on_finished_playback'
+
+rtttl_ns = cg.esphome_ns.namespace('rtttl')
+
+Rtttl = rtttl_ns .class_('Rtttl', cg.Component)
+PlayAction = rtttl_ns.class_('PlayAction', automation.Action)
+StopAction = rtttl_ns.class_('StopAction', automation.Action)
+FinishedPlaybackTrigger = rtttl_ns.class_('FinishedPlaybackTrigger',
+                                          automation.Trigger.template())
+IsPlayingCondition = rtttl_ns.class_('IsPlayingCondition', automation.Condition)
 
 MULTI_CONF = True
+
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_ID): cv.declare_id(Rtttl),
     cv.Required(CONF_OUTPUT): cv.use_id(FloatOutput),
+    cv.Optional(CONF_ON_FINISHED_PLAYBACK): automation.validate_automation({
+        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(FinishedPlaybackTrigger),
+    }),
 }).extend(cv.COMPONENT_SCHEMA)
 
 
@@ -24,8 +34,12 @@ def to_code(config):
     out = yield cg.get_variable(config[CONF_OUTPUT])
     cg.add(var.set_output(out))
 
+    for conf in config.get(CONF_ON_FINISHED_PLAYBACK, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [], conf)
 
-@automation.register_action('rtttl.play', RtttlPlayAction, cv.maybe_simple_value({
+
+@automation.register_action('rtttl.play', PlayAction, cv.maybe_simple_value({
     cv.GenerateID(CONF_ID): cv.use_id(Rtttl),
     cv.Required(CONF_RTTTL): cv.templatable(cv.string)
 }, key=CONF_RTTTL))
@@ -34,4 +48,22 @@ def rtttl_play_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = yield cg.templatable(config[CONF_RTTTL], args, cg.std_string)
     cg.add(var.set_value(template_))
+    yield var
+
+
+@automation.register_action('rtttl.stop', StopAction, cv.Schema({
+    cv.GenerateID(): cv.use_id(Rtttl),
+}))
+def rtttl_stop_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    yield cg.register_parented(var, config[CONF_ID])
+    yield var
+
+
+@automation.register_condition('rtttl.is_playing', IsPlayingCondition, cv.Schema({
+    cv.GenerateID(): cv.use_id(Rtttl),
+}))
+def rtttl_is_playing_to_code(config, condition_id, template_arg, args):
+    var = cg.new_Pvariable(condition_id, template_arg)
+    yield cg.register_parented(var, config[CONF_ID])
     yield var

--- a/esphome/components/rtttl/__init__.py
+++ b/esphome/components/rtttl/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.automation import maybe_simple_id
 from esphome.components.output import FloatOutput
 from esphome.const import CONF_ID, CONF_OUTPUT
 
@@ -26,10 +25,10 @@ def to_code(config):
     cg.add(var.set_output(out))
 
 
-@automation.register_action('rtttl.play', RtttlPlayAction, cv.Schema({
+@automation.register_action('rtttl.play', RtttlPlayAction, cv.maybe_simple_value({
     cv.GenerateID(CONF_ID): cv.use_id(Rtttl),
     cv.Required(CONF_RTTTL): cv.templatable(cv.string)
-}))
+}, key=CONF_RTTTL))
 def rtttl_play_to_code(config, action_id, template_arg, args):
     paren = yield cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/rtttl/__init__.py
+++ b/esphome/components/rtttl/__init__.py
@@ -1,0 +1,38 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.automation import maybe_simple_id
+from esphome.components.output import FloatOutput
+from esphome.const import CONF_ID, CONF_OUTPUT
+
+rtttl_ns = cg.esphome_ns.namespace('rtttl')
+Rtttl = rtttl_ns .class_('Rtttl', cg.Component)
+RtttlPlayAction = rtttl_ns.class_('RtttlPlayAction', automation.Action)
+
+CONF_RTTTL = 'rtttl'
+
+MULTI_CONF = True
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(CONF_ID): cv.declare_id(Rtttl),
+    cv.Required(CONF_OUTPUT): cv.use_id(FloatOutput),
+}).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+
+    out = yield cg.get_variable(config[CONF_OUTPUT])
+    cg.add(var.set_output(out))
+
+
+@automation.register_action('rtttl.play', RtttlPlayAction, cv.Schema({
+    cv.GenerateID(CONF_ID): cv.use_id(Rtttl),
+    cv.Required(CONF_RTTTL): cv.templatable(cv.string)
+}))
+def rtttl_play_to_code(config, action_id, template_arg, args):
+    paren = yield cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = yield cg.templatable(config[CONF_RTTTL], args, cg.std_string)
+    cg.add(var.set_value(template_))
+    yield var

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -69,7 +69,7 @@ void Rtttl::play(std::string rtttl) {
   if (num != 0)
     bpm = num;
 
-  position_ = rtttl_.find(":", position_);
+  position_ = rtttl_.find(':', position_);
   if (position_ == std::string::npos) {
     ESP_LOGE(TAG, "Missing second ':'");
     return;

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -1,14 +1,10 @@
 #include "rtttl.h"
 #include "esphome/core/log.h"
 
-#include "../esp8266_pwm/esp8266_pwm.h"
-
 namespace esphome {
 namespace rtttl {
 
 static const char* TAG = "rtttl";
-
-static const uint8_t OCTAVE_OFFSET = 0;
 
 // These values can also be found as constants in the Tone library (Tone.h)
 static const uint16_t NOTES[] = {0,    262,  277,  294,  311,  330,  349,  370,  392,  415,  440,  466,  494,
@@ -16,7 +12,16 @@ static const uint16_t NOTES[] = {0,    262,  277,  294,  311,  330,  349,  370, 
                                  1109, 1175, 1245, 1319, 1397, 1480, 1568, 1661, 1760, 1865, 1976, 2093, 2217,
                                  2349, 2489, 2637, 2794, 2960, 3136, 3322, 3520, 3729, 3951};
 
-#define is_digit(n) (n >= '0' && n <= '9')
+#define SKIP_CHAR_OR_SPACE(p, char) \
+  while (*p == char || *p == ' ') \
+    p++;
+#define GET_INTEGER(p, var) \
+  var = 0; \
+  while (isdigit(*p)) { \
+    var = (var * 10) + (*p++ - '0'); \
+  }
+
+void Rtttl::dump_config() { ESP_LOGCONFIG(TAG, "Rtttl"); }
 
 void Rtttl::play(std::string rtttl) {
   // Absolutely no error checking in here
@@ -26,8 +31,8 @@ void Rtttl::play(std::string rtttl) {
 
   p_ = rtttl_.cbegin();
 
-  this->default_dur_ = 4;
-  this->default_oct_ = 6;
+  this->default_duration_ = 4;
+  this->default_octave_ = 6;
   int bpm = 63;
   int num;
 
@@ -38,52 +43,42 @@ void Rtttl::play(std::string rtttl) {
   while (*p_ != ':')
     p_++;
 
-  // skip colon and spaces
-  while (*p_ == ':' || *p_ == ' ')
-    p_++;
+  SKIP_CHAR_OR_SPACE(p_, ':')
 
   // get default duration
   if (*p_ == 'd') {
     p_++;
     p_++;  // skip "d="
-    num = 0;
-    while (is_digit(*p_)) {
-      num = (num * 10) + (*p_++ - '0');
-    }
+    GET_INTEGER(p_, num)
     if (num > 0)
-      default_dur_ = num;
-    p_++;  // skip comma
+      default_duration_ = num;
+    SKIP_CHAR_OR_SPACE(p_, ',')
   }
 
   // get default octave
   if (*p_ == 'o') {
     p_++;
     p_++;  // skip "o="
-    num = *p_++ - '0';
+    GET_INTEGER(p_, num)
     if (num >= 3 && num <= 7)
-      default_oct_ = num;
-    // skip comma and spaces
-    while (*p_ == ',' || *p_ == ' ')
-      p_++;
+      default_octave_ = num;
+    SKIP_CHAR_OR_SPACE(p_, ',')
   }
 
   // get BPM
   if (*p_ == 'b') {
     p_++;
     p_++;  // skip "b="
-    num = 0;
-    while (is_digit(*p_)) {
-      num = (num * 10) + (*p_++ - '0');
-    }
-    bpm = num;
-    // skip colon and spaces
-    while (*p_ == ':' || *p_ == ' ')
-      p_++;
+    GET_INTEGER(p_, num)
+    if (num != 0)
+      bpm = num;
+    SKIP_CHAR_OR_SPACE(p_, ':')
   }
 
   // BPM usually expresses the number of quarter notes per minute
   this->wholenote_ = (60 * 1000L / bpm) * 4;  // this is the time for whole note (in milliseconds)
 
+  output_freq_ = 0;
   note_playing_ = false;
   next_tone_play_ = millis();
 }
@@ -92,34 +87,27 @@ void Rtttl::loop() {
   if (next_tone_play_ == 0 || millis() < next_tone_play_)
     return;
 
-  if (note_playing_) {
-    // add small silence between notes, but this should be done only when repeating notes.
-    next_tone_play_ = millis() + 10;
-    output_->set_level(0);
-    note_playing_ = false;
-    return;
-  }
-
   if (p_ == rtttl_.cend()) {
     output_->set_level(0.0);
-    ESP_LOGD(TAG, "Play ended");
+    ESP_LOGD(TAG, "Playback finished");
+    this->on_finished_playback_callback_.call();
     next_tone_play_ = 0;
     return;
   }
 
   // first, get note duration, if available
-  auto num = 0;
-  while (is_digit(*p_)) {
-    num = (num * 10) + (*p_++ - '0');
-  }
+  uint8_t num;
+  GET_INTEGER(p_, num)
+
+  uint32_t duration;
 
   if (num)
-    this->duration_ = wholenote_ / num;
+    duration = wholenote_ / num;
   else
-    this->duration_ = wholenote_ / default_dur_;  // we will need to check if we are a dotted note after
+    duration = wholenote_ / default_duration_;  // we will need to check if we are a dotted note after
 
   // now get the note
-  uint8_t note = 0;
+  uint8_t note;
 
   switch (*p_) {
     case 'c':
@@ -144,7 +132,6 @@ void Rtttl::loop() {
       note = 12;
       break;
     case 'p':
-      note = 0;
     default:
       note = 0;
   }
@@ -158,39 +145,40 @@ void Rtttl::loop() {
 
   // now, get optional '.' dotted note
   if (*p_ == '.') {
-    duration_ += duration_ / 2;
+    duration += duration / 2;
     p_++;
   }
 
   // now, get scale
   uint8_t scale;
-  if (isdigit(*p_)) {
-    scale = *p_ - '0';
-    p_++;
-  } else {
-    scale = default_oct_;
-  }
+  GET_INTEGER(p_, scale)
+  if (!scale)
+    scale = default_octave_;
 
-  scale += OCTAVE_OFFSET;
-
-  if (*p_ == ',')
-    p_++;  // skip comma for next note (or we may be at the end)
+  // skip comma for next note (or we may be at the end)
+  SKIP_CHAR_OR_SPACE(p_, ',')
 
   // Now play the note
-
   if (note) {
     auto freq = NOTES[(scale - 4) * 12 + note];
 
-    ESP_LOGVV(TAG, "playing note: %d %d %d", duration_, note);
+    if (note_playing_ && freq == output_freq_) {
+      // Add small silence gap between same note
+      output_->set_level(0.0);
+      delay(10);
+    }
+    output_freq_ = freq;
+
+    ESP_LOGVV(TAG, "playing note: %d for %dms", note, duration);
     output_->update_frequency(freq);
     output_->set_level(0.5);
     note_playing_ = true;
   } else {
-    ESP_LOGVV(TAG, "waiting: %d", duration_);
+    ESP_LOGVV(TAG, "waiting: %dms", duration);
     output_->set_level(0.0);
     note_playing_ = false;
   }
-  next_tone_play_ += duration_;
+  next_tone_play_ += duration;
 }
 }  // namespace rtttl
 }  // namespace esphome

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -6,8 +6,6 @@ namespace rtttl {
 
 static const char* TAG = "rtttl";
 
-static const char* INVALID_RTTTL = "Invalid rtttl string provided.";
-
 static const uint32_t DOUBLE_NOTE_GAP_MS = 10;
 
 // These values can also be found as constants in the Tone library (Tone.h)
@@ -31,7 +29,7 @@ void Rtttl::play(std::string rtttl) {
 
   // it's somewhat documented to be up to 10 characters but let's be a bit flexible here
   if (position_ == std::string::npos || position_ > 15) {
-    ESP_LOGE(TAG, INVALID_RTTTL);
+    ESP_LOGE(TAG, "Missing ':' when looking for name.");
     return;
   }
 
@@ -41,7 +39,7 @@ void Rtttl::play(std::string rtttl) {
   // get default duration
   position_ = this->rtttl_.find("d=", position_);
   if (position_ == std::string::npos) {
-    ESP_LOGE(TAG, INVALID_RTTTL);
+    ESP_LOGE(TAG, "Missing 'd='");
     return;
   }
   position_ += 2;
@@ -52,7 +50,7 @@ void Rtttl::play(std::string rtttl) {
   // get default octave
   position_ = rtttl_.find("o=", position_);
   if (position_ == std::string::npos) {
-    ESP_LOGE(TAG, INVALID_RTTTL);
+    ESP_LOGE(TAG, "Missing 'o=");
     return;
   }
   position_ += 2;
@@ -63,7 +61,7 @@ void Rtttl::play(std::string rtttl) {
   // get BPM
   position_ = rtttl_.find("b=", position_);
   if (position_ == std::string::npos) {
-    ESP_LOGE(TAG, INVALID_RTTTL);
+    ESP_LOGE(TAG, "Missing b=");
     return;
   }
   position_ += 2;
@@ -73,7 +71,7 @@ void Rtttl::play(std::string rtttl) {
 
   position_ = rtttl_.find(":", position_);
   if (position_ == std::string::npos) {
-    ESP_LOGE(TAG, INVALID_RTTTL);
+    ESP_LOGE(TAG, "Missing second ':'");
     return;
   }
   position_++;
@@ -161,8 +159,7 @@ void Rtttl::loop() {
   if (note) {
     auto note_index = (scale - 4) * 12 + note;
     if (note_index < 0 || note_index >= sizeof(NOTES)) {
-      ESP_LOGE(TAG, INVALID_RTTTL);
-      ESP_LOGD(TAG, "Note index: %d", note_index);
+      ESP_LOGE(TAG, "Note out of valid range");
       return;
     }
     auto freq = NOTES[note_index];

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -1,0 +1,187 @@
+#include "rtttl.h"
+#include "esphome/core/log.h"
+
+#include "../esp8266_pwm/esp8266_pwm.h"
+
+namespace esphome {
+namespace rtttl {
+
+static const char* TAG = "rtttl";
+
+static const uint8_t OCTAVE_OFFSET = 0;
+
+// These values can also be found as constants in the Tone library (Tone.h)
+static const uint16_t NOTES[] = {0,    262,  277,  294,  311,  330,  349,  370,  392,  415,  440,  466,  494,
+                                 523,  554,  587,  622,  659,  698,  740,  784,  831,  880,  932,  988,  1047,
+                                 1109, 1175, 1245, 1319, 1397, 1480, 1568, 1661, 1760, 1865, 1976, 2093, 2217,
+                                 2349, 2489, 2637, 2794, 2960, 3136, 3322, 3520, 3729, 3951};
+
+#define is_digit(n) (n >= '0' && n <= '9')
+
+void Rtttl::play(std::string rtttl) {
+  // Absolutely no error checking in here
+  const char* p = rtttl.c_str();
+
+  ESP_LOGD(TAG, "Playing song %s", p);
+
+  this->default_dur_ = 4;
+  this->default_oct_ = 6;
+  int bpm = 63;
+  int num;
+
+  // format: d=N,o=N,b=NNN:
+  // find the start (skip name, etc)
+
+  while (*p != ':')
+    p++;  // ignore name
+
+  // skip colon and spaces
+  while (*p == ':' || *p == ' ')
+    p++;
+
+  // get default duration
+  if (*p == 'd') {
+    p++;
+    p++;  // skip "d="
+    num = 0;
+    while (is_digit(*p)) {
+      num = (num * 10) + (*p++ - '0');
+    }
+    if (num > 0)
+      default_dur_ = num;
+    p++;  // skip comma
+  }
+
+  // get default octave
+  if (*p == 'o') {
+    p++;
+    p++;  // skip "o="
+    num = *p++ - '0';
+    if (num >= 3 && num <= 7)
+      default_oct_ = num;
+    // skip comma and spaces
+    while (*p == ',' || *p == ' ')
+      p++;
+  }
+
+  // get BPM
+  if (*p == 'b') {
+    p++;
+    p++;  // skip "b="
+    num = 0;
+    while (is_digit(*p)) {
+      num = (num * 10) + (*p++ - '0');
+    }
+    bpm = num;
+    // skip colon and spaces
+    while (*p == ':' || *p == ' ')
+      p++;
+  }
+
+  // BPM usually expresses the number of quarter notes per minute
+  this->wholenote_ = (60 * 1000L / bpm) * 4;  // this is the time for whole note (in milliseconds)
+
+  this->play_pointer_ = p;
+  note_delay_ = millis();
+}
+
+void Rtttl::loop() {
+  const char* p = this->play_pointer_;
+  if (p == nullptr)
+    return;
+
+  if (millis() < note_delay_)
+    return;
+
+  if (!(*p)) {
+    output_->set_level(0.0);
+    this->play_pointer_ = nullptr;
+    return;
+  }
+
+  // first, get note duration, if available
+  auto num = 0;
+  while (is_digit(*p)) {
+    num = (num * 10) + (*p++ - '0');
+  }
+
+  if (num)
+    this->duration_ = wholenote_ / num;
+  else
+    this->duration_ = wholenote_ / default_dur_;  // we will need to check if we are a dotted note after
+
+  // now get the note
+  uint8_t note = 0;
+
+  switch (*p) {
+    case 'c':
+      note = 1;
+      break;
+    case 'd':
+      note = 3;
+      break;
+    case 'e':
+      note = 5;
+      break;
+    case 'f':
+      note = 6;
+      break;
+    case 'g':
+      note = 8;
+      break;
+    case 'a':
+      note = 10;
+      break;
+    case 'b':
+      note = 12;
+      break;
+    case 'p':
+      note = 0;
+    default:
+      note = 0;
+  }
+  p++;
+
+  // now, get optional '#' sharp
+  if (*p == '#') {
+    note++;
+    p++;
+  }
+
+  // now, get optional '.' dotted note
+  if (*p == '.') {
+    duration_ += duration_ / 2;
+    p++;
+  }
+
+  // now, get scale
+  uint8_t scale;
+  if (isdigit(*p)) {
+    scale = *p - '0';
+    p++;
+  } else {
+    scale = default_oct_;
+  }
+
+  scale += OCTAVE_OFFSET;
+
+  if (*p == ',')
+    p++;  // skip comma for next note (or we may be at the end)
+
+  // Now play the note
+
+  if (note) {
+    auto freq = NOTES[(scale - 4) * 12 + note];
+
+    ESP_LOGVV(TAG, "playing note: %d %d %d", duration_, note);
+    output_->update_frequency(freq);
+    output_->set_level(0.5);
+  } else {
+    ESP_LOGVV(TAG, "waiting: %d", duration_);
+    output_->set_level(0.0);
+  }
+  this->play_pointer_ = p;
+  note_delay_ += duration_;
+}
+}  // namespace rtttl
+}  // namespace esphome

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -14,12 +14,12 @@ class Rtttl : public Component {
   void set_output(output::FloatOutput *output) { output_ = output; }
   void play(std::string rtttl);
   void stop() {
-    next_tone_play_ = 0;
+    note_duration_ = 0;
     output_->set_level(0.0);
   }
   void dump_config() override;
 
-  bool is_playing() { return next_tone_play_ != 0; }
+  bool is_playing() { return note_duration_ != 0; }
   void loop() override;
 
   void add_on_finished_playback_callback(std::function<void()> callback) {
@@ -27,15 +27,23 @@ class Rtttl : public Component {
   }
 
  protected:
-  std::string rtttl_;
-  std::string::const_iterator p_;
-  uint32_t wholenote_;
-  uint32_t default_duration_;
-  uint32_t default_octave_;
+  inline uint8_t get_integer_() {
+    uint8_t ret = 0;
+    while (isdigit(rtttl_[position_])) {
+      ret = (ret * 10) + (rtttl_[position_++] - '0');
+    }
+    return ret;
+  }
 
-  uint32_t next_tone_play_{0};
+  std::string rtttl_;
+  size_t position_;
+  uint16_t wholenote_;
+  uint16_t default_duration_;
+  uint16_t default_octave_;
+  uint32_t last_note_;
+  uint16_t note_duration_;
+
   uint32_t output_freq_;
-  bool note_playing_;
   output::FloatOutput *output_;
 
   CallbackManager<void()> on_finished_playback_callback_;

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -15,20 +15,22 @@ class Rtttl : public Component {
   void set_output(output::FloatOutput *output) { output_ = output; }
   void play(std::string rtttl);
 
-  //   void setup() override {}
+  void setup() override {}
   //   void dump_config() override;
 
   void loop() override;
 
  protected:
-  const char *play_pointer_ = nullptr;
-
+  std::string rtttl_;
+  std::string::const_iterator p_{};
   uint32_t duration_;
   uint32_t wholenote_;
   uint32_t default_dur_;
   uint32_t default_oct_;
 
-  uint32_t note_delay_;
+  uint32_t next_tone_play_{0};
+
+  bool note_playing_;
 
   output::FloatOutput *output_;
 };

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/output/float_output.h"
+
+namespace esphome {
+namespace rtttl {
+
+extern uint32_t global_rtttl_id;
+
+class Rtttl : public Component {
+ public:
+  void set_output(output::FloatOutput *output) { output_ = output; }
+  void play(std::string rtttl);
+
+  //   void setup() override {}
+  //   void dump_config() override;
+
+  void loop() override;
+
+ protected:
+  const char *play_pointer_ = nullptr;
+
+  uint32_t duration_;
+  uint32_t wholenote_;
+  uint32_t default_dur_;
+  uint32_t default_oct_;
+
+  uint32_t note_delay_;
+
+  output::FloatOutput *output_;
+};
+
+template<typename... Ts> class RtttlPlayAction : public Action<Ts...> {
+ public:
+  RtttlPlayAction(Rtttl *rtttl) : rtttl_(rtttl) {}
+  TEMPLATABLE_VALUE(std::string, value)
+
+  void play(Ts... x) override { this->rtttl_->play(this->value_.value(x...)); }
+
+ protected:
+  Rtttl *rtttl_;
+};
+
+}  // namespace rtttl
+}  // namespace esphome

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -2,7 +2,6 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
-#include "esphome/core/helpers.h"
 #include "esphome/components/output/float_output.h"
 
 namespace esphome {
@@ -14,36 +13,60 @@ class Rtttl : public Component {
  public:
   void set_output(output::FloatOutput *output) { output_ = output; }
   void play(std::string rtttl);
+  void stop() {
+    next_tone_play_ = 0;
+    output_->set_level(0.0);
+  }
+  void dump_config() override;
 
-  void setup() override {}
-  //   void dump_config() override;
-
+  bool is_playing() { return next_tone_play_ != 0; }
   void loop() override;
+
+  void add_on_finished_playback_callback(std::function<void()> callback) {
+    this->on_finished_playback_callback_.add(std::move(callback));
+  }
 
  protected:
   std::string rtttl_;
-  std::string::const_iterator p_{};
-  uint32_t duration_;
+  std::string::const_iterator p_;
   uint32_t wholenote_;
-  uint32_t default_dur_;
-  uint32_t default_oct_;
+  uint32_t default_duration_;
+  uint32_t default_octave_;
 
   uint32_t next_tone_play_{0};
-
+  uint32_t output_freq_;
   bool note_playing_;
-
   output::FloatOutput *output_;
+
+  CallbackManager<void()> on_finished_playback_callback_;
 };
 
-template<typename... Ts> class RtttlPlayAction : public Action<Ts...> {
+template<typename... Ts> class PlayAction : public Action<Ts...> {
  public:
-  RtttlPlayAction(Rtttl *rtttl) : rtttl_(rtttl) {}
+  PlayAction(Rtttl *rtttl) : rtttl_(rtttl) {}
   TEMPLATABLE_VALUE(std::string, value)
 
   void play(Ts... x) override { this->rtttl_->play(this->value_.value(x...)); }
 
  protected:
   Rtttl *rtttl_;
+};
+
+template<typename... Ts> class StopAction : public Action<Ts...>, public Parented<Rtttl> {
+ public:
+  void play(Ts... x) override { this->parent_->stop(); }
+};
+
+template<typename... Ts> class IsPlayingCondition : public Condition<Ts...>, public Parented<Rtttl> {
+ public:
+  bool check(Ts... x) override { return this->parent_->is_playing(); }
+};
+
+class FinishedPlaybackTrigger : public Trigger<> {
+ public:
+  explicit FinishedPlaybackTrigger(Rtttl *parent) {
+    parent->add_on_finished_playback_callback([this]() { this->trigger(); });
+  }
 };
 
 }  // namespace rtttl

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1773,3 +1773,6 @@ sn74hc595:
     latch_pin: GPIO22
     oe_pin: GPIO32
     sr_count: 2
+
+rtttl:
+  output: gpio_19


### PR DESCRIPTION
## Description:

A quick implementation of a rtttl player, works with esp8266 and esp32, 

It's proposing some changes to have an `update_frequency` abstraction on the float output.

test code:

```yaml

output:
  - platform: esp8266_pwm
    pin: D1
    frequency: 1000 Hz
    id: rtttl_out

rtttl:
  output: rtttl_out

api:
  services:
    - service: play_rtttl
      variables:
        song_str: string
      then:
        - rtttl.play:
            rtttl: !lambda 'return song_str;'

binary_sensor:
  - platform: gpio
    id: flash_btn
    pin: GPIO0
    on_press:
      - rtttl.play:
          rtttl: 'MissionImp:d=16,o=6,b=95:32d,32d#,32d,32d#,32d,32d#,32d,32d#,32d,32d,32d#,32e,32f,32f#,32g,g,8p,g,8p,a#,p,c7,p,g,8p,g,8p,f,p,f#,p,g,8p,g,8p,a#,p,c7,p,g,8p,g,8p,f,p,f#,p,a#,g,2d,32p,a#,g,2c#,32p,a#,g,2c,a#5,8c,2p,32p,a#5,g5,2f#,32p,a#5,g5,2f,32p,a#5,g5,2e,d#,8d'
          delay: 30s
          rtttl: 'StarWars:d=4,o=5,b=45:32p,32f#,32f#,32f#,8b.,8f#.6,32e6,32d#6,32c#6,8b.6,16f#.6,32e6,32d#6,32c#6,8b.6,16f#.6,32e6,32d#6,32e6,8c#.6,32f#,32f#,32f#,8b.,8f#.6,32e6,32d#6,32c#6,8b.6,16f#.6,32e6,32d#6,32c#6,8b.6,16f#.6,32e6,32d#6,32e6,8c#6'

```` 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#700

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
