### PR TITLE
Fix AS3935 sensor configuration issues

### DIFF
--- a/esphome/components/as3935/__init__.py
+++ b/esphome/components/as3935/__init__.py
@@ -25,7 +25,7 @@ AS3935_SCHEMA = cv.Schema({
     cv.Optional(CONF_SPIKE_REJECTION, default=2): cv.int_range(min=1, max=11),
     cv.Optional(CONF_LIGHTNING_THRESHOLD, default=1): cv.one_of(1, 5, 9, 16, int=True),
     cv.Optional(CONF_MASK_DISTURBER, default=False): cv.boolean,
-    cv.Optional(CONF_DIV_RATIO, default=0): cv.one_of(0, 16, 22, 64, 128, int=True),
+    cv.Optional(CONF_DIV_RATIO, default=0): cv.one_of(0, 16, 32, 64, 128, int=True),
     cv.Optional(CONF_CAPACITANCE, default=0): cv.int_range(min=0, max=15),
 })
 

--- a/esphome/components/as3935/as3935.cpp
+++ b/esphome/components/as3935/as3935.cpp
@@ -26,6 +26,9 @@ void AS3935Component::setup() {
 void AS3935Component::dump_config() {
   ESP_LOGCONFIG(TAG, "AS3935:");
   LOG_PIN("  Interrupt Pin: ", this->irq_pin_);
+  LOG_BINARY_SENSOR("  ", "Thunder alert", this->thunder_alert_binary_sensor_);
+  LOG_SENSOR("  ", "Distance", this->distance_sensor_);
+  LOG_SENSOR("  ", "Lightning energy", this->energy_sensor_);
 }
 
 float AS3935Component::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/as3935/sensor.py
+++ b/esphome/components/as3935/sensor.py
@@ -27,4 +27,4 @@ def to_code(config):
     if CONF_LIGHTNING_ENERGY in config:
         conf = config[CONF_LIGHTNING_ENERGY]
         lightning_energy_sensor = yield sensor.new_sensor(conf)
-        cg.add(hub.set_distance_sensor(lightning_energy_sensor))
+        cg.add(hub.set_energy_sensor(lightning_energy_sensor))


### PR DESCRIPTION
## Description:
Fixes issue https://github.com/esphome/issues/issues/1366 - this didn't allow setting proper configuration
Fixes issue https://github.com/esphome/issues/issues/1305 - this mixup led to distance sensor not producing any values, after fixing, lightning energy and distance is perfectly accessible

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/1366
https://github.com/esphome/issues/issues/1305

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
