### PR TITLE
fix safe_mode

### DIFF
--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -208,6 +208,7 @@ def _esp8266_add_lwip_type():
     # Other projects like Tasmota & ESPEasy also use this
     cg.add_build_flag('-DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH')
 
+
 @coroutine_with_priority(30.0)
 def _add_automations(config):
     for conf in config.get(CONF_ON_BOOT, []):
@@ -224,6 +225,7 @@ def _add_automations(config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
         yield cg.register_component(trigger, conf)
         yield automation.build_automation(trigger, [], conf)
+
 
 @coroutine_with_priority(100.0)
 def to_code(config):


### PR DESCRIPTION
## Description:
Ensures safe mode is loaded before automations are ran. Automations containing a lambda were previously run before safe mode started, resulting in a potential permanent boot loop.

I'm not sure if this will have an effect on other components or if this is the proper way of doing this, but I have tested it and haven't found any issues thus far. Open to suggestions for improvements or other solutions to this.

**Related issue (if applicable):** fixes esphome/issues#1686

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
