### PR TITLE
enable the use of 16 bit address registers in I2C

### DIFF
--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -135,6 +135,14 @@ bool I2CComponent::read_bytes(uint8_t address, uint8_t a_register, uint8_t *data
     delay(conversion);
   return this->raw_receive(address, data, len);
 }
+bool I2CComponent::read_bytes(uint8_t address, uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {
+  if (!this->write_bytes(address, a_register, nullptr, 0))
+    return false;
+
+  if (conversion > 0)
+    delay(conversion);
+  return this->raw_receive(address, data, len);
+}
 bool I2CComponent::read_bytes_raw(uint8_t address, uint8_t *data, uint8_t len) {
   return this->raw_receive(address, data, len);
 }
@@ -147,9 +155,22 @@ bool I2CComponent::read_bytes_16(uint8_t address, uint8_t a_register, uint16_t *
     delay(conversion);
   return this->raw_receive_16(address, data, len);
 }
+bool I2CComponent::read_bytes_16(uint8_t address, uint16_t a_register, uint16_t *data, uint8_t len,
+                                 uint32_t conversion) {
+  if (!this->write_bytes(address, a_register, nullptr, 0))
+    return false;
+
+  if (conversion > 0)
+    delay(conversion);
+  return this->raw_receive_16(address, data, len);
+}
 bool I2CComponent::read_byte(uint8_t address, uint8_t a_register, uint8_t *data, uint32_t conversion) {
   return this->read_bytes(address, a_register, data, 1, conversion);
 }
+bool I2CComponent::read_byte(uint8_t address, uint16_t a_register, uint8_t *data, uint32_t conversion) {
+  return this->read_bytes(address, a_register, data, 1, conversion);
+}
+
 bool I2CComponent::read_byte_16(uint8_t address, uint8_t a_register, uint16_t *data, uint32_t conversion) {
   return this->read_bytes_16(address, a_register, data, 1, conversion);
 }

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -127,18 +127,9 @@ bool I2CComponent::raw_receive_16(uint8_t address, uint16_t *data, uint8_t len) 
   }
   return true;
 }
-bool I2CComponent::read_bytes(uint8_t address, uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {
-  if (!this->write_bytes(address, a_register, nullptr, 0))
+bool I2CComponent::read_bytes(uint8_t address, uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion, uint8_t a_register_width) {
+  if (!this->write_bytes(address, a_register, nullptr, 0, a_register_width))
     return false;
-
-  if (conversion > 0)
-    delay(conversion);
-  return this->raw_receive(address, data, len);
-}
-bool I2CComponent::read_bytes(uint8_t address, uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {
-  if (!this->write_bytes(address, a_register, nullptr, 0))
-    return false;
-
   if (conversion > 0)
     delay(conversion);
   return this->raw_receive(address, data, len);
@@ -146,17 +137,8 @@ bool I2CComponent::read_bytes(uint8_t address, uint16_t a_register, uint8_t *dat
 bool I2CComponent::read_bytes_raw(uint8_t address, uint8_t *data, uint8_t len) {
   return this->raw_receive(address, data, len);
 }
-bool I2CComponent::read_bytes_16(uint8_t address, uint8_t a_register, uint16_t *data, uint8_t len,
-                                 uint32_t conversion) {
-  if (!this->write_bytes(address, a_register, nullptr, 0))
-    return false;
-
-  if (conversion > 0)
-    delay(conversion);
-  return this->raw_receive_16(address, data, len);
-}
 bool I2CComponent::read_bytes_16(uint8_t address, uint16_t a_register, uint16_t *data, uint8_t len,
-                                 uint32_t conversion) {
+                                 uint32_t conversion, uint8_t a_register_width) {
   if (!this->write_bytes(address, a_register, nullptr, 0))
     return false;
 
@@ -164,25 +146,16 @@ bool I2CComponent::read_bytes_16(uint8_t address, uint16_t a_register, uint16_t 
     delay(conversion);
   return this->raw_receive_16(address, data, len);
 }
-bool I2CComponent::read_byte(uint8_t address, uint8_t a_register, uint8_t *data, uint32_t conversion) {
-  return this->read_bytes(address, a_register, data, 1, conversion);
-}
-bool I2CComponent::read_byte(uint8_t address, uint16_t a_register, uint8_t *data, uint32_t conversion) {
-  return this->read_bytes(address, a_register, data, 1, conversion);
+bool I2CComponent::read_byte(uint8_t address, uint16_t a_register, uint8_t *data, uint32_t conversion, uint8_t a_register_width) {
+  return this->read_bytes(address, a_register, data, 1, conversion, a_register_width);
 }
 
-bool I2CComponent::read_byte_16(uint8_t address, uint8_t a_register, uint16_t *data, uint32_t conversion) {
-  return this->read_bytes_16(address, a_register, data, 1, conversion);
+bool I2CComponent::read_byte_16(uint8_t address, uint16_t a_register, uint16_t *data, uint32_t conversion, uint8_t a_register_width) {
+  return this->read_bytes_16(address, a_register, data, 1, conversion, a_register_width);
 }
-bool I2CComponent::write_bytes(uint8_t address, uint8_t a_register, const uint8_t *data, uint8_t len) {
+bool I2CComponent::write_bytes(uint8_t address, uint16_t a_register, const uint8_t *data, uint8_t len, uint8_t a_register_width) {
   this->raw_begin_transmission(address);
-  this->raw_write(address, &a_register, 1);
-  this->raw_write(address, data, len);
-  return this->raw_end_transmission(address);
-}
-bool I2CComponent::write_bytes(uint8_t address, uint16_t a_register, const uint8_t *data, uint8_t len) {
-  this->raw_begin_transmission(address);
-  this->raw_write_16(address, &a_register, 1);
+  (a_register_width == 8) ? this->raw_write(address, (uint8_t*)&a_register, 1) : this->raw_write_16(address, &a_register, 1);
   this->raw_write(address, data, len);
   return this->raw_end_transmission(address);
 }
@@ -191,79 +164,43 @@ bool I2CComponent::write_bytes_raw(uint8_t address, const uint8_t *data, uint8_t
   this->raw_write(address, data, len);
   return this->raw_end_transmission(address);
 }
-bool I2CComponent::write_bytes_16(uint8_t address, uint8_t a_register, const uint16_t *data, uint8_t len) {
+bool I2CComponent::write_bytes_16(uint8_t address, uint16_t a_register, const uint16_t *data, uint8_t len, uint8_t a_register_width) {
   this->raw_begin_transmission(address);
-  this->raw_write(address, &a_register, 1);
+  (a_register_width == 8) ? this->raw_write(address, (uint8_t*)&a_register, 1) : this->raw_write_16(address, &a_register, 1);
   this->raw_write_16(address, data, len);
   return this->raw_end_transmission(address);
 }
-bool I2CComponent::write_bytes_16(uint8_t address, uint16_t a_register, const uint16_t *data, uint8_t len) {
-  this->raw_begin_transmission(address);
-  this->raw_write_16(address, &a_register, 1);
-  this->raw_write_16(address, data, len);
-  return this->raw_end_transmission(address);
+bool I2CComponent::write_byte(uint8_t address, uint16_t a_register, uint8_t data, uint8_t a_register_width) {
+  return this->write_bytes(address, a_register, &data, 1, a_register_width);
 }
-bool I2CComponent::write_byte(uint8_t address, uint8_t a_register, uint8_t data) {
-  return this->write_bytes(address, a_register, &data, 1);
-}
-bool I2CComponent::write_byte(uint8_t address, uint16_t a_register, uint8_t data) {
-  return this->write_bytes(address, a_register, &data, 1);
-}
-bool I2CComponent::write_byte_16(uint8_t address, uint8_t a_register, uint16_t data) {
-  return this->write_bytes_16(address, a_register, &data, 1);
-}
-bool I2CComponent::write_byte_16(uint8_t address, uint16_t a_register, uint16_t data) {
-  return this->write_bytes_16(address, a_register, &data, 1);
+bool I2CComponent::write_byte_16(uint8_t address, uint16_t a_register, uint16_t data, uint8_t a_register_width) {
+  return this->write_bytes_16(address, a_register, &data, 1, a_register_width);
 }
 
 void I2CDevice::set_i2c_address(uint8_t address) { this->address_ = address; }
-bool I2CDevice::read_bytes(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_bytes(this->address_, a_register, data, len, conversion);
+bool I2CDevice::read_bytes(uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->read_bytes(this->address_, a_register, data, len, conversion, a_register_width);
 }
-bool I2CDevice::read_bytes(uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_bytes(this->address_, a_register, data, len, conversion);
+bool I2CDevice::read_byte(uint16_t a_register, uint8_t *data, uint32_t conversion, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->read_byte(this->address_, a_register, data, conversion, a_register_width);
 }
-bool I2CDevice::read_byte(uint8_t a_register, uint8_t *data, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_byte(this->address_, a_register, data, conversion);
+bool I2CDevice::write_bytes(uint16_t a_register, const uint8_t *data, uint8_t len, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->write_bytes(this->address_, a_register, data, len, a_register_width);
 }
-bool I2CDevice::read_byte(uint16_t a_register, uint8_t *data, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_byte(this->address_, a_register, data, conversion);
+bool I2CDevice::write_byte(uint16_t a_register, uint8_t data, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->write_byte(this->address_, a_register, data, a_register_width);
 }
-bool I2CDevice::write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len) {  // NOLINT
-  return this->parent_->write_bytes(this->address_, a_register, data, len);
+bool I2CDevice::read_bytes_16(uint16_t a_register, uint16_t *data, uint8_t len, uint32_t conversion, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->read_bytes_16(this->address_, a_register, data, len, conversion, a_register_width);
 }
-bool I2CDevice::write_bytes(uint16_t a_register, const uint8_t *data, uint8_t len) {  // NOLINT
-  return this->parent_->write_bytes(this->address_, a_register, data, len);
+bool I2CDevice::read_byte_16(uint16_t a_register, uint16_t *data, uint32_t conversion, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->read_byte_16(this->address_, a_register, data, conversion, a_register_width);
 }
-bool I2CDevice::write_byte(uint8_t a_register, uint8_t data) {  // NOLINT
-  return this->parent_->write_byte(this->address_, a_register, data);
+bool I2CDevice::write_bytes_16(uint16_t a_register, const uint16_t *data, uint8_t len, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->write_bytes_16(this->address_, a_register, data, len, a_register_width);
 }
-bool I2CDevice::write_byte(uint16_t a_register, uint8_t data) {  // NOLINT
-  return this->parent_->write_byte(this->address_, a_register, data);
-}
-bool I2CDevice::read_bytes_16(uint8_t a_register, uint16_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_bytes_16(this->address_, a_register, data, len, conversion);
-}
-bool I2CDevice::read_bytes_16(uint16_t a_register, uint16_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_bytes_16(this->address_, a_register, data, len, conversion);
-}
-bool I2CDevice::read_byte_16(uint8_t a_register, uint16_t *data, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_byte_16(this->address_, a_register, data, conversion);
-}
-bool I2CDevice::read_byte_16(uint16_t a_register, uint16_t *data, uint32_t conversion) {  // NOLINT
-  return this->parent_->read_byte_16(this->address_, a_register, data, conversion);
-}
-bool I2CDevice::write_bytes_16(uint8_t a_register, const uint16_t *data, uint8_t len) {  // NOLINT
-  return this->parent_->write_bytes_16(this->address_, a_register, data, len);
-}
-bool I2CDevice::write_bytes_16(uint16_t a_register, const uint16_t *data, uint8_t len) {  // NOLINT
-  return this->parent_->write_bytes_16(this->address_, a_register, data, len);
-}
-bool I2CDevice::write_byte_16(uint8_t a_register, uint16_t data) {  // NOLINT
-  return this->parent_->write_byte_16(this->address_, a_register, data);
-}
-bool I2CDevice::write_byte_16(uint16_t a_register, uint16_t data) {  // NOLINT
-  return this->parent_->write_byte_16(this->address_, a_register, data);
+bool I2CDevice::write_byte_16(uint16_t a_register, uint16_t data, uint8_t a_register_width) {  // NOLINT
+  return this->parent_->write_byte_16(this->address_, a_register, data, a_register_width);
 }
 void I2CDevice::set_i2c_parent(I2CComponent *parent) { this->parent_ = parent; }
 
@@ -274,49 +211,34 @@ uint8_t next_i2c_bus_num_ = 0;
 // As the internal representation of an I2C register is now always 16 bit,
 // a check if the actual address is 8 bit or 16 bit is neccecary 
 I2CRegister &I2CRegister::operator=(uint8_t value) {
-  if (this->register_ >> 8 == 0x0) //upper 8bits are zero -> address = 8bit
-    this->parent_->write_byte((uint8_t)this->register_, value);
-  else
-    this->parent_->write_byte(this->register_, value);
+  this->parent_->write_byte(this->register_, value, this->register_width_);
   return *this;
 }
 
 I2CRegister &I2CRegister::operator&=(uint8_t value) {
-  if (this->register_ >> 8 == 0x0)
-    this->parent_->write_byte((uint8_t)this->register_, this->get() & value);
-  else
-    this->parent_->write_byte(this->register_, this->get() & value);
+  this->parent_->write_byte(this->register_, this->get() & value, this->register_width_);
   return *this;
 }
 
 I2CRegister &I2CRegister::operator|=(uint8_t value) {
-  if (this->register_ >> 8 == 0x0)
-    this->parent_->write_byte((uint8_t)this->register_, this->get() | value);
-  else
-    this->parent_->write_byte(this->register_, this->get() | value);
+  this->parent_->write_byte(this->register_, this->get() | value, this->register_width_);
   return *this;
 }
 
 uint8_t I2CRegister::get() {
   uint8_t value = 0x00;
-  if (this->register_ >> 8 == 0x0)
-    this->parent_->read_byte((uint8_t)this->register_, &value);
-  else
-    this->parent_->read_byte(this->register_, &value);
+  this->parent_->read_byte(this->register_, &value, this->register_width_);
   return value;
 }
 
 I2CRegister &I2CRegister::operator=(const std::vector<uint8_t> &value) {
-  if (this->register_ >> 8 == 0x0)
-    this->parent_->write_bytes((uint8_t)this->register_, value);
-  else
-    this->parent_->write_bytes(this->register_, value);
+  this->parent_->write_bytes(this->register_, value, this->register_width_);
   return *this;
 }
 
 
-uint16_t switch_lsb_msb_order(uint16_t a_register) {
-  return (a_register<<8) | (a_register>>(8));
+uint16_t switch_lsb_msb(uint16_t value) {
+  return (value<<8) | (value>>(8));
 }
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -159,6 +159,12 @@ bool I2CComponent::write_bytes(uint8_t address, uint8_t a_register, const uint8_
   this->raw_write(address, data, len);
   return this->raw_end_transmission(address);
 }
+bool I2CComponent::write_bytes(uint8_t address, uint16_t a_register, const uint8_t *data, uint8_t len) {
+  this->raw_begin_transmission(address);
+  this->raw_write_16(address, &a_register, 1);
+  this->raw_write(address, data, len);
+  return this->raw_end_transmission(address);
+}
 bool I2CComponent::write_bytes_raw(uint8_t address, const uint8_t *data, uint8_t len) {
   this->raw_begin_transmission(address);
   this->raw_write(address, data, len);
@@ -170,10 +176,22 @@ bool I2CComponent::write_bytes_16(uint8_t address, uint8_t a_register, const uin
   this->raw_write_16(address, data, len);
   return this->raw_end_transmission(address);
 }
+bool I2CComponent::write_bytes_16(uint8_t address, uint16_t a_register, const uint16_t *data, uint8_t len) {
+  this->raw_begin_transmission(address);
+  this->raw_write_16(address, &a_register, 1);
+  this->raw_write_16(address, data, len);
+  return this->raw_end_transmission(address);
+}
 bool I2CComponent::write_byte(uint8_t address, uint8_t a_register, uint8_t data) {
   return this->write_bytes(address, a_register, &data, 1);
 }
+bool I2CComponent::write_byte(uint8_t address, uint16_t a_register, uint8_t data) {
+  return this->write_bytes(address, a_register, &data, 1);
+}
 bool I2CComponent::write_byte_16(uint8_t address, uint8_t a_register, uint16_t data) {
+  return this->write_bytes_16(address, a_register, &data, 1);
+}
+bool I2CComponent::write_byte_16(uint8_t address, uint16_t a_register, uint16_t data) {
   return this->write_bytes_16(address, a_register, &data, 1);
 }
 
@@ -181,25 +199,49 @@ void I2CDevice::set_i2c_address(uint8_t address) { this->address_ = address; }
 bool I2CDevice::read_bytes(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
   return this->parent_->read_bytes(this->address_, a_register, data, len, conversion);
 }
+bool I2CDevice::read_bytes(uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
+  return this->parent_->read_bytes(this->address_, a_register, data, len, conversion);
+}
 bool I2CDevice::read_byte(uint8_t a_register, uint8_t *data, uint32_t conversion) {  // NOLINT
+  return this->parent_->read_byte(this->address_, a_register, data, conversion);
+}
+bool I2CDevice::read_byte(uint16_t a_register, uint8_t *data, uint32_t conversion) {  // NOLINT
   return this->parent_->read_byte(this->address_, a_register, data, conversion);
 }
 bool I2CDevice::write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len) {  // NOLINT
   return this->parent_->write_bytes(this->address_, a_register, data, len);
 }
+bool I2CDevice::write_bytes(uint16_t a_register, const uint8_t *data, uint8_t len) {  // NOLINT
+  return this->parent_->write_bytes(this->address_, a_register, data, len);
+}
 bool I2CDevice::write_byte(uint8_t a_register, uint8_t data) {  // NOLINT
+  return this->parent_->write_byte(this->address_, a_register, data);
+}
+bool I2CDevice::write_byte(uint16_t a_register, uint8_t data) {  // NOLINT
   return this->parent_->write_byte(this->address_, a_register, data);
 }
 bool I2CDevice::read_bytes_16(uint8_t a_register, uint16_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
   return this->parent_->read_bytes_16(this->address_, a_register, data, len, conversion);
 }
+bool I2CDevice::read_bytes_16(uint16_t a_register, uint16_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
+  return this->parent_->read_bytes_16(this->address_, a_register, data, len, conversion);
+}
 bool I2CDevice::read_byte_16(uint8_t a_register, uint16_t *data, uint32_t conversion) {  // NOLINT
+  return this->parent_->read_byte_16(this->address_, a_register, data, conversion);
+}
+bool I2CDevice::read_byte_16(uint16_t a_register, uint16_t *data, uint32_t conversion) {  // NOLINT
   return this->parent_->read_byte_16(this->address_, a_register, data, conversion);
 }
 bool I2CDevice::write_bytes_16(uint8_t a_register, const uint16_t *data, uint8_t len) {  // NOLINT
   return this->parent_->write_bytes_16(this->address_, a_register, data, len);
 }
+bool I2CDevice::write_bytes_16(uint16_t a_register, const uint16_t *data, uint8_t len) {  // NOLINT
+  return this->parent_->write_bytes_16(this->address_, a_register, data, len);
+}
 bool I2CDevice::write_byte_16(uint8_t a_register, uint16_t data) {  // NOLINT
+  return this->parent_->write_byte_16(this->address_, a_register, data);
+}
+bool I2CDevice::write_byte_16(uint16_t a_register, uint16_t data) {  // NOLINT
   return this->parent_->write_byte_16(this->address_, a_register, data);
 }
 void I2CDevice::set_i2c_parent(I2CComponent *parent) { this->parent_ = parent; }
@@ -212,14 +254,26 @@ I2CRegister &I2CRegister::operator=(uint8_t value) {
   this->parent_->write_byte(this->register_, value);
   return *this;
 }
+I2CRegister &I2CRegister::operator=(uint16_t value) {
+  this->parent_->write_byte(this->register16_, value);
+  return *this;
+}
 
 I2CRegister &I2CRegister::operator&=(uint8_t value) {
   this->parent_->write_byte(this->register_, this->get() & value);
   return *this;
 }
+I2CRegister &I2CRegister::operator&=(uint16_t value) {
+  this->parent_->write_byte(this->register16_, this->get() & value);
+  return *this;
+}
 
 I2CRegister &I2CRegister::operator|=(uint8_t value) {
   this->parent_->write_byte(this->register_, this->get() | value);
+  return *this;
+}
+I2CRegister &I2CRegister::operator|=(uint16_t value) {
+  this->parent_->write_byte(this->register16_, this->get() | value);
   return *this;
 }
 
@@ -228,9 +282,22 @@ uint8_t I2CRegister::get() {
   this->parent_->read_byte(this->register_, &value);
   return value;
 }
+uint16_t I2CRegister::get() {
+  uint16_t value = 0x0000;
+  this->parent_->read_byte(this->register16_, &value);
+  return value;
+}
 I2CRegister &I2CRegister::operator=(const std::vector<uint8_t> &value) {
   this->parent_->write_bytes(this->register_, value);
   return *this;
+}
+I2CRegister &I2CRegister::operator=(const std::vector<uint16_t> &value) {
+  this->parent_->write_bytes(this->register16_, value);
+  return *this;
+}
+
+unit16_t switch_lsb_msb_order(uint16_t a_register) {
+  return (a_register<<8) | (a_register>>(8));
 }
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -268,6 +268,8 @@ class I2CDevice {
   /// Write a single 16-bit word of data into the specified register. Return true if successful.
   bool write_byte_16(uint8_t a_register, uint16_t data);
 
+  uint16_t switch_lsb_msb_order(uint16_t a_register);
+
  protected:
   uint8_t address_{0x00};
   I2CComponent *parent_{nullptr};

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -42,6 +42,7 @@ class I2CComponent : public Component {
    * @return If the operation was successful.
    */
   bool read_bytes(uint8_t address, uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
+  bool read_bytes(uint8_t address, uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
   bool read_bytes_raw(uint8_t address, uint8_t *data, uint8_t len);
 
   /** Read len amount of 16-bit words (MSB first) from a register into data.
@@ -54,13 +55,13 @@ class I2CComponent : public Component {
    * @return If the operation was successful.
    */
   bool read_bytes_16(uint8_t address, uint8_t a_register, uint16_t *data, uint8_t len, uint32_t conversion = 0);
-
+  bool read_bytes_16(uint8_t address, uint16_t a_register, uint16_t *data, uint8_t len, uint32_t conversion = 0);
   /// Read a single byte from a register into the data variable. Return true if successful.
   bool read_byte(uint8_t address, uint8_t a_register, uint8_t *data, uint32_t conversion = 0);
-
+  bool read_byte(uint8_t address, uint16_t a_register, uint8_t *data, uint32_t conversion = 0);
   /// Read a single 16-bit words (MSB first) from a register into the data variable. Return true if successful.
   bool read_byte_16(uint8_t address, uint8_t a_register, uint16_t *data, uint32_t conversion = 0);
-
+  bool read_byte_16(uint8_t address, uint16_t a_register, uint16_t *data, uint32_t conversion = 0);
   /** Write len amount of 8-bit bytes to the specified register for address.
    *
    * @param address The address to use for the transmission.
@@ -70,8 +71,8 @@ class I2CComponent : public Component {
    * @return If the operation was successful.
    */
   bool write_bytes(uint8_t address, uint8_t a_register, const uint8_t *data, uint8_t len);
+  bool write_bytes(uint8_t address, uint16_t a_register, const uint8_t *data, uint8_t len);
   bool write_bytes_raw(uint8_t address, const uint8_t *data, uint8_t len);
-
   /** Write len amount of 16-bit words (MSB first) to the specified register for address.
    *
    * @param address The address to use for the transmission.
@@ -81,12 +82,13 @@ class I2CComponent : public Component {
    * @return If the operation was successful.
    */
   bool write_bytes_16(uint8_t address, uint8_t a_register, const uint16_t *data, uint8_t len);
-
+  bool write_bytes_16(uint8_t address, uint16_t a_register, const uint16_t *data, uint8_t len);
   /// Write a single byte of data into the specified register of address. Return true if successful.
   bool write_byte(uint8_t address, uint8_t a_register, uint8_t data);
-
+  bool write_byte(uint8_t address, uint16_t a_register, uint8_t data);
   /// Write a single 16-bit word of data into the specified register of address. Return true if successful.
   bool write_byte_16(uint8_t address, uint8_t a_register, uint16_t data);
+  bool write_byte_16(uint8_t address, uint16_t a_register, uint16_t data);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -139,17 +141,26 @@ class I2CDevice;
 class I2CRegister {
  public:
   I2CRegister(I2CDevice *parent, uint8_t a_register) : parent_(parent), register_(a_register) {}
-
+  I2CRegister(I2CDevice *parent, uint16_t a_register) : parent_(parent), register16_(a_register) {}
+  
+  // 8 bit version
   I2CRegister &operator=(uint8_t value);
   I2CRegister &operator=(const std::vector<uint8_t> &value);
   I2CRegister &operator&=(uint8_t value);
   I2CRegister &operator|=(uint8_t value);
+  //16 bit version 
+  I2CRegister &operator=(uint16_t value);
+  I2CRegister &operator=(const std::vector<uint16_t> &value);
+  I2CRegister &operator&=(uint16_t value);
+  I2CRegister &operator|=(uint16_t value);
 
   uint8_t get();
+  uint16_t get();
 
  protected:
   I2CDevice *parent_;
   uint8_t register_;
+  uint16_t register16_;
 };
 
 /** All components doing communication on the I2C bus should subclass I2CDevice.
@@ -172,6 +183,7 @@ class I2CDevice {
   void set_i2c_parent(I2CComponent *parent);
 
   I2CRegister reg(uint8_t a_register) { return {this, a_register}; }
+  I2CRegister reg(uint16_t a_register) { return {this, a_register}; }
 
   /** Read len amount of bytes from a register into data. Optionally with a conversion time after
    * writing the register value to the bus.
@@ -183,9 +195,17 @@ class I2CDevice {
    * @return If the operation was successful.
    */
   bool read_bytes(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
+  bool read_bytes(uint16_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
   bool read_bytes_raw(uint8_t *data, uint8_t len) { return this->parent_->read_bytes_raw(this->address_, data, len); }
 
   template<size_t N> optional<std::array<uint8_t, N>> read_bytes(uint8_t a_register) {
+    std::array<uint8_t, N> res;
+    if (!this->read_bytes(a_register, res.data(), N)) {
+      return {};
+    }
+    return res;
+  }
+  template<size_t N> optional<std::array<uint8_t, N>> read_bytes(uint16_t a_register) {
     std::array<uint8_t, N> res;
     if (!this->read_bytes(a_register, res.data(), N)) {
       return {};
@@ -209,11 +229,19 @@ class I2CDevice {
    * @return If the operation was successful.
    */
   bool read_bytes_16(uint8_t a_register, uint16_t *data, uint8_t len, uint32_t conversion = 0);
+  bool read_bytes_16(uint16_t a_register, uint16_t *data, uint8_t len, uint32_t conversion = 0);
 
   /// Read a single byte from a register into the data variable. Return true if successful.
   bool read_byte(uint8_t a_register, uint8_t *data, uint32_t conversion = 0);
+  bool read_byte(uint16_t a_register, uint8_t *data, uint32_t conversion = 0);
 
   optional<uint8_t> read_byte(uint8_t a_register) {
+    uint8_t data;
+    if (!this->read_byte(a_register, &data))
+      return {};
+    return data;
+  }
+  optional<uint8_t> read_byte(uint16_t a_register) {
     uint8_t data;
     if (!this->read_byte(a_register, &data))
       return {};
@@ -222,6 +250,7 @@ class I2CDevice {
 
   /// Read a single 16-bit words (MSB first) from a register into the data variable. Return true if successful.
   bool read_byte_16(uint8_t a_register, uint16_t *data, uint32_t conversion = 0);
+  bool read_byte_16(uint16_t a_register, uint16_t *data, uint32_t conversion = 0);
 
   /** Write len amount of 8-bit bytes to the specified register.
    *
@@ -231,6 +260,7 @@ class I2CDevice {
    * @return If the operation was successful.
    */
   bool write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len);
+  bool write_bytes(uint16_t a_register, const uint8_t *data, uint8_t len);
   bool write_bytes_raw(const uint8_t *data, uint8_t len) {
     return this->parent_->write_bytes_raw(this->address_, data, len);
   }
@@ -244,9 +274,15 @@ class I2CDevice {
   bool write_bytes(uint8_t a_register, const std::vector<uint8_t> &data) {
     return this->write_bytes(a_register, data.data(), data.size());
   }
+  bool write_bytes(uint16_t a_register, const std::vector<uint8_t> &data) {
+    return this->write_bytes(a_register, data.data(), data.size());
+  }
   bool write_bytes_raw(const std::vector<uint8_t> &data) { return this->write_bytes_raw(data.data(), data.size()); }
 
   template<size_t N> bool write_bytes(uint8_t a_register, const std::array<uint8_t, N> &data) {
+    return this->write_bytes(a_register, data.data(), data.size());
+  }
+  template<size_t N> bool write_bytes(uint16_t a_register, const std::array<uint8_t, N> &data) {
     return this->write_bytes(a_register, data.data(), data.size());
   }
   template<size_t N> bool write_bytes_raw(const std::array<uint8_t, N> &data) {
@@ -260,13 +296,17 @@ class I2CDevice {
    * @param len The amount of bytes to write to the bus.
    * @return If the operation was successful.
    */
+  
   bool write_bytes_16(uint8_t a_register, const uint16_t *data, uint8_t len);
+  bool write_bytes_16(uint16_t a_register, const uint16_t *data, uint8_t len);
 
   /// Write a single byte of data into the specified register. Return true if successful.
   bool write_byte(uint8_t a_register, uint8_t data);
+  bool write_byte(uint16_t a_register, uint8_t data);
 
   /// Write a single 16-bit word of data into the specified register. Return true if successful.
   bool write_byte_16(uint8_t a_register, uint16_t data);
+  bool write_byte_16(uint16_t a_register, uint16_t data);
 
  protected:
   uint8_t address_{0x00};


### PR DESCRIPTION
## Description:
Currently, the address registers are fixed to 8 bit. Some devices however use 16 bit address registers. The PR implements the usage of 16 bit address registers.
It tries to be as non-invasive as possible. Devices with 8bit address registers will not see any difference in terms of communication.

!!! This PR is not intended for merging yet. It compiles but was not tested yet. It should enable a discussion and further development !!!

**Related issue (if applicable):** fixes <link to issue>
<https://github.com/esphome/feature-requests/issues/875>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
