### PR TITLE
scd30: Allow setting ambient pressure compensation

### DIFF
--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -44,7 +44,7 @@ void SCD30Component::setup() {
            uint16_t(raw_firmware_version[0] & 0xFF));
 
   /// Sensor initialization
-  if (!this->write_command_(SCD30_CMD_START_CONTINUOUS_MEASUREMENTS, 0)) {
+  if (!this->write_command_(SCD30_CMD_START_CONTINUOUS_MEASUREMENTS, this->ambient_pressure_compensation_)) {
     ESP_LOGE(TAG, "Sensor SCD30 error starting continuous measurements.");
     this->error_code_ = MEASUREMENT_INIT_FAILED;
     this->mark_failed();
@@ -94,6 +94,7 @@ void SCD30Component::dump_config() {
     ESP_LOGCONFIG(TAG, "  Altitude compensation: %dm", this->altitude_compensation_);
   }
   ESP_LOGCONFIG(TAG, "  Automatic self calibration: %s", ONOFF(this->enable_asc_));
+  ESP_LOGCONFIG(TAG, "  Ambient pressure compensation: %dmBar", this->ambient_pressure_compensation_);
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -15,6 +15,9 @@ class SCD30Component : public PollingComponent, public i2c::I2CDevice {
   void set_temperature_sensor(sensor::Sensor *temperature) { temperature_sensor_ = temperature; }
   void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
   void set_altitude_compensation(uint16_t altitude) { altitude_compensation_ = altitude; }
+  void set_ambient_pressure_compensation(float pressure) {
+    ambient_pressure_compensation_ = (uint16_t)(pressure * 1000);
+  }
 
   void setup() override;
   void update() override;
@@ -35,6 +38,7 @@ class SCD30Component : public PollingComponent, public i2c::I2CDevice {
   } error_code_{UNKNOWN};
   bool enable_asc_{true};
   uint16_t altitude_compensation_{0xFFFF};
+  uint16_t ambient_pressure_compensation_{0x0000};
 
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -13,6 +13,7 @@ SCD30Component = scd30_ns.class_('SCD30Component', cg.PollingComponent, i2c.I2CD
 
 CONF_AUTOMATIC_SELF_CALIBRATION = 'automatic_self_calibration'
 CONF_ALTITUDE_COMPENSATION = 'altitude_compensation'
+CONF_AMBIENT_PRESSURE_COMPENSATION = 'ambient_pressure_compensation'
 
 
 def remove_altitude_suffix(value):
@@ -29,6 +30,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_ALTITUDE_COMPENSATION): cv.All(remove_altitude_suffix,
                                                     cv.int_range(min=0, max=0xFFFF,
                                                                  max_included=False)),
+    cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
 }).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x61))
 
 
@@ -40,6 +42,9 @@ def to_code(config):
     cg.add(var.set_automatic_self_calibration(config[CONF_AUTOMATIC_SELF_CALIBRATION]))
     if CONF_ALTITUDE_COMPENSATION in config:
         cg.add(var.set_altitude_compensation(config[CONF_ALTITUDE_COMPENSATION]))
+
+    if CONF_AMBIENT_PRESSURE_COMPENSATION in config:
+        cg.add(var.set_ambient_pressure_compensation(config[CONF_AMBIENT_PRESSURE_COMPENSATION]))
 
     if CONF_CO2 in config:
         sens = yield sensor.new_sensor(config[CONF_CO2])

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -622,6 +622,7 @@ _temperature_c = float_with_unit("temperature", "(°C|° C|°|C)?")
 _temperature_k = float_with_unit("temperature", "(° K|° K|K)?")
 _temperature_f = float_with_unit("temperature", "(°F|° F|F)?")
 decibel = float_with_unit("decibel", "(dB|dBm|db|dbm)", optional_unit=True)
+pressure = float_with_unit("pressure", "(bar|Bar)", optional_unit=True)
 
 
 def temperature(value):

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -618,6 +618,7 @@ sensor:
     update_interval: 15s
     automatic_self_calibration: true
     altitude_compensation: 10m
+    ambient_pressure_compensation: 961mBar
   - platform: sgp30
     eco2:
       name: "Workshop eCO2"


### PR DESCRIPTION
## Description:

This PR allows configuring the ambient pressure compensation for the Sensirion SCD30 CO2 sensor.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#842

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
