### PR TITLE
Add on_clockwise and on_anticlockwise triggers to rotary encoder

### DIFF
--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -94,10 +94,12 @@ void ICACHE_RAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensor
   if ((new_state & arg->resolution & STATE_HAS_INCREMENTED) != 0) {
     if (arg->counter < arg->max_value)
       arg->counter++;
+    arg->on_clockwise_callback_.call();
   }
   if ((new_state & arg->resolution & STATE_HAS_DECREMENTED) != 0) {
     if (arg->counter > arg->min_value)
       arg->counter--;
+    arg->on_anticlockwise_callback_.call();
   }
 
   arg->state = new_state;

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -27,6 +27,9 @@ struct RotaryEncoderSensorStore {
   int32_t last_read{0};
   uint8_t state{0};
 
+  CallbackManager<void()> on_clockwise_callback_;
+  CallbackManager<void()> on_anticlockwise_callback_;
+
   static void gpio_intr(RotaryEncoderSensorStore *arg);
 };
 
@@ -62,6 +65,14 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
 
   float get_setup_priority() const override;
 
+  void add_on_clockwise_callback(std::function<void()> callback) {
+    this->store_.on_clockwise_callback_.add(std::move(callback));
+  }
+
+  void add_on_anticlockwise_callback(std::function<void()> callback) {
+    this->store_.on_anticlockwise_callback_.add(std::move(callback));
+  }
+
  protected:
   GPIOPin *pin_a_;
   GPIOPin *pin_b_;
@@ -79,6 +90,20 @@ template<typename... Ts> class RotaryEncoderSetValueAction : public Action<Ts...
 
  protected:
   RotaryEncoderSensor *encoder_;
+};
+
+class RotaryEncoderClockwiseTrigger : public Trigger<> {
+ public:
+  explicit RotaryEncoderClockwiseTrigger(RotaryEncoderSensor *parent) {
+    parent->add_on_clockwise_callback([this]() { this->trigger(); });
+  }
+};
+
+class RotaryEncoderAnticlockwiseTrigger : public Trigger<> {
+ public:
+  explicit RotaryEncoderAnticlockwiseTrigger(RotaryEncoderSensor *parent) {
+    parent->add_on_anticlockwise_callback([this]() { this->trigger(); });
+  }
 };
 
 }  // namespace rotary_encoder

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -586,6 +586,10 @@ sensor:
       - sensor.rotary_encoder.set_value:
           id: rotary_encoder1
           value: !lambda 'return -1;'
+    on_clockwise:
+      - logger.log: "Clockwise"
+    on_anticlockwise:
+      - logger.log: "Anticlockwise"
   - platform: pulse_width
     name: Pulse Width
     pin: GPIO12


### PR DESCRIPTION
## Description:

Adds 2 new triggers to the `rotary_encoder` sensor component. This allows you to run actions based on the direction of the turning and not the value.

**Related issue (if applicable):** fixes esphome/feature-requests#944

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#807

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
