### PR TITLE
Fix mDNS webserver port and expose prometheus service

### DIFF
--- a/esphome/components/prometheus/__init__.py
+++ b/esphome/components/prometheus/__init__.py
@@ -18,5 +18,7 @@ CONFIG_SCHEMA = cv.Schema({
 def to_code(config):
     paren = yield cg.get_variable(config[CONF_WEB_SERVER_BASE_ID])
 
+    cg.add_define('USE_PROMETHEUS')
+
     var = cg.new_Pvariable(config[CONF_ID], paren)
     yield cg.register_component(var, config)

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -36,6 +36,7 @@ def to_code(config):
     yield cg.register_component(var, config)
 
     cg.add(paren.set_port(config[CONF_PORT]))
+    cg.add_define('WEBSERVER_PORT', config[CONF_PORT])
     cg.add(var.set_css_url(config[CONF_CSS_URL]))
     cg.add(var.set_js_url(config[CONF_JS_URL]))
     if CONF_AUTH in config:

--- a/esphome/core/util.cpp
+++ b/esphome/core/util.cpp
@@ -43,6 +43,10 @@ bool network_is_connected() {
 bool mdns_setup;
 #endif
 
+#ifndef WEBSERVER_PORT
+static const uint8_t WEBSERVER_PORT = 80;
+#endif
+
 #ifdef ARDUINO_ARCH_ESP8266
 void network_setup_mdns(IPAddress address, int interface) {
   // Latest arduino framework breaks mDNS for AP interface
@@ -65,9 +69,9 @@ void network_setup_mdns(IPAddress address, int interface) {
       MDNS.addServiceTxt("esphomelib", "tcp", "mac", get_mac_address().c_str());
     } else {
 #endif
-      // Publish "http" service if not using native API.
+      // Publish "http" service if not using native API nor the webserver component
       // This is just to have *some* mDNS service so that .local resolution works
-      MDNS.addService("http", "tcp", 80);
+      MDNS.addService("http", "tcp", WEBSERVER_PORT);
       MDNS.addServiceTxt("http", "tcp", "version", ESPHOME_VERSION);
 #ifdef USE_API
     }

--- a/esphome/core/util.cpp
+++ b/esphome/core/util.cpp
@@ -76,6 +76,9 @@ void network_setup_mdns(IPAddress address, int interface) {
 #ifdef USE_API
     }
 #endif
+#ifdef USE_PROMETHEUS
+    MDNS.addService("prometheus-http", "tcp", WEBSERVER_PORT);
+#endif
   }
   void network_tick_mdns() {
 #ifdef ARDUINO_ARCH_ESP8266


### PR DESCRIPTION
## Description:

This PR fixes the issues that via mDNS always port 80 is exposed no matter what is configured and if prometheus is enabled,
expose that service too.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
