### PR TITLE
Add support for string-type Tuya datapoints

### DIFF
--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -30,6 +30,7 @@ struct TuyaDatapoint {
     uint8_t value_enum;
     uint16_t value_bitmask;
   };
+  std::string value_string;
 };
 
 struct TuyaDatapointListener {


### PR DESCRIPTION
## Description:
Adds support for string-type Tuya datapoints, in preparation for supporting devices which use them.

**Related issue (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
