### PR TITLE
fix HTTP Request reusing connections with different hosts

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -27,10 +27,7 @@ class HttpRequestComponent : public Component {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
-  void set_url(std::string url) {
-    this->url_ = url;
-    this->secure_ = url.compare(0, 6, "https:") == 0;
-  }
+  void set_url(std::string url);
   void set_method(const char *method) { this->method_ = method; }
   void set_useragent(const char *useragent) { this->useragent_ = useragent; }
   void set_timeout(uint16_t timeout) { this->timeout_ = timeout; }
@@ -43,6 +40,7 @@ class HttpRequestComponent : public Component {
  protected:
   HTTPClient client_{};
   std::string url_;
+  std::string last_url_;
   const char *method_;
   const char *useragent_{nullptr};
   bool secure_;


### PR DESCRIPTION
## Description:
Don't reuse connection if URL has been changed

**Related issue (if applicable):** 
closes https://github.com/esphome/esphome/pull/1374 
fixes https://github.com/esphome/issues/issues/1232

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
