### PR TITLE
Fix base config should override packages config

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -38,7 +38,7 @@ def do_packages_pass(config: dict):
                 recursive_package = package_config
                 if isinstance(package_config, dict):
                     recursive_package = do_packages_pass(package_config)
-                config = _merge_package(config, recursive_package)
+                config = _merge_package(recursive_package, config)
 
         del config[CONF_PACKAGES]
     return config


### PR DESCRIPTION
## Description:

That was an error in my previous PR. The config in the base file should override that of the package, not the other way around.


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
