### PR TITLE
Clean up ALLOWED_CHARS

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -11,9 +11,9 @@ from string import ascii_letters, digits
 import voluptuous as vol
 
 from esphome import core
-from esphome.const import CONF_AVAILABILITY, CONF_COMMAND_TOPIC, CONF_DISCOVERY, CONF_ID, \
-    CONF_INTERNAL, CONF_NAME, CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, \
-    CONF_RETAIN, CONF_SETUP_PRIORITY, CONF_STATE_TOPIC, CONF_TOPIC, \
+from esphome.const import ALLOWED_NAME_CHARS, CONF_AVAILABILITY, CONF_COMMAND_TOPIC, \
+    CONF_DISCOVERY, CONF_ID, CONF_INTERNAL, CONF_NAME, CONF_PAYLOAD_AVAILABLE, \
+    CONF_PAYLOAD_NOT_AVAILABLE, CONF_RETAIN, CONF_SETUP_PRIORITY, CONF_STATE_TOPIC, CONF_TOPIC, \
     CONF_HOUR, CONF_MINUTE, CONF_SECOND, CONF_VALUE, CONF_UPDATE_INTERVAL, CONF_TYPE_ID, CONF_TYPE
 from esphome.core import CORE, HexInt, IPAddress, Lambda, TimePeriod, TimePeriodMicroseconds, \
     TimePeriodMilliseconds, TimePeriodSeconds, TimePeriodMinutes
@@ -39,8 +39,6 @@ Inclusive = vol.Inclusive
 ALLOW_EXTRA = vol.ALLOW_EXTRA
 UNDEFINED = vol.UNDEFINED
 RequiredFieldInvalid = vol.RequiredFieldInvalid
-
-ALLOWED_NAME_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_'
 
 RESERVED_IDS = [
     # C++ keywords http://en.cppreference.com/w/cpp/keyword

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -11,6 +11,7 @@ from esphome.helpers import color, get_bool_env, write_file
 from esphome.pins import ESP32_BOARD_PINS, ESP8266_BOARD_PINS
 from esphome.storage_json import StorageJSON, ext_storage_path
 from esphome.util import safe_print
+from esphome.const import ALLOWED_NAME_CHARS
 
 CORE_BIG = r"""    _____ ____  _____  ______
    / ____/ __ \|  __ \|  ____|
@@ -171,7 +172,7 @@ def wizard(path):
             safe_print(color("red", "Oh noes, \"{}\" isn't a valid name. Names can only include "
                                     "numbers, lower-case letters and underscores.".format(name)))
             name = strip_accents(name).lower().replace(' ', '_')
-            name = ''.join(c for c in name if c in cv.ALLOWED_NAME_CHARS)
+            name = ''.join(c for c in name if c in ALLOWED_NAME_CHARS)
             safe_print("Shall I use \"{}\" as the name instead?".format(color('cyan', name)))
             sleep(0.5)
             name = default_input("(name [{}]): ", name)


### PR DESCRIPTION
## Description:
As per discusson [here](https://github.com/esphome/esphome/pull/1223#issuecomment-666238697) maintaining two copies of `ALLOWED_NAME_CHARS` is unnecessary.
https://github.com/esphome/esphome/blob/009cea1abf8c039ac947e2234618934d8c076cbf/esphome/const.py#L13
https://github.com/esphome/esphome/blob/009cea1abf8c039ac947e2234618934d8c076cbf/esphome/config_validation.py#L43

**Related issue (if applicable):** N/A - just cleanup

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] **N/A** Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] **N/A** Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
