### PR TITLE
Fix prometheus has wrong setup priority

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -26,6 +26,10 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
     this->base_->init();
     this->base_->add_handler(this);
   }
+  float get_setup_priority() const override {
+    // After WiFi
+    return setup_priority::WIFI - 1.0f;
+  }
 
  protected:
 #ifdef USE_SENSOR


### PR DESCRIPTION
## Description:

prometheus handler was being set up too early - before wifi interface was initialized.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1377

Tested with:

```yaml
web_server:
prometheus:
```

and 

```bash
$ curl http://test32.local/metrics
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
