### PR TITLE
Fix ci-custom.py const.py ordered check and improve code

### DIFF
--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -417,8 +417,8 @@ def lint_pragma_once(fname, content):
     return None
 
 
-@lint_re_check(r'(whitelist|Whitelist|WHITELIST|Blacklist|blacklist|BLACKLIST|slave|Slave|SLAVE)',
-               exclude=['script/ci-custom.py'])
+@lint_re_check(r'(whitelist|blacklist|slave)',
+               exclude=['script/ci-custom.py'], flags=re.IGNORECASE | re.MULTILINE)
 def lint_inclusive_language(fname, match):
     # From https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=49decddd39e5f6132ccd7d9fdc3d7c470b0061bb
     return ("Avoid the use of whitelist/blacklist/slave.\n"

--- a/script/quicklint
+++ b/script/quicklint
@@ -6,6 +6,6 @@ cd "$(dirname "$0")/.."
 
 set -x
 
-script/ci-custom.py
+script/ci-custom.py -c
 script/lint-python -c
 script/lint-cpp -c


### PR DESCRIPTION
## Description:

ci script was failing sometimes due to error in `lint_const_ordered` check (line numer is not an int).

Fixed that bug and also improved the code:
 - print which check had an exception
 - add reason for const.py ordered
 - convert to f-strings

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
