### PR TITLE
1.16.0b3

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -676,8 +676,10 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) 
     }
   }
 
-  this->client_->add(reinterpret_cast<char *>(header.data()), header.size());
-  this->client_->add(reinterpret_cast<char *>(buffer.get_buffer()->data()), buffer.get_buffer()->size());
+  this->client_->add(reinterpret_cast<char *>(header.data()), header.size(),
+                     ASYNC_WRITE_FLAG_COPY | ASYNC_WRITE_FLAG_MORE);
+  this->client_->add(reinterpret_cast<char *>(buffer.get_buffer()->data()), buffer.get_buffer()->size(),
+                     ASYNC_WRITE_FLAG_COPY);
   bool ret = this->client_->send();
   return ret;
 }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 16
-PATCH_VERSION = '0b2'
+PATCH_VERSION = '0b3'
 __short_version__ = f'{MAJOR_VERSION}.{MINOR_VERSION}'
 __version__ = f'{__short_version__}.{PATCH_VERSION}'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pytz==2020.5
 pyserial==3.5
 ifaddr==0.1.7
 platformio==5.0.4
-esptool==3.0
+esptool==2.8
 click==7.1.2


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"There are two major products that come out of Berkeley: LSD and UNIX.  We don’t believe this to be a coincidence."_

~ Jeremy S. Anderson
- esphome: API: copy the data to send into the tcp internal buffer [esphome#1455](https://github.com/esphome/esphome/pull/1455)
- esphome: Revert esptool to 2.8 [esphome#1460](https://github.com/esphome/esphome/pull/1460)
- docs: fixed duplicate id in example for dac output [docs#909](https://github.com/esphome/esphome-docs/pull/909)
- docs: Add example for human readable uptime sensor [docs#923](https://github.com/esphome/esphome-docs/pull/923)
- docs: Update diy.rst [docs#922](https://github.com/esphome/esphome-docs/pull/922)
- docs: Spelling and grammar fixes [docs#928](https://github.com/esphome/esphome-docs/pull/928)
- docs: Fix duplicated "on_ble" in on_ble_service_data_advertise heading [docs#927](https://github.com/esphome/esphome-docs/pull/927)
- docs: Add hint for swapped data and clock pin [docs#914](https://github.com/esphome/esphome-docs/pull/914)
- docs: Update nextion.rst [docs#912](https://github.com/esphome/esphome-docs/pull/912)
- docs: Update mirabella-genio-bulb.rst to show potential use of GPIO14 instead of GPIO13 for specific monochromatic dimmable globes  [docs#911](https://github.com/esphome/esphome-docs/pull/911)
