### PR TITLE
Fix scheduler with too many cancelled timers

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -8,6 +8,7 @@ namespace esphome {
 static const char *TAG = "scheduler";
 
 static const uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
+static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 10;
 
 // Uncomment to debug scheduler
 // #define ESPHOME_DEBUG_SCHEDULER
@@ -110,7 +111,7 @@ void ICACHE_RAM_ATTR HOT Scheduler::call() {
   auto to_remove_was = to_remove_;
   auto items_was = items_.size();
   // If we have too many items to remove
-  if (to_remove_ > 10) {
+  if (to_remove_ > MAX_LOGICALLY_DELETED_ITEMS) {
     std::vector<std::unique_ptr<SchedulerItem>> valid_items;
     while (!this->empty_()) {
       auto item = std::move(this->items_[0]);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -121,7 +121,7 @@ void ICACHE_RAM_ATTR HOT Scheduler::call() {
 
     // The following should not happen unless I'm missing something
     if (to_remove_ != 0) {
-      ESP_LOGW(TAG, "to_remove_ was %d now: %d items where %d now %d. Please report this", to_remove_was, to_remove_,
+      ESP_LOGW(TAG, "to_remove_ was %u now: %u items where %zu now %zu. Please report this", to_remove_was, to_remove_,
                items_was, items_.size());
       to_remove_ = 0;
     }

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -61,6 +61,7 @@ class Scheduler {
   std::vector<std::unique_ptr<SchedulerItem>> to_add_;
   uint32_t last_millis_{0};
   uint8_t millis_major_{0};
+  uint32_t to_remove_{0};
 };
 
 }  // namespace esphome


### PR DESCRIPTION
## Description:

Scheduler is using a min heap to store the pending interval or timeouts timer calls.
Since this structure only has access to the top item (which is due earliest) old items are stored in behind the head item.
If too many old items are stored in the memory which are due later than the top item, memory fills up, the program is not buggy as the items stored are marked for removal, but removal only happens after top item is due, so they are not happening soon enough and in some circumstances the ESP runs out of memory and crashes.

To consistently reproduce this issue I use the following code:

```yaml
esphome:
  name: test_esp8266
  platform: ESP8266
  board: nodemcuv2

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_pass

logger:
  level: DEBUG

api:

binary_sensor:
  - platform: gpio
    id: io14
    pin: GPIO14
    filters:
      - delayed_on_off: 10s

interval:
  interval: 2s
  then:
    - logger.log: "interval timer"
```

Now you have to trigger GPIO14 on, off quickly enough, I connected it to a 1Khz square wave function generator.

Delayed on_off will cancel the `"ON_OFF"` timer every time the GPIO14 ticks, but there is a timer for the interval which will be due before the `interval: 2s` and thus in 2s the memory will be filled and ESP will crash.

This PR adds a counter of how many pending to remove timers are in the heap, and if there are more than 10 it just recreates the heap without the removed items.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1090

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
