### PR TITLE
Fix stepper half half step mode

### DIFF
--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -70,7 +70,7 @@ void ULN2003::write_step_(int32_t step) {
     }
     case ULN2003_STEP_MODE_HALF_STEP: {
       // A, AB, B, BC, C, CD, D, DA
-      if (i == 0 || i == 2 || i == 7)
+      if (i == 0 || i == 1 || i == 7)
         res |= 1 << 0;
       if (i == 1 || i == 2 || i == 3)
         res |= 1 << 1;

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -71,7 +71,7 @@ void ULN2003::write_step_(int32_t step) {
     case ULN2003_STEP_MODE_HALF_STEP: {
       // A, AB, B, BC, C, CD, D, DA
       res |= 1 << (i >> 1);
-      res |= 1 << ( ( (i + 1) >> 1) & 0x3);
+      res |= 1 << (((i + 1) >> 1) & 0x3);
       break;
     }
     case ULN2003_STEP_MODE_WAVE_DRIVE: {

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -70,11 +70,8 @@ void ULN2003::write_step_(int32_t step) {
     }
     case ULN2003_STEP_MODE_HALF_STEP: {
       // A, AB, B, BC, C, CD, D, DA
-      uint32_t j = i >> 1;
-      uint32_t k = i  & 1;
-
-      res |= 1 << j;
-      res |= 1 << ((j + k) & 0x3);
+      res |= 1 << (i >> 1);
+      res |= 1 << ( (i + 1) >> 1) & 0x3);
       break;
     }
     case ULN2003_STEP_MODE_WAVE_DRIVE: {

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -71,7 +71,7 @@ void ULN2003::write_step_(int32_t step) {
     case ULN2003_STEP_MODE_HALF_STEP: {
       // A, AB, B, BC, C, CD, D, DA
       res |= 1 << (i >> 1);
-      res |= 1 << ( (i + 1) >> 1) & 0x3);
+      res |= 1 << ( ( (i + 1) >> 1) & 0x3);
       break;
     }
     case ULN2003_STEP_MODE_WAVE_DRIVE: {

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -70,14 +70,11 @@ void ULN2003::write_step_(int32_t step) {
     }
     case ULN2003_STEP_MODE_HALF_STEP: {
       // A, AB, B, BC, C, CD, D, DA
-      if (i == 0 || i == 1 || i == 7)
-        res |= 1 << 0;
-      if (i == 1 || i == 2 || i == 3)
-        res |= 1 << 1;
-      if (i == 3 || i == 4 || i == 5)
-        res |= 1 << 2;
-      if (i == 5 || i == 6 || i == 7)
-        res |= 1 << 3;
+      uint32_t j = i >> 1;
+      uint32_t k = i  & 1;
+
+      res |= 1 << j;
+      res |= 1 << ((j + k) & 0x3);
       break;
     }
     case ULN2003_STEP_MODE_WAVE_DRIVE: {


### PR DESCRIPTION
##Description:
Half step mode originally had second and third steps mixed up for output A.

**Related issue (if applicable):** fixes <link to issue> [https://github.com/esphome/issues/issues/1655](https://github.com/esphome/issues/issues/1655)



## Checklist:
  - [Y ] The code change is tested and works locally.
  - [N/A ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
