### PR TITLE
Improve ccs811 precision

### DIFF
--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -108,8 +108,6 @@ void CCS811Component::send_env_data_() {
   // https://github.com/adafruit/Adafruit_CCS811/blob/0990f5c620354d8bc087c4706bec091d8e6e5dfd/Adafruit_CCS811.cpp#L135-L142
   uint16_t hum_conv = static_cast<uint16_t>(lroundf(humidity * 512.0f + 0.5f));
   uint16_t temp_conv = static_cast<uint16_t>(lroundf(temperature * 512.0f + 0.5f));
-  ESP_LOGD(TAG, "  Env Humidity: %u", hum_conv);
-  ESP_LOGD(TAG, "  Env Temperature: %u", temp_conv);
   this->write_bytes(0x05, {(uint8_t)((hum_conv >> 8) & 0xff), (uint8_t)((hum_conv & 0xff)),
                            (uint8_t)((temp_conv >> 8) & 0xff), (uint8_t)((temp_conv & 0xff))});
 }

--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -102,18 +102,16 @@ void CCS811Component::send_env_data_() {
   // temperature has a 25° offset to allow negative temperatures
   temperature += 25;
 
-  // At page 18 of:  https://cdn.sparkfun.com/datasheets/BreakoutBoards/CCS811_Programming_Guide.pdf
-  // Reference code: https://github.com/adafruit/Adafruit_CCS811/blob/0990f5c620354d8bc087c4706bec091d8e6e5dfd/Adafruit_CCS811.cpp#L135-L142
+  // At page 18 of:
+  // https://cdn.sparkfun.com/datasheets/BreakoutBoards/CCS811_Programming_Guide.pdf
+  // Reference code:
+  // https://github.com/adafruit/Adafruit_CCS811/blob/0990f5c620354d8bc087c4706bec091d8e6e5dfd/Adafruit_CCS811.cpp#L135-L142
   uint16_t hum_conv = static_cast<uint16_t>(humidity * 512.0f + 0.5f);
   uint16_t temp_conv = static_cast<uint16_t>(temperature * 512.0f + 0.5f);
   ESP_LOGD(TAG, "  Env Humidity: %u", hum_conv);
   ESP_LOGD(TAG, "  Env Temperature: %u", temp_conv);
-  this->write_bytes(0x05, {
-    (uint8_t)((hum_conv >> 8) & 0xff),
-    (uint8_t)((hum_conv & 0xff)),
-    (uint8_t)((temp_conv >> 8) & 0xff),
-    (uint8_t)((temp_conv & 0xff))
-  });
+  this->write_bytes(0x05, {(uint8_t)((hum_conv >> 8) & 0xff), (uint8_t)((hum_conv & 0xff)),
+                           (uint8_t)((temp_conv >> 8) & 0xff), (uint8_t)((temp_conv & 0xff))});
 }
 void CCS811Component::dump_config() {
   ESP_LOGCONFIG(TAG, "CCS811");

--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -106,8 +106,8 @@ void CCS811Component::send_env_data_() {
   // https://cdn.sparkfun.com/datasheets/BreakoutBoards/CCS811_Programming_Guide.pdf
   // Reference code:
   // https://github.com/adafruit/Adafruit_CCS811/blob/0990f5c620354d8bc087c4706bec091d8e6e5dfd/Adafruit_CCS811.cpp#L135-L142
-  uint16_t hum_conv = static_cast<uint16_t>(humidity * 512.0f + 0.5f);
-  uint16_t temp_conv = static_cast<uint16_t>(temperature * 512.0f + 0.5f);
+  uint16_t hum_conv = static_cast<uint16_t>(lroundf(humidity * 512.0f + 0.5f));
+  uint16_t temp_conv = static_cast<uint16_t>(lroundf(temperature * 512.0f + 0.5f));
   ESP_LOGD(TAG, "  Env Humidity: %u", hum_conv);
   ESP_LOGD(TAG, "  Env Temperature: %u", temp_conv);
   this->write_bytes(0x05, {(uint8_t)((hum_conv >> 8) & 0xff), (uint8_t)((hum_conv & 0xff)),


### PR DESCRIPTION
Update ccs811 environment setting precision

## Description:


**Related issue (if applicable):**

This pull request improves the ccs811 sensor's environment value precision.

The previous implementation just left shift 1 bit of humidity and temperature value as high byte, and leave low byte as 0x00.

According to [ccs811 programmer manual](https://cdn.sparkfun.com/datasheets/BreakoutBoards/CCS811_Programming_Guide.pdf) page 18, this approach loses the precision of the 9bit fraction field.

A better implementation is from [Adafruit_CCS811](https://github.com/adafruit/Adafruit_CCS811/blob/0990f5c620354d8bc087c4706bec091d8e6e5dfd/Adafruit_CCS811.cpp#L135-L142). I ported this implementation and created this pull request.

~**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>~
  - The `esphome-docs` is not affected.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] ~Tests have been added to verify that the new code works (under `tests/` folder).~
    - No new test needed
    - ~I added serial debug output of the humidity and temperature value sent to ccs811, see line 111-112~ Deleted

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~
    - No user exposed functionality is affected
