### PR TITLE
Add hyphen to supported name characters

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -40,7 +40,7 @@ ALLOW_EXTRA = vol.ALLOW_EXTRA
 UNDEFINED = vol.UNDEFINED
 RequiredFieldInvalid = vol.RequiredFieldInvalid
 
-ALLOWED_NAME_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_'
+ALLOWED_NAME_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_-'
 
 RESERVED_IDS = [
     # C++ keywords http://en.cppreference.com/w/cpp/keyword

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -10,7 +10,7 @@ ESP_PLATFORM_ESP32 = 'ESP32'
 ESP_PLATFORM_ESP8266 = 'ESP8266'
 ESP_PLATFORMS = [ESP_PLATFORM_ESP32, ESP_PLATFORM_ESP8266]
 
-ALLOWED_NAME_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_'
+ALLOWED_NAME_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_-'
 ARDUINO_VERSION_ESP32_DEV = 'https://github.com/platformio/platform-espressif32.git'
 ARDUINO_VERSION_ESP32_1_0_0 = 'espressif32@1.5.0'
 ARDUINO_VERSION_ESP32_1_0_1 = 'espressif32@1.6.0'

--- a/esphome/dashboard/templates/index.html
+++ b/esphome/dashboard/templates/index.html
@@ -359,7 +359,7 @@
                 <p>
                   Names must be all <strong>lowercase</strong> and <strong>must not contain any spaces</strong>!
                   Characters that are allowed are: <code class="inlinecode">a-z</code>,
-                  <code class="inlinecode">0-9</code> and <code class="inlinecode">_</code>.
+                  <code class="inlinecode">0-9</code>, <code class="inlinecode">_</code> and <code class="inlinecode">-</code>.
                 </p>
 
                 <div class="input-field col s12">

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -168,8 +168,9 @@ def wizard(path):
             name = cv.valid_name(name)
             break
         except vol.Invalid:
-            safe_print(color("red", "Oh noes, \"{}\" isn't a valid name. Names can only include "
-                                    "numbers, lower-case letters, underscores and hyphens.".format(name)))
+            safe_print(color("red", f"Oh noes, \"{name}\" isn't a valid name. Names can only "
+                                    f"include numbers, lower-case letters, underscores and "
+                                    f"hyphens."))
             name = strip_accents(name).lower().replace(' ', '_')
             name = ''.join(c for c in name if c in cv.ALLOWED_NAME_CHARS)
             safe_print("Shall I use \"{}\" as the name instead?".format(color('cyan', name)))

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -169,7 +169,7 @@ def wizard(path):
             break
         except vol.Invalid:
             safe_print(color("red", "Oh noes, \"{}\" isn't a valid name. Names can only include "
-                                    "numbers, lower-case letters and underscores.".format(name)))
+                                    "numbers, lower-case letters, underscores and hyphens.".format(name)))
             name = strip_accents(name).lower().replace(' ', '_')
             name = ''.join(c for c in name if c in cv.ALLOWED_NAME_CHARS)
             safe_print("Shall I use \"{}\" as the name instead?".format(color('cyan', name)))

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -5,7 +5,7 @@ esphome:
   build_path: build/test4
 
 substitutions:
-  devicename: test4
+  devicename: test-4
 
 ethernet:
   type: LAN8720

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -27,7 +27,7 @@ def test_alphanumeric__invalid(value):
         actual = config_validation.alphanumeric(value)
 
 
-@given(value=text(alphabet=string.ascii_lowercase + string.digits + "_"))
+@given(value=text(alphabet=string.ascii_lowercase + string.digits + "_-"))
 def test_valid_name__valid(value):
     actual = config_validation.valid_name(value)
 


### PR DESCRIPTION
## Description:
This is a duplicate of esphome/esphome#740 since that PR went stale last year (and wasn't rejected outright).

I'm a PR-virgin, so go easy on me.  I'm trying.  I've made the changes that I can see that are required, and tested.  This has already been discussed between @dannysauer and @OttoWinter.  The key points I can see are:
 - Apparently hyphen _used to be_ invalid due to HA MQTT discovery (as per https://github.com/esphome/esphome/pull/740#issuecomment-543312315).  They support hyphens now (I found the specific commit where this changed [back in 2017](https://github.com/home-assistant/core/commit/be53cc70682ca55ec983630d283d3afbe2736a02#diff-7c6eaa44a1a537b1fbd15e6c05b14522).
 - @OttoWinter states the the dashboard matching logic needs updating.  The allowable characters are defined in [esphome/config_validation.py](https://github.com/ianleeder/esphome/blob/ba1a862a76ebafb095d6c28aa1db8a91b0032b4d/esphome/config_validation.py#L43) included in this PR.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/418

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#719

## Checklist:
  - [x] The code change is tested and works locally.

  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
