### PR TITLE
Float output: Fix min_power and max_power adjusting when output is inverted

### DIFF
--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -29,10 +29,9 @@ void FloatOutput::set_level(float state) {
     this->power_.unrequest();
   }
 #endif
-
-  float adjusted_value = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
   if (this->is_inverted())
-    adjusted_value = 1.0f - adjusted_value;
+    state = 1.0f - state;
+  float adjusted_value = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
   this->write_state(adjusted_value);
 }
 


### PR DESCRIPTION
This patch fixes faulty behaviour when both, invert and min_power/max_power
are set for a float output (e.g. PWM). The current code scales the output
level to the range [min_power, max_power] and subsequently inverts the value.
This leads to values that are outside the range [min_power, max_power].

This patch fixes the problem by inverting the requested level first and then
scaling it to the interval [min_power, max_power].

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
