### PR TITLE
Updates align default for one of the printf overrides

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -299,7 +299,7 @@ void DisplayBuffer::printf(int x, int y, Font *font, TextAlign align, const char
 void DisplayBuffer::printf(int x, int y, Font *font, const char *format, ...) {
   va_list arg;
   va_start(arg, format);
-  this->vprintf_(x, y, font, COLOR_ON, TextAlign::CENTER_LEFT, format, arg);
+  this->vprintf_(x, y, font, COLOR_ON, TextAlign::TOP_LEFT, format, arg);
   va_end(arg);
 }
 void DisplayBuffer::set_writer(display_writer_t &&writer) { this->writer_ = writer; }


### PR DESCRIPTION
## Description:
Updates align default for one of the printf overrides to be consistent with the others

This is a breaking-change as it changes default behaviour.  
But the documentation states: 
``` text
By default, ESPHome will align the text at the top left
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
