### PR TITLE
Enable reverse display of the Max7219 digit

### DIFF
--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -58,7 +58,7 @@ def to_code(config):
     cg.add(var.set_scroll_delay(config[CONF_SCROLL_DELAY]))
     cg.add(var.set_scroll(config[CONF_SCROLL_ENABLE]))
     cg.add(var.set_scroll_mode(config[CONF_SCROLL_MODE]))
-    cg.add(var.set_scroll(config[CONF_REVERSE_ENABLE]))
+    cg.add(var.set_reverse(config[CONF_REVERSE_ENABLE]))
 
     if CONF_LAMBDA in config:
         lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], [(MAX7219ComponentRef, 'it')],

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -11,6 +11,7 @@ CONF_SCROLL_DWELL = 'scroll_dwell'
 CONF_SCROLL_DELAY = 'scroll_delay'
 CONF_SCROLL_ENABLE = 'scroll_enable'
 CONF_SCROLL_MODE = 'scroll_mode'
+CONF_REVERSE_ENABLE = 'reverse_enable'
 
 SCROLL_MODES = {
     'CONTINUOUS': 0,
@@ -39,6 +40,7 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend({
     cv.Optional(CONF_SCROLL_SPEED, default='250ms'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_SCROLL_DELAY, default='1000ms'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_SCROLL_DWELL, default='1000ms'): cv.positive_time_period_milliseconds,
+    cv.Optional(CONF_REVERSE_ENABLE, default=False): cv.boolean,
 }).extend(cv.polling_component_schema('500ms')).extend(spi.spi_device_schema(cs_pin_required=True))
 
 
@@ -56,6 +58,7 @@ def to_code(config):
     cg.add(var.set_scroll_delay(config[CONF_SCROLL_DELAY]))
     cg.add(var.set_scroll(config[CONF_SCROLL_ENABLE]))
     cg.add(var.set_scroll_mode(config[CONF_SCROLL_MODE]))
+    cg.add(var.set_scroll(config[CONF_REVERSE_ENABLE]))
 
     if CONF_LAMBDA in config:
         lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], [(MAX7219ComponentRef, 'it')],

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -109,7 +109,7 @@ void MAX7219Component::display() {
   for (uint8_t i = 0; i < this->num_chips_; i++) {
     for (uint8_t j = 0; j < 8; j++) {
       if (this->reverse_) {
-        pixels[j] = this->max_displaybuffer_[(this->num_chips_ - i -1) * 8 + j];
+        pixels[j] = this->max_displaybuffer_[(this->num_chips_ - i - 1) * 8 + j];
       } else {
         pixels[j] = this->max_displaybuffer_[i * 8 + j];
       }

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -108,7 +108,11 @@ void MAX7219Component::display() {
   // Send the data to the chip
   for (uint8_t i = 0; i < this->num_chips_; i++) {
     for (uint8_t j = 0; j < 8; j++) {
-      pixels[j] = this->max_displaybuffer_[i * 8 + j];
+      if (this->reverse_) {
+        pixels[j] = this->max_displaybuffer_[(this->num_chips_ - i -1) * 8 + j];
+      } else {
+        pixels[j] = this->max_displaybuffer_[i * 8 + j];
+      }
     }
     this->send64pixels(i, pixels);
   }

--- a/esphome/components/max7219digit/max7219digit.h
+++ b/esphome/components/max7219digit/max7219digit.h
@@ -52,6 +52,7 @@ class MAX7219Component : public PollingComponent,
   void set_scroll_delay(uint16_t delay) { this->scroll_delay_ = delay; };
   void set_scroll(bool on_off) { this->scroll_ = on_off; };
   void set_scroll_mode(uint8_t mode) { this->scroll_mode_ = mode; };
+  void set_reverse(bool on_off) { this->reverse_ = on_off; };
 
   void send_char(byte chip, byte data);
   void send64pixels(byte chip, const byte pixels[8]);
@@ -87,6 +88,7 @@ class MAX7219Component : public PollingComponent,
   uint8_t intensity_;  /// Intensity of the display from 0 to 15 (most)
   uint8_t num_chips_;
   bool scroll_;
+  bool reverse_;
   bool update_{false};
   uint16_t scroll_speed_;
   uint16_t scroll_delay_;


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/14 See comment of @adadrag

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#726

## Checklist:
  - [X ] The code change is tested and works locally.
  - [X ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
