### PR TITLE
Adds support for Tuya Climate temperature multiplier

### DIFF
--- a/esphome/components/tuya/climate/__init__.py
+++ b/esphome/components/tuya/climate/__init__.py
@@ -2,7 +2,6 @@ from esphome.components import climate
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import CONF_ID, CONF_SWITCH_DATAPOINT
-from esphome.util import Registry
 from .. import tuya_ns, CONF_TUYA_ID, Tuya
 
 DEPENDENCIES = ['tuya']

--- a/esphome/components/tuya/climate/__init__.py
+++ b/esphome/components/tuya/climate/__init__.py
@@ -2,14 +2,15 @@ from esphome.components import climate
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import CONF_ID, CONF_SWITCH_DATAPOINT
+from esphome.util import Registry
 from .. import tuya_ns, CONF_TUYA_ID, Tuya
 
 DEPENDENCIES = ['tuya']
 CODEOWNERS = ['@jesserockz']
 
-CONF_TARGET_TEMPERATURE_DATAPOINT = "target_temperature_datapoint"
-CONF_CURRENT_TEMPERATURE_DATAPOINT = "current_temperature_datapoint"
-# CONF_ECO_MODE_DATAPOINT = "eco_mode_datapoint"
+CONF_TARGET_TEMPERATURE_DATAPOINT = 'target_temperature_datapoint'
+CONF_CURRENT_TEMPERATURE_DATAPOINT = 'current_temperature_datapoint'
+CONF_TEMPERATURE_MULTIPLIER = 'temperature_multiplier'
 
 TuyaClimate = tuya_ns.class_('TuyaClimate', climate.Climate, cg.Component)
 
@@ -19,7 +20,7 @@ CONFIG_SCHEMA = cv.All(climate.CLIMATE_SCHEMA.extend({
     cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
     cv.Optional(CONF_TARGET_TEMPERATURE_DATAPOINT): cv.uint8_t,
     cv.Optional(CONF_CURRENT_TEMPERATURE_DATAPOINT): cv.uint8_t,
-    # cv.Optional(CONF_ECO_MODE_DATAPOINT): cv.uint8_t,
+    cv.Optional(CONF_TEMPERATURE_MULTIPLIER, default=1): cv.positive_float,
 }).extend(cv.COMPONENT_SCHEMA), cv.has_at_least_one_key(
     CONF_TARGET_TEMPERATURE_DATAPOINT, CONF_SWITCH_DATAPOINT))
 
@@ -38,5 +39,4 @@ def to_code(config):
         cg.add(var.set_target_temperature_id(config[CONF_TARGET_TEMPERATURE_DATAPOINT]))
     if CONF_CURRENT_TEMPERATURE_DATAPOINT in config:
         cg.add(var.set_current_temperature_id(config[CONF_CURRENT_TEMPERATURE_DATAPOINT]))
-    # if CONF_ECO_MODE_DATAPOINT in config:
-    #     cg.add(var.set_eco_mode_id(config[CONF_ECO_MODE_DATAPOINT]))
+    cg.add(var.set_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER]))

--- a/esphome/components/tuya/climate/tuya_climate.cpp
+++ b/esphome/components/tuya/climate/tuya_climate.cpp
@@ -24,15 +24,15 @@ void TuyaClimate::setup() {
       this->target_temperature = datapoint.value_int * this->temperature_multiplier_;
       this->compute_state_();
       this->publish_state();
-      ESP_LOGD(TAG, "MCU reported target temperature is: %d", datapoint.value_int);
+      ESP_LOGD(TAG, "MCU reported target temperature is: %.1f", this->target_temperature);
     });
   }
   if (this->current_temperature_id_.has_value()) {
     this->parent_->register_listener(*this->current_temperature_id_, [this](TuyaDatapoint datapoint) {
-      this->current_temperature = datapoint.value_int *= this->temperature_multiplier_;
+      this->current_temperature = datapoint.value_int * this->temperature_multiplier_;
       this->compute_state_();
       this->publish_state();
-      ESP_LOGD(TAG, "MCU reported current temperature is: %d", datapoint.value_int);
+      ESP_LOGD(TAG, "MCU reported current temperature is: %.1f", this->current_temperature);
     });
   }
 }
@@ -57,7 +57,7 @@ void TuyaClimate::control(const climate::ClimateCall &call) {
     datapoint.type = TuyaDatapointType::INTEGER;
     datapoint.value_int = (int) (this->target_temperature / this->temperature_multiplier_);
     this->parent_->set_datapoint_value(datapoint);
-    ESP_LOGD(TAG, "Setting target temperature: %d", datapoint.value_int);
+    ESP_LOGD(TAG, "Setting target temperature: %.1f", this->target_temperature);
   }
 
   this->compute_state_();

--- a/esphome/components/tuya/climate/tuya_climate.h
+++ b/esphome/components/tuya/climate/tuya_climate.h
@@ -18,7 +18,9 @@ class TuyaClimate : public climate::Climate, public Component {
   void set_current_temperature_id(uint8_t current_temperature_id) {
     this->current_temperature_id_ = current_temperature_id;
   }
-  // void set_eco_mode_id(uint8_t eco_mode_id) { this->eco_mode_id_ = eco_mode_id; }
+  void set_temperature_multiplier(float temperature_multiplier) {
+    this->temperature_multiplier_ = temperature_multiplier;
+  }
 
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
 
@@ -38,7 +40,7 @@ class TuyaClimate : public climate::Climate, public Component {
   optional<uint8_t> switch_id_{};
   optional<uint8_t> target_temperature_id_{};
   optional<uint8_t> current_temperature_id_{};
-  // optional<uint8_t> eco_mode_id_{};
+  float temperature_multiplier_{1.0f};
 };
 
 }  // namespace tuya

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -87,6 +87,7 @@ climate:
     id: tuya_climate
     switch_datapoint: 1
     target_temperature_datapoint: 3
+    temperature_multiplier: 0.5
 
 switch:
   - platform: tuya


### PR DESCRIPTION
## Description:
Some tuya based climate devices report the temperature with a multiplied factor. Tuya only uses `int` as its data type so this is required to get `.5` values.

```
[17:14:11][C][tuya:023]: Tuya:
[17:14:11][C][tuya:032]:   Datapoint 1: switch (value: OFF)     -- on/off
[17:14:11][C][tuya:034]:   Datapoint 2: int value (value: 42)   -- setpoint (21)
[17:14:11][C][tuya:034]:   Datapoint 3: int value (value: 47)   -- current temp (23.5)
[17:14:11][C][tuya:034]:   Datapoint 102: int value (value: 44) -- current floor temp (22)
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#756

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
