### PR TITLE
Added support for MCP23S08 SPI I/O expander

### DIFF
--- a/esphome/components/mcp23s08/__init__.py
+++ b/esphome/components/mcp23s08/__init__.py
@@ -21,7 +21,7 @@ MCP23S08GPIOPin = mcp23s08_ns.class_('MCP23S08GPIOPin', cg.GPIOPin)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.Required(CONF_ID): cv.declare_id(MCP23S08),
-    cv.Required(CONF_ADDRESS): cv.hex_uint8_t,
+    cv.Optional(CONF_ADDRESS, default=0x40): cv.hex_uint8_t,
 }).extend(cv.COMPONENT_SCHEMA).extend(
     spi.spi_device_schema(cs_pin_required=True))
 

--- a/esphome/components/mcp23s08/__init__.py
+++ b/esphome/components/mcp23s08/__init__.py
@@ -1,0 +1,59 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import spi
+from esphome.const import CONF_ID, CONF_NUMBER, CONF_MODE, CONF_INVERTED, \
+    CONF_ADDRESS
+
+DEPENDENCIES = ['spi']
+MULTI_CONF = True
+
+mcp23s08_ns = cg.esphome_ns.namespace('mcp23s08')
+MCP23S08GPIOMode = mcp23s08_ns.enum('MCP23S08GPIOMode')
+MCP23S08_GPIO_MODES = {
+    'INPUT': MCP23S08GPIOMode.MCP23S08_INPUT,
+    'INPUT_PULLUP': MCP23S08GPIOMode.MCP23S08_INPUT_PULLUP,
+    'OUTPUT': MCP23S08GPIOMode.MCP23S08_OUTPUT,
+}
+
+MCP23S08 = mcp23s08_ns.class_('MCP23S08', cg.Component, spi.SPIDevice)
+MCP23S08GPIOPin = mcp23s08_ns.class_('MCP23S08GPIOPin', cg.GPIOPin)
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.Required(CONF_ID): cv.declare_id(MCP23S08),
+    cv.Required(CONF_ADDRESS): cv.hex_uint8_t,
+}).extend(cv.COMPONENT_SCHEMA).extend(
+    spi.spi_device_schema(cs_pin_required=True))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_address(config[CONF_ADDRESS]))
+    yield cg.register_component(var, config)
+    yield spi.register_spi_device(var, config)
+
+
+CONF_MCP23S08 = 'mcp23s08'
+MCP23S08_OUTPUT_PIN_SCHEMA = cv.Schema({
+    cv.Required(CONF_MCP23S08): cv.use_id(MCP23S08),
+    cv.Required(CONF_NUMBER): cv.int_,
+    cv.Optional(CONF_MODE, default="OUTPUT"): cv.enum(MCP23S08_GPIO_MODES,
+                                                      upper=True),
+    cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+})
+MCP23S08_INPUT_PIN_SCHEMA = cv.Schema({
+    cv.Required(CONF_MCP23S08): cv.use_id(MCP23S08),
+    cv.Required(CONF_NUMBER): cv.int_,
+    cv.Optional(CONF_MODE, default="INPUT"): cv.enum(MCP23S08_GPIO_MODES,
+                                                     upper=True),
+    cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+})
+
+
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_MCP23S08,
+                                   (MCP23S08_OUTPUT_PIN_SCHEMA,
+                                    MCP23S08_INPUT_PIN_SCHEMA))
+def mcp23008_pin_to_code(config):
+    parent = yield cg.get_variable(config[CONF_MCP23S08])
+    yield MCP23S08GPIOPin.new(parent, config[CONF_NUMBER],
+                              config[CONF_MODE], config[CONF_INVERTED])

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -35,7 +35,6 @@ bool MCP23S08::digital_read(uint8_t pin) {
 void MCP23S08::digital_write(uint8_t pin, bool value) {
   uint8_t reg_addr = MCP23S08_OLAT;
 
-
   this->update_reg_(pin, value, reg_addr);
 }
 void MCP23S08::pin_mode(uint8_t pin, uint8_t mode) {

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -1,0 +1,115 @@
+#include "mcp23s08.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace mcp23s08 {
+
+static const char *TAG = "mcp23s08";
+
+void MCP23S08::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up MCP23S08...");
+  this->spi_setup();
+  uint8_t iocon;
+  if (!this->read_reg_(MCP23S08_IOCON, &iocon)) {
+    this->mark_failed();
+    return;
+  }
+
+  // all pins input
+  this->write_reg_(MCP23S08_IODIR, 0xFF);
+}
+
+void MCP23S08::dump_config() {
+  ESP_LOGCONFIG(TAG, "MCP23S08:");
+  ESP_LOGCONFIG(TAG, "  Address: %#02x", this->address_);
+  LOG_PIN("  CS Pin: ", this->cs_);
+}
+
+bool MCP23S08::digital_read(uint8_t pin) {
+  uint8_t bit = pin % 8;
+  uint8_t reg_addr = MCP23S08_GPIO;
+  uint8_t value = 0;
+  this->read_reg_(reg_addr, &value);
+  return value & (1 << bit);
+}
+void MCP23S08::digital_write(uint8_t pin, bool value) {
+  uint8_t reg_addr = MCP23S08_OLAT;
+
+
+  this->update_reg_(pin, value, reg_addr);
+}
+void MCP23S08::pin_mode(uint8_t pin, uint8_t mode) {
+  uint8_t iodir = MCP23S08_IODIR;
+  uint8_t gppu = MCP23S08_GPPU;
+  switch (mode) {
+    case MCP23S08_INPUT:
+      this->update_reg_(pin, true, iodir);
+      break;
+    case MCP23S08_INPUT_PULLUP:
+      this->update_reg_(pin, true, iodir);
+      this->update_reg_(pin, true, gppu);
+      break;
+    case MCP23S08_OUTPUT:
+      this->update_reg_(pin, false, iodir);
+      break;
+    default:
+      break;
+  }
+}
+
+float MCP23S08::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+bool MCP23S08::read_reg_(uint8_t reg, uint8_t *value) {
+  uint8_t data;
+  if (this->is_failed())
+    return false;
+  this->enable();
+  this->transfer_byte(this->address_ | 1);
+  this->transfer_byte(reg);
+  data = this->transfer_byte(0);
+  this->disable();
+  *value = data;
+  return true;
+}
+
+bool MCP23S08::write_reg_(uint8_t reg, uint8_t value) {
+  if (this->is_failed())
+    return false;
+  this->enable();
+  this->transfer_byte(this->address_ | 0);
+  this->transfer_byte(reg);
+  this->transfer_byte(value);
+  this->disable();
+  return true;
+}
+
+void MCP23S08::update_reg_(uint8_t pin, bool pin_value, uint8_t reg_addr) {
+  uint8_t bit = pin % 8;
+  uint8_t reg_value = 0;
+  if (reg_addr == MCP23S08_OLAT) {
+    reg_value = this->olat_;
+  } else {
+    this->read_reg_(reg_addr, &reg_value);
+  }
+
+  if (pin_value)
+    reg_value |= 1 << bit;
+  else
+    reg_value &= ~(1 << bit);
+
+  this->write_reg_(reg_addr, reg_value);
+
+  if (reg_addr == MCP23S08_OLAT) {
+    this->olat_ = reg_value;
+  }
+}
+
+MCP23S08GPIOPin::MCP23S08GPIOPin(MCP23S08 *parent, uint8_t pin, uint8_t mode, bool inverted)
+    : GPIOPin(pin, mode, inverted), parent_(parent) {}
+void MCP23S08GPIOPin::setup() { this->pin_mode(this->mode_); }
+void MCP23S08GPIOPin::pin_mode(uint8_t mode) { this->parent_->pin_mode(this->pin_, mode); }
+bool MCP23S08GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
+void MCP23S08GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
+
+}  // namespace mcp23s08
+}  // namespace esphome

--- a/esphome/components/mcp23s08/mcp23s08.h
+++ b/esphome/components/mcp23s08/mcp23s08.h
@@ -30,9 +30,7 @@ enum MCP23S08GPIORegisters {
 };
 
 class MCP23S08 : public Component,
-                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST,
-                                       spi::CLOCK_POLARITY_LOW,
-                                       spi::CLOCK_PHASE_LEADING,
+                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                        spi::DATA_RATE_1MHZ> {
  public:
   MCP23S08() = default;
@@ -61,8 +59,7 @@ class MCP23S08 : public Component,
 
 class MCP23S08GPIOPin : public GPIOPin {
  public:
-  MCP23S08GPIOPin(MCP23S08 *parent, uint8_t pin,
-                  uint8_t mode, bool inverted = false);
+  MCP23S08GPIOPin(MCP23S08 *parent, uint8_t pin, uint8_t mode, bool inverted = false);
 
   void setup() override;
   void pin_mode(uint8_t mode) override;

--- a/esphome/components/mcp23s08/mcp23s08.h
+++ b/esphome/components/mcp23s08/mcp23s08.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome {
+namespace mcp23s08 {
+
+/// Modes for MCP23S08 pins
+enum MCP23S08GPIOMode : uint8_t {
+  MCP23S08_INPUT = INPUT,                // 0x00
+  MCP23S08_INPUT_PULLUP = INPUT_PULLUP,  // 0x02
+  MCP23S08_OUTPUT = OUTPUT               // 0x01
+};
+
+enum MCP23S08GPIORegisters {
+  // A side
+  MCP23S08_IODIR = 0x00,
+  MCP23S08_IPOL = 0x01,
+  MCP23S08_GPINTEN = 0x02,
+  MCP23S08_DEFVAL = 0x03,
+  MCP23S08_INTCON = 0x04,
+  MCP23S08_IOCON = 0x05,
+  MCP23S08_GPPU = 0x06,
+  MCP23S08_INTF = 0x07,
+  MCP23S08_INTCAP = 0x08,
+  MCP23S08_GPIO = 0x09,
+  MCP23S08_OLAT = 0x0A,
+};
+
+class MCP23S08 : public Component,
+                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST,
+                                       spi::CLOCK_POLARITY_LOW,
+                                       spi::CLOCK_PHASE_LEADING,
+                                       spi::DATA_RATE_1MHZ> {
+ public:
+  MCP23S08() = default;
+
+  void setup() override;
+  void dump_config() override;
+
+  bool digital_read(uint8_t pin);
+  void digital_write(uint8_t pin, bool value);
+  void pin_mode(uint8_t pin, uint8_t mode);
+  void set_address(uint8_t address) { address_ = address; }
+
+  float get_setup_priority() const override;
+
+ protected:
+  // read a given register
+  bool read_reg_(uint8_t reg, uint8_t *value);
+  // write a value to a given register
+  bool write_reg_(uint8_t reg, uint8_t value);
+  // update registers with given pin value.
+  void update_reg_(uint8_t pin, bool pin_value, uint8_t reg_a);
+
+  uint8_t olat_{0x00};
+  uint8_t address_;
+};
+
+class MCP23S08GPIOPin : public GPIOPin {
+ public:
+  MCP23S08GPIOPin(MCP23S08 *parent, uint8_t pin,
+                  uint8_t mode, bool inverted = false);
+
+  void setup() override;
+  void pin_mode(uint8_t mode) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+
+ protected:
+  MCP23S08 *parent_;
+};
+
+}  // namespace mcp23s08
+}  // namespace esphome

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1717,6 +1717,7 @@ mcp23008:
 mcp23s08:
   - id: 'mcp23s08_hub'
     address: 0x40
+    cs_pin: GPIO32
 
 mcp23016:
   - id: 'mcp23016_hub'

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -898,6 +898,13 @@ binary_sensor:
       mode: INPUT_PULLUP
       inverted: False
   - platform: gpio
+    name: "MCP24 binary sensor"
+    pin:
+      mcp23s08: mcp23s08_hub
+      number: 7
+      mode: INPUT_PULLUP
+      inverted: False
+  - platform: gpio
     name: "MCP23 binary sensor"
     pin:
       mcp23016: mcp23016_hub
@@ -1024,6 +1031,13 @@ output:
     id: id23
     pin:
       mcp23008: mcp23008_hub
+      number: 0
+      mode: OUTPUT
+      inverted: False
+  - platform: gpio
+    id: id26
+    pin:
+      mcp23s08: mcp23s08_hub
       number: 0
       mode: OUTPUT
       inverted: False
@@ -1699,6 +1713,10 @@ mcp23017:
 mcp23008:
   - id: 'mcp23008_hub'
     address: 0x22
+
+mcp23s08:
+  - id: 'mcp23s08_hub'
+    address: 0x40
 
 mcp23016:
   - id: 'mcp23016_hub'


### PR DESCRIPTION
## Description:
Adds MCP23S08 SPI I/O Expander, enabling products such as PRODINo ESP32 to work with esphome. Multiple I2C versions of this device have been added already (MCP23008, MCP23016, MCP23017) and it is debatable if these should all be merged into one.

[MCP23S08 Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/MCP23008-MCP23S08-Data-Sheet-20001919F.pdf)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#800

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
