### PR TITLE
Revert esptool to 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pytz==2020.5
 pyserial==3.5
 ifaddr==0.1.7
 platformio==5.0.4
-esptool==3.0
+esptool==2.8
 click==7.1.2


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/1702

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
