### PR TITLE
Revert "Sort keys in dicts in output yaml for 'config' command (#1049)"

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -800,6 +800,7 @@ def mqtt_qos(value):
 
 def requires_component(comp):
     """Validate that this option can only be specified when the component `comp` is loaded."""
+    # pylint: disable=unsupported-membership-test
     def validator(value):
         if comp not in CORE.raw_config:
             raise Invalid(f"This option requires component {comp}")
@@ -1164,6 +1165,7 @@ class OnlyWith(Optional):
 
     @property
     def default(self):
+        # pylint: disable=unsupported-membership-test
         if self._component not in CORE.raw_config:
             return vol.UNDEFINED
         return self._default

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -186,6 +186,7 @@ def ensure_list(*validators):
     None and empty dictionaries are converted to empty lists.
     """
     user = All(*validators)
+    list_schema = Schema([user])
 
     def validator(value):
         check_not_templatable(value)
@@ -193,19 +194,7 @@ def ensure_list(*validators):
             return []
         if not isinstance(value, list):
             return [user(value)]
-        ret = []
-        errs = []
-        for i, val in enumerate(value):
-            try:
-                with prepend_path([i]):
-                    ret.append(user(val))
-            except MultipleInvalid as err:
-                errs.extend(err.errors)
-            except Invalid as err:
-                errs.append(err)
-        if errs:
-            raise MultipleInvalid(errs)
-        return ret
+        return list_schema(value)
 
     return validator
 

--- a/esphome/core.py
+++ b/esphome/core.py
@@ -553,7 +553,6 @@ class EsphomeCore:
         if self.config is None:
             raise ValueError("Config has not been loaded yet")
 
-        # pylint: disable=unsupported-membership-test,unsubscriptable-object
         if 'wifi' in self.config:
             return self.config[CONF_WIFI][CONF_USE_ADDRESS]
 
@@ -567,7 +566,6 @@ class EsphomeCore:
         if self.config is None:
             raise ValueError("Config has not been loaded yet")
 
-        # pylint: disable=unsubscriptable-object
         if CONF_COMMENT in self.config[CONF_ESPHOME]:
             return self.config[CONF_ESPHOME][CONF_COMMENT]
 
@@ -584,7 +582,6 @@ class EsphomeCore:
         if self.config is None:
             raise ValueError("Config has not been loaded yet")
 
-        # pylint: disable=unsubscriptable-object
         return self.config[CONF_ESPHOME][CONF_ARDUINO_VERSION]
 
     @property

--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -52,7 +52,8 @@ class _Schema(vol.Schema):
         all_required_keys = {key for key in schema if isinstance(key, vol.Required)}
 
         # Keys that may have defaults
-        all_default_keys = {key for key in schema if isinstance(key, vol.Optional)}
+        # This is a list because sets do not guarantee insertion order
+        all_default_keys = [key for key in schema if isinstance(key, vol.Optional)]
 
         # Recursively compile schema
         _compiled_schema = {}

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -338,7 +338,7 @@ class ESPHomeDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors
             self.represented_objects[self.alias_key] = node
         best_style = True
         if hasattr(mapping, 'items'):
-            mapping = sorted(mapping.items(), key=lambda item: item[0])
+            mapping = list(mapping.items())
         for item_key, item_value in mapping:
             node_key = self.represent_data(item_key)
             node_value = self.represent_data(item_value)

--- a/pylintrc
+++ b/pylintrc
@@ -25,3 +25,6 @@ disable=
   stop-iteration-return,
   no-self-use,
   import-outside-toplevel,
+  # Broken
+  unsupported-membership-test,
+  unsubscriptable-object,


### PR DESCRIPTION
This reverts commit 64bd33a94eb723ea882d4afa36360780fea3cfb8.

## Description:

See also https://github.com/esphome/esphome/pull/1049#issuecomment-663655056

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
