### PR TITLE
Fix color_interlock behavior

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -395,13 +395,13 @@ LightColorValues LightCall::validate_() {
 
   // sets RGB to 100% if only White specified
   if (this->white_.has_value()) {
-    if (!this->red_.has_value() && !this->green_.has_value() && !this->blue_.has_value()) {
-      this->red_ = optional<float>(1.0f);
-      this->green_ = optional<float>(1.0f);
-      this->blue_ = optional<float>(1.0f);
-    }
-    // make white values binary aka 0.0f or 1.0f...this allows brightness to do its job
     if (traits.get_supports_color_interlock()) {
+      if (!this->red_.has_value() && !this->green_.has_value() && !this->blue_.has_value()) {
+        this->red_ = optional<float>(1.0f);
+        this->green_ = optional<float>(1.0f);
+        this->blue_ = optional<float>(1.0f);
+      }
+      // make white values binary aka 0.0f or 1.0f...this allows brightness to do its job
       if (*this->white_ > 0.0f) {
         this->white_ = optional<float>(1.0f);
       } else {
@@ -411,11 +411,13 @@ LightColorValues LightCall::validate_() {
   }
   // White to 0% if (exclusively) setting any RGB value that isn't 255,255,255
   else if (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value()) {
-    if (*this->red_ == 1.0f && *this->green_ == 1.0f && *this->blue_ == 1.0f && traits.get_supports_rgb_white_value() &&
-        traits.get_supports_color_interlock()) {
-      this->white_ = optional<float>(1.0f);
-    } else if (!this->white_.has_value() || !traits.get_supports_rgb_white_value()) {
-      this->white_ = optional<float>(0.0f);
+    if (traits.get_supports_color_interlock()) {
+      if (*this->red_ == 1.0f && *this->green_ == 1.0f && *this->blue_ == 1.0f &&
+          traits.get_supports_rgb_white_value() && traits.get_supports_color_interlock()) {
+        this->white_ = optional<float>(1.0f);
+      } else if (!this->white_.has_value() || !traits.get_supports_rgb_white_value()) {
+        this->white_ = optional<float>(0.0f);
+      }
     }
   }
   // if changing Kelvin alone, change to white light


### PR DESCRIPTION
## Description:
This PR does ensure, that RGB and White value only influence each other when color_interlock is set.
This fixes the impossibility to manually adjust both channels via Home Assistant introduced in 1.15

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1531

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
