### PR TITLE
Fix senseair flush input buffer wrong log level

### DIFF
--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -24,11 +24,11 @@ void SenseAirComponent::update() {
 
     this->status_set_warning();
     while (this->available()) {
-      unsigned char b;
+      uint8_t b;
       if (this->read_byte(&b)) {
-        ESP_LOGD(TAG, "    ... %02x", b);
+        ESP_LOGV(TAG, "    ... %02x", b);
       } else {
-        ESP_LOGD(TAG, "    ... nothing read");
+        ESP_LOGV(TAG, "    ... nothing read");
       }
     }
     return;


### PR DESCRIPTION
See also https://github.com/esphome/esphome/pull/1017/files

## Description:

Just a very minor fix

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
