### PR TITLE
SPI wasnt being disabled after display update

### DIFF
--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -454,6 +454,7 @@ void HOT ST7735::write_display_data_() {
   } else {
     this->write_array(this->buffer_, this->get_buffer_length());
   }
+  this->disable();
 }
 
 void ST7735::spi_master_write_addr_(uint16_t addr1, uint16_t addr2) {


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1

## Checklist:
  - [X] The code change is tested and works locally.
  - [ NA] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
