### PR TITLE
Move sync to header rc_switch_protocol

### DIFF
--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -55,13 +55,13 @@ void RCSwitchBase::sync(RemoteTransmitData *dst) const {
 }
 void RCSwitchBase::transmit(RemoteTransmitData *dst, uint64_t code, uint8_t len) const {
   dst->set_carrier_frequency(0);
+  this->sync(dst);
   for (int16_t i = len - 1; i >= 0; i--) {
     if (code & ((uint64_t) 1 << i))
       this->one(dst);
     else
       this->zero(dst);
   }
-  this->sync(dst);
 }
 
 bool RCSwitchBase::expect_one(RemoteReceiveData &src) const {


### PR DESCRIPTION
Sync pulse `rc_switch_protocol` was located at the end of the frame, but should be located at the beginning of the frame.

## Description:

The sync pulse was located at the end of the frame, but should be located at the beginning of the frame.

**Related issue (if applicable):** fixes <link to issue>

https://github.com/esphome/issues/issues/1718

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

Partially tested, as `tests/` does not contain full integration tests.

Verified Samsung code and custom protocols with a protocol analyzer and sync pulse is now correct at the beginning of each frame, before the data starts:

```yaml
switch:
  - platform: template
    name: Samsung
    turn_on_action:
      remote_transmitter.transmit_samsung:
        data: 0xABCDEF
        repeat: 4
```

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

https://github.com/esphome/esphome-docs/pull/899