### PR TITLE
Adds new homeassistant.tag_scanned action

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -3,7 +3,8 @@ import esphome.config_validation as cv
 from esphome import automation
 from esphome.automation import Condition
 from esphome.const import CONF_DATA, CONF_DATA_TEMPLATE, CONF_ID, CONF_PASSWORD, CONF_PORT, \
-    CONF_REBOOT_TIMEOUT, CONF_SERVICE, CONF_VARIABLES, CONF_SERVICES, CONF_TRIGGER_ID, CONF_EVENT
+    CONF_REBOOT_TIMEOUT, CONF_SERVICE, CONF_VARIABLES, CONF_SERVICES, CONF_TRIGGER_ID, CONF_EVENT, \
+    CONF_TAG
 from esphome.core import coroutine_with_priority
 
 DEPENDENCIES = ['network']
@@ -134,6 +135,24 @@ def homeassistant_event_to_code(config, action_id, template_arg, args):
     for key, value in config[CONF_VARIABLES].items():
         templ = yield cg.templatable(value, args, None)
         cg.add(var.add_variable(key, templ))
+    yield var
+
+
+HOMEASSISTANT_TAG_SCANNED_ACTION_SCHEMA = cv.maybe_simple_value({
+    cv.GenerateID(): cv.use_id(APIServer),
+    cv.Required(CONF_TAG): cv.templatable(cv.string_strict),
+}, key=CONF_TAG)
+
+
+@automation.register_action('homeassistant.tag_scanned', HomeAssistantServiceCallAction,
+                            HOMEASSISTANT_TAG_SCANNED_ACTION_SCHEMA)
+def homeassistant_tag_scanned_to_code(config, action_id, template_arg, args):
+    serv = yield cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, serv, True)
+    cg.add(var.set_service('esphome.tag_scanned'))
+    templ = yield cg.templatable(config[CONF_TAG], args, cg.std_string)
+    cg.add(var.add_data('tag_id', templ))
+    cg.add(var.add_data('device_id', cg.App.get_name()))
     yield var
 
 

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -152,7 +152,6 @@ def homeassistant_tag_scanned_to_code(config, action_id, template_arg, args):
     cg.add(var.set_service('esphome.tag_scanned'))
     templ = yield cg.templatable(config[CONF_TAG], args, cg.std_string)
     cg.add(var.add_data('tag_id', templ))
-    cg.add(var.add_data('device_id', cg.App.get_name()))
     yield var
 
 

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -280,6 +280,9 @@ text_sensor:
           service: light.turn_on
           data:
             entity_id: light.my_light
+      - homeassistant.tag_scanned:
+          tag: 1234-abcd
+      - homeassistant.tag_scanned: 1234-abcd
   - platform: template
     name: "Template Text Sensor"
     lambda: |-


### PR DESCRIPTION
## Description:
This adds a new action which pushes a new event `esphome.tag_scanned` which can be picked up by home-assistant/core#40128 automatically to fire the internal tag events.

**Related issue (if applicable):** closes esphome/feature-requests#848

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#763

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
