### PR TITLE
fix(cover yaml validation): adds gate to coincide with Home Assistant

### DIFF
--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -11,7 +11,7 @@ IS_PLATFORM_COMPONENT = True
 
 DEVICE_CLASSES = [
     '', 'awning', 'blind', 'curtain', 'damper', 'door', 'garage',
-    'shade', 'shutter', 'window'
+    'gate', 'shade', 'shutter', 'window'
 ]
 
 cover_ns = cg.esphome_ns.namespace('cover')


### PR DESCRIPTION
## Description:

This PR adds the "gate" option to cover.yaml validation. I have not edited docs because this change brings esphome in line with current docs.

I'm not sure if I need to add a test for this, since the garage is already being used as a test.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1365
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
