### PR TITLE
Configurable OTA Safe Mode

### DIFF
--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
-	CONF_ID, CONF_NUM_ATTEMPTS, CONF_PASSWORD,
+    CONF_ID, CONF_NUM_ATTEMPTS, CONF_PASSWORD,
     CONF_PORT, CONF_REBOOT_TIMEOUT, CONF_SAFE_MODE
 )
 from esphome.core import CORE, coroutine_with_priority

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -1,7 +1,9 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_NUM_ATTEMPTS, CONF_PASSWORD,
-CONF_PORT, CONF_REBOOT_TIMEOUT, CONF_SAFE_MODE
+from esphome.const import (
+	CONF_ID, CONF_NUM_ATTEMPTS, CONF_PASSWORD,
+    CONF_PORT, CONF_REBOOT_TIMEOUT, CONF_SAFE_MODE
+)
 from esphome.core import CORE, coroutine_with_priority
 
 CODEOWNERS = ['@esphome/core']

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_PASSWORD, CONF_PORT, CONF_SAFE_MODE
+from esphome.const import CONF_ID, CONF_NUM_ATTEMPTS, CONF_PASSWORD, CONF_PORT, CONF_REBOOT_TIMEOUT, CONF_SAFE_MODE
 from esphome.core import CORE, coroutine_with_priority
 
 CODEOWNERS = ['@esphome/core']
@@ -14,6 +14,8 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_SAFE_MODE, default=True): cv.boolean,
     cv.SplitDefault(CONF_PORT, esp8266=8266, esp32=3232): cv.port,
     cv.Optional(CONF_PASSWORD, default=''): cv.string,
+    cv.Optional(CONF_REBOOT_TIMEOUT, default='5min'): cv.positive_time_period_milliseconds,
+    cv.Optional(CONF_NUM_ATTEMPTS, default='10'): cv.positive_not_null_int
 }).extend(cv.COMPONENT_SCHEMA)
 
 
@@ -26,7 +28,7 @@ def to_code(config):
     yield cg.register_component(var, config)
 
     if config[CONF_SAFE_MODE]:
-        cg.add(var.start_safe_mode())
+        cg.add(var.start_safe_mode(config[CONF_NUM_ATTEMPTS], config[CONF_REBOOT_TIMEOUT]))
 
     if CORE.is_esp8266:
         cg.add_library('Update', None)

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_NUM_ATTEMPTS, CONF_PASSWORD, CONF_PORT, CONF_REBOOT_TIMEOUT, CONF_SAFE_MODE
+from esphome.const import CONF_ID, CONF_NUM_ATTEMPTS, CONF_PASSWORD,
+CONF_PORT, CONF_REBOOT_TIMEOUT, CONF_SAFE_MODE
 from esphome.core import CORE, coroutine_with_priority
 
 CODEOWNERS = ['@esphome/core']

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -47,7 +47,7 @@ class OTAComponent : public Component {
   /// Manually set the port OTA should listen on.
   void set_port(uint16_t port);
 
-  void start_safe_mode(uint8_t num_attempts = 10, uint32_t enable_time = 120000);
+  void start_safe_mode(uint8_t num_attempts, uint32_t enable_time);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -154,6 +154,8 @@ ota:
   safe_mode: True
   password: 'superlongpasswordthatnoonewillknow'
   port: 3286
+  reboot_timeout: 2min
+  num_attempts: 5
 
 logger:
   baud_rate: 0

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -40,6 +40,7 @@ uart:
 ota:
   safe_mode: True
   port: 3286
+  num_attempts: 15
 
 logger:
   level: DEBUG

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -204,6 +204,7 @@ uart:
 ota:
   safe_mode: True
   port: 3286
+  reboot_timeout: 15min
 
 logger:
   hardware_uart: UART1


### PR DESCRIPTION
## Description:
Allows for configurable options for OTA safe mode reboot timeout and boot attempts before entering OTA safe mode. Changes default OTA timeout to 5 min instead of 2 min.

**Related issue (if applicable):** fixes esphome/issues#1629

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#859

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
