### PR TITLE
make powered on assume public

### DIFF
--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -41,11 +41,11 @@ void WhirlpoolClimate::transmit_state() {
   remote_state[18] = 0x08;
 
   auto powered_on = this->mode != climate::CLIMATE_MODE_OFF;
-  if (powered_on != this->powered_on_assumed_) {
+  if (powered_on != this->powered_on_assumed) {
     // Set power toggle command
     remote_state[2] = 4;
     remote_state[15] = 1;
-    this->powered_on_assumed_ = powered_on;
+    this->powered_on_assumed = powered_on;
   }
   switch (this->mode) {
     case climate::CLIMATE_MODE_AUTO:
@@ -215,14 +215,14 @@ bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
 
     if (powered_on) {
       this->mode = climate::CLIMATE_MODE_OFF;
-      this->powered_on_assumed_ = false;
+      this->powered_on_assumed = false;
     } else {
-      this->powered_on_assumed_ = true;
+      this->powered_on_assumed = true;
     }
   }
 
   // Set received mode
-  if (powered_on_assumed_) {
+  if (powered_on_assumed) {
     auto mode = remote_state[3] & 0x7;
     ESP_LOGV(TAG, "Mode: %02X", mode);
     switch (mode) {

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -28,7 +28,7 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   void setup() override {
     climate_ir::ClimateIR::setup();
 
-    this->powered_on_assumed_ = this->mode != climate::CLIMATE_MODE_OFF;
+    this->powered_on_assumed = this->mode != climate::CLIMATE_MODE_OFF;
   }
 
   /// Override control to change settings of the climate device.
@@ -39,14 +39,14 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
 
   void set_model(Model model) { this->model_ = model; }
 
+  // used to track when to send the power toggle command
+  bool powered_on_assumed;
+
  protected:
   /// Transmit via IR the state of this climate controller.
   void transmit_state() override;
   /// Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
-
-  // used to track when to send the power toggle command
-  bool powered_on_assumed_;
 
   bool send_swing_cmd_{false};
   Model model_;


### PR DESCRIPTION
## Description:
This is just making a field public, so it is a bit hackable, allows a work around to sync the power on state by checking by other means if the AC is on, will document and point to example later.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
