### PR TITLE
handle windows filenames

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -205,7 +205,7 @@ def process_stacktrace(config, line, backtrace_state):
     # ESP8266 Exception type
     match = re.match(STACKTRACE_ESP8266_EXCEPTION_TYPE_RE, line)
     if match is not None:
-        code = match.group(1)
+        code = int(match.group(1))
         _LOGGER.warning("Exception type: %s", ESP8266_EXCEPTION_CODES.get(code, 'unknown'))
 
     # ESP8266 PC/EXCVADDR
@@ -273,4 +273,9 @@ class IDEData:
         if cc_path is None:
             return None
         # replace gcc at end with addr2line
+
+        # Windows
+        if cc_path.endswith('.exe'):
+            return cc_path[:-7] + 'addr2line.exe'
+
         return cc_path[:-3] + 'addr2line'


### PR DESCRIPTION
## Description:
Just some path handling for .exe files on windows, stack traces decoder fails otherwise

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
