### PR TITLE
Rotary Encoder: Don't call callbacks in the isr

### DIFF
--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -153,9 +153,9 @@ void RotaryEncoderSensor::loop() {
 
   for (int i = 0; i < direction_count; ++i) {
     if (direction_vector[i] /* == true */) {
-      this->store_.on_clockwise_callback_.call();
+      this->on_clockwise_callback_.call();
     } else {
-      this->store_.on_anticlockwise_callback_.call();
+      this->on_anticlockwise_callback_.call();
     }
   }
 

--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -90,23 +90,36 @@ void ICACHE_RAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensor
   if (arg->pin_b->digital_read())
     input_state |= STATE_PIN_B_HIGH;
 
+  int8_t rotation_dir = 0;
   uint16_t new_state = STATE_LOOKUP_TABLE[input_state];
   if ((new_state & arg->resolution & STATE_HAS_INCREMENTED) != 0) {
     if (arg->counter < arg->max_value)
       arg->counter++;
-    if (arg->direction_count < arg->direction_vector.size()) {
-      arg->direction_vector[arg->direction_count] = true;  // true means clockwise
-      arg->direction_count++;
-    }
+    rotation_dir = 1;
   }
   if ((new_state & arg->resolution & STATE_HAS_DECREMENTED) != 0) {
     if (arg->counter > arg->min_value)
       arg->counter--;
-    if (arg->direction_count < arg->direction_vector.size()) {
-      arg->direction_vector[arg->direction_count] = false;  // false means anticlockwise
-      arg->direction_count++;
+    rotation_dir = -1;
+  }
+
+  if (rotation_dir != 0) {
+    auto first_zero = std::find(arg->rotation_events.begin(), arg->rotation_events.end(), 0);  // find first zero
+    if (first_zero == arg->rotation_events.begin()  // are we at the start (first event this loop iteration)
+        || std::signbit(*std::prev(first_zero)) !=
+               std::signbit(rotation_dir)  // or is the last stored event the wrong direction
+        || *std::prev(first_zero) == std::numeric_limits<int8_t>::lowest()  // or the last event slot is full (negative)
+        || *std::prev(first_zero) == std::numeric_limits<int8_t>::max()) {  // or the last event slot is full (positive)
+      if (first_zero != arg->rotation_events.end()) {                       // we have a free rotation slot
+        *first_zero += rotation_dir;                                        // store the rotation into a new slot
+      } else {
+        arg->rotation_events_overflow = true;
+      }
+    } else {
+      *std::prev(first_zero) += rotation_dir;  // store the rotation into the previous slot
     }
   }
+
   arg->state = new_state;
 }
 
@@ -142,25 +155,33 @@ void RotaryEncoderSensor::dump_config() {
   }
 }
 void RotaryEncoderSensor::loop() {
-  uint8_t direction_count;
-  std::bitset<128> direction_vector;
+  std::array<int8_t, 8> rotation_events;
+  bool rotation_events_overflow;
   ets_intr_lock();
-  direction_vector = this->store_.direction_vector;
-  direction_count = this->store_.direction_count;
+  rotation_events = this->store_.rotation_events;
+  rotation_events_overflow = this->store_.rotation_events_overflow;
 
-  this->store_.direction_count = 0;
+  this->store_.rotation_events.fill(0);
+  this->store_.rotation_events_overflow = false;
   ets_intr_unlock();
 
-  for (int i = 0; i < direction_count; ++i) {
-    if (direction_vector[i] /* == true */) {
-      this->on_clockwise_callback_.call();
-    } else {
-      this->on_anticlockwise_callback_.call();
-    }
+  if (rotation_events_overflow) {
+    ESP_LOGW(TAG, "Captured more rotation events than expected");
   }
 
-  if (direction_count == direction_vector.size()) {
-    ESP_LOGW(TAG, "Captured maybe more rotation events than expected");
+  for (auto events : rotation_events) {
+    if (events == 0)  // we are at the end of the recorded events
+      break;
+
+    if (events > 0) {
+      while (events--) {
+        this->on_clockwise_callback_.call();
+      }
+    } else {
+      while (events++) {
+        this->on_anticlockwise_callback_.call();
+      }
+    }
   }
 
   if (this->pin_i_ != nullptr && this->pin_i_->digital_read()) {

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -31,8 +31,6 @@ struct RotaryEncoderSensorStore {
 
   std::bitset<128> direction_vector;
   volatile uint8_t direction_count;
-  CallbackManager<void()> on_clockwise_callback_;
-  CallbackManager<void()> on_anticlockwise_callback_;
 
   static void gpio_intr(RotaryEncoderSensorStore *arg);
 };
@@ -70,11 +68,11 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
   float get_setup_priority() const override;
 
   void add_on_clockwise_callback(std::function<void()> callback) {
-    this->store_.on_clockwise_callback_.add(std::move(callback));
+    this->on_clockwise_callback_.add(std::move(callback));
   }
 
   void add_on_anticlockwise_callback(std::function<void()> callback) {
-    this->store_.on_anticlockwise_callback_.add(std::move(callback));
+    this->on_anticlockwise_callback_.add(std::move(callback));
   }
 
  protected:
@@ -83,6 +81,9 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
   GPIOPin *pin_i_{nullptr};  /// Index pin, if this is not nullptr, the counter will reset to 0 once this pin is HIGH.
 
   RotaryEncoderSensorStore store_{};
+
+  CallbackManager<void()> on_clockwise_callback_;
+  CallbackManager<void()> on_anticlockwise_callback_;
 };
 
 template<typename... Ts> class RotaryEncoderSetValueAction : public Action<Ts...> {

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bitset>
+
 #include "esphome/core/component.h"
 #include "esphome/core/esphal.h"
 #include "esphome/core/automation.h"
@@ -27,6 +29,8 @@ struct RotaryEncoderSensorStore {
   int32_t last_read{0};
   uint8_t state{0};
 
+  std::bitset<128> direction_vector;
+  volatile uint8_t direction_count;
   CallbackManager<void()> on_clockwise_callback_;
   CallbackManager<void()> on_anticlockwise_callback_;
 

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <bitset>
+#include <array>
 
 #include "esphome/core/component.h"
 #include "esphome/core/esphal.h"
@@ -29,8 +29,8 @@ struct RotaryEncoderSensorStore {
   int32_t last_read{0};
   uint8_t state{0};
 
-  std::bitset<128> direction_vector;
-  volatile uint8_t direction_count;
+  std::array<int8_t, 8> rotation_events{};
+  bool rotation_events_overflow{false};
 
   static void gpio_intr(RotaryEncoderSensorStore *arg);
 };


### PR DESCRIPTION
Calling the on_clockwise and on_anticlockwise callbacks in an isr is not a good idea because they could do a lot of things which are not interrupt save (for example call delay())
Just accumulate the actions in a bitset and execute the callbacks in the correct order in loop

## Description:
I had a lot of crashes with a simple monochromatic light, a rotary encoder which sets the relative brightness of the light and a connected Home Assistant instance. Fast rotations overflow the tcp send buffer which causes rescheduling attempts which can't work in interrupts.
This is one possible way I came up and I had no problems after this.
Its not optimal because if you cause more than the 128 events between two loop calls (quite easy with debug logging on and a few connected clients) some events gets dropped but I think in reality its quite unrealistic to have more than 128 events in 15ms

**Related issue (if applicable):** nothing found

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** I don't think mentioning in the docs is necessary?

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). < I don't see how this could currently be tested
