### PR TITLE
fix: Incorrect time delay conversion breaks remote_transmitter_esp8266.cpp

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -175,11 +175,11 @@ void delay_microseconds_accurate(uint32_t usec) {
   if (usec == 0)
     return;
 
-  if (usec <= 16383UL) {
+  if (usec <= 1000UL) {
     delayMicroseconds(usec);
   } else {
-    delay(usec / 16383UL);
-    delayMicroseconds(usec % 16383UL);
+    delay(usec / 1000UL);
+    delayMicroseconds(usec % 1000UL);
   }
 }
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -175,7 +175,7 @@ void delay_microseconds_accurate(uint32_t usec) {
   if (usec == 0)
     return;
 
-  if (usec <= 1000UL) {
+  if (usec <= 16383UL) {
     delayMicroseconds(usec);
   } else {
     delay(usec / 1000UL);


### PR DESCRIPTION
## Description:

I'm unsure why the conversion from microseconds into whole milliseconds and remaining microseconds is done using a value of 16383, rather than 1000. This breaks the "on" and "off" times, as well as the repeat wait_time in the Remote Transmitter component for ESP8266. Only a time period of more than 16383 microseconds will cause the issue.

An infrared code for one of my devices contains an 'off' time of 21615 microseconds, which is why I ended up here after investigating. I have confirmed behaviour with an oscilloscope. See https://community.home-assistant.io/t/infrared-remote-transmitter-not-working/232825

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). **(I need help with this).**

No user exposed functionality or configuration variables are added/changed.