### PR TITLE
Fixed logger broken by colorama

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -235,6 +235,9 @@ def setup_log(debug=False, quiet=False):
     logging.getLogger('urllib3').setLevel(logging.WARNING)
 
     try:
+        import colorama
+        colorama.init(strip=True)
+
         from colorlog import ColoredFormatter
         logging.getLogger().handlers[0].setFormatter(ColoredFormatter(
             colorfmt,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 voluptuous==0.12.0
 PyYAML==5.3.1
 paho-mqtt==1.5.1
+colorama==0.4.4
 colorlog==4.6.2
 tornado==6.0.4
 protobuf==3.13.0


### PR DESCRIPTION
## Description:
Logger broken by `colorlog` update here: https://github.com/esphome/esphome/pull/1323
Reason: https://github.com/borntyping/python-colorlog/commit/d6665aac1ca945414bb8dbdda8ca29594a1cae55
I returned ansi strip logic to esphome.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1609

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
