### PR TITLE
1.16.0b6

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -100,3 +100,4 @@ esphome/components/version/* @esphome/core
 esphome/components/web_server_base/* @OttoWinter
 esphome/components/whirlpool/* @glmnet
 esphome/components/xiaomi_lywsd03mmc/* @ahpohl
+esphome/components/xiaomi_mhoc401/* @vevsvevs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,10 @@ ENV USERNAME="" PASSWORD=""
 # Expose the dashboard to Docker
 EXPOSE 6052
 
+# Run healthcheck (heartbeat)
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl --fail http://localhost:6052 || exit 1
+
 # The directory the user should mount their configuration files to
 WORKDIR /config
 # Set entrypoint to esphome so that the user doesn't have to type 'esphome'

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -30,6 +30,7 @@ struct TuyaDatapoint {
     uint8_t value_enum;
     uint16_t value_bitmask;
   };
+  std::string value_string;
 };
 
 struct TuyaDatapointListener {

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -194,6 +194,9 @@ optional<XiaomiParseResult> parse_xiaomi_header(const esp32_ble_tracker::Service
     result.name = "MJYD02YLA";
     if (raw.size() == 19)
       result.raw_offset -= 6;
+  } else if ((raw[2] == 0x87) && (raw[3] == 0x03)) {  // square body, e-ink display
+    result.type = XiaomiParseResult::TYPE_MHOC401;
+    result.name = "MHOC401";
   } else {
     ESP_LOGVV(TAG, "parse_xiaomi_header(): unknown device, no magic bytes.");
     return {};

--- a/esphome/components/xiaomi_ble/xiaomi_ble.h
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.h
@@ -21,7 +21,8 @@ struct XiaomiParseResult {
     TYPE_JQJCY01YM,
     TYPE_MUE4094RT,
     TYPE_WX08ZM,
-    TYPE_MJYD02YLA
+    TYPE_MJYD02YLA,
+    TYPE_MHOC401
   } type;
   std::string name;
   optional<float> temperature;

--- a/esphome/components/xiaomi_mhoc401/sensor.py
+++ b/esphome/components/xiaomi_mhoc401/sensor.py
@@ -1,0 +1,43 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, esp32_ble_tracker
+from esphome.const import CONF_BATTERY_LEVEL, CONF_HUMIDITY, CONF_MAC_ADDRESS, CONF_TEMPERATURE, \
+    UNIT_CELSIUS, ICON_THERMOMETER, UNIT_PERCENT, ICON_WATER_PERCENT, ICON_BATTERY, CONF_ID, \
+    CONF_BINDKEY
+
+CODEOWNERS = ['@vevsvevs']
+DEPENDENCIES = ['esp32_ble_tracker']
+AUTO_LOAD = ['xiaomi_ble']
+
+xiaomi_mhoc401_ns = cg.esphome_ns.namespace('xiaomi_mhoc401')
+XiaomiMHOC401 = xiaomi_mhoc401_ns.class_('XiaomiMHOC401',
+                                         esp32_ble_tracker.ESPBTDeviceListener,
+                                         cg.Component)
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(XiaomiMHOC401),
+    cv.Required(CONF_BINDKEY): cv.bind_key,
+    cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
+    cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
+    cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 0),
+    cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(UNIT_PERCENT, ICON_BATTERY, 0),
+}).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield esp32_ble_tracker.register_ble_device(var, config)
+
+    cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
+    cg.add(var.set_bindkey(config[CONF_BINDKEY]))
+
+    if CONF_TEMPERATURE in config:
+        sens = yield sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature(sens))
+    if CONF_HUMIDITY in config:
+        sens = yield sensor.new_sensor(config[CONF_HUMIDITY])
+        cg.add(var.set_humidity(sens))
+    if CONF_BATTERY_LEVEL in config:
+        sens = yield sensor.new_sensor(config[CONF_BATTERY_LEVEL])
+        cg.add(var.set_battery_level(sens))

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -1,0 +1,81 @@
+#include "xiaomi_mhoc401.h"
+#include "esphome/core/log.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+namespace esphome {
+namespace xiaomi_mhoc401 {
+
+static const char *TAG = "xiaomi_mhoc401";
+
+void XiaomiMHOC401::dump_config() {
+  ESP_LOGCONFIG(TAG, "Xiaomi MHOC401");
+  ESP_LOGCONFIG(TAG, "  Bindkey: %s", hexencode(this->bindkey_, 16).c_str());
+  LOG_SENSOR("  ", "Temperature", this->temperature_);
+  LOG_SENSOR("  ", "Humidity", this->humidity_);
+  LOG_SENSOR("  ", "Battery Level", this->battery_level_);
+}
+
+bool XiaomiMHOC401::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+  if (device.address_uint64() != this->address_) {
+    ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
+    return false;
+  }
+  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str().c_str());
+
+  bool success = false;
+  for (auto &service_data : device.get_service_datas()) {
+    auto res = xiaomi_ble::parse_xiaomi_header(service_data);
+    if (!res.has_value()) {
+      continue;
+    }
+    if (res->is_duplicate) {
+      continue;
+    }
+    if (res->has_encryption &&
+        (!(xiaomi_ble::decrypt_xiaomi_payload(const_cast<std::vector<uint8_t> &>(service_data.data), this->bindkey_,
+                                              this->address_)))) {
+      continue;
+    }
+    if (!(xiaomi_ble::parse_xiaomi_message(service_data.data, *res))) {
+      continue;
+    }
+    if (res->humidity.has_value() && this->humidity_ != nullptr) {
+      // see https://github.com/custom-components/sensor.mitemp_bt/issues/7#issuecomment-595948254
+      *res->humidity = trunc(*res->humidity);
+    }
+    if (!(xiaomi_ble::report_xiaomi_results(res, device.address_str()))) {
+      continue;
+    }
+    if (res->temperature.has_value() && this->temperature_ != nullptr)
+      this->temperature_->publish_state(*res->temperature);
+    if (res->humidity.has_value() && this->humidity_ != nullptr)
+      this->humidity_->publish_state(*res->humidity);
+    if (res->battery_level.has_value() && this->battery_level_ != nullptr)
+      this->battery_level_->publish_state(*res->battery_level);
+    success = true;
+  }
+
+  if (!success) {
+    return false;
+  }
+
+  return true;
+}
+
+void XiaomiMHOC401::set_bindkey(const std::string &bindkey) {
+  memset(bindkey_, 0, 16);
+  if (bindkey.size() != 32) {
+    return;
+  }
+  char temp[3] = {0};
+  for (int i = 0; i < 16; i++) {
+    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
+    bindkey_[i] = std::strtoul(temp, NULL, 16);
+  }
+}
+
+}  // namespace xiaomi_mhoc401
+}  // namespace esphome
+
+#endif

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/xiaomi_ble/xiaomi_ble.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+namespace esphome {
+namespace xiaomi_mhoc401 {
+
+class XiaomiMHOC401 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+ public:
+  void set_address(uint64_t address) { address_ = address; };
+  void set_bindkey(const std::string &bindkey);
+
+  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
+  void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
+  void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
+
+ protected:
+  uint64_t address_;
+  uint8_t bindkey_[16];
+  sensor::Sensor *temperature_{nullptr};
+  sensor::Sensor *humidity_{nullptr};
+  sensor::Sensor *battery_level_{nullptr};
+};
+
+}  // namespace xiaomi_mhoc401
+}  // namespace esphome
+
+#endif

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 16
-PATCH_VERSION = '0b5'
+PATCH_VERSION = '0b6'
 __short_version__ = f'{MAJOR_VERSION}.{MINOR_VERSION}'
 __version__ = f'{__short_version__}.{PATCH_VERSION}'
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Programming is like sex: one mistake and you’re providing support for a lifetime."_

~ Michael Sinz
- esphome: Add support for string-type Tuya datapoints [esphome#1488](https://github.com/esphome/esphome/pull/1488)
- esphome: Add healthcheck [esphome#1492](https://github.com/esphome/esphome/pull/1492)
- docs: Add link to baseboard thermostat by rjmurph2241 [docs#958](https://github.com/esphome/esphome-docs/pull/958)
- docs: Document color_temp [docs#951](https://github.com/esphome/esphome-docs/pull/951)
- docs: Update tuya.rst [docs#950](https://github.com/esphome/esphome-docs/pull/950)
- docs: Minor uptime docs fixes [docs#948](https://github.com/esphome/esphome-docs/pull/948)
- esphome: Support for MHO-C401 (fix) [esphome#1486](https://github.com/esphome/esphome/pull/1486) (new-integration)
- docs: Update image type for st7789 display [docs#945](https://github.com/esphome/esphome-docs/pull/945)
- docs: Add MHO-C401 [docs#957](https://github.com/esphome/esphome-docs/pull/957)
