### PR TITLE
Bump ESPAsyncWebServer-esphome to v1.2.7

### DIFF
--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -24,4 +24,4 @@ def to_code(config):
     if CORE.is_esp32:
         cg.add_library('FS', None)
     # https://github.com/OttoWinter/ESPAsyncWebServer/blob/master/library.json
-    cg.add_library('ESPAsyncWebServer-esphome', '1.2.6')
+    cg.add_library('ESPAsyncWebServer-esphome', '1.2.7')

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ lib_deps =
     AsyncTCP-esphome@1.1.1
     AsyncMqttClient-esphome@0.8.4
     ArduinoJson-esphomelib@5.13.3
-    ESPAsyncWebServer-esphome@1.2.6
+    ESPAsyncWebServer-esphome@1.2.7
     FastLED@3.3.2
     NeoPixelBus-esphome@2.5.7
     ESPAsyncTCP-esphome@1.2.2


### PR DESCRIPTION
## Description:

Includes https://github.com/OttoWinter/ESPAsyncWebServer/pull/1 :

 - Fixes `AsyncEventSource::send()`
 - Increases `SEE_MAX_QUEUED_MESSAGES` to 32 on ESP8266.

**Status:** Waiting for platformio lib crawler to pick up the change. See https://platformio.org/lib/show/6758/ESPAsyncWebServer-esphome

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/806

## Checklist:
  - [x] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).
