### PR TITLE
Pin mode validation

### DIFF
--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -9,7 +9,7 @@ GPIOBinarySensor = gpio_ns.class_('GPIOBinarySensor', binary_sensor.BinarySensor
 
 CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(GPIOBinarySensor),
-    cv.Required(CONF_PIN): pins.gpio_input_pin_schema
+    cv.Required(CONF_PIN): pins.gpio_strict_input_pin_schema
 }).extend(cv.COMPONENT_SCHEMA)
 
 

--- a/esphome/components/gpio/output/__init__.py
+++ b/esphome/components/gpio/output/__init__.py
@@ -10,7 +10,7 @@ GPIOBinaryOutput = gpio_ns.class_('GPIOBinaryOutput', output.BinaryOutput,
 
 CONFIG_SCHEMA = output.BINARY_OUTPUT_SCHEMA.extend({
     cv.Required(CONF_ID): cv.declare_id(GPIOBinaryOutput),
-    cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+    cv.Required(CONF_PIN): pins.gpio_strict_output_pin_schema,
 }).extend(cv.COMPONENT_SCHEMA)
 
 

--- a/esphome/components/gpio/switch/__init__.py
+++ b/esphome/components/gpio/switch/__init__.py
@@ -18,7 +18,7 @@ RESTORE_MODES = {
 CONF_INTERLOCK_WAIT_TIME = 'interlock_wait_time'
 CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(GPIOSwitch),
-    cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+    cv.Required(CONF_PIN): pins.gpio_strict_output_pin_schema,
     cv.Optional(CONF_RESTORE_MODE, default='RESTORE_DEFAULT_OFF'):
         cv.enum(RESTORE_MODES, upper=True, space='_'),
     cv.Optional(CONF_INTERLOCK): cv.ensure_list(cv.use_id(switch.Switch)),

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -132,7 +132,7 @@ void HOT MAX7219Component::draw_absolute_pixel_internal(int x, int y, Color colo
     this->max_displaybuffer_.resize(x + 1, this->bckgrnd_);
   }
 
-  if ((y >= this->get_height_internal()) || (y < 0) || (x < 0))  // If pixel is outside display then dont draw
+  if (y >= this->get_height_internal() || y < 0)  // If pixel is outside display then dont draw
     return;
 
   uint16_t pos = x;    // X is starting at 0 top left

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -132,7 +132,7 @@ void HOT MAX7219Component::draw_absolute_pixel_internal(int x, int y, Color colo
     this->max_displaybuffer_.resize(x + 1, this->bckgrnd_);
   }
 
-  if (y >= this->get_height_internal() || y < 0)  // If pixel is outside display then dont draw
+  if ((y >= this->get_height_internal()) || (y < 0) || (x < 0))  // If pixel is outside display then dont draw
     return;
 
   uint16_t pos = x;    // X is starting at 0 top left

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -508,7 +508,7 @@ def gpio_strict_output_pin_schema(value):
     if isinstance(value, dict):
         for key, entry in PIN_SCHEMA_REGISTRY.items():
             if key in value:
-                return entry[1][2](value)
+                return entry[1][0](value)
     return internal_gpio_output_pin_schema(value, True)
 
 
@@ -538,7 +538,7 @@ def gpio_strict_input_pin_schema(value):
     if isinstance(value, dict):
         for key, entry in PIN_SCHEMA_REGISTRY.items():
             if key in value:
-                return entry[1][3](value)
+                return entry[1][1](value)
     return internal_gpio_input_pin_schema(value, True)
 
 

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -406,10 +406,12 @@ def pin_mode(value):
     if CORE.is_esp8266:
         return cv.one_of(*PIN_MODES_ESP8266, upper=True)(value)
     raise NotImplementedError
-    
+
+
 def pin_mode_output(value):
     return cv.one_of(*PIN_MODE_OUTPUT, upper=True)(value)
-    
+
+
 def pin_mode_input(value):
     if CORE.is_esp32:
         return cv.one_of(*PIN_MODE_INPUT_ESP32, upper=True)(value)

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -378,7 +378,7 @@ def analog_pin(value):
 input_output_pin = cv.All(input_pin, output_pin)
 
 PIN_MODE_OUTPUT = [
-    'OUTPUT', 'OUTPUT_OPEN_DRAIN,
+    'OUTPUT', 'OUTPUT_OPEN_DRAIN
 ]
 PIN_MODE_INPUT_ESP32 = [
     'INPUT', 'INPUT_PULLUP', 'INPUT_PULLDOWN',

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -377,6 +377,15 @@ def analog_pin(value):
 
 input_output_pin = cv.All(input_pin, output_pin)
 
+PIN_MODE_OUTPUT = [
+    'OUTPUT', 'OUTPUT_OPEN_DRAIN,
+]
+PIN_MODE_INPUT_ESP32 = [
+    'INPUT', 'INPUT_PULLUP', 'INPUT_PULLDOWN',
+]
+PIN_MODE_INPUT_ESP8266 = [
+    'INPUT', 'INPUT_PULLUP', 'INPUT_PULLDOWN_16',
+]
 PIN_MODES_ESP8266 = [
     'INPUT', 'OUTPUT', 'INPUT_PULLUP', 'OUTPUT_OPEN_DRAIN', 'SPECIAL', 'FUNCTION_1',
     'FUNCTION_2', 'FUNCTION_3', 'FUNCTION_4',
@@ -396,17 +405,28 @@ def pin_mode(value):
     if CORE.is_esp8266:
         return cv.one_of(*PIN_MODES_ESP8266, upper=True)(value)
     raise NotImplementedError
+    
+def pin_mode_output(value):
+    return cv.one_of(*PIN_MODE_OUTPUT, upper=True)(value)
+    raise NotImplementedError
+    
+def pin_mode_input(value):
+    if CORE.is_esp32:
+        return cv.one_of(*PIN_MODE_INPUT_ESP32, upper=True)(value)
+    if CORE.is_esp8266:
+        return cv.one_of(*PIN_MODE_INPUT_ESP8266, upper=True)(value)
+    raise NotImplementedError
 
 
 GPIO_FULL_OUTPUT_PIN_SCHEMA = cv.Schema({
     cv.Required(CONF_NUMBER): output_pin,
-    cv.Optional(CONF_MODE, default='OUTPUT'): pin_mode,
+    cv.Optional(CONF_MODE, default='OUTPUT'): pin_mode_output,
     cv.Optional(CONF_INVERTED, default=False): cv.boolean,
 })
 
 GPIO_FULL_INPUT_PIN_SCHEMA = cv.Schema({
     cv.Required(CONF_NUMBER): input_pin,
-    cv.Optional(CONF_MODE, default='INPUT'): pin_mode,
+    cv.Optional(CONF_MODE, default='INPUT'): pin_mode_input,
     cv.Optional(CONF_INVERTED, default=False): cv.boolean,
 })
 
@@ -457,7 +477,10 @@ PIN_SCHEMA_REGISTRY = SimpleRegistry()
 
 
 def internal_gpio_output_pin_schema(value):
+    # print (value)
     if isinstance(value, dict):
+        print (GPIO_FULL_OUTPUT_PIN_SCHEMA(value))
+        exit()
         return GPIO_FULL_OUTPUT_PIN_SCHEMA(value)
     return shorthand_output_pin(value)
 
@@ -467,6 +490,7 @@ def gpio_output_pin_schema(value):
         for key, entry in PIN_SCHEMA_REGISTRY.items():
             if key in value:
                 return entry[1][0](value)
+
     return internal_gpio_output_pin_schema(value)
 
 

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -378,7 +378,7 @@ def analog_pin(value):
 input_output_pin = cv.All(input_pin, output_pin)
 
 PIN_MODE_OUTPUT = [
-    'OUTPUT', 'OUTPUT_OPEN_DRAIN
+    'OUTPUT', 'OUTPUT_OPEN_DRAIN',
 ]
 PIN_MODE_INPUT_ESP32 = [
     'INPUT', 'INPUT_PULLUP', 'INPUT_PULLDOWN',


### PR DESCRIPTION
## Description:
Add the possibility to define a pin as strict input or strict output.

Some components can't be defined with a pin as input or output,
so with this commit it becomes possible to define a pin as strict input or output so that the yaml validation detects the inconsistency.
This concept is added to gpio defined into:
- binary_sensor which can have only input pins
- output which can have only output pins
- switch which can have only output pins
Hence, it becomes impossible to define for example:
output:
  - platform: gpio
    pin:
        number : 25
        mode: INPUT

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
No necessary doc