### PR TITLE
Add option to suppress embedded MCU updates on certain datapoints 

### DIFF
--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -18,6 +18,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS): cv.ensure_list(cv.uint8_t),
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
+
 def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
@@ -28,4 +29,3 @@ def to_code(config):
     if CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS in config:
         for dp in config[CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS]:
             cg.add(var.add_ignore_mcu_update_on_datapoints(dp))
-

--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -6,6 +6,8 @@ from esphome.const import CONF_ID, CONF_TIME_ID
 
 DEPENDENCIES = ['uart']
 
+CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS = "ignore_mcu_update_on_datapoints"
+
 tuya_ns = cg.esphome_ns.namespace('tuya')
 Tuya = tuya_ns.class_('Tuya', cg.Component, uart.UARTDevice)
 
@@ -13,8 +15,8 @@ CONF_TUYA_ID = 'tuya_id'
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(Tuya),
     cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+    cv.Optional(CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS): cv.ensure_list(cv.uint8_t),
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
-
 
 def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
@@ -23,3 +25,7 @@ def to_code(config):
     if CONF_TIME_ID in config:
         time_ = yield cg.get_variable(config[CONF_TIME_ID])
         cg.add(var.set_time_id(time_))
+    if CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS in config:
+        for dp in config[CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS]:
+            cg.add(var.add_ignore_mcu_update_on_datapoints(dp))
+

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -342,7 +342,7 @@ void Tuya::set_datapoint_value(TuyaDatapoint datapoint) {
   std::vector<uint8_t> buffer;
   ESP_LOGV(TAG, "Datapoint %u set to %u", datapoint.id, datapoint.value_uint);
   for (auto &other : this->datapoints_) {
-    if (other.id == datapoint.id && datapoint.id != 0x2) {
+    if (other.id == datapoint.id) {
       if (other.value_uint == datapoint.value_uint) {
         ESP_LOGV(TAG, "Not sending unchanged value");
         return;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -104,10 +104,8 @@ bool Tuya::validate_message_() {
 
   // valid message
   const uint8_t *message_data = data + 6;
-  if (command != 0x00) {
-    ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
-             hexencode(message_data, length).c_str(), this->init_state_);
-  }
+  ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
+           hexencode(message_data, length).c_str(), this->init_state_);
   this->handle_command_(command, version, message_data, length);
 
   // return false to reset rx buffer
@@ -125,7 +123,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
   this->last_command_timestamp_ = millis();
   switch ((TuyaCommandType) command) {
     case TuyaCommandType::HEARTBEAT:
-      // ESP_LOGV(TAG, "MCU Heartbeat (0x%02X)", buffer[0]);
+      ESP_LOGV(TAG, "MCU Heartbeat (0x%02X)", buffer[0]);
       if (buffer[0] == 0) {
         ESP_LOGI(TAG, "MCU restarted");
         this->init_state_ = TuyaInitState::INIT_HEARTBEAT;
@@ -323,10 +321,8 @@ void Tuya::send_command_(TuyaCommandType command, const uint8_t *buffer, uint16_
   uint8_t len_lo = len >> 0;
   uint8_t version = 0;
 
-  if (command != TuyaCommandType::HEARTBEAT) {
-    ESP_LOGV(TAG, "Sending Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
-             hexencode(buffer, len).c_str(), this->init_state_);
-  }
+  ESP_LOGV(TAG, "Sending Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
+           hexencode(buffer, len).c_str(), this->init_state_);
 
   this->write_array({0x55, 0xAA, version, (uint8_t) command, len_hi, len_lo});
   if (len != 0)

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -257,10 +257,11 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
   datapoint.value_uint = 0;
 
   // drop update if datapoint is in ignore_mcu_datapoint_update list
-  for (size_t i = 0; i < this->ignore_mcu_update_on_datapoints_.size(); i++) {
-    if (datapoint.id == this->ignore_mcu_update_on_datapoints_[i])
+  for (auto i : this->ignore_mcu_update_on_datapoints_) {
+    if (datapoint.id == i) {
       ESP_LOGV(TAG, "Datapoint %u found in ignore_mcu_update_on_datapoints list, dropping MCU update", datapoint.id);
       return;
+    }
   }
 
   size_t data_size = (buffer[2] << 8) + buffer[3];

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -338,7 +338,7 @@ void Tuya::set_datapoint_value(TuyaDatapoint datapoint) {
   std::vector<uint8_t> buffer;
   ESP_LOGV(TAG, "Datapoint %u set to %u", datapoint.id, datapoint.value_uint);
   for (auto &other : this->datapoints_) {
-    if (other.id == datapoint.id && datapoint.id != 0x2) {
+    if (other.id == datapoint.id) {
       if (other.value_uint == datapoint.value_uint) {
         ESP_LOGV(TAG, "Not sending unchanged value");
         return;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -256,6 +256,9 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
   datapoint.type = (TuyaDatapointType) buffer[1];
   datapoint.value_uint = 0;
 
+  if (datapoint.id == 0x2)
+    return;
+
   size_t data_size = (buffer[2] << 8) + buffer[3];
   const uint8_t *data = buffer + 4;
   size_t data_len = len - 4;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -104,10 +104,8 @@ bool Tuya::validate_message_() {
 
   // valid message
   const uint8_t *message_data = data + 6;
-  if (command != 0x00) {
-    ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
-             hexencode(message_data, length).c_str(), this->init_state_);
-  }
+  ESP_LOGV(TAG, "Received Tuya: CMD=0x%02X VERSION=%u DATA=[%s] INIT_STATE=%u", command, version,  // NOLINT
+           hexencode(message_data, length).c_str(), this->init_state_);
   this->handle_command_(command, version, message_data, length);
 
   // return false to reset rx buffer

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -72,7 +72,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
 #endif
   void add_ignore_mcu_update_on_datapoints(uint8_t ignore_mcu_update_on_datapoints) {
-	  this->ignore_mcu_update_on_datapoints_.push_back(ignore_mcu_update_on_datapoints);
+    this->ignore_mcu_update_on_datapoints_.push_back(ignore_mcu_update_on_datapoints);
   }
 
  protected:

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -71,6 +71,9 @@ class Tuya : public Component, public uart::UARTDevice {
 #ifdef USE_TIME
   void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
 #endif
+  void add_ignore_mcu_update_on_datapoints(uint8_t ignore_mcu_update_on_datapoints) {
+	  this->ignore_mcu_update_on_datapoints_.push_back(ignore_mcu_update_on_datapoints);
+  }
 
  protected:
   void handle_char_(uint8_t c);
@@ -93,6 +96,7 @@ class Tuya : public Component, public uart::UARTDevice {
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;
   std::vector<uint8_t> rx_message_;
+  std::vector<uint8_t> ignore_mcu_update_on_datapoints_{};
 };
 
 }  // namespace tuya


### PR DESCRIPTION
## Description: Adds a config option to the tuya component to ignore embedded MCU updates on a list of datapoints.

I have some hardware (a DM_WF_MDV4 dimmer module) that gives essentially bogus updates on the dimmer datapoint *sometimes*.  Since this module has no local control of the dimmer setting, the updates on that datapoint aren't needed and are actually harmful.  I'm also using this option to debug some other hardware.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#868

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
