### PR TITLE
Add function to set SDS011 sensor in sleeping mode

### DIFF
--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -50,6 +50,21 @@ void SDS011Component::setup() {
   this->sds011_write_command_(command_data);
 }
 
+void SDS011Component::set_working_state(bool working_state) {
+  if (this->rx_mode_only_) {
+    // In RX-only mode we do not setup the sensor, it is assumed to be setup
+    // already
+    return;
+  }
+  uint8_t command_data[SDS011_DATA_REQUEST_LENGTH] = {0};
+  command_data[0] = SDS011_COMMAND_SLEEP;
+  command_data[1] = SDS011_SET_MODE;
+  command_data[2] = working_state ? SDS011_MODE_WORK : SDS011_MODE_SLEEP;
+  command_data[13] = 0xff;
+  command_data[14] = 0xff;
+  this->sds011_write_command_(command_data);
+}
+
 void SDS011Component::dump_config() {
   ESP_LOGCONFIG(TAG, "SDS011:");
   ESP_LOGCONFIG(TAG, "  Update Interval: %u min", this->update_interval_min_);

--- a/esphome/components/sds011/sds011.h
+++ b/esphome/components/sds011/sds011.h
@@ -25,6 +25,7 @@ class SDS011Component : public Component, public uart::UARTDevice {
   void set_update_interval(uint32_t val) { /* ignore */
   }
   void set_update_interval_min(uint8_t update_interval_min);
+  void set_working_state(bool working_state);
 
  protected:
   void sds011_write_command_(const uint8_t *command);


### PR DESCRIPTION
## Description:

Since the sds011 fan is a little noisy, I wanted the ability to turn it on and off from home-assistant.

I have added a function to be able to set it to sleep mode from a lambda function.

Here is my exemple with a template switch from my config : 

```switch:
  - platform: template
    id: my_output_id
    name: my_output_id
    icon: "mdi:power"
    turn_on_action:
      - lambda: |-
          id(air_sensor).set_working_state(true);
          id(air_sensor).dump_config();
      - switch.template.publish:
          id: my_output_id
          state: ON
    turn_off_action:
      - light.turn_off:
          id: light_1
      - lambda: |-
          id(air_sensor).set_working_state(false);
          id(air_sensor).dump_config();
      - switch.template.publish:
          id: my_output_id
          state: OFF`
```

I have tested this quickly and it works.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

~~If user exposed functionality or configuration variables are added/changed:~~
~~- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~~
