### PR TITLE
Script mode fix

### DIFF
--- a/esphome/components/script/__init__.py
+++ b/esphome/components/script/__init__.py
@@ -18,14 +18,14 @@ ParallelScript = script_ns.class_('ParallelScript', Script)
 
 CONF_SINGLE = 'single'
 CONF_RESTART = 'restart'
-CONF_QUEUE = 'queue'
+CONF_QUEUED = 'queued'
 CONF_PARALLEL = 'parallel'
 CONF_MAX_RUNS = 'max_runs'
 
 SCRIPT_MODES = {
     CONF_SINGLE: SingleScript,
     CONF_RESTART: RestartScript,
-    CONF_QUEUE: QueueingScript,
+    CONF_QUEUED: QueueingScript,
     CONF_PARALLEL: ParallelScript,
 }
 
@@ -33,7 +33,7 @@ SCRIPT_MODES = {
 def check_max_runs(value):
     if CONF_MAX_RUNS not in value:
         return value
-    if value[CONF_MODE] not in [CONF_QUEUE, CONF_PARALLEL]:
+    if value[CONF_MODE] not in [CONF_QUEUED, CONF_PARALLEL]:
         raise cv.Invalid("The option 'max_runs' is only valid in 'queue' and 'parallel' mode.",
                          path=[CONF_MAX_RUNS])
     return value
@@ -65,7 +65,7 @@ def to_code(config):
         if CONF_MAX_RUNS in conf:
             cg.add(trigger.set_max_runs(conf[CONF_MAX_RUNS]))
 
-        if conf[CONF_MODE] == CONF_QUEUE:
+        if conf[CONF_MODE] == CONF_QUEUED:
             yield cg.register_component(trigger, conf)
 
         triggers.append((trigger, conf))

--- a/esphome/components/script/script.cpp
+++ b/esphome/components/script/script.cpp
@@ -33,7 +33,7 @@ void QueueingScript::execute() {
       return;
     }
 
-    ESP_LOGD(TAG, "Script '%s' queueing new instance (mode: queue)", this->name_.c_str());
+    ESP_LOGD(TAG, "Script '%s' queueing new instance (mode: queued)", this->name_.c_str());
     this->num_runs_++;
     return;
   }

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -292,6 +292,21 @@ text_sensor:
 
 script:
   - id: my_script
+    mode: single
+    then:
+      - lambda: 'ESP_LOGD("main", "Hello World!");'
+  - id: my_script_queued
+    mode: queued
+    max_runs: 2
+    then:
+      - lambda: 'ESP_LOGD("main", "Hello World!");'
+  - id: my_script_parallel
+    mode: parallel
+    max_runs: 2
+    then:
+      - lambda: 'ESP_LOGD("main", "Hello World!");'
+  - id: my_script_restart
+    mode: restart
     then:
       - lambda: 'ESP_LOGD("main", "Hello World!");'
 
@@ -316,5 +331,3 @@ interval:
     - logger.log: "Interval Run"
 
 display:
-
-


### PR DESCRIPTION
## Description:
Updates `queued` mode from incorrect config string (`queue`) to follow the docs and HA.

!Breaking Change!

https://www.home-assistant.io/blog/2020/07/22/release-113/#automations--scripts-running-modes
https://next.esphome.io/guides/automations.html#script

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
