### PR TITLE
fix sntp timezone

### DIFF
--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -33,10 +33,6 @@ void SNTPComponent::setup() {
     sntp_setservername(2, strdup(this->server_3_.c_str()));
   }
 
-#ifdef ARDUINO_ARCH_ESP8266
-  // let localtime/gmtime handle timezones, not sntp
-  sntp_set_timezone(0);
-#endif
   sntp_init();
 }
 void SNTPComponent::dump_config() {


### PR DESCRIPTION
## Description:
See also https://github.com/esphome/issues/issues/1434

This is happening since Arduino 2.7.0 may be related: https://github.com/esp8266/Arduino/pull/6993 Don't know exactly the cause but seems like the fix proposed by @f403 works reliable.

Actually a lot of code to review to find the reason, I find it easier to just test it and confirm the issue. If someone does a research job and finds root issue somewhere that's welcomed.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1434

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
