### PR TITLE
1.15.0b2

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up env variables
         run: |
-          base_version="2.3.4"
+          base_version="2.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -190,7 +190,7 @@ jobs:
           echo "::set-env name=TAG::${TAG}"
       - name: Set up env variables
         run: |
-          base_version="2.3.4"
+          base_version="2.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
           echo "::set-env name=TAG::${TAG}"
       - name: Set up env variables
         run: |
-          base_version="2.3.4"
+          base_version="2.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:2.3.4
+ARG BUILD_FROM=esphome/esphome-base-amd64:2.4.0
 FROM ${BUILD_FROM}
 
 # First install requirements to leverage caching when requirements don't change

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:2.3.4
+FROM esphome/esphome-base-amd64:2.4.0
 
 COPY . .
 

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM esphome/esphome-lint-base:2.3.4
+FROM esphome/esphome-lint-base:2.4.0
 
 COPY requirements.txt requirements_test.txt /
 RUN pip3 install --no-cache-dir -r /requirements.txt -r /requirements_test.txt

--- a/esphome/components/as3935/__init__.py
+++ b/esphome/components/as3935/__init__.py
@@ -25,7 +25,7 @@ AS3935_SCHEMA = cv.Schema({
     cv.Optional(CONF_SPIKE_REJECTION, default=2): cv.int_range(min=1, max=11),
     cv.Optional(CONF_LIGHTNING_THRESHOLD, default=1): cv.one_of(1, 5, 9, 16, int=True),
     cv.Optional(CONF_MASK_DISTURBER, default=False): cv.boolean,
-    cv.Optional(CONF_DIV_RATIO, default=0): cv.one_of(0, 16, 22, 64, 128, int=True),
+    cv.Optional(CONF_DIV_RATIO, default=0): cv.one_of(0, 16, 32, 64, 128, int=True),
     cv.Optional(CONF_CAPACITANCE, default=0): cv.int_range(min=0, max=15),
 })
 

--- a/esphome/components/as3935/as3935.cpp
+++ b/esphome/components/as3935/as3935.cpp
@@ -26,6 +26,9 @@ void AS3935Component::setup() {
 void AS3935Component::dump_config() {
   ESP_LOGCONFIG(TAG, "AS3935:");
   LOG_PIN("  Interrupt Pin: ", this->irq_pin_);
+  LOG_BINARY_SENSOR("  ", "Thunder alert", this->thunder_alert_binary_sensor_);
+  LOG_SENSOR("  ", "Distance", this->distance_sensor_);
+  LOG_SENSOR("  ", "Lightning energy", this->energy_sensor_);
 }
 
 float AS3935Component::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/as3935/sensor.py
+++ b/esphome/components/as3935/sensor.py
@@ -27,4 +27,4 @@ def to_code(config):
     if CONF_LIGHTNING_ENERGY in config:
         conf = config[CONF_LIGHTNING_ENERGY]
         lightning_energy_sensor = yield sensor.new_sensor(conf)
-        cg.add(hub.set_distance_sensor(lightning_energy_sensor))
+        cg.add(hub.set_energy_sensor(lightning_energy_sensor))

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -36,5 +36,7 @@ def new_fastled_light(config):
 
     yield light.register_light(var, config)
     # https://github.com/FastLED/FastLED/blob/master/library.json
-    cg.add_library('FastLED', '3.3.3')
+    # 3.3.3 has an issue on ESP32 with RMT and fastled_clockless:
+    # https://github.com/esphome/issues/issues/1375
+    cg.add_library('FastLED', '3.3.2')
     yield var

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -4,7 +4,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.const import CONF_ID, CONF_TIMEOUT, CONF_ESPHOME, CONF_METHOD, \
-    CONF_ARDUINO_VERSION, ARDUINO_VERSION_ESP8266_2_5_1, CONF_URL
+    CONF_ARDUINO_VERSION, ARDUINO_VERSION_ESP8266, CONF_URL
 from esphome.core import CORE, Lambda
 from esphome.core_config import PLATFORMIO_ESP8266_LUT
 
@@ -34,7 +34,7 @@ def validate_framework(config):
         return config
 
     framework = PLATFORMIO_ESP8266_LUT[version] if version in PLATFORMIO_ESP8266_LUT else version
-    if framework < ARDUINO_VERSION_ESP8266_2_5_1:
+    if framework < ARDUINO_VERSION_ESP8266['2.5.1']:
         raise cv.Invalid('This component is not supported on arduino framework version below 2.5.1')
     return config
 

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -38,7 +38,7 @@ def do_packages_pass(config: dict):
                 recursive_package = package_config
                 if isinstance(package_config, dict):
                     recursive_package = do_packages_pass(package_config)
-                config = _merge_package(config, recursive_package)
+                config = _merge_package(recursive_package, config)
 
         del config[CONF_PACKAGES]
     return config

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -26,6 +26,10 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
     this->base_->init();
     this->base_->add_handler(this);
   }
+  float get_setup_priority() const override {
+    // After WiFi
+    return setup_priority::WIFI - 1.0f;
+  }
 
  protected:
 #ifdef USE_SENSOR

--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -1,6 +1,7 @@
 from esphome.components import time as time_
 import esphome.config_validation as cv
 import esphome.codegen as cg
+from esphome.core import CORE
 from esphome.const import CONF_ID, CONF_SERVERS
 
 
@@ -27,3 +28,7 @@ def to_code(config):
 
     yield cg.register_component(var, config)
     yield time_.register_time(var, config)
+
+    if CORE.is_esp8266 and len(servers) > 1:
+        # We need LwIP features enabled to get 3 SNTP servers (not just one)
+        cg.add_build_flag('-DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY')

--- a/esphome/components/wifi/wifi_component_esp32.cpp
+++ b/esphome/components/wifi/wifi_component_esp32.cpp
@@ -391,6 +391,18 @@ void WiFiComponent::wifi_event_callback_(system_event_id_t event, system_event_i
       auto it = info.auth_change;
       ESP_LOGV(TAG, "Event: Authmode Change old=%s new=%s", get_auth_mode_str(it.old_mode),
                get_auth_mode_str(it.new_mode));
+      // Mitigate CVE-2020-12638
+      // https://lbsfilm.at/blog/wpa2-authenticationmode-downgrade-in-espressif-microprocessors
+      if (it.old_mode != WIFI_AUTH_OPEN && it.new_mode == WIFI_AUTH_OPEN) {
+        ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting...");
+        // we can't call retry_connect() from this context, so disconnect immediately
+        // and notify main thread with error_from_callback_
+        err_t err = esp_wifi_disconnect();
+        if (err != ESP_OK) {
+          ESP_LOGW(TAG, "Disconnect failed: %s", esp_err_to_name(err));
+        }
+        this->error_from_callback_ = true;
+      }
       break;
     }
     case SYSTEM_EVENT_STA_GOT_IP: {

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 15
-PATCH_VERSION = '0b1'
+PATCH_VERSION = '0b2'
 __short_version__ = f'{MAJOR_VERSION}.{MINOR_VERSION}'
 __version__ = f'{__short_version__}.{PATCH_VERSION}'
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -11,17 +11,34 @@ ESP_PLATFORM_ESP8266 = 'ESP8266'
 ESP_PLATFORMS = [ESP_PLATFORM_ESP32, ESP_PLATFORM_ESP8266]
 
 ALLOWED_NAME_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_'
-ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git'
-ARDUINO_VERSION_ESP32_1_0_0 = 'espressif32@1.5.0'
-ARDUINO_VERSION_ESP32_1_0_1 = 'espressif32@1.6.0'
-ARDUINO_VERSION_ESP32_1_0_2 = 'espressif32@1.9.0'
-ARDUINO_VERSION_ESP32_1_0_3 = 'espressif32@1.10.0'
-ARDUINO_VERSION_ESP32_1_0_4 = 'espressif32@1.11.0'
-ARDUINO_VERSION_ESP8266_DEV = 'https://github.com/platformio/platform-espressif8266.git'
-ARDUINO_VERSION_ESP8266_2_5_0 = 'espressif8266@2.0.1'
-ARDUINO_VERSION_ESP8266_2_5_1 = 'espressif8266@2.1.0'
-ARDUINO_VERSION_ESP8266_2_5_2 = 'espressif8266@2.2.3'
-ARDUINO_VERSION_ESP8266_2_3_0 = 'espressif8266@1.5.0'
+# Lookup table from ESP32 arduino framework version to latest platformio
+# package with that version
+# See also https://github.com/platformio/platform-espressif32/releases
+ARDUINO_VERSION_ESP32 = {
+    'dev': 'https://github.com/platformio/platform-espressif32.git',
+    '1.0.4': 'espressif32@1.12.4',
+    '1.0.3': 'espressif32@1.10.0',
+    '1.0.2': 'espressif32@1.9.0',
+    '1.0.1': 'espressif32@1.7.0',
+    '1.0.0': 'espressif32@1.5.0',
+}
+# See also https://github.com/platformio/platform-espressif8266/releases
+ARDUINO_VERSION_ESP8266 = {
+    'dev': 'https://github.com/platformio/platform-espressif8266.git',
+    '2.7.2': 'espressif8266@2.6.0',
+    '2.7.1': 'espressif8266@2.5.3',
+    '2.7.0': 'espressif8266@2.5.0',
+    '2.6.3': 'espressif8266@2.4.0',
+    '2.6.2': 'espressif8266@2.3.1',
+    '2.6.1': 'espressif8266@2.3.0',
+    '2.5.2': 'espressif8266@2.2.3',
+    '2.5.1': 'espressif8266@2.1.1',
+    '2.5.0': 'espressif8266@2.0.4',
+    '2.4.2': 'espressif8266@1.8.0',
+    '2.4.1': 'espressif8266@1.7.3',
+    '2.4.0': 'espressif8266@1.6.0',
+    '2.3.0': 'espressif8266@1.5.0',
+}
 SOURCE_FILE_EXTENSIONS = {'.cpp', '.hpp', '.h', '.c', '.tcc', '.ino'}
 HEADER_FILE_EXTENSIONS = {'.h', '.hpp', '.tcc'}
 

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -5,17 +5,14 @@ import re
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation, pins
-from esphome.const import ARDUINO_VERSION_ESP32_DEV, ARDUINO_VERSION_ESP8266_DEV, \
-    CONF_ARDUINO_VERSION, CONF_BOARD, CONF_BOARD_FLASH_MODE, CONF_BUILD_PATH, \
-    CONF_COMMENT, CONF_ESPHOME, CONF_INCLUDES, CONF_LIBRARIES, \
+from esphome.const import CONF_ARDUINO_VERSION, CONF_BOARD, CONF_BOARD_FLASH_MODE, \
+    CONF_BUILD_PATH, CONF_COMMENT, CONF_ESPHOME, CONF_INCLUDES, CONF_LIBRARIES, \
     CONF_NAME, CONF_ON_BOOT, CONF_ON_LOOP, CONF_ON_SHUTDOWN, CONF_PLATFORM, \
     CONF_PLATFORMIO_OPTIONS, CONF_PRIORITY, CONF_TRIGGER_ID, \
-    CONF_ESP8266_RESTORE_FROM_FLASH, ARDUINO_VERSION_ESP8266_2_3_0, \
-    ARDUINO_VERSION_ESP8266_2_5_0, ARDUINO_VERSION_ESP8266_2_5_1, ARDUINO_VERSION_ESP8266_2_5_2, \
-    ESP_PLATFORMS
+    CONF_ESP8266_RESTORE_FROM_FLASH, ARDUINO_VERSION_ESP8266, \
+    ARDUINO_VERSION_ESP32, ESP_PLATFORMS
 from esphome.core import CORE, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, walk_files
-from esphome.pins import ESP8266_FLASH_SIZES, ESP8266_LD_SCRIPTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,33 +43,17 @@ def validate_board(value):
 validate_platform = cv.one_of(*ESP_PLATFORMS, upper=True)
 
 PLATFORMIO_ESP8266_LUT = {
-    '2.7.2': 'espressif8266@2.6.0',
-    '2.7.1': 'espressif8266@2.5.1',
-    '2.7.0': 'espressif8266@2.5.0',
-    '2.6.3': 'espressif8266@2.4.0',
-    '2.6.2': 'espressif8266@2.3.1',
-    '2.6.1': 'espressif8266@2.3.0',
-    '2.5.2': 'espressif8266@2.2.3',
-    '2.5.1': 'espressif8266@2.1.0',
-    '2.5.0': 'espressif8266@2.0.1',
-    '2.4.2': 'espressif8266@1.8.0',
-    '2.4.1': 'espressif8266@1.7.3',
-    '2.4.0': 'espressif8266@1.6.0',
-    '2.3.0': 'espressif8266@1.5.0',
-    'RECOMMENDED': 'espressif8266@2.2.3',
+    **ARDUINO_VERSION_ESP8266,
+    'RECOMMENDED': ARDUINO_VERSION_ESP8266['2.7.2'],
     'LATEST': 'espressif8266',
-    'DEV': ARDUINO_VERSION_ESP8266_DEV,
+    'DEV': ARDUINO_VERSION_ESP8266['dev'],
 }
 
 PLATFORMIO_ESP32_LUT = {
-    '1.0.0': 'espressif32@1.4.0',
-    '1.0.1': 'espressif32@1.6.0',
-    '1.0.2': 'espressif32@1.9.0',
-    '1.0.3': 'espressif32@1.10.0',
-    '1.0.4': 'espressif32@1.12.4',
-    'RECOMMENDED': 'espressif32@1.12.1',
+    **ARDUINO_VERSION_ESP32,
+    'RECOMMENDED': ARDUINO_VERSION_ESP32['1.0.4'],
     'LATEST': 'espressif32',
-    'DEV': ARDUINO_VERSION_ESP32_DEV,
+    'DEV': ARDUINO_VERSION_ESP32['dev'],
 }
 
 
@@ -208,6 +189,26 @@ def add_includes(includes):
             include_file(path, basename)
 
 
+@coroutine_with_priority(-1000.0)
+def _esp8266_add_lwip_type():
+    # If any component has already set this, do not change it
+    if any(flag.startswith('-DPIO_FRAMEWORK_ARDUINO_LWIP2_') for flag in CORE.build_flags):
+        return
+
+    # Default for platformio is LWIP2_LOW_MEMORY with:
+    #  - MSS=536
+    #  - LWIP_FEATURES enabled
+    #     - this only adds some optional features like IP incoming packet reassembly and NAPT
+    #       see also:
+    #  https://github.com/esp8266/Arduino/blob/master/tools/sdk/lwip2/include/lwipopts.h
+
+    # Instead we use LWIP2_HIGHER_BANDWIDTH_LOW_FLASH with:
+    #  - MSS=1460
+    #  - LWIP_FEATURES disabled (because we don't need them)
+    # Other projects like Tasmota & ESPEasy also use this
+    cg.add_build_flag('-DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH')
+
+
 @coroutine_with_priority(100.0)
 def to_code(config):
     cg.add_global(cg.global_ns.namespace('esphome').using)
@@ -228,22 +229,9 @@ def to_code(config):
         yield cg.register_component(trigger, conf)
         yield automation.build_automation(trigger, [], conf)
 
-    # Build flags
-    if CORE.is_esp8266 and CORE.board in ESP8266_FLASH_SIZES and \
-            CORE.arduino_version != ARDUINO_VERSION_ESP8266_2_3_0:
-        flash_size = ESP8266_FLASH_SIZES[CORE.board]
-        ld_scripts = ESP8266_LD_SCRIPTS[flash_size]
-        ld_script = None
-
-        if CORE.arduino_version in ('espressif8266@1.8.0', 'espressif8266@1.7.3',
-                                    'espressif8266@1.6.0'):
-            ld_script = ld_scripts[0]
-        elif CORE.arduino_version in (ARDUINO_VERSION_ESP8266_DEV, ARDUINO_VERSION_ESP8266_2_5_0,
-                                      ARDUINO_VERSION_ESP8266_2_5_1, ARDUINO_VERSION_ESP8266_2_5_2):
-            ld_script = ld_scripts[1]
-
-        if ld_script is not None:
-            cg.add_build_flag(f'-Wl,-T{ld_script}')
+    # Set LWIP build constants for ESP8266
+    if CORE.is_esp8266:
+        CORE.add_job(_esp8266_add_lwip_type)
 
     cg.add_build_flag('-fno-exceptions')
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -4,11 +4,12 @@ import re
 
 from esphome.config import iter_components
 from esphome.const import CONF_BOARD_FLASH_MODE, CONF_ESPHOME, CONF_PLATFORMIO_OPTIONS, \
-    HEADER_FILE_EXTENSIONS, SOURCE_FILE_EXTENSIONS, __version__
+    HEADER_FILE_EXTENSIONS, SOURCE_FILE_EXTENSIONS, __version__, ARDUINO_VERSION_ESP8266
 from esphome.core import CORE, EsphomeError
 from esphome.helpers import mkdir_p, read_file, write_file_if_changed, walk_files, \
     copy_file_if_changed
 from esphome.storage_json import StorageJSON, storage_path
+from esphome.pins import ESP8266_FLASH_SIZES, ESP8266_LD_SCRIPTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -212,6 +213,28 @@ def get_ini_content():
     if CONF_BOARD_FLASH_MODE in CORE.config[CONF_ESPHOME]:
         flash_mode = CORE.config[CONF_ESPHOME][CONF_BOARD_FLASH_MODE]
         data['board_build.flash_mode'] = flash_mode
+
+    # Build flags
+    if CORE.is_esp8266 and CORE.board in ESP8266_FLASH_SIZES:
+        flash_size = ESP8266_FLASH_SIZES[CORE.board]
+        ld_scripts = ESP8266_LD_SCRIPTS[flash_size]
+
+        versions_with_old_ldscripts = [
+            ARDUINO_VERSION_ESP8266['2.4.0'],
+            ARDUINO_VERSION_ESP8266['2.4.1'],
+            ARDUINO_VERSION_ESP8266['2.4.2'],
+        ]
+        if CORE.arduino_version == ARDUINO_VERSION_ESP8266['2.3.0']:
+            # No ld script support
+            ld_script = None
+        if CORE.arduino_version in versions_with_old_ldscripts:
+            # Old ld script path
+            ld_script = ld_scripts[0]
+        else:
+            ld_script = ld_scripts[1]
+
+        if ld_script is not None:
+            data['board_build.ldscript'] = ld_script
 
     # Ignore libraries that are not explicitly used, but may
     # be added by LDF

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ lib_deps =
     AsyncMqttClient-esphome@0.8.4
     ArduinoJson-esphomelib@5.13.3
     ESPAsyncWebServer-esphome@1.2.6
-    FastLED@3.3.3
+    FastLED@3.3.2
     NeoPixelBus-esphome@2.5.7
     ESPAsyncTCP-esphome@1.2.2
     1655@1.0.2  ; TinyGPSPlus (has name conflict)

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<tests/livingroom8266.cpp>
 
 [env:livingroom32]
-platform = espressif32@1.12.1
+platform = espressif32@1.12.4
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}


### PR DESCRIPTION
**Remember to use merge commit, not squash**

> _"The difference between theory and practice is that in theory, there is no difference between theory and practice."_

~ Richard Moore
- esphome: Mitigate CVE-2020-12638 WiFi WPA Downgrade [esphome#1207](https://github.com/esphome/esphome/pull/1207)
- esphome: ESP8266 change recommended framework version to 2.7.2 [esphome#1208](https://github.com/esphome/esphome/pull/1208)
- esphome: Fix base config should override packages config [esphome#1209](https://github.com/esphome/esphome/pull/1209)
- docs: ESP8266 change recommended framework version to 2.7.2 [docs#714](https://github.com/esphome/esphome-docs/pull/714)
- esphome: Fix AS3935 sensor configuration issues [esphome#1210](https://github.com/esphome/esphome/pull/1210)
- esphome: Fix prometheus has wrong setup priority [esphome#1211](https://github.com/esphome/esphome/pull/1211)
- esphome: Downgrade FastLED to 3.3.2 [esphome#1212](https://github.com/esphome/esphome/pull/1212)
- docs: Fix old screenshots [docs#716](https://github.com/esphome/esphome-docs/pull/716)
- docs: Add tuya platforms to changelog table [docs#715](https://github.com/esphome/esphome-docs/pull/715)
