### PR TITLE
Adds generic NDEF classes and implements reading in PN532

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,6 +39,7 @@ esphome/components/ledc/* @OttoWinter
 esphome/components/light/* @esphome/core
 esphome/components/logger/* @esphome/core
 esphome/components/network/* @esphome/core
+esphome/components/nfc/* @jesserockz
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core
 esphome/components/pid/* @OttoWinter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,7 +43,7 @@ esphome/components/nfc/* @jesserockz
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core
 esphome/components/pid/* @OttoWinter
-esphome/components/pn532/* @OttoWinter
+esphome/components/pn532/* @OttoWinter @jesserockz
 esphome/components/power_supply/* @esphome/core
 esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz

--- a/esphome/components/nfc/__init__.py
+++ b/esphome/components/nfc/__init__.py
@@ -1,0 +1,7 @@
+import esphome.codegen as cg
+
+CODEOWNERS = ['@jesserockz']
+
+nfc_ns = cg.esphome_ns.namespace('nfc')
+
+NfcTag = nfc_ns.class_('NfcTag')

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -1,0 +1,97 @@
+#include "ndef_message.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char *TAG = "nfc.ndef_message";
+
+NdefMessage::NdefMessage(std::vector<uint8_t> data) {
+  uint8_t index = 0;
+  while (index <= data.size()) {
+    uint8_t tnf_byte = data[index];
+    bool me = tnf_byte & 0x40;
+    bool sr = tnf_byte & 0x10;
+    bool il = tnf_byte & 0x08;
+    uint8_t tnf = tnf_byte & 0x07;
+
+    NdefRecord *record = new NdefRecord();
+    record->set_tnf(tnf);
+
+    index++;
+    uint8_t type_length = data[index];
+    uint32_t payload_length = 0;
+    if (sr) {
+      index++;
+      payload_length = data[index];
+    } else {
+      payload_length = (static_cast<uint32_t>(data[index]) << 24) | (static_cast<uint32_t>(data[index + 1]) << 16) |
+                       (static_cast<uint32_t>(data[index + 2]) << 8) | static_cast<uint32_t>(data[index + 3]);
+      index += 4;
+    }
+
+    uint8_t id_length = 0;
+    if (il) {
+      index++;
+      id_length = data[index];
+    }
+
+    index++;
+    record->set_type(std::string(data[index], type_length));
+    index += type_length;
+
+    if (il) {
+      record->set_id(std::string(data[index], id_length));
+      index += id_length;
+    }
+
+    record->set_payload(std::string(data[index], payload_length));
+    index += payload_length;
+
+    this->add_record(record);
+
+    if (me)
+      break;
+  }
+}
+
+boolean NdefMessage::add_record(NdefRecord *record) {
+  if (this->records_.size() < MAX_NDEF_RECORDS) {
+    this->records_.push_back(*record);
+    return true;
+  } else {
+    ESP_LOGE(TAG, "Too many records. Max: %d", MAX_NDEF_RECORDS);
+    return false;
+  }
+}
+
+boolean NdefMessage::add_text_record(std::string text) { return this->add_text_record(text, "en"); };
+
+boolean NdefMessage::add_text_record(std::string text, std::string encoding) {
+  std::string payload = to_string(text.length()) + encoding + text;
+  NdefRecord r = NdefRecord(TNF_WELL_KNOWN, "T", payload);
+  return this->add_record(&r);
+}
+
+boolean NdefMessage::add_uri_record(std::string uri) {
+  std::string payload = '\0' + uri;
+  NdefRecord r = NdefRecord(TNF_WELL_KNOWN, "U", payload);
+  return this->add_record(&r);
+}
+
+boolean NdefMessage::add_empty_record() {
+  NdefRecord r = NdefRecord();
+  r.set_tnf(TNF_EMPTY);
+  return this->add_record(&r);
+}
+
+void NdefMessage::encode(uint8_t *data) {
+  uint8_t *data_ptr = &data[0];
+
+  for (uint8_t i = 0; i < this->records_.size(); i++) {
+    this->records_[i].encode(data_ptr, i == 0, (i + 1) == this->records_.size());
+    data_ptr += this->records_[i].get_encoded_size();
+  }
+}
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/ndef_message.h
+++ b/esphome/components/nfc/ndef_message.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "ndef_record.h"
+
+static const uint8_t MAX_NDEF_RECORDS = 4;
+
+namespace esphome {
+namespace nfc {
+
+class NdefMessage {
+ public:
+  NdefMessage(){};
+  NdefMessage(std::vector<uint8_t> data);
+
+  std::vector<NdefRecord> get_records() { return this->records_; };
+
+  boolean add_record(NdefRecord* record);
+  boolean add_text_record(std::string text);
+  boolean add_text_record(std::string text, std::string encoding);
+  boolean add_uri_record(std::string uri);
+  boolean add_empty_record();
+
+  void encode(uint8_t* data);
+
+ protected:
+  std::vector<NdefRecord> records_;
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/ndef_record.cpp
+++ b/esphome/components/nfc/ndef_record.cpp
@@ -1,0 +1,76 @@
+#include "ndef_record.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char* TAG = "nfc.ndef_record";
+
+uint32_t NdefRecord::get_encoded_size() {
+  uint32_t size = 2;
+  if (this->payload_.length() > 255) {
+    size += 4;
+  } else {
+    size += 1;
+  }
+  if (this->id_.length()) {
+    size += 1;
+  }
+  size += (this->type_.length() + this->payload_.length() + this->id_.length());
+  return size;
+}
+
+void NdefRecord::encode(uint8_t* data, bool first, bool last) {
+  uint8_t* data_ptr = &data[0];
+
+  *data_ptr = get_tnf_byte(first, last);
+  data_ptr += 1;
+
+  *data_ptr = this->type_.length();
+  data_ptr += 1;
+
+  if (this->payload_.length() <= 255) {
+    *data_ptr = this->payload_.length();
+    data_ptr += 1;
+  } else {
+    data_ptr[0] = 0;
+    data_ptr[1] = 0;
+    data_ptr[2] = (this->payload_.length() >> 8) & 0xFF;
+    data_ptr[3] = this->payload_.length() & 0xFF;
+    data_ptr += 4;
+  }
+
+  if (this->id_.length()) {
+    *data_ptr = this->id_.length();
+    data_ptr += 1;
+  }
+
+  memcpy(data_ptr, this->type_.c_str(), this->type_.length());
+  data_ptr += this->type_.length();
+
+  if (this->id_.length()) {
+    memcpy(data_ptr, this->id_.c_str(), this->id_.length());
+    data_ptr += this->id_.length();
+  }
+
+  memcpy(data_ptr, this->payload_.c_str(), this->payload_.length());
+}
+
+uint8_t NdefRecord::get_tnf_byte(bool first, bool last) {
+  uint8_t value = this->tnf_;
+  if (first) {
+    value = value | 0x80;
+  }
+  if (last) {
+    value = value | 0x40;
+  }
+  if (this->payload_.length() <= 255) {
+    value = value | 0x10;
+  }
+  if (this->id_.length()) {
+    value = value | 0x08;
+  }
+  return value;
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+static const uint8_t TNF_EMPTY = 0x00;
+static const uint8_t TNF_WELL_KNOWN = 0x01;
+static const uint8_t TNF_MIME_MEDIA = 0x02;
+static const uint8_t TNF_ABSOLUTE_URI = 0x03;
+static const uint8_t TNF_EXTERNAL_TYPE = 0x04;
+static const uint8_t TNF_UNKNOWN = 0x05;
+static const uint8_t TNF_UNCHANGED = 0x06;
+static const uint8_t TNF_RESERVED = 0x07;
+
+namespace esphome {
+namespace nfc {
+
+class NdefRecord {
+ public:
+  NdefRecord(){};
+  NdefRecord(uint8_t tnf, std::string type, std::string payload) {
+    this->tnf_ = tnf;
+    this->type_ = type;
+    this->payload_ = payload;
+  };
+  NdefRecord(uint8_t tnf, std::string type, std::string payload, std::string id) {
+    this->tnf_ = tnf;
+    this->type_ = type;
+    this->payload_ = payload;
+    this->id_ = id;
+  };
+  void set_tnf(uint8_t tnf) { this->tnf_ = tnf; };
+  void set_type(std::string type) { this->type_ = type; };
+  void set_payload(std::string payload) { this->payload_ = payload; };
+  void set_id(std::string id) { this->id_ = id; };
+
+  uint32_t get_encoded_size();
+
+  void encode(uint8_t* data, bool first, bool last);
+  uint8_t get_tnf_byte(bool first, bool last);
+
+  std::string get_type() { return this->type_; };
+  std::string get_payload() { return this->payload_; };
+  std::string get_id() { return this->id_; };
+
+ protected:
+  uint8_t tnf_;
+  std::string type_;
+  std::string payload_;
+  std::string id_;
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -1,0 +1,89 @@
+#include "nfc.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char *TAG = "nfc";
+
+std::string format_uid(std::vector<uint8_t> uid) {
+  char buf[32];
+  int offset = 0;
+  for (uint8_t i = 0; i < uid.size(); i++) {
+    const char *format = "%02X";
+    if (i + 1 < uid.size())
+      format = "%02X-";
+    offset += sprintf(buf + offset, format, uid[i]);
+  }
+  return std::string(buf);
+}
+
+uint8_t guess_tag_type(uint8_t uid_length) {
+  if (uid_length == 4) {
+    return TAG_TYPE_MIFARE_CLASSIC;
+  } else {
+    return TAG_TYPE_2;
+  }
+}
+
+uint8_t get_ndef_start_index(std::vector<uint8_t> data) {
+  for (uint8_t i = 0; i < BLOCK_SIZE; i++) {
+    if (data[i] == 0x00) {
+      // Do nothing, skip
+    } else if (data[i] == 0x03) {
+      return i;
+    } else {
+      return -2;
+    }
+  }
+  return -1;
+}
+
+bool decode_mifare_classic_tlv(std::vector<uint8_t> data, uint32_t &message_length, uint8_t &message_start_index) {
+  uint8_t i = get_ndef_start_index(data);
+  if (i < 0 || data[i] != 0x03) {
+    ESP_LOGE(TAG, "Error, Can't decode message length.");
+    return false;
+  } else {
+    if (data[i + 1] == 0xFF) {
+      message_length = ((0xFF & data[i + 2]) << 8) | (0xFF & data[i + 3]);
+      message_start_index = i + LONG_TLV_SIZE;
+    } else {
+      message_length = data[i + 1];
+      message_start_index = i + SHORT_TLV_SIZE;
+    }
+  }
+  return true;
+}
+
+uint32_t get_buffer_size(uint32_t message_length) {
+  uint32_t buffer_size = message_length;
+  if (message_length < 255) {
+    buffer_size += SHORT_TLV_SIZE + 1;
+  } else {
+    buffer_size += LONG_TLV_SIZE + 1;
+  }
+  if (buffer_size % BLOCK_SIZE != 0) {
+    buffer_size = ((buffer_size / BLOCK_SIZE) + 1) * BLOCK_SIZE;
+  }
+  return buffer_size;
+}
+
+bool mifare_classic_is_first_block(uint8_t block_num) {
+  if (block_num < 128) {
+    return (block_num % 4 == 0);
+  } else {
+    return (block_num % 16 == 0);
+  }
+}
+
+bool mifare_classic_is_trailer_block(uint8_t block_num) {
+  if (block_num < 128) {
+    return ((block_num + 1) % 4 == 0);
+  } else {
+    return ((block_num + 1) % 16 == 0);
+  }
+}
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include "ndef_record.h"
+#include "ndef_message.h"
+#include "nfc_tag.h"
+
+static const uint8_t BLOCK_SIZE = 16;
+static const uint8_t LONG_TLV_SIZE = 4;
+static const uint8_t SHORT_TLV_SIZE = 2;
+
+static const uint8_t TAG_TYPE_MIFARE_CLASSIC = 0;
+static const uint8_t TAG_TYPE_1 = 1;
+static const uint8_t TAG_TYPE_2 = 2;
+static const uint8_t TAG_TYPE_3 = 3;
+static const uint8_t TAG_TYPE_4 = 4;
+static const uint8_t TAG_TYPE_UNKNOWN = 99;
+
+static const uint8_t MIFARE_KEY_A = 0x60;
+static const uint8_t MIFARE_KEY_B = 0x61;
+
+#define MIFARE_CLASSIC ("Mifare Classic")
+
+namespace esphome {
+namespace nfc {
+
+std::string format_uid(std::vector<uint8_t> uid);
+
+uint8_t guess_tag_type(uint8_t uid_length);
+uint8_t get_ndef_start_index(std::vector<uint8_t> data);
+bool decode_mifare_classic_tlv(std::vector<uint8_t> data, uint32_t &message_length, uint8_t &message_start_index);
+uint32_t get_buffer_size(uint32_t message_length);
+
+bool mifare_classic_is_first_block(uint8_t block_num);
+bool mifare_classic_is_trailer_block(uint8_t block_num);
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -25,8 +25,8 @@ static const uint8_t TAG_TYPE_UNKNOWN = 99;
 // Mifare Commands
 static const uint8_t MIFARE_CMD_AUTH_A = 0x60;
 static const uint8_t MIFARE_CMD_AUTH_B = 0x61;
-static const uint8_t MIFARE_CMD_READ   = 0x30;
-static const uint8_t MIFARE_CMD_WRITE  = 0xA0;
+static const uint8_t MIFARE_CMD_READ = 0x30;
+static const uint8_t MIFARE_CMD_WRITE = 0xA0;
 
 std::string format_uid(std::vector<uint8_t> uid);
 

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -6,6 +6,11 @@
 #include "ndef_message.h"
 #include "nfc_tag.h"
 
+#define MIFARE_CLASSIC ("Mifare Classic")
+
+namespace esphome {
+namespace nfc {
+
 static const uint8_t BLOCK_SIZE = 16;
 static const uint8_t LONG_TLV_SIZE = 4;
 static const uint8_t SHORT_TLV_SIZE = 2;
@@ -17,13 +22,11 @@ static const uint8_t TAG_TYPE_3 = 3;
 static const uint8_t TAG_TYPE_4 = 4;
 static const uint8_t TAG_TYPE_UNKNOWN = 99;
 
-static const uint8_t MIFARE_KEY_A = 0x60;
-static const uint8_t MIFARE_KEY_B = 0x61;
-
-#define MIFARE_CLASSIC ("Mifare Classic")
-
-namespace esphome {
-namespace nfc {
+// Mifare Commands
+static const uint8_t MIFARE_CMD_AUTH_A = 0x60;
+static const uint8_t MIFARE_CMD_AUTH_B = 0x61;
+static const uint8_t MIFARE_CMD_READ   = 0x30;
+static const uint8_t MIFARE_CMD_WRITE  = 0xA0;
 
 std::string format_uid(std::vector<uint8_t> uid);
 

--- a/esphome/components/nfc/nfc_tag.cpp
+++ b/esphome/components/nfc/nfc_tag.cpp
@@ -1,0 +1,9 @@
+#include "nfc_tag.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char *TAG = "nfc.tag";
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -35,6 +35,7 @@ class NfcTag {
   std::string get_tag_type() { return this->tag_type_; };
   boolean has_ndef_message() { return this->ndef_message_ != nullptr; };
   NdefMessage get_ndef_message() { return *this->ndef_message_; };
+  void set_ndef_message(NdefMessage *ndef_message) { this->ndef_message_ = ndef_message; };
 
  protected:
   std::vector<uint8_t> uid_;

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "ndef_message.h"
+
+namespace esphome {
+namespace nfc {
+
+class NfcTag {
+ public:
+  NfcTag() {
+    this->uid_ = {};
+    this->tag_type_ = "Unknown";
+  };
+  NfcTag(std::vector<uint8_t> uid) {
+    this->uid_ = uid;
+    this->tag_type_ = "Unknown";
+  };
+  NfcTag(std::vector<uint8_t> uid, std::string tag_type) {
+    this->uid_ = uid;
+    this->tag_type_ = tag_type;
+  };
+  NfcTag(std::vector<uint8_t> uid, std::string tag_type, NdefMessage *ndef_message) {
+    this->uid_ = uid;
+    this->tag_type_ = tag_type;
+    this->ndef_message_ = ndef_message;
+  };
+  NfcTag(std::vector<uint8_t> uid, std::string tag_type, std::vector<uint8_t> ndef_data) {
+    this->uid_ = uid;
+    this->tag_type_ = tag_type;
+    this->ndef_message_ = new NdefMessage(ndef_data);
+  };
+
+  std::vector<uint8_t> get_uid() { return this->uid_; };
+  std::string get_tag_type() { return this->tag_type_; };
+  boolean has_ndef_message() { return this->ndef_message_ != nullptr; };
+  NdefMessage get_ndef_message() { return *this->ndef_message_; };
+
+ protected:
+  std::vector<uint8_t> uid_;
+  std::string tag_type_;
+  NdefMessage *ndef_message_{nullptr};
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -1,12 +1,13 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
+from esphome.components import nfc
 from esphome.components import spi
 from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID
 
-CODEOWNERS = ['@OttoWinter']
+CODEOWNERS = ['@OttoWinter', '@jesserockz']
 DEPENDENCIES = ['spi']
-AUTO_LOAD = ['binary_sensor']
+AUTO_LOAD = ['binary_sensor', 'nfc']
 MULTI_CONF = True
 
 pn532_ns = cg.esphome_ns.namespace('pn532')
@@ -29,4 +30,5 @@ def to_code(config):
     for conf in config.get(CONF_ON_TAG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
         cg.add(var.register_trigger(trigger))
-        yield automation.build_automation(trigger, [(cg.std_string, 'x')], conf)
+        yield automation.build_automation(trigger, [(cg.std_string, 'x'), (nfc.NfcTag, 'tag')],
+                                          conf)

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -220,7 +220,7 @@ std::vector<uint8_t> PN532::read_mifare_classic_block_(uint8_t block_num) {
 
   std::vector<uint8_t> response = this->pn532_read_data_();
 
-  if (response.size() == 0 || response[0] != 0x00) {
+  if (response.empty() || response[0] != 0x00) {
     return {};
   }
   return response;
@@ -242,7 +242,7 @@ bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> uid, uint8_t block_n
 
   std::vector<uint8_t> response = this->pn532_read_data_();
 
-  if (response.size() == 0 || response[0] != 0x00) {
+  if (response.empty() || response[0] != 0x00) {
     ESP_LOGE(TAG, "Authentication failed");
     return false;
   }
@@ -407,7 +407,7 @@ bool PN532::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> 
 
   std::vector<uint8_t> response = this->pn532_read_data_();
 
-  if (response.size() == 0) {
+  if (response.empty()) {
     ESP_LOGE(TAG, "Error writing block %d", block_num);
     return false;
   }

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -254,8 +254,8 @@ void PN532::turn_off_rf_() {
   ESP_LOGVV(TAG, "Turning RF field OFF");
   this->pn532_write_command_check_ack_({
       PN532_COMMAND_RFCONFIGURATION,
-      0x01,   // RF Field
-      0x00,    // Off
+      0x01,  // RF Field
+      0x00,  // Off
   });
 }
 
@@ -340,22 +340,24 @@ bool PN532::clean_tag_(nfc::NfcTag tag) {
   return false;
 }
 
-bool PN532::write_tag_(nfc::NfcTag tag) {
-  return true;
-}
+bool PN532::write_tag_(nfc::NfcTag tag) { return false; }
 
-bool PN532::format_mifare_classic_mifare_(nfc::NfcTag tag) {
-  return true;
-}
+bool PN532::format_mifare_classic_mifare_(nfc::NfcTag tag) { return false; }
 
 bool PN532::format_mifare_classic_ndef_(nfc::NfcTag tag) {
-  uint8_t key_a[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-  std::vector<uint8_t> empty_ndef_message({0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> sector_buffer_0({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> sector_buffer_1({0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> sector_buffer_2({0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> sector_buffer_3({0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  std::vector<uint8_t> sector_buffer_4({0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  uint8_t key_a[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  std::vector<uint8_t> empty_ndef_message(
+      {0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  std::vector<uint8_t> sector_buffer_0(
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  std::vector<uint8_t> sector_buffer_1(
+      {0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
+  std::vector<uint8_t> sector_buffer_2(
+      {0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
+  std::vector<uint8_t> sector_buffer_3(
+      {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  std::vector<uint8_t> sector_buffer_4(
+      {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
 
   if (!this->auth_mifare_classic_block_(tag.get_uid(), 0, nfc::MIFARE_CMD_AUTH_A, key_a)) {
     ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting!");
@@ -368,7 +370,7 @@ bool PN532::format_mifare_classic_ndef_(nfc::NfcTag tag) {
   if (!this->write_mifare_classic_block_(3, sector_buffer_3))
     return false;
 
-  for (int i = 4; i < 64; i+=4) {
+  for (int i = 4; i < 64; i += 4) {
     if (!this->auth_mifare_classic_block_(tag.get_uid(), i, nfc::MIFARE_CMD_AUTH_A, key_a)) {
       ESP_LOGE(TAG, "Failed to authenticate with block %d", i);
       continue;
@@ -380,12 +382,12 @@ bool PN532::format_mifare_classic_ndef_(nfc::NfcTag tag) {
       if (!this->write_mifare_classic_block_(i, sector_buffer_0))
         ESP_LOGE(TAG, "Unable to write block %d", i);
     }
-    if (!this->write_mifare_classic_block_(i+1, sector_buffer_0))
-        ESP_LOGE(TAG, "Unable to write block %d", i+1);
-    if (!this->write_mifare_classic_block_(i+2, sector_buffer_0))
-        ESP_LOGE(TAG, "Unable to write block %d", i+2);
-    if (!this->write_mifare_classic_block_(i+3, sector_buffer_4))
-        ESP_LOGE(TAG, "Unable to write block %d", i+3);
+    if (!this->write_mifare_classic_block_(i + 1, sector_buffer_0))
+      ESP_LOGE(TAG, "Unable to write block %d", i + 1);
+    if (!this->write_mifare_classic_block_(i + 2, sector_buffer_0))
+      ESP_LOGE(TAG, "Unable to write block %d", i + 2);
+    if (!this->write_mifare_classic_block_(i + 3, sector_buffer_4))
+      ESP_LOGE(TAG, "Unable to write block %d", i + 3);
   }
   return true;
 }
@@ -393,7 +395,7 @@ bool PN532::format_mifare_classic_ndef_(nfc::NfcTag tag) {
 bool PN532::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> write_data) {
   std::vector<uint8_t> data({
       PN532_COMMAND_INDATAEXCHANGE,
-      0x01,       // One card
+      0x01,  // One card
       nfc::MIFARE_CMD_WRITE,
       block_num,  // Block number
   });

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -29,7 +29,7 @@ void PN532::setup() {
   // do not actually read any data, this should be OK according to datasheet
 
   this->pn532_write_command_({
-      0x14,  // SAM config command
+      PN532_COMMAND_SAMCONFIGURATION,
       0x01,  // normal mode
       0x14,  // zero timeout (not in virtual card mode)
       0x01,
@@ -54,7 +54,7 @@ void PN532::setup() {
   // Set up SAM (secure access module)
   uint8_t sam_timeout = std::min(255u, this->update_interval_ / 50);
   bool ret = this->pn532_write_command_check_ack_({
-      0x14,         // SAM config command
+      PN532_COMMAND_SAMCONFIGURATION,
       0x01,         // normal mode
       sam_timeout,  // timeout as multiple of 50ms (actually only for virtual card mode, but shouldn't matter)
       0x01,         // Enable IRQ
@@ -85,7 +85,7 @@ void PN532::update() {
     obj->on_scan_end();
 
   bool success = this->pn532_write_command_check_ack_({
-      0x4A,  // INLISTPASSIVETARGET
+      PN532_COMMAND_INLISTPASSIVETARGET,
       0x01,  // max 1 card
       0x00,  // baud rate ISO14443A (106 kbit/s)
   });
@@ -152,13 +152,13 @@ void PN532::loop() {
 nfc::NfcTag PN532::read_tag_(std::vector<uint8_t> uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
 
-  if (type == TAG_TYPE_MIFARE_CLASSIC) {
+  if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
     uint8_t key[6] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7};
     uint8_t current_block = 4;
     uint8_t message_start_index = 0;
     uint32_t message_length = 0;
 
-    if (this->auth_mifare_classic_block_(uid, current_block, MIFARE_KEY_A, key)) {
+    if (this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_A, key)) {
       std::vector<uint8_t> data = this->read_mifare_classic_block_(current_block);
       if (!data.empty()) {
         if (!nfc::decode_mifare_classic_tlv(data, message_length, message_start_index)) {
@@ -179,7 +179,7 @@ nfc::NfcTag PN532::read_tag_(std::vector<uint8_t> uid) {
 
     while (index < buffer_size) {
       if (nfc::mifare_classic_is_first_block(current_block)) {
-        if (!this->auth_mifare_classic_block_(uid, current_block, MIFARE_KEY_A, key)) {
+        if (!this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_A, key)) {
           ESP_LOGE(TAG, "Error, Block authentication failed for %d", current_block);
         }
       }
@@ -190,7 +190,7 @@ nfc::NfcTag PN532::read_tag_(std::vector<uint8_t> uid) {
         ESP_LOGE(TAG, "Error reading block %d", current_block);
       }
 
-      index += BLOCK_SIZE;
+      index += nfc::BLOCK_SIZE;
       current_block++;
 
       if (nfc::mifare_classic_is_trailer_block(current_block)) {
@@ -199,10 +199,10 @@ nfc::NfcTag PN532::read_tag_(std::vector<uint8_t> uid) {
     }
 
     return nfc::NfcTag(uid, MIFARE_CLASSIC, std::vector<uint8_t>(buffer.begin() + message_start_index, buffer.end()));
-  } else if (type == TAG_TYPE_2) {
+  } else if (type == nfc::TAG_TYPE_2) {
     // TODO: do the ultralight code
     return nfc::NfcTag(uid);
-  } else if (type == TAG_TYPE_UNKNOWN) {
+  } else if (type == nfc::TAG_TYPE_UNKNOWN) {
     ESP_LOGV(TAG, "Cannot determine tag type");
     return nfc::NfcTag(uid);
   } else {
@@ -212,15 +212,15 @@ nfc::NfcTag PN532::read_tag_(std::vector<uint8_t> uid) {
 
 std::vector<uint8_t> PN532::read_mifare_classic_block_(uint8_t block_num) {
   this->pn532_write_command_({
-      0x40,  // INDATAEXCHANGE
+      PN532_COMMAND_INDATAEXCHANGE,
       0x01,  // One card
-      0x30,  // MIFARE_CMD_READ
+      nfc::MIFARE_CMD_READ,
       block_num,
   });
 
   std::vector<uint8_t> response = this->pn532_read_data_();
 
-  if (response[0] != 0x00) {
+  if (response.size() == 0 || response[0] != 0x00) {
     return {};
   }
   return response;
@@ -228,9 +228,9 @@ std::vector<uint8_t> PN532::read_mifare_classic_block_(uint8_t block_num) {
 
 bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> uid, uint8_t block_num, uint8_t key_num, uint8_t *key) {
   std::vector<uint8_t> data({
-      0x40,       // INDATAEXCHANGE
+      PN532_COMMAND_INDATAEXCHANGE,
       0x01,       // One card
-      key_num,    // Key B : Key A
+      key_num,    // Mifare Key slot
       block_num,  // Block number
   });
   data.insert(data.end(), key, key + 6);
@@ -242,7 +242,7 @@ bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> uid, uint8_t block_n
 
   std::vector<uint8_t> response = this->pn532_read_data_();
 
-  if (response[0] != 0x00) {
+  if (response.size() == 0 || response[0] != 0x00) {
     ESP_LOGE(TAG, "Authentication failed");
     return false;
   }
@@ -253,9 +253,9 @@ bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> uid, uint8_t block_n
 void PN532::turn_off_rf_() {
   ESP_LOGVV(TAG, "Turning RF field OFF");
   this->pn532_write_command_check_ack_({
-      0x32,  // RFConfiguration
-      0x1,   // RF Field
-      0x0    // Off
+      PN532_COMMAND_RFCONFIGURATION,
+      0x01,   // RF Field
+      0x00,    // Off
   });
 }
 
@@ -311,6 +311,102 @@ bool PN532::pn532_write_command_check_ack_(const std::vector<uint8_t> &data) {
   // 3. read ack
   if (!this->read_ack_()) {
     ESP_LOGV(TAG, "Invalid ACK frame received from PN532!");
+    return false;
+  }
+
+  return true;
+}
+
+bool PN532::erase_tag_(nfc::NfcTag tag) {
+  nfc::NdefMessage message = nfc::NdefMessage();
+  message.add_empty_record();
+  tag.set_ndef_message(&message);
+  return this->write_tag_(tag);
+}
+
+bool PN532::format_tag_(nfc::NfcTag tag) {
+  if (tag.get_tag_type() == MIFARE_CLASSIC) {
+    return this->format_mifare_classic_ndef_(tag);
+  }
+  ESP_LOGE(TAG, "Unsupported Tag for formatting");
+  return false;
+}
+
+bool PN532::clean_tag_(nfc::NfcTag tag) {
+  if (tag.get_tag_type() == MIFARE_CLASSIC) {
+    return this->format_mifare_classic_mifare_(tag);
+  }
+  ESP_LOGE(TAG, "Unsupported Tag for formatting");
+  return false;
+}
+
+bool PN532::write_tag_(nfc::NfcTag tag) {
+  return true;
+}
+
+bool PN532::format_mifare_classic_mifare_(nfc::NfcTag tag) {
+  return true;
+}
+
+bool PN532::format_mifare_classic_ndef_(nfc::NfcTag tag) {
+  uint8_t key_a[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+  std::vector<uint8_t> empty_ndef_message({0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  std::vector<uint8_t> sector_buffer_0({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  std::vector<uint8_t> sector_buffer_1({0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
+  std::vector<uint8_t> sector_buffer_2({0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
+  std::vector<uint8_t> sector_buffer_3({0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  std::vector<uint8_t> sector_buffer_4({0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+
+  if (!this->auth_mifare_classic_block_(tag.get_uid(), 0, nfc::MIFARE_CMD_AUTH_A, key_a)) {
+    ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting!");
+    return false;
+  }
+  if (!this->write_mifare_classic_block_(1, sector_buffer_1))
+    return false;
+  if (!this->write_mifare_classic_block_(2, sector_buffer_2))
+    return false;
+  if (!this->write_mifare_classic_block_(3, sector_buffer_3))
+    return false;
+
+  for (int i = 4; i < 64; i+=4) {
+    if (!this->auth_mifare_classic_block_(tag.get_uid(), i, nfc::MIFARE_CMD_AUTH_A, key_a)) {
+      ESP_LOGE(TAG, "Failed to authenticate with block %d", i);
+      continue;
+    }
+    if (i == 4) {
+      if (!this->write_mifare_classic_block_(i, empty_ndef_message))
+        ESP_LOGE(TAG, "Unable to write block %d", i);
+    } else {
+      if (!this->write_mifare_classic_block_(i, sector_buffer_0))
+        ESP_LOGE(TAG, "Unable to write block %d", i);
+    }
+    if (!this->write_mifare_classic_block_(i+1, sector_buffer_0))
+        ESP_LOGE(TAG, "Unable to write block %d", i+1);
+    if (!this->write_mifare_classic_block_(i+2, sector_buffer_0))
+        ESP_LOGE(TAG, "Unable to write block %d", i+2);
+    if (!this->write_mifare_classic_block_(i+3, sector_buffer_4))
+        ESP_LOGE(TAG, "Unable to write block %d", i+3);
+  }
+  return true;
+}
+
+bool PN532::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> write_data) {
+  std::vector<uint8_t> data({
+      PN532_COMMAND_INDATAEXCHANGE,
+      0x01,       // One card
+      nfc::MIFARE_CMD_WRITE,
+      block_num,  // Block number
+  });
+  data.insert(data.end(), write_data.begin(), write_data.end());
+  this->pn532_write_command_(data);
+
+  if (!this->wait_ready_())
+    return false;
+
+  std::vector<uint8_t> response = this->pn532_read_data_();
+
+  if (response.size() == 0) {
+    ESP_LOGE(TAG, "Error writing block %d", block_num);
     return false;
   }
 

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -4,11 +4,16 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/spi/spi.h"
-#include "esphome/components/nfc/nfc_tag.h"
 #include "esphome/components/nfc/nfc.h"
 
 namespace esphome {
 namespace pn532 {
+
+static const uint8_t PN532_COMMAND_SAMCONFIGURATION    = 0x14;
+static const uint8_t PN532_COMMAND_RFCONFIGURATION     = 0x32;
+static const uint8_t PN532_COMMAND_INDATAEXCHANGE      = 0x40;
+static const uint8_t PN532_COMMAND_INLISTPASSIVETARGET = 0x4A;
+
 
 class PN532BinarySensor;
 class PN532Trigger;
@@ -60,8 +65,19 @@ class PN532 : public PollingComponent,
   void turn_off_rf_();
 
   nfc::NfcTag read_tag_(std::vector<uint8_t> uid);
+
+  bool erase_tag_(nfc::NfcTag tag);
+  bool format_tag_(nfc::NfcTag tag);
+  bool clean_tag_(nfc::NfcTag tag);
+  bool write_tag_(nfc::NfcTag tag);
+
+
   std::vector<uint8_t> read_mifare_classic_block_(uint8_t block_num);
+  bool write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> data);
+
   bool auth_mifare_classic_block_(std::vector<uint8_t> uid, uint8_t block_num, uint8_t key_num, uint8_t *key);
+  bool format_mifare_classic_mifare_(nfc::NfcTag tag);
+  bool format_mifare_classic_ndef_(nfc::NfcTag tag);
 
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -4,6 +4,8 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/spi/spi.h"
+#include "esphome/components/nfc/nfc_tag.h"
+#include "esphome/components/nfc/nfc.h"
 
 namespace esphome {
 namespace pn532 {
@@ -57,6 +59,10 @@ class PN532 : public PollingComponent,
 
   void turn_off_rf_();
 
+  nfc::NfcTag read_tag_(std::vector<uint8_t> uid);
+  std::vector<uint8_t> read_mifare_classic_block_(uint8_t block_num);
+  bool auth_mifare_classic_block_(std::vector<uint8_t> uid, uint8_t block_num, uint8_t key_num, uint8_t *key);
+
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;
   std::vector<PN532Trigger *> triggers_;
@@ -71,7 +77,7 @@ class PN532BinarySensor : public binary_sensor::BinarySensor {
  public:
   void set_uid(const std::vector<uint8_t> &uid) { uid_ = uid; }
 
-  bool process(const uint8_t *data, uint8_t len);
+  bool process(std::vector<uint8_t> data);
 
   void on_scan_end() {
     if (!this->found_) {
@@ -85,9 +91,9 @@ class PN532BinarySensor : public binary_sensor::BinarySensor {
   bool found_{false};
 };
 
-class PN532Trigger : public Trigger<std::string> {
+class PN532Trigger : public Trigger<std::string, nfc::NfcTag> {
  public:
-  void process(const uint8_t *uid, uint8_t uid_length);
+  void process(nfc::NfcTag *tag);
 };
 
 }  // namespace pn532

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -9,11 +9,10 @@
 namespace esphome {
 namespace pn532 {
 
-static const uint8_t PN532_COMMAND_SAMCONFIGURATION    = 0x14;
-static const uint8_t PN532_COMMAND_RFCONFIGURATION     = 0x32;
-static const uint8_t PN532_COMMAND_INDATAEXCHANGE      = 0x40;
+static const uint8_t PN532_COMMAND_SAMCONFIGURATION = 0x14;
+static const uint8_t PN532_COMMAND_RFCONFIGURATION = 0x32;
+static const uint8_t PN532_COMMAND_INDATAEXCHANGE = 0x40;
 static const uint8_t PN532_COMMAND_INLISTPASSIVETARGET = 0x4A;
-
 
 class PN532BinarySensor;
 class PN532Trigger;
@@ -70,7 +69,6 @@ class PN532 : public PollingComponent,
   bool format_tag_(nfc::NfcTag tag);
   bool clean_tag_(nfc::NfcTag tag);
   bool write_tag_(nfc::NfcTag tag);
-
 
   std::vector<uint8_t> read_mifare_classic_block_(uint8_t block_num);
   bool write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> data);


### PR DESCRIPTION
## Description:

# WORK IN PROGRESS

This PR attempts to add NFC NDEF support to ESPHome.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
