### PR TITLE
zyaura: Fix operation on ESP32 (floats not allowed in ISRs)

### DIFF
--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -57,15 +57,15 @@ void ICACHE_RAM_ATTR ZaSensorStore::interrupt(ZaSensorStore *arg) {
 void ICACHE_RAM_ATTR ZaSensorStore::set_data_(ZaMessage *message) {
   switch (message->type) {
     case HUMIDITY:
-      this->humidity = (message->value > 10000) ? NAN : ((double)message->value / 100.0);
+      this->humidity = (message->value > 10000) ? NAN : ((double) message->value / 100.0);
       break;
 
     case TEMPERATURE:
-      this->temperature = (message->value > 5970) ? NAN : ((double)message->value / 16.0 - 273.15);
+      this->temperature = (message->value > 5970) ? NAN : ((double) message->value / 16.0 - 273.15);
       break;
 
     case CO2:
-      this->co2 = (message->value > 10000) ? NAN : (double)message->value;
+      this->co2 = (message->value > 10000) ? NAN : (double) message->value;
       break;
 
     default:
@@ -79,7 +79,7 @@ bool ZyAuraSensor::publish_state_(sensor::Sensor *sensor, double *value) {
     return true;
   }
 
-  sensor->publish_state((float)*value);
+  sensor->publish_state((float) *value);
 
   // Sensor reported wrong value
   if (isnan(*value)) {

--- a/esphome/components/zyaura/zyaura.cpp
+++ b/esphome/components/zyaura/zyaura.cpp
@@ -57,15 +57,15 @@ void ICACHE_RAM_ATTR ZaSensorStore::interrupt(ZaSensorStore *arg) {
 void ICACHE_RAM_ATTR ZaSensorStore::set_data_(ZaMessage *message) {
   switch (message->type) {
     case HUMIDITY:
-      this->humidity = (message->value > 10000) ? NAN : (message->value / 100.0f);
+      this->humidity = (message->value > 10000) ? NAN : ((double)message->value / 100.0);
       break;
 
     case TEMPERATURE:
-      this->temperature = (message->value > 5970) ? NAN : (message->value / 16.0f - 273.15f);
+      this->temperature = (message->value > 5970) ? NAN : ((double)message->value / 16.0 - 273.15);
       break;
 
     case CO2:
-      this->co2 = (message->value > 10000) ? NAN : message->value;
+      this->co2 = (message->value > 10000) ? NAN : (double)message->value;
       break;
 
     default:
@@ -73,13 +73,13 @@ void ICACHE_RAM_ATTR ZaSensorStore::set_data_(ZaMessage *message) {
   }
 }
 
-bool ZyAuraSensor::publish_state_(sensor::Sensor *sensor, float *value) {
+bool ZyAuraSensor::publish_state_(sensor::Sensor *sensor, double *value) {
   // Sensor doesn't added to configuration
   if (sensor == nullptr) {
     return true;
   }
 
-  sensor->publish_state(*value);
+  sensor->publish_state((float)*value);
 
   // Sensor reported wrong value
   if (isnan(*value)) {

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -42,9 +42,9 @@ class ZaDataProcessor {
 
 class ZaSensorStore {
  public:
-  float co2 = NAN;
-  float temperature = NAN;
-  float humidity = NAN;
+  double co2 = NAN;
+  double temperature = NAN;
+  double humidity = NAN;
 
   void setup(GPIOPin *pin_clock, GPIOPin *pin_data);
   static void interrupt(ZaSensorStore *arg);
@@ -79,7 +79,7 @@ class ZyAuraSensor : public PollingComponent {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
 
-  bool publish_state_(sensor::Sensor *sensor, float *value);
+  bool publish_state_(sensor::Sensor *sensor, double *value);
 };
 
 }  // namespace zyaura


### PR DESCRIPTION
## Description:

As per https://esp32.com/viewtopic.php?t=831, it is not safe to use
floating point operations in an interrupt routine.

The current ZyAura driver does this, and fails with this error:

  Guru Meditation Error: Core  1 panic'ed (Coprocessor exception)

Changing all variables accessed in the ISR to double is the fix.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1782

## Checklist:
  - [X] The code change is tested and works locally.
  - [NA] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [NA] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
