### PR TITLE
Add options to control pulse duration on Climate_IR_LG Component

### DIFF
--- a/esphome/components/climate_ir_lg/climate.py
+++ b/esphome/components/climate_ir_lg/climate.py
@@ -8,11 +8,28 @@ AUTO_LOAD = ['climate_ir']
 climate_ir_lg_ns = cg.esphome_ns.namespace('climate_ir_lg')
 LgIrClimate = climate_ir_lg_ns.class_('LgIrClimate', climate_ir.ClimateIR)
 
+CONF_CLIMATE_IR_LG_HEADER_HIGH = 'header_high'
+CONF_CLIMATE_IR_LG_HEADER_LOW = 'header_low'
+CONF_CLIMATE_IR_LG_BIT_HIGH = 'bit_high'
+CONF_CLIMATE_IR_LG_BIT_ONE_LOW = 'bit_one_low'
+CONF_CLIMATE_IR_LG_BIT_ZERO_LOW = 'bit_zero_low'
+
 CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(LgIrClimate),
+    cv.Optional(CONF_CLIMATE_IR_LG_HEADER_HIGH, default = 8000): cv.int_,
+    cv.Optional(CONF_CLIMATE_IR_LG_HEADER_LOW, default = 4000): cv.int_,
+    cv.Optional(CONF_CLIMATE_IR_LG_BIT_HIGH, default = 600): cv.int_,
+    cv.Optional(CONF_CLIMATE_IR_LG_BIT_ONE_LOW, default = 1600): cv.int_,
+    cv.Optional(CONF_CLIMATE_IR_LG_BIT_ZERO_LOW, default = 550): cv.int_,
 })
 
 
 def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield climate_ir.register_climate_ir(var, config)
+
+    cg.add(var.set_header_high(config[CONF_CLIMATE_IR_LG_HEADER_HIGH]))
+    cg.add(var.set_header_low(config[CONF_CLIMATE_IR_LG_HEADER_LOW]))
+    cg.add(var.set_bit_high(config[CONF_CLIMATE_IR_LG_BIT_HIGH]))
+    cg.add(var.set_bit_one_low(config[CONF_CLIMATE_IR_LG_BIT_ONE_LOW]))
+    cg.add(var.set_bit_zero_low(config[CONF_CLIMATE_IR_LG_BIT_ZERO_LOW]))

--- a/esphome/components/climate_ir_lg/climate.py
+++ b/esphome/components/climate_ir_lg/climate.py
@@ -16,11 +16,11 @@ CONF_BIT_ZERO_LOW = 'bit_zero_low'
 
 CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(LgIrClimate),
-    cv.Optional(CONF_HEADER_HIGH, default = 8000): cv.int_,
-    cv.Optional(CONF_HEADER_LOW, default = 4000): cv.int_,
-    cv.Optional(CONF_BIT_HIGH, default = 600): cv.int_,
-    cv.Optional(CONF_BIT_ONE_LOW, default = 1600): cv.int_,
-    cv.Optional(CONF_BIT_ZERO_LOW, default = 550): cv.int_,
+    cv.Optional(CONF_HEADER_HIGH, default=8000): cv.int_,
+    cv.Optional(CONF_HEADER_LOW, default=4000): cv.int_,
+    cv.Optional(CONF_BIT_HIGH, default=600): cv.int_,
+    cv.Optional(CONF_BIT_ONE_LOW, default=1600): cv.int_,
+    cv.Optional(CONF_BIT_ZERO_LOW, default=550): cv.int_,
 })
 
 

--- a/esphome/components/climate_ir_lg/climate.py
+++ b/esphome/components/climate_ir_lg/climate.py
@@ -8,19 +8,19 @@ AUTO_LOAD = ['climate_ir']
 climate_ir_lg_ns = cg.esphome_ns.namespace('climate_ir_lg')
 LgIrClimate = climate_ir_lg_ns.class_('LgIrClimate', climate_ir.ClimateIR)
 
-CONF_CLIMATE_IR_LG_HEADER_HIGH = 'header_high'
-CONF_CLIMATE_IR_LG_HEADER_LOW = 'header_low'
-CONF_CLIMATE_IR_LG_BIT_HIGH = 'bit_high'
-CONF_CLIMATE_IR_LG_BIT_ONE_LOW = 'bit_one_low'
-CONF_CLIMATE_IR_LG_BIT_ZERO_LOW = 'bit_zero_low'
+CONF_HEADER_HIGH = 'header_high'
+CONF_HEADER_LOW = 'header_low'
+CONF_BIT_HIGH = 'bit_high'
+CONF_BIT_ONE_LOW = 'bit_one_low'
+CONF_BIT_ZERO_LOW = 'bit_zero_low'
 
 CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(LgIrClimate),
-    cv.Optional(CONF_CLIMATE_IR_LG_HEADER_HIGH, default = 8000): cv.int_,
-    cv.Optional(CONF_CLIMATE_IR_LG_HEADER_LOW, default = 4000): cv.int_,
-    cv.Optional(CONF_CLIMATE_IR_LG_BIT_HIGH, default = 600): cv.int_,
-    cv.Optional(CONF_CLIMATE_IR_LG_BIT_ONE_LOW, default = 1600): cv.int_,
-    cv.Optional(CONF_CLIMATE_IR_LG_BIT_ZERO_LOW, default = 550): cv.int_,
+    cv.Optional(CONF_HEADER_HIGH, default = 8000): cv.int_,
+    cv.Optional(CONF_HEADER_LOW, default = 4000): cv.int_,
+    cv.Optional(CONF_BIT_HIGH, default = 600): cv.int_,
+    cv.Optional(CONF_BIT_ONE_LOW, default = 1600): cv.int_,
+    cv.Optional(CONF_BIT_ZERO_LOW, default = 550): cv.int_,
 })
 
 
@@ -28,8 +28,8 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield climate_ir.register_climate_ir(var, config)
 
-    cg.add(var.set_header_high(config[CONF_CLIMATE_IR_LG_HEADER_HIGH]))
-    cg.add(var.set_header_low(config[CONF_CLIMATE_IR_LG_HEADER_LOW]))
-    cg.add(var.set_bit_high(config[CONF_CLIMATE_IR_LG_BIT_HIGH]))
-    cg.add(var.set_bit_one_low(config[CONF_CLIMATE_IR_LG_BIT_ONE_LOW]))
-    cg.add(var.set_bit_zero_low(config[CONF_CLIMATE_IR_LG_BIT_ZERO_LOW]))
+    cg.add(var.set_header_high(config[CONF_HEADER_HIGH]))
+    cg.add(var.set_header_low(config[CONF_HEADER_LOW]))
+    cg.add(var.set_bit_high(config[CONF_BIT_HIGH]))
+    cg.add(var.set_bit_one_low(config[CONF_BIT_ONE_LOW]))
+    cg.add(var.set_bit_zero_low(config[CONF_BIT_ZERO_LOW]))

--- a/esphome/components/climate_ir_lg/climate.py
+++ b/esphome/components/climate_ir_lg/climate.py
@@ -16,11 +16,11 @@ CONF_BIT_ZERO_LOW = 'bit_zero_low'
 
 CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(LgIrClimate),
-    cv.Optional(CONF_HEADER_HIGH, default=8000): cv.int_,
-    cv.Optional(CONF_HEADER_LOW, default=4000): cv.int_,
-    cv.Optional(CONF_BIT_HIGH, default=600): cv.int_,
-    cv.Optional(CONF_BIT_ONE_LOW, default=1600): cv.int_,
-    cv.Optional(CONF_BIT_ZERO_LOW, default=550): cv.int_,
+    cv.Optional(CONF_HEADER_HIGH, default=8000): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_HEADER_LOW, default=4000): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_BIT_HIGH, default=600): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_BIT_ONE_LOW, default=1600): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_BIT_ZERO_LOW, default=550): cv.positive_time_period_microseconds,
 })
 
 

--- a/esphome/components/climate_ir_lg/climate.py
+++ b/esphome/components/climate_ir_lg/climate.py
@@ -16,11 +16,11 @@ CONF_BIT_ZERO_LOW = 'bit_zero_low'
 
 CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(LgIrClimate),
-    cv.Optional(CONF_HEADER_HIGH, default=8000): cv.positive_time_period_microseconds,
-    cv.Optional(CONF_HEADER_LOW, default=4000): cv.positive_time_period_microseconds,
-    cv.Optional(CONF_BIT_HIGH, default=600): cv.positive_time_period_microseconds,
-    cv.Optional(CONF_BIT_ONE_LOW, default=1600): cv.positive_time_period_microseconds,
-    cv.Optional(CONF_BIT_ZERO_LOW, default=550): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_HEADER_HIGH, default='8000us'): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_HEADER_LOW, default='4000us'): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_BIT_HIGH, default='600us'): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_BIT_ONE_LOW, default='1600us'): cv.positive_time_period_microseconds,
+    cv.Optional(CONF_BIT_ZERO_LOW, default='550us'): cv.positive_time_period_microseconds,
 })
 
 

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -179,7 +179,6 @@ void LgIrClimate::transmit_(uint32_t value) {
   data->set_carrier_frequency(38000);
   data->reserve(2 + BITS * 2u);
 
-
   data->item(this->header_high_, this->header_low_);
 
   for (uint32_t mask = 1UL << (BITS - 1); mask != 0; mask >>= 1) {

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -183,9 +183,9 @@ void LgIrClimate::transmit_(uint32_t value) {
   data->item(this->header_high_, this->header_low_);
 
   for (uint32_t mask = 1UL << (BITS - 1); mask != 0; mask >>= 1) {
-    if (value & mask){
+    if (value & mask) {
       data->item(this->bit_high_, this->bit_one_low_);
-    }else{
+    } else {
       data->item(this->bit_high_, this->bit_zero_low_);
     }
   }

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -108,13 +108,13 @@ bool LgIrClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t nbits = 0;
   uint32_t remote_state = 0;
 
-  if (!data.expect_item(HEADER_HIGH_US, HEADER_LOW_US))
+  if (!data.expect_item(this->header_high_, this->header_low_))
     return false;
 
   for (nbits = 0; nbits < 32; nbits++) {
-    if (data.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
+    if (data.expect_item(this->bit_high_, this->bit_one_low_)) {
       remote_state = (remote_state << 1) | 1;
-    } else if (data.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
+    } else if (data.expect_item(this->bit_high_, this->bit_zero_low_)) {
       remote_state = (remote_state << 1) | 0;
     } else if (nbits == BITS) {
       break;
@@ -179,15 +179,17 @@ void LgIrClimate::transmit_(uint32_t value) {
   data->set_carrier_frequency(38000);
   data->reserve(2 + BITS * 2u);
 
-  data->item(HEADER_HIGH_US, HEADER_LOW_US);
+
+  data->item(this->header_high_, this->header_low_);
 
   for (uint32_t mask = 1UL << (BITS - 1); mask != 0; mask >>= 1) {
-    if (value & mask)
-      data->item(BIT_HIGH_US, BIT_ONE_LOW_US);
-    else
-      data->item(BIT_HIGH_US, BIT_ZERO_LOW_US);
+    if (value & mask){
+      data->item(this->bit_high_, this->bit_one_low_);
+    }else{
+      data->item(this->bit_high_, this->bit_zero_low_);
+    }
   }
-  data->mark(BIT_HIGH_US);
+  data->mark(this->bit_high_);
   transmit.perform();
 }
 void LgIrClimate::calc_checksum_(uint32_t &value) {

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -28,7 +28,6 @@ const uint8_t TEMP_RANGE = TEMP_MAX - TEMP_MIN + 1;
 const uint32_t TEMP_MASK = 0XF00;
 const uint32_t TEMP_SHIFT = 8;
 
-
 const uint16_t BITS = 28;
 
 void LgIrClimate::transmit_state() {

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -28,12 +28,6 @@ const uint8_t TEMP_RANGE = TEMP_MAX - TEMP_MIN + 1;
 const uint32_t TEMP_MASK = 0XF00;
 const uint32_t TEMP_SHIFT = 8;
 
-// Constants
-static const uint32_t HEADER_HIGH_US = 8000;
-static const uint32_t HEADER_LOW_US = 4000;
-static const uint32_t BIT_HIGH_US = 600;
-static const uint32_t BIT_ONE_LOW_US = 1600;
-static const uint32_t BIT_ZERO_LOW_US = 550;
 
 const uint16_t BITS = 28;
 

--- a/esphome/components/climate_ir_lg/climate_ir_lg.h
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.h
@@ -25,6 +25,11 @@ class LgIrClimate : public climate_ir::ClimateIR {
       this->swing_mode = climate::CLIMATE_SWING_OFF;
     climate_ir::ClimateIR::control(call);
   }
+  void set_header_high(uint32_t header_high) { this->header_high_ = header_high; }
+  void set_header_low(uint32_t header_low) { this->header_low_ = header_low; }
+  void set_bit_high(uint32_t bit_high) { this->bit_high_ = bit_high; }
+  void set_bit_one_low(uint32_t bit_one_low) { this->bit_one_low_ = bit_one_low; }
+  void set_bit_zero_low(uint32_t bit_zero_low) { this->bit_zero_low_ = bit_zero_low; }
 
  protected:
   /// Transmit via IR the state of this climate controller.
@@ -36,6 +41,12 @@ class LgIrClimate : public climate_ir::ClimateIR {
 
   void calc_checksum_(uint32_t &value);
   void transmit_(uint32_t value);
+
+  uint32_t header_high_;
+  uint32_t header_low_;
+  uint32_t bit_high_;
+  uint32_t bit_one_low_;
+  uint32_t bit_zero_low_;
 
   climate::ClimateMode mode_before_{climate::CLIMATE_MODE_OFF};
 };


### PR DESCRIPTION
 

## Description:
Added Parameters:
header_high
header_low
bit_high
bit_one_low
bit_zero_low

These parameters control the timings of the protocol used for LG AC Units. In Brazil, for example, some units use different than standard timings but the protocol is essentially the same.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#963

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
