### PR TITLE
Stop infinite loop in light on_turn_on

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -103,7 +103,10 @@ class LightTurnOnTrigger : public Trigger<> {
   LightTurnOnTrigger(LightState *a_light) {
     a_light->add_new_remote_values_callback([this, a_light]() {
       auto is_on = a_light->current_values.is_on();
+      // only trigger when going from off to on
       auto should_trigger = is_on && !last_on_;
+      // Set new state immediately so that trigger() doesn't devolve
+      // into infinite loop
       last_on_ = is_on;
       if (should_trigger) {
         this->trigger();
@@ -121,7 +124,10 @@ class LightTurnOffTrigger : public Trigger<> {
   LightTurnOffTrigger(LightState *a_light) {
     a_light->add_new_remote_values_callback([this, a_light]() {
       auto is_on = a_light->current_values.is_on();
+      // only trigger when going from on to off
       auto should_trigger = !is_on && last_on_;
+      // Set new state immediately so that trigger() doesn't devolve
+      // into infinite loop
       last_on_ = is_on;
       if (should_trigger) {
         this->trigger();

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -103,10 +103,11 @@ class LightTurnOnTrigger : public Trigger<> {
   LightTurnOnTrigger(LightState *a_light) {
     a_light->add_new_remote_values_callback([this, a_light]() {
       auto is_on = a_light->current_values.is_on();
-      if (is_on && !last_on_) {
+      auto should_trigger = is_on && !last_on_;
+      last_on_ = is_on;
+      if (should_trigger) {
         this->trigger();
       }
-      last_on_ = is_on;
     });
     last_on_ = a_light->current_values.is_on();
   }
@@ -120,10 +121,11 @@ class LightTurnOffTrigger : public Trigger<> {
   LightTurnOffTrigger(LightState *a_light) {
     a_light->add_new_remote_values_callback([this, a_light]() {
       auto is_on = a_light->current_values.is_on();
-      if (!is_on && last_on_) {
+      auto should_trigger = !is_on && last_on_;
+      last_on_ = is_on;
+      if (should_trigger) {
         this->trigger();
       }
-      last_on_ = is_on;
     });
     last_on_ = a_light->current_values.is_on();
   }


### PR DESCRIPTION
## Description:

For config:
```
light:
  - platform: monochromatic
    output: gpio_12
    id: indoor_light
    name: "Indoor light"
    default_transition_length: 0s
    effects:
      - strobe:
          name: Blink
          colors:
            - state: True
              duration: 1s
            - state: False
              duration: 1s
    on_turn_on:
      then:
        - light.control:
            id: indoor_light
            effect: Blink
```
Because the on_turn_on changes the same light as it is triggered on before this diff it caused an infinite loop.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).