### PR TITLE
Fix SN74HC595 with optional OE pin

### DIFF
--- a/esphome/components/sn74hc595/__init__.py
+++ b/esphome/components/sn74hc595/__init__.py
@@ -34,8 +34,9 @@ def to_code(config):
     cg.add(var.set_clock_pin(clock_pin))
     latch_pin = yield cg.gpio_pin_expression(config[CONF_LATCH_PIN])
     cg.add(var.set_latch_pin(latch_pin))
-    oe_pin = yield cg.gpio_pin_expression(config[CONF_OE_PIN])
-    cg.add(var.set_oe_pin(oe_pin))
+    if CONF_OE_PIN in config:
+        oe_pin = yield cg.gpio_pin_expression(config[CONF_OE_PIN])
+        cg.add(var.set_oe_pin(oe_pin))
     cg.add(var.set_sr_count(config[CONF_SR_COUNT]))
 
 


### PR DESCRIPTION
:cherries: picked from esphome/esphome@32a4680 branch (fix-sn74hc595-optional-oe-pin) by @OttoWinter

## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1453

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
