### PR TITLE
Add reverse_enable for max7219

### DIFF
--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -9,11 +9,14 @@ max7219_ns = cg.esphome_ns.namespace('max7219')
 MAX7219Component = max7219_ns.class_('MAX7219Component', cg.PollingComponent, spi.SPIDevice)
 MAX7219ComponentRef = MAX7219Component.operator('ref')
 
+CONF_REVERSE_ENABLE = 'reverse_enable'
+
 CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(MAX7219Component),
 
     cv.Optional(CONF_NUM_CHIPS, default=1): cv.int_range(min=1, max=255),
     cv.Optional(CONF_INTENSITY, default=15): cv.int_range(min=0, max=15),
+    cv.Optional(CONF_REVERSE_ENABLE, default=False): cv.boolean,
 }).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema())
 
 
@@ -25,6 +28,7 @@ def to_code(config):
 
     cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
+    cg.add(var.set_reverse(config[CONF_REVERSE_ENABLE]))
 
     if CONF_LAMBDA in config:
         lambda_ = yield cg.process_lambda(config[CONF_LAMBDA], [(MAX7219ComponentRef, 'it')],

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -142,9 +142,11 @@ void MAX7219Component::dump_config() {
 void MAX7219Component::display() {
   for (uint8_t i = 0; i < 8; i++) {
     this->enable();
-    for (uint8_t j = 0; j < this->num_chips_; j++) {
-      this->send_byte_(8 - i, this->buffer_[j * 8 + i]);
-    }
+    for (uint8_t j = 0; j < this->num_chips_; j++)
+      if (reverse_)
+        this->send_byte_(8 - i, buffer_[(num_chips_ - j - 1) * 8 + i]);
+      else
+        this->send_byte_(8 - i, buffer_[j * 8 + i]);
     this->disable();
   }
 }

--- a/esphome/components/max7219/max7219.h
+++ b/esphome/components/max7219/max7219.h
@@ -34,6 +34,7 @@ class MAX7219Component : public PollingComponent,
 
   void set_intensity(uint8_t intensity);
   void set_num_chips(uint8_t num_chips);
+  void set_reverse(bool reverse) { this->reverse_ = reverse; };
 
   /// Evaluate the printf-format and print the result at the given position.
   uint8_t printf(uint8_t pos, const char *format, ...) __attribute__((format(printf, 3, 4)));
@@ -60,6 +61,7 @@ class MAX7219Component : public PollingComponent,
   uint8_t intensity_{15};  /// Intensity of the display from 0 to 15 (most)
   uint8_t num_chips_{1};
   uint8_t *buffer_;
+  bool reverse_{false};
   optional<max7219_writer_t> writer_{};
 };
 


### PR DESCRIPTION
## Description:
Fixes the order that data is written to multiple chips.
Someone on Facebook was asking why the string he printed was written to the second display first and continued on the first one.  On checking the code, it looks wrong to me.  The data for the farthest chip needs to be written first.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#983

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
