### PR TITLE
Improve safety and correctness of color computations

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -454,7 +454,7 @@ bool Image::get_pixel(int x, int y) const {
 }
 Color Image::get_color_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
-    return 0;
+    return Color();
   const uint32_t pos = (x + y * this->width_) * 3;
   const uint32_t color32 = (pgm_read_byte(this->data_start_ + pos + 2) << 0) |
                            (pgm_read_byte(this->data_start_ + pos + 1) << 8) |
@@ -463,7 +463,7 @@ Color Image::get_color_pixel(int x, int y) const {
 }
 Color Image::get_grayscale_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
-    return 0;
+    return Color();
   const uint32_t pos = (x + y * this->width_);
   const uint8_t gray = pgm_read_byte(this->data_start_ + pos);
   return Color(gray | gray << 8 | gray << 16 | gray << 24);

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -89,8 +89,8 @@ void SSD1306::setup() {
 
   set_brightness(this->brightness_);
 
-  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();    // ...write buffer, which actually clears the display's memory
+  this->fill(Color(BLACK));  // clear display - ensures we do not see garbage at power-on
+  this->display();           // ...write buffer, which actually clears the display's memory
 
   this->turn_on();
 }

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -114,9 +114,9 @@ void SSD1325::setup() {
   this->command(0x0D | 0x02);
   this->command(SSD1325_NORMALDISPLAY);  // set display mode
   set_brightness(this->brightness_);
-  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();    // ...write buffer, which actually clears the display's memory
-  this->turn_on();    // display ON
+  this->fill(Color(BLACK));  // clear display - ensures we do not see garbage at power-on
+  this->display();           // ...write buffer, which actually clears the display's memory
+  this->turn_on();           // display ON
 }
 void SSD1325::display() {
   this->command(SSD1325_SETCOLADDR);  // set column address

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -87,9 +87,9 @@ void SSD1351::setup() {
   this->data(0x80);
   this->data(0xC8);
   set_brightness(this->brightness_);
-  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();    // ...write buffer, which actually clears the display's memory
-  this->turn_on();    // display ON
+  this->fill(Color(BLACK));  // clear display - ensures we do not see garbage at power-on
+  this->display();           // ...write buffer, which actually clears the display's memory
+  this->turn_on();           // display ON
 }
 void SSD1351::display() {
   this->command(SSD1351_SETCOLUMN);  // set column address

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -31,18 +31,14 @@ struct Color {
     uint32_t raw_32;
   };
   inline Color() ALWAYS_INLINE : r(0), g(0), b(0), w(0) {}  // NOLINT
-  inline Color(float red, float green, float blue) ALWAYS_INLINE : r(uint8_t(red * 255)),
-                                                                   g(uint8_t(green * 255)),
-                                                                   b(uint8_t(blue * 255)),
-                                                                   w(0) {}
-  inline Color(float red, float green, float blue, float white) ALWAYS_INLINE : r(uint8_t(red * 255)),
-                                                                                g(uint8_t(green * 255)),
-                                                                                b(uint8_t(blue * 255)),
-                                                                                w(uint8_t(white * 255)) {}
-  inline Color(uint32_t colorcode) ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
-                                                   g((colorcode >> 8) & 0xFF),
-                                                   b((colorcode >> 0) & 0xFF),
-                                                   w((colorcode >> 24) & 0xFF) {}
+  inline Color(float red, float green, float blue, float white = 0.f) ALWAYS_INLINE : r(uint8_t(red * 255)),
+                                                                                      g(uint8_t(green * 255)),
+                                                                                      b(uint8_t(blue * 255)),
+                                                                                      w(uint8_t(white * 255)) {}
+  inline explicit Color(uint32_t colorcode) ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
+                                                            g((colorcode >> 8) & 0xFF),
+                                                            b((colorcode >> 0) & 0xFF),
+                                                            w((colorcode >> 24) & 0xFF) {}
   inline bool is_on() ALWAYS_INLINE { return this->raw_32 != 0; }
   inline Color &operator=(const Color &rhs) ALWAYS_INLINE {
     this->r = rhs.r;

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -56,8 +56,12 @@ struct Color {
   }
   inline uint8_t &operator[](uint8_t x) ALWAYS_INLINE { return this->raw[x]; }
   inline Color operator*(uint8_t scale) const ALWAYS_INLINE {
-    return Color(esp_scale8(this->red, scale), esp_scale8(this->green, scale), esp_scale8(this->blue, scale),
-                 esp_scale8(this->white, scale));
+    Color out;
+    out.red = esp_scale8(this->red, scale);
+    out.green = esp_scale8(this->green, scale);
+    out.blue = esp_scale8(this->blue, scale);
+    out.white = esp_scale8(this->white, scale);
+    return out;
   }
   inline Color &operator*=(uint8_t scale) ALWAYS_INLINE {
     this->red = esp_scale8(this->red, scale);
@@ -67,8 +71,12 @@ struct Color {
     return *this;
   }
   inline Color operator*(const Color &scale) const ALWAYS_INLINE {
-    return Color(esp_scale8(this->red, scale.red), esp_scale8(this->green, scale.green),
-                 esp_scale8(this->blue, scale.blue), esp_scale8(this->white, scale.white));
+    Color out;
+    out.red = esp_scale8(this->red, scale.red);
+    out.green = esp_scale8(this->green, scale.green);
+    out.blue = esp_scale8(this->blue, scale.blue);
+    out.white = esp_scale8(this->white, scale.white);
+    return out;
   }
   inline Color &operator*=(const Color &scale) ALWAYS_INLINE {
     this->red = esp_scale8(this->red, scale.red);
@@ -98,7 +106,11 @@ struct Color {
     return ret;
   }
   inline Color &operator+=(const Color &add) ALWAYS_INLINE { return *this = (*this) + add; }
-  inline Color operator+(uint8_t add) const ALWAYS_INLINE { return (*this) + Color(add, add, add, add); }
+  inline Color operator+(uint8_t add) const ALWAYS_INLINE {
+    Color addend;
+    addend.r = addend.g = addend.b = addend.w = add;
+    return (*this) + addend;
+  }
   inline Color &operator+=(uint8_t add) ALWAYS_INLINE { return *this = (*this) + add; }
   inline Color operator-(const Color &subtract) const ALWAYS_INLINE {
     Color ret;
@@ -122,7 +134,9 @@ struct Color {
   }
   inline Color &operator-=(const Color &subtract) ALWAYS_INLINE { return *this = (*this) - subtract; }
   inline Color operator-(uint8_t subtract) const ALWAYS_INLINE {
-    return (*this) - Color(subtract, subtract, subtract, subtract);
+    Color subtrahend;
+    subtrahend.r = subtrahend.g = subtrahend.b = subtrahend.w = subtract;
+    return (*this) - subtrahend;
   }
   inline Color &operator-=(uint8_t subtract) ALWAYS_INLINE { return *this = (*this) - subtract; }
   static Color random_color() {


### PR DESCRIPTION
## Description:
Fixes issue with `Color::fade_to_black` being basically a step function because its underlying `operator*` was incorrectly converting `uint8_t` color components to `float` without the appropriate scaling factor.

These changes make integer conversions to `Color` stricter and fixes issues with `operator*`, `operator+`, and `operator-` each creating temporaries from `uint8_t` color components as if they had range 0–1.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    _xo: not sure where to write C++ unit tests_

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
