### PR TITLE
scd30: Allow setting temperature offset

### DIFF
--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -51,6 +51,14 @@ void SCD30Component::setup() {
     return;
   }
 
+  if (this->temperature_offset_ != 0) {
+    if (!this->write_command_(SCD30_CMD_TEMPERATURE_OFFSET, (uint16_t)(temperature_offset_ * 100.0))) {
+      ESP_LOGE(TAG, "Sensor SCD30 error setting temperature offset.");
+      this->error_code_ = MEASUREMENT_INIT_FAILED;
+      this->mark_failed();
+      return;
+    }
+  }
   // The start measurement command disables the altitude compensation, if any, so we only set it if it's turned on
   if (this->altitude_compensation_ != 0xFFFF) {
     if (!this->write_command_(SCD30_CMD_ALTITUDE_COMPENSATION, altitude_compensation_)) {
@@ -95,6 +103,7 @@ void SCD30Component::dump_config() {
   }
   ESP_LOGCONFIG(TAG, "  Automatic self calibration: %s", ONOFF(this->enable_asc_));
   ESP_LOGCONFIG(TAG, "  Ambient pressure compensation: %dmBar", this->ambient_pressure_compensation_);
+  ESP_LOGCONFIG(TAG, "  Temperature offset: %.2f °C", this->temperature_offset_);
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -18,6 +18,7 @@ class SCD30Component : public PollingComponent, public i2c::I2CDevice {
   void set_ambient_pressure_compensation(float pressure) {
     ambient_pressure_compensation_ = (uint16_t)(pressure * 1000);
   }
+  void set_temperature_offset(float offset) { temperature_offset_ = offset; }
 
   void setup() override;
   void update() override;
@@ -39,6 +40,7 @@ class SCD30Component : public PollingComponent, public i2c::I2CDevice {
   bool enable_asc_{true};
   uint16_t altitude_compensation_{0xFFFF};
   uint16_t ambient_pressure_compensation_{0x0000};
+  float temperature_offset_{0.0};
 
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -14,6 +14,7 @@ SCD30Component = scd30_ns.class_('SCD30Component', cg.PollingComponent, i2c.I2CD
 CONF_AUTOMATIC_SELF_CALIBRATION = 'automatic_self_calibration'
 CONF_ALTITUDE_COMPENSATION = 'altitude_compensation'
 CONF_AMBIENT_PRESSURE_COMPENSATION = 'ambient_pressure_compensation'
+CONF_TEMPERATURE_OFFSET = 'temperature_offset'
 
 
 def remove_altitude_suffix(value):
@@ -31,6 +32,7 @@ CONFIG_SCHEMA = cv.Schema({
                                                     cv.int_range(min=0, max=0xFFFF,
                                                                  max_included=False)),
     cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
+    cv.Optional(CONF_TEMPERATURE_OFFSET): cv.temperature,
 }).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x61))
 
 
@@ -45,6 +47,9 @@ def to_code(config):
 
     if CONF_AMBIENT_PRESSURE_COMPENSATION in config:
         cg.add(var.set_ambient_pressure_compensation(config[CONF_AMBIENT_PRESSURE_COMPENSATION]))
+
+    if CONF_TEMPERATURE_OFFSET in config:
+        cg.add(var.set_temperature_offset(config[CONF_TEMPERATURE_OFFSET]))
 
     if CONF_CO2 in config:
         sens = yield sensor.new_sensor(config[CONF_CO2])

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -619,6 +619,7 @@ sensor:
     automatic_self_calibration: true
     altitude_compensation: 10m
     ambient_pressure_compensation: 961mBar
+    temperature_offset: 4.2C
   - platform: sgp30
     eco2:
       name: 'Workshop eCO2'


### PR DESCRIPTION
## Description:

The on-board humidity/temperature sensor is influenced by thermal
self-heating of the scd30 and other components. Temperature and humidity
offsets may occur when operating the sensor in end-customer devices. This
commit allows the compensation of those effects by setting a temperature
offset.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#864

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
