### PR TITLE
Mitigate CVE-2020-12638 WiFi WPA Downgrade

### DIFF
--- a/esphome/components/wifi/wifi_component_esp32.cpp
+++ b/esphome/components/wifi/wifi_component_esp32.cpp
@@ -169,14 +169,6 @@ bool WiFiComponent::wifi_sta_connect_(WiFiAP ap) {
     conf.sta.channel = *ap.get_channel();
   }
 
-  if (ap.get_password().empty()) {
-    conf.threshold.authmode = WIFI_AUTH_OPEN;
-  } else {
-    // Only allow auth modes with at least WPA2
-    // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html?highlight=wifi_auth_wpa2_psk#_CPPv416wifi_auth_mode_t
-    conf.threshold.authmode = WIFI_AUTH_WPA_PSK;
-  }
-
   wifi_config_t current_conf;
   esp_err_t err;
   esp_wifi_get_config(WIFI_IF_STA, &current_conf);

--- a/esphome/components/wifi/wifi_component_esp32.cpp
+++ b/esphome/components/wifi/wifi_component_esp32.cpp
@@ -393,8 +393,8 @@ void WiFiComponent::wifi_event_callback_(system_event_id_t event, system_event_i
                get_auth_mode_str(it.new_mode));
       // Mitigate CVE-2020-12638
       // https://lbsfilm.at/blog/wpa2-authenticationmode-downgrade-in-espressif-microprocessors
-      if (it.old_mode == WIFI_AUTH_OPEN && it.new_mode == WIFI_AUTH_OPEN) {
-        ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting...", esp_err_to_name(err));
+      if (it.old_mode != WIFI_AUTH_OPEN && it.new_mode == WIFI_AUTH_OPEN) {
+        ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting...");
         // we can't call retry_connect() from this context, so disconnect immediately
         // and notify main thread with error_from_callback_
         err_t err = esp_wifi_disconnect();

--- a/esphome/components/wifi/wifi_component_esp32.cpp
+++ b/esphome/components/wifi/wifi_component_esp32.cpp
@@ -169,6 +169,14 @@ bool WiFiComponent::wifi_sta_connect_(WiFiAP ap) {
     conf.sta.channel = *ap.get_channel();
   }
 
+  if (ap.get_password().empty()) {
+    conf.threshold.authmode = WIFI_AUTH_OPEN;
+  } else {
+    // Only allow auth modes with at least WPA2
+    // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html?highlight=wifi_auth_wpa2_psk#_CPPv416wifi_auth_mode_t
+    conf.threshold.authmode = WIFI_AUTH_WPA_PSK;
+  }
+
   wifi_config_t current_conf;
   esp_err_t err;
   esp_wifi_get_config(WIFI_IF_STA, &current_conf);

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -401,8 +401,8 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
                get_auth_mode_str(it.new_mode));
       // Mitigate CVE-2020-12638
       // https://lbsfilm.at/blog/wpa2-authenticationmode-downgrade-in-espressif-microprocessors
-      if (it.old_mode == WIFI_AUTH_OPEN && it.new_mode == WIFI_AUTH_OPEN) {
-        ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting...", esp_err_to_name(err));
+      if (it.old_mode != AUTH_OPEN && it.new_mode == AUTH_OPEN) {
+        ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting...");
         // we can't call retry_connect() from this context, so disconnect immediately
         // and notify main thread with error_from_callback_
         wifi_station_disconnect();

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -407,7 +407,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
         // we can't call retry_connect() from this context, so disconnect immediately
         // and notify main thread with error_from_callback_
         wifi_station_disconnect();
-        this->error_from_callback_ = true;
+        global_wifi_component->error_from_callback_ = true;
       }
       break;
     }

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -220,6 +220,7 @@ bool WiFiComponent::wifi_sta_connect_(WiFiAP ap) {
   if (ap.get_password().empty()) {
     conf.threshold.authmode = AUTH_OPEN;
   } else {
+    // Only allow auth modes with at least WPA2
     conf.threshold.authmode = AUTH_WPA_PSK;
   }
   conf.threshold.rssi = -127;

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -220,7 +220,7 @@ bool WiFiComponent::wifi_sta_connect_(WiFiAP ap) {
   if (ap.get_password().empty()) {
     conf.threshold.authmode = AUTH_OPEN;
   } else {
-    // Only allow auth modes with at least WPA2
+    // Only allow auth modes with at least WPA
     conf.threshold.authmode = AUTH_WPA_PSK;
   }
   conf.threshold.rssi = -127;


### PR DESCRIPTION
## Description:

Got contacted by @s00500 about a CVE for ESP8266/ESP32 where sending a specially crafted beacon frame during an active wifi connection can downgrade encrypted connections to open ones.

See also https://lbsfilm.at/blog/wpa2-authenticationmode-downgrade-in-espressif-microprocessors and https://github.com/esp8266/Arduino/pull/7486

TODO:

 - [x] Test nothing breaks (when does AUTHMODE_CHANGE event occur, also during connecting?)
 - [x] Is the check exhaustive enough? Couldn't this be used to also downgrade to WEP, and then break that? I will have to look at how WEP attacks work (if it's during handshake phase or later)
 - [ ] Test the mitigation actually works (not sure if I'll be able to do that, I don't have the hardware around to create wifi packets in promiscuous mode)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
