### PR TITLE
Readds the battery level for xiaomi_hhccjcy01

### DIFF
--- a/esphome/components/xiaomi_hhccjcy01/sensor.py
+++ b/esphome/components/xiaomi_hhccjcy01/sensor.py
@@ -1,8 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, esp32_ble_tracker
-from esphome.const import CONF_MAC_ADDRESS, CONF_TEMPERATURE, \
-    UNIT_CELSIUS, ICON_THERMOMETER, UNIT_PERCENT, ICON_WATER_PERCENT, CONF_ID, \
+from esphome.const import CONF_BATTERY_LEVEL, CONF_MAC_ADDRESS, CONF_TEMPERATURE, \
+    UNIT_CELSIUS, ICON_THERMOMETER, UNIT_PERCENT, ICON_WATER_PERCENT, ICON_BATTERY, CONF_ID, \
     CONF_MOISTURE, CONF_ILLUMINANCE, ICON_BRIGHTNESS_5, UNIT_LUX, CONF_CONDUCTIVITY, \
     UNIT_MICROSIEMENS_PER_CENTIMETER, ICON_FLOWER
 
@@ -19,6 +19,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
     cv.Optional(CONF_MOISTURE): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 0),
     cv.Optional(CONF_ILLUMINANCE): sensor.sensor_schema(UNIT_LUX, ICON_BRIGHTNESS_5, 0),
+    cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(UNIT_PERCENT, ICON_BATTERY, 0),
     cv.Optional(CONF_CONDUCTIVITY):
         sensor.sensor_schema(UNIT_MICROSIEMENS_PER_CENTIMETER, ICON_FLOWER, 0),
 }).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
@@ -43,3 +44,6 @@ def to_code(config):
     if CONF_CONDUCTIVITY in config:
         sens = yield sensor.new_sensor(config[CONF_CONDUCTIVITY])
         cg.add(var.set_conductivity(sens))
+    if CONF_BATTERY_LEVEL in config:
+        sens = yield sensor.new_sensor(config[CONF_BATTERY_LEVEL])
+        cg.add(var.set_battery_level(sens))

--- a/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.cpp
+++ b/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.cpp
@@ -14,6 +14,7 @@ void XiaomiHHCCJCY01::dump_config() {
   LOG_SENSOR("  ", "Moisture", this->moisture_);
   LOG_SENSOR("  ", "Conductivity", this->conductivity_);
   LOG_SENSOR("  ", "Illuminance", this->illuminance_);
+  LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
 
 bool XiaomiHHCCJCY01::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
@@ -50,6 +51,8 @@ bool XiaomiHHCCJCY01::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
       this->conductivity_->publish_state(*res->conductivity);
     if (res->illuminance.has_value() && this->illuminance_ != nullptr)
       this->illuminance_->publish_state(*res->illuminance);
+    if (res->battery_level.has_value() && this->battery_level_ != nullptr)
+      this->battery_level_->publish_state(*res->battery_level);
     success = true;
   }
 

--- a/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
+++ b/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
@@ -22,6 +22,7 @@ class XiaomiHHCCJCY01 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   void set_moisture(sensor::Sensor *moisture) { moisture_ = moisture; }
   void set_conductivity(sensor::Sensor *conductivity) { conductivity_ = conductivity; }
   void set_illuminance(sensor::Sensor *illuminance) { illuminance_ = illuminance; }
+  void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
 
  protected:
   uint64_t address_;
@@ -29,6 +30,7 @@ class XiaomiHHCCJCY01 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   sensor::Sensor *moisture_{nullptr};
   sensor::Sensor *conductivity_{nullptr};
   sensor::Sensor *illuminance_{nullptr};
+  sensor::Sensor *battery_level_{nullptr};
 };
 
 }  // namespace xiaomi_hhccjcy01

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -101,6 +101,8 @@ sensor:
       name: "Xiaomi HHCCJCY01 Illuminance"
     conductivity:
       name: "Xiaomi HHCCJCY01 Soil Conductivity"
+    battery_level:
+      name: "Xiaomi HHCCJCY01 Battery Level"
   - platform: xiaomi_lywsdcgq
     mac_address: 7A:80:8E:19:36:BA
     temperature:


### PR DESCRIPTION
## Description:
`battery_level` was removed in #1027 with no explanation. It was never removed from the docs though. This adds the option back. 

I am unable to test as I do not have the device.


**Related issue (if applicable):** fixes esphome/issues#1485

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
