### PR TITLE
Fix Tuya initialisation regression

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -160,7 +160,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       }
       if (this->init_state_ == TuyaInitState::INIT_CONF) {
         // If mcu returned status gpio, then we can ommit sending wifi state
-        if (this->gpio_status_ != 0) {
+        if (this->gpio_status_ != -1) {
           this->init_state_ = TuyaInitState::INIT_DATAPOINT;
           this->schedule_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
         } else {


### PR DESCRIPTION
## Description:

Some Tuya MCUs don't report "GPIO status" via the serial protocol. In this case, the `gpio_status_` field is never updated and stays uninitialised as `-1`.

9fed7cab5f7423148e6ea428eb3cd58456d54524 introduces different initialisation behavour for MCUs that report "GPIO status", however this checks for a `gpio_status_ != 0` rather than `-1`. This results in esphome getting stuck in the `INIT_DATAPOINT` init_state.  Instead checking for `-1` to revert to the previous behaviour for MCUs that don't report "GPIO status" restores the functionality of ESPHome.