### PR TITLE
Limit the value range of TimePeriod definitions

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -1,5 +1,7 @@
 import re
 
+from voluptuous import Range
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
@@ -12,7 +14,7 @@ from esphome.const import CONF_AVAILABILITY, CONF_BIRTH_MESSAGE, CONF_BROKER, CO
     CONF_QOS, CONF_REBOOT_TIMEOUT, CONF_RETAIN, CONF_SHUTDOWN_MESSAGE, CONF_SSL_FINGERPRINTS, \
     CONF_STATE_TOPIC, CONF_TOPIC, CONF_TOPIC_PREFIX, CONF_TRIGGER_ID, CONF_USERNAME, \
     CONF_WILL_MESSAGE
-from esphome.core import coroutine_with_priority, coroutine, CORE
+from esphome.core import coroutine_with_priority, coroutine, CORE, TimePeriod
 
 DEPENDENCIES = ['network']
 AUTO_LOAD = ['json', 'async_tcp']
@@ -120,7 +122,9 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
 
     cv.Optional(CONF_SSL_FINGERPRINTS): cv.All(cv.only_on_esp8266,
                                                cv.ensure_list(validate_fingerprint)),
-    cv.Optional(CONF_KEEPALIVE, default='15s'): cv.positive_time_period_seconds,
+    cv.Optional(CONF_KEEPALIVE, default='15s'): cv.All(
+        cv.positive_time_period_seconds,
+        Range(max=TimePeriod(seconds=65535))),
     cv.Optional(CONF_REBOOT_TIMEOUT, default='15min'): cv.positive_time_period_milliseconds,
     cv.Optional(CONF_ON_MESSAGE): automation.validate_automation({
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MQTTMessageTrigger),

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -4,7 +4,7 @@ from esphome import pins
 from esphome.components import remote_base
 from esphome.const import CONF_BUFFER_SIZE, CONF_DUMP, CONF_FILTER, CONF_ID, CONF_IDLE, \
     CONF_PIN, CONF_TOLERANCE, CONF_MEMORY_BLOCKS
-from esphome.core import CORE
+from esphome.core import CORE, TimePeriod
 
 AUTO_LOAD = ['remote_base']
 remote_receiver_ns = cg.esphome_ns.namespace('remote_receiver')
@@ -20,7 +20,9 @@ CONFIG_SCHEMA = remote_base.validate_triggers(cv.Schema({
     cv.Optional(CONF_DUMP, default=[]): remote_base.validate_dumpers,
     cv.Optional(CONF_TOLERANCE, default=25): cv.All(cv.percentage_int, cv.Range(min=0)),
     cv.SplitDefault(CONF_BUFFER_SIZE, esp32='10000b', esp8266='1000b'): cv.validate_bytes,
-    cv.Optional(CONF_FILTER, default='50us'): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_FILTER, default='50us'): cv.All(
+        cv.positive_time_period_microseconds,
+        cv.Range(max=TimePeriod(microseconds=255))),
     cv.Optional(CONF_IDLE, default='10ms'): cv.positive_time_period_microseconds,
     cv.Optional(CONF_MEMORY_BLOCKS, default=3): cv.Range(min=1, max=8),
 }).extend(cv.COMPONENT_SCHEMA))

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -512,7 +512,8 @@ def update_interval(value):
 
 
 time_period = Any(time_period_str_unit, time_period_str_colon, time_period_dict)
-positive_time_period = All(time_period, Range(min=TimePeriod()))
+positive_time_period = All(time_period, Range(min=TimePeriod(), max=TimePeriod(4294967295),
+                                              max_included=False)) # 4294967295 means 'never'
 positive_time_period_milliseconds = All(positive_time_period, time_period_in_milliseconds_)
 positive_time_period_seconds = All(positive_time_period, time_period_in_seconds_)
 positive_time_period_minutes = All(positive_time_period, time_period_in_minutes_)

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -512,15 +512,34 @@ def update_interval(value):
 
 
 time_period = Any(time_period_str_unit, time_period_str_colon, time_period_dict)
-positive_time_period = All(time_period, Range(min=TimePeriod(), max=TimePeriod(4294967295),
-                                              max_included=False))  # 4294967295 means 'never'
-positive_time_period_milliseconds = All(positive_time_period, time_period_in_milliseconds_)
-positive_time_period_seconds = All(positive_time_period, time_period_in_seconds_)
-positive_time_period_minutes = All(positive_time_period, time_period_in_minutes_)
-time_period_microseconds = All(time_period, time_period_in_microseconds_)
-positive_time_period_microseconds = All(positive_time_period, time_period_in_microseconds_)
-positive_not_null_time_period = All(time_period,
-                                    Range(min=TimePeriod(), min_included=False))
+positive_time_period = All(
+    time_period,
+    Range(min=TimePeriod()))
+positive_time_period_milliseconds = All(
+    positive_time_period,
+    Range(max=TimePeriod(milliseconds=4294967295),
+          max_included=False),  # 4294967295ms means 'never'
+    time_period_in_milliseconds_)
+positive_time_period_seconds = All(
+    positive_time_period,
+    Range(max=TimePeriod(seconds=4294967295)),
+    time_period_in_seconds_)
+positive_time_period_minutes = All(
+    positive_time_period,
+    Range(max=TimePeriod(minutes=4294967295)),
+    time_period_in_minutes_)
+time_period_microseconds = All(
+    time_period,
+    Range(min=TimePeriod(microseconds=-2147483648),
+          max=TimePeriod(microseconds=2147483647)),
+    time_period_in_microseconds_)
+positive_time_period_microseconds = All(
+    positive_time_period,
+    Range(max=TimePeriod(microseconds=4294967295)),
+    time_period_in_microseconds_)
+positive_not_null_time_period = All(
+    time_period,
+    Range(min=TimePeriod(), min_included=False))
 
 
 def time_of_day(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -513,7 +513,7 @@ def update_interval(value):
 
 time_period = Any(time_period_str_unit, time_period_str_colon, time_period_dict)
 positive_time_period = All(time_period, Range(min=TimePeriod(), max=TimePeriod(4294967295),
-                                              max_included=False)) # 4294967295 means 'never'
+                                              max_included=False))  # 4294967295 means 'never'
 positive_time_period_milliseconds = All(positive_time_period, time_period_in_milliseconds_)
 positive_time_period_seconds = All(positive_time_period, time_period_in_seconds_)
 positive_time_period_minutes = All(positive_time_period, time_period_in_minutes_)


### PR DESCRIPTION
The internal representation of a TimePeriod is an unsigned 32 bit integer counting milliseconds.

The maximum value 4294967295 is used to encode the special value 'never', thus the maximum usable value for a TimePeriod is 4294967294 milliseconds or a little more than one month, 19 days and six and a half hours.

Without this change, code is generated that leads to an integer overflow for too large TimePeriods. The compiler would warn, but this verification makes sure that the values are within bounds before the code is generated and compiled.

    src/main.cpp: In function 'void setup()':
    src/main.cpp:1005:53: warning: large integer implicitly truncated to unsigned type [-Woverflow]
       ota_otacomponent->start_safe_mode(5, 4294967295ULL);

## Checklist:
  - [X] The code change is tested and works locally.
  - ~~Tests have been added to verify that the new code works (under `tests/` folder).~~
  - The effectiveness has been proven by setting the `boot_timeout` for the `ota` component in `tests/test1.yaml` to `4294967295ms` which makes the test fail as expected. Any other TimerPeriod parameter would be checked exatly the same way.
