### PR TITLE
Adding delay to aht10.cpp (issue  #1635)

### DIFF
--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -60,6 +60,7 @@ void AHT10Component::update() {
     delay = AHT10_HUMIDITY_DELAY;
   for (int i = 0; i < AHT10_ATTEMPS; ++i) {
     ESP_LOGVV(TAG, "Attemps %u at %6ld", i, millis());
+    delay_microseconds_accurate(4);
     if (!this->read_bytes(0, data, 6, delay)) {
       ESP_LOGD(TAG, "Communication with AHT10 failed, waiting...");
     } else if ((data[0] & 0x80) == 0x80) {  // Bit[7] = 0b1, device is busy


### PR DESCRIPTION
Added "delay_microseconds_accurate(4);" to resolve issue esphome/issues#1635

## Description:


**Related issue (if applicable):** fixes esphome/issues#1635

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
