### PR TITLE
Add support for Tuya MCU 0x1C (obtain local time)

### DIFF
--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -1,3 +1,4 @@
+from esphome.components import time
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
@@ -9,8 +10,10 @@ tuya_ns = cg.esphome_ns.namespace('tuya')
 Tuya = tuya_ns.class_('Tuya', cg.Component, uart.UARTDevice)
 
 CONF_TUYA_ID = 'tuya_id'
+CONF_CLOCK = 'clock'
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(Tuya),
+    cv.Optional(CONF_CLOCK): cv.use_id(time.RealTimeClock),
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
 
@@ -18,3 +21,6 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     yield uart.register_uart_device(var, config)
+    if CONF_CLOCK in config:
+        time_ = yield cg.get_variable(config[CONF_CLOCK])
+        cg.add(var.set_clock(time_))

--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -2,7 +2,7 @@ from esphome.components import time
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_TIME_ID
 
 DEPENDENCIES = ['uart']
 
@@ -10,10 +10,9 @@ tuya_ns = cg.esphome_ns.namespace('tuya')
 Tuya = tuya_ns.class_('Tuya', cg.Component, uart.UARTDevice)
 
 CONF_TUYA_ID = 'tuya_id'
-CONF_CLOCK = 'clock'
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(Tuya),
-    cv.Optional(CONF_CLOCK): cv.use_id(time.RealTimeClock),
+    cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
 
@@ -21,6 +20,6 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     yield uart.register_uart_device(var, config)
-    if CONF_CLOCK in config:
-        time_ = yield cg.get_variable(config[CONF_CLOCK])
-        cg.add(var.set_clock(time_))
+    if CONF_TIME_ID in config:
+        time_ = yield cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time_id(time_))

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -206,9 +206,9 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
     }
     case TuyaCommandType::LOCAL_TIME_QUERY: {
 #ifdef USE_TIME
-      if (this->clock_.has_value()) {
-        auto clock = *this->clock_;
-        auto now = clock->now();
+      if (this->time_id_.has_value()) {
+        auto time_id = *this->time_id_;
+        auto now = time_id->now();
 
         if (now.is_valid()) {
           this->set_timeout(COMMAND_DELAY, [this, now] {
@@ -235,7 +235,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
           });
         }
       } else {
-        ESP_LOGW(TAG, "TUYA_CMD_LOCAL_TIME_QUERY is not handled because clock is not configured");
+        ESP_LOGW(TAG, "TUYA_CMD_LOCAL_TIME_QUERY is not handled because time is not configured");
       }
 #else
       ESP_LOGE(TAG, "LOCAL_TIME_QUERY is not handled");

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -205,6 +205,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       break;
     }
     case TuyaCommandType::LOCAL_TIME_QUERY: {
+#ifdef USE_TIME
       if (this->clock_.has_value()) {
         auto clock = *this->clock_;
         auto now = clock->now();
@@ -236,6 +237,9 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       } else {
         ESP_LOGW(TAG, "TUYA_CMD_LOCAL_TIME_QUERY is not handled because clock is not configured");
       }
+#else
+      ESP_LOGE(TAG, "LOCAL_TIME_QUERY is not handled");
+#endif
       break;
     }
     default:

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "esphome/components/uart/uart.h"
+
+#ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
+#endif
 
 namespace esphome {
 namespace tuya {
@@ -64,7 +68,9 @@ class Tuya : public Component, public uart::UARTDevice {
   void dump_config() override;
   void register_listener(uint8_t datapoint_id, const std::function<void(TuyaDatapoint)> &func);
   void set_datapoint_value(TuyaDatapoint datapoint);
+#ifdef USE_TIME
   void set_clock(time::RealTimeClock *clock) { this->clock_ = clock; }
+#endif
 
  protected:
   void handle_char_(uint8_t c);
@@ -76,7 +82,9 @@ class Tuya : public Component, public uart::UARTDevice {
   void send_empty_command_(TuyaCommandType command) { this->send_command_(command, nullptr, 0); }
   void schedule_empty_command_(TuyaCommandType command);
 
+#ifdef USE_TIME
   optional<time::RealTimeClock *> clock_{};
+#endif
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -71,10 +71,12 @@ class Tuya : public Component, public uart::UARTDevice {
   void handle_command_(uint8_t command, uint8_t version, const uint8_t *buffer, size_t len);
   void send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_t len);
   void send_empty_command_(TuyaCommandType command) { this->send_command_(command, nullptr, 0); }
+  void schedule_empty_command_(TuyaCommandType command);
 
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;
+  uint32_t last_command_timestamp_ = 0;
   std::string product_ = "";
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
+#include "esphome/components/time/real_time_clock.h"
 
 namespace esphome {
 namespace tuya {
@@ -43,6 +44,7 @@ enum class TuyaCommandType : uint8_t {
   DATAPOINT_REPORT = 0x07,
   DATAPOINT_QUERY = 0x08,
   WIFI_TEST = 0x0E,
+  LOCAL_TIME_QUERY = 0x1C,
 };
 
 enum class TuyaInitState : uint8_t {
@@ -62,6 +64,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void dump_config() override;
   void register_listener(uint8_t datapoint_id, const std::function<void(TuyaDatapoint)> &func);
   void set_datapoint_value(TuyaDatapoint datapoint);
+  void set_clock(time::RealTimeClock *clock) { this->clock_ = clock; }
 
  protected:
   void handle_char_(uint8_t c);
@@ -73,6 +76,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void send_empty_command_(TuyaCommandType command) { this->send_command_(command, nullptr, 0); }
   void schedule_empty_command_(TuyaCommandType command);
 
+  optional<time::RealTimeClock *> clock_{};
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;
   int gpio_reset_ = -1;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -69,7 +69,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void register_listener(uint8_t datapoint_id, const std::function<void(TuyaDatapoint)> &func);
   void set_datapoint_value(TuyaDatapoint datapoint);
 #ifdef USE_TIME
-  void set_clock(time::RealTimeClock *clock) { this->clock_ = clock; }
+  void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
 #endif
 
  protected:
@@ -83,7 +83,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void schedule_empty_command_(TuyaCommandType command);
 
 #ifdef USE_TIME
-  optional<time::RealTimeClock *> clock_{};
+  optional<time::RealTimeClock *> time_id_{};
 #endif
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   int gpio_status_ = -1;

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -49,7 +49,12 @@ web_server:
     username: admin
     password: admin
 
+time:
+  - platform: sntp
+    id: sntp_time
+
 tuya:
+  time_id: sntp_time
 
 sensor:
   - platform: homeassistant


### PR DESCRIPTION
## Description:
Tuya MCU allows obtaining local time by MCU from esp by 0x1C command.
https://developer.tuya.com/en/docs/iot/device-development/access-mode-mcu/wifi-general-solution/software-reference-wifi/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb#title-16-Obtaining%20local%20time

**Related issue (if applicable):** 

This PR is intended to be merged after https://github.com/esphome/esphome/pull/1341, as it uses the same delays.
If the previous PR will not be merged or will be significantly changed, I will make changes to accomodate that .

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):
https://github.com/esphome/esphome-docs/pull/827

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
