### PR TITLE
1.15.2

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -3,7 +3,8 @@ import esphome.config_validation as cv
 from esphome import automation
 from esphome.automation import Condition
 from esphome.const import CONF_DATA, CONF_DATA_TEMPLATE, CONF_ID, CONF_PASSWORD, CONF_PORT, \
-    CONF_REBOOT_TIMEOUT, CONF_SERVICE, CONF_VARIABLES, CONF_SERVICES, CONF_TRIGGER_ID, CONF_EVENT
+    CONF_REBOOT_TIMEOUT, CONF_SERVICE, CONF_VARIABLES, CONF_SERVICES, CONF_TRIGGER_ID, CONF_EVENT, \
+    CONF_TAG
 from esphome.core import coroutine_with_priority
 
 DEPENDENCIES = ['network']
@@ -134,6 +135,23 @@ def homeassistant_event_to_code(config, action_id, template_arg, args):
     for key, value in config[CONF_VARIABLES].items():
         templ = yield cg.templatable(value, args, None)
         cg.add(var.add_variable(key, templ))
+    yield var
+
+
+HOMEASSISTANT_TAG_SCANNED_ACTION_SCHEMA = cv.maybe_simple_value({
+    cv.GenerateID(): cv.use_id(APIServer),
+    cv.Required(CONF_TAG): cv.templatable(cv.string_strict),
+}, key=CONF_TAG)
+
+
+@automation.register_action('homeassistant.tag_scanned', HomeAssistantServiceCallAction,
+                            HOMEASSISTANT_TAG_SCANNED_ACTION_SCHEMA)
+def homeassistant_tag_scanned_to_code(config, action_id, template_arg, args):
+    serv = yield cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, serv, True)
+    cg.add(var.set_service('esphome.tag_scanned'))
+    templ = yield cg.templatable(config[CONF_TAG], args, cg.std_string)
+    cg.add(var.add_data('tag_id', templ))
     yield var
 
 

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -11,6 +11,7 @@ static const char *TAG = "remote_receiver.esp32";
 
 void RemoteReceiverComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Remote Receiver...");
+  this->pin_->setup();
   rmt_config_t rmt{};
   this->config_rmt(rmt);
   rmt.gpio_num = gpio_num_t(this->pin_->get_pin());

--- a/esphome/components/xiaomi_hhccjcy01/sensor.py
+++ b/esphome/components/xiaomi_hhccjcy01/sensor.py
@@ -1,8 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, esp32_ble_tracker
-from esphome.const import CONF_MAC_ADDRESS, CONF_TEMPERATURE, \
-    UNIT_CELSIUS, ICON_THERMOMETER, UNIT_PERCENT, ICON_WATER_PERCENT, CONF_ID, \
+from esphome.const import CONF_BATTERY_LEVEL, CONF_MAC_ADDRESS, CONF_TEMPERATURE, \
+    UNIT_CELSIUS, ICON_THERMOMETER, UNIT_PERCENT, ICON_WATER_PERCENT, ICON_BATTERY, CONF_ID, \
     CONF_MOISTURE, CONF_ILLUMINANCE, ICON_BRIGHTNESS_5, UNIT_LUX, CONF_CONDUCTIVITY, \
     UNIT_MICROSIEMENS_PER_CENTIMETER, ICON_FLOWER
 
@@ -19,6 +19,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
     cv.Optional(CONF_MOISTURE): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 0),
     cv.Optional(CONF_ILLUMINANCE): sensor.sensor_schema(UNIT_LUX, ICON_BRIGHTNESS_5, 0),
+    cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(UNIT_PERCENT, ICON_BATTERY, 0),
     cv.Optional(CONF_CONDUCTIVITY):
         sensor.sensor_schema(UNIT_MICROSIEMENS_PER_CENTIMETER, ICON_FLOWER, 0),
 }).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
@@ -43,3 +44,6 @@ def to_code(config):
     if CONF_CONDUCTIVITY in config:
         sens = yield sensor.new_sensor(config[CONF_CONDUCTIVITY])
         cg.add(var.set_conductivity(sens))
+    if CONF_BATTERY_LEVEL in config:
+        sens = yield sensor.new_sensor(config[CONF_BATTERY_LEVEL])
+        cg.add(var.set_battery_level(sens))

--- a/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.cpp
+++ b/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.cpp
@@ -14,6 +14,7 @@ void XiaomiHHCCJCY01::dump_config() {
   LOG_SENSOR("  ", "Moisture", this->moisture_);
   LOG_SENSOR("  ", "Conductivity", this->conductivity_);
   LOG_SENSOR("  ", "Illuminance", this->illuminance_);
+  LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
 
 bool XiaomiHHCCJCY01::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
@@ -50,6 +51,8 @@ bool XiaomiHHCCJCY01::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
       this->conductivity_->publish_state(*res->conductivity);
     if (res->illuminance.has_value() && this->illuminance_ != nullptr)
       this->illuminance_->publish_state(*res->illuminance);
+    if (res->battery_level.has_value() && this->battery_level_ != nullptr)
+      this->battery_level_->publish_state(*res->battery_level);
     success = true;
   }
 

--- a/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
+++ b/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
@@ -22,6 +22,7 @@ class XiaomiHHCCJCY01 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   void set_moisture(sensor::Sensor *moisture) { moisture_ = moisture; }
   void set_conductivity(sensor::Sensor *conductivity) { conductivity_ = conductivity; }
   void set_illuminance(sensor::Sensor *illuminance) { illuminance_ = illuminance; }
+  void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
 
  protected:
   uint64_t address_;
@@ -29,6 +30,7 @@ class XiaomiHHCCJCY01 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   sensor::Sensor *moisture_{nullptr};
   sensor::Sensor *conductivity_{nullptr};
   sensor::Sensor *illuminance_{nullptr};
+  sensor::Sensor *battery_level_{nullptr};
 };
 
 }  // namespace xiaomi_hhccjcy01

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 15
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = f'{MAJOR_VERSION}.{MINOR_VERSION}'
 __version__ = f'{__short_version__}.{PATCH_VERSION}'
 

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -280,6 +280,9 @@ text_sensor:
           service: light.turn_on
           data:
             entity_id: light.my_light
+      - homeassistant.tag_scanned:
+          tag: 1234-abcd
+      - homeassistant.tag_scanned: 1234-abcd
   - platform: template
     name: "Template Text Sensor"
     lambda: |-

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -101,6 +101,8 @@ sensor:
       name: "Xiaomi HHCCJCY01 Illuminance"
     conductivity:
       name: "Xiaomi HHCCJCY01 Soil Conductivity"
+    battery_level:
+      name: "Xiaomi HHCCJCY01 Battery Level"
   - platform: xiaomi_lywsdcgq
     mac_address: 7A:80:8E:19:36:BA
     temperature:


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Debugging is twice as hard as writing the code in the first place. Therefore, if you write the code as cleverly as possible, you are, by definition, not smart enough to debug it."_

~ Brian Kernighan
- docs: Light triggers referenced in the "automation" guide. [docs#746](https://github.com/esphome/esphome-docs/pull/746)
- docs: specific MacOS Docker command to launch dashboard [docs#553](https://github.com/esphome/esphome-docs/pull/553)
- docs: Update index.rst [docs#757](https://github.com/esphome/esphome-docs/pull/757)
- esphome: Adds new homeassistant.tag_scanned action [esphome#1281](https://github.com/esphome/esphome/pull/1281)
- docs: add custom uart id usage [docs#765](https://github.com/esphome/esphome-docs/pull/765)
- esphome: Readds the battery level for xiaomi_hhccjcy01 [esphome#1288](https://github.com/esphome/esphome/pull/1288)
- esphome: fix(remote_receiver): Add missing pin setup for ESP32 [esphome#1252](https://github.com/esphome/esphome/pull/1252)
- docs: Add docs for homeassistant.tag_scanned action [docs#763](https://github.com/esphome/esphome-docs/pull/763)
