### PR TITLE
Fix ESP8266 core has a broken settimeofday implementation

### DIFF
--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -4,6 +4,7 @@
 #ifdef ARDUINO_ARCH_ESP8266
 #include "sys/time.h"
 #endif
+#include "errno.h"
 
 namespace esphome {
 namespace time {

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -20,7 +20,7 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   struct timeval timev {
     .tv_sec = static_cast<time_t>(epoch), .tv_usec = 0,
   };
-  ESP_LOGVV(TAG, "Got epoch %u (%llu)", epoch, epoch * 1000000ULL);
+  ESP_LOGVV(TAG, "Got epoch %u", epoch);
   timezone tz = {0, 0};
   int ret = settimeofday(&timev, &tz);
   if (ret == EINVAL) {


### PR DESCRIPTION
## Description:

ESP8266 has updated `settimeofday` to return `EINVAL` when the timezone parameter is not NULL, but according to my man page `timezone` parameter must not be NULL.

https://github.com/esp8266/Arduino/blob/master/cores/esp8266/sntp-lwip2.cpp#L75


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1385

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
