### PR TITLE
Fix behaviour of tuya dimmer

### DIFF
--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -19,9 +19,8 @@ CONFIG_SCHEMA = cv.All(light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend({
     cv.Optional(CONF_MIN_VALUE): cv.int_,
     cv.Optional(CONF_MAX_VALUE): cv.int_,
 
-    # Change the default gamma_correct and default transition length settings.
-    # The Tuya MCU handles transitions and gamma correction on its own.
-    cv.Optional(CONF_GAMMA_CORRECT, default=1.0): cv.positive_float,
+    # Change the default transition length setting.
+    # The Tuya MCU handles transitions on its own.
     cv.Optional(CONF_DEFAULT_TRANSITION_LENGTH, default='0s'): cv.positive_time_period_milliseconds,
 }).extend(cv.COMPONENT_SCHEMA), cv.has_at_least_one_key(CONF_DIMMER_DATAPOINT,
                                                         CONF_SWITCH_DATAPOINT))

--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -1,7 +1,7 @@
 from esphome.components import light
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import CONF_OUTPUT_ID, CONF_MIN_VALUE, CONF_MAX_VALUE, CONF_GAMMA_CORRECT, \
+from esphome.const import CONF_OUTPUT_ID, CONF_MIN_VALUE, CONF_MAX_VALUE, \
     CONF_DEFAULT_TRANSITION_LENGTH, CONF_SWITCH_DATAPOINT
 from .. import tuya_ns, CONF_TUYA_ID, Tuya
 

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -15,16 +15,29 @@ void TuyaLight::setup() {
       auto lower = std::min(this->min_value_, this->max_value_);
       auto upper = std::max(this->min_value_, this->max_value_);
       auto value = std::min(upper, std::max(lower, static_cast<int32_t>(datapoint.value_uint)));
+      float brightness = float(value - this->min_value_) / (this->max_value_ - this->min_value_);  // Don't use lower/upper here to allow inversion
+      brightness = powf(brightness, 1.0 / this->state_->get_gamma_correct()); // Apply inverse gamma correction
 
+      // Handle case where reported value is <= lower bound but not
+      // zero, but we don't want light to appear off by setting
+      // brightness = 0.0.
+      // This can occur when we sent a value near the lower bound
+      // and the returned value is not exactly what we set.
+      if (lower > 0 && brightness == 0.0f) {
+        brightness = 1.0 / (upper - lower);
+      }
+
+      ESP_LOGV(TAG, "Received brightness: %f %d", brightness, value);
       auto call = this->state_->make_call();
-      call.set_brightness(float(value - this->min_value_) / (this->max_value_ - this->min_value_)); // Don't use lower/upper here to allow inversion
+      call.set_brightness(brightness);
       call.perform();
     });
   }
+
   if (switch_id_.has_value()) {
     this->parent_->register_listener(*this->switch_id_, [this](TuyaDatapoint datapoint) {
       this->inhibit_next_send_ = true;
-
+      ESP_LOGV(TAG, "Received switch: %d", datapoint.value_bool);
       auto call = this->state_->make_call();
       call.set_state(datapoint.value_bool);
       call.perform();
@@ -57,22 +70,25 @@ void TuyaLight::write_state(light::LightState *state) {
 
   float brightness;
   state->current_values_as_brightness(&brightness);
-  auto brightness_int = static_cast<uint32_t>(brightness * (this->max_value_ - this->min_value_) + this->min_value_);
-  bool is_off = brightness == 0.0f;
+  bool is_on = brightness != 0.0f;
 
   if (this->dimmer_id_.has_value()) {
+    uint32_t brightness_int = std::ceil(brightness * (this->max_value_ - this->min_value_) + this->min_value_);
+    ESP_LOGV(TAG, "Setting brightness: %f %d", brightness, brightness_int);
+
     TuyaDatapoint datapoint{};
     datapoint.id = *this->dimmer_id_;
     datapoint.type = TuyaDatapointType::INTEGER;
-    datapoint.value_int = is_off ? 0 : brightness_int; // Ensure turn off even when min value is set
+    datapoint.value_int = is_on ? brightness_int : 0; // Ensure turn off even when min value is set
     parent_->set_datapoint_value(datapoint);
   }
 
   if (this->switch_id_.has_value()) {
+    ESP_LOGV(TAG, "Setting switch: %d", is_on);
     TuyaDatapoint datapoint{};
     datapoint.id = *this->switch_id_;
     datapoint.type = TuyaDatapointType::BOOLEAN;
-    datapoint.value_bool = is_off != 0.0f;
+    datapoint.value_bool = is_on;
     parent_->set_datapoint_value(datapoint);
   }
 }

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -9,6 +9,12 @@ static const char *TAG = "tuya.light";
 void TuyaLight::setup() {
   if (this->dimmer_id_.has_value()) {
     this->parent_->register_listener(*this->dimmer_id_, [this](TuyaDatapoint datapoint) {
+      // Ignore dimmer values received once switch is off, such as during switch-off
+      // fade out. This allows restoring the present brightness on next switch on
+      if (!this->state_->current_values.is_on()) {
+        return;
+      }
+
       this->inhibit_next_send_ = true;
 
       // Clip value to expected range, allowing for inverted range

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -15,8 +15,9 @@ void TuyaLight::setup() {
       auto lower = std::min(this->min_value_, this->max_value_);
       auto upper = std::max(this->min_value_, this->max_value_);
       auto value = std::min(upper, std::max(lower, static_cast<int32_t>(datapoint.value_uint)));
-      float brightness = float(value - this->min_value_) / (this->max_value_ - this->min_value_);  // Don't use lower/upper here to allow inversion
-      brightness = powf(brightness, 1.0 / this->state_->get_gamma_correct()); // Apply inverse gamma correction
+      float brightness = float(value - this->min_value_) /
+                         (this->max_value_ - this->min_value_);  // Don't use lower/upper here to allow inversion
+      brightness = powf(brightness, 1.0 / this->state_->get_gamma_correct());  // Apply inverse gamma correction
 
       // Handle case where reported value is <= lower bound but not
       // zero, but we don't want light to appear off by setting
@@ -79,7 +80,7 @@ void TuyaLight::write_state(light::LightState *state) {
     TuyaDatapoint datapoint{};
     datapoint.id = *this->dimmer_id_;
     datapoint.type = TuyaDatapointType::INTEGER;
-    datapoint.value_int = is_on ? brightness_int : 0; // Ensure turn off even when min value is set
+    datapoint.value_int = is_on ? brightness_int : 0;  // Ensure turn off even when min value is set
     parent_->set_datapoint_value(datapoint);
   }
 

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -9,16 +9,22 @@ static const char *TAG = "tuya.light";
 void TuyaLight::setup() {
   if (this->dimmer_id_.has_value()) {
     this->parent_->register_listener(*this->dimmer_id_, [this](TuyaDatapoint datapoint) {
-      auto call = this->state_->make_call();
+      this->inhibit_next_send_ = true;
+
+      // Clip value to expected range, allowing for inverted range
       auto lower = std::min(this->min_value_, this->max_value_);
       auto upper = std::max(this->min_value_, this->max_value_);
       auto value = std::min(upper, std::max(lower, static_cast<int32_t>(datapoint.value_uint)));
-      call.set_brightness(float(value - this->min_value_) / (this->max_value_ - this->min_value_));
+
+      auto call = this->state_->make_call();
+      call.set_brightness(float(value - this->min_value_) / (this->max_value_ - this->min_value_)); // Don't use lower/upper here to allow inversion
       call.perform();
     });
   }
   if (switch_id_.has_value()) {
     this->parent_->register_listener(*this->switch_id_, [this](TuyaDatapoint datapoint) {
+      this->inhibit_next_send_ = true;
+
       auto call = this->state_->make_call();
       call.set_state(datapoint.value_bool);
       call.perform();
@@ -43,41 +49,30 @@ light::LightTraits TuyaLight::get_traits() {
 void TuyaLight::setup_state(light::LightState *state) { state_ = state; }
 
 void TuyaLight::write_state(light::LightState *state) {
-  float brightness;
-  state->current_values_as_brightness(&brightness);
-
-  if (brightness == 0.0f) {
-    // turning off, first try via switch (if exists), then dimmer
-    if (switch_id_.has_value()) {
-      TuyaDatapoint datapoint{};
-      datapoint.id = *this->switch_id_;
-      datapoint.type = TuyaDatapointType::BOOLEAN;
-      datapoint.value_bool = false;
-      parent_->set_datapoint_value(datapoint);
-    } else if (dimmer_id_.has_value()) {
-      TuyaDatapoint datapoint{};
-      datapoint.id = *this->dimmer_id_;
-      datapoint.type = TuyaDatapointType::INTEGER;
-      datapoint.value_int = 0;
-      parent_->set_datapoint_value(datapoint);
-    }
+  // Don't echo state back to MCU
+  if (this->inhibit_next_send_) {
+    this->inhibit_next_send_ = false;
     return;
   }
 
+  float brightness;
+  state->current_values_as_brightness(&brightness);
   auto brightness_int = static_cast<uint32_t>(brightness * (this->max_value_ - this->min_value_) + this->min_value_);
+  bool is_off = brightness == 0.0f;
 
   if (this->dimmer_id_.has_value()) {
     TuyaDatapoint datapoint{};
     datapoint.id = *this->dimmer_id_;
     datapoint.type = TuyaDatapointType::INTEGER;
-    datapoint.value_int = brightness_int;
+    datapoint.value_int = is_off ? 0 : brightness_int; // Ensure turn off even when min value is set
     parent_->set_datapoint_value(datapoint);
   }
+
   if (this->switch_id_.has_value()) {
     TuyaDatapoint datapoint{};
     datapoint.id = *this->switch_id_;
     datapoint.type = TuyaDatapointType::BOOLEAN;
-    datapoint.value_bool = true;
+    datapoint.value_bool = is_off != 0.0f;
     parent_->set_datapoint_value(datapoint);
   }
 }

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -14,21 +14,18 @@ class TuyaLight : public Component, public light::LightOutput {
   void set_dimmer_id(uint8_t dimmer_id) { this->dimmer_id_ = dimmer_id; }
   void set_switch_id(uint8_t switch_id) { this->switch_id_ = switch_id; }
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
-  void set_min_value(uint32_t min_value) { min_value_ = min_value; }
-  void set_max_value(uint32_t max_value) { max_value_ = max_value; }
+  void set_min_value(int32_t min_value) { min_value_ = min_value; }
+  void set_max_value(int32_t max_value) { max_value_ = max_value; }
   light::LightTraits get_traits() override;
   void setup_state(light::LightState *state) override;
   void write_state(light::LightState *state) override;
 
  protected:
-  void update_dimmer_(uint32_t value);
-  void update_switch_(uint32_t value);
-
   Tuya *parent_;
   optional<uint8_t> dimmer_id_{};
   optional<uint8_t> switch_id_{};
-  uint32_t min_value_ = 0;
-  uint32_t max_value_ = 255;
+  int32_t min_value_ = 0;
+  int32_t max_value_ = 255;
   light::LightState *state_{nullptr};
 };
 

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -27,6 +27,7 @@ class TuyaLight : public Component, public light::LightOutput {
   int32_t min_value_ = 0;
   int32_t max_value_ = 255;
   light::LightState *state_{nullptr};
+  bool inhibit_next_send_ = false;
 };
 
 }  // namespace tuya


### PR DESCRIPTION
## Description:

- Fixed application of min/max to ensure brightness matches with sent/received values.
- Support inverted range dimmers (max < min).
- Fixed behaviour when physical button pushed, where the brightness would jump to 100% and then fade out.
- Added support for gamma correction.
- Support restoration of existing dimmer value on power-on remotely.

**Related issue (if applicable):** fixes esphome/issues#852 and fixes esphome/issues#1448

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#774

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
