### PR TITLE
ESP8266 change recommended framework version to 2.7.2

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up env variables
         run: |
-          base_version="2.3.4"
+          base_version="2.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -190,7 +190,7 @@ jobs:
           echo "::set-env name=TAG::${TAG}"
       - name: Set up env variables
         run: |
-          base_version="2.3.4"
+          base_version="2.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
           echo "::set-env name=TAG::${TAG}"
       - name: Set up env variables
         run: |
-          base_version="2.3.4"
+          base_version="2.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:2.3.4
+ARG BUILD_FROM=esphome/esphome-base-amd64:2.4.0
 FROM ${BUILD_FROM}
 
 # First install requirements to leverage caching when requirements don't change

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:2.3.4
+FROM esphome/esphome-base-amd64:2.4.0
 
 COPY . .
 

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM esphome/esphome-lint-base:2.3.4
+FROM esphome/esphome-lint-base:2.4.0
 
 COPY requirements.txt requirements_test.txt /
 RUN pip3 install --no-cache-dir -r /requirements.txt -r /requirements_test.txt

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -4,7 +4,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.const import CONF_ID, CONF_TIMEOUT, CONF_ESPHOME, CONF_METHOD, \
-    CONF_ARDUINO_VERSION, ARDUINO_VERSION_ESP8266_2_5_1, CONF_URL
+    CONF_ARDUINO_VERSION, ARDUINO_VERSION_ESP8266, CONF_URL
 from esphome.core import CORE, Lambda
 from esphome.core_config import PLATFORMIO_ESP8266_LUT
 
@@ -34,7 +34,7 @@ def validate_framework(config):
         return config
 
     framework = PLATFORMIO_ESP8266_LUT[version] if version in PLATFORMIO_ESP8266_LUT else version
-    if framework < ARDUINO_VERSION_ESP8266_2_5_1:
+    if framework < ARDUINO_VERSION_ESP8266['2.5.1']:
         raise cv.Invalid('This component is not supported on arduino framework version below 2.5.1')
     return config
 

--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -29,6 +29,6 @@ def to_code(config):
     yield cg.register_component(var, config)
     yield time_.register_time(var, config)
 
-    if CORE.is_esp8266:
+    if CORE.is_esp8266 and len(servers) > 1:
         # We need LwIP features enabled to get 3 SNTP servers (not just one)
         cg.add_build_flag('-DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY')

--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -30,6 +30,5 @@ def to_code(config):
     yield time_.register_time(var, config)
 
     if CORE.is_esp8266:
-        # When LWIP_FEATURES is disabled, the default number of sntp servers is 1
-        # but our code expects 3.
-        cg.add_build_flag('-DLWIP_DHCP_MAX_NTP_SERVERS=3')
+        # We need LwIP features enabled to get 3 SNTP servers (not just one)
+        cg.add_build_flag('-DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY')

--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -1,6 +1,7 @@
 from esphome.components import time as time_
 import esphome.config_validation as cv
 import esphome.codegen as cg
+from esphome.core import CORE
 from esphome.const import CONF_ID, CONF_SERVERS
 
 
@@ -27,3 +28,8 @@ def to_code(config):
 
     yield cg.register_component(var, config)
     yield time_.register_time(var, config)
+
+    if CORE.is_esp8266:
+        # When LWIP_FEATURES is disabled, the default number of sntp servers is 1
+        # but our code expects 3.
+        cg.add_build_flag('-DLWIP_DHCP_MAX_NTP_SERVERS=3')

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -11,17 +11,34 @@ ESP_PLATFORM_ESP8266 = 'ESP8266'
 ESP_PLATFORMS = [ESP_PLATFORM_ESP32, ESP_PLATFORM_ESP8266]
 
 ALLOWED_NAME_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_'
-ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git'
-ARDUINO_VERSION_ESP32_1_0_0 = 'espressif32@1.5.0'
-ARDUINO_VERSION_ESP32_1_0_1 = 'espressif32@1.6.0'
-ARDUINO_VERSION_ESP32_1_0_2 = 'espressif32@1.9.0'
-ARDUINO_VERSION_ESP32_1_0_3 = 'espressif32@1.10.0'
-ARDUINO_VERSION_ESP32_1_0_4 = 'espressif32@1.11.0'
-ARDUINO_VERSION_ESP8266_DEV = 'https://github.com/platformio/platform-espressif8266.git'
-ARDUINO_VERSION_ESP8266_2_5_0 = 'espressif8266@2.0.1'
-ARDUINO_VERSION_ESP8266_2_5_1 = 'espressif8266@2.1.0'
-ARDUINO_VERSION_ESP8266_2_5_2 = 'espressif8266@2.2.3'
-ARDUINO_VERSION_ESP8266_2_3_0 = 'espressif8266@1.5.0'
+# Lookup table from ESP32 arduino framework version to latest platformio
+# package with that version
+# See also https://github.com/platformio/platform-espressif32/releases
+ARDUINO_VERSION_ESP32 = {
+    'dev': 'https://github.com/platformio/platform-espressif32.git',
+    '1.0.4': 'espressif32@1.12.4',
+    '1.0.3': 'espressif32@1.10.0',
+    '1.0.2': 'espressif32@1.9.0',
+    '1.0.1': 'espressif32@1.7.0',
+    '1.0.0': 'espressif32@1.5.0',
+}
+# See also https://github.com/platformio/platform-espressif8266/releases
+ARDUINO_VERSION_ESP8266 = {
+    'dev': 'https://github.com/platformio/platform-espressif8266.git',
+    '2.7.2': 'espressif8266@2.6.0',
+    '2.7.1': 'espressif8266@2.5.3',
+    '2.7.0': 'espressif8266@2.5.0',
+    '2.6.3': 'espressif8266@2.4.0',
+    '2.6.2': 'espressif8266@2.3.1',
+    '2.6.1': 'espressif8266@2.3.0',
+    '2.5.2': 'espressif8266@2.2.3',
+    '2.5.1': 'espressif8266@2.1.1',
+    '2.5.0': 'espressif8266@2.0.4',
+    '2.4.2': 'espressif8266@1.8.0',
+    '2.4.1': 'espressif8266@1.7.3',
+    '2.4.0': 'espressif8266@1.6.0',
+    '2.3.0': 'espressif8266@1.5.0',
+}
 SOURCE_FILE_EXTENSIONS = {'.cpp', '.hpp', '.h', '.c', '.tcc', '.ino'}
 HEADER_FILE_EXTENSIONS = {'.h', '.hpp', '.tcc'}
 

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -5,14 +5,12 @@ import re
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation, pins
-from esphome.const import ARDUINO_VERSION_ESP32_DEV, ARDUINO_VERSION_ESP8266_DEV, \
-    CONF_ARDUINO_VERSION, CONF_BOARD, CONF_BOARD_FLASH_MODE, CONF_BUILD_PATH, \
-    CONF_COMMENT, CONF_ESPHOME, CONF_INCLUDES, CONF_LIBRARIES, \
+from esphome.const import CONF_ARDUINO_VERSION, CONF_BOARD, CONF_BOARD_FLASH_MODE, \
+    CONF_BUILD_PATH, CONF_COMMENT, CONF_ESPHOME, CONF_INCLUDES, CONF_LIBRARIES, \
     CONF_NAME, CONF_ON_BOOT, CONF_ON_LOOP, CONF_ON_SHUTDOWN, CONF_PLATFORM, \
     CONF_PLATFORMIO_OPTIONS, CONF_PRIORITY, CONF_TRIGGER_ID, \
-    CONF_ESP8266_RESTORE_FROM_FLASH, ARDUINO_VERSION_ESP8266_2_3_0, \
-    ARDUINO_VERSION_ESP8266_2_5_0, ARDUINO_VERSION_ESP8266_2_5_1, ARDUINO_VERSION_ESP8266_2_5_2, \
-    ESP_PLATFORMS
+    CONF_ESP8266_RESTORE_FROM_FLASH, ARDUINO_VERSION_ESP8266, \
+    ARDUINO_VERSION_ESP32, ESP_PLATFORMS
 from esphome.core import CORE, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, walk_files
 from esphome.pins import ESP8266_FLASH_SIZES, ESP8266_LD_SCRIPTS
@@ -46,33 +44,17 @@ def validate_board(value):
 validate_platform = cv.one_of(*ESP_PLATFORMS, upper=True)
 
 PLATFORMIO_ESP8266_LUT = {
-    '2.7.2': 'espressif8266@2.6.0',
-    '2.7.1': 'espressif8266@2.5.1',
-    '2.7.0': 'espressif8266@2.5.0',
-    '2.6.3': 'espressif8266@2.4.0',
-    '2.6.2': 'espressif8266@2.3.1',
-    '2.6.1': 'espressif8266@2.3.0',
-    '2.5.2': 'espressif8266@2.2.3',
-    '2.5.1': 'espressif8266@2.1.0',
-    '2.5.0': 'espressif8266@2.0.1',
-    '2.4.2': 'espressif8266@1.8.0',
-    '2.4.1': 'espressif8266@1.7.3',
-    '2.4.0': 'espressif8266@1.6.0',
-    '2.3.0': 'espressif8266@1.5.0',
-    'RECOMMENDED': 'espressif8266@2.2.3',
+    **ARDUINO_VERSION_ESP8266,
+    'RECOMMENDED': ARDUINO_VERSION_ESP8266['2.7.2'],
     'LATEST': 'espressif8266',
-    'DEV': ARDUINO_VERSION_ESP8266_DEV,
+    'DEV': ARDUINO_VERSION_ESP8266['dev'],
 }
 
 PLATFORMIO_ESP32_LUT = {
-    '1.0.0': 'espressif32@1.4.0',
-    '1.0.1': 'espressif32@1.6.0',
-    '1.0.2': 'espressif32@1.9.0',
-    '1.0.3': 'espressif32@1.10.0',
-    '1.0.4': 'espressif32@1.12.4',
-    'RECOMMENDED': 'espressif32@1.12.1',
+    **ARDUINO_VERSION_ESP32,
+    'RECOMMENDED': ARDUINO_VERSION_ESP32['1.0.4'],
     'LATEST': 'espressif32',
-    'DEV': ARDUINO_VERSION_ESP32_DEV,
+    'DEV': ARDUINO_VERSION_ESP32['dev'],
 }
 
 
@@ -229,21 +211,40 @@ def to_code(config):
         yield automation.build_automation(trigger, [], conf)
 
     # Build flags
-    if CORE.is_esp8266 and CORE.board in ESP8266_FLASH_SIZES and \
-            CORE.arduino_version != ARDUINO_VERSION_ESP8266_2_3_0:
+    if CORE.is_esp8266 and CORE.board in ESP8266_FLASH_SIZES:
         flash_size = ESP8266_FLASH_SIZES[CORE.board]
         ld_scripts = ESP8266_LD_SCRIPTS[flash_size]
-        ld_script = None
 
-        if CORE.arduino_version in ('espressif8266@1.8.0', 'espressif8266@1.7.3',
-                                    'espressif8266@1.6.0'):
+        versions_with_old_ldscripts = [
+            ARDUINO_VERSION_ESP8266['2.4.0'],
+            ARDUINO_VERSION_ESP8266['2.4.1'],
+            ARDUINO_VERSION_ESP8266['2.4.2'],
+        ]
+        if CORE.arduino_version == ARDUINO_VERSION_ESP8266['2.3.0']:
+            # No ld script support
+            ld_script = None
+        if CORE.arduino_version in versions_with_old_ldscripts:
+            # Old ld script path
             ld_script = ld_scripts[0]
-        elif CORE.arduino_version in (ARDUINO_VERSION_ESP8266_DEV, ARDUINO_VERSION_ESP8266_2_5_0,
-                                      ARDUINO_VERSION_ESP8266_2_5_1, ARDUINO_VERSION_ESP8266_2_5_2):
+        else:
             ld_script = ld_scripts[1]
 
-        if ld_script is not None:
-            cg.add_build_flag(f'-Wl,-T{ld_script}')
+        cg.add_build_flag(f'-Wl,-T{ld_script}')
+
+    # Set LWIP build constants for ESP8266
+    if CORE.is_esp8266:
+        # Default for platformio is LWIP2_LOW_MEMORY with:
+        #  - MSS=536
+        #  - LWIP_FEATURES enabled
+        #     - this only adds some optional features like IP incoming packet reassembly and NAPT
+        #       see also:
+        #  https://github.com/esp8266/Arduino/blob/master/tools/sdk/lwip2/include/lwipopts.h
+
+        # Instead we use LWIP2_HIGHER_BANDWIDTH_LOW_FLASH with:
+        #  - MSS=1460
+        #  - LWIP_FEATURES disabled (because we don't need them)
+        # Other projects like Tasmota & ESPEasy also use this
+        cg.add_build_flag('-DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH')
 
     cg.add_build_flag('-fno-exceptions')
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -4,11 +4,12 @@ import re
 
 from esphome.config import iter_components
 from esphome.const import CONF_BOARD_FLASH_MODE, CONF_ESPHOME, CONF_PLATFORMIO_OPTIONS, \
-    HEADER_FILE_EXTENSIONS, SOURCE_FILE_EXTENSIONS, __version__
+    HEADER_FILE_EXTENSIONS, SOURCE_FILE_EXTENSIONS, __version__, ARDUINO_VERSION_ESP8266
 from esphome.core import CORE, EsphomeError
 from esphome.helpers import mkdir_p, read_file, write_file_if_changed, walk_files, \
     copy_file_if_changed
 from esphome.storage_json import StorageJSON, storage_path
+from esphome.pins import ESP8266_FLASH_SIZES, ESP8266_LD_SCRIPTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -212,6 +213,28 @@ def get_ini_content():
     if CONF_BOARD_FLASH_MODE in CORE.config[CONF_ESPHOME]:
         flash_mode = CORE.config[CONF_ESPHOME][CONF_BOARD_FLASH_MODE]
         data['board_build.flash_mode'] = flash_mode
+
+    # Build flags
+    if CORE.is_esp8266 and CORE.board in ESP8266_FLASH_SIZES:
+        flash_size = ESP8266_FLASH_SIZES[CORE.board]
+        ld_scripts = ESP8266_LD_SCRIPTS[flash_size]
+
+        versions_with_old_ldscripts = [
+            ARDUINO_VERSION_ESP8266['2.4.0'],
+            ARDUINO_VERSION_ESP8266['2.4.1'],
+            ARDUINO_VERSION_ESP8266['2.4.2'],
+        ]
+        if CORE.arduino_version == ARDUINO_VERSION_ESP8266['2.3.0']:
+            # No ld script support
+            ld_script = None
+        if CORE.arduino_version in versions_with_old_ldscripts:
+            # Old ld script path
+            ld_script = ld_scripts[0]
+        else:
+            ld_script = ld_scripts[1]
+
+        if ld_script is not None:
+            data['board_build.ldscript'] = ld_script
 
     # Ignore libraries that are not explicitly used, but may
     # be added by LDF

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<tests/livingroom8266.cpp>
 
 [env:livingroom32]
-platform = espressif32@1.12.1
+platform = espressif32@1.12.4
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}


### PR DESCRIPTION
## Description:

I checked 2.7.2 on my ESP8266 devices and it worked well for some time now. Today I looked at Tasmota and ESPEasy and they also switched to 2.7.2, so it's safe to assume this framework version will perform well on most devices.

Additionally, I saw those other projects use a flag to tell platformio to use a different LwIP static library with some features disabled (none of which we use)

TODO:

 - [x] Check if sntp works for ESP8266 with 3 servers. I'm not sure if the build flag is used for compiling the static lib.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/714

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
