### PR TITLE
Added ability to change sleep mode and sleep_activated touch

### DIFF
--- a/esphome/components/nextion/binary_sensor.py
+++ b/esphome/components/nextion/binary_sensor.py
@@ -8,6 +8,7 @@ from .display import Nextion
 DEPENDENCIES = ['display']
 
 CONF_NEXTION_ID = 'nextion_id'
+CONF_SLEEP_ACTIVATED = 'sleep_activated'
 
 NextionTouchComponent = nextion_ns.class_('NextionTouchComponent', binary_sensor.BinarySensor)
 
@@ -17,6 +18,7 @@ CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend({
 
     cv.Required(CONF_PAGE_ID): cv.uint8_t,
     cv.Required(CONF_COMPONENT_ID): cv.uint8_t,
+    cv.Optional(CONF_SLEEP_ACTIVATED, default=False): cv.boolean,
 })
 
 
@@ -29,3 +31,4 @@ def to_code(config):
 
     cg.add(var.set_component_id(config[CONF_COMPONENT_ID]))
     cg.add(var.set_page_id(config[CONF_PAGE_ID]))
+    cg.add(var.set_sleep_activated(config[CONF_SLEEP_ACTIVATED]))

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -360,6 +360,18 @@ class Nextion : public PollingComponent, public uart::UARTDevice {
    * `thup`.
    */
   void set_touch_sleep_timeout(uint16_t timeout);
+  /**
+   * Put the unit to sleep
+   * @param sleep - Go to sleep true or false (wake up)
+   *
+   * Example:
+   * ```cpp
+   * it.set_sleep(true);  // go to sleep
+   * it.set_sleep(false); // wake up
+   * ```
+   * `thup`.
+   */
+  void set_sleep(bool sleep);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -400,11 +412,13 @@ class NextionTouchComponent : public binary_sensor::BinarySensorInitiallyOff {
  public:
   void set_page_id(uint8_t page_id) { page_id_ = page_id; }
   void set_component_id(uint8_t component_id) { component_id_ = component_id; }
+  void set_sleep_activated(bool sleep_activated) { sleep_activated_ = sleep_activated; }
   void process(uint8_t page_id, uint8_t component_id, bool on);
 
  protected:
   uint8_t page_id_;
   uint8_t component_id_;
+  bool sleep_activated_;
 };
 
 }  // namespace nextion

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -851,6 +851,11 @@ binary_sensor:
     page_id: 0
     component_id: 2
     name: "Nextion Component 2 Touch"
+  - platform: nextion
+    page_id: 0
+    component_id: 2
+    sleep_activated: true
+    name: "Nextion Component 2 Touch"
   - platform: template
     name: "Garage Door Open"
     id: garage_door


### PR DESCRIPTION
set_sleep(bool) put the unit sleep mode or not
add in sleep_activated: bool

## Description:
set_sleep will set sleep mode or not on the unit. its helpful to bring it out of sleep mode off of a pir or something.
sleep_activated: bool for the binary sensor. In sleep mode the unit will only send the coordinates you touch. If a binary sensor is set to sleep_activated than it will trigger when the unit is in sleep and esphome just receives those coordinates. The page and component IDs dont matter in this case. 

Since sleep_activated doesnt need page or component we could make those optional of sleep_activated is set but i am unsure how to do that in the python code. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
