### PR TITLE
Expose port 6052 to make reverse proxy work

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,9 @@ RUN pip3 install --no-cache-dir -e .
 # Settings for dashboard
 ENV USERNAME="" PASSWORD=""
 
+# Expose the dashboard to Docker
+EXPOSE 6052
+
 # The directory the user should mount their configuration files to
 WORKDIR /config
 # Set entrypoint to esphome so that the user doesn't have to type 'esphome'


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
