### PR TITLE
Update max31855.cpp

### DIFF
--- a/esphome/components/max31855/max31855.cpp
+++ b/esphome/components/max31855/max31855.cpp
@@ -44,7 +44,7 @@ void MAX31855Sensor::read_data_() {
   const uint32_t mem = data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3] << 0;
 
   // Verify we got data
-  if (mem != 0 && mem != 0xFFFFFFFF) {
+  if (mem != 0xFFFFFFFF) {
     this->status_clear_error();
   } else {
     ESP_LOGE(TAG, "No data received from MAX31855 (0x%08X). Check wiring!", mem);


### PR DESCRIPTION
line 47: mem 

It's valid to have mem value of zero (0) when the temperature of the IC and the k-probe equals exactly zero degrees. 
Optionally, you can check for bit 0 and 1 and 2 if they are set, because then the IC signals an error active.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
