### PR TITLE
Fix sdist missing requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include requirements.txt
 include esphome/dashboard/templates/*.html
 recursive-include esphome/dashboard/static *.ico *.js *.css *.woff* LICENSE
 recursive-include esphome *.cpp *.h *.tcc


### PR DESCRIPTION
## Description:

See attached issue - add requirements.txt to the manifest so that sdist installs work.

**Related issue (if applicable):** Fixes https://github.com/esphome/issues/issues/1378

## Checklist:
  - [x] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
