### PR TITLE
Fix tuya.cpp compile warning

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -22,8 +22,8 @@ void Tuya::loop() {
 void Tuya::dump_config() {
   ESP_LOGCONFIG(TAG, "Tuya:");
   if (this->init_state_ != TuyaInitState::INIT_DONE) {
-    ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",  // NOLINT
-                  this->init_state_);
+    ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",
+                  static_cast<uint8_t>(this->init_state_));
     ESP_LOGCONFIG(TAG, "  If no further output is received, confirm that this is a supported Tuya device.");
     return;
   }


### PR DESCRIPTION
## Description:

```
In file included from src/esphome/components/tuya/tuya.cpp:2:0:
src/esphome/components/tuya/tuya.cpp: In member function 'virtual void esphome::tuya::Tuya::dump_config()':      
src/esphome/core/log.h:90:101: warning: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'esphome::tuya::TuyaInitState' [-Wformat=]                                                                   
   esp_log_printf_(ESPHOME_LOG_LEVEL_CONFIG, tag, __LINE__, ESPHOME_LOG_FORMAT(format), ##__VA_ARGS__)           
                                                                                                     ^           
src/esphome/core/log.h:150:33: note: in expansion of macro 'esph_log_config'                                     
 #define ESP_LOGCONFIG(tag, ...) esph_log_config(tag, __VA_ARGS__)                                               
                                 ^                                                                               
src/esphome/components/tuya/tuya.cpp:25:5: note: in expansion of macro 'ESP_LOGCONFIG'                           
     ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",  // NOLINT 
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
