### PR TITLE
Fix Light Trigger

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -98,6 +98,8 @@ template<typename... Ts> class LightIsOffCondition : public Condition<Ts...> {
   LightState *state_;
 };
 
+
+
 class LightTurnOnTrigger : public Trigger<> {
  public:
   LightTurnOnTrigger(LightState *a_light) {
@@ -126,19 +128,11 @@ class LightTurnOffTrigger : public Trigger<> {
     a_light->add_new_target_state_reached_callback([this, a_light]() {
       auto is_on = a_light->current_values.is_on();
       // only trigger when going from on to off
-      auto should_trigger = !is_on && this->last_on_;
-      // Set new state immediately so that trigger() doesn't devolve
-      // into infinite loop
-      this->last_on_ = is_on;
-      if (should_trigger) {
+      if (!is_on) {
         this->trigger();
       }
     });
-    this->last_on_ = a_light->current_values.is_on();
   }
-
- protected:
-  bool last_on_;
 };
 
 template<typename... Ts> class AddressableSet : public Action<Ts...> {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -123,7 +123,7 @@ class LightTurnOnTrigger : public Trigger<> {
 class LightTurnOffTrigger : public Trigger<> {
  public:
   LightTurnOffTrigger(LightState *a_light) {
-    a_light->add_new_remote_values_callback([this, a_light]() {
+    a_light->add_new_target_state_reached_callback([this, a_light]() {
       auto is_on = a_light->current_values.is_on();
       // only trigger when going from on to off
       auto should_trigger = !is_on && this->last_on_;

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -98,8 +98,6 @@ template<typename... Ts> class LightIsOffCondition : public Condition<Ts...> {
   LightState *state_;
 };
 
-
-
 class LightTurnOnTrigger : public Trigger<> {
  public:
   LightTurnOnTrigger(LightState *a_light) {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -102,17 +102,18 @@ class LightTurnOnTrigger : public Trigger<> {
  public:
   LightTurnOnTrigger(LightState *a_light) {
     a_light->add_new_remote_values_callback([this, a_light]() {
-      auto is_on = a_light->current_values.is_on();
+      // using the remote value because of transitions we need to trigger as early as possible
+      auto is_on = a_light->remote_values.is_on();
       // only trigger when going from off to on
-      auto should_trigger = is_on && !last_on_;
+      auto should_trigger = is_on && !this->last_on_;
       // Set new state immediately so that trigger() doesn't devolve
       // into infinite loop
-      last_on_ = is_on;
+      this->last_on_ = is_on;
       if (should_trigger) {
         this->trigger();
       }
     });
-    last_on_ = a_light->current_values.is_on();
+    this->last_on_ = a_light->current_values.is_on();
   }
 
  protected:
@@ -125,15 +126,15 @@ class LightTurnOffTrigger : public Trigger<> {
     a_light->add_new_remote_values_callback([this, a_light]() {
       auto is_on = a_light->current_values.is_on();
       // only trigger when going from on to off
-      auto should_trigger = !is_on && last_on_;
+      auto should_trigger = !is_on && this->last_on_;
       // Set new state immediately so that trigger() doesn't devolve
       // into infinite loop
-      last_on_ = is_on;
+      this->last_on_ = is_on;
       if (should_trigger) {
         this->trigger();
       }
     });
-    last_on_ = a_light->current_values.is_on();
+    this->last_on_ = a_light->current_values.is_on();
   }
 
  protected:

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -337,6 +337,9 @@ void LightCall::perform() {
     this->parent_->set_immediately_(v, this->publish_);
   }
 
+  if (!this->has_transition_()) {
+    this->parent_->target_state_reached_callback_.call();
+  }
   if (this->publish_) {
     this->parent_->publish_state();
   }

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -145,7 +145,6 @@ void LightState::loop() {
   if (this->transformer_ != nullptr) {
     if (this->transformer_->is_finished()) {
       this->remote_values = this->current_values = this->transformer_->get_end_values();
-      ESP_LOGD(TAG, "Reached the target state of %.5f.", this->current_values.get_state());
       this->target_state_reached_callback_.call();
       if (this->transformer_->publish_at_end())
         this->publish_state();

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -145,6 +145,8 @@ void LightState::loop() {
   if (this->transformer_ != nullptr) {
     if (this->transformer_->is_finished()) {
       this->remote_values = this->current_values = this->transformer_->get_end_values();
+      ESP_LOGD(TAG, "Reached the target state of %.5f.", this->current_values.get_state());
+      this->target_state_reached_callback_.call();
       if (this->transformer_->publish_at_end())
         this->publish_state();
       this->transformer_ = nullptr;
@@ -752,6 +754,12 @@ void LightState::current_values_as_cwww(float *cold_white, float *warm_white, bo
 void LightState::add_new_remote_values_callback(std::function<void()> &&send_callback) {
   this->remote_values_callback_.add(std::move(send_callback));
 }
+
+void LightState::add_new_target_state_reached_callback(std::function<void()> &&send_callback) {
+  this->target_state_reached_callback_.add(std::move(send_callback));
+}
+
+
 LightEffect *LightState::get_active_effect_() {
   if (this->active_effect_index_ == 0)
     return nullptr;

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -754,11 +754,9 @@ void LightState::current_values_as_cwww(float *cold_white, float *warm_white, bo
 void LightState::add_new_remote_values_callback(std::function<void()> &&send_callback) {
   this->remote_values_callback_.add(std::move(send_callback));
 }
-
 void LightState::add_new_target_state_reached_callback(std::function<void()> &&send_callback) {
   this->target_state_reached_callback_.add(std::move(send_callback));
 }
-
 
 LightEffect *LightState::get_active_effect_() {
   if (this->active_effect_index_ == 0)

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -242,6 +242,13 @@ class LightState : public Nameable, public Component {
    */
   void add_new_remote_values_callback(std::function<void()> &&send_callback);
 
+  /**
+   * The callback is called once the state of current_values and remote_values are equal
+   *
+   * @param send_callback
+   */
+  void add_new_target_state_reached_callback(std::function<void()> &&send_callback);
+
   /// Return whether the light has any effects that meet the trait requirements.
   bool supports_effects();
 
@@ -318,6 +325,12 @@ class LightState : public Nameable, public Component {
    * starting with the beginning of the transition.
    */
   CallbackManager<void()> remote_values_callback_{};
+
+  /** Callback to call when the state of current_values and remote_values are equal
+   * This should be called once the state of current_values changed and equals the state of remote_values
+   */
+  CallbackManager<void()> target_state_reached_callback_{};
+
   LightOutput *output_;  ///< Store the output to allow effects to have more access.
   /// Whether the light value should be written in the next cycle.
   bool next_write_{true};

--- a/esphome/components/light/light_transformer.h
+++ b/esphome/components/light/light_transformer.h
@@ -65,7 +65,7 @@ class LightTransitionTransformer : public LightTransformer {
     return LightColorValues::lerp(this->get_start_values_(), this->get_target_values_(), v);
   }
 
-  bool publish_at_end() override { return false; }
+  bool publish_at_end() override { return true; }
   bool is_transition() override { return true; }
 
   static float smoothed_progress(float x) { return x * x * x * (x * (x * 6.0f - 15.0f) + 10.0f); }

--- a/esphome/components/light/light_transformer.h
+++ b/esphome/components/light/light_transformer.h
@@ -65,7 +65,7 @@ class LightTransitionTransformer : public LightTransformer {
     return LightColorValues::lerp(this->get_start_values_(), this->get_target_values_(), v);
   }
 
-  bool publish_at_end() override { return true; }
+  bool publish_at_end() override { return false; }
   bool is_transition() override { return true; }
 
   static float smoothed_progress(float x) { return x * x * x * (x * (x * 6.0f - 15.0f) + 10.0f); }


### PR DESCRIPTION
## Description:

The trigger `on_turn_on` now triggers immediately when the light is turned on.
The trigger `on_turn_off` now triggers after the light is actually off.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1521
fixes https://github.com/esphome/issues/issues/1526
fixes https://github.com/esphome/issues/issues/1534

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
