### PR TITLE
Add option to use Shelly temperature sensor addon with the dallas com…

### DIFF
--- a/esphome/components/dallas/__init__.py
+++ b/esphome/components/dallas/__init__.py
@@ -1,25 +1,33 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.const import CONF_ID, CONF_PIN
+from esphome.const import CONF_ID, CONF_PIN, CONF_PIN_A
 
 MULTI_CONF = True
 AUTO_LOAD = ['sensor']
 
 CONF_ONE_WIRE_ID = 'one_wire_id'
+CONF_SHELLY_ONE_WIRE_ID = 'shelly_one_wire_id'
 dallas_ns = cg.esphome_ns.namespace('dallas')
 DallasComponent = dallas_ns.class_('DallasComponent', cg.PollingComponent)
 ESPOneWire = dallas_ns.class_('ESPOneWire')
+ShellyOneWire = dallas_ns.class_('ShellyOneWire')
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(DallasComponent),
     cv.GenerateID(CONF_ONE_WIRE_ID): cv.declare_id(ESPOneWire),
+    cv.GenerateID(CONF_SHELLY_ONE_WIRE_ID): cv.declare_id(ShellyOneWire),
     cv.Required(CONF_PIN): pins.gpio_input_pin_schema,
+    cv.Optional(CONF_PIN_A): pins.gpio_output_pin_schema,
 }).extend(cv.polling_component_schema('60s'))
 
 
 def to_code(config):
     pin = yield cg.gpio_pin_expression(config[CONF_PIN])
-    one_wire = cg.new_Pvariable(config[CONF_ONE_WIRE_ID], pin)
+    if CONF_PIN_A in config:
+        pin_out = yield cg.gpio_pin_expression(config[CONF_PIN_A])
+        one_wire = cg.new_Pvariable(config[CONF_SHELLY_ONE_WIRE_ID], pin, pin_out)
+    else:
+        one_wire = cg.new_Pvariable(config[CONF_ONE_WIRE_ID], pin)
     var = cg.new_Pvariable(config[CONF_ID], one_wire)
     yield cg.register_component(var, config)

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -70,7 +70,7 @@ void DallasComponent::setup() {
 }
 void DallasComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "DallasComponent:");
-  LOG_PIN("  Pin: ", this->one_wire_->get_pin());
+  // LOG_PIN("  Pin: ", this->one_wire_->get_pin());
   LOG_UPDATE_INTERVAL(this);
 
   if (this->found_sensors_.empty()) {
@@ -155,7 +155,8 @@ void DallasComponent::update() {
     });
   }
 }
-DallasComponent::DallasComponent(ESPOneWire *one_wire) : one_wire_(one_wire) {}
+
+DallasComponent::DallasComponent(ESPOneWireBase *one_wire) : one_wire_(one_wire) {}
 
 DallasTemperatureSensor::DallasTemperatureSensor(uint64_t address, uint8_t resolution, DallasComponent *parent)
     : parent_(parent) {
@@ -176,7 +177,7 @@ const std::string &DallasTemperatureSensor::get_address_name() {
   return this->address_name_;
 }
 bool ICACHE_RAM_ATTR DallasTemperatureSensor::read_scratch_pad() {
-  ESPOneWire *wire = this->parent_->one_wire_;
+  ESPOneWireBase *wire = this->parent_->one_wire_;
   if (!wire->reset()) {
     return false;
   }
@@ -228,7 +229,7 @@ bool DallasTemperatureSensor::setup_sensor() {
       break;
   }
 
-  ESPOneWire *wire = this->parent_->one_wire_;
+  ESPOneWireBase *wire = this->parent_->one_wire_;
   {
     InterruptLock lock;
     if (wire->reset()) {

--- a/esphome/components/dallas/dallas_component.h
+++ b/esphome/components/dallas/dallas_component.h
@@ -11,7 +11,7 @@ class DallasTemperatureSensor;
 
 class DallasComponent : public PollingComponent {
  public:
-  explicit DallasComponent(ESPOneWire *one_wire);
+  explicit DallasComponent(ESPOneWireBase *one_wire);
 
   DallasTemperatureSensor *get_sensor_by_address(uint64_t address, uint8_t resolution);
   DallasTemperatureSensor *get_sensor_by_index(uint8_t index, uint8_t resolution);
@@ -25,7 +25,7 @@ class DallasComponent : public PollingComponent {
  protected:
   friend DallasTemperatureSensor;
 
-  ESPOneWire *one_wire_;
+  ESPOneWireBase *one_wire_;
   std::vector<DallasTemperatureSensor *> sensors_;
   std::vector<uint64_t> found_sensors_;
 };

--- a/esphome/components/dallas/esp_one_wire.cpp
+++ b/esphome/components/dallas/esp_one_wire.cpp
@@ -10,7 +10,7 @@ static const char *TAG = "dallas.one_wire";
 const uint8_t ONE_WIRE_ROM_SELECT = 0x55;
 const int ONE_WIRE_ROM_SEARCH = 0xF0;
 
-ESPOneWire::ESPOneWire(GPIOPin *pin) : pin_(pin) {}
+ESPOneWire::ESPOneWire(GPIOPin *pin) : ESPOneWireBase(), pin_(pin) {}
 
 bool HOT ICACHE_RAM_ATTR ESPOneWire::reset() {
   uint8_t retries = 125;
@@ -76,43 +76,113 @@ bool HOT ICACHE_RAM_ATTR ESPOneWire::read_bit() {
   return r;
 }
 
-void ICACHE_RAM_ATTR ESPOneWire::write8(uint8_t val) {
+ShellyOneWire::ShellyOneWire(GPIOPin *pin_a, GPIOPin *pin_b) : ESPOneWireBase(), in_pin_(pin_a), out_pin_(pin_b) {
+  this->in_pin_->pin_mode(INPUT);
+  this->out_pin_->pin_mode(OUTPUT);
+  this->out_pin_->digital_write(true);
+}
+
+bool HOT ICACHE_RAM_ATTR ShellyOneWire::reset() {
+  uint8_t retries = 125;
+
+  do {
+    if (--retries == 0)
+      return false;
+    delayMicroseconds(2);
+  } while (!this->in_pin_->digital_read());
+
+  // Send 480µs LOW TX reset pulse
+  // FIXME this->pin_->pin_mode(OUTPUT);
+  this->out_pin_->digital_write(false);
+  delayMicroseconds(480);
+  this->out_pin_->digital_write(true);
+
+  // Switch into RX mode, letting the pin float
+  // FIXME this->pin_->pin_mode(INPUT_PULLUP);
+  // after 15µs-60µs wait time, device pulls low for 60µs-240µs
+  // let's have 70µs just in case
+  delayMicroseconds(70);
+
+  bool r = !this->in_pin_->digital_read();
+  delayMicroseconds(410);
+  return r;
+}
+
+void HOT ICACHE_RAM_ATTR ShellyOneWire::write_bit(bool bit) {
+  // Initiate write/read by pulling low.
+  // FIXME this->pin_->pin_mode(OUTPUT);
+  this->out_pin_->digital_write(false);
+
+  // bus sampled within 15µs and 60µs after pulling LOW.
+  if (bit) {
+    // pull high/release within 15µs
+    delayMicroseconds(10);
+    this->out_pin_->digital_write(true);
+    // in total minimum of 60µs long
+    delayMicroseconds(55);
+  } else {
+    // continue pulling LOW for at least 60µs
+    delayMicroseconds(65);
+    this->out_pin_->digital_write(true);
+    // grace period, 1µs recovery time
+    delayMicroseconds(5);
+  }
+}
+
+bool HOT ICACHE_RAM_ATTR ShellyOneWire::read_bit() {
+  // Initiate read slot by pulling LOW for at least 1µs
+  // FIXME this->pin_->pin_mode(OUTPUT);
+  this->out_pin_->digital_write(false);
+  delayMicroseconds(3);
+  this->out_pin_->digital_write(true);
+
+  // release bus, we have to sample within 15µs of pulling low
+  // FIXME this->pin_->pin_mode(INPUT_PULLUP);
+  delayMicroseconds(10);
+
+  bool r = this->in_pin_->digital_read();
+  // read time slot at least 60µs long + 1µs recovery time between slots
+  delayMicroseconds(53);
+  return r;
+}
+
+void ICACHE_RAM_ATTR ESPOneWireBase::write8(uint8_t val) {
   for (uint8_t i = 0; i < 8; i++) {
     this->write_bit(bool((1u << i) & val));
   }
 }
 
-void ICACHE_RAM_ATTR ESPOneWire::write64(uint64_t val) {
+void ICACHE_RAM_ATTR ESPOneWireBase::write64(uint64_t val) {
   for (uint8_t i = 0; i < 64; i++) {
     this->write_bit(bool((1ULL << i) & val));
   }
 }
 
-uint8_t ICACHE_RAM_ATTR ESPOneWire::read8() {
+uint8_t ICACHE_RAM_ATTR ESPOneWireBase::read8() {
   uint8_t ret = 0;
   for (uint8_t i = 0; i < 8; i++) {
     ret |= (uint8_t(this->read_bit()) << i);
   }
   return ret;
 }
-uint64_t ICACHE_RAM_ATTR ESPOneWire::read64() {
+uint64_t ICACHE_RAM_ATTR ESPOneWireBase::read64() {
   uint64_t ret = 0;
   for (uint8_t i = 0; i < 8; i++) {
     ret |= (uint64_t(this->read_bit()) << i);
   }
   return ret;
 }
-void ICACHE_RAM_ATTR ESPOneWire::select(uint64_t address) {
+void ICACHE_RAM_ATTR ESPOneWireBase::select(uint64_t address) {
   this->write8(ONE_WIRE_ROM_SELECT);
   this->write64(address);
 }
-void ICACHE_RAM_ATTR ESPOneWire::reset_search() {
+void ICACHE_RAM_ATTR ESPOneWireBase::reset_search() {
   this->last_discrepancy_ = 0;
   this->last_device_flag_ = false;
   this->last_family_discrepancy_ = 0;
   this->rom_number_ = 0;
 }
-uint64_t HOT ICACHE_RAM_ATTR ESPOneWire::search() {
+uint64_t HOT ICACHE_RAM_ATTR ESPOneWireBase::search() {
   if (this->last_device_flag_) {
     return 0u;
   }
@@ -196,7 +266,7 @@ uint64_t HOT ICACHE_RAM_ATTR ESPOneWire::search() {
 
   return this->rom_number_;
 }
-std::vector<uint64_t> ICACHE_RAM_ATTR ESPOneWire::search_vec() {
+std::vector<uint64_t> ICACHE_RAM_ATTR ESPOneWireBase::search_vec() {
   std::vector<uint64_t> res;
 
   this->reset_search();
@@ -206,12 +276,13 @@ std::vector<uint64_t> ICACHE_RAM_ATTR ESPOneWire::search_vec() {
 
   return res;
 }
-void ICACHE_RAM_ATTR ESPOneWire::skip() {
+void ICACHE_RAM_ATTR ESPOneWireBase::skip() {
   this->write8(0xCC);  // skip ROM
 }
-GPIOPin *ESPOneWire::get_pin() { return this->pin_; }
 
-uint8_t ICACHE_RAM_ATTR *ESPOneWire::rom_number8_() { return reinterpret_cast<uint8_t *>(&this->rom_number_); }
+// GPIOPin *ESPOneWireBase::get_pin() { return this->pin_; }
+
+uint8_t ICACHE_RAM_ATTR *ESPOneWireBase::rom_number8_() { return reinterpret_cast<uint8_t *>(&this->rom_number_); }
 
 }  // namespace dallas
 }  // namespace esphome

--- a/esphome/components/dallas/esp_one_wire.h
+++ b/esphome/components/dallas/esp_one_wire.h
@@ -9,9 +9,9 @@ namespace dallas {
 extern const uint8_t ONE_WIRE_ROM_SELECT;
 extern const int ONE_WIRE_ROM_SEARCH;
 
-class ESPOneWire {
+class ESPOneWireBase {
  public:
-  explicit ESPOneWire(GPIOPin *pin);
+  explicit ESPOneWireBase() {}
 
   /** Reset the bus, should be done before all write operations.
    *
@@ -19,13 +19,13 @@ class ESPOneWire {
    *
    * @return Whether the operation was successful.
    */
-  bool reset();
+  virtual bool reset() = 0;
 
   /// Write a single bit to the bus, takes about 70µs.
-  void write_bit(bool bit);
+  virtual void write_bit(bool bit) = 0;
 
   /// Read a single bit from the bus, takes about 70µs
-  bool read_bit();
+  virtual bool read_bit();
 
   /// Write a word to the bus. LSB first.
   void write8(uint8_t val);
@@ -54,17 +54,50 @@ class ESPOneWire {
   /// Helper that wraps search in a std::vector.
   std::vector<uint64_t> search_vec();
 
-  GPIOPin *get_pin();
+  // Removed check if it is usefull
+  // GPIOPin *get_pin();
 
  protected:
   /// Helper to get the internal 64-bit unsigned rom number as a 8-bit integer pointer.
   inline uint8_t *rom_number8_();
 
-  GPIOPin *pin_;
   uint8_t last_discrepancy_{0};
   uint8_t last_family_discrepancy_{0};
   bool last_device_flag_{false};
   uint64_t rom_number_{0};
+};
+
+class ESPOneWire : public ESPOneWireBase {
+ public:
+  explicit ESPOneWire(GPIOPin *pin);
+
+  bool reset() override;
+
+  /// Write a single bit to the bus, takes about 70µs.
+  void write_bit(bool bit) override;
+
+  /// Read a single bit from the bus, takes about 70µs
+  bool read_bit() override;
+
+ protected:
+  GPIOPin *pin_;
+};
+
+class ShellyOneWire : public ESPOneWireBase {
+ public:
+  explicit ShellyOneWire(GPIOPin *pin_a, GPIOPin *pin_b);
+
+  bool reset() override;
+
+  /// Write a single bit to the bus, takes about 70µs.
+  void write_bit(bool bit) override;
+
+  /// Read a single bit from the bus, takes about 70µs
+  bool read_bit() override;
+
+ protected:
+  GPIOPin *in_pin_;
+  GPIOPin *out_pin_;
 };
 
 }  // namespace dallas

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -47,6 +47,9 @@ logger:
 as3935_i2c:
   irq_pin: GPIO12
 
+dallas:
+  pin: GPIO3
+  pin_a: GPIO0
 
 sensor:
   - platform: homeassistant
@@ -169,6 +172,15 @@ sensor:
       name: "JQJCY01YM Formaldehyde"
     battery_level:
       name: "JQJCY01YM Battery Level"
+  - platform: dallas
+    address: 0xCA011938282E5128
+    name: "Temperature #1"
+  - platform: dallas
+    address: 0x0B01193807DD3128
+    name: "Temperature #2"
+  - platform: dallas
+    address: 0x6E0119384DC70728
+    name: "Temperature #3"
 
 
 time:


### PR DESCRIPTION
A patch to the Dallas component to make it compatible with the Temperature Sensor AddOn for Shelly 1/1PM

This sensor board uses a different way to access the onwire bus, the OneWire patch will create a new base class called ESPOneWireBase that contains all the bus logic and two derived class one for the standard one wire bus physical access and one for the temperature sensor.

The instance of the correct derived class is created during the config: If there is a pin_a attribute the shelly temp. the sensor is instantiated, otherwise is instantiated in the standard OneWIre class. In this way, the config is backward compatible.

Example config:
```yaml
dallas:
  pin: GPIO3
  pin_a: GPIO0
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
