### PR TITLE
make fade_to*, lighten, and darken const

### DIFF
--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -149,10 +149,10 @@ struct ESPColor {
     return ESPColor(uint8_t((uint16_t(r) * 255U / max_rgb)), uint8_t((uint16_t(g) * 255U / max_rgb)),
                     uint8_t((uint16_t(b) * 255U / max_rgb)), w);
   }
-  ESPColor fade_to_white(uint8_t amnt) { return ESPColor(255, 255, 255, 255) - (*this * amnt); }
-  ESPColor fade_to_black(uint8_t amnt) { return *this * amnt; }
-  ESPColor lighten(uint8_t delta) { return *this + delta; }
-  ESPColor darken(uint8_t delta) { return *this - delta; }
+  ESPColor fade_to_white(uint8_t amnt) const { return ESPColor(255, 255, 255, 255) - (*this * amnt); }
+  ESPColor fade_to_black(uint8_t amnt) const { return *this * amnt; }
+  ESPColor lighten(uint8_t delta) const { return *this + delta; }
+  ESPColor darken(uint8_t delta) const { return *this - delta; }
 
   static const ESPColor BLACK;
   static const ESPColor WHITE;


### PR DESCRIPTION
## Description:

otherwise you cannot call them on `const ESPColor`s

```
static const auto COLOR = ESPColor(255, 0, 0);
it.all() = COLOR.fade_to_black(10);
```

```
src/main.cpp: In lambda function:
src/main.cpp:223:63: error: passing 'const esphome::light::ESPColor' as 'this' argument discards qualifiers [-fpermissive]
       it.all() = COLOR.fade_to_black(progress * COLOR_PER_TICK);
                                                               ^
In file included from src/esphome/components/fastled_base/fastled_light.h:5:0,
                 from src/esphome.h:13,
                 from src/main.cpp:3:
src/esphome/components/light/addressable_light.h:153:12: note:   in call to 'esphome::light::ESPColor esphome::light::ESPColor::fade_to_black(uint8_t)'
   ESPColor fade_to_black(uint8_t amnt) { return *this * amnt; }
            ^
*** [.pioenvs/bildschirm/src/main.cpp.o] Error 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
