### PR TITLE
Add new codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -58,6 +58,7 @@ esphome/components/switch/* @esphome/core
 esphome/components/tcl112/* @glmnet
 esphome/components/time/* @OttoWinter
 esphome/components/tm1637/* @glmnet
+esphome/components/tmp102/* @timsavage
 esphome/components/tuya/binary_sensor/* @jesserockz
 esphome/components/tuya/climate/* @jesserockz
 esphome/components/tuya/sensor/* @jesserockz

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,7 @@ esphome/components/json/* @OttoWinter
 esphome/components/ledc/* @OttoWinter
 esphome/components/light/* @esphome/core
 esphome/components/logger/* @esphome/core
+esphome/components/mcp9808/* @k7hpn
 esphome/components/network/* @esphome/core
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core

--- a/esphome/components/mcp9808/sensor.py
+++ b/esphome/components/mcp9808/sensor.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import i2c, sensor
 from esphome.const import CONF_ID, ICON_THERMOMETER, UNIT_CELSIUS
 
+CODEOWNERS = ['@k7hpn']
 DEPENDENCIES = ['i2c']
 
 mcp9808_ns = cg.esphome_ns.namespace('mcp9808')

--- a/esphome/components/tmp102/sensor.py
+++ b/esphome/components/tmp102/sensor.py
@@ -12,6 +12,7 @@ import esphome.config_validation as cv
 from esphome.components import i2c, sensor
 from esphome.const import CONF_ID, UNIT_CELSIUS, ICON_THERMOMETER
 
+CODEOWNERS = ['@timsavage']
 DEPENDENCIES = ['i2c']
 
 tmp102_ns = cg.esphome_ns.namespace('tmp102')


### PR DESCRIPTION
## Description:

Adding codeowners for some older PRs that are finally being merged

- `tmp102` #929
- `mcp9808` #1169 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
