### PR TITLE
Add support for WPA2-EAP enterprise WiFi to ESP8266s.

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -60,7 +60,7 @@ STA_MANUAL_IP_SCHEMA = AP_MANUAL_IP_SCHEMA.extend({
     cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipv4,
 })
 
-EAP_AUTH_SCHEMA = cv.All(cv.only_on_esp32, cv.Schema({
+EAP_AUTH_SCHEMA = cv.All(cv.Schema({
     cv.Optional(CONF_IDENTITY): cv.string_strict,
     cv.Optional(CONF_USERNAME): cv.string_strict,
     cv.Optional(CONF_PASSWORD): cv.string_strict,

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -242,7 +242,7 @@ bool WiFiComponent::wifi_sta_connect_(WiFiAP ap) {
     return false;
   }
 
-    // setup enterprise authentication if required
+  // setup enterprise authentication if required
 #ifdef ESPHOME_WIFI_WPA2_EAP
   if (ap.get_eap().has_value()) {
     // note: all certificates and keys have to be null terminated. Lengths are appended by +1 to include \0.
@@ -265,8 +265,8 @@ bool WiFiComponent::wifi_sta_connect_(WiFiAP ap) {
     if (client_cert_len && client_key_len) {
       // if we have certs, this must be EAP-TLS
       ret = wifi_station_set_enterprise_cert_key((uint8_t *) eap.client_cert, client_cert_len + 1,
-                                               (uint8_t *) eap.client_key, client_key_len + 1,
-                                               (uint8_t *) eap.password.c_str(), strlen(eap.password.c_str()));
+                                                 (uint8_t *) eap.client_key, client_key_len + 1,
+                                                 (uint8_t *) eap.password.c_str(), strlen(eap.password.c_str()));
       if (ret) {
         ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_cert_key failed! %d", ret);
       }

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -6,6 +6,9 @@
 
 #include <utility>
 #include <algorithm>
+#ifdef ESPHOME_WIFI_WPA2_EAP
+#include <wpa2_enterprise.h>
+#endif
 
 extern "C" {
 #include "lwip/err.h"
@@ -238,6 +241,52 @@ bool WiFiComponent::wifi_sta_connect_(WiFiAP ap) {
   if (!this->wifi_sta_ip_config_(ap.get_manual_ip())) {
     return false;
   }
+
+    // setup enterprise authentication if required
+#ifdef ESPHOME_WIFI_WPA2_EAP
+  if (ap.get_eap().has_value()) {
+    // note: all certificates and keys have to be null terminated. Lengths are appended by +1 to include \0.
+    EAPAuth eap = ap.get_eap().value();
+    ret = wifi_station_set_enterprise_identity((uint8_t *) eap.identity.c_str(), eap.identity.length());
+    if (ret) {
+      ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_identity failed! %d", ret);
+    }
+    int ca_cert_len = strlen(eap.ca_cert);
+    int client_cert_len = strlen(eap.client_cert);
+    int client_key_len = strlen(eap.client_key);
+    if (ca_cert_len) {
+      ret = wifi_station_set_enterprise_ca_cert((uint8_t *) eap.ca_cert, ca_cert_len + 1);
+      if (ret) {
+        ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_ca_cert failed! %d", ret);
+      }
+    }
+    // workout what type of EAP this is
+    // validation is not required as the config tool has already validated it
+    if (client_cert_len && client_key_len) {
+      // if we have certs, this must be EAP-TLS
+      ret = wifi_station_set_enterprise_cert_key((uint8_t *) eap.client_cert, client_cert_len + 1,
+                                               (uint8_t *) eap.client_key, client_key_len + 1,
+                                               (uint8_t *) eap.password.c_str(), strlen(eap.password.c_str()));
+      if (ret) {
+        ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_cert_key failed! %d", ret);
+      }
+    } else {
+      // in the absence of certs, assume this is username/password based
+      ret = wifi_station_set_enterprise_username((uint8_t *) eap.username.c_str(), eap.username.length());
+      if (ret) {
+        ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_username failed! %d", ret);
+      }
+      ret = wifi_station_set_enterprise_password((uint8_t *) eap.password.c_str(), eap.password.length());
+      if (ret) {
+        ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_password failed! %d", ret);
+      }
+    }
+    ret = wifi_station_set_wpa2_enterprise_auth(true);
+    if (ret) {
+      ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_enable failed! %d", ret);
+    }
+  }
+#endif  // ESPHOME_WIFI_WPA2_EAP
 
   this->wifi_apply_hostname_();
 


### PR DESCRIPTION
## Description:
Previously in #1080 I added support for WPA2-EAP enterprise WiFi authentication on ESP32s, however I could not find documentation for the same function on an ESP8266 and did not have one available at the time to test with. Having now purchased a couple of Sonoff relays I've been able to implement this for the ESP8266 as well to complete the featureset.

Tested using my internal EAP-TLS setup with valid and invalid certs.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#814

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
