### PR TITLE
http_request don't reuse TCP connection

### DIFF
--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -14,35 +14,35 @@ void HttpRequestComponent::dump_config() {
 
 void HttpRequestComponent::send() {
   bool begin_status = false;
-  this->client_.setReuse(true);
+  HTTPClient client;
+  client.setReuse(true);
   const String url = this->url_.c_str();
 #ifdef ARDUINO_ARCH_ESP32
-  begin_status = this->client_.begin(url);
+  begin_status = client.begin(url);
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
 #ifndef CLANG_TIDY
-  this->client_.setFollowRedirects(true);
-  this->client_.setRedirectLimit(3);
-  begin_status = this->client_.begin(*this->get_wifi_client_(), url);
+  client.setFollowRedirects(true);
+  client.setRedirectLimit(3);
+  begin_status = client.begin(*this->get_wifi_client_(), url);
 #endif
 #endif
 
   if (!begin_status) {
-    this->client_.end();
     this->status_set_warning();
     ESP_LOGW(TAG, "HTTP Request failed at the begin phase. Please check the configuration");
     return;
   }
 
-  this->client_.setTimeout(this->timeout_);
+  client.setTimeout(this->timeout_);
   if (this->useragent_ != nullptr) {
-    this->client_.setUserAgent(this->useragent_);
+    client.setUserAgent(this->useragent_);
   }
   for (const auto &header : this->headers_) {
-    this->client_.addHeader(header.name, header.value, false, true);
+    client.addHeader(header.name, header.value, false, true);
   }
 
-  int http_code = this->client_.sendRequest(this->method_, this->body_.c_str());
+  int http_code = client.sendRequest(this->method_, this->body_.c_str());
   if (http_code < 0) {
     ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s", this->url_.c_str(),
              HTTPClient::errorToString(http_code).c_str());
@@ -77,13 +77,6 @@ WiFiClient *HttpRequestComponent::get_wifi_client_() {
   return this->wifi_client_;
 }
 #endif
-
-void HttpRequestComponent::close() { this->client_.end(); }
-
-const char *HttpRequestComponent::get_string() {
-  static const String STR = this->client_.getString();
-  return STR.c_str();
-}
 
 }  // namespace http_request
 }  // namespace esphome

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -37,11 +37,8 @@ class HttpRequestComponent : public Component {
   void set_body(std::string body) { this->body_ = body; }
   void set_headers(std::list<Header> headers) { this->headers_ = headers; }
   void send();
-  void close();
-  const char *get_string();
 
  protected:
-  HTTPClient client_{};
   std::string url_;
   const char *method_;
   const char *useragent_{nullptr};
@@ -103,7 +100,6 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
       this->parent_->set_headers(headers);
     }
     this->parent_->send();
-    this->parent_->close();
   }
 
  protected:


### PR DESCRIPTION
## Description:
HTTPClient library, configured the way it currently is, attempts to re-use the TCP connection. The problem is that while it is a good thing for redirects, it is not if you want to reuse HTTPClient instance for another URL.
There can be only one instance of http_request and it's documentation doesn't explicitly forbid using it to communicate with multiple servers, hence this:

```
script:
  - id: luftdaten_pm
    mode: single
    then:
      - http_request.post:
          url: http://api.sensor.community/v1/push-sensor-data/
      - http_request.post:
          url: http://api-rrd.madavi.de/data.php
```
should work. It does not - it will send both POSTs through the very same TCP connection to api.sensor.community.

**Related issue (if applicable):** really fixes https://github.com/esphome/issues/issues/1232

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not applicable

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
