### PR TITLE
Add a datapoint to sync the Tuya MCU minimum brightness

### DIFF
--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -8,6 +8,7 @@ from .. import tuya_ns, CONF_TUYA_ID, Tuya
 DEPENDENCIES = ['tuya']
 
 CONF_DIMMER_DATAPOINT = "dimmer_datapoint"
+CONF_MIN_VALUE_DATAPOINT = "min_value_datapoint"
 
 TuyaLight = tuya_ns.class_('TuyaLight', light.LightOutput, cg.Component)
 
@@ -15,6 +16,7 @@ CONFIG_SCHEMA = cv.All(light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend({
     cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(TuyaLight),
     cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
     cv.Optional(CONF_DIMMER_DATAPOINT): cv.uint8_t,
+    cv.Optional(CONF_MIN_VALUE_DATAPOINT): cv.uint8_t,
     cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
     cv.Optional(CONF_MIN_VALUE): cv.int_,
     cv.Optional(CONF_MAX_VALUE): cv.int_,
@@ -34,6 +36,8 @@ def to_code(config):
 
     if CONF_DIMMER_DATAPOINT in config:
         cg.add(var.set_dimmer_id(config[CONF_DIMMER_DATAPOINT]))
+    if CONF_MIN_VALUE_DATAPOINT in config:
+        cg.add(var.set_min_value_datapoint_id(config[CONF_MIN_VALUE_DATAPOINT]))
     if CONF_SWITCH_DATAPOINT in config:
         cg.add(var.set_switch_id(config[CONF_SWITCH_DATAPOINT]))
     if CONF_MIN_VALUE in config:

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -21,6 +21,13 @@ void TuyaLight::setup() {
       call.perform();
     });
   }
+  if (min_value_datapoint_id_.has_value()) {
+    TuyaDatapoint datapoint{};
+    datapoint.id = *this->min_value_datapoint_id_;
+    datapoint.type = TuyaDatapointType::INTEGER;
+    datapoint.value_int = this->min_value_;
+    parent_->set_datapoint_value(datapoint);
+  }
 }
 
 void TuyaLight::dump_config() {

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -12,6 +12,9 @@ class TuyaLight : public Component, public light::LightOutput {
   void setup() override;
   void dump_config() override;
   void set_dimmer_id(uint8_t dimmer_id) { this->dimmer_id_ = dimmer_id; }
+  void set_min_value_datapoint_id(uint8_t min_value_datapoint_id) {
+    this->min_value_datapoint_id_ = min_value_datapoint_id;
+  }
   void set_switch_id(uint8_t switch_id) { this->switch_id_ = switch_id; }
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
   void set_min_value(uint32_t min_value) { min_value_ = min_value; }
@@ -26,6 +29,7 @@ class TuyaLight : public Component, public light::LightOutput {
 
   Tuya *parent_;
   optional<uint8_t> dimmer_id_{};
+  optional<uint8_t> min_value_datapoint_id_{};
   optional<uint8_t> switch_id_{};
   uint32_t min_value_ = 0;
   uint32_t max_value_ = 255;


### PR DESCRIPTION
## Description:

The Tuya MCU keeps its own internal minimum brightness setting.  This value may
not match the minimum brightness setting for ESPHome, leading to some issues:

1. Dimming is limited--on some devices the default minimum is as high as 10%,
meaning the dimmest ESPHome will go is still quite bright.

2. HA will allow a user to set a value below the MCU minimum, but the MCU will
reject it and keep the previous setting, so the UI is confusing.

This PR adds a setting to configure the datapoint for setting the MCU minimum
brightness.  If the setting is set, then ESPHome will synchronize the MCU's
minimum brightness with the one configured for ESPHome on startup.

**Related issue (if applicable):** _possibly_ fixes https://github.com/esphome/issues/issues/1585 (I'm honestly not sure if this is the same underlying cause as that issue but it would make sense)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/832

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
