### PR TITLE
Tuya dimmer fixes

### DIFF
--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -27,7 +27,7 @@ void TuyaLight::setup() {
       auto brightness = float(brightness_int) / 255.0f;
 
       auto call = this->state_->make_call();
-      call.set_brightness(brightness_float);
+      call.set_brightness(brightness);
       call.perform();
     });
   }

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -6,15 +6,13 @@ namespace tuya {
 
 static const char *TAG = "tuya.light";
 
-bool TuyaLight::shouldIgnoreDimmerCommand()
-{
-  if (this->ignore_dimmer_cmd_timeout > millis())
-  {
-      ESP_LOGV(TAG, "dimmer_cmd: ignored");
-      return true;
+bool TuyaLight::shouldIgnoreDimmerCommand() {
+  if (this->ignore_dimmer_cmd_timeout > millis()) {
+    ESP_LOGV(TAG, "dimmer_cmd: ignored");
+    return true;
   }
 
-  this->ignore_write_state = true; // Ignore next write_state call
+  this->ignore_write_state = true;  // Ignore next write_state call
   return false;
 }
 
@@ -62,17 +60,16 @@ light::LightTraits TuyaLight::get_traits() {
 void TuyaLight::setup_state(light::LightState *state) { state_ = state; }
 
 void TuyaLight::write_state(light::LightState *state) {
-  if (this->ignore_write_state)
-  {
-      this->ignore_write_state = false;
-      ESP_LOGV(TAG, "write_state: ignored");
-      return;
+  if (this->ignore_write_state) {
+    this->ignore_write_state = false;
+    ESP_LOGV(TAG, "write_state: ignored");
+    return;
   }
 
   float brightness;
   state->current_values_as_brightness(&brightness);
 
-  this->ignore_dimmer_cmd_timeout = millis() + 250; // Ignore serial received dim commands for the next 250ms
+  this->ignore_dimmer_cmd_timeout = millis() + 250;  // Ignore serial received dim commands for the next 250ms
 
   if (brightness == 0.0f) {
     // turning off, first try via switch (if exists), then dimmer

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -24,8 +24,12 @@ void TuyaLight::setup() {
       if (this->shouldIgnoreDimmerCommand())
         return;
 
+      int brightness_int = map(datapoint.value_uint, this->min_value_, this->max_value_, 0, 255);
+      brightness_int = max(brightness_int, 0);
+      auto brightness = float(brightness_int) / 255.0f;
+
       auto call = this->state_->make_call();
-      call.set_brightness(float(datapoint.value_uint) / this->max_value_);
+      call.set_brightness(brightness_float);
       call.perform();
     });
   }
@@ -89,8 +93,8 @@ void TuyaLight::write_state(light::LightState *state) {
     return;
   }
 
-  auto brightness_int = static_cast<uint32_t>(brightness * this->max_value_);
-  brightness_int = std::max(brightness_int, this->min_value_);
+  auto brightness_int = static_cast<uint32_t>(brightness * 255);
+  brightness_int = map(brightness_int, 0, 255, this->min_value_, this->max_value_);
 
   if (this->dimmer_id_.has_value()) {
     TuyaDatapoint datapoint{};

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -30,8 +30,9 @@ class TuyaLight : public Component, public light::LightOutput {
   optional<uint8_t> switch_id_{};
   uint32_t min_value_ = 0;
   uint32_t max_value_ = 255;
-  bool ignore_write_state = false; // Flag indicating whether write_state calls should be ignored to avoid sending the received value back to the hardware
-  uint32_t ignore_dimmer_cmd_timeout = 0; // Time until which received dimmer commands should be ignored
+  bool ignore_write_state = false;  // Flag indicating whether write_state calls should be ignored to avoid sending the
+                                    // received value back to the hardware
+  uint32_t ignore_dimmer_cmd_timeout = 0;  // Time until which received dimmer commands should be ignored
   light::LightState *state_{nullptr};
 };
 

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -23,12 +23,15 @@ class TuyaLight : public Component, public light::LightOutput {
  protected:
   void update_dimmer_(uint32_t value);
   void update_switch_(uint32_t value);
+  bool shouldIgnoreDimmerCommand();
 
   Tuya *parent_;
   optional<uint8_t> dimmer_id_{};
   optional<uint8_t> switch_id_{};
   uint32_t min_value_ = 0;
   uint32_t max_value_ = 255;
+  bool ignore_write_state = false; // Flag indicating whether write_state calls should be ignored to avoid sending the received value back to the hardware
+  uint32_t ignore_dimmer_cmd_timeout = 0; // Time until which received dimmer commands should be ignored
   light::LightState *state_{nullptr};
 };
 

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -31,7 +31,7 @@ class TuyaLight : public Component, public light::LightOutput {
   uint32_t min_value_ = 0;
   uint32_t max_value_ = 255;
   bool ignore_write_state_ = false;  // Flag indicating whether write_state calls should be ignored to avoid sending the
-                                    // received value back to the hardware
+                                     // received value back to the hardware
   uint32_t ignore_dimmer_cmd_timeout_ = 0;  // Time until which received dimmer commands should be ignored
   light::LightState *state_{nullptr};
 };

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -23,16 +23,16 @@ class TuyaLight : public Component, public light::LightOutput {
  protected:
   void update_dimmer_(uint32_t value);
   void update_switch_(uint32_t value);
-  bool shouldIgnoreDimmerCommand();
+  bool should_ignore_dimmer_command_();
 
   Tuya *parent_;
   optional<uint8_t> dimmer_id_{};
   optional<uint8_t> switch_id_{};
   uint32_t min_value_ = 0;
   uint32_t max_value_ = 255;
-  bool ignore_write_state = false;  // Flag indicating whether write_state calls should be ignored to avoid sending the
+  bool ignore_write_state_ = false;  // Flag indicating whether write_state calls should be ignored to avoid sending the
                                     // received value back to the hardware
-  uint32_t ignore_dimmer_cmd_timeout = 0;  // Time until which received dimmer commands should be ignored
+  uint32_t ignore_dimmer_cmd_timeout_ = 0;  // Time until which received dimmer commands should be ignored
   light::LightState *state_{nullptr};
 };
 


### PR DESCRIPTION
## Description:
Following [Tasmota strategy](https://github.com/arendst/Tasmota/blob/38179062aed0e8fe3a2224079790aba5c574f0d5/tasmota/xdrv_16_tuyamcu.ino#L72), ignore logic has been included in tuya light component to avoid repetitive status updates:

- **ignore_dimmer_cmd_timeout**: used to ignore dimmer command updates sent by the mcu after a command issue frame has been sent.
- **ignore_write_state**: Flag indicating whether write_state calls should be ignored to avoid sending the received value back to the hardware

Some brightness mapping corrections has been included to re-range correctly the LightOutput.brightness value from [0.0f, 1.0f] to [min_value, max_value]

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
