### PR TITLE
Fix Home Assistant API disconnects when using st7789v display.

### DIFF
--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend({
     cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
     cv.Required(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
     cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
-}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema())
+}).extend(cv.polling_component_schema('5s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1332

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not applicable

## Checklist:
  - [X] The code change is tested and works locally.
  - [NA] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [NA] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
