### PR TITLE
rename read/write to read/time/write_time

### DIFF
--- a/esphome/components/ds1307/ds1307.cpp
+++ b/esphome/components/ds1307/ds1307.cpp
@@ -14,7 +14,7 @@ void DS1307Component::setup() {
   if (!this->read_rtc_()) {
     this->mark_failed();
   }
-  this->set_interval(15 * 60 * 1000, [&]() { this->read(); });
+  this->set_interval(15 * 60 * 1000, [&]() { this->read_time(); });
 }
 
 void DS1307Component::dump_config() {
@@ -28,7 +28,7 @@ void DS1307Component::dump_config() {
 
 float DS1307Component::get_setup_priority() const { return setup_priority::DATA; }
 
-void DS1307Component::read() {
+void DS1307Component::read_time() {
   if (!this->read_rtc_()) {
     return;
   }
@@ -52,7 +52,7 @@ void DS1307Component::read() {
   time::RealTimeClock::synchronize_epoch_(rtc_time.timestamp);
 }
 
-void DS1307Component::write() {
+void DS1307Component::write_time() {
   auto now = time::RealTimeClock::utcnow();
   if (!now.is_valid()) {
     ESP_LOGE(TAG, "Invalid system time, not syncing to RTC.");

--- a/esphome/components/ds1307/ds1307.h
+++ b/esphome/components/ds1307/ds1307.h
@@ -12,8 +12,8 @@ class DS1307Component : public time::RealTimeClock, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  void read();
-  void write();
+  void read_time();
+  void write_time();
 
  protected:
   bool read_rtc_();
@@ -58,12 +58,12 @@ class DS1307Component : public time::RealTimeClock, public i2c::I2CDevice {
 
 template<typename... Ts> class WriteAction : public Action<Ts...>, public Parented<DS1307Component> {
  public:
-  void play(Ts... x) override { this->parent_->write(); }
+  void play(Ts... x) override { this->parent_->write_time(); }
 };
 
 template<typename... Ts> class ReadAction : public Action<Ts...>, public Parented<DS1307Component> {
  public:
-  void play(Ts... x) override { this->parent_->read(); }
+  void play(Ts... x) override { this->parent_->read_time(); }
 };
 }  // namespace ds1307
 }  // namespace esphome

--- a/esphome/components/ds1307/time.py
+++ b/esphome/components/ds1307/time.py
@@ -18,19 +18,19 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend({
 }).extend(i2c.i2c_device_schema(0x68))
 
 
-@automation.register_action('ds1307.write', WriteAction, cv.Schema({
+@automation.register_action('ds1307.write_time', WriteAction, cv.Schema({
     cv.GenerateID(): cv.use_id(DS1307Component),
 }))
-def ds1307_write_to_code(config, action_id, template_arg, args):
+def ds1307_write_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     yield cg.register_parented(var, config[CONF_ID])
     yield var
 
 
-@automation.register_action('ds1307.read', ReadAction, automation.maybe_simple_id({
+@automation.register_action('ds1307.read_time', ReadAction, automation.maybe_simple_id({
     cv.GenerateID(): cv.use_id(DS1307Component),
 }))
-def ds1307_read_to_code(config, action_id, template_arg, args):
+def ds1307_read_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     yield cg.register_parented(var, config[CONF_ID])
     yield var

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1847,16 +1847,14 @@ time:
       seconds: 0
       minutes: /15
       then:
-        ds1307.write:
+        ds1307.write_time:
           id: ds1307_time
   - platform: ds1307
     id: ds1307_time
     on_time:
       seconds: 0
       then:
-          ds1307.read
-
-
+        ds1307.read_time
 
 cover:
   - platform: template


### PR DESCRIPTION
## Description:

The read/write methods have been renamed according to the proposal in esphome/esphome-docs#924.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#924

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been ~~added~~ *updated*  to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
