### PR TITLE
Support wildcard uid in PN532BinarySensor

### DIFF
--- a/esphome/components/pn532/binary_sensor.py
+++ b/esphome/components/pn532/binary_sensor.py
@@ -10,6 +10,8 @@ DEPENDENCIES = ['pn532']
 
 def validate_uid(value):
     value = cv.string_strict(value)
+    if value == '*':
+        return value
     for x in value.split('-'):
         if len(x) != 2:
             raise cv.Invalid("Each part (separated by '-') of the UID must be two characters "
@@ -38,5 +40,8 @@ def to_code(config):
 
     hub = yield cg.get_variable(config[CONF_PN532_ID])
     cg.add(hub.register_tag(var))
-    addr = [HexInt(int(x, 16)) for x in config[CONF_UID].split('-')]
-    cg.add(var.set_uid(addr))
+    if config[CONF_UID] == "*":
+        cg.add(var.set_uid([]))
+    else:
+        addr = [HexInt(int(x, 16)) for x in config[CONF_UID].split('-')]
+        cg.add(var.set_uid(addr))

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -338,6 +338,12 @@ void PN532::dump_config() {
 }
 
 bool PN532BinarySensor::process(std::vector<uint8_t> &data) {
+  if(this->uid_.size() == 0) {
+    this->publish_state(true);
+    this->found_ = true;
+    return true;
+  }
+
   if (data.size() != this->uid_.size())
     return false;
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -935,6 +935,9 @@ binary_sensor:
   - platform: pn532
     uid: 74-10-37-94
     name: 'PN532 NFC Tag'
+  - platform: pn532
+    uid: '*'
+    name: 'PN532 wildcard NFC Tag'
   - platform: rdm6300
     uid: 7616525
     name: 'RDM6300 NFC Tag'


### PR DESCRIPTION
## Description:

Add wildcard uid support for PN532BinarySensor to be able to detect whether any token is present