### PR TITLE
1.16.0b7

### DIFF
--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -23,10 +23,10 @@ def remove_altitude_suffix(value):
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(SCD30Component),
-    cv.Required(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION,
+    cv.Optional(CONF_CO2): sensor.sensor_schema(UNIT_PARTS_PER_MILLION,
                                                 ICON_MOLECULE_CO2, 0),
-    cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
-    cv.Required(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),
+    cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
+    cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),
     cv.Optional(CONF_AUTOMATIC_SELF_CALIBRATION, default=True): cv.boolean,
     cv.Optional(CONF_ALTITUDE_COMPENSATION): cv.All(remove_altitude_suffix,
                                                     cv.int_range(min=0, max=0xFFFF,

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 16
-PATCH_VERSION = '0b6'
+PATCH_VERSION = '0b7'
 __short_version__ = f'{MAJOR_VERSION}.{MINOR_VERSION}'
 __version__ = f'{__short_version__}.{PATCH_VERSION}'
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"It always takes longer than you expect, even when you take into account Hofstadter’s Law."_

~ Hofstadter’s Law
- esphome: Allow SCD30 sensors to be optional [esphome#1502](https://github.com/esphome/esphome/pull/1502)
- docs: Update scd30 docs to show sensors are optional [docs#970](https://github.com/esphome/esphome-docs/pull/970)
