### PR TITLE
Added RGB Color Temperature Emulation to RGB Light

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -3,6 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
 #include "light_traits.h"
+#include "esphome/core/log.h"
 
 #ifdef USE_JSON
 #include "esphome/components/json/json_util.h"
@@ -179,7 +180,7 @@ class LightColorValues {
   }
 
   /// Convert these light color values to an RGB representation and write them to red, green, blue.
-  void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false) const {
+  /*void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false) const {
     float brightness = this->state_ * this->brightness_;
     if (color_interlock) {
       brightness = brightness * (1.0f - this->white_);
@@ -187,6 +188,54 @@ class LightColorValues {
     *red = gamma_correct(brightness * this->red_, gamma);
     *green = gamma_correct(brightness * this->green_, gamma);
     *blue = gamma_correct(brightness * this->blue_, gamma);
+  }*/
+
+  /// Convert color temperature to an RGB representation and write them to red, green, blue.
+  void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false, bool rgb_temperature_emulation = true) const {
+    float brightness = this->state_ * this->brightness_;
+    float temp_r = 0;
+    float temp_g = 0;
+    float temp_b = 0;
+    float color_fraction = (1.0f - this->white_);
+    if (rgb_temperature_emulation){
+      // Implementation comming from https://github.com/Aircoookie/Espalexa/issues/33
+
+    	int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
+      //int k = clamp(this->color_temperature_, 2000, 40000);
+    	int ktemp = k / 100;
+    	if ( ktemp <= 66 ) {
+    		temp_r = 255;
+    		//temp_g = _ct;
+    		temp_g = ktemp - 10;
+    		temp_g = ( 138.5177312231 * log(temp_g) - 305.0447927307) * 1.8;
+    		//temp_g = 99.4708025861 * log(temp_g) - 161.1195681661;
+    		if ( ktemp <= 19) {
+    			temp_b = 0;
+    		} else {
+    			temp_b = ktemp - 10;
+    			temp_b = 138.5177312231 * log(temp_b) - 305.0447927307;
+    		}
+    	} else {
+    		temp_r = ktemp - 60;
+    		temp_r = 329.698727446 * pow(temp_r, -0.1332047592);
+    		temp_g = ktemp - 60;
+    		temp_g = 288.1221695283 * pow(temp_g, -0.0755148492 );
+    		temp_b = 255;
+    	}
+      ESP_LOGD("Debug", "red: %.1f green: %.1f blue: %.1f white: %.1f k: %d temp: %.1f", temp_r, temp_g, temp_b, this->white_, k, this->color_temperature_);
+      temp_r = this->white_ * clamp(temp_r/255, 0, 1);
+      temp_g = this->white_ * clamp(temp_g/255, 0, 1);
+      temp_b = this->white_ * clamp(temp_b/255, 0, 1);
+
+    } else {
+      if (color_interlock) {
+        brightness = brightness * color_fraction;
+      }
+    }
+    *red = gamma_correct(brightness * (color_fraction*this->red_ + temp_r), gamma);
+    *green = gamma_correct(brightness * (color_fraction*this->green_ + temp_g), gamma);
+    *blue = gamma_correct(brightness * (color_fraction*this->blue_ + temp_b), gamma);
+
   }
 
   /// Convert these light color values to an RGBW representation and write them to red, green, blue, white.

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -188,25 +188,25 @@ class LightColorValues {
     if (rgb_temperature_emulation) {
       color_fraction = (1.0f - this->white_);
       // Implementation adapted from https://github.com/Aircoookie/Espalexa/issues/33
-    	int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
-    	int ktemp = k / 100;
-    	if ( ktemp <= 66 ) {
-    		temp_r = 255;
-    		temp_g = ktemp - 10;
-    		temp_g = ( 138.5177312231 * log(temp_g) - 305.0447927307) * 1.8;
-    		if ( ktemp <= 19) {
-    			temp_b = 0;
-    		} else {
-    			temp_b = ktemp - 10;
-    			temp_b = 138.5177312231 * log(temp_b) - 305.0447927307;
-    		}
-    	} else {
-    		temp_r = ktemp - 60;
-    		temp_r = 329.698727446 * pow(temp_r, -0.1332047592);
-    		temp_g = ktemp - 60;
-    		temp_g = 288.1221695283 * pow(temp_g, -0.0755148492 );
-    		temp_b = 255;
-    	}
+      int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
+      int ktemp = k / 100;
+      if ( ktemp <= 66 ) {
+        temp_r = 255;
+        temp_g = ktemp - 10;
+        temp_g = ( 138.5177312231 * log(temp_g) - 305.0447927307) * 1.8;
+        if ( ktemp <= 19) {
+          temp_b = 0;
+        } else {
+          temp_b = ktemp - 10;
+          temp_b = 138.5177312231 * log(temp_b) - 305.0447927307;
+        }
+      } else {
+        temp_r = ktemp - 60;
+        temp_r = 329.698727446 * pow(temp_r, -0.1332047592);
+        temp_g = ktemp - 60;
+        temp_g = 288.1221695283 * pow(temp_g, -0.0755148492 );
+        temp_b = 255;
+      }
       temp_r = this->white_ * clamp(temp_r/255, 0, 1);
       temp_g = this->white_ * clamp(temp_g/255, 0, 1);
       temp_b = this->white_ * clamp(temp_b/255, 0, 1);

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -186,18 +186,15 @@ class LightColorValues {
     float temp_g = 0;
     float temp_b = 0;
     float color_fraction = 1.0;
-    if (rgb_temperature_emulation){
+    if (rgb_temperature_emulation) {
       color_fraction = (1.0f - this->white_);
-      // Implementation comming from https://github.com/Aircoookie/Espalexa/issues/33
+      // Implementation adapted from https://github.com/Aircoookie/Espalexa/issues/33
     	int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
-      //int k = clamp(this->color_temperature_, 2000, 40000);
     	int ktemp = k / 100;
     	if ( ktemp <= 66 ) {
     		temp_r = 255;
-    		//temp_g = _ct;
     		temp_g = ktemp - 10;
     		temp_g = ( 138.5177312231 * log(temp_g) - 305.0447927307) * 1.8;
-    		//temp_g = 99.4708025861 * log(temp_g) - 161.1195681661;
     		if ( ktemp <= 19) {
     			temp_b = 0;
     		} else {
@@ -215,7 +212,6 @@ class LightColorValues {
       temp_r = this->white_ * clamp(temp_r/255, 0, 1);
       temp_g = this->white_ * clamp(temp_g/255, 0, 1);
       temp_b = this->white_ * clamp(temp_b/255, 0, 1);
-
     } else {
       if (color_interlock) {
         brightness = brightness * color_fraction;
@@ -224,7 +220,6 @@ class LightColorValues {
     *red = gamma_correct(brightness * (color_fraction*this->red_ + temp_r), gamma);
     *green = gamma_correct(brightness * (color_fraction*this->green_ + temp_g), gamma);
     *blue = gamma_correct(brightness * (color_fraction*this->blue_ + temp_b), gamma);
-
   }
 
   /// Convert these light color values to an RGBW representation and write them to red, green, blue, white.

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -189,7 +189,7 @@ class LightColorValues {
     if (rgb_temperature_emulation) {
       color_fraction = (1.0f - this->white_);
       // Implementation adapted from https://github.com/Aircoookie/Espalexa/issues/33
-      int k = (int)(1000000 / clamp(this->color_temperature_, 1, 500));
+      int k = (int) (1000000 / clamp(this->color_temperature_, 1, 500));
       int ktemp = k / 100;
       if (ktemp <= 66) {
         temp_r = 255;

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -3,7 +3,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
 #include "light_traits.h"
-#include "esphome/core/log.h"
 
 #ifdef USE_JSON
 #include "esphome/components/json/json_util.h"
@@ -208,7 +207,6 @@ class LightColorValues {
     		temp_g = 288.1221695283 * pow(temp_g, -0.0755148492 );
     		temp_b = 255;
     	}
-      ESP_LOGD("Debug", "red: %.1f green: %.1f blue: %.1f white: %.1f k: %d temp: %.1f", temp_r, temp_g, temp_b, this->white_, k, this->color_temperature_);
       temp_r = this->white_ * clamp(temp_r/255, 0, 1);
       temp_g = this->white_ * clamp(temp_g/255, 0, 1);
       temp_b = this->white_ * clamp(temp_b/255, 0, 1);

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -179,17 +179,6 @@ class LightColorValues {
     *brightness = gamma_correct(this->state_ * this->brightness_, gamma);
   }
 
-  /// Convert these light color values to an RGB representation and write them to red, green, blue.
-  /*void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false) const {
-    float brightness = this->state_ * this->brightness_;
-    if (color_interlock) {
-      brightness = brightness * (1.0f - this->white_);
-    }
-    *red = gamma_correct(brightness * this->red_, gamma);
-    *green = gamma_correct(brightness * this->green_, gamma);
-    *blue = gamma_correct(brightness * this->blue_, gamma);
-  }*/
-
   /// Convert color temperature to an RGB representation and write them to red, green, blue.
   void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false, bool rgb_temperature_emulation = true) const {
     float brightness = this->state_ * this->brightness_;
@@ -199,7 +188,6 @@ class LightColorValues {
     float color_fraction = (1.0f - this->white_);
     if (rgb_temperature_emulation){
       // Implementation comming from https://github.com/Aircoookie/Espalexa/issues/33
-
     	int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
       //int k = clamp(this->color_temperature_, 2000, 40000);
     	int ktemp = k / 100;

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -180,13 +180,14 @@ class LightColorValues {
   }
 
   /// Convert color temperature to an RGB representation and write them to red, green, blue.
-  void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false, bool rgb_temperature_emulation = true) const {
+  void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false, bool rgb_temperature_emulation = false) const {
     float brightness = this->state_ * this->brightness_;
     float temp_r = 0;
     float temp_g = 0;
     float temp_b = 0;
-    float color_fraction = (1.0f - this->white_);
+    float color_fraction = 1.0;
     if (rgb_temperature_emulation){
+      color_fraction = (1.0f - this->white_);
       // Implementation comming from https://github.com/Aircoookie/Espalexa/issues/33
     	int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
       //int k = clamp(this->color_temperature_, 2000, 40000);

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -179,7 +179,8 @@ class LightColorValues {
   }
 
   /// Convert color temperature to an RGB representation and write them to red, green, blue.
-  void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false, bool rgb_temperature_emulation = false) const {
+  void as_rgb(float *red, float *green, float *blue, float gamma = 0, bool color_interlock = false,
+              bool rgb_temperature_emulation = false) const {
     float brightness = this->state_ * this->brightness_;
     float temp_r = 0;
     float temp_g = 0;
@@ -190,11 +191,11 @@ class LightColorValues {
       // Implementation adapted from https://github.com/Aircoookie/Espalexa/issues/33
       int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
       int ktemp = k / 100;
-      if ( ktemp <= 66 ) {
+      if (ktemp <= 66) {
         temp_r = 255;
         temp_g = ktemp - 10;
-        temp_g = ( 138.5177312231 * log(temp_g) - 305.0447927307) * 1.8;
-        if ( ktemp <= 19) {
+        temp_g = (138.5177312231 * log(temp_g) - 305.0447927307) * 1.8;
+        if (ktemp <= 19) {
           temp_b = 0;
         } else {
           temp_b = ktemp - 10;
@@ -204,20 +205,20 @@ class LightColorValues {
         temp_r = ktemp - 60;
         temp_r = 329.698727446 * pow(temp_r, -0.1332047592);
         temp_g = ktemp - 60;
-        temp_g = 288.1221695283 * pow(temp_g, -0.0755148492 );
+        temp_g = 288.1221695283 * pow(temp_g, -0.0755148492);
         temp_b = 255;
       }
-      temp_r = this->white_ * clamp(temp_r/255, 0, 1);
-      temp_g = this->white_ * clamp(temp_g/255, 0, 1);
-      temp_b = this->white_ * clamp(temp_b/255, 0, 1);
+      temp_r = this->white_ * clamp(temp_r / 255, 0, 1);
+      temp_g = this->white_ * clamp(temp_g / 255, 0, 1);
+      temp_b = this->white_ * clamp(temp_b / 255, 0, 1);
     } else {
       if (color_interlock) {
         brightness = brightness * color_fraction;
       }
     }
-    *red = gamma_correct(brightness * (color_fraction*this->red_ + temp_r), gamma);
-    *green = gamma_correct(brightness * (color_fraction*this->green_ + temp_g), gamma);
-    *blue = gamma_correct(brightness * (color_fraction*this->blue_ + temp_b), gamma);
+    *red = gamma_correct(brightness * (color_fraction * this->red_ + temp_r), gamma);
+    *green = gamma_correct(brightness * (color_fraction * this->green_ + temp_g), gamma);
+    *blue = gamma_correct(brightness * (color_fraction * this->blue_ + temp_b), gamma);
   }
 
   /// Convert these light color values to an RGBW representation and write them to red, green, blue, white.

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -189,17 +189,17 @@ class LightColorValues {
     if (rgb_temperature_emulation) {
       color_fraction = (1.0f - this->white_);
       // Implementation adapted from https://github.com/Aircoookie/Espalexa/issues/33
-      int k = round(1000000 / clamp(this->color_temperature_, 1, 500));
+      int k = (int)(1000000 / clamp(this->color_temperature_, 1, 500));
       int ktemp = k / 100;
       if (ktemp <= 66) {
         temp_r = 255;
         temp_g = ktemp - 10;
-        temp_g = (138.5177312231 * log(temp_g) - 305.0447927307) * 1.8;
+        temp_g = (138.5177312231 * logf(temp_g) - 305.0447927307) * 1.8;
         if (ktemp <= 19) {
           temp_b = 0;
         } else {
           temp_b = ktemp - 10;
-          temp_b = 138.5177312231 * log(temp_b) - 305.0447927307;
+          temp_b = 138.5177312231 * logf(temp_b) - 305.0447927307;
         }
       } else {
         temp_r = ktemp - 60;

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -737,7 +737,12 @@ void LightState::current_values_as_brightness(float *brightness) {
 }
 void LightState::current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock) {
   auto traits = this->get_traits();
-  this->current_values.as_rgb(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock());
+  /*if (this->color_temperature_.has_value()) { //this means we want to emulate CWWW with the RGB output
+    this->current_values.as_rgb_from_temperature(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock());
+  }
+  else{*/
+    this->current_values.as_rgb(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock());
+  //}
 }
 void LightState::current_values_as_rgbw(float *red, float *green, float *blue, float *white, bool color_interlock) {
   auto traits = this->get_traits();

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -735,9 +735,11 @@ void LightState::current_values_as_binary(bool *binary) { this->current_values.a
 void LightState::current_values_as_brightness(float *brightness) {
   this->current_values.as_brightness(brightness, this->gamma_correct_);
 }
-void LightState::current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock, bool rgb_temperature_emulation) {
+void LightState::current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock,
+                                       bool rgb_temperature_emulation) {
   auto traits = this->get_traits();
-  this->current_values.as_rgb(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock(), rgb_temperature_emulation);
+  this->current_values.as_rgb(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock(),
+                              rgb_temperature_emulation);
 }
 void LightState::current_values_as_rgbw(float *red, float *green, float *blue, float *white, bool color_interlock) {
   auto traits = this->get_traits();

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -735,14 +735,9 @@ void LightState::current_values_as_binary(bool *binary) { this->current_values.a
 void LightState::current_values_as_brightness(float *brightness) {
   this->current_values.as_brightness(brightness, this->gamma_correct_);
 }
-void LightState::current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock) {
+void LightState::current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock, bool rgb_temperature_emulation) {
   auto traits = this->get_traits();
-  /*if (this->color_temperature_.has_value()) { //this means we want to emulate CWWW with the RGB output
-    this->current_values.as_rgb_from_temperature(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock());
-  }
-  else{*/
-    this->current_values.as_rgb(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock());
-  //}
+  this->current_values.as_rgb(red, green, blue, this->gamma_correct_, traits.get_supports_color_interlock(), rgb_temperature_emulation);
 }
 void LightState::current_values_as_rgbw(float *red, float *green, float *blue, float *white, bool color_interlock) {
   auto traits = this->get_traits();

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -273,7 +273,8 @@ class LightState : public Nameable, public Component {
 
   void current_values_as_brightness(float *brightness);
 
-  void current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock = false, bool rgb_temperature_emulation = false);
+  void current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock = false,
+                             bool rgb_temperature_emulation = false);
 
   void current_values_as_rgbw(float *red, float *green, float *blue, float *white, bool color_interlock = false);
 

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -273,7 +273,7 @@ class LightState : public Nameable, public Component {
 
   void current_values_as_brightness(float *brightness);
 
-  void current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock = false);
+  void current_values_as_rgb(float *red, float *green, float *blue, bool color_interlock = false, bool rgb_temperature_emulation = false);
 
   void current_values_as_rgbw(float *red, float *green, float *blue, float *white, bool color_interlock = false);
 

--- a/esphome/components/light/light_traits.h
+++ b/esphome/components/light/light_traits.h
@@ -24,6 +24,10 @@ class LightTraits {
   void set_supports_color_interlock(bool supports_color_interlock) {
     this->supports_color_interlock_ = supports_color_interlock;
   }
+  bool get_supports_rgb_temperature_emulation() const { return this->supports_rgb_temperature_emulation_; }
+  void set_supports_rgb_temperature_emulation(bool supports_rgb_temperature_emulation) {
+    this->supports_rgb_temperature_emulation_ = supports_rgb_temperature_emulation;
+  }
   float get_min_mireds() const { return this->min_mireds_; }
   void set_min_mireds(float min_mireds) { this->min_mireds_ = min_mireds; }
   float get_max_mireds() const { return this->max_mireds_; }
@@ -37,6 +41,7 @@ class LightTraits {
   float min_mireds_{0};
   float max_mireds_{0};
   bool supports_color_interlock_{false};
+  bool supports_rgb_temperature_emulation_{false};
 };
 
 }  // namespace light

--- a/esphome/components/rgb/light.py
+++ b/esphome/components/rgb/light.py
@@ -1,16 +1,22 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import light, output
-from esphome.const import CONF_BLUE, CONF_GREEN, CONF_RED, CONF_OUTPUT_ID
+from esphome.const import CONF_BLUE, CONF_GREEN, CONF_RED, CONF_OUTPUT_ID, CONF_COLD_WHITE_COLOR_TEMPERATURE, \
+CONF_WARM_WHITE_COLOR_TEMPERATURE
 
 rgb_ns = cg.esphome_ns.namespace('rgb')
 RGBLightOutput = rgb_ns.class_('RGBLightOutput', light.LightOutput)
+
+CONF_RGB_TEMPERATURE_EMULATION = 'rgb_temperature_emulation'
 
 CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend({
     cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(RGBLightOutput),
     cv.Required(CONF_RED): cv.use_id(output.FloatOutput),
     cv.Required(CONF_GREEN): cv.use_id(output.FloatOutput),
     cv.Required(CONF_BLUE): cv.use_id(output.FloatOutput),
+    cv.Optional(CONF_COLD_WHITE_COLOR_TEMPERATURE, default='6700 K'): cv.color_temperature,
+    cv.Optional(CONF_WARM_WHITE_COLOR_TEMPERATURE, default='2700 K'): cv.color_temperature,
+    cv.Optional(CONF_RGB_TEMPERATURE_EMULATION, default=False): cv.boolean,
 })
 
 
@@ -24,3 +30,7 @@ def to_code(config):
     cg.add(var.set_green(green))
     blue = yield cg.get_variable(config[CONF_BLUE])
     cg.add(var.set_blue(blue))
+
+    cg.add(var.set_cold_white_temperature(config[CONF_COLD_WHITE_COLOR_TEMPERATURE]))
+    cg.add(var.set_warm_white_temperature(config[CONF_WARM_WHITE_COLOR_TEMPERATURE]))
+    cg.add(var.set_rgb_temperature_emulation(config[CONF_RGB_TEMPERATURE_EMULATION]))

--- a/esphome/components/rgb/light.py
+++ b/esphome/components/rgb/light.py
@@ -1,8 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import light, output
-from esphome.const import CONF_BLUE, CONF_GREEN, CONF_RED, CONF_OUTPUT_ID, CONF_COLD_WHITE_COLOR_TEMPERATURE, \
-CONF_WARM_WHITE_COLOR_TEMPERATURE
+from esphome.const import CONF_BLUE, CONF_GREEN, CONF_RED, CONF_OUTPUT_ID, \
+    CONF_COLD_WHITE_COLOR_TEMPERATURE, CONF_WARM_WHITE_COLOR_TEMPERATURE
 
 rgb_ns = cg.esphome_ns.namespace('rgb')
 RGBLightOutput = rgb_ns.class_('RGBLightOutput', light.LightOutput)

--- a/esphome/components/rgb/rgb_light_output.h
+++ b/esphome/components/rgb/rgb_light_output.h
@@ -18,7 +18,7 @@ class RGBLightOutput : public light::LightOutput {
   void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
   void set_rgb_temperature_emulation(bool rgb_temperature_emulation) {
     rgb_temperature_emulation_ = rgb_temperature_emulation;
-    if ( rgb_temperature_emulation_ ){
+    if (rgb_temperature_emulation_){
       this->color_interlock_ = true;
     }
   }
@@ -28,7 +28,7 @@ class RGBLightOutput : public light::LightOutput {
     traits.set_supports_rgb(true);
     traits.set_min_mireds(this->cold_white_temperature_);
     traits.set_max_mireds(this->warm_white_temperature_);
-    if(this->rgb_temperature_emulation_){
+    if (this->rgb_temperature_emulation_) {
       traits.set_supports_color_interlock(true);
       traits.set_supports_color_temperature(true);
     }

--- a/esphome/components/rgb/rgb_light_output.h
+++ b/esphome/components/rgb/rgb_light_output.h
@@ -14,14 +14,19 @@ class RGBLightOutput : public light::LightOutput {
   void set_red(output::FloatOutput *red) { red_ = red; }
   void set_green(output::FloatOutput *green) { green_ = green; }
   void set_blue(output::FloatOutput *blue) { blue_ = blue; }
+  void set_cold_white_temperature(float cold_white_temperature) { cold_white_temperature_ = cold_white_temperature; }
+  void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
+  void set_rgb_temperature_emulation(bool rgb_temperature_emulation) { rgb_temperature_emulation_ = rgb_temperature_emulation; }
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supports_brightness(true);
     traits.set_supports_rgb(true);
-    traits.set_supports_color_temperature(true);
-    traits.set_min_mireds(100);
-    traits.set_max_mireds(500);
-    traits.set_supports_color_interlock(true);
+    traits.set_min_mireds(this->cold_white_temperature_);
+    traits.set_max_mireds(this->warm_white_temperature_);
+    if(this->rgb_temperature_emulation_){
+      traits.set_supports_color_interlock(true);
+      traits.set_supports_color_temperature(true);
+    }
     return traits;
   }
   void write_state(light::LightState *state) override {
@@ -39,6 +44,9 @@ class RGBLightOutput : public light::LightOutput {
   output::FloatOutput *red_;
   output::FloatOutput *green_;
   output::FloatOutput *blue_;
+  float cold_white_temperature_;
+  float warm_white_temperature_;
+  bool rgb_temperature_emulation_;
 };
 
 }  // namespace rgb

--- a/esphome/components/rgb/rgb_light_output.h
+++ b/esphome/components/rgb/rgb_light_output.h
@@ -18,7 +18,7 @@ class RGBLightOutput : public light::LightOutput {
   void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
   void set_rgb_temperature_emulation(bool rgb_temperature_emulation) {
     rgb_temperature_emulation_ = rgb_temperature_emulation;
-    if (rgb_temperature_emulation_){
+    if (rgb_temperature_emulation_) {
       this->color_interlock_ = true;
     }
   }

--- a/esphome/components/rgb/rgb_light_output.h
+++ b/esphome/components/rgb/rgb_light_output.h
@@ -16,7 +16,12 @@ class RGBLightOutput : public light::LightOutput {
   void set_blue(output::FloatOutput *blue) { blue_ = blue; }
   void set_cold_white_temperature(float cold_white_temperature) { cold_white_temperature_ = cold_white_temperature; }
   void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
-  void set_rgb_temperature_emulation(bool rgb_temperature_emulation) { rgb_temperature_emulation_ = rgb_temperature_emulation; }
+  void set_rgb_temperature_emulation(bool rgb_temperature_emulation) {
+    rgb_temperature_emulation_ = rgb_temperature_emulation;
+    if ( rgb_temperature_emulation_ ){
+      this->color_interlock_ = true;
+    }
+  }
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supports_brightness(true);
@@ -31,7 +36,7 @@ class RGBLightOutput : public light::LightOutput {
   }
   void write_state(light::LightState *state) override {
     float red, green, blue;
-    state->current_values_as_rgb(&red, &green, &blue, false);
+    state->current_values_as_rgb(&red, &green, &blue, this->color_interlock_, this->rgb_temperature_emulation_);
 
     this->red_->set_level(red);
     this->green_->set_level(green);
@@ -46,6 +51,7 @@ class RGBLightOutput : public light::LightOutput {
   output::FloatOutput *blue_;
   float cold_white_temperature_;
   float warm_white_temperature_;
+  bool color_interlock_ = false;
   bool rgb_temperature_emulation_;
 };
 

--- a/esphome/components/rgb/rgb_light_output.h
+++ b/esphome/components/rgb/rgb_light_output.h
@@ -7,24 +7,32 @@
 namespace esphome {
 namespace rgb {
 
+static const char *TAG = "RGBlight";
+
 class RGBLightOutput : public light::LightOutput {
  public:
   void set_red(output::FloatOutput *red) { red_ = red; }
   void set_green(output::FloatOutput *green) { green_ = green; }
   void set_blue(output::FloatOutput *blue) { blue_ = blue; }
-
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supports_brightness(true);
     traits.set_supports_rgb(true);
+    traits.set_supports_color_temperature(true);
+    traits.set_min_mireds(100);
+    traits.set_max_mireds(500);
+    traits.set_supports_color_interlock(true);
     return traits;
   }
   void write_state(light::LightState *state) override {
     float red, green, blue;
     state->current_values_as_rgb(&red, &green, &blue, false);
+
     this->red_->set_level(red);
     this->green_->set_level(green);
     this->blue_->set_level(blue);
+    ESP_LOGD(TAG, "red: %.1f green: %.1f blue: %.1f", red, green, blue);
+    //ESP_LOGD(TAG, "  Color Temperature: %.1f mireds", v.get_color_temperature());
   }
 
  protected:

--- a/esphome/components/rgb/rgb_light_output.h
+++ b/esphome/components/rgb/rgb_light_output.h
@@ -37,12 +37,9 @@ class RGBLightOutput : public light::LightOutput {
   void write_state(light::LightState *state) override {
     float red, green, blue;
     state->current_values_as_rgb(&red, &green, &blue, this->color_interlock_, this->rgb_temperature_emulation_);
-
     this->red_->set_level(red);
     this->green_->set_level(green);
     this->blue_->set_level(blue);
-    ESP_LOGD(TAG, "red: %.1f green: %.1f blue: %.1f", red, green, blue);
-    //ESP_LOGD(TAG, "  Color Temperature: %.1f mireds", v.get_color_temperature());
   }
 
  protected:


### PR DESCRIPTION
## Description:
Added an RGB Color Temperature Emulation parameter that enables simple RGB lights to Emulate RGBWW lights by converting color temperature to RGB using an adaptation from the implementation on https://github.com/Aircoookie/Espalexa/issues/33.

Parameters to control how far you want to go in the temperature scale were also added to enable controlling the min and max color temperatures.

Parameters added:

- cold_white_color_temperature: 6700 K
- warm_white_color_temperature: 2700 K
- rgb_temperature_emulation: False

**Related issue (if applicable):** implements part of https://github.com/esphome/feature-requests/issues/260 but not all.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#969

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
