### PR TITLE
fix config check in OnlyWith configuration helper

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -14,7 +14,8 @@ from esphome import core
 from esphome.const import ALLOWED_NAME_CHARS, CONF_AVAILABILITY, CONF_COMMAND_TOPIC, \
     CONF_DISCOVERY, CONF_ID, CONF_INTERNAL, CONF_NAME, CONF_PAYLOAD_AVAILABLE, \
     CONF_PAYLOAD_NOT_AVAILABLE, CONF_RETAIN, CONF_SETUP_PRIORITY, CONF_STATE_TOPIC, CONF_TOPIC, \
-    CONF_HOUR, CONF_MINUTE, CONF_SECOND, CONF_VALUE, CONF_UPDATE_INTERVAL, CONF_TYPE_ID, CONF_TYPE
+    CONF_HOUR, CONF_MINUTE, CONF_SECOND, CONF_VALUE, CONF_UPDATE_INTERVAL, CONF_TYPE_ID, CONF_TYPE, \
+    CONF_PACKAGES
 from esphome.core import CORE, HexInt, IPAddress, Lambda, TimePeriod, TimePeriodMicroseconds, \
     TimePeriodMilliseconds, TimePeriodSeconds, TimePeriodMinutes
 from esphome.helpers import list_starts_with, add_class_to_obj
@@ -1173,9 +1174,12 @@ class OnlyWith(Optional):
     @property
     def default(self):
         # pylint: disable=unsupported-membership-test
-        if self._component not in CORE.raw_config:
-            return vol.UNDEFINED
-        return self._default
+        if (self._component in CORE.raw_config or
+                (CONF_PACKAGES in CORE.raw_config and
+                    self._component in
+                        {list(x.keys())[0] for x in CORE.raw_config[CONF_PACKAGES].values()})):
+            return self._default
+        return vol.UNDEFINED
 
     @default.setter
     def default(self, value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1177,7 +1177,7 @@ class OnlyWith(Optional):
         if (self._component in CORE.raw_config or
                 (CONF_PACKAGES in CORE.raw_config and
                     self._component in
-                        {list(x.keys())[0] for x in CORE.raw_config[CONF_PACKAGES].values()})):
+                    {list(x.keys())[0] for x in CORE.raw_config[CONF_PACKAGES].values()})):
             return self._default
         return vol.UNDEFINED
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -14,8 +14,8 @@ from esphome import core
 from esphome.const import ALLOWED_NAME_CHARS, CONF_AVAILABILITY, CONF_COMMAND_TOPIC, \
     CONF_DISCOVERY, CONF_ID, CONF_INTERNAL, CONF_NAME, CONF_PAYLOAD_AVAILABLE, \
     CONF_PAYLOAD_NOT_AVAILABLE, CONF_RETAIN, CONF_SETUP_PRIORITY, CONF_STATE_TOPIC, CONF_TOPIC, \
-    CONF_HOUR, CONF_MINUTE, CONF_SECOND, CONF_VALUE, CONF_UPDATE_INTERVAL, CONF_TYPE_ID, CONF_TYPE, \
-    CONF_PACKAGES
+    CONF_HOUR, CONF_MINUTE, CONF_SECOND, CONF_VALUE, CONF_UPDATE_INTERVAL, CONF_TYPE_ID, \
+    CONF_TYPE, CONF_PACKAGES
 from esphome.core import CORE, HexInt, IPAddress, Lambda, TimePeriod, TimePeriodMicroseconds, \
     TimePeriodMilliseconds, TimePeriodSeconds, TimePeriodMinutes
 from esphome.helpers import list_starts_with, add_class_to_obj


### PR DESCRIPTION
## Description:

MQTT wrapper components were not correctly configured for sensors/switches/etc. due to the failure of `OnlyWith` check which verified whether a component is registered in raw device YAML configuration only. The check was extended to verify `packages` configurations as well.

**Related issue:** fixes a part of esphome/issues#1487

## Checklist:
  - [X] The code change is tested and works locally.