### PR TITLE
ESP8266 Disable Pin Initialization on Boot to fix pin toggling

### DIFF
--- a/esphome/core/esphal.cpp
+++ b/esphome/core/esphal.cpp
@@ -304,3 +304,14 @@ void *memchr(const void *s, int c, size_t n) {
 }
 };
 #endif
+
+#ifdef ARDUINO_ARCH_ESP8266
+extern "C" {
+extern void resetPins() {
+  // Added in framework 2.7.0
+  // usually this sets up all pins to be in INPUT mode
+  // however, not strictly needed as we set up the pins properly
+  // ourselves and this causes pins to toggle during reboot.
+}
+}
+#endif

--- a/esphome/core/esphal.cpp
+++ b/esphome/core/esphal.cpp
@@ -307,7 +307,7 @@ void *memchr(const void *s, int c, size_t n) {
 
 #ifdef ARDUINO_ARCH_ESP8266
 extern "C" {
-extern void resetPins() {
+extern void resetPins() {  // NOLINT
   // Added in framework 2.7.0
   // usually this sets up all pins to be in INPUT mode
   // however, not strictly needed as we set up the pins properly


### PR DESCRIPTION
## Description:

ESP8266 Framework has a new hook in v2.7.0: https://github.com/esp8266/Arduino/pull/7044/files

With this we can change how pins are initialized, and fix the longstanding issue with pins toggling on reboot.

This needs `arduino_version: 2.7.2` in the `esphome` section.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
