### PR TITLE
Sgp30 sensor improvements

### DIFF
--- a/esphome/components/sgp30/sensor.py
+++ b/esphome/components/sgp30/sensor.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c, sensor
 from esphome.const import CONF_ID, ICON_RADIATOR, UNIT_PARTS_PER_MILLION, \
-    UNIT_PARTS_PER_BILLION, ICON_MOLECULE_CO2
+    UNIT_PARTS_PER_BILLION, UNIT_EMPTY, ICON_MOLECULE_CO2
 
 DEPENDENCIES = ['i2c']
 
@@ -14,6 +14,7 @@ CONF_TVOC = 'tvoc'
 CONF_BASELINE = 'baseline'
 CONF_ECO2_BASELINE = 'eco2_baseline'
 CONF_TVOC_BASELINE = 'tvoc_baseline'
+CONF_STORE_BASELINE = 'store_baseline'
 CONF_UPTIME = 'uptime'
 CONF_COMPENSATION = 'compensation'
 CONF_HUMIDITY_SOURCE = 'humidity_source'
@@ -24,6 +25,9 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Required(CONF_ECO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION,
                                                  ICON_MOLECULE_CO2, 0),
     cv.Required(CONF_TVOC): sensor.sensor_schema(UNIT_PARTS_PER_BILLION, ICON_RADIATOR, 0),
+    cv.Optional(CONF_ECO2_BASELINE): sensor.sensor_schema(UNIT_EMPTY, ICON_MOLECULE_CO2, 0),
+    cv.Optional(CONF_TVOC_BASELINE): sensor.sensor_schema(UNIT_EMPTY, ICON_RADIATOR, 0),
+    cv.Optional(CONF_STORE_BASELINE, default=False): cv.boolean,
     cv.Optional(CONF_BASELINE): cv.Schema({
         cv.Required(CONF_ECO2_BASELINE): cv.hex_uint16_t,
         cv.Required(CONF_TVOC_BASELINE): cv.hex_uint16_t,
@@ -47,6 +51,17 @@ def to_code(config):
     if CONF_TVOC in config:
         sens = yield sensor.new_sensor(config[CONF_TVOC])
         cg.add(var.set_tvoc_sensor(sens))
+
+    if CONF_ECO2_BASELINE in config:
+        sens = yield sensor.new_sensor(config[CONF_ECO2_BASELINE])
+        cg.add(var.set_eco2_baseline_sensor(sens))
+
+    if CONF_TVOC_BASELINE in config:
+        sens = yield sensor.new_sensor(config[CONF_TVOC_BASELINE])
+        cg.add(var.set_tvoc_baseline_sensor(sens))
+
+    if CONF_STORE_BASELINE in config:
+        cg.add(var.set_store_baseline(config[CONF_STORE_BASELINE]))
 
     if CONF_BASELINE in config:
         baseline_config = config[CONF_BASELINE]

--- a/esphome/components/sgp30/sensor.py
+++ b/esphome/components/sgp30/sensor.py
@@ -36,7 +36,7 @@ CONFIG_SCHEMA = cv.Schema({
         cv.Required(CONF_HUMIDITY_SOURCE): cv.use_id(sensor.Sensor),
         cv.Required(CONF_TEMPERATURE_SOURCE): cv.use_id(sensor.Sensor)
     }),
-}).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x58))
+}).extend(cv.polling_component_schema('1s')).extend(i2c.i2c_device_schema(0x58))
 
 
 def to_code(config):

--- a/esphome/components/sgp30/sensor.py
+++ b/esphome/components/sgp30/sensor.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Required(CONF_TVOC): sensor.sensor_schema(UNIT_PARTS_PER_BILLION, ICON_RADIATOR, 0),
     cv.Optional(CONF_ECO2_BASELINE): sensor.sensor_schema(UNIT_EMPTY, ICON_MOLECULE_CO2, 0),
     cv.Optional(CONF_TVOC_BASELINE): sensor.sensor_schema(UNIT_EMPTY, ICON_RADIATOR, 0),
-    cv.Optional(CONF_STORE_BASELINE, default=False): cv.boolean,
+    cv.Optional(CONF_STORE_BASELINE, default=True): cv.boolean,
     cv.Optional(CONF_BASELINE): cv.Schema({
         cv.Required(CONF_ECO2_BASELINE): cv.hex_uint16_t,
         cv.Required(CONF_TVOC_BASELINE): cv.hex_uint16_t,

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -17,11 +17,13 @@ static const uint16_t SGP30_CMD_SET_IAQ_BASELINE = 0x201E;
 
 // Sensor baseline should first be relied on after 1H of operation,
 // if the sensor starts with a baseline value provided
-const long IAQ_BASELINE_WARM_UP_SECONDS_WITH_BASELINE_PROVIDED = 3600;
+//const long IAQ_BASELINE_WARM_UP_SECONDS_WITH_BASELINE_PROVIDED = 3600;
+const long IAQ_BASELINE_WARM_UP_SECONDS_WITH_BASELINE_PROVIDED = 30;
 
 // Sensor baseline could first be relied on after 12H of operation,
 // if the sensor starts without any prior baseline value provided
-const long IAQ_BASELINE_WARM_UP_SECONDS_WITHOUT_BASELINE = 43200;
+//const long IAQ_BASELINE_WARM_UP_SECONDS_WITHOUT_BASELINE = 43200;
+const long IAQ_BASELINE_WARM_UP_SECONDS_WITHOUT_BASELINE = 60;
 
 void SGP30Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SGP30...");

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -17,13 +17,11 @@ static const uint16_t SGP30_CMD_SET_IAQ_BASELINE = 0x201E;
 
 // Sensor baseline should first be relied on after 1H of operation,
 // if the sensor starts with a baseline value provided
-//const long IAQ_BASELINE_WARM_UP_SECONDS_WITH_BASELINE_PROVIDED = 3600;
-const long IAQ_BASELINE_WARM_UP_SECONDS_WITH_BASELINE_PROVIDED = 30;
+const long IAQ_BASELINE_WARM_UP_SECONDS_WITH_BASELINE_PROVIDED = 3600;
 
 // Sensor baseline could first be relied on after 12H of operation,
 // if the sensor starts without any prior baseline value provided
-//const long IAQ_BASELINE_WARM_UP_SECONDS_WITHOUT_BASELINE = 43200;
-const long IAQ_BASELINE_WARM_UP_SECONDS_WITHOUT_BASELINE = 60;
+const long IAQ_BASELINE_WARM_UP_SECONDS_WITHOUT_BASELINE = 43200;
 
 void SGP30Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SGP30...");

--- a/esphome/components/sgp30/sgp30.h
+++ b/esphome/components/sgp30/sgp30.h
@@ -3,16 +3,25 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
+#include "esphome/core/preferences.h"
 #include <cmath>
 
 namespace esphome {
 namespace sgp30 {
+
+struct SGP30Baselines {
+  uint16_t eco2;
+  uint16_t tvoc;
+} PACKED;  // NOLINT
 
 /// This class implements support for the Sensirion SGP30 i2c GAS (VOC and CO2eq) sensors.
 class SGP30Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_eco2_sensor(sensor::Sensor *eco2) { eco2_sensor_ = eco2; }
   void set_tvoc_sensor(sensor::Sensor *tvoc) { tvoc_sensor_ = tvoc; }
+  void set_eco2_baseline_sensor(sensor::Sensor *eco2_baseline) { eco2_sensor_baseline_ = eco2_baseline; }
+  void set_tvoc_baseline_sensor(sensor::Sensor *tvoc_baseline) { tvoc_sensor_baseline_ = tvoc_baseline; }
+  void set_store_baseline(bool store_baseline) { store_baseline_ = store_baseline; }
   void set_eco2_baseline(uint16_t eco2_baseline) { eco2_baseline_ = eco2_baseline; }
   void set_tvoc_baseline(uint16_t tvoc_baseline) { tvoc_baseline_ = tvoc_baseline; }
   void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
@@ -34,6 +43,7 @@ class SGP30Component : public PollingComponent, public i2c::I2CDevice {
   uint64_t serial_number_;
   uint16_t featureset_;
   long required_warm_up_time_;
+  ESPPreferenceObject pref_;
 
   enum ErrorCode {
     COMMUNICATION_FAILED,
@@ -45,8 +55,12 @@ class SGP30Component : public PollingComponent, public i2c::I2CDevice {
 
   sensor::Sensor *eco2_sensor_{nullptr};
   sensor::Sensor *tvoc_sensor_{nullptr};
+  sensor::Sensor *eco2_sensor_baseline_{nullptr};
+  sensor::Sensor *tvoc_sensor_baseline_{nullptr};
   uint16_t eco2_baseline_{0x0000};
   uint16_t tvoc_baseline_{0x0000};
+  bool store_baseline_;
+
   /// Input sensor for humidity and temperature compensation.
   sensor::Sensor *humidity_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};


### PR DESCRIPTION
## Description:

Updated the SGP30 sensor with configuration options to persistently store the eCO2/TVOC baselines so that it survives a power cycle. It removes the need to recompile and OTA the configuration file when the baselines have been determined after the calibration period (of 12 hours). 

As a convenience, the baseline values can also be configured as sensors so that they are published to Home assistant. 

Last, the update interval default is set to 1 second which is advised by the datasheet.

Please note that the amount of writes to the NVS (non-volatile-storage) is kept to a bare mininum to prevent wear and tear. Reason is that after the calibration period of 12 hours or after startup (1 hour), the baseline does not change that often. And ofcourse ony the NVS is written when the baseline value has changed.

**Related issue (if applicable):** fixes <link to issue>
#673
#668

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#972

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
