### PR TITLE
fix esp8266 remote_transmitter using incorrect timings

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -175,12 +175,9 @@ void delay_microseconds_accurate(uint32_t usec) {
   if (usec == 0)
     return;
 
-  if (usec <= 16383UL) {
-    delayMicroseconds(usec);
-  } else {
-    delay(usec / 1000UL);
-    delayMicroseconds(usec % 1000UL);
-  }
+  for (; usec > 16383UL; usec -= 16383UL)
+    delayMicroseconds(16383UL);
+  delayMicroseconds(usec);
 }
 
 uint8_t reverse_bits_8(uint8_t x) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -175,13 +175,14 @@ uint8_t crc8(uint8_t *data, uint8_t len) {
 void delay_microseconds_accurate(uint32_t usec) {
   if (usec == 0)
     return;
-
-  uint32_t start = micros();
-  for (uint32_t us_left = usec; us_left > 2000UL; us_left -= 1000UL) {
-    delay(0);
+  if (usec < 5000UL) {
     delayMicroseconds(usec);
+    return;
   }
-  delayMicroseconds(start + usec - micros());
+  uint32_t start = micros();
+  while ( micros() < (start + usec)) {
+    delay(0);
+  }
 }
 
 uint8_t reverse_bits_8(uint8_t x) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -180,7 +180,7 @@ void delay_microseconds_accurate(uint32_t usec) {
     return;
   }
   uint32_t start = micros();
-  while ( micros() < (start + usec)) {
+  while (micros() - start < usec) {
     delay(0);
   }
 }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -177,7 +177,7 @@ void delay_microseconds_accurate(uint32_t usec) {
     return;
 
   uint32_t start = micros();
-  for (uint32_t us_left=usec; us_left > 2000UL; us_left -= 1000UL) {
+  for (uint32_t us_left = usec; us_left > 2000UL; us_left -= 1000UL) {
     delay(0);
     delayMicroseconds(usec);
   }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -171,13 +171,17 @@ uint8_t crc8(uint8_t *data, uint8_t len) {
   }
   return crc;
 }
+
 void delay_microseconds_accurate(uint32_t usec) {
   if (usec == 0)
     return;
 
-  for (; usec > 16383UL; usec -= 16383UL)
-    delayMicroseconds(16383UL);
-  delayMicroseconds(usec);
+  uint32_t start = micros();
+  for (uint32_t us_left=usec; us_left > 2000UL; us_left -= 1000UL) {
+    delay(0);
+    delayMicroseconds(usec);
+  }
+  delayMicroseconds(start + usec - micros());
 }
 
 uint8_t reverse_bits_8(uint8_t x) {


### PR DESCRIPTION
## Description:

Inside the helpers.delayMicroseconds() the `delay()` is actually never working when used in the remote_transmitter since the interrupts are stopped. Replacing with a loop of delayMicroseconds then make it work since this does not need an interrupt.

Point of discussion: by doing so, there is a possibility of WDT and not sure if we need to deal with it.
At the moment, long pauses with helpers.delayMicroseconds are only impacting in the daikin component.

**Related issue (if applicable):** fixes [#1595](https://github.com/esphome/issues/issues/1595)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
