### PR TITLE
Pn532 upgrades

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,7 +42,9 @@ esphome/components/network/* @esphome/core
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core
 esphome/components/pid/* @OttoWinter
-esphome/components/pn532/* @OttoWinter
+esphome/components/pn532/* @OttoWinter @jesserockz
+esphome/components/pn532_i2c/* @OttoWinter @jesserockz
+esphome/components/pn532_spi/* @OttoWinter @jesserockz
 esphome/components/power_supply/* @esphome/core
 esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -1,30 +1,37 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import spi
-from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID
+from esphome.const import CONF_ON_TAG, CONF_TRIGGER_ID
+from esphome.core import coroutine
 
-CODEOWNERS = ['@OttoWinter']
-DEPENDENCIES = ['spi']
+CODEOWNERS = ['@OttoWinter', '@jesserockz']
 AUTO_LOAD = ['binary_sensor']
 MULTI_CONF = True
 
+CONF_PN532_ID = 'pn532_id'
+
 pn532_ns = cg.esphome_ns.namespace('pn532')
-PN532 = pn532_ns.class_('PN532', cg.PollingComponent, spi.SPIDevice)
+PN532 = pn532_ns.class_('PN532', cg.PollingComponent)
+
 PN532Trigger = pn532_ns.class_('PN532Trigger', automation.Trigger.template(cg.std_string))
 
-CONFIG_SCHEMA = cv.Schema({
+PN532_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(PN532),
     cv.Optional(CONF_ON_TAG): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PN532Trigger),
     }),
-}).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema())
+}).extend(cv.polling_component_schema('1s'))
 
 
-def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+def CONFIG_SCHEMA(conf):
+    if conf:
+        raise cv.Invalid("This component has been moved in 1.16, please see the docs for updated "
+                         "instructions. https://esphome.io/components/binary_sensor/pn532.html")
+
+
+@coroutine
+def setup_pn532(var, config):
     yield cg.register_component(var, config)
-    yield spi.register_spi_device(var, config)
 
     for conf in config.get(CONF_ON_TAG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])

--- a/esphome/components/pn532/binary_sensor.py
+++ b/esphome/components/pn532/binary_sensor.py
@@ -3,11 +3,9 @@ import esphome.config_validation as cv
 from esphome.components import binary_sensor
 from esphome.const import CONF_UID, CONF_ID
 from esphome.core import HexInt
-from . import pn532_ns, PN532
+from . import pn532_ns, PN532, CONF_PN532_ID
 
 DEPENDENCIES = ['pn532']
-
-CONF_PN532_ID = 'pn532_id'
 
 
 def validate_uid(value):

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -156,7 +156,7 @@ void PN532::loop() {
     trigger->process(nfcid);
 
   if (report) {
-    ESP_LOGD(TAG, "Found tag '%s'", format_uid(nfcid).c_str());
+    ESP_LOGD(TAG, "Found new tag '%s'", format_uid(nfcid).c_str());
   }
 
   this->turn_off_rf_();

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -24,16 +24,14 @@ void format_uid(char *buf, const uint8_t *uid, uint8_t uid_length) {
 void PN532::setup() {
   ESP_LOGCONFIG(TAG, "Setting up PN532...");
 
-  delay(20);
-
   // Get version data
-  if (!this->pn532_write_command_check_ack_({0x02})) {
+  if (!this->write_command_({0x02})) {
     ESP_LOGE(TAG, "Error sending version command");
     this->mark_failed();
     return;
   }
 
-  std::vector<uint8_t> version_data = this->pn532_read_data();
+  auto version_data = this->read_response_();
 
   if (version_data.empty()) {
     ESP_LOGE(TAG, "Error getting version");
@@ -43,25 +41,19 @@ void PN532::setup() {
   ESP_LOGD(TAG, "Found chip PN%02X", version_data[0]);
   ESP_LOGD(TAG, "Firmware ver. %d.%d", version_data[1], version_data[2]);
 
-  this->pn532_write_command({
-      0x14,  // SAM config command
-      0x01,  // normal mode
-      0x14,  // zero timeout (not in virtual card mode)
-      0x01,
-  });
-
-  delay(2);
-
-  if (!this->read_ack()) {
+  if (!this->write_command_({
+          0x14,  // SAM config command
+          0x01,  // normal mode
+          0x14,  // zero timeout (not in virtual card mode)
+          0x01,
+      })) {
     ESP_LOGE(TAG, "No wakeup ack");
     this->mark_failed();
     return;
   }
 
-  delay(5);
-
   // read data packet for wakeup result
-  std::vector<uint8_t> wakeup_result = this->pn532_read_data();
+  auto wakeup_result = this->read_response_();
   if (wakeup_result.size() != 1) {
     this->error_code_ = WAKEUP_FAILED;
     this->mark_failed();
@@ -70,20 +62,18 @@ void PN532::setup() {
 
   // Set up SAM (secure access module)
   uint8_t sam_timeout = std::min(255u, this->update_interval_ / 50);
-  bool ret = this->pn532_write_command_check_ack_({
-      0x14,         // SAM config command
-      0x01,         // normal mode
-      sam_timeout,  // timeout as multiple of 50ms (actually only for virtual card mode, but shouldn't matter)
-      0x01,         // Enable IRQ
-  });
-
-  if (!ret) {
+  if (!this->write_command_({
+          0x14,         // SAM config command
+          0x01,         // normal mode
+          sam_timeout,  // timeout as multiple of 50ms (actually only for virtual card mode, but shouldn't matter)
+          0x01,         // Enable IRQ
+      })) {
     this->error_code_ = SAM_COMMAND_FAILED;
     this->mark_failed();
     return;
   }
 
-  std::vector<uint8_t> sam_result = this->pn532_read_data();
+  auto sam_result = this->read_response_();
   if (sam_result.size() != 1) {
     ESP_LOGV(TAG, "Invalid SAM result: (%u)", sam_result.size());  // NOLINT
     for (uint8_t dat : sam_result) {
@@ -101,12 +91,11 @@ void PN532::update() {
   for (auto *obj : this->binary_sensors_)
     obj->on_scan_end();
 
-  bool success = this->pn532_write_command_check_ack_({
-      0x4A,  // INLISTPASSIVETARGET
-      0x01,  // max 1 card
-      0x00,  // baud rate ISO14443A (106 kbit/s)
-  });
-  if (!success) {
+  if (!this->write_command_({
+          0x4A,  // INLISTPASSIVETARGET
+          0x01,  // max 1 card
+          0x00,  // baud rate ISO14443A (106 kbit/s)
+      })) {
     ESP_LOGW(TAG, "Requesting tag read failed!");
     this->status_set_warning();
     return;
@@ -119,7 +108,7 @@ void PN532::loop() {
   if (!this->requested_read_)
     return;
 
-  auto read = this->pn532_read_data();
+  auto read = this->read_response_();
   this->requested_read_ = false;
 
   if (read.size() <= 2 || read[0] != 0x4B) {
@@ -169,122 +158,14 @@ void PN532::loop() {
 
 void PN532::turn_off_rf_() {
   ESP_LOGVV(TAG, "Turning RF field OFF");
-  this->pn532_write_command_check_ack_({
+  this->write_command_({
       0x32,  // RFConfiguration
       0x1,   // RF Field
       0x0    // Off
   });
 }
 
-float PN532::get_setup_priority() const { return setup_priority::LATE; }
-
-bool PN532::pn532_write_command_check_ack_(const std::vector<uint8_t> &data) {
-  // 1. write command
-  this->pn532_write_command(data);
-
-  // 2. wait for readiness
-  if (!this->wait_ready_())
-    return false;
-
-  // 3. read ack
-  if (!this->read_ack()) {
-    ESP_LOGV(TAG, "Invalid ACK frame received from PN532!");
-    return false;
-  }
-
-  return true;
-}
-
-bool PN532::wait_ready_() {
-  uint32_t start_time = millis();
-  while (!this->is_ready()) {
-    if (millis() - start_time > 100) {
-      ESP_LOGE(TAG, "Timed out waiting for readiness from PN532!");
-      return false;
-    }
-    yield();
-  }
-  return true;
-}
-
-void PN532::dump_config() {
-  ESP_LOGCONFIG(TAG, "PN532:");
-  switch (this->error_code_) {
-    case NONE:
-      break;
-    case WAKEUP_FAILED:
-      ESP_LOGE(TAG, "Wake Up command failed!");
-      break;
-    case SAM_COMMAND_FAILED:
-      ESP_LOGE(TAG, "SAM command failed!");
-      break;
-  }
-
-  LOG_UPDATE_INTERVAL(this);
-
-  for (auto *child : this->binary_sensors_) {
-    LOG_BINARY_SENSOR("  ", "Tag", child);
-  }
-}
-
-std::vector<uint8_t> PN532::pn532_read_data() {
-  std::vector<uint8_t> header = this->pn532_read_bytes(3);
-
-  if (header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF) {
-    // invalid packet
-    ESP_LOGV(TAG, "read data invalid preamble!");
-    return {};
-  }
-
-  std::vector<uint8_t> header2 = this->pn532_read_bytes(3);
-
-  bool valid_header = (header[0] == 0x00 &&                                                        // preamble
-                       header[1] == 0x00 &&                                                        // start code
-                       header[2] == 0xFF && static_cast<uint8_t>(header2[0] + header2[1]) == 0 &&  // LCS, len + lcs = 0
-                       header2[2] == 0xD5  // TFI - frame from PN532 to system controller
-  );
-  if (!valid_header) {
-    ESP_LOGV(TAG, "read data invalid header!");
-    return {};
-  }
-
-  // full length of message, including TFI
-  uint8_t full_len = header2[0];
-  // length of data, excluding TFI
-  uint8_t len = full_len - 1;
-  if (full_len == 0)
-    len = 0;
-
-  std::vector<uint8_t> ret = this->pn532_read_bytes(len);
-
-  uint8_t checksum = 0xD5;
-  for (uint8_t dat : ret)
-    checksum += dat;
-  checksum = ~checksum + 1;
-
-  std::vector<uint8_t> dcs = this->pn532_read_bytes(1);
-  if (dcs[0] != checksum) {
-    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", dcs[0], checksum);
-    return {};
-  }
-
-  std::vector<uint8_t> postamble = this->pn532_read_bytes(1);
-  if (postamble[0] != 0x00) {
-    ESP_LOGV(TAG, "read data invalid postamble!");
-    return {};
-  }
-
-#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-  ESP_LOGVV(TAG, "PN532 Data Frame: (%u)", ret.size());  // NOLINT
-  for (uint8_t dat : ret) {
-    ESP_LOGVV(TAG, "  0x%02X", dat);
-  }
-#endif
-
-  return ret;
-}
-
-void PN532::pn532_write_command(const std::vector<uint8_t> &data) {
+bool PN532::write_command_(const std::vector<uint8_t> &data) {
   std::vector<uint8_t> write_data;
   // Preamble
   write_data.push_back(0x00);
@@ -316,21 +197,134 @@ void PN532::pn532_write_command(const std::vector<uint8_t> &data) {
   // Postamble
   write_data.push_back(0x00);
 
-  this->pn532_write_bytes(write_data);
+  this->write_data(write_data);
+
+  return this->read_ack();
 }
 
-bool PN532::read_ack() {
+std::vector<uint8_t> PN532::read_response_() {
+  uint8_t len = this->read_response_length_();
+  if (len < 0) {
+    return {};
+  }
+
+  std::vector<uint8_t> data = this->read_data(6 + len + 2);
+  if (data.empty()) {
+    return {};
+  }
+
+  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
+    // invalid packet
+    ESP_LOGV(TAG, "read data invalid preamble!");
+    return {};
+  }
+
+  bool valid_header = (static_cast<uint8_t>(data[4] + data[5]) == 0 &&  // LCS, len + lcs = 0
+                       data[6] == 0xD5);                                // TFI - frame from PN532 to system controller
+
+  if (!valid_header) {
+    ESP_LOGV(TAG, "read data invalid header!");
+    return {};
+  }
+
+  data.erase(data.begin(), data.begin() + 7);
+
+  uint8_t checksum = 0xD5;
+  for (int i = 0; i < len; i++) {
+    uint8_t dat = data[i];
+    checksum += dat;
+  }
+  checksum = ~checksum + 1;
+
+  if (data[len] != checksum) {
+    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", data[len], checksum);
+    return {};
+  }
+
+  if (data[len + 1] != 0x00) {
+    ESP_LOGV(TAG, "read data invalid postamble!");
+    return {};
+  }
+
+  data.erase(data.end() - 2, data.end());
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+  ESP_LOGD(TAG, "PN532 Data Frame: (%u)", data.size());  // NOLINT
+  for (uint8_t dat : data) {
+    ESP_LOGD(TAG, "  0x%02X", dat);
+  }
+#endif
+
+  return data;
+}
+
+uint8_t PN532::read_response_length_() {
+  std::vector<uint8_t> data = this->read_data(6);
+  if (data.empty()) {
+    return -1;
+  }
+
+  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
+    // invalid packet
+    ESP_LOGV(TAG, "read data invalid preamble!");
+    return -1;
+  }
+
+  bool valid_header = (static_cast<uint8_t>(data[4] + data[5]) == 0 &&  // LCS, len + lcs = 0
+                       data[6] == 0xD5);                                // TFI - frame from PN532 to system controller
+
+  if (!valid_header) {
+    ESP_LOGV(TAG, "read data invalid header!");
+    return -1;
+  }
+
+  this->write_data({0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00});  // NACK - Retransmit last message
+
+  // full length of message, including TFI
+  uint8_t full_len = data[4];
+  // length of data, excluding TFI
+  uint8_t len = full_len - 1;
+  if (full_len == 0)
+    len = 0;
+  return len;
+}
+
+bool PN532::read_ack_() {
   ESP_LOGVV(TAG, "Reading ACK...");
 
-  std::vector<uint8_t> ack = this->pn532_read_bytes(6);
+  std::vector<uint8_t> data = this->read_data(6);
+  if (data.empty()) {
+    return false;
+  }
 
-  bool matches = (ack[0] == 0x00 &&                    // preamble
-                  ack[1] == 0x00 &&                    // start of packet
-                  ack[2] == 0xFF && ack[3] == 0x00 &&  // ACK packet code
-                  ack[4] == 0xFF && ack[5] == 0x00     // postamble
-  );
+  bool matches = (data[1] == 0x00 &&                     // preamble
+                  data[2] == 0x00 &&                     // start of packet
+                  data[3] == 0xFF && data[4] == 0x00 &&  // ACK packet code
+                  data[5] == 0xFF && data[6] == 0x00);   // postamble
   ESP_LOGVV(TAG, "ACK valid: %s", YESNO(matches));
   return matches;
+}
+
+float PN532::get_setup_priority() const { return setup_priority::LATE; }
+
+void PN532::dump_config() {
+  ESP_LOGCONFIG(TAG, "PN532:");
+  switch (this->error_code_) {
+    case NONE:
+      break;
+    case WAKEUP_FAILED:
+      ESP_LOGE(TAG, "Wake Up command failed!");
+      break;
+    case SAM_COMMAND_FAILED:
+      ESP_LOGE(TAG, "SAM command failed!");
+      break;
+  }
+
+  LOG_UPDATE_INTERVAL(this);
+
+  for (auto *child : this->binary_sensors_) {
+    LOG_BINARY_SENSOR("  ", "Tag", child);
+  }
 }
 
 bool PN532BinarySensor::process(const uint8_t *data, uint8_t len) {

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -208,7 +208,7 @@ bool PN532::write_command_(const std::vector<uint8_t> &data) {
   return this->read_ack_();
 }
 
-bool PN532::read_response_(uint8_t command, std::vector<uint8_t> &response) {
+bool PN532::read_response_(uint8_t command, std::vector<uint8_t> &data) {
   ESP_LOGV(TAG, "Reading response");
   uint8_t len = this->read_response_length_();
   if (len == 0) {
@@ -216,8 +216,7 @@ bool PN532::read_response_(uint8_t command, std::vector<uint8_t> &response) {
   }
 
   ESP_LOGV(TAG, "Reading response of length %d", len);
-  std::vector<uint8_t> data = this->read_data(6 + len + 2);
-  if (data.empty()) {
+  if (!this->read_data(data, 6 + len + 2)) {
     ESP_LOGD(TAG, "No response data");
     return false;
   }
@@ -270,8 +269,8 @@ bool PN532::read_response_(uint8_t command, std::vector<uint8_t> &response) {
 }
 
 uint8_t PN532::read_response_length_() {
-  std::vector<uint8_t> data = this->read_data(6);
-  if (data.empty()) {
+  std::vector<uint8_t> data;
+  if (!this->read_data(data, 6)) {
     return 0;
   }
 
@@ -303,8 +302,8 @@ uint8_t PN532::read_response_length_() {
 bool PN532::read_ack_() {
   ESP_LOGVV(TAG, "Reading ACK...");
 
-  std::vector<uint8_t> data = this->read_data(6);
-  if (data.empty()) {
+  std::vector<uint8_t> data;
+  if (!this->read_data(data, 6)) {
     return false;
   }
 

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -25,7 +25,7 @@ void PN532::setup() {
   ESP_LOGCONFIG(TAG, "Setting up PN532...");
 
   // Get version data
-  if (!this->write_command_({0x02})) {
+  if (!this->write_command_({PN532_COMMAND_VERSION_DATA})) {
     ESP_LOGE(TAG, "Error sending version command");
     this->mark_failed();
     return;
@@ -42,7 +42,7 @@ void PN532::setup() {
   ESP_LOGD(TAG, "Firmware ver. %d.%d", version_data[1], version_data[2]);
 
   if (!this->write_command_({
-          0x14,  // SAM config command
+          PN532_COMMAND_SAMCONFIGURATION,
           0x01,  // normal mode
           0x14,  // zero timeout (not in virtual card mode)
           0x01,
@@ -63,7 +63,7 @@ void PN532::setup() {
   // Set up SAM (secure access module)
   uint8_t sam_timeout = std::min(255u, this->update_interval_ / 50);
   if (!this->write_command_({
-          0x14,         // SAM config command
+          PN532_COMMAND_SAMCONFIGURATION,
           0x01,         // normal mode
           sam_timeout,  // timeout as multiple of 50ms (actually only for virtual card mode, but shouldn't matter)
           0x01,         // Enable IRQ
@@ -92,7 +92,7 @@ void PN532::update() {
     obj->on_scan_end();
 
   if (!this->write_command_({
-          0x4A,  // INLISTPASSIVETARGET
+          PN532_COMMAND_INLISTPASSIVETARGET,
           0x01,  // max 1 card
           0x00,  // baud rate ISO14443A (106 kbit/s)
       })) {
@@ -159,7 +159,7 @@ void PN532::loop() {
 void PN532::turn_off_rf_() {
   ESP_LOGVV(TAG, "Turning RF field OFF");
   this->write_command_({
-      0x32,  // RFConfiguration
+      PN532_COMMAND_RFCONFIGURATION,
       0x1,   // RF Field
       0x0    // Off
   });

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -28,20 +28,12 @@ void PN532::setup() {
   this->pn532_write_commandcheck_ack_({0x02});  // get firmware version command
   // do not actually read any data, this should be OK according to datasheet
 
-  this->pn532_write_command({
-      0x14,  // SAM config command
+  this->pn532_write_command_check_ack_({
+      PN532_COMMAND_SAMCONFIGURATION,
       0x01,  // normal mode
       0x14,  // zero timeout (not in virtual card mode)
       0x01,
   });
-
-  // do not wait for ready bit, this is a dummy command
-  delay(2);
-
-  // Try to read ACK, if it fails it might be because there's data from a previous power cycle left
-  this->read_ack();
-  // do not wait for ready bit for return data
-  delay(5);
 
   // read data packet for wakeup result
   auto wakeup_result = this->pn532_read_data();
@@ -97,8 +89,9 @@ void PN532::update() {
   this->status_clear_warning();
   this->requested_read_ = true;
 }
+
 void PN532::loop() {
-  if (!this->requested_read_ || !this->is_ready())
+  if (!this->requested_read_)
     return;
 
   auto read = this->pn532_read_data();

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -24,8 +24,7 @@ void format_uid(char *buf, const uint8_t *uid, uint8_t uid_length) {
 void PN532::setup() {
   ESP_LOGCONFIG(TAG, "Setting up PN532...");
 
-
-  delay(1000);
+  delay(20);
 
   // Get version data
   if (!this->pn532_write_command_check_ack_({0x02})) {
@@ -36,7 +35,7 @@ void PN532::setup() {
 
   std::vector<uint8_t> version_data = this->pn532_read_data();
 
-  if (version_data.size() == 0) {
+  if (version_data.empty()) {
     ESP_LOGE(TAG, "Error getting version");
     this->mark_failed();
     return;
@@ -53,7 +52,7 @@ void PN532::setup() {
 
   delay(2);
 
-  if(!this->read_ack()) {
+  if (!this->read_ack()) {
     ESP_LOGE(TAG, "No wakeup ack");
     this->mark_failed();
     return;

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -23,22 +23,12 @@ void format_uid(char *buf, const uint8_t *uid, uint8_t uid_length) {
 
 void PN532::setup() {
   ESP_LOGCONFIG(TAG, "Setting up PN532...");
-  this->spi_setup();
-
-  // Wake the chip up from power down
-  // 1. Enable the SS line for at least 2ms
-  // 2. Send a dummy command to get the protocol synced up
-  //    (this may time out, but that's ok)
-  // 3. Send SAM config command with normal mode without waiting for ready bit (IRQ not initialized yet)
-  // 4. Probably optional, send SAM config again, this time checking ACK and return value
-  this->cs_->digital_write(false);
-  delay(10);
 
   // send dummy firmware version command to get synced up
-  this->pn532_write_command_check_ack_({0x02});  // get firmware version command
+  this->pn532_write_commandcheck_ack_({0x02});  // get firmware version command
   // do not actually read any data, this should be OK according to datasheet
 
-  this->pn532_write_command_({
+  this->pn532_write_command({
       0x14,  // SAM config command
       0x01,  // normal mode
       0x14,  // zero timeout (not in virtual card mode)
@@ -49,12 +39,12 @@ void PN532::setup() {
   delay(2);
 
   // Try to read ACK, if it fails it might be because there's data from a previous power cycle left
-  this->read_ack_();
+  this->read_ack();
   // do not wait for ready bit for return data
   delay(5);
 
   // read data packet for wakeup result
-  auto wakeup_result = this->pn532_read_data_();
+  auto wakeup_result = this->pn532_read_data();
   if (wakeup_result.size() != 1) {
     this->error_code_ = WAKEUP_FAILED;
     this->mark_failed();
@@ -63,7 +53,7 @@ void PN532::setup() {
 
   // Set up SAM (secure access module)
   uint8_t sam_timeout = std::min(255u, this->update_interval_ / 50);
-  bool ret = this->pn532_write_command_check_ack_({
+  bool ret = this->pn532_write_commandcheck_ack_({
       0x14,         // SAM config command
       0x01,         // normal mode
       sam_timeout,  // timeout as multiple of 50ms (actually only for virtual card mode, but shouldn't matter)
@@ -76,7 +66,7 @@ void PN532::setup() {
     return;
   }
 
-  auto sam_result = this->pn532_read_data_();
+  auto sam_result = this->pn532_read_data();
   if (sam_result.size() != 1) {
     ESP_LOGV(TAG, "Invalid SAM result: (%u)", sam_result.size());  // NOLINT
     for (auto dat : sam_result) {
@@ -94,7 +84,7 @@ void PN532::update() {
   for (auto *obj : this->binary_sensors_)
     obj->on_scan_end();
 
-  bool success = this->pn532_write_command_check_ack_({
+  bool success = this->pn532_write_commandcheck_ack_({
       0x4A,  // INLISTPASSIVETARGET
       0x01,  // max 1 card
       0x00,  // baud rate ISO14443A (106 kbit/s)
@@ -108,10 +98,10 @@ void PN532::update() {
   this->requested_read_ = true;
 }
 void PN532::loop() {
-  if (!this->requested_read_ || !this->is_ready_())
+  if (!this->requested_read_ || !this->is_ready())
     return;
 
-  auto read = this->pn532_read_data_();
+  auto read = this->pn532_read_data();
   this->requested_read_ = false;
 
   if (read.size() <= 2 || read[0] != 0x4B) {
@@ -161,7 +151,7 @@ void PN532::loop() {
 
 void PN532::turn_off_rf_() {
   ESP_LOGVV(TAG, "Turning RF field OFF");
-  this->pn532_write_command_check_ack_({
+  this->pn532_write_commandcheck_ack_({
       0x32,  // RFConfiguration
       0x1,   // RF Field
       0x0    // Off
@@ -170,55 +160,16 @@ void PN532::turn_off_rf_() {
 
 float PN532::get_setup_priority() const { return setup_priority::DATA; }
 
-void PN532::pn532_write_command_(const std::vector<uint8_t> &data) {
-  this->enable();
-  delay(2);
-  // First byte, communication mode: Write data
-  this->write_byte(0x01);
-
-  // Preamble
-  this->write_byte(0x00);
-
-  // Start code
-  this->write_byte(0x00);
-  this->write_byte(0xFF);
-
-  // Length of message, TFI + data bytes
-  const uint8_t real_length = data.size() + 1;
-  // LEN
-  this->write_byte(real_length);
-  // LCS (Length checksum)
-  this->write_byte(~real_length + 1);
-
-  // TFI (Frame Identifier, 0xD4 means to PN532, 0xD5 means from PN532)
-  this->write_byte(0xD4);
-  // calculate checksum, TFI is part of checksum
-  uint8_t checksum = 0xD4;
-
-  // DATA
-  for (uint8_t dat : data) {
-    this->write_byte(dat);
-    checksum += dat;
-  }
-
-  // DCS (Data checksum)
-  this->write_byte(~checksum + 1);
-  // Postamble
-  this->write_byte(0x00);
-
-  this->disable();
-}
-
-bool PN532::pn532_write_command_check_ack_(const std::vector<uint8_t> &data) {
+bool PN532::pn532_write_commandcheck_ack_(const std::vector<uint8_t> &data) {
   // 1. write command
-  this->pn532_write_command_(data);
+  this->pn532_write_command(data);
 
   // 2. wait for readiness
   if (!this->wait_ready_())
     return false;
 
   // 3. read ack
-  if (!this->read_ack_()) {
+  if (!this->read_ack()) {
     ESP_LOGV(TAG, "Invalid ACK frame received from PN532!");
     return false;
   }
@@ -226,122 +177,9 @@ bool PN532::pn532_write_command_check_ack_(const std::vector<uint8_t> &data) {
   return true;
 }
 
-std::vector<uint8_t> PN532::pn532_read_data_() {
-  this->enable();
-  delay(2);
-  // Read data (transmission from the PN532 to the host)
-  this->write_byte(0x03);
-
-  // sometimes preamble is not transmitted for whatever reason
-  // mostly happens during startup.
-  // just read the first two bytes and check if that is the case
-  uint8_t header[6];
-  this->read_array(header, 2);
-  if (header[0] == 0x00 && header[1] == 0x00) {
-    // normal packet, preamble included
-    this->read_array(header + 2, 4);
-  } else if (header[0] == 0x00 && header[1] == 0xFF) {
-    // weird packet, preamble skipped; make it look like a normal packet
-    header[0] = 0x00;
-    header[1] = 0x00;
-    header[2] = 0xFF;
-    this->read_array(header + 3, 3);
-  } else {
-    // invalid packet
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid preamble!");
-    return {};
-  }
-
-  bool valid_header = (header[0] == 0x00 &&                                                      // preamble
-                       header[1] == 0x00 &&                                                      // start code
-                       header[2] == 0xFF && static_cast<uint8_t>(header[3] + header[4]) == 0 &&  // LCS, len + lcs = 0
-                       header[5] == 0xD5  // TFI - frame from PN532 to system controller
-  );
-  if (!valid_header) {
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid header!");
-    return {};
-  }
-
-  std::vector<uint8_t> ret;
-  // full length of message, including TFI
-  const uint8_t full_len = header[3];
-  // length of data, excluding TFI
-  uint8_t len = full_len - 1;
-  if (full_len == 0)
-    len = 0;
-
-  ret.resize(len);
-  this->read_array(ret.data(), len);
-
-  uint8_t checksum = 0xD5;
-  for (uint8_t dat : ret)
-    checksum += dat;
-  checksum = ~checksum + 1;
-
-  uint8_t dcs = this->read_byte();
-  if (dcs != checksum) {
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", dcs, checksum);
-    return {};
-  }
-
-  if (this->read_byte() != 0x00) {
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid postamble!");
-    return {};
-  }
-  this->disable();
-
-#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-  ESP_LOGVV(TAG, "PN532 Data Frame: (%u)", ret.size());  // NOLINT
-  for (uint8_t dat : ret) {
-    ESP_LOGVV(TAG, "  0x%02X", dat);
-  }
-#endif
-
-  return ret;
-}
-bool PN532::is_ready_() {
-  this->enable();
-  // First byte, communication mode: Read state
-  this->write_byte(0x02);
-  // PN532 returns a single data byte,
-  // "After having sent a command, the host controller must wait for bit 0 of Status byte equals 1
-  // before reading the data from the PN532."
-  bool ret = this->read_byte() == 0x01;
-  this->disable();
-
-  if (ret) {
-    ESP_LOGVV(TAG, "Chip is ready!");
-  }
-  return ret;
-}
-bool PN532::read_ack_() {
-  ESP_LOGVV(TAG, "Reading ACK...");
-  this->enable();
-  delay(2);
-  // "Read data (transmission from the PN532 to the host) "
-  this->write_byte(0x03);
-
-  uint8_t ack[6];
-  memset(ack, 0, sizeof(ack));
-
-  this->read_array(ack, 6);
-  this->disable();
-
-  bool matches = (ack[0] == 0x00 &&                    // preamble
-                  ack[1] == 0x00 &&                    // start of packet
-                  ack[2] == 0xFF && ack[3] == 0x00 &&  // ACK packet code
-                  ack[4] == 0xFF && ack[5] == 0x00     // postamble
-  );
-  ESP_LOGVV(TAG, "ACK valid: %s", YESNO(matches));
-  return matches;
-}
 bool PN532::wait_ready_() {
   uint32_t start_time = millis();
-  while (!this->is_ready_()) {
+  while (!this->is_ready()) {
     if (millis() - start_time > 100) {
       ESP_LOGE(TAG, "Timed out waiting for readiness from PN532!");
       return false;
@@ -364,7 +202,6 @@ void PN532::dump_config() {
       break;
   }
 
-  LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
 
   for (auto *child : this->binary_sensors_) {

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -33,12 +33,12 @@ class PN532 : public PollingComponent {
  protected:
   void turn_off_rf_();
   bool write_command_(const std::vector<uint8_t> &data);
-  bool read_response_(uint8_t command, std::vector<uint8_t> &response);
+  bool read_response_(uint8_t command, std::vector<uint8_t> &data);
   bool read_ack_();
   uint8_t read_response_length_();
 
   virtual bool write_data(const std::vector<uint8_t> &data) = 0;
-  virtual std::vector<uint8_t> read_data(uint8_t len) = 0;
+  virtual bool read_data(std::vector<uint8_t> &data, uint8_t len) = 0;
 
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -26,8 +26,8 @@ class PN532 : public PollingComponent {
 
  protected:
   /// Write the full command given in data to the PN532
-  virtual void pn532_write_command(const std::vector<uint8_t> &data) = 0;
-  bool pn532_write_commandcheck_ack_(const std::vector<uint8_t> &data);
+  virtual void pn532_write_command_(const std::vector<uint8_t> &data);
+  bool pn532_write_command_check_ack_(const std::vector<uint8_t> &data);
 
   /** Read a data frame from the PN532 and return the result as a vector.
    *
@@ -35,7 +35,7 @@ class PN532 : public PollingComponent {
    *
    * On failure, an empty vector is returned.
    */
-  virtual std::vector<uint8_t> pn532_read_data() = 0;
+  virtual std::vector<uint8_t> pn532_read_data_();
 
   /** Checks if the PN532 has set its ready status flag.
    *
@@ -50,9 +50,12 @@ class PN532 : public PollingComponent {
   virtual bool is_ready() = 0;
   bool wait_ready_();
 
-  virtual bool read_ack() = 0;
+  virtual bool read_ack_();
 
   void turn_off_rf_();
+
+  virtual std::vector<uint8_t> pn532_read_bytes(uint8_t len) = 0;
+  virtual void pn532_write_bytes(std::vector<uint8_t> data) = 0;
 
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -3,7 +3,6 @@
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/spi/spi.h"
 
 namespace esphome {
 namespace pn532 {
@@ -11,9 +10,7 @@ namespace pn532 {
 class PN532BinarySensor;
 class PN532Trigger;
 
-class PN532 : public PollingComponent,
-              public spi::SPIDevice<spi::BIT_ORDER_LSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
-                                    spi::DATA_RATE_1MHZ> {
+class PN532 : public PollingComponent {
  public:
   void setup() override;
 
@@ -29,8 +26,8 @@ class PN532 : public PollingComponent,
 
  protected:
   /// Write the full command given in data to the PN532
-  void pn532_write_command_(const std::vector<uint8_t> &data);
-  bool pn532_write_command_check_ack_(const std::vector<uint8_t> &data);
+  virtual void pn532_write_command(const std::vector<uint8_t> &data) = 0;
+  bool pn532_write_commandcheck_ack_(const std::vector<uint8_t> &data);
 
   /** Read a data frame from the PN532 and return the result as a vector.
    *
@@ -38,22 +35,22 @@ class PN532 : public PollingComponent,
    *
    * On failure, an empty vector is returned.
    */
-  std::vector<uint8_t> pn532_read_data_();
+  virtual std::vector<uint8_t> pn532_read_data() = 0;
 
   /** Checks if the PN532 has set its ready status flag.
    *
    * Procedure goes as follows:
    * - Host sends command to PN532 "write data"
-   * - Wait for readiness (until PN532 has processed command) by polling "read status"/is_ready_
+   * - Wait for readiness (until PN532 has processed command) by polling "read status"/is_ready
    * - Parse ACK/NACK frame with "read data" byte
    *
    * - If data required, wait until device reports readiness again
    * - Then call "read data" and read certain number of bytes (length is given at offset 4 of frame)
    */
-  bool is_ready_();
+  virtual bool is_ready() = 0;
   bool wait_ready_();
 
-  bool read_ack_();
+  virtual bool read_ack() = 0;
 
   void turn_off_rf_();
 

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -26,7 +26,7 @@ class PN532 : public PollingComponent {
 
  protected:
   /// Write the full command given in data to the PN532
-  virtual void pn532_write_command_(const std::vector<uint8_t> &data);
+  virtual void pn532_write_command(const std::vector<uint8_t> &data);
   bool pn532_write_command_check_ack_(const std::vector<uint8_t> &data);
 
   /** Read a data frame from the PN532 and return the result as a vector.
@@ -35,7 +35,7 @@ class PN532 : public PollingComponent {
    *
    * On failure, an empty vector is returned.
    */
-  virtual std::vector<uint8_t> pn532_read_data_();
+  virtual std::vector<uint8_t> pn532_read_data();
 
   /** Checks if the PN532 has set its ready status flag.
    *
@@ -50,7 +50,7 @@ class PN532 : public PollingComponent {
   virtual bool is_ready() = 0;
   bool wait_ready_();
 
-  virtual bool read_ack_();
+  virtual bool read_ack();
 
   void turn_off_rf_();
 

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -25,37 +25,14 @@ class PN532 : public PollingComponent {
   void register_trigger(PN532Trigger *trig) { this->triggers_.push_back(trig); }
 
  protected:
-  /// Write the full command given in data to the PN532
-  virtual void pn532_write_command(const std::vector<uint8_t> &data);
-  bool pn532_write_command_check_ack_(const std::vector<uint8_t> &data);
-
-  /** Read a data frame from the PN532 and return the result as a vector.
-   *
-   * Note that is_ready needs to be checked first before requesting this method.
-   *
-   * On failure, an empty vector is returned.
-   */
-  virtual std::vector<uint8_t> pn532_read_data();
-
-  /** Checks if the PN532 has set its ready status flag.
-   *
-   * Procedure goes as follows:
-   * - Host sends command to PN532 "write data"
-   * - Wait for readiness (until PN532 has processed command) by polling "read status"/is_ready
-   * - Parse ACK/NACK frame with "read data" byte
-   *
-   * - If data required, wait until device reports readiness again
-   * - Then call "read data" and read certain number of bytes (length is given at offset 4 of frame)
-   */
-  virtual bool is_ready() = 0;
-  bool wait_ready_();
-
-  virtual bool read_ack();
-
   void turn_off_rf_();
+  bool write_command_(const std::vector<uint8_t> &data);
+  std::vector<uint8_t> read_response_();
+  bool read_ack_();
+  uint8_t read_response_length_();
 
-  virtual std::vector<uint8_t> pn532_read_bytes(uint8_t len) = 0;
-  virtual void pn532_write_bytes(std::vector<uint8_t> data) = 0;
+  virtual bool write_data(const std::vector<uint8_t> &data) = 0;
+  virtual std::vector<uint8_t> read_data(uint8_t len) = 0;
 
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -33,7 +33,7 @@ class PN532 : public PollingComponent {
  protected:
   void turn_off_rf_();
   bool write_command_(const std::vector<uint8_t> &data);
-  std::vector<uint8_t> read_response_();
+  bool read_response_(uint8_t command, std::vector<uint8_t> &response);
   bool read_ack_();
   uint8_t read_response_length_();
 
@@ -43,6 +43,7 @@ class PN532 : public PollingComponent {
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;
   std::vector<PN532Trigger *> triggers_;
+  std::vector<uint8_t> current_uid_;
   enum PN532Error {
     NONE = 0,
     WAKEUP_FAILED,
@@ -54,7 +55,7 @@ class PN532BinarySensor : public binary_sensor::BinarySensor {
  public:
   void set_uid(const std::vector<uint8_t> &uid) { uid_ = uid; }
 
-  bool process(const uint8_t *data, uint8_t len);
+  bool process(std::vector<uint8_t> &data);
 
   void on_scan_end() {
     if (!this->found_) {
@@ -70,7 +71,7 @@ class PN532BinarySensor : public binary_sensor::BinarySensor {
 
 class PN532Trigger : public Trigger<std::string> {
  public:
-  void process(const uint8_t *uid, uint8_t uid_length);
+  void process(std::vector<uint8_t> &data);
 };
 
 }  // namespace pn532

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -7,6 +7,12 @@
 namespace esphome {
 namespace pn532 {
 
+static const uint8_t PN532_COMMAND_VERSION_DATA = 0x02;
+static const uint8_t PN532_COMMAND_SAMCONFIGURATION = 0x14;
+static const uint8_t PN532_COMMAND_RFCONFIGURATION = 0x32;
+static const uint8_t PN532_COMMAND_INDATAEXCHANGE = 0x40;
+static const uint8_t PN532_COMMAND_INLISTPASSIVETARGET = 0x4A;
+
 class PN532BinarySensor;
 class PN532Trigger;
 

--- a/esphome/components/pn532_i2c/__init__.py
+++ b/esphome/components/pn532_i2c/__init__.py
@@ -1,0 +1,21 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, pn532
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ['pn532']
+CODEOWNERS = ['@OttoWinter', '@jesserockz']
+DEPENDENCIES = ['i2c']
+
+pn532_i2c_ns = cg.esphome_ns.namespace('pn532_i2c')
+PN532I2C = pn532_i2c_ns.class_('PN532I2C', pn532.PN532, i2c.I2CDevice)
+
+CONFIG_SCHEMA = cv.All(pn532.PN532_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(PN532I2C),
+}).extend(i2c.i2c_device_schema(0x48)))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield pn532.setup_pn532(var, config)
+    yield i2c.register_i2c_device(var, config)

--- a/esphome/components/pn532_i2c/__init__.py
+++ b/esphome/components/pn532_i2c/__init__.py
@@ -12,7 +12,7 @@ PN532I2C = pn532_i2c_ns.class_('PN532I2C', pn532.PN532, i2c.I2CDevice)
 
 CONFIG_SCHEMA = cv.All(pn532.PN532_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(PN532I2C),
-}).extend(i2c.i2c_device_schema(0x48)))
+}).extend(i2c.i2c_device_schema(0x24)))
 
 
 def to_code(config):

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -13,7 +13,7 @@ static const char *TAG = "pn532_i2c";
 
 bool PN532I2C::write_data(const std::vector<uint8_t> &data) { return this->write_bytes_raw(data.data(), data.size()); }
 
-std::vector<uint8_t> PN532I2C::read_data(uint8_t len) {
+bool PN532I2C::read_data(std::vector<uint8_t> &data, uint8_t len) {
   delay(5);
 
   std::vector<uint8_t> ready;
@@ -27,14 +27,13 @@ std::vector<uint8_t> PN532I2C::read_data(uint8_t len) {
 
     if (millis() - start_time > 100) {
       ESP_LOGV(TAG, "Timed out waiting for readiness from PN532!");
-      return {};
+      return false;
     }
   }
 
-  std::vector<uint8_t> data;
   data.resize(len + 1);
   this->read_bytes_raw(data.data(), len + 1);
-  return data;
+  return true;
 }
 
 void PN532I2C::dump_config() {

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -11,134 +11,20 @@ namespace pn532_i2c {
 
 static const char *TAG = "pn532_i2c";
 
-void PN532I2C::pn532_write_command(const std::vector<uint8_t> &data) {
-  std::vector<uint8_t> write_data;
-  // Preamble
-  write_data.push_back(0x00);
-
-  // Start code
-  write_data.push_back(0x00);
-  write_data.push_back(0xFF);
-
-  // Length of message, TFI + data bytes
-  const uint8_t real_length = data.size() + 1;
-  // LEN
-  write_data.push_back(real_length);
-  // LCS (Length checksum)
-  write_data.push_back(~real_length + 1);
-
-  // TFI (Frame Identifier, 0xD4 means to PN532, 0xD5 means from PN532)
-  write_data.push_back(0xD4);
-  // calculate checksum, TFI is part of checksum
-  uint8_t checksum = 0xD4;
-
-  // DATA
-  for (uint8_t dat : data) {
-    write_data.push_back(dat);
-    checksum += dat;
-  }
-
-  // DCS (Data checksum)
-  write_data.push_back(~checksum + 1);
-  // Postamble
-  write_data.push_back(0x00);
-
-  this->write_bytes_raw(write_data);
-}
-
-std::vector<uint8_t> PN532I2C::pn532_read_data() {
-
+std::vector<uint8_t> PN532I2C::pn532_read_data_() {
   if (!this->wait_ready_())
     return {};
 
-  // sometimes preamble is not transmitted for whatever reason
-  // mostly happens during startup.
-  // just read the first two bytes and check if that is the case
-  uint8_t header[6];
-  this->read_bytes_raw(header, 3);
-  if (header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF) {
-    // invalid packet
-    ESP_LOGV(TAG, "read data invalid preamble!");
-    return {};
-  }
-
-  this->read_bytes_raw(header + 3, 3);
-
-  bool valid_header = (header[0] == 0x00 &&                                                      // preamble
-                       header[1] == 0x00 &&                                                      // start code
-                       header[2] == 0xFF && static_cast<uint8_t>(header[3] + header[4]) == 0 &&  // LCS, len + lcs = 0
-                       header[5] == 0xD5  // TFI - frame from PN532 to system controller
-  );
-  if (!valid_header) {
-    ESP_LOGV(TAG, "read data invalid header!");
-    return {};
-  }
-
-  std::vector<uint8_t> ret;
-  // full length of message, including TFI
-  const uint8_t full_len = header[3];
-  // length of data, excluding TFI
-  uint8_t len = full_len - 1;
-  if (full_len == 0)
-    len = 0;
-
-  ret.resize(len);
-  this->read_bytes_raw(ret.data(), len);
-
-  uint8_t checksum = 0xD5;
-  for (uint8_t dat : ret)
-    checksum += dat;
-  checksum = ~checksum + 1;
-
-  std::vector<uint8_t> dcs(1);
-  this->read_bytes_raw(dcs.data(), 1);
-  if (dcs[0] != checksum) {
-    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", dcs[0], checksum);
-    return {};
-  }
-
-  std::vector<uint8_t> postamble(1);
-  this->read_bytes_raw(postamble.data(), 1);
-  if (postamble[0] != 0x00) {
-    ESP_LOGV(TAG, "read data invalid postamble!");
-    return {};
-  }
-
-#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-  ESP_LOGVV(TAG, "PN532 Data Frame: (%u)", ret.size());  // NOLINT
-  for (uint8_t dat : ret) {
-    ESP_LOGVV(TAG, "  0x%02X", dat);
-  }
-#endif
-
-  return ret;
+  return PN532::pn532_read_data_();
 }
 
 bool PN532I2C::is_ready() {
   // PN532 returns a single data byte,
   // "After having sent a command, the host controller must wait for bit 0 of Status byte equals 1
   // before reading the data from the PN532."
-  std::vector<uint8_t> data;
-  this->read_bytes_raw(data.data(), 1);
+  std::vector<uint8_t> data = this->pn532_read_bytes(1);
 
   return data.size() == 1 && data[0] == 0x01;
-}
-
-bool PN532I2C::read_ack() {
-  ESP_LOGVV(TAG, "Reading ACK...");
-
-  uint8_t ack[6];
-  memset(ack, 0, sizeof(ack));
-
-  this->read_bytes_raw(ack, 6);
-
-  bool matches = (ack[0] == 0x00 &&                    // preamble
-                  ack[1] == 0x00 &&                    // start of packet
-                  ack[2] == 0xFF && ack[3] == 0x00 &&  // ACK packet code
-                  ack[4] == 0xFF && ack[5] == 0x00     // postamble
-  );
-  ESP_LOGVV(TAG, "ACK valid: %s", YESNO(matches));
-  return matches;
 }
 
 void PN532I2C::dump_config() {

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -1,0 +1,142 @@
+#include "pn532_i2c.h"
+#include "esphome/core/log.h"
+
+// Based on:
+// - https://cdn-shop.adafruit.com/datasheets/PN532C106_Application+Note_v1.2.pdf
+// - https://www.nxp.com/docs/en/nxp/application-notes/AN133910.pdf
+// - https://www.nxp.com/docs/en/nxp/application-notes/153710.pdf
+
+namespace esphome {
+namespace pn532_i2c {
+
+static const char *TAG = "pn532_i2c";
+
+void PN532I2C::pn532_write_command(const std::vector<uint8_t> &data) {
+  std::vector<uint8_t> write_data;
+  // Preamble
+  write_data.push_back(0x00);
+
+  // Start code
+  write_data.push_back(0x00);
+  write_data.push_back(0xFF);
+
+  // Length of message, TFI + data bytes
+  const uint8_t real_length = data.size() + 1;
+  // LEN
+  write_data.push_back(real_length);
+  // LCS (Length checksum)
+  write_data.push_back(~real_length + 1);
+
+  // TFI (Frame Identifier, 0xD4 means to PN532, 0xD5 means from PN532)
+  write_data.push_back(0xD4);
+  // calculate checksum, TFI is part of checksum
+  uint8_t checksum = 0xD4;
+
+  // DATA
+  for (uint8_t dat : data) {
+    write_data.push_back(dat);
+    checksum += dat;
+  }
+
+  // DCS (Data checksum)
+  write_data.push_back(~checksum + 1);
+  // Postamble
+  write_data.push_back(0x00);
+
+  this->write_bytes_raw(write_data);
+}
+
+std::vector<uint8_t> PN532I2C::pn532_read_data() {
+  // sometimes preamble is not transmitted for whatever reason
+  // mostly happens during startup.
+  // just read the first two bytes and check if that is the case
+  uint8_t header[6];
+  this->read_bytes_raw(header, 2);
+  if (header[0] == 0x00 && header[1] == 0x00) {
+    // normal packet, preamble included
+    this->read_bytes_raw(header + 2, 4);
+  } else if (header[0] == 0x00 && header[1] == 0xFF) {
+    // weird packet, preamble skipped; make it look like a normal packet
+    header[0] = 0x00;
+    header[1] = 0x00;
+    header[2] = 0xFF;
+    this->read_bytes_raw(header + 3, 3);
+  } else {
+    // invalid packet
+    ESP_LOGV(TAG, "read data invalid preamble!");
+    return {};
+  }
+
+  bool valid_header = (header[0] == 0x00 &&                                                      // preamble
+                       header[1] == 0x00 &&                                                      // start code
+                       header[2] == 0xFF && static_cast<uint8_t>(header[3] + header[4]) == 0 &&  // LCS, len + lcs = 0
+                       header[5] == 0xD5  // TFI - frame from PN532 to system controller
+  );
+  if (!valid_header) {
+    ESP_LOGV(TAG, "read data invalid header!");
+    return {};
+  }
+
+  std::vector<uint8_t> ret;
+  // full length of message, including TFI
+  const uint8_t full_len = header[3];
+  // length of data, excluding TFI
+  uint8_t len = full_len - 1;
+  if (full_len == 0)
+    len = 0;
+
+  ret.resize(len);
+  this->read_bytes_raw(ret.data(), len);
+
+  uint8_t checksum = 0xD5;
+  for (uint8_t dat : ret)
+    checksum += dat;
+  checksum = ~checksum + 1;
+
+  std::vector<uint8_t> dcs(1);
+  this->read_bytes_raw(dcs.data(), 1);
+  if (dcs[0] != checksum) {
+    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", dcs[0], checksum);
+    return {};
+  }
+
+  std::vector<uint8_t> postamble(1);
+  this->read_bytes_raw(postamble.data(), 1);
+  if (postamble[0] != 0x00) {
+    ESP_LOGV(TAG, "read data invalid postamble!");
+    return {};
+  }
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+  ESP_LOGVV(TAG, "PN532 Data Frame: (%u)", ret.size());  // NOLINT
+  for (uint8_t dat : ret) {
+    ESP_LOGVV(TAG, "  0x%02X", dat);
+  }
+#endif
+
+  return ret;
+}
+bool PN532I2C::read_ack() {
+  ESP_LOGVV(TAG, "Reading ACK...");
+
+  uint8_t ack[6];
+  memset(ack, 0, sizeof(ack));
+
+  this->read_bytes_raw(ack, 6);
+
+  bool matches = (ack[0] == 0x00 &&                    // preamble
+                  ack[1] == 0x00 &&                    // start of packet
+                  ack[2] == 0xFF && ack[3] == 0x00 &&  // ACK packet code
+                  ack[4] == 0xFF && ack[5] == 0x00     // postamble
+  );
+  ESP_LOGVV(TAG, "ACK valid: %s", YESNO(matches));
+  return matches;
+}
+
+void PN532I2C::dump_config() {
+  PN532::dump_config();
+  LOG_I2C_DEVICE(this);
+}
+
+}  // namespace pn532_i2c
+}  // namespace esphome

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -14,6 +14,8 @@ static const char *TAG = "pn532_i2c";
 bool PN532I2C::write_data(const std::vector<uint8_t> &data) { return this->write_bytes_raw(data.data(), data.size()); }
 
 std::vector<uint8_t> PN532I2C::read_data(uint8_t len) {
+  delay(5);
+
   std::vector<uint8_t> ready;
   ready.resize(1);
   uint32_t start_time = millis();

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -11,11 +11,11 @@ namespace pn532_i2c {
 
 static const char *TAG = "pn532_i2c";
 
-std::vector<uint8_t> PN532I2C::pn532_read_data_() {
+std::vector<uint8_t> PN532I2C::pn532_read_data() {
   if (!this->wait_ready_())
     return {};
 
-  return PN532::pn532_read_data_();
+  return PN532::pn532_read_data();
 }
 
 bool PN532I2C::is_ready() {

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/pn532/pn532.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace pn532_i2c {
+
+class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
+ public:
+  void dump_config() override;
+
+ protected:
+  /// Write the full command given in data to the PN532
+  void pn532_write_command(const std::vector<uint8_t> &data) override;
+
+  std::vector<uint8_t> pn532_read_data() override;
+
+  bool is_ready() override { return true; };
+
+  bool read_ack() override;
+};
+
+}  // namespace pn532_i2c
+}  // namespace esphome

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -12,14 +12,19 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
   void dump_config() override;
 
  protected:
-  /// Write the full command given in data to the PN532
-  void pn532_write_command(const std::vector<uint8_t> &data) override;
-
-  std::vector<uint8_t> pn532_read_data() override;
+  std::vector<uint8_t> pn532_read_data_() override;
 
   bool is_ready() override;
 
-  bool read_ack() override;
+  std::vector<uint8_t> pn532_read_bytes(uint8_t len) override {
+    std::vector<uint8_t> data;
+    this->read_bytes_raw(data.data(), len);
+    return data;
+  }
+
+  void pn532_write_bytes(std::vector<uint8_t> data) override {
+    this->write_bytes_raw(data);
+  }
 };
 
 }  // namespace pn532_i2c

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -12,17 +12,8 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
   void dump_config() override;
 
  protected:
-  std::vector<uint8_t> pn532_read_data() override;
-
-  bool is_ready() override;
-
-  std::vector<uint8_t> pn532_read_bytes(uint8_t len) override {
-    std::vector<uint8_t> data;
-    this->read_bytes_raw(data.data(), len);
-    return data;
-  }
-
-  void pn532_write_bytes(std::vector<uint8_t> data) override { this->write_bytes_raw(data); }
+  bool write_data(const std::vector<uint8_t> &data) override;
+  std::vector<uint8_t> read_data(uint8_t len) override;
 };
 
 }  // namespace pn532_i2c

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -13,7 +13,7 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
 
  protected:
   bool write_data(const std::vector<uint8_t> &data) override;
-  std::vector<uint8_t> read_data(uint8_t len) override;
+  bool read_data(std::vector<uint8_t> &data, uint8_t len) override;
 };
 
 }  // namespace pn532_i2c

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -12,7 +12,7 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
   void dump_config() override;
 
  protected:
-  std::vector<uint8_t> pn532_read_data_() override;
+  std::vector<uint8_t> pn532_read_data() override;
 
   bool is_ready() override;
 
@@ -22,9 +22,7 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
     return data;
   }
 
-  void pn532_write_bytes(std::vector<uint8_t> data) override {
-    this->write_bytes_raw(data);
-  }
+  void pn532_write_bytes(std::vector<uint8_t> data) override { this->write_bytes_raw(data); }
 };
 
 }  // namespace pn532_i2c

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -17,7 +17,7 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
 
   std::vector<uint8_t> pn532_read_data() override;
 
-  bool is_ready() override { return true; };
+  bool is_ready() override;
 
   bool read_ack() override;
 };

--- a/esphome/components/pn532_spi/__init__.py
+++ b/esphome/components/pn532_spi/__init__.py
@@ -1,0 +1,21 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import spi, pn532
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ['pn532']
+CODEOWNERS = ['@OttoWinter', '@jesserockz']
+DEPENDENCIES = ['spi']
+
+pn532_spi_ns = cg.esphome_ns.namespace('pn532_spi')
+PN532Spi = pn532_spi_ns.class_('PN532Spi', pn532.PN532, spi.SPIDevice)
+
+CONFIG_SCHEMA = cv.All(pn532.PN532_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(PN532Spi),
+}).extend(spi.spi_device_schema(cs_pin_required=True)))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield pn532.setup_pn532(var, config)
+    yield spi.register_spi_device(var, config)

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -27,47 +27,18 @@ void PN532Spi::setup() {
   PN532::setup();
 }
 
-void PN532Spi::pn532_write_command(const std::vector<uint8_t> &data) {
+void PN532Spi::pn532_write_command_(const std::vector<uint8_t> &data) {
   this->enable();
   delay(2);
   // First byte, communication mode: Write data
   this->write_byte(0x01);
 
-  // Preamble
-  this->write_byte(0x00);
-
-  // Start code
-  this->write_byte(0x00);
-  this->write_byte(0xFF);
-
-  // Length of message, TFI + data bytes
-  const uint8_t real_length = data.size() + 1;
-  // LEN
-  this->write_byte(real_length);
-  // LCS (Length checksum)
-  this->write_byte(~real_length + 1);
-
-  // TFI (Frame Identifier, 0xD4 means to PN532, 0xD5 means from PN532)
-  this->write_byte(0xD4);
-  // calculate checksum, TFI is part of checksum
-  uint8_t checksum = 0xD4;
-
-  // DATA
-  for (uint8_t dat : data) {
-    this->write_byte(dat);
-    checksum += dat;
-  }
-
-  // DCS (Data checksum)
-  this->write_byte(~checksum + 1);
-  // Postamble
-  this->write_byte(0x00);
+  PN532::pn532_write_command_(data);
 
   this->disable();
 }
 
-std::vector<uint8_t> PN532Spi::pn532_read_data() {
-
+std::vector<uint8_t> PN532Spi::pn532_read_data_() {
   if (!this->wait_ready_())
     return {};
 
@@ -76,71 +47,11 @@ std::vector<uint8_t> PN532Spi::pn532_read_data() {
   // Read data (transmission from the PN532 to the host)
   this->write_byte(0x03);
 
-  // sometimes preamble is not transmitted for whatever reason
-  // mostly happens during startup.
-  // just read the first two bytes and check if that is the case
-  uint8_t header[6];
-  this->read_array(header, 3);
-  if (header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF) {
-  } else {
-    // invalid packet
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid preamble!");
-    return {};
-  }
-
-  this->read_array(header + 3, 3);
-
-  bool valid_header = (header[0] == 0x00 &&                                                      // preamble
-                       header[1] == 0x00 &&                                                      // start code
-                       header[2] == 0xFF && static_cast<uint8_t>(header[3] + header[4]) == 0 &&  // LCS, len + lcs = 0
-                       header[5] == 0xD5  // TFI - frame from PN532 to system controller
-  );
-  if (!valid_header) {
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid header!");
-    return {};
-  }
-
-  std::vector<uint8_t> ret;
-  // full length of message, including TFI
-  const uint8_t full_len = header[3];
-  // length of data, excluding TFI
-  uint8_t len = full_len - 1;
-  if (full_len == 0)
-    len = 0;
-
-  ret.resize(len);
-  this->read_array(ret.data(), len);
-
-  uint8_t checksum = 0xD5;
-  for (uint8_t dat : ret)
-    checksum += dat;
-  checksum = ~checksum + 1;
-
-  uint8_t dcs = this->read_byte();
-  if (dcs != checksum) {
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", dcs, checksum);
-    return {};
-  }
-
-  if (this->read_byte() != 0x00) {
-    this->disable();
-    ESP_LOGV(TAG, "read data invalid postamble!");
-    return {};
-  }
+  std::vector<uint8_t> ret = PN532::pn532_read_data_();
   this->disable();
-
-#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-  ESP_LOGVV(TAG, "PN532 Data Frame: (%u)", ret.size());  // NOLINT
-  for (uint8_t dat : ret) {
-    ESP_LOGVV(TAG, "  0x%02X", dat);
-  }
-#endif
-
   return ret;
 }
+
 bool PN532Spi::is_ready() {
   this->enable();
   // First byte, communication mode: Read state
@@ -148,39 +59,26 @@ bool PN532Spi::is_ready() {
   // PN532 returns a single data byte,
   // "After having sent a command, the host controller must wait for bit 0 of Status byte equals 1
   // before reading the data from the PN532."
-  bool ret = this->read_byte() == 0x01;
+  std::vector<uint8_t> data = this->pn532_read_bytes(1);
   this->disable();
-
-  if (ret) {
-    ESP_LOGVV(TAG, "Chip is ready!");
-  }
-  return ret;
-}
-bool PN532Spi::read_ack() {
-  ESP_LOGVV(TAG, "Reading ACK...");
-  this->enable();
-  delay(2);
-  // "Read data (transmission from the PN532 to the host) "
-  this->write_byte(0x03);
-
-  uint8_t ack[6];
-  memset(ack, 0, sizeof(ack));
-
-  this->read_array(ack, 6);
-  this->disable();
-
-  bool matches = (ack[0] == 0x00 &&                    // preamble
-                  ack[1] == 0x00 &&                    // start of packet
-                  ack[2] == 0xFF && ack[3] == 0x00 &&  // ACK packet code
-                  ack[4] == 0xFF && ack[5] == 0x00     // postamble
-  );
-  ESP_LOGVV(TAG, "ACK valid: %s", YESNO(matches));
-  return matches;
+  return data.size() == 1 && data[0] == 0x01;
 }
 
 void PN532Spi::dump_config() {
   PN532::dump_config();
   LOG_PIN("  CS Pin: ", this->cs_);
+}
+
+bool PN532Spi::read_ack_() {
+  this->enable();
+  delay(2);
+  // "Read data (transmission from the PN532 to the host) "
+  this->write_byte(0x03);
+
+  bool matches = PN532::read_ack_();
+
+  this->disable();
+  return matches;
 }
 
 }  // namespace pn532_spi

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -27,18 +27,18 @@ void PN532Spi::setup() {
   PN532::setup();
 }
 
-void PN532Spi::pn532_write_command_(const std::vector<uint8_t> &data) {
+void PN532Spi::pn532_write_command(const std::vector<uint8_t> &data) {
   this->enable();
   delay(2);
   // First byte, communication mode: Write data
   this->write_byte(0x01);
 
-  PN532::pn532_write_command_(data);
+  PN532::pn532_write_command(data);
 
   this->disable();
 }
 
-std::vector<uint8_t> PN532Spi::pn532_read_data_() {
+std::vector<uint8_t> PN532Spi::pn532_read_data() {
   if (!this->wait_ready_())
     return {};
 
@@ -47,7 +47,7 @@ std::vector<uint8_t> PN532Spi::pn532_read_data_() {
   // Read data (transmission from the PN532 to the host)
   this->write_byte(0x03);
 
-  std::vector<uint8_t> ret = PN532::pn532_read_data_();
+  std::vector<uint8_t> ret = PN532::pn532_read_data();
   this->disable();
   return ret;
 }
@@ -69,13 +69,13 @@ void PN532Spi::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
 }
 
-bool PN532Spi::read_ack_() {
+bool PN532Spi::read_ack() {
   this->enable();
   delay(2);
   // "Read data (transmission from the PN532 to the host) "
   this->write_byte(0x03);
 
-  bool matches = PN532::read_ack_();
+  bool matches = PN532::read_ack();
 
   this->disable();
   return matches;

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -1,0 +1,189 @@
+#include "pn532_spi.h"
+#include "esphome/core/log.h"
+
+// Based on:
+// - https://cdn-shop.adafruit.com/datasheets/PN532C106_Application+Note_v1.2.pdf
+// - https://www.nxp.com/docs/en/nxp/application-notes/AN133910.pdf
+// - https://www.nxp.com/docs/en/nxp/application-notes/153710.pdf
+
+namespace esphome {
+namespace pn532_spi {
+
+static const char *TAG = "pn532_spi";
+
+void PN532Spi::setup() {
+  ESP_LOGI(TAG, "PN532Spi setup started!");
+  this->spi_setup();
+
+  // Wake the chip up from power down
+  // 1. Enable the SS line for at least 2ms
+  // 2. Send a dummy command to get the protocol synced up
+  //    (this may time out, but that's ok)
+  // 3. Send SAM config command with normal mode without waiting for ready bit (IRQ not initialized yet)
+  // 4. Probably optional, send SAM config again, this time checking ACK and return value
+  this->cs_->digital_write(false);
+  delay(10);
+  ESP_LOGI(TAG, "SPI setup finished!");
+  PN532::setup();
+}
+
+void PN532Spi::pn532_write_command(const std::vector<uint8_t> &data) {
+  this->enable();
+  delay(2);
+  // First byte, communication mode: Write data
+  this->write_byte(0x01);
+
+  // Preamble
+  this->write_byte(0x00);
+
+  // Start code
+  this->write_byte(0x00);
+  this->write_byte(0xFF);
+
+  // Length of message, TFI + data bytes
+  const uint8_t real_length = data.size() + 1;
+  // LEN
+  this->write_byte(real_length);
+  // LCS (Length checksum)
+  this->write_byte(~real_length + 1);
+
+  // TFI (Frame Identifier, 0xD4 means to PN532, 0xD5 means from PN532)
+  this->write_byte(0xD4);
+  // calculate checksum, TFI is part of checksum
+  uint8_t checksum = 0xD4;
+
+  // DATA
+  for (uint8_t dat : data) {
+    this->write_byte(dat);
+    checksum += dat;
+  }
+
+  // DCS (Data checksum)
+  this->write_byte(~checksum + 1);
+  // Postamble
+  this->write_byte(0x00);
+
+  this->disable();
+}
+
+std::vector<uint8_t> PN532Spi::pn532_read_data() {
+  this->enable();
+  delay(2);
+  // Read data (transmission from the PN532 to the host)
+  this->write_byte(0x03);
+
+  // sometimes preamble is not transmitted for whatever reason
+  // mostly happens during startup.
+  // just read the first two bytes and check if that is the case
+  uint8_t header[6];
+  this->read_array(header, 2);
+  if (header[0] == 0x00 && header[1] == 0x00) {
+    // normal packet, preamble included
+    this->read_array(header + 2, 4);
+  } else if (header[0] == 0x00 && header[1] == 0xFF) {
+    // weird packet, preamble skipped; make it look like a normal packet
+    header[0] = 0x00;
+    header[1] = 0x00;
+    header[2] = 0xFF;
+    this->read_array(header + 3, 3);
+  } else {
+    // invalid packet
+    this->disable();
+    ESP_LOGV(TAG, "read data invalid preamble!");
+    return {};
+  }
+
+  bool valid_header = (header[0] == 0x00 &&                                                      // preamble
+                       header[1] == 0x00 &&                                                      // start code
+                       header[2] == 0xFF && static_cast<uint8_t>(header[3] + header[4]) == 0 &&  // LCS, len + lcs = 0
+                       header[5] == 0xD5  // TFI - frame from PN532 to system controller
+  );
+  if (!valid_header) {
+    this->disable();
+    ESP_LOGV(TAG, "read data invalid header!");
+    return {};
+  }
+
+  std::vector<uint8_t> ret;
+  // full length of message, including TFI
+  const uint8_t full_len = header[3];
+  // length of data, excluding TFI
+  uint8_t len = full_len - 1;
+  if (full_len == 0)
+    len = 0;
+
+  ret.resize(len);
+  this->read_array(ret.data(), len);
+
+  uint8_t checksum = 0xD5;
+  for (uint8_t dat : ret)
+    checksum += dat;
+  checksum = ~checksum + 1;
+
+  uint8_t dcs = this->read_byte();
+  if (dcs != checksum) {
+    this->disable();
+    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", dcs, checksum);
+    return {};
+  }
+
+  if (this->read_byte() != 0x00) {
+    this->disable();
+    ESP_LOGV(TAG, "read data invalid postamble!");
+    return {};
+  }
+  this->disable();
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+  ESP_LOGVV(TAG, "PN532 Data Frame: (%u)", ret.size());  // NOLINT
+  for (uint8_t dat : ret) {
+    ESP_LOGVV(TAG, "  0x%02X", dat);
+  }
+#endif
+
+  return ret;
+}
+bool PN532Spi::is_ready() {
+  this->enable();
+  // First byte, communication mode: Read state
+  this->write_byte(0x02);
+  // PN532 returns a single data byte,
+  // "After having sent a command, the host controller must wait for bit 0 of Status byte equals 1
+  // before reading the data from the PN532."
+  bool ret = this->read_byte() == 0x01;
+  this->disable();
+
+  if (ret) {
+    ESP_LOGVV(TAG, "Chip is ready!");
+  }
+  return ret;
+}
+bool PN532Spi::read_ack() {
+  ESP_LOGVV(TAG, "Reading ACK...");
+  this->enable();
+  delay(2);
+  // "Read data (transmission from the PN532 to the host) "
+  this->write_byte(0x03);
+
+  uint8_t ack[6];
+  memset(ack, 0, sizeof(ack));
+
+  this->read_array(ack, 6);
+  this->disable();
+
+  bool matches = (ack[0] == 0x00 &&                    // preamble
+                  ack[1] == 0x00 &&                    // start of packet
+                  ack[2] == 0xFF && ack[3] == 0x00 &&  // ACK packet code
+                  ack[4] == 0xFF && ack[5] == 0x00     // postamble
+  );
+  ESP_LOGVV(TAG, "ACK valid: %s", YESNO(matches));
+  return matches;
+}
+
+void PN532Spi::dump_config() {
+  PN532::dump_config();
+  LOG_PIN("  CS Pin: ", this->cs_);
+}
+
+}  // namespace pn532_spi
+}  // namespace esphome

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -33,7 +33,7 @@ bool PN532Spi::write_data(const std::vector<uint8_t> &data) {
   return true;
 }
 
-std::vector<uint8_t> PN532Spi::read_data(uint8_t len) {
+bool PN532Spi::read_data(std::vector<uint8_t> &data, uint8_t len) {
   this->enable();
   // First byte, communication mode: Read state
   this->write_byte(0x02);
@@ -46,19 +46,18 @@ std::vector<uint8_t> PN532Spi::read_data(uint8_t len) {
     if (millis() - start_time > 100) {
       this->disable();
       ESP_LOGV(TAG, "Timed out waiting for readiness from PN532!");
-      return {};
+      return false;
     }
   }
 
   // Read data (transmission from the PN532 to the host)
   this->write_byte(0x03);
 
-  std::vector<uint8_t> data;
   data.resize(len);
   this->read_array(data.data(), len);
   this->disable();
   data.insert(data.begin(), 0x01);
-  return data;
+  return true;
 };
 
 void PN532Spi::dump_config() {

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -16,21 +16,8 @@ class PN532Spi : public pn532::PN532,
   void dump_config() override;
 
  protected:
-  void pn532_write_command(const std::vector<uint8_t> &data) override;
-
-  std::vector<uint8_t> pn532_read_data() override;
-
-  bool is_ready() override;
-
-  bool read_ack() override;
-
-  std::vector<uint8_t> pn532_read_bytes(uint8_t len) override {
-    std::vector<uint8_t> data;
-    this->read_array(data.data(), len);
-    return data;
-  };
-
-  void pn532_write_bytes(std::vector<uint8_t> data) override { this->write_array(data); };
+  bool write_data(const std::vector<uint8_t> &data) override;
+  std::vector<uint8_t> read_data(uint8_t len) override;
 };
 
 }  // namespace pn532_spi

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -16,13 +16,13 @@ class PN532Spi : public pn532::PN532,
   void dump_config() override;
 
  protected:
-  void pn532_write_command_(const std::vector<uint8_t> &data) override;
+  void pn532_write_command(const std::vector<uint8_t> &data) override;
 
-  std::vector<uint8_t> pn532_read_data_() override;
+  std::vector<uint8_t> pn532_read_data() override;
 
   bool is_ready() override;
 
-  bool read_ack_() override;
+  bool read_ack() override;
 
   std::vector<uint8_t> pn532_read_bytes(uint8_t len) override {
     std::vector<uint8_t> data;
@@ -30,9 +30,7 @@ class PN532Spi : public pn532::PN532,
     return data;
   };
 
-  void pn532_write_bytes(std::vector<uint8_t> data) override {
-    this->write_array(data);
-  };
+  void pn532_write_bytes(std::vector<uint8_t> data) override { this->write_array(data); };
 };
 
 }  // namespace pn532_spi

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -17,7 +17,7 @@ class PN532Spi : public pn532::PN532,
 
  protected:
   bool write_data(const std::vector<uint8_t> &data) override;
-  std::vector<uint8_t> read_data(uint8_t len) override;
+  bool read_data(std::vector<uint8_t> &data, uint8_t len) override;
 };
 
 }  // namespace pn532_spi

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/pn532/pn532.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome {
+namespace pn532_spi {
+
+class PN532Spi : public pn532::PN532,
+                 public spi::SPIDevice<spi::BIT_ORDER_LSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                                       spi::DATA_RATE_1MHZ> {
+ public:
+  void setup() override;
+
+  void dump_config() override;
+
+ protected:
+  /// Write the full command given in data to the PN532
+  void pn532_write_command(const std::vector<uint8_t> &data) override;
+
+  /** Read a data frame from the PN532 and return the result as a vector.
+   *
+   * Note that is_ready needs to be checked first before requesting this method.
+   *
+   * On failure, an empty vector is returned.
+   */
+  std::vector<uint8_t> pn532_read_data() override;
+
+  /** Checks if the PN532 has set its ready status flag.
+   *
+   * Procedure goes as follows:
+   * - Host sends command to PN532 "write data"
+   * - Wait for readiness (until PN532 has processed command) by polling "read status"/is_ready
+   * - Parse ACK/NACK frame with "read data" byte
+   *
+   * - If data required, wait until device reports readiness again
+   * - Then call "read data" and read certain number of bytes (length is given at offset 4 of frame)
+   */
+  bool is_ready() override;
+
+  bool read_ack() override;
+};
+
+}  // namespace pn532_spi
+}  // namespace esphome

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -16,30 +16,23 @@ class PN532Spi : public pn532::PN532,
   void dump_config() override;
 
  protected:
-  /// Write the full command given in data to the PN532
-  void pn532_write_command(const std::vector<uint8_t> &data) override;
+  void pn532_write_command_(const std::vector<uint8_t> &data) override;
 
-  /** Read a data frame from the PN532 and return the result as a vector.
-   *
-   * Note that is_ready needs to be checked first before requesting this method.
-   *
-   * On failure, an empty vector is returned.
-   */
-  std::vector<uint8_t> pn532_read_data() override;
+  std::vector<uint8_t> pn532_read_data_() override;
 
-  /** Checks if the PN532 has set its ready status flag.
-   *
-   * Procedure goes as follows:
-   * - Host sends command to PN532 "write data"
-   * - Wait for readiness (until PN532 has processed command) by polling "read status"/is_ready
-   * - Parse ACK/NACK frame with "read data" byte
-   *
-   * - If data required, wait until device reports readiness again
-   * - Then call "read data" and read certain number of bytes (length is given at offset 4 of frame)
-   */
   bool is_ready() override;
 
-  bool read_ack() override;
+  bool read_ack_() override;
+
+  std::vector<uint8_t> pn532_read_bytes(uint8_t len) override {
+    std::vector<uint8_t> data;
+    this->read_array(data.data(), len);
+    return data;
+  };
+
+  void pn532_write_bytes(std::vector<uint8_t> data) override {
+    this->write_array(data);
+  };
 };
 
 }  // namespace pn532_spi

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1652,6 +1652,8 @@ pn532_spi:
         topic: the/topic
         payload: !lambda 'return x;'
 
+pn532_i2c:
+
 rdm6300:
 
 gps:

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1642,7 +1642,7 @@ remote_receiver:
 status_led:
   pin: GPIO2
 
-pn532:
+pn532_spi:
   cs_pin: GPIO23
   update_interval: 1s
   on_tag:


### PR DESCRIPTION
## Description:

This adds support for the I2C connection on the PN532 board.

## Breaking Change
To achieve this, and in line with other multi comms components I have moved the existing `pn532:` to `pn532_spi:` and you will get a config error pointing to the docs for this change.

## Extra information

Usage in Home Assistant Addon
```
esphome_version: jesserockz:pn532-upgrades
```


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#798

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
