### PR TITLE
Fix some Tuya devices not handling commands sent without delay

### DIFF
--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -71,10 +71,12 @@ class Tuya : public Component, public uart::UARTDevice {
   void handle_command_(uint8_t command, uint8_t version, const uint8_t *buffer, size_t len);
   void send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_t len);
   void send_empty_command_(TuyaCommandType command) { this->send_command_(command, nullptr, 0); }
+  void schedule_empty_command_(TuyaCommandType command);
 
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;
+  uint32_t last_command_timestamp_ = 0;
   std::string product_ = "";
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;


### PR DESCRIPTION
## Description:
Some Tuya MCUs are not working properly if a command is sent right after receiving the previous command or is sent while the previous response is not been sent yet. 

Also, according to the [Tuya documentation](https://developer.tuya.com/en/docs/iot/device-development/access-mode-mcu/wifi-general-solution/software-reference-wifi/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb#title-7-Querying%20working%20mode) 
if MCU is working in "The self-processing mode" and providing status GPIO pin, the WiFi reporting can be omitted.

I have ME81AH thermostat, which was not working before these changes.

**Related issue (if applicable):** 
Simillar PR: https://github.com/esphome/esphome/pull/958

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#
No docs changed

## Checklist:
  - [x] The code change is tested and works locally.

  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
