### PR TITLE
make time components polling components

### DIFF
--- a/esphome/components/ds1307/ds1307.cpp
+++ b/esphome/components/ds1307/ds1307.cpp
@@ -14,8 +14,9 @@ void DS1307Component::setup() {
   if (!this->read_rtc_()) {
     this->mark_failed();
   }
-  this->set_interval(15 * 60 * 1000, [&]() { this->read(); });
 }
+
+void DS1307Component::update() { this->read(); }
 
 void DS1307Component::dump_config() {
   ESP_LOGCONFIG(TAG, "DS1307:");

--- a/esphome/components/ds1307/ds1307.h
+++ b/esphome/components/ds1307/ds1307.h
@@ -10,6 +10,7 @@ namespace ds1307 {
 class DS1307Component : public time::RealTimeClock, public i2c::I2CDevice {
  public:
   void setup() override;
+  void update() override;
   void dump_config() override;
   float get_setup_priority() const override;
   void read();

--- a/esphome/components/gps/time/__init__.py
+++ b/esphome/components/gps/time/__init__.py
@@ -6,12 +6,12 @@ from .. import gps_ns, GPSListener, CONF_GPS_ID, GPS
 
 DEPENDENCIES = ['gps']
 
-GPSTime = gps_ns.class_('GPSTime', time_.RealTimeClock, GPSListener)
+GPSTime = gps_ns.class_('GPSTime', cg.PollingComponent, time_.RealTimeClock, GPSListener)
 
 CONFIG_SCHEMA = time_.TIME_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(GPSTime),
     cv.GenerateID(CONF_GPS_ID): cv.use_id(GPS),
-}).extend(cv.COMPONENT_SCHEMA)
+}).extend(cv.polling_component_schema('5min'))
 
 
 def to_code(config):

--- a/esphome/components/gps/time/gps_time.h
+++ b/esphome/components/gps/time/gps_time.h
@@ -9,12 +9,10 @@ namespace gps {
 
 class GPSTime : public time::RealTimeClock, public GPSListener {
  public:
+  void update() override { this->from_tiny_gps_(this->get_tiny_gps()); };
   void on_update(TinyGPSPlus &tiny_gps) override {
     if (!this->has_time_)
       this->from_tiny_gps_(tiny_gps);
-  }
-  void setup() override {
-    this->set_interval(5 * 60 * 1000, [this]() { this->from_tiny_gps_(this->get_tiny_gps()); });
   }
 
  protected:

--- a/esphome/components/homeassistant/time/homeassistant_time.cpp
+++ b/esphome/components/homeassistant/time/homeassistant_time.cpp
@@ -10,17 +10,13 @@ void HomeassistantTime::dump_config() {
   ESP_LOGCONFIG(TAG, "Home Assistant Time:");
   ESP_LOGCONFIG(TAG, "  Timezone: '%s'", this->timezone_.c_str());
 }
-float HomeassistantTime::get_setup_priority() const { return setup_priority::DATA; }
-void HomeassistantTime::setup() {
-  global_homeassistant_time = this;
 
-  this->set_interval(15 * 60 * 1000, []() {
-    // re-request time every 15 minutes
-    api::global_api_server->request_time();
-  });
-}
+float HomeassistantTime::get_setup_priority() const { return setup_priority::DATA; }
+
+void HomeassistantTime::setup() { global_homeassistant_time = this; }
+
+void HomeassistantTime::update() { api::global_api_server->request_time(); }
 
 HomeassistantTime *global_homeassistant_time = nullptr;
-
 }  // namespace homeassistant
 }  // namespace esphome

--- a/esphome/components/homeassistant/time/homeassistant_time.h
+++ b/esphome/components/homeassistant/time/homeassistant_time.h
@@ -10,6 +10,7 @@ namespace homeassistant {
 class HomeassistantTime : public time::RealTimeClock {
  public:
   void setup() override;
+  void update() override;
   void dump_config() override;
   void set_epoch_time(uint32_t epoch) { this->synchronize_epoch_(epoch); }
   float get_setup_priority() const override;

--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -42,6 +42,7 @@ void SNTPComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Server 3: '%s'", this->server_3_.c_str());
   ESP_LOGCONFIG(TAG, "  Timezone: '%s'", this->timezone_.c_str());
 }
+void SNTPComponent::update() {}
 void SNTPComponent::loop() {
   if (this->has_time_)
     return;

--- a/esphome/components/sntp/sntp_component.h
+++ b/esphome/components/sntp/sntp_component.h
@@ -24,6 +24,7 @@ class SNTPComponent : public time::RealTimeClock {
   }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
+  void update() override;
   void loop() override;
 
  protected:

--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -22,7 +22,7 @@ CODEOWNERS = ['@OttoWinter']
 IS_PLATFORM_COMPONENT = True
 
 time_ns = cg.esphome_ns.namespace('time')
-RealTimeClock = time_ns.class_('RealTimeClock', cg.Component)
+RealTimeClock = time_ns.class_('RealTimeClock', cg.PollingComponent)
 CronTrigger = time_ns.class_('CronTrigger', automation.Trigger.template(), cg.Component)
 ESPTime = time_ns.struct('ESPTime')
 TimeHasTimeCondition = time_ns.class_('TimeHasTimeCondition', Condition)
@@ -294,7 +294,7 @@ TIME_SCHEMA = cv.Schema({
         cv.Optional(CONF_CRON): validate_cron_raw,
         cv.Optional(CONF_AT): validate_time_at,
     }, validate_cron_keys),
-})
+}).extend(cv.polling_component_schema('15min'))
 
 
 @coroutine

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -15,7 +15,7 @@ RealTimeClock::RealTimeClock() = default;
 void RealTimeClock::call_setup() {
   setenv("TZ", this->timezone_.c_str(), 1);
   tzset();
-  this->setup();
+  PollingComponent::call_setup();
 }
 void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   struct timeval timev {

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -106,7 +106,7 @@ struct ESPTime {
 /// The C library (newlib) available on ESPs only supports TZ strings that specify an offset and DST info;
 /// you cannot specify zone names or paths to zoneinfo files.
 /// \see https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
-class RealTimeClock : public Component {
+class RealTimeClock : public PollingComponent {
  public:
   explicit RealTimeClock();
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1837,6 +1837,7 @@ time:
       then:
         - lambda: 'ESP_LOGD("main", "time");'
   - platform: gps
+    update_interval: 1h
     on_time:
       seconds: 0
       minutes: /15
@@ -1845,12 +1846,11 @@ time:
           id: ds1307_time
   - platform: ds1307
     id: ds1307_time
+    update_interval: never
     on_time:
       seconds: 0
       then:
           ds1307.read
-
-
 
 cover:
   - platform: template


### PR DESCRIPTION
## Description:

I'd suggest that real time components should be implemented as polling components so that the `update_interval` can be configured in the same way as for other components (where applicable, the sntp will run in the `loop()` instead of `update()` e.g.).

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs): esphome/esphome-docs#924
