### PR TITLE
Add encode_uint32 method, similar to encode_uint16

### DIFF
--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -62,8 +62,7 @@ void ProtoMessage::decode(const uint8_t *buffer, size_t length) {
           error = true;
           break;
         }
-        uint32_t val = (uint32_t(buffer[i]) << 0) | (uint32_t(buffer[i + 1]) << 8) | (uint32_t(buffer[i + 2]) << 16) |
-                       (uint32_t(buffer[i + 3]) << 24);
+        uint32_t val = encode_uint32(buffer[i + 3], buffer[i + 2], buffer[i + 1], buffer[i]);
         if (!this->decode_32bit(field_id, Proto32Bit(val))) {
           ESP_LOGV(TAG, "Cannot decode 32-bit field %u with value %u!", field_id, val);
         }

--- a/esphome/components/max31855/max31855.cpp
+++ b/esphome/components/max31855/max31855.cpp
@@ -41,7 +41,7 @@ void MAX31855Sensor::read_data_() {
   this->read_array(data, 4);
   this->disable();
 
-  const uint32_t mem = data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3] << 0;
+  const uint32_t mem = encode_uint32(data[0], data[1], data[2], data[3]);
 
   // Verify we got data
   if (mem != 0xFFFFFFFF) {

--- a/esphome/components/rdm6300/rdm6300.cpp
+++ b/esphome/components/rdm6300/rdm6300.cpp
@@ -46,8 +46,7 @@ void rdm6300::RDM6300Component::loop() {
       } else {
         // Valid data
         this->status_clear_warning();
-        const uint32_t result = (uint32_t(this->buffer_[1]) << 24) | (uint32_t(this->buffer_[2]) << 16) |
-                                (uint32_t(this->buffer_[3]) << 8) | this->buffer_[4];
+        const uint32_t result = encode_uint32(this->buffer_[1], this->buffer_[2], this->buffer_[3], this->buffer_[4]);
         bool report = result != last_id_;
         for (auto *card : this->cards_) {
           if (card->process(result)) {

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -281,8 +281,7 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
     case TuyaDatapointType::INTEGER:
       if (data_len != 4)
         return;
-      datapoint.value_uint =
-          (uint32_t(data[0]) << 24) | (uint32_t(data[1]) << 16) | (uint32_t(data[2]) << 8) | (uint32_t(data[3]) << 0);
+      datapoint.value_uint = encode_uint32(data[0], data[1], data[2], data[3]);
       break;
     case TuyaDatapointType::ENUM:
       if (data_len != 1)

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -70,8 +70,7 @@ bool parse_xiaomi_value(uint8_t value_type, const uint8_t *data, uint8_t value_l
   }
   // idle time since last motion, 4 byte, 32-bit unsigned integer, 1 min
   else if ((value_type == 0x17) && (value_length == 4)) {
-    const uint32_t idle_time =
-        uint32_t(data[0]) | (uint32_t(data[1]) << 8) | (uint32_t(data[2]) << 16) | (uint32_t(data[2]) << 24);
+    const uint32_t idle_time = encode_uint32(data[3], data[2], data[1], data[0]);
     result.idle_time = idle_time / 60.0f;
     result.has_motion = (idle_time) ? false : true;
   } else {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -299,6 +299,11 @@ std::array<uint8_t, 2> decode_uint16(uint16_t value) {
   return {msb, lsb};
 }
 
+uint32_t encode_uint32(uint8_t msb, uint8_t byte2, uint8_t byte3, uint8_t lsb) {
+  return ((uint32_t(msb) << 24) | (uint32_t(byte2) << 16)
+          | (uint32_t(byte3) << 8) | (uint32_t(lsb)));
+}
+
 std::string hexencode(const uint8_t *data, uint32_t len) {
   char buf[20];
   std::string res;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -300,8 +300,7 @@ std::array<uint8_t, 2> decode_uint16(uint16_t value) {
 }
 
 uint32_t encode_uint32(uint8_t msb, uint8_t byte2, uint8_t byte3, uint8_t lsb) {
-  return ((uint32_t(msb) << 24) | (uint32_t(byte2) << 16)
-          | (uint32_t(byte3) << 8) | (uint32_t(lsb)));
+  return (uint32_t(msb) << 24) | (uint32_t(byte2) << 16) | (uint32_t(byte3) << 8) | uint32_t(lsb);
 }
 
 std::string hexencode(const uint8_t *data, uint32_t len) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -132,6 +132,8 @@ uint32_t reverse_bits_32(uint32_t x);
 uint16_t encode_uint16(uint8_t msb, uint8_t lsb);
 /// Decode a 16-bit unsigned integer into an array of two values: most significant byte, least significant byte.
 std::array<uint8_t, 2> decode_uint16(uint16_t value);
+/// Encode a 32-bit unsigned integer given four bytes in MSB -> LSB order
+uint32_t encode_uint32(uint8_t msb, uint8_t byte2, uint8_t byte3, uint8_t lsb);
 
 /***
  * An interrupt helper class.


### PR DESCRIPTION
## Description:
This method takes four bytes, and combines them into a `uint32_t`.

I'm (occasionally) poking at esphome/feature-requests#932, and saw/was using `encode_uint16` https://github.com/esphome/esphome/blob/ac15ce576b1c22e59a7186014de0202e79de959b/esphome/core/helpers.cpp#L295

I _think_ it makes sense to add a corresponding `encode_uint32` method, and update the various places that take 4 bytes and turn them into a `uint32_t` to use the new method. That's what this PR does, in order to get your feedback on the idea.

**Note**: I believe the implementation in `xiaomi_ble` had an error, it was using the `data[2]` byte twice, and never used `data[3]`, despite having 4 bytes in the data buffer. I've fixed this, but don't have one of these devices to test with. In addition to DRY, I feel like this may illustrate a benefit: it makes it a little easier to see which bytes are being combined, and in which order.
https://github.com/esphome/esphome/blob/ac15ce576b1c22e59a7186014de0202e79de959b/esphome/components/xiaomi_ble/xiaomi_ble.cpp#L74

OTOH: I'd understand if you felt this was uncommon enough / not valuable enough to spend the code size on (or is it approximately a wash due to usage in proto.cpp? I don't know). Or maybe it's not worth it because it "hides" a common pattern behind an opaque-ish method call.

**Related issue (if applicable):** (no related issue)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** No docs changes necessary

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
