### PR TITLE
Partially revert make SPI CS pin optional

### DIFF
--- a/esphome/components/as3935_spi/__init__.py
+++ b/esphome/components/as3935_spi/__init__.py
@@ -11,7 +11,7 @@ SPIAS3935 = as3935_spi_ns.class_('SPIAS3935Component', as3935.AS3935, spi.SPIDev
 
 CONFIG_SCHEMA = cv.All(as3935.AS3935_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(SPIAS3935),
-}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema(CS_PIN_required=True)))
+}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema(cs_pin_required=True)))
 
 
 def to_code(config):

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend({
     cv.Optional(CONF_SCROLL_SPEED, default='250ms'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_SCROLL_DELAY, default='1000ms'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_SCROLL_DWELL, default='1000ms'): cv.positive_time_period_milliseconds,
-}).extend(cv.polling_component_schema('500ms')).extend(spi.spi_device_schema(CS_PIN_required=True))
+}).extend(cv.polling_component_schema('500ms')).extend(spi.spi_device_schema(cs_pin_required=True))
 
 
 def to_code(config):

--- a/esphome/components/mcp3008/__init__.py
+++ b/esphome/components/mcp3008/__init__.py
@@ -14,7 +14,7 @@ MCP3008 = mcp3008_ns.class_('MCP3008', cg.Component, spi.SPIDevice)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(MCP3008),
-}).extend(spi.spi_device_schema(CS_PIN_required=True))
+}).extend(spi.spi_device_schema(cs_pin_required=True))
 
 
 def to_code(config):

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -31,8 +31,7 @@ void PN532::setup() {
   //    (this may time out, but that's ok)
   // 3. Send SAM config command with normal mode without waiting for ready bit (IRQ not initialized yet)
   // 4. Probably optional, send SAM config again, this time checking ACK and return value
-  if (this->cs_)
-    this->cs_->digital_write(false);
+  this->cs_->digital_write(false);
   delay(10);
 
   // send dummy firmware version command to get synced up

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -34,15 +34,15 @@ def to_code(config):
         cg.add(var.set_mosi(mosi))
 
 
-def spi_device_schema(CS_PIN_required=False):
+def spi_device_schema(cs_pin_required=True):
     """Create a schema for an SPI device.
-    :param CS_PIN_required: If true, make the CS_PIN required in the config.
+    :param cs_pin_required: If true, make the CS_PIN required in the config.
     :return: The SPI device schema, `extend` this in your config schema.
     """
     schema = {
         cv.GenerateID(CONF_SPI_ID): cv.use_id(SPIComponent),
     }
-    if CS_PIN_required:
+    if cs_pin_required:
         schema[cv.Required(CONF_CS_PIN)] = pins.gpio_output_pin_schema
     else:
         schema[cv.Optional(CONF_CS_PIN)] = pins.gpio_output_pin_schema

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -127,18 +127,20 @@ class SPIComponent : public Component {
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE, uint32_t DATA_RATE>
   void enable(GPIOPin *cs) {
-    if (cs) {
+    if (cs != nullptr) {
       SPIComponent::debug_enable(cs->get_pin());
+    }
 
-      if (this->hw_spi_ != nullptr) {
-        uint8_t data_mode = (uint8_t(CLOCK_POLARITY) << 1) | uint8_t(CLOCK_PHASE);
-        SPISettings settings(DATA_RATE, BIT_ORDER, data_mode);
-        this->hw_spi_->beginTransaction(settings);
-      } else {
-        this->clk_->digital_write(CLOCK_POLARITY);
-        this->wait_cycle_ = uint32_t(F_CPU) / DATA_RATE / 2ULL;
-      }
+    if (this->hw_spi_ != nullptr) {
+      uint8_t data_mode = (uint8_t(CLOCK_POLARITY) << 1) | uint8_t(CLOCK_PHASE);
+      SPISettings settings(DATA_RATE, BIT_ORDER, data_mode);
+      this->hw_spi_->beginTransaction(settings);
+    } else {
+      this->clk_->digital_write(CLOCK_POLARITY);
+      this->wait_cycle_ = uint32_t(F_CPU) / DATA_RATE / 2ULL;
+    }
 
+    if (cs != nullptr) {
       this->active_cs_ = cs;
       this->active_cs_->digital_write(false);
     }

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -13,7 +13,7 @@ SPISSD1325 = ssd1325_spi.class_('SPISSD1325', ssd1325_base.SSD1325, spi.SPIDevic
 CONFIG_SCHEMA = cv.All(ssd1325_base.SSD1325_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(SPISSD1325),
     cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
-}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema()),
+}).extend(cv.COMPONENT_SCHEMA).extend(spi.spi_device_schema(cs_pin_required=False)),
                        cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA))
 
 


### PR DESCRIPTION
## Description:

See also https://github.com/esphome/esphome/pull/988#discussion_r460126366

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
