### PR TITLE
Replace CENTER_LEFT with TOP_LEFT to match other printf function

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -299,7 +299,7 @@ void DisplayBuffer::printf(int x, int y, Font *font, TextAlign align, const char
 void DisplayBuffer::printf(int x, int y, Font *font, const char *format, ...) {
   va_list arg;
   va_start(arg, format);
-  this->vprintf_(x, y, font, COLOR_ON, TextAlign::CENTER_LEFT, format, arg);
+  this->vprintf_(x, y, font, COLOR_ON, TextAlign::TOP_LEFT, format, arg);
   va_end(arg);
 }
 void DisplayBuffer::set_writer(display_writer_t &&writer) { this->writer_ = writer; }


### PR DESCRIPTION
## Description:

When I tried to use the printf function within the display component, all of a sudden the text was not aligned as expected anymore.

So here are two examples with different default alignment.
Example 1:
```yaml
display:
  - platform: max7219digit
    cs_pin: D4
    num_chips: 4
    intensity: 15
    lambda: |-
      it.print(0, 0, id(digit_font), "Test");
```
![image](https://user-images.githubusercontent.com/1368405/93833269-6e98bc80-fc78-11ea-9a56-6ac618d1a708.png)


Example 2
```yaml
display:
  - platform: max7219digit
    cs_pin: D4
    num_chips: 4
    intensity: 15
    lambda: |-
      it.printf(0, 0, id(digit_font), "%s", id(matrix_text).state.c_str());
```
![image](https://user-images.githubusercontent.com/1368405/93833261-693b7200-fc78-11ea-8ecf-66570c01721b.png)


I'm able to fix this when changing the lambda function to this:
```yaml
it.printf(0, 0, id(digit_font), TextAlign::TOP_LEFT, "%s", id(matrix_text).state.c_str());
```

In order to fix this, I replaced `CENTER_LEFT` with `TOP_LEFT`. 

But the documentation states:

> By default, ESPHome will align the text at the top left

**Related issue (if applicable):** none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
