### PR TITLE
Add new time.has_time condition

### DIFF
--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -10,10 +10,11 @@ import tzlocal
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.const import CONF_CRON, CONF_DAYS_OF_MONTH, CONF_DAYS_OF_WEEK, CONF_HOURS, \
+from esphome.const import CONF_ID, CONF_CRON, CONF_DAYS_OF_MONTH, CONF_DAYS_OF_WEEK, CONF_HOURS, \
     CONF_MINUTES, CONF_MONTHS, CONF_ON_TIME, CONF_SECONDS, CONF_TIMEZONE, CONF_TRIGGER_ID, \
     CONF_AT, CONF_SECOND, CONF_HOUR, CONF_MINUTE
 from esphome.core import coroutine, coroutine_with_priority
+from esphome.automation import Condition
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ time_ns = cg.esphome_ns.namespace('time')
 RealTimeClock = time_ns.class_('RealTimeClock', cg.Component)
 CronTrigger = time_ns.class_('CronTrigger', automation.Trigger.template(), cg.Component)
 ESPTime = time_ns.struct('ESPTime')
+TimeHasTimeCondition = time_ns.class_('TimeHasTimeCondition', Condition)
 
 
 def _tz_timedelta(td):
@@ -328,3 +330,11 @@ def register_time(time_var, config):
 def to_code(config):
     cg.add_define('USE_TIME')
     cg.add_global(time_ns.using)
+
+
+@automation.register_condition('time.has_time', TimeHasTimeCondition, cv.Schema({
+    cv.GenerateID(): cv.use_id(RealTimeClock),
+}))
+def time_has_time_to_code(config, condition_id, template_arg, args):
+    paren = yield cg.get_variable(config[CONF_ID])
+    yield cg.new_Pvariable(condition_id, template_arg, paren)

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/automation.h"
 #include <stdlib.h>
 #include <time.h>
 #include <bitset>
@@ -131,6 +132,15 @@ class RealTimeClock : public Component {
   void synchronize_epoch_(uint32_t epoch);
 
   std::string timezone_{};
+};
+
+template<typename... Ts> class TimeHasTimeCondition : public Condition<Ts...> {
+ public:
+  TimeHasTimeCondition(RealTimeClock *parent) : parent_(parent) {}
+  bool check(Ts... x) override { return this->parent_->now().is_valid(); }
+
+ protected:
+  RealTimeClock *parent_;
 };
 
 }  // namespace time

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -8,6 +8,7 @@ esphome:
     - wait_until:
         - api.connected
         - wifi.connected
+        - time.has_time
   includes:
     - custom.h
 


### PR DESCRIPTION
## Description:

This PR adds the `time.has_time` condition which can be used as part of a [wait_until](https://esphome.io/guides/automations.html#wait-until-action) action, e.g.

```yaml
script:
  - id: on_boot
    then:
      - logger.log:
          level: INFO
          format: "Starting on_boot.."
      - script.execute: prevent_sleep
      - logger.log:
          level: INFO
          format: "Waiting for WIFI, MQTT and NTP.."
      - wait_until:
          - time.has_time:
          - mqtt.connected:
      - logger.log:
          level: INFO
          format: "WIFI, MQTT and NTP up!"
      - script.execute: mqtt_ping
      - script.execute: do_work
```

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#782

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs) - https://github.com/esphome/esphome-docs/pull/782
