### PR TITLE
Fixed type mismatch between result field and preference of integration sensor

### DIFF
--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -10,7 +10,7 @@ static const char *TAG = "integration";
 void IntegrationSensor::setup() {
   if (this->restore_) {
     this->rtc_ = global_preferences.make_preference<float>(this->get_object_id_hash());
-    float preference_value;
+    float preference_value = 0;
     this->rtc_.load(&preference_value);
     this->result_ = preference_value;
   }

--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -9,8 +9,10 @@ static const char *TAG = "integration";
 
 void IntegrationSensor::setup() {
   if (this->restore_) {
-    this->rtc_ = global_preferences.make_preference<double>(this->get_object_id_hash());
-    this->rtc_.load(&this->result_);
+    this->rtc_ = global_preferences.make_preference<float>(this->get_object_id_hash());
+    float preference_value;
+    this->rtc_.load(&preference_value);
+    this->result_ = preference_value;
   }
 
   this->last_update_ = millis();

--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -9,7 +9,7 @@ static const char *TAG = "integration";
 
 void IntegrationSensor::setup() {
   if (this->restore_) {
-    this->rtc_ = global_preferences.make_preference<float>(this->get_object_id_hash());
+    this->rtc_ = global_preferences.make_preference<double>(this->get_object_id_hash());
     this->rtc_.load(&this->result_);
   }
 


### PR DESCRIPTION
## Description:
Fixes reloading of intagration sesor value from oreferences sometimes results in INF or -INF

**Related issue (if applicable):** fixes <link to issue>

https://github.com/esphome/issues/issues/1333


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
