### PR TITLE
Add NDEF reading and writing to PN532

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,7 @@ esphome/components/light/* @esphome/core
 esphome/components/logger/* @esphome/core
 esphome/components/mcp9808/* @k7hpn
 esphome/components/network/* @esphome/core
+esphome/components/nfc/* @jesserockz
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core
 esphome/components/pid/* @OttoWinter

--- a/esphome/components/nfc/__init__.py
+++ b/esphome/components/nfc/__init__.py
@@ -1,0 +1,7 @@
+import esphome.codegen as cg
+
+CODEOWNERS = ['@jesserockz']
+
+nfc_ns = cg.esphome_ns.namespace('nfc')
+
+NfcTag = nfc_ns.class_('NfcTag')

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -17,7 +17,8 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
 
     ESP_LOGVV(TAG, "me=%s, sr=%s, il=%s, tnf=%d", YESNO(me), YESNO(sr), YESNO(il), tnf);
 
-    auto record = new NdefRecord(tnf);
+    auto record = new NdefRecord();
+    record->set_tnf(tnf);
 
     uint8_t type_length = data[index++];
     uint32_t payload_length = 0;
@@ -87,13 +88,7 @@ bool NdefMessage::add_text_record(const std::string &text, const std::string &en
 }
 
 bool NdefMessage::add_uri_record(const std::string &uri) {
-  std::string payload = uri;
-  auto r = new NdefRecord(TNF_WELL_KNOWN, "U", payload);
-  return this->add_record(r);
-}
-
-bool NdefMessage::add_empty_record() {
-  auto r = new NdefRecord(TNF_EMPTY);
+  auto r = new NdefRecord(TNF_WELL_KNOWN, "U", uri);
   return this->add_record(r);
 }
 

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -46,7 +46,18 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
       index += id_length;
     }
 
+    uint8_t payload_identifier = 0x00;
+    if (type_str == "U") {
+      payload_identifier = data[index++];
+      payload_length -= 1;
+    }
+
     std::string payload_str(data.begin() + index, data.begin() + index + payload_length);
+
+    if (payload_identifier > 0x00 && payload_identifier <= PAYLOAD_IDENTIFIERS_COUNT) {
+      payload_str.insert(0, PAYLOAD_IDENTIFIERS[payload_identifier]);
+    }
+
     record->set_payload(payload_str);
     index += payload_length;
 
@@ -76,7 +87,7 @@ bool NdefMessage::add_text_record(const std::string &text, const std::string &en
 }
 
 bool NdefMessage::add_uri_record(const std::string &uri) {
-  std::string payload = '\0' + uri;
+  std::string payload = uri;
   auto r = new NdefRecord(TNF_WELL_KNOWN, "U", payload);
   return this->add_record(r);
 }

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -15,6 +15,8 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
     bool il = tnf_byte & 0x08;
     uint8_t tnf = tnf_byte & 0x07;
 
+    ESP_LOGVV(TAG, "me=%s, sr=%s, il=%s, tnf=%d", YESNO(me), YESNO(sr), YESNO(il), tnf);
+
     auto record = new NdefRecord(tnf);
 
     uint8_t type_length = data[index++];
@@ -31,6 +33,8 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
     if (il) {
       id_length = data[index++];
     }
+
+    ESP_LOGVV(TAG, "Lengths: type=%d, payload=%d, id=%d", type_length, payload_length, id_length);
 
     std::string type_str(data.begin() + index, data.begin() + index + type_length);
     record->set_type(type_str);

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -1,0 +1,96 @@
+#include "ndef_message.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char *TAG = "nfc.ndef_message";
+
+NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
+  uint8_t index = 0;
+  while (index <= data.size()) {
+    uint8_t tnf_byte = data[index];
+    bool me = tnf_byte & 0x40;
+    bool sr = tnf_byte & 0x10;
+    bool il = tnf_byte & 0x08;
+    uint8_t tnf = tnf_byte & 0x07;
+
+    auto record = make_unique<NdefRecord>();
+    record->set_tnf(tnf);
+
+    index++;
+    uint8_t type_length = data[index];
+    uint32_t payload_length = 0;
+    if (sr) {
+      index++;
+      payload_length = data[index];
+    } else {
+      payload_length = (static_cast<uint32_t>(data[index]) << 24) | (static_cast<uint32_t>(data[index + 1]) << 16) |
+                       (static_cast<uint32_t>(data[index + 2]) << 8) | static_cast<uint32_t>(data[index + 3]);
+      index += 4;
+    }
+
+    uint8_t id_length = 0;
+    if (il) {
+      index++;
+      id_length = data[index];
+    }
+
+    index++;
+    record->set_type(std::string(data[index], type_length));
+    index += type_length;
+
+    if (il) {
+      record->set_id(std::string(data[index], id_length));
+      index += id_length;
+    }
+
+    record->set_payload(std::string(data[index], payload_length));
+    index += payload_length;
+
+    this->add_record(std::move(record));
+
+    if (me)
+      break;
+  }
+}
+
+bool NdefMessage::add_record(std::unique_ptr<NdefRecord> record) {
+  if (this->records_.size() >= MAX_NDEF_RECORDS) {
+    ESP_LOGE(TAG, "Too many records. Max: %d", MAX_NDEF_RECORDS);
+    return false;
+  }
+  this->records_.push_back(std::move(record));
+  return true;
+}
+
+bool NdefMessage::add_text_record(const std::string &text) { return this->add_text_record(text, "en"); };
+
+bool NdefMessage::add_text_record(const std::string &text, const std::string &encoding) {
+  std::string payload = to_string(text.length()) + encoding + text;
+  auto r = make_unique<NdefRecord>(TNF_WELL_KNOWN, "T", payload);
+  return this->add_record(std::move(r));
+}
+
+bool NdefMessage::add_uri_record(const std::string &uri) {
+  std::string payload = '\0' + uri;
+  auto r = make_unique<NdefRecord>(TNF_WELL_KNOWN, "U", payload);
+  return this->add_record(std::move(r));
+}
+
+bool NdefMessage::add_empty_record() {
+  auto r = make_unique<NdefRecord>();
+  r->set_tnf(TNF_EMPTY);
+  return this->add_record(std::move(r));
+}
+
+void NdefMessage::encode(uint8_t *data) {
+  uint8_t *data_ptr = &data[0];
+
+  for (uint8_t i = 0; i < this->records_.size(); i++) {
+    this->records_[i]->encode(data_ptr, i == 0, (i + 1) == this->records_.size());
+    data_ptr += this->records_[i]->get_encoded_size();
+  }
+}
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/ndef_message.h
+++ b/esphome/components/nfc/ndef_message.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "ndef_record.h"
+
+
+namespace esphome {
+namespace nfc {
+
+static const uint8_t MAX_NDEF_RECORDS = 4;
+
+class NdefMessage {
+ public:
+  NdefMessage(){};
+  NdefMessage(std::vector<uint8_t> &data);
+
+  std::vector<std::unique_ptr<NdefRecord>> get_records() { return this->records_; };
+
+  bool add_record(std::unique_ptr<NdefRecord> record);
+  bool add_text_record(const std::string &text);
+  bool add_text_record(const std::string &text, const std::string &encoding);
+  bool add_uri_record(const std::string &uri);
+  bool add_empty_record();
+
+  void encode(uint8_t* data);
+
+ protected:
+  std::vector<std::unique_ptr<NdefRecord>> records_;
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/ndef_message.h
+++ b/esphome/components/nfc/ndef_message.h
@@ -4,7 +4,6 @@
 #include "esphome/core/log.h"
 #include "ndef_record.h"
 
-
 namespace esphome {
 namespace nfc {
 
@@ -15,18 +14,18 @@ class NdefMessage {
   NdefMessage(){};
   NdefMessage(std::vector<uint8_t> &data);
 
-  std::vector<std::unique_ptr<NdefRecord>> get_records() { return this->records_; };
+  std::vector<NdefRecord *> get_records() { return this->records_; };
 
-  bool add_record(std::unique_ptr<NdefRecord> record);
+  bool add_record(NdefRecord *record);
   bool add_text_record(const std::string &text);
   bool add_text_record(const std::string &text, const std::string &encoding);
   bool add_uri_record(const std::string &uri);
   bool add_empty_record();
 
-  void encode(uint8_t* data);
+  std::vector<uint8_t> encode();
 
  protected:
-  std::vector<std::unique_ptr<NdefRecord>> records_;
+  std::vector<NdefRecord *> records_;
 };
 
 }  // namespace nfc

--- a/esphome/components/nfc/ndef_message.h
+++ b/esphome/components/nfc/ndef_message.h
@@ -20,7 +20,6 @@ class NdefMessage {
   bool add_text_record(const std::string &text);
   bool add_text_record(const std::string &text, const std::string &encoding);
   bool add_uri_record(const std::string &uri);
-  bool add_empty_record();
 
   std::vector<uint8_t> encode();
 

--- a/esphome/components/nfc/ndef_record.cpp
+++ b/esphome/components/nfc/ndef_record.cpp
@@ -1,0 +1,76 @@
+#include "ndef_record.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char* TAG = "nfc.ndef_record";
+
+uint32_t NdefRecord::get_encoded_size() {
+  uint32_t size = 2;
+  if (this->payload_.length() > 255) {
+    size += 4;
+  } else {
+    size += 1;
+  }
+  if (this->id_.length()) {
+    size += 1;
+  }
+  size += (this->type_.length() + this->payload_.length() + this->id_.length());
+  return size;
+}
+
+void NdefRecord::encode(uint8_t* data, bool first, bool last) {
+  uint8_t* data_ptr = &data[0];
+
+  *data_ptr = get_tnf_byte(first, last);
+  data_ptr += 1;
+
+  *data_ptr = this->type_.length();
+  data_ptr += 1;
+
+  if (this->payload_.length() <= 255) {
+    *data_ptr = this->payload_.length();
+    data_ptr += 1;
+  } else {
+    data_ptr[0] = 0;
+    data_ptr[1] = 0;
+    data_ptr[2] = (this->payload_.length() >> 8) & 0xFF;
+    data_ptr[3] = this->payload_.length() & 0xFF;
+    data_ptr += 4;
+  }
+
+  if (this->id_.length()) {
+    *data_ptr = this->id_.length();
+    data_ptr += 1;
+  }
+
+  memcpy(data_ptr, this->type_.c_str(), this->type_.length());
+  data_ptr += this->type_.length();
+
+  if (this->id_.length()) {
+    memcpy(data_ptr, this->id_.c_str(), this->id_.length());
+    data_ptr += this->id_.length();
+  }
+
+  memcpy(data_ptr, this->payload_.c_str(), this->payload_.length());
+}
+
+uint8_t NdefRecord::get_tnf_byte(bool first, bool last) {
+  uint8_t value = this->tnf_;
+  if (first) {
+    value = value | 0x80;
+  }
+  if (last) {
+    value = value | 0x40;
+  }
+  if (this->payload_.length() <= 255) {
+    value = value | 0x10;
+  }
+  if (this->id_.length()) {
+    value = value | 0x08;
+  }
+  return value;
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/ndef_record.cpp
+++ b/esphome/components/nfc/ndef_record.cpp
@@ -19,40 +19,34 @@ uint32_t NdefRecord::get_encoded_size() {
   return size;
 }
 
-void NdefRecord::encode(uint8_t* data, bool first, bool last) {
-  uint8_t* data_ptr = &data[0];
+std::vector<uint8_t> NdefRecord::encode(bool first, bool last) {
+  std::vector<uint8_t> data;
 
-  *data_ptr = get_tnf_byte(first, last);
-  data_ptr += 1;
+  data.push_back(get_tnf_byte(first, last));
 
-  *data_ptr = this->type_.length();
-  data_ptr += 1;
+  data.push_back(this->type_.length());
 
   if (this->payload_.length() <= 255) {
-    *data_ptr = this->payload_.length();
-    data_ptr += 1;
+    data.push_back(this->payload_.length());
   } else {
-    data_ptr[0] = 0;
-    data_ptr[1] = 0;
-    data_ptr[2] = (this->payload_.length() >> 8) & 0xFF;
-    data_ptr[3] = this->payload_.length() & 0xFF;
-    data_ptr += 4;
+    data.push_back(0);
+    data.push_back(0);
+    data.push_back((this->payload_.length() >> 8) & 0xFF);
+    data.push_back(this->payload_.length() & 0xFF);
   }
 
   if (this->id_.length()) {
-    *data_ptr = this->id_.length();
-    data_ptr += 1;
+    data.push_back(this->id_.length());
   }
 
-  memcpy(data_ptr, this->type_.c_str(), this->type_.length());
-  data_ptr += this->type_.length();
+  data.insert(data.end(), this->type_.begin(), this->type_.end());
 
   if (this->id_.length()) {
-    memcpy(data_ptr, this->id_.c_str(), this->id_.length());
-    data_ptr += this->id_.length();
+    data.insert(data.end(), this->id_.begin(), this->id_.end());
   }
 
-  memcpy(data_ptr, this->payload_.c_str(), this->payload_.length());
+  data.insert(data.end(), this->payload_.begin(), this->payload_.end());
+  return data;
 }
 
 uint8_t NdefRecord::get_tnf_byte(bool first, bool last) {

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -15,6 +15,15 @@ static const uint8_t TNF_UNKNOWN = 0x05;
 static const uint8_t TNF_UNCHANGED = 0x06;
 static const uint8_t TNF_RESERVED = 0x07;
 
+static const uint8_t PAYLOAD_IDENTIFIERS_COUNT = 0x23;
+static const char *PAYLOAD_IDENTIFIERS[] = {
+  "", "http://www.", "https://www.", "http://", "https://", "tel:", "mailto:",
+  "ftp://anonymous:anonymous@", "ftp://ftp.", "ftps://", "sftp://", "smb://", "nfs://", "ftp://",
+  "dav://", "news:", "telnet://", "imap:", "rtsp://", "urn:", "pop:", "sip:", "sips:", "tftp:",
+  "btspp://", "btl2cap://", "btgoep://", "tcpobex://", "irdaobex://", "file://", "urn:epc:id:",
+  "urn:epc:tag:", "urn:epc:pat:", "urn:epc:raw:", "urn:epc:", "urn:nfc:"
+};
+
 class NdefRecord {
  public:
   NdefRecord(){};
@@ -22,22 +31,26 @@ class NdefRecord {
   NdefRecord(uint8_t tnf, const std::string &type, const std::string &payload) {
     this->tnf_ = tnf;
     this->type_ = type;
-    this->payload_ = payload;
+    this->set_payload(payload);
   };
   NdefRecord(uint8_t tnf, const std::string &type, const std::string &payload, const std::string &id) {
     this->tnf_ = tnf;
     this->type_ = type;
-    this->payload_ = payload;
+    this->set_payload(payload);
     this->id_ = id;
   };
   NdefRecord(const NdefRecord &rhs) {
     this->tnf_ = rhs.tnf_;
     this->type_ = rhs.type_;
     this->payload_ = rhs.payload_;
+    this->payload_identifier_ = rhs.payload_identifier_;
     this->id_ = rhs.id_;
   };
   void set_tnf(uint8_t tnf) { this->tnf_ = tnf; };
   void set_type(const std::string &type) { this->type_ = type; };
+  void set_payload_identifier(uint8_t payload_identifier) {
+    this->payload_identifier_ = payload_identifier;
+  };
   void set_payload(const std::string &payload) { this->payload_ = payload; };
   void set_id(const std::string &id) { this->id_ = id; };
 
@@ -53,6 +66,7 @@ class NdefRecord {
  protected:
   uint8_t tnf_;
   std::string type_;
+  uint8_t payload_identifier_;
   std::string payload_;
   std::string id_;
 };

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -18,6 +18,7 @@ static const uint8_t TNF_RESERVED = 0x07;
 class NdefRecord {
  public:
   NdefRecord(){};
+  NdefRecord(uint8_t tnf) { this->tnf_ = tnf; };
   NdefRecord(uint8_t tnf, const std::string &type, const std::string &payload) {
     this->tnf_ = tnf;
     this->type_ = type;
@@ -29,6 +30,12 @@ class NdefRecord {
     this->payload_ = payload;
     this->id_ = id;
   };
+  NdefRecord(const NdefRecord &rhs) {
+    this->tnf_ = rhs.tnf_;
+    this->type_ = rhs.type_;
+    this->payload_ = rhs.payload_;
+    this->id_ = rhs.id_;
+  };
   void set_tnf(uint8_t tnf) { this->tnf_ = tnf; };
   void set_type(const std::string &type) { this->type_ = type; };
   void set_payload(const std::string &payload) { this->payload_ = payload; };
@@ -36,7 +43,7 @@ class NdefRecord {
 
   uint32_t get_encoded_size();
 
-  void encode(uint8_t* data, bool first, bool last);
+  std::vector<uint8_t> encode(bool first, bool last);
   uint8_t get_tnf_byte(bool first, bool last);
 
   const std::string &get_type() { return this->type_; };

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -16,18 +16,46 @@ static const uint8_t TNF_UNCHANGED = 0x06;
 static const uint8_t TNF_RESERVED = 0x07;
 
 static const uint8_t PAYLOAD_IDENTIFIERS_COUNT = 0x23;
-static const char *PAYLOAD_IDENTIFIERS[] = {
-  "", "http://www.", "https://www.", "http://", "https://", "tel:", "mailto:",
-  "ftp://anonymous:anonymous@", "ftp://ftp.", "ftps://", "sftp://", "smb://", "nfs://", "ftp://",
-  "dav://", "news:", "telnet://", "imap:", "rtsp://", "urn:", "pop:", "sip:", "sips:", "tftp:",
-  "btspp://", "btl2cap://", "btgoep://", "tcpobex://", "irdaobex://", "file://", "urn:epc:id:",
-  "urn:epc:tag:", "urn:epc:pat:", "urn:epc:raw:", "urn:epc:", "urn:nfc:"
-};
+static const char *PAYLOAD_IDENTIFIERS[] = {"",
+                                            "http://www.",
+                                            "https://www.",
+                                            "http://",
+                                            "https://",
+                                            "tel:",
+                                            "mailto:",
+                                            "ftp://anonymous:anonymous@",
+                                            "ftp://ftp.",
+                                            "ftps://",
+                                            "sftp://",
+                                            "smb://",
+                                            "nfs://",
+                                            "ftp://",
+                                            "dav://",
+                                            "news:",
+                                            "telnet://",
+                                            "imap:",
+                                            "rtsp://",
+                                            "urn:",
+                                            "pop:",
+                                            "sip:",
+                                            "sips:",
+                                            "tftp:",
+                                            "btspp://",
+                                            "btl2cap://",
+                                            "btgoep://",
+                                            "tcpobex://",
+                                            "irdaobex://",
+                                            "file://",
+                                            "urn:epc:id:",
+                                            "urn:epc:tag:",
+                                            "urn:epc:pat:",
+                                            "urn:epc:raw:",
+                                            "urn:epc:",
+                                            "urn:nfc:"};
 
 class NdefRecord {
  public:
   NdefRecord(){};
-  NdefRecord(uint8_t tnf) { this->tnf_ = tnf; };
   NdefRecord(uint8_t tnf, const std::string &type, const std::string &payload) {
     this->tnf_ = tnf;
     this->type_ = type;
@@ -48,9 +76,7 @@ class NdefRecord {
   };
   void set_tnf(uint8_t tnf) { this->tnf_ = tnf; };
   void set_type(const std::string &type) { this->type_ = type; };
-  void set_payload_identifier(uint8_t payload_identifier) {
-    this->payload_identifier_ = payload_identifier;
-  };
+  void set_payload_identifier(uint8_t payload_identifier) { this->payload_identifier_ = payload_identifier; };
   void set_payload(const std::string &payload) { this->payload_ = payload; };
   void set_id(const std::string &id) { this->id_ = id; };
 

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace nfc {
+
+static const uint8_t TNF_EMPTY = 0x00;
+static const uint8_t TNF_WELL_KNOWN = 0x01;
+static const uint8_t TNF_MIME_MEDIA = 0x02;
+static const uint8_t TNF_ABSOLUTE_URI = 0x03;
+static const uint8_t TNF_EXTERNAL_TYPE = 0x04;
+static const uint8_t TNF_UNKNOWN = 0x05;
+static const uint8_t TNF_UNCHANGED = 0x06;
+static const uint8_t TNF_RESERVED = 0x07;
+
+class NdefRecord {
+ public:
+  NdefRecord(){};
+  NdefRecord(uint8_t tnf, const std::string &type, const std::string &payload) {
+    this->tnf_ = tnf;
+    this->type_ = type;
+    this->payload_ = payload;
+  };
+  NdefRecord(uint8_t tnf, const std::string &type, const std::string &payload, const std::string &id) {
+    this->tnf_ = tnf;
+    this->type_ = type;
+    this->payload_ = payload;
+    this->id_ = id;
+  };
+  void set_tnf(uint8_t tnf) { this->tnf_ = tnf; };
+  void set_type(const std::string &type) { this->type_ = type; };
+  void set_payload(const std::string &payload) { this->payload_ = payload; };
+  void set_id(const std::string &id) { this->id_ = id; };
+
+  uint32_t get_encoded_size();
+
+  void encode(uint8_t* data, bool first, bool last);
+  uint8_t get_tnf_byte(bool first, bool last);
+
+  const std::string &get_type() { return this->type_; };
+  const std::string &get_id() { return this->id_; };
+  const std::string &get_payload() { return this->payload_; };
+
+ protected:
+  uint8_t tnf_;
+  std::string type_;
+  std::string payload_;
+  std::string id_;
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -67,7 +67,14 @@ bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_len
   return true;
 }
 
-uint32_t get_buffer_size(uint32_t message_length) {
+uint32_t get_mifare_ultralight_buffer_size(uint32_t message_length) {
+    uint32_t buffer_size = message_length + 2 + 1;
+    if (buffer_size % MIFARE_ULTRALIGHT_READ_SIZE != 0)
+      buffer_size = ((buffer_size / MIFARE_ULTRALIGHT_READ_SIZE) + 1) * MIFARE_ULTRALIGHT_READ_SIZE;
+    return buffer_size;
+}
+
+uint32_t get_mifare_classic_buffer_size(uint32_t message_length) {
   uint32_t buffer_size = message_length;
   if (message_length < 255) {
     buffer_size += MIFARE_CLASSIC_SHORT_TLV_SIZE + 1;

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -38,7 +38,7 @@ uint8_t guess_tag_type(uint8_t uid_length) {
   }
 }
 
-uint8_t get_ndef_start_index(std::vector<uint8_t> &data) {
+uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data) {
   for (uint8_t i = 0; i < MIFARE_CLASSIC_BLOCK_SIZE; i++) {
     if (data[i] == 0x00) {
       // Do nothing, skip
@@ -52,7 +52,7 @@ uint8_t get_ndef_start_index(std::vector<uint8_t> &data) {
 }
 
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index) {
-  uint8_t i = get_ndef_start_index(data);
+  uint8_t i = get_mifare_classic_ndef_start_index(data);
   if (i < 0 || data[i] != 0x03) {
     ESP_LOGE(TAG, "Error, Can't decode message length.");
     return false;

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -1,0 +1,88 @@
+#include "nfc.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char *TAG = "nfc";
+
+std::string format_uid(std::vector<uint8_t> &uid) {
+  char buf[32];
+  int offset = 0;
+  for (uint8_t i = 0; i < uid.size(); i++) {
+    const char *format = "%02X";
+    if (i + 1 < uid.size())
+      format = "%02X-";
+    offset += sprintf(buf + offset, format, uid[i]);
+  }
+  return std::string(buf);
+}
+
+uint8_t guess_tag_type(uint8_t uid_length) {
+  if (uid_length == 4) {
+    return TAG_TYPE_MIFARE_CLASSIC;
+  } else {
+    return TAG_TYPE_2;
+  }
+}
+
+uint8_t get_ndef_start_index(std::vector<uint8_t> &data) {
+  for (uint8_t i = 0; i < BLOCK_SIZE; i++) {
+    if (data[i] == 0x00) {
+      // Do nothing, skip
+    } else if (data[i] == 0x03) {
+      return i;
+    } else {
+      return -2;
+    }
+  }
+  return -1;
+}
+
+bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index) {
+  uint8_t i = get_ndef_start_index(data);
+  if (i < 0 || data[i] != 0x03) {
+    ESP_LOGE(TAG, "Error, Can't decode message length.");
+    return false;
+  }
+  if (data[i + 1] == 0xFF) {
+    message_length = ((0xFF & data[i + 2]) << 8) | (0xFF & data[i + 3]);
+    message_start_index = i + LONG_TLV_SIZE;
+  } else {
+    message_length = data[i + 1];
+    message_start_index = i + SHORT_TLV_SIZE;
+  }
+  return true;
+}
+
+uint32_t get_buffer_size(uint32_t message_length) {
+  uint32_t buffer_size = message_length;
+  if (message_length < 255) {
+    buffer_size += SHORT_TLV_SIZE + 1;
+  } else {
+    buffer_size += LONG_TLV_SIZE + 1;
+  }
+  if (buffer_size % BLOCK_SIZE != 0) {
+    buffer_size = ((buffer_size / BLOCK_SIZE) + 1) * BLOCK_SIZE;
+  }
+  return buffer_size;
+}
+
+bool mifare_classic_is_first_block(uint8_t block_num) {
+  if (block_num < 128) {
+    return (block_num % 4 == 0);
+  } else {
+    return (block_num % 16 == 0);
+  }
+}
+
+bool mifare_classic_is_trailer_block(uint8_t block_num) {
+  if (block_num < 128) {
+    return ((block_num + 1) % 4 == 0);
+  } else {
+    return ((block_num + 1) % 16 == 0);
+  }
+}
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -7,7 +7,7 @@ namespace nfc {
 static const char *TAG = "nfc";
 
 std::string format_uid(std::vector<uint8_t> &uid) {
-  char buf[32];
+  char buf[(uid.size() * 2) + uid.size() - 1];
   int offset = 0;
   for (uint8_t i = 0; i < uid.size(); i++) {
     const char *format = "%02X";
@@ -27,7 +27,7 @@ uint8_t guess_tag_type(uint8_t uid_length) {
 }
 
 uint8_t get_ndef_start_index(std::vector<uint8_t> &data) {
-  for (uint8_t i = 0; i < BLOCK_SIZE; i++) {
+  for (uint8_t i = 0; i < MIFARE_CLASSIC_BLOCK_SIZE; i++) {
     if (data[i] == 0x00) {
       // Do nothing, skip
     } else if (data[i] == 0x03) {
@@ -47,10 +47,10 @@ bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_len
   }
   if (data[i + 1] == 0xFF) {
     message_length = ((0xFF & data[i + 2]) << 8) | (0xFF & data[i + 3]);
-    message_start_index = i + LONG_TLV_SIZE;
+    message_start_index = i + MIFARE_CLASSIC_LONG_TLV_SIZE;
   } else {
     message_length = data[i + 1];
-    message_start_index = i + SHORT_TLV_SIZE;
+    message_start_index = i + MIFARE_CLASSIC_SHORT_TLV_SIZE;
   }
   return true;
 }
@@ -58,12 +58,12 @@ bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_len
 uint32_t get_buffer_size(uint32_t message_length) {
   uint32_t buffer_size = message_length;
   if (message_length < 255) {
-    buffer_size += SHORT_TLV_SIZE + 1;
+    buffer_size += MIFARE_CLASSIC_SHORT_TLV_SIZE + 1;
   } else {
-    buffer_size += LONG_TLV_SIZE + 1;
+    buffer_size += MIFARE_CLASSIC_LONG_TLV_SIZE + 1;
   }
-  if (buffer_size % BLOCK_SIZE != 0) {
-    buffer_size = ((buffer_size / BLOCK_SIZE) + 1) * BLOCK_SIZE;
+  if (buffer_size % MIFARE_CLASSIC_BLOCK_SIZE != 0) {
+    buffer_size = ((buffer_size / MIFARE_CLASSIC_BLOCK_SIZE) + 1) * MIFARE_CLASSIC_BLOCK_SIZE;
   }
   return buffer_size;
 }

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -68,10 +68,10 @@ bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_len
 }
 
 uint32_t get_mifare_ultralight_buffer_size(uint32_t message_length) {
-    uint32_t buffer_size = message_length + 2 + 1;
-    if (buffer_size % MIFARE_ULTRALIGHT_READ_SIZE != 0)
-      buffer_size = ((buffer_size / MIFARE_ULTRALIGHT_READ_SIZE) + 1) * MIFARE_ULTRALIGHT_READ_SIZE;
-    return buffer_size;
+  uint32_t buffer_size = message_length + 2 + 1;
+  if (buffer_size % MIFARE_ULTRALIGHT_READ_SIZE != 0)
+    buffer_size = ((buffer_size / MIFARE_ULTRALIGHT_READ_SIZE) + 1) * MIFARE_ULTRALIGHT_READ_SIZE;
+  return buffer_size;
 }
 
 uint32_t get_mifare_classic_buffer_size(uint32_t message_length) {

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -18,6 +18,18 @@ std::string format_uid(std::vector<uint8_t> &uid) {
   return std::string(buf);
 }
 
+std::string format_bytes(std::vector<uint8_t> &bytes) {
+  char buf[(bytes.size() * 2) + bytes.size() - 1];
+  int offset = 0;
+  for (uint8_t i = 0; i < bytes.size(); i++) {
+    const char *format = "%02X";
+    if (i + 1 < bytes.size())
+      format = "%02X ";
+    offset += sprintf(buf + offset, format, bytes[i]);
+  }
+  return std::string(buf);
+}
+
 uint8_t guess_tag_type(uint8_t uid_length) {
   if (uid_length == 4) {
     return TAG_TYPE_MIFARE_CLASSIC;

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -27,12 +27,14 @@ static const uint8_t MIFARE_CMD_READ = 0x30;
 static const uint8_t MIFARE_CMD_WRITE = 0xA0;
 
 static const char *MIFARE_CLASSIC = "Mifare Classic";
+static const char *NFC_FORUM_TYPE_2 = "NFC Forum Type 2";
 static const char *ERROR = "Error";
 
 static const uint8_t DEFAULT_KEY[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 static const uint8_t NDEF_KEY[6] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7};
 
 std::string format_uid(std::vector<uint8_t> &uid);
+std::string format_bytes(std::vector<uint8_t> &bytes);
 
 uint8_t guess_tag_type(uint8_t uid_length);
 uint8_t get_ndef_start_index(std::vector<uint8_t> &data);

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -32,8 +32,6 @@ static const uint8_t MIFARE_CMD_READ = 0x30;
 static const uint8_t MIFARE_CMD_WRITE = 0xA0;
 static const uint8_t MIFARE_CMD_WRITE_ULTRALIGHT = 0xA2;
 
-
-
 static const char *MIFARE_CLASSIC = "Mifare Classic";
 static const char *NFC_FORUM_TYPE_2 = "NFC Forum Type 2";
 static const char *ERROR = "Error";

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include "ndef_record.h"
+#include "ndef_message.h"
+#include "nfc_tag.h"
+
+namespace esphome {
+namespace nfc {
+
+static const uint8_t BLOCK_SIZE = 16;
+static const uint8_t LONG_TLV_SIZE = 4;
+static const uint8_t SHORT_TLV_SIZE = 2;
+
+static const uint8_t TAG_TYPE_MIFARE_CLASSIC = 0;
+static const uint8_t TAG_TYPE_1 = 1;
+static const uint8_t TAG_TYPE_2 = 2;
+static const uint8_t TAG_TYPE_3 = 3;
+static const uint8_t TAG_TYPE_4 = 4;
+static const uint8_t TAG_TYPE_UNKNOWN = 99;
+
+// Mifare Commands
+static const uint8_t MIFARE_CMD_AUTH_A = 0x60;
+static const uint8_t MIFARE_CMD_AUTH_B = 0x61;
+static const uint8_t MIFARE_CMD_READ = 0x30;
+static const uint8_t MIFARE_CMD_WRITE = 0xA0;
+
+static const char *MIFARE_CLASSIC = "Mifare Classic";
+static const char *ERROR = "Error";
+
+std::string format_uid(std::vector<uint8_t> &uid);
+
+uint8_t guess_tag_type(uint8_t uid_length);
+uint8_t get_ndef_start_index(std::vector<uint8_t> &data);
+bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index);
+uint32_t get_buffer_size(uint32_t message_length);
+
+bool mifare_classic_is_first_block(uint8_t block_num);
+bool mifare_classic_is_trailer_block(uint8_t block_num);
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -44,7 +44,7 @@ std::string format_uid(std::vector<uint8_t> &uid);
 std::string format_bytes(std::vector<uint8_t> &bytes);
 
 uint8_t guess_tag_type(uint8_t uid_length);
-uint8_t get_ndef_start_index(std::vector<uint8_t> &data);
+uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data);
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index);
 uint32_t get_mifare_classic_buffer_size(uint32_t message_length);
 

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -9,9 +9,9 @@
 namespace esphome {
 namespace nfc {
 
-static const uint8_t BLOCK_SIZE = 16;
-static const uint8_t LONG_TLV_SIZE = 4;
-static const uint8_t SHORT_TLV_SIZE = 2;
+static const uint8_t MIFARE_CLASSIC_BLOCK_SIZE = 16;
+static const uint8_t MIFARE_CLASSIC_LONG_TLV_SIZE = 4;
+static const uint8_t MIFARE_CLASSIC_SHORT_TLV_SIZE = 2;
 
 static const uint8_t TAG_TYPE_MIFARE_CLASSIC = 0;
 static const uint8_t TAG_TYPE_1 = 1;

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -29,6 +29,9 @@ static const uint8_t MIFARE_CMD_WRITE = 0xA0;
 static const char *MIFARE_CLASSIC = "Mifare Classic";
 static const char *ERROR = "Error";
 
+static const uint8_t DEFAULT_KEY[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+static const uint8_t NDEF_KEY[6] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7};
+
 std::string format_uid(std::vector<uint8_t> &uid);
 
 uint8_t guess_tag_type(uint8_t uid_length);

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -13,6 +13,11 @@ static const uint8_t MIFARE_CLASSIC_BLOCK_SIZE = 16;
 static const uint8_t MIFARE_CLASSIC_LONG_TLV_SIZE = 4;
 static const uint8_t MIFARE_CLASSIC_SHORT_TLV_SIZE = 2;
 
+static const uint8_t MIFARE_ULTRALIGHT_PAGE_SIZE = 4;
+static const uint8_t MIFARE_ULTRALIGHT_READ_SIZE = 4;
+static const uint8_t MIFARE_ULTRALIGHT_DATA_START_PAGE = 4;
+static const uint8_t MIFARE_ULTRALIGHT_MAX_PAGE = 63;
+
 static const uint8_t TAG_TYPE_MIFARE_CLASSIC = 0;
 static const uint8_t TAG_TYPE_1 = 1;
 static const uint8_t TAG_TYPE_2 = 2;
@@ -25,6 +30,9 @@ static const uint8_t MIFARE_CMD_AUTH_A = 0x60;
 static const uint8_t MIFARE_CMD_AUTH_B = 0x61;
 static const uint8_t MIFARE_CMD_READ = 0x30;
 static const uint8_t MIFARE_CMD_WRITE = 0xA0;
+static const uint8_t MIFARE_CMD_WRITE_ULTRALIGHT = 0xA2;
+
+
 
 static const char *MIFARE_CLASSIC = "Mifare Classic";
 static const char *NFC_FORUM_TYPE_2 = "NFC Forum Type 2";
@@ -32,6 +40,7 @@ static const char *ERROR = "Error";
 
 static const uint8_t DEFAULT_KEY[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 static const uint8_t NDEF_KEY[6] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7};
+static const uint8_t MAD_KEY[6] = {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5};
 
 std::string format_uid(std::vector<uint8_t> &uid);
 std::string format_bytes(std::vector<uint8_t> &bytes);
@@ -39,10 +48,12 @@ std::string format_bytes(std::vector<uint8_t> &bytes);
 uint8_t guess_tag_type(uint8_t uid_length);
 uint8_t get_ndef_start_index(std::vector<uint8_t> &data);
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index);
-uint32_t get_buffer_size(uint32_t message_length);
+uint32_t get_mifare_classic_buffer_size(uint32_t message_length);
 
 bool mifare_classic_is_first_block(uint8_t block_num);
 bool mifare_classic_is_trailer_block(uint8_t block_num);
+
+uint32_t get_mifare_ultralight_buffer_size(uint32_t message_length);
 
 }  // namespace nfc
 }  // namespace esphome

--- a/esphome/components/nfc/nfc_tag.cpp
+++ b/esphome/components/nfc/nfc_tag.cpp
@@ -1,0 +1,9 @@
+#include "nfc_tag.h"
+
+namespace esphome {
+namespace nfc {
+
+static const char *TAG = "nfc.tag";
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -20,6 +20,11 @@ class NfcTag {
     this->uid_ = uid;
     this->tag_type_ = tag_type;
   };
+  NfcTag(std::vector<uint8_t> &uid, const std::string &tag_type, nfc::NdefMessage *ndef_message) {
+    this->uid_ = uid;
+    this->tag_type_ = tag_type;
+    this->ndef_message_ = ndef_message;
+  };
   NfcTag(std::vector<uint8_t> &uid, const std::string &tag_type, std::vector<uint8_t> &ndef_data) {
     this->uid_ = uid;
     this->tag_type_ = tag_type;

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "ndef_message.h"
+
+namespace esphome {
+namespace nfc {
+
+class NfcTag {
+ public:
+  NfcTag() {
+    this->uid_ = {};
+    this->tag_type_ = "Unknown";
+  };
+  NfcTag(std::vector<uint8_t> &uid) {
+    this->uid_ = uid;
+    this->tag_type_ = "Unknown";
+  };
+  NfcTag(std::vector<uint8_t> &uid, const std::string &tag_type) {
+    this->uid_ = uid;
+    this->tag_type_ = tag_type;
+  };
+  NfcTag(std::vector<uint8_t> &uid, const std::string &tag_type, std::vector<uint8_t> &ndef_data) {
+    this->uid_ = uid;
+    this->tag_type_ = tag_type;
+    this->ndef_message_ = new NdefMessage(ndef_data);
+  };
+
+  std::vector<uint8_t> &get_uid() { return this->uid_; };
+  const std::string &get_tag_type() { return this->tag_type_; };
+  bool has_ndef_message() { return this->ndef_message_ != nullptr; };
+  NdefMessage *get_ndef_message() { return this->ndef_message_; };
+  void set_ndef_message(NdefMessage *ndef_message) { this->ndef_message_ = ndef_message; };
+
+ protected:
+  std::vector<uint8_t> uid_;
+  std::string tag_type_;
+  NdefMessage *ndef_message_{nullptr};
+};
+
+}  // namespace nfc
+}  // namespace esphome

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -1,11 +1,12 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
+from esphome.components import nfc
 from esphome.const import CONF_ON_TAG, CONF_TRIGGER_ID
 from esphome.core import coroutine
 
 CODEOWNERS = ['@OttoWinter', '@jesserockz']
-AUTO_LOAD = ['binary_sensor']
+AUTO_LOAD = ['binary_sensor', 'nfc']
 MULTI_CONF = True
 
 CONF_PN532_ID = 'pn532_id'
@@ -36,4 +37,5 @@ def setup_pn532(var, config):
     for conf in config.get(CONF_ON_TAG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
         cg.add(var.register_trigger(trigger))
-        yield automation.build_automation(trigger, [(cg.std_string, 'x')], conf)
+        yield automation.build_automation(trigger, [(cg.std_string, 'x'), (nfc.NfcTag, 'tag')],
+                                          conf)

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -15,8 +15,10 @@ CONF_ON_FINISHED_WRITE = 'on_finished_write'
 pn532_ns = cg.esphome_ns.namespace('pn532')
 PN532 = pn532_ns.class_('PN532', cg.PollingComponent)
 
-PN532OnTagTrigger = pn532_ns.class_('PN532OnTagTrigger', automation.Trigger.template(cg.std_string, nfc.NfcTag))
-PN532OnFinishedWriteTrigger = pn532_ns.class_('PN532OnFinishedWriteTrigger', automation.Trigger.template())
+PN532OnTagTrigger = pn532_ns.class_('PN532OnTagTrigger',
+                                    automation.Trigger.template(cg.std_string, nfc.NfcTag))
+PN532OnFinishedWriteTrigger = pn532_ns.class_('PN532OnFinishedWriteTrigger',
+                                              automation.Trigger.template())
 
 PN532IsWritingCondition = pn532_ns.class_('PN532IsWritingCondition', automation.Condition)
 
@@ -50,6 +52,7 @@ def setup_pn532(var, config):
     for conf in config.get(CONF_ON_FINISHED_WRITE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         yield automation.build_automation(trigger, [], conf)
+
 
 @automation.register_condition('pn532.is_writing', PN532IsWritingCondition, cv.Schema({
     cv.GenerateID(): cv.use_id(PN532),

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import nfc
-from esphome.const import CONF_ON_TAG, CONF_TRIGGER_ID
+from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID
 from esphome.core import coroutine
 
 CODEOWNERS = ['@OttoWinter', '@jesserockz']
@@ -10,16 +10,23 @@ AUTO_LOAD = ['binary_sensor', 'nfc']
 MULTI_CONF = True
 
 CONF_PN532_ID = 'pn532_id'
+CONF_ON_FINISHED_WRITE = 'on_finished_write'
 
 pn532_ns = cg.esphome_ns.namespace('pn532')
 PN532 = pn532_ns.class_('PN532', cg.PollingComponent)
 
-PN532Trigger = pn532_ns.class_('PN532Trigger', automation.Trigger.template(cg.std_string))
+PN532OnTagTrigger = pn532_ns.class_('PN532OnTagTrigger', automation.Trigger.template(cg.std_string, nfc.NfcTag))
+PN532OnFinishedWriteTrigger = pn532_ns.class_('PN532OnFinishedWriteTrigger', automation.Trigger.template())
+
+PN532IsWritingCondition = pn532_ns.class_('PN532IsWritingCondition', automation.Condition)
 
 PN532_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(PN532),
     cv.Optional(CONF_ON_TAG): automation.validate_automation({
-        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PN532Trigger),
+        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PN532OnTagTrigger),
+    }),
+    cv.Optional(CONF_ON_FINISHED_WRITE): automation.validate_automation({
+        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PN532OnFinishedWriteTrigger),
     }),
 }).extend(cv.polling_component_schema('1s'))
 
@@ -39,3 +46,15 @@ def setup_pn532(var, config):
         cg.add(var.register_trigger(trigger))
         yield automation.build_automation(trigger, [(cg.std_string, 'x'), (nfc.NfcTag, 'tag')],
                                           conf)
+
+    for conf in config.get(CONF_ON_FINISHED_WRITE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [], conf)
+
+@automation.register_condition('pn532.is_writing', PN532IsWritingCondition, cv.Schema({
+    cv.GenerateID(): cv.use_id(PN532),
+}))
+def pn532_is_writing_to_code(config, condition_id, template_arg, args):
+    var = cg.new_Pvariable(condition_id, template_arg)
+    yield cg.register_parented(var, config[CONF_ID])
+    yield var

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -168,12 +168,6 @@ void PN532::loop() {
       ESP_LOGE(TAG, "Error formatting tag as NDEF");
     }
     ESP_LOGD(TAG, "  Tag formatted!");
-  } else if (next_task_ == ERASE) {
-    ESP_LOGD(TAG, "  Tag erasing...");
-    if (!this->erase_tag_(nfcid)) {
-      ESP_LOGE(TAG, "Tag was not erased successfully");
-    }
-    ESP_LOGD(TAG, "  Tag erased!");
   } else if (next_task_ == WRITE) {
     if (this->next_task_message_to_write_ != nullptr) {
       ESP_LOGD(TAG, "  Tag writing...");
@@ -377,11 +371,6 @@ void PN532::clean_mode(bool continuous) {
   this->next_task_continuous_ = continuous;
   ESP_LOGD(TAG, "Waiting to clean next tag");
 }
-void PN532::erase_mode(bool continuous) {
-  this->next_task_ = ERASE;
-  this->next_task_continuous_ = continuous;
-  ESP_LOGD(TAG, "Waiting to erase next tag");
-}
 void PN532::format_mode(bool continuous) {
   this->next_task_ = FORMAT;
   this->next_task_continuous_ = continuous;
@@ -403,12 +392,6 @@ bool PN532::clean_tag_(std::vector<uint8_t> &uid) {
   }
   ESP_LOGE(TAG, "Unsupported Tag for formatting");
   return false;
-}
-
-bool PN532::erase_tag_(std::vector<uint8_t> &uid) {
-  auto message = new nfc::NdefMessage();
-  message->add_empty_record();
-  return this->write_tag_(uid, message);
 }
 
 bool PN532::format_tag_(std::vector<uint8_t> &uid) {

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -174,21 +174,20 @@ void PN532::loop() {
       ESP_LOGD(TAG, "  Tag formatting...");
       if (!this->format_tag_(nfcid)) {
         ESP_LOGE(TAG, "  Tag could not be formatted for writing");
-        this->turn_off_rf_();
-        return;
+      } else {
+        ESP_LOGD(TAG, "  Writing NDEF data");
+        if (!this->write_tag_(nfcid, this->next_task_message_to_write_)) {
+          ESP_LOGE(TAG, "  Failed to write message to tag");
+        }
+        ESP_LOGD(TAG, "  Finished writing NDEF data");
+        delete this->next_task_message_to_write_;
+        this->next_task_message_to_write_ = nullptr;
+        this->on_finished_write_callback_.call();
       }
-      ESP_LOGD(TAG, "  Writing NDEF data");
-      if (!this->write_tag_(nfcid, this->next_task_message_to_write_)) {
-        ESP_LOGE(TAG, "  Failed to write message to tag");
-      }
-      ESP_LOGD(TAG, "  Finished writing NDEF data");
-      delete this->next_task_message_to_write_;
-      this->next_task_message_to_write_ = nullptr;
-      this->on_finished_write_callback_.call();
     }
   }
 
-  this->next_task_ = READ;
+  this->read_mode();
 
   this->turn_off_rf_();
 }

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -350,8 +350,8 @@ nfc::NfcTag *PN532::read_tag_(std::vector<uint8_t> &uid) {
     ESP_LOGD(TAG, "  Mifare classic");
     return this->read_mifare_classic_tag_(uid);
   } else if (type == nfc::TAG_TYPE_2) {
-    // TODO: do the ultralight code
-    return new nfc::NfcTag(uid);
+    ESP_LOGD(TAG, "  Mifare ultralight");
+    return this->read_mifare_ultralight_tag_(uid);
   } else if (type == nfc::TAG_TYPE_UNKNOWN) {
     ESP_LOGV(TAG, "Cannot determine tag type");
     return new nfc::NfcTag(uid);

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -62,6 +62,13 @@ class PN532 : public PollingComponent {
   bool format_mifare_classic_ndef_(std::vector<uint8_t> &uid);
   bool write_mifare_classic_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
 
+  nfc::NfcTag *read_mifare_ultralight_tag_(std::vector<uint8_t> &uid);
+  bool read_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &data);
+  bool is_mifare_ultralight_formatted_();
+  uint16_t read_mifare_ultralight_capacity();
+  bool find_mifare_ultralight_ndef_(uint8_t &message_length, uint8_t &message_start_index);
+
+
   bool requested_read_{false};
   bool next_task_continuous_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -54,7 +54,7 @@ class PN532 : public PollingComponent {
   bool write_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
 
   nfc::NfcTag *read_mifare_classic_tag_(std::vector<uint8_t> &uid);
-  std::vector<uint8_t> read_mifare_classic_block_(uint8_t block_num);
+  bool read_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
   bool write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
   bool auth_mifare_classic_block_(std::vector<uint8_t> &uid, uint8_t block_num, uint8_t key_num, const uint8_t *key);
   bool format_mifare_classic_mifare_(std::vector<uint8_t> &uid);

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -32,10 +32,11 @@ class PN532 : public PollingComponent {
   void register_tag(PN532BinarySensor *tag) { this->binary_sensors_.push_back(tag); }
   void register_trigger(PN532Trigger *trig) { this->triggers_.push_back(trig); }
 
-  void clean_tag(bool continuous = false);
-  void erase_tag(bool continuous = false);
-  void format_tag(bool continuous = false);
-  void write_tag(nfc::NdefMessage *message, bool continuous = false);
+  void read_mode();
+  void clean_mode(bool continuous = false);
+  void erase_mode(bool continuous = false);
+  void format_mode(bool continuous = false);
+  void write_mode(nfc::NdefMessage *message, bool continuous = false);
 
  protected:
   void turn_off_rf_();
@@ -67,6 +68,9 @@ class PN532 : public PollingComponent {
   bool is_mifare_ultralight_formatted_();
   uint16_t read_mifare_ultralight_capacity();
   bool find_mifare_ultralight_ndef_(uint8_t &message_length, uint8_t &message_start_index);
+  bool write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data);
+  bool write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
+  bool clean_mifare_ultralight_();
 
 
   bool requested_read_{false};

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -34,7 +34,6 @@ class PN532 : public PollingComponent {
 
   void read_mode();
   void clean_mode(bool continuous = false);
-  void erase_mode(bool continuous = false);
   void format_mode(bool continuous = false);
   void write_mode(nfc::NdefMessage *message, bool continuous = false);
 
@@ -50,7 +49,6 @@ class PN532 : public PollingComponent {
 
   nfc::NfcTag *read_tag_(std::vector<uint8_t> &uid);
 
-  bool erase_tag_(std::vector<uint8_t> &uid);
   bool format_tag_(std::vector<uint8_t> &uid);
   bool clean_tag_(std::vector<uint8_t> &uid);
   bool write_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
@@ -66,12 +64,11 @@ class PN532 : public PollingComponent {
   nfc::NfcTag *read_mifare_ultralight_tag_(std::vector<uint8_t> &uid);
   bool read_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &data);
   bool is_mifare_ultralight_formatted_();
-  uint16_t read_mifare_ultralight_capacity();
+  uint16_t read_mifare_ultralight_capacity_();
   bool find_mifare_ultralight_ndef_(uint8_t &message_length, uint8_t &message_start_index);
   bool write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data);
   bool write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
   bool clean_mifare_ultralight_();
-
 
   bool requested_read_{false};
   bool next_task_continuous_{false};
@@ -83,7 +80,6 @@ class PN532 : public PollingComponent {
     READ = 0,
     CLEAN,
     FORMAT,
-    ERASE,
     WRITE,
   } next_task_{READ};
   enum PN532Error {

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -54,12 +54,13 @@ class PN532 : public PollingComponent {
   bool clean_tag_(std::vector<uint8_t> &uid);
   bool write_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
 
+  nfc::NfcTag *read_mifare_classic_tag_(std::vector<uint8_t> &uid);
   std::vector<uint8_t> read_mifare_classic_block_(uint8_t block_num);
   bool write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
-
   bool auth_mifare_classic_block_(std::vector<uint8_t> &uid, uint8_t block_num, uint8_t key_num, const uint8_t *key);
   bool format_mifare_classic_mifare_(std::vector<uint8_t> &uid);
   bool format_mifare_classic_ndef_(std::vector<uint8_t> &uid);
+  bool write_mifare_classic_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
 
   bool requested_read_{false};
   bool next_task_continuous_{false};

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/nfc/nfc_tag.h"
+#include "esphome/components/nfc/nfc.h"
 
 namespace esphome {
 namespace pn532 {
@@ -40,6 +42,20 @@ class PN532 : public PollingComponent {
   virtual bool write_data(const std::vector<uint8_t> &data) = 0;
   virtual bool read_data(std::vector<uint8_t> &data, uint8_t len) = 0;
 
+  nfc::NfcTag *read_tag_(std::vector<uint8_t> &uid);
+
+  bool erase_tag_(nfc::NfcTag &tag);
+  bool format_tag_(nfc::NfcTag &tag);
+  bool clean_tag_(nfc::NfcTag &tag);
+  bool write_tag_(nfc::NfcTag &tag);
+
+  std::vector<uint8_t> read_mifare_classic_block_(uint8_t block_num);
+  bool write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
+
+  bool auth_mifare_classic_block_(std::vector<uint8_t> &uid, uint8_t block_num, uint8_t key_num, uint8_t *key);
+  bool format_mifare_classic_mifare_(nfc::NfcTag &tag);
+  bool format_mifare_classic_ndef_(nfc::NfcTag &tag);
+
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;
   std::vector<PN532Trigger *> triggers_;
@@ -69,9 +85,9 @@ class PN532BinarySensor : public binary_sensor::BinarySensor {
   bool found_{false};
 };
 
-class PN532Trigger : public Trigger<std::string> {
+class PN532Trigger : public Trigger<std::string, nfc::NfcTag> {
  public:
-  void process(std::vector<uint8_t> &data);
+  void process(nfc::NfcTag *tag);
 };
 
 }  // namespace pn532

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -1,0 +1,166 @@
+#include "pn532.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace pn532 {
+
+static const char *TAG = "pn532.mifare";
+
+std::vector<uint8_t> PN532::read_mifare_classic_block_(uint8_t block_num) {
+  if (!this->write_command_({
+          PN532_COMMAND_INDATAEXCHANGE,
+          0x01,  // One card
+          nfc::MIFARE_CMD_READ,
+          block_num,
+      })) {
+    return {};
+  }
+
+  std::vector<uint8_t> response;
+  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response) || response[0] != 0x00) {
+    return {};
+  }
+  response.erase(response.begin());
+  return response;
+}
+
+bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> &uid, uint8_t block_num, uint8_t key_num,
+                                       const uint8_t *key) {
+  std::vector<uint8_t> data({
+      PN532_COMMAND_INDATAEXCHANGE,
+      0x01,       // One card
+      key_num,    // Mifare Key slot
+      block_num,  // Block number
+  });
+  data.insert(data.end(), key, key + 6);
+  data.insert(data.end(), uid.begin(), uid.end());
+  if (!this->write_command_(data)) {
+    ESP_LOGE(TAG, "Authentication failed");
+    return false;
+  }
+
+  std::vector<uint8_t> response;
+  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response) || response[0] != 0x00) {
+    ESP_LOGE(TAG, "Authentication failed");
+    return false;
+  }
+
+  return true;
+}
+
+
+bool PN532::format_mifare_classic_mifare_(std::vector<uint8_t> &uid) {
+  std::vector<uint8_t> blank_buffer(
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  std::vector<uint8_t> trailer_buffer(
+      {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+
+  bool error = false;
+
+  for (int idx = 0; idx < 16; idx++) {
+    if (!this->auth_mifare_classic_block_(uid, (4 * idx) + 3, nfc::MIFARE_CMD_AUTH_B, nfc::DEFAULT_KEY)) {
+      ESP_LOGE(TAG, "No keys work!!! sector %d", idx);
+      continue;
+    }
+
+    if (idx == 0) {
+      if (!this->write_mifare_classic_block_((4 * idx) + 1, blank_buffer)) {
+        ESP_LOGE(TAG, "Unable to write sector %d-%d", idx, (4 * idx) + 1);
+        error = true;
+      }
+    } else {
+      if (!this->write_mifare_classic_block_((4 * idx), blank_buffer)) {
+        ESP_LOGE(TAG, "Unable to write sector %d-%d", idx, (4 * idx));
+        error = true;
+      }
+      if (!this->write_mifare_classic_block_((4 * idx) + 1, blank_buffer)) {
+        ESP_LOGE(TAG, "Unable to write sector %d-%d", idx, (4 * idx) + 1);
+        error = true;
+      }
+    }
+
+    if (!this->write_mifare_classic_block_((4 * idx) + 2, blank_buffer)) {
+      ESP_LOGE(TAG, "Unable to write sector %d-%d", idx, (4 * idx) + 2);
+      error = true;
+    }
+
+    if (!this->write_mifare_classic_block_((4 * idx) + 3, trailer_buffer)) {
+      ESP_LOGE(TAG, "Unable to write trailer of sector %d-%d", idx, (4 * idx) + 3);
+      error = true;
+    }
+  }
+
+  return !error;
+}
+
+bool PN532::format_mifare_classic_ndef_(std::vector<uint8_t> &uid) {
+  std::vector<uint8_t> empty_ndef_message(
+      {0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  std::vector<uint8_t> sector_buffer_0(
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  std::vector<uint8_t> sector_buffer_1(
+      {0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
+  std::vector<uint8_t> sector_buffer_2(
+      {0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
+  std::vector<uint8_t> sector_buffer_3(
+      {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  std::vector<uint8_t> sector_buffer_4(
+      {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+
+  if (!this->auth_mifare_classic_block_(uid, 0, nfc::MIFARE_CMD_AUTH_A, nfc::DEFAULT_KEY)) {
+    ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting!");
+    return false;
+  }
+  if (!this->write_mifare_classic_block_(1, sector_buffer_1))
+    return false;
+  if (!this->write_mifare_classic_block_(2, sector_buffer_2))
+    return false;
+  if (!this->write_mifare_classic_block_(3, sector_buffer_3))
+    return false;
+
+  for (int i = 4; i < 64; i += 4) {
+    if (!this->auth_mifare_classic_block_(uid, i, nfc::MIFARE_CMD_AUTH_A, nfc::DEFAULT_KEY)) {
+      ESP_LOGE(TAG, "Failed to authenticate with block %d", i);
+      continue;
+    }
+    if (i == 4) {
+      if (!this->write_mifare_classic_block_(i, empty_ndef_message))
+        ESP_LOGE(TAG, "Unable to write block %d", i);
+    } else {
+      if (!this->write_mifare_classic_block_(i, sector_buffer_0))
+        ESP_LOGE(TAG, "Unable to write block %d", i);
+    }
+    if (!this->write_mifare_classic_block_(i + 1, sector_buffer_0))
+      ESP_LOGE(TAG, "Unable to write block %d", i + 1);
+    if (!this->write_mifare_classic_block_(i + 2, sector_buffer_0))
+      ESP_LOGE(TAG, "Unable to write block %d", i + 2);
+    if (!this->write_mifare_classic_block_(i + 3, sector_buffer_4))
+      ESP_LOGE(TAG, "Unable to write block %d", i + 3);
+  }
+  return true;
+}
+
+bool PN532::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &write_data) {
+  std::vector<uint8_t> data({
+      PN532_COMMAND_INDATAEXCHANGE,
+      0x01,  // One card
+      nfc::MIFARE_CMD_WRITE,
+      block_num,  // Block number
+  });
+  data.insert(data.end(), write_data.begin(), write_data.end());
+  if (!this->write_command_(data)) {
+    ESP_LOGE(TAG, "Error writing block %d", block_num);
+    return false;
+  }
+
+  std::vector<uint8_t> response;
+  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response)) {
+    ESP_LOGE(TAG, "Error writing block %d", block_num);
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace pn532
+}  // namespace esphome

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -13,7 +13,7 @@ nfc::NfcTag *PN532::read_mifare_classic_tag_(std::vector<uint8_t> &uid) {
 
   if (this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_A, nfc::NDEF_KEY)) {
     std::vector<uint8_t> data;
-    if (!this->read_mifare_classic_block_(current_block, data)) {
+    if (this->read_mifare_classic_block_(current_block, data)) {
       if (!nfc::decode_mifare_classic_tlv(data, message_length, message_start_index)) {
         return new nfc::NfcTag(uid, nfc::ERROR);
       }

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -96,7 +96,6 @@ bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> &uid, uint8_t block_
   return true;
 }
 
-
 bool PN532::format_mifare_classic_mifare_(std::vector<uint8_t> &uid) {
   std::vector<uint8_t> blank_buffer(
       {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -90,7 +90,7 @@ bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> &uid, uint8_t block_
 
   std::vector<uint8_t> response;
   if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response) || response[0] != 0x00) {
-    ESP_LOGE(TAG, "Authentication failed - Block %d", block_num);
+    ESP_LOGE(TAG, "Authentication failed - Block 0x%02x", block_num);
     return false;
   }
 

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -4,7 +4,55 @@
 namespace esphome {
 namespace pn532 {
 
-static const char *TAG = "pn532.mifare";
+static const char *TAG = "pn532.mifare_classic";
+
+nfc::NfcTag *PN532::read_mifare_classic_tag_(std::vector<uint8_t> &uid) {
+  uint8_t current_block = 4;
+  uint8_t message_start_index = 0;
+  uint32_t message_length = 0;
+
+  if (this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_A, nfc::NDEF_KEY)) {
+    std::vector<uint8_t> data = this->read_mifare_classic_block_(current_block);
+    if (!data.empty()) {
+      if (!nfc::decode_mifare_classic_tlv(data, message_length, message_start_index)) {
+        return new nfc::NfcTag(uid, nfc::ERROR);
+      }
+    } else {
+      ESP_LOGE(TAG, "Failed to read block %d", current_block);
+      return new nfc::NfcTag(uid, nfc::MIFARE_CLASSIC);
+    }
+  } else {
+    ESP_LOGV(TAG, "Tag is not NDEF formatted");
+    return new nfc::NfcTag(uid, nfc::MIFARE_CLASSIC);
+  }
+
+  uint32_t index = 0;
+  uint32_t buffer_size = nfc::get_buffer_size(message_length);
+  std::vector<uint8_t> buffer;
+
+  while (index < buffer_size) {
+    if (nfc::mifare_classic_is_first_block(current_block)) {
+      if (!this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_A, nfc::NDEF_KEY)) {
+        ESP_LOGE(TAG, "Error, Block authentication failed for %d", current_block);
+      }
+    }
+    std::vector<uint8_t> data = this->read_mifare_classic_block_(current_block);
+    if (!data.empty()) {
+      buffer.insert(buffer.end(), data.begin(), data.end());
+    } else {
+      ESP_LOGE(TAG, "Error reading block %d", current_block);
+    }
+
+    index += nfc::MIFARE_CLASSIC_BLOCK_SIZE;
+    current_block++;
+
+    if (nfc::mifare_classic_is_trailer_block(current_block)) {
+      current_block++;
+    }
+  }
+  buffer.erase(buffer.begin(), buffer.begin() + message_start_index);
+  return new nfc::NfcTag(uid, nfc::MIFARE_CLASSIC, buffer);
+}
 
 std::vector<uint8_t> PN532::read_mifare_classic_block_(uint8_t block_num) {
   if (!this->write_command_({
@@ -159,6 +207,47 @@ bool PN532::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> 
     return false;
   }
 
+  return true;
+}
+
+bool PN532::write_mifare_classic_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message) {
+  auto encoded = message->encode();
+
+  if (encoded.size() < 255) {
+    encoded.insert(encoded.begin(), 0x03);
+    encoded.insert(encoded.begin() + 1, encoded.size());
+    encoded.push_back(0xFE);
+  } else {
+    encoded.insert(encoded.begin(), 0x03);
+    encoded.insert(encoded.begin() + 1, 0xFF);
+    encoded.insert(encoded.begin() + 2, (encoded.size() >> 8) & 0xFF);
+    encoded.insert(encoded.begin() + 2, encoded.size() & 0xFF);
+    encoded.push_back(0xFE);
+  }
+
+  uint32_t index = 0;
+  uint8_t current_block = 4;
+
+  while (index < encoded.size()) {
+    if (nfc::mifare_classic_is_first_block(current_block)) {
+      ESP_LOGD(TAG, "Trying to auth %d", current_block);
+      if (!this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_A, nfc::NDEF_KEY)) {
+        return false;
+      }
+    }
+
+    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_CLASSIC_BLOCK_SIZE);
+    if (!this->write_mifare_classic_block_(current_block, data)) {
+      return false;
+    }
+    index += nfc::MIFARE_CLASSIC_BLOCK_SIZE;
+    current_block++;
+
+    if (nfc::mifare_classic_is_trailer_block(current_block)) {
+      // Skipping as cannot write to trailer
+      current_block++;
+    }
+  }
   return true;
 }
 

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -25,7 +25,7 @@ nfc::NfcTag *PN532::read_mifare_ultralight_tag_(std::vector<uint8_t> &uid) {
   }
   std::vector<uint8_t> data;
   uint8_t index = 0;
-  for (uint8_t page = 4; page < 63; page++) {
+  for (uint8_t page = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; page < nfc::MIFARE_ULTRALIGHT_MAX_PAGE; page++) {
     std::vector<uint8_t> page_data;
     if (!this->read_mifare_ultralight_page_(page, page_data)) {
       ESP_LOGE(TAG, "Error reading page %d", page);
@@ -104,33 +104,81 @@ bool PN532::find_mifare_ultralight_ndef_(uint8_t &message_length, uint8_t &messa
   return false;
 }
 
+bool PN532::write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message) {
 
+  uint32_t capacity = this->read_mifare_ultralight_capacity();
 
+  auto encoded = message->encode();
 
-// bool PN532::write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message) {
-//   auto encoded = message->encode();
+  uint32_t message_length = encoded.size();
+  uint32_t buffer_length = nfc::get_mifare_ultralight_buffer_size(message_length);
 
-//   if (encoded.size() < 255) {
-//     encoded.insert(encoded.begin(), 0x03);
-//     encoded.insert(encoded.begin() + 1, encoded.size());
-//     encoded.push_back(0xFE);
-//   } else {
-//     encoded.insert(encoded.begin(), 0x03);
-//     encoded.insert(encoded.begin() + 1, 0xFF);
-//     encoded.insert(encoded.begin() + 2, (encoded.size() >> 8) & 0xFF);
-//     encoded.insert(encoded.begin() + 2, encoded.size() & 0xFF);
-//     encoded.push_back(0xFE);
-//   }
+  if (buffer_length > capacity) {
+    ESP_LOGE(TAG, "Message length exceeds tag capacity %d > %d", buffer_length, capacity);
+    return false;
+  }
 
-//   uint32_t index = 0;
-//   uint8_t current_page = 4;
+  encoded.insert(encoded.begin(), 0x03);
+  if (message_length < 255) {
+    encoded.insert(encoded.begin() + 1, message_length);
+  } else {
+    encoded.insert(encoded.begin() + 1, 0xFF);
+    encoded.insert(encoded.begin() + 2, (message_length >> 8) & 0xFF);
+    encoded.insert(encoded.begin() + 2, message_length & 0xFF);
+  }
+  encoded.push_back(0xFE);
 
-//   while (index < encoded.size()) {
-//     std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::BLOCK_SIZE);
-//     this->write_mifare_ultralight_page_(current_page,)
-//   }
-//   return true;
-// }
+  encoded.resize(buffer_length, 0);
+
+  uint32_t index = 0;
+  uint8_t current_page = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
+
+  while (index < buffer_length) {
+    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_ULTRALIGHT_PAGE_SIZE);
+    if (!this->write_mifare_ultralight_page_(current_page, data)) {
+      return false;
+    }
+    index += nfc::MIFARE_ULTRALIGHT_PAGE_SIZE;
+    current_page++;
+  }
+  return true;
+}
+
+bool PN532::clean_mifare_ultralight_() {
+  uint32_t capacity = this->read_mifare_ultralight_capacity();
+  uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
+
+  std::vector<uint8_t> blank_data = {0x00, 0x00, 0x00, 0x00};
+
+  for (int i = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; i < pages; i++) {
+    if (!this->write_mifare_ultralight_page_(i, blank_data)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool PN532::write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data) {
+  std::vector<uint8_t> data({
+      PN532_COMMAND_INDATAEXCHANGE,
+      0x01,  // One card
+      nfc::MIFARE_CMD_WRITE_ULTRALIGHT,
+      page_num,
+  });
+  data.insert(data.end(), write_data.begin(), write_data.end());
+  if (!this->write_command_(data)) {
+    ESP_LOGE(TAG, "Error writing page %d", page_num);
+    return false;
+  }
+
+  std::vector<uint8_t> response;
+  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response)) {
+    ESP_LOGE(TAG, "Error writing page %d", page_num);
+    return false;
+  }
+
+  return true;
+}
 
 }  // namespace pn532
 }  // namespace esphome

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -1,0 +1,136 @@
+#include "pn532.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace pn532 {
+
+static const char *TAG = "pn532.mifare_ultralight";
+
+nfc::NfcTag *PN532::read_mifare_ultralight_tag_(std::vector<uint8_t> &uid) {
+  if (!this->is_mifare_ultralight_formatted_()) {
+    ESP_LOGD(TAG, "Not NDEF formatted");
+    return new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2);
+  }
+
+  uint8_t message_length;
+  uint8_t message_start_index;
+  if (!this->find_mifare_ultralight_ndef_(message_length, message_start_index)) {
+    return new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2);
+  }
+
+  if (message_length == 0) {
+    auto message = new nfc::NdefMessage();
+    message->add_empty_record();
+    return new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2, message);
+  }
+  std::vector<uint8_t> data;
+  uint8_t index = 0;
+  for (uint8_t page = 4; page < 63; page++) {
+    std::vector<uint8_t> page_data;
+    if (!this->read_mifare_ultralight_page_(page, page_data)) {
+      ESP_LOGE(TAG, "Error reading page %d", page);
+      message_length = 0;
+      break;
+    }
+    data.insert(data.end(), page_data.begin(), page_data.end());
+
+    if (index >= (message_length + message_start_index))
+      break;
+
+    index += page_data.size();
+  }
+
+  data.erase(data.begin(), data.begin() + message_start_index);
+
+  return new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2, data);
+}
+
+bool PN532::read_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &data) {
+  if (!this->write_command_({
+          PN532_COMMAND_INDATAEXCHANGE,
+          0x01,  // One card
+          nfc::MIFARE_CMD_READ,
+          page_num,
+      })) {
+    return false;
+  }
+
+  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, data) || data[0] != 0x00) {
+    return false;
+  }
+  data.erase(data.begin());
+  // We only want 1 page of data but the PN532 returns 4 at once.
+  data.erase(data.begin() + 4, data.end());
+
+  ESP_LOGVV(TAG, "Pages %d-%d: %s", page_num, page_num + 4, nfc::format_bytes(data).c_str());
+
+  return true;
+}
+
+bool PN532::is_mifare_ultralight_formatted_() {
+  std::vector<uint8_t> data;
+  if (this->read_mifare_ultralight_page_(4, data)) {
+    return !(data[0] == 0xFF && data[1] == 0xFF && data[2] == 0xFF && data[3] == 0xFF);
+  }
+  return true;
+}
+
+uint16_t PN532::read_mifare_ultralight_capacity() {
+  std::vector<uint8_t> data;
+  if (this->read_mifare_ultralight_page_(3, data)) {
+    return data[2] * 8U;
+  }
+  return 0;
+}
+
+bool PN532::find_mifare_ultralight_ndef_(uint8_t &message_length, uint8_t &message_start_index) {
+  std::vector<uint8_t> data;
+  for (int page = 4; page < 6; page++) {
+    std::vector<uint8_t> page_data;
+    if (!this->read_mifare_ultralight_page_(page, page_data)) {
+      return false;
+    }
+    data.insert(data.end(), page_data.begin(), page_data.end());
+  }
+  if (data[0] == 0x03) {
+    message_length = data[1];
+    message_start_index = 2;
+    return true;
+  } else if (data[5] == 0x03) {
+    message_length = data[6];
+    message_start_index = 7;
+    return true;
+  }
+  return false;
+}
+
+
+
+
+// bool PN532::write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message) {
+//   auto encoded = message->encode();
+
+//   if (encoded.size() < 255) {
+//     encoded.insert(encoded.begin(), 0x03);
+//     encoded.insert(encoded.begin() + 1, encoded.size());
+//     encoded.push_back(0xFE);
+//   } else {
+//     encoded.insert(encoded.begin(), 0x03);
+//     encoded.insert(encoded.begin() + 1, 0xFF);
+//     encoded.insert(encoded.begin() + 2, (encoded.size() >> 8) & 0xFF);
+//     encoded.insert(encoded.begin() + 2, encoded.size() & 0xFF);
+//     encoded.push_back(0xFE);
+//   }
+
+//   uint32_t index = 0;
+//   uint8_t current_page = 4;
+
+//   while (index < encoded.size()) {
+//     std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::BLOCK_SIZE);
+//     this->write_mifare_ultralight_page_(current_page,)
+//   }
+//   return true;
+// }
+
+}  // namespace pn532
+}  // namespace esphome

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -19,9 +19,7 @@ nfc::NfcTag *PN532::read_mifare_ultralight_tag_(std::vector<uint8_t> &uid) {
   }
 
   if (message_length == 0) {
-    auto message = new nfc::NdefMessage();
-    message->add_empty_record();
-    return new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2, message);
+    return new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2);
   }
   std::vector<uint8_t> data;
   uint8_t index = 0;
@@ -29,8 +27,7 @@ nfc::NfcTag *PN532::read_mifare_ultralight_tag_(std::vector<uint8_t> &uid) {
     std::vector<uint8_t> page_data;
     if (!this->read_mifare_ultralight_page_(page, page_data)) {
       ESP_LOGE(TAG, "Error reading page %d", page);
-      message_length = 0;
-      break;
+      return new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2);
     }
     data.insert(data.end(), page_data.begin(), page_data.end());
 
@@ -75,7 +72,7 @@ bool PN532::is_mifare_ultralight_formatted_() {
   return true;
 }
 
-uint16_t PN532::read_mifare_ultralight_capacity() {
+uint16_t PN532::read_mifare_ultralight_capacity_() {
   std::vector<uint8_t> data;
   if (this->read_mifare_ultralight_page_(3, data)) {
     return data[2] * 8U;
@@ -105,8 +102,7 @@ bool PN532::find_mifare_ultralight_ndef_(uint8_t &message_length, uint8_t &messa
 }
 
 bool PN532::write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message) {
-
-  uint32_t capacity = this->read_mifare_ultralight_capacity();
+  uint32_t capacity = this->read_mifare_ultralight_capacity_();
 
   auto encoded = message->encode();
 
@@ -145,7 +141,7 @@ bool PN532::write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMes
 }
 
 bool PN532::clean_mifare_ultralight_() {
-  uint32_t capacity = this->read_mifare_ultralight_capacity();
+  uint32_t capacity = this->read_mifare_ultralight_capacity_();
   uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
   std::vector<uint8_t> blank_data = {0x00, 0x00, 0x00, 0x00};

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -14,7 +14,7 @@ static const char *TAG = "pn532_i2c";
 bool PN532I2C::write_data(const std::vector<uint8_t> &data) { return this->write_bytes_raw(data.data(), data.size()); }
 
 bool PN532I2C::read_data(std::vector<uint8_t> &data, uint8_t len) {
-  delay(5);
+  delay(1);
 
   std::vector<uint8_t> ready;
   ready.resize(1);


### PR DESCRIPTION
## Description:

This PR adds NFC NDEF reading and writing support to ESPHome.

A rewrite of #1316 after #1302 was merged in.

**Related issue (if applicable):** closes esphome/feature-requests#925

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#936

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
