### PR TITLE
wpa2 enterprise fixes: also copy eap parameters, don't require psk password to be set

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -206,12 +206,15 @@ void WiFiComponent::start_connecting(const WiFiAP &ap, bool two) {
   if (ap.get_eap().has_value()) {
     ESP_LOGV(TAG, "  WPA2 Enterprise authentication configured:");
     EAPAuth eap_config = ap.get_eap().value();
-    ESP_LOGV(TAG, "    identity: " LOG_SECRET("'%s'"), eap_config.identity.c_str());
-    ESP_LOGV(TAG, "    username: " LOG_SECRET("'%s'"), eap_config.username.c_str());
-    ESP_LOGV(TAG, "    password: " LOG_SECRET("'%s'"), eap_config.password.c_str());
-    ESP_LOGV(TAG, "    CA cert:     %s", strlen(eap_config.ca_cert) ? "present" : "not present");
-    ESP_LOGV(TAG, "    Client cert: %s", strlen(eap_config.client_cert) ? "present" : "not present");
-    ESP_LOGV(TAG, "    Client key:  %s", strlen(eap_config.client_key) ? "present" : "not present");
+    ESP_LOGV(TAG, "    Identity: " LOG_SECRET("'%s'"), eap_config.identity.c_str());
+    ESP_LOGV(TAG, "    Username: " LOG_SECRET("'%s'"), eap_config.username.c_str());
+    ESP_LOGV(TAG, "    Password: " LOG_SECRET("'%s'"), eap_config.password.c_str());
+    bool ca_cert_present = eap_config.ca_cert != nullptr && strlen(eap_config.ca_cert);
+    bool client_cert_present = eap_config.client_cert != nullptr && strlen(eap_config.client_cert);
+    bool client_key_present = eap_config.client_key != nullptr && strlen(eap_config.client_key);
+    ESP_LOGV(TAG, "    CA Cert:     %s", ca_cert_present ? "present" : "not present");
+    ESP_LOGV(TAG, "    Client Cert: %s", client_cert_present ? "present" : "not present");
+    ESP_LOGV(TAG, "    Client Key:  %s", client_key_present ? "present" : "not present");
   } else {
 #endif
     ESP_LOGV(TAG, "  Password: " LOG_SECRET("'%s'"), ap.get_password().c_str());

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -612,6 +612,7 @@ bool WiFiScanResult::matches(const WiFiAP &config) {
 #else
   // If PSK given, only match for networks with auth (and vice versa)
   if (config.get_password().empty() == this->with_auth_)
+    return false;
 #endif
 
   // If channel configured, only match networks on that channel.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1379

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Checklist:
  - [X] The code change is tested and works locally.
  - [NA] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [NA] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
