### PR TITLE
Fix PN532 SPI communication

### DIFF
--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -22,7 +22,7 @@ void PN532::setup() {
   }
 
   std::vector<uint8_t> version_data;
-  if (!this->read_response_(PN532_COMMAND_VERSION_DATA, version_data)) {
+  if (!this->read_response(PN532_COMMAND_VERSION_DATA, version_data)) {
     ESP_LOGE(TAG, "Error getting version");
     this->mark_failed();
     return;
@@ -42,7 +42,7 @@ void PN532::setup() {
   }
 
   std::vector<uint8_t> wakeup_result;
-  if (!this->read_response_(PN532_COMMAND_SAMCONFIGURATION, wakeup_result)) {
+  if (!this->read_response(PN532_COMMAND_SAMCONFIGURATION, wakeup_result)) {
     this->error_code_ = WAKEUP_FAILED;
     this->mark_failed();
     return;
@@ -62,7 +62,7 @@ void PN532::setup() {
   }
 
   std::vector<uint8_t> sam_result;
-  if (!this->read_response_(PN532_COMMAND_SAMCONFIGURATION, sam_result)) {
+  if (!this->read_response(PN532_COMMAND_SAMCONFIGURATION, sam_result)) {
     ESP_LOGV(TAG, "Invalid SAM result: (%u)", sam_result.size());  // NOLINT
     for (uint8_t dat : sam_result) {
       ESP_LOGV(TAG, " 0x%02X", dat);
@@ -97,7 +97,7 @@ void PN532::loop() {
     return;
 
   std::vector<uint8_t> read;
-  bool success = this->read_response_(PN532_COMMAND_INLISTPASSIVETARGET, read);
+  bool success = this->read_response(PN532_COMMAND_INLISTPASSIVETARGET, read);
 
   this->requested_read_ = false;
 
@@ -230,7 +230,7 @@ bool PN532::write_command_(const std::vector<uint8_t> &data) {
 }
 
 bool PN532::read_ack_() {
-  ESP_LOGVV(TAG, "Reading ACK...");
+  ESP_LOGV(TAG, "Reading ACK...");
 
   std::vector<uint8_t> data;
   if (!this->read_data(data, 6)) {
@@ -241,96 +241,18 @@ bool PN532::read_ack_() {
                   data[2] == 0x00 &&                     // start of packet
                   data[3] == 0xFF && data[4] == 0x00 &&  // ACK packet code
                   data[5] == 0xFF && data[6] == 0x00);   // postamble
-  ESP_LOGVV(TAG, "ACK valid: %s", YESNO(matches));
+  ESP_LOGV(TAG, "ACK valid: %s", YESNO(matches));
   return matches;
 }
 
-bool PN532::read_response_(uint8_t command, std::vector<uint8_t> &data) {
-  ESP_LOGV(TAG, "Reading response");
-  uint8_t len = this->read_response_length_();
-  if (len == 0) {
-    return false;
-  }
-
-  ESP_LOGV(TAG, "Reading response of length %d", len);
-  if (!this->read_data(data, 6 + len + 2)) {
-    ESP_LOGD(TAG, "No response data");
-    return false;
-  }
-
-  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
-    // invalid packet
-    ESP_LOGV(TAG, "read data invalid preamble!");
-    return false;
-  }
-
-  bool valid_header = (static_cast<uint8_t>(data[4] + data[5]) == 0 &&  // LCS, len + lcs = 0
-                       data[6] == 0xD5 &&                               // TFI - frame from PN532 to system controller
-                       data[7] == command + 1);                         // Correct command response
-
-  if (!valid_header) {
-    ESP_LOGV(TAG, "read data invalid header!");
-    return false;
-  }
-
-  data.erase(data.begin(), data.begin() + 6);  // Remove headers
-
-  uint8_t checksum = 0;
-  for (int i = 0; i < len + 1; i++) {
-    uint8_t dat = data[i];
-    checksum += dat;
-  }
-  checksum = ~checksum + 1;
-
-  if (data[len + 1] != checksum) {
-    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", data[len], checksum);
-    return false;
-  }
-
-  if (data[len + 2] != 0x00) {
-    ESP_LOGV(TAG, "read data invalid postamble!");
-    return false;
-  }
-
-  data.erase(data.begin(), data.begin() + 2);  // Remove TFI and command code
-  data.erase(data.end() - 2, data.end());      // Remove checksum and postamble
-
-  return true;
-}
-
-uint8_t PN532::read_response_length_() {
-  std::vector<uint8_t> data;
-  if (!this->read_data(data, 6)) {
-    return 0;
-  }
-
-  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
-    // invalid packet
-    ESP_LOGV(TAG, "read data invalid preamble!");
-    return 0;
-  }
-
-  bool valid_header = (static_cast<uint8_t>(data[4] + data[5]) == 0 &&  // LCS, len + lcs = 0
-                       data[6] == 0xD5);                                // TFI - frame from PN532 to system controller
-
-  if (!valid_header) {
-    ESP_LOGV(TAG, "read data invalid header!");
-    return 0;
-  }
-
-  this->write_data({0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00});  // NACK - Retransmit last message
-
-  // full length of message, including TFI
-  uint8_t full_len = data[4];
-  // length of data, excluding TFI
-  uint8_t len = full_len - 1;
-  if (full_len == 0)
-    len = 0;
-  return len;
+void PN532::send_nack_() {
+  ESP_LOGV(TAG, "Sending NACK for retransmit");
+  this->write_data({0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00});
+  delay(10);
 }
 
 void PN532::turn_off_rf_() {
-  ESP_LOGVV(TAG, "Turning RF field OFF");
+  ESP_LOGV(TAG, "Turning RF field OFF");
   this->write_command_({
       PN532_COMMAND_RFCONFIGURATION,
       0x01,  // RF Field

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -46,12 +46,12 @@ class PN532 : public PollingComponent {
  protected:
   void turn_off_rf_();
   bool write_command_(const std::vector<uint8_t> &data);
-  bool read_response_(uint8_t command, std::vector<uint8_t> &data);
   bool read_ack_();
-  uint8_t read_response_length_();
+  void send_nack_();
 
   virtual bool write_data(const std::vector<uint8_t> &data) = 0;
   virtual bool read_data(std::vector<uint8_t> &data, uint8_t len) = 0;
+  virtual bool read_response(uint8_t command, std::vector<uint8_t> &data) = 0;
 
   nfc::NfcTag *read_tag_(std::vector<uint8_t> &uid);
 

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -64,7 +64,7 @@ bool PN532::read_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &
     return false;
   }
 
-  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, data) || data[0] != 0x00) {
+  if (!this->read_response(PN532_COMMAND_INDATAEXCHANGE, data) || data[0] != 0x00) {
     return false;
   }
   data.erase(data.begin());
@@ -89,7 +89,7 @@ bool PN532::auth_mifare_classic_block_(std::vector<uint8_t> &uid, uint8_t block_
   }
 
   std::vector<uint8_t> response;
-  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response) || response[0] != 0x00) {
+  if (!this->read_response(PN532_COMMAND_INDATAEXCHANGE, response) || response[0] != 0x00) {
     ESP_LOGE(TAG, "Authentication failed - Block 0x%02x", block_num);
     return false;
   }
@@ -194,7 +194,7 @@ bool PN532::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> 
   }
 
   std::vector<uint8_t> response;
-  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response)) {
+  if (!this->read_response(PN532_COMMAND_INDATAEXCHANGE, response)) {
     ESP_LOGE(TAG, "Error writing block %d", block_num);
     return false;
   }

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -52,7 +52,7 @@ bool PN532::read_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> 
     return false;
   }
 
-  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, data) || data[0] != 0x00) {
+  if (!this->read_response(PN532_COMMAND_INDATAEXCHANGE, data) || data[0] != 0x00) {
     return false;
   }
   data.erase(data.begin());
@@ -168,7 +168,7 @@ bool PN532::write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t>
   }
 
   std::vector<uint8_t> response;
-  if (!this->read_response_(PN532_COMMAND_INDATAEXCHANGE, response)) {
+  if (!this->read_response(PN532_COMMAND_INDATAEXCHANGE, response)) {
     ESP_LOGE(TAG, "Error writing page %d", page_num);
     return false;
   }

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -36,7 +36,6 @@ bool PN532I2C::read_data(std::vector<uint8_t> &data, uint8_t len) {
   return true;
 }
 
-
 bool PN532I2C::read_response(uint8_t command, std::vector<uint8_t> &data) {
   ESP_LOGV(TAG, "Reading response");
   uint8_t len = this->read_response_length_();

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -36,6 +36,91 @@ bool PN532I2C::read_data(std::vector<uint8_t> &data, uint8_t len) {
   return true;
 }
 
+
+bool PN532I2C::read_response(uint8_t command, std::vector<uint8_t> &data) {
+  ESP_LOGV(TAG, "Reading response");
+  uint8_t len = this->read_response_length_();
+  if (len == 0) {
+    return false;
+  }
+
+  ESP_LOGV(TAG, "Reading response of length %d", len);
+  if (!this->read_data(data, 6 + len + 2)) {
+    ESP_LOGD(TAG, "No response data");
+    return false;
+  }
+
+  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
+    // invalid packet
+    ESP_LOGV(TAG, "read data invalid preamble!");
+    return false;
+  }
+
+  bool valid_header = (static_cast<uint8_t>(data[4] + data[5]) == 0 &&  // LCS, len + lcs = 0
+                       data[6] == 0xD5 &&                               // TFI - frame from PN532 to system controller
+                       data[7] == command + 1);                         // Correct command response
+
+  if (!valid_header) {
+    ESP_LOGV(TAG, "read data invalid header!");
+    return false;
+  }
+
+  data.erase(data.begin(), data.begin() + 6);  // Remove headers
+
+  uint8_t checksum = 0;
+  for (int i = 0; i < len + 1; i++) {
+    uint8_t dat = data[i];
+    checksum += dat;
+  }
+  checksum = ~checksum + 1;
+
+  if (data[len + 1] != checksum) {
+    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", data[len], checksum);
+    return false;
+  }
+
+  if (data[len + 2] != 0x00) {
+    ESP_LOGV(TAG, "read data invalid postamble!");
+    return false;
+  }
+
+  data.erase(data.begin(), data.begin() + 2);  // Remove TFI and command code
+  data.erase(data.end() - 2, data.end());      // Remove checksum and postamble
+
+  return true;
+}
+
+uint8_t PN532I2C::read_response_length_() {
+  std::vector<uint8_t> data;
+  if (!this->read_data(data, 6)) {
+    return 0;
+  }
+
+  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
+    // invalid packet
+    ESP_LOGV(TAG, "read data invalid preamble!");
+    return 0;
+  }
+
+  bool valid_header = (static_cast<uint8_t>(data[4] + data[5]) == 0 &&  // LCS, len + lcs = 0
+                       data[6] == 0xD5);                                // TFI - frame from PN532 to system controller
+
+  if (!valid_header) {
+    ESP_LOGV(TAG, "read data invalid header!");
+    return 0;
+  }
+
+  this->send_nack_();
+
+  // full length of message, including TFI
+  uint8_t full_len = data[4];
+  // length of data, excluding TFI
+  uint8_t len = full_len - 1;
+  if (full_len == 0)
+    len = 0;
+  return len;
+}
+
 void PN532I2C::dump_config() {
   PN532::dump_config();
   LOG_I2C_DEVICE(this);

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -14,6 +14,8 @@ class PN532I2C : public pn532::PN532, public i2c::I2CDevice {
  protected:
   bool write_data(const std::vector<uint8_t> &data) override;
   bool read_data(std::vector<uint8_t> &data, uint8_t len) override;
+  bool read_response(uint8_t command, std::vector<uint8_t> &data) override;
+  uint8_t read_response_length_();
 };
 
 }  // namespace pn532_i2c

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -26,7 +26,7 @@ bool PN532Spi::write_data(const std::vector<uint8_t> &data) {
   delay(2);
   // First byte, communication mode: Write data
   this->write_byte(0x01);
-
+  ESP_LOGV(TAG, "Writing data: %s", hexencode(data).c_str());
   this->write_array(data.data(), data.size());
   this->disable();
 
@@ -34,31 +34,124 @@ bool PN532Spi::write_data(const std::vector<uint8_t> &data) {
 }
 
 bool PN532Spi::read_data(std::vector<uint8_t> &data, uint8_t len) {
-  this->enable();
-  // First byte, communication mode: Read state
-  this->write_byte(0x02);
+
+  ESP_LOGV(TAG, "Waiting for ready byte...");
 
   uint32_t start_time = millis();
   while (true) {
-    if (this->read_byte() & 0x01)
+    this->enable();
+    // First byte, communication mode: Read state
+    this->write_byte(0x02);
+    bool ready = this->read_byte() == 0x01;
+    this->disable();
+    if (ready)
       break;
+    ESP_LOGV(TAG, "Not ready yet...");
 
     if (millis() - start_time > 100) {
-      this->disable();
       ESP_LOGV(TAG, "Timed out waiting for readiness from PN532!");
       return false;
     }
+    yield();
   }
 
   // Read data (transmission from the PN532 to the host)
+  this->enable();
+  delay(2);
   this->write_byte(0x03);
+
+  ESP_LOGV(TAG, "Reading data...");
 
   data.resize(len);
   this->read_array(data.data(), len);
   this->disable();
   data.insert(data.begin(), 0x01);
+  ESP_LOGV(TAG, "Read data: %s", hexencode(data).c_str());
   return true;
-};
+}
+
+bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
+  ESP_LOGV(TAG, "Reading response");
+
+  uint32_t start_time = millis();
+  while (true) {
+    this->enable();
+    // First byte, communication mode: Read state
+    this->write_byte(0x02);
+    bool ready = this->read_byte() == 0x01;
+    this->disable();
+    if (ready)
+      break;
+    ESP_LOGV(TAG, "Not ready yet...");
+
+    if (millis() - start_time > 100) {
+      ESP_LOGV(TAG, "Timed out waiting for readiness from PN532!");
+      return false;
+    }
+    yield();
+  }
+
+  this->enable();
+  delay(2);
+  this->write_byte(0x03);
+
+  std::vector<uint8_t> header(7);
+  this->read_array(header.data(), 7);
+
+  ESP_LOGV(TAG, "Header data: %s", hexencode(header).c_str());
+
+  if (header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF) {
+    // invalid packet
+    ESP_LOGV(TAG, "read data invalid preamble!");
+    return false;
+  }
+
+  bool valid_header = (static_cast<uint8_t>(header[3] + header[4]) == 0 &&  // LCS, len + lcs = 0
+                       header[5] == 0xD5 &&                                 // TFI - frame from PN532 to system controller
+                       header[6] == command + 1);                           // Correct command response
+
+  if (!valid_header) {
+    ESP_LOGV(TAG, "read data invalid header!");
+    return false;
+  }
+
+  // full length of message, including command response
+  uint8_t full_len = header[3];
+  // length of data, excluding command response
+  uint8_t len = full_len - 1;
+  if (full_len == 0)
+    len = 0;
+
+  ESP_LOGV(TAG, "Reading response of length %d", len);
+
+  data.resize(len+1);
+  this->read_array(data.data(), len + 1);
+  this->disable();
+
+  ESP_LOGV(TAG, "Response data: %s", hexencode(data).c_str());
+
+
+  uint8_t checksum = header[5] + header[6]; // TFI + Command response code
+  for (int i = 0; i < len - 1; i++) {
+    uint8_t dat = data[i];
+    checksum += dat;
+  }
+  checksum = ~checksum + 1;
+
+  if (data[len - 1] != checksum) {
+    ESP_LOGV(TAG, "read data invalid checksum! %02X != %02X", data[len - 1], checksum);
+    return false;
+  }
+
+  if (data[len] != 0x00) {
+    ESP_LOGV(TAG, "read data invalid postamble!");
+    return false;
+  }
+
+  data.erase(data.end() - 2, data.end());      // Remove checksum and postamble
+
+  return true;
+}
 
 void PN532Spi::dump_config() {
   PN532::dump_config();

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -34,7 +34,6 @@ bool PN532Spi::write_data(const std::vector<uint8_t> &data) {
 }
 
 bool PN532Spi::read_data(std::vector<uint8_t> &data, uint8_t len) {
-
   ESP_LOGV(TAG, "Waiting for ready byte...");
 
   uint32_t start_time = millis();
@@ -107,8 +106,8 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
   }
 
   bool valid_header = (static_cast<uint8_t>(header[3] + header[4]) == 0 &&  // LCS, len + lcs = 0
-                       header[5] == 0xD5 &&                                 // TFI - frame from PN532 to system controller
-                       header[6] == command + 1);                           // Correct command response
+                       header[5] == 0xD5 &&        // TFI - frame from PN532 to system controller
+                       header[6] == command + 1);  // Correct command response
 
   if (!valid_header) {
     ESP_LOGV(TAG, "read data invalid header!");
@@ -124,14 +123,13 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
 
   ESP_LOGV(TAG, "Reading response of length %d", len);
 
-  data.resize(len+1);
+  data.resize(len + 1);
   this->read_array(data.data(), len + 1);
   this->disable();
 
   ESP_LOGV(TAG, "Response data: %s", hexencode(data).c_str());
 
-
-  uint8_t checksum = header[5] + header[6]; // TFI + Command response code
+  uint8_t checksum = header[5] + header[6];  // TFI + Command response code
   for (int i = 0; i < len - 1; i++) {
     uint8_t dat = data[i];
     checksum += dat;
@@ -148,7 +146,7 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
     return false;
   }
 
-  data.erase(data.end() - 2, data.end());      // Remove checksum and postamble
+  data.erase(data.end() - 2, data.end());  // Remove checksum and postamble
 
   return true;
 }

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -18,6 +18,7 @@ class PN532Spi : public pn532::PN532,
  protected:
   bool write_data(const std::vector<uint8_t> &data) override;
   bool read_data(std::vector<uint8_t> &data, uint8_t len) override;
+  bool read_response(uint8_t command, std::vector<uint8_t> &data) override;
 };
 
 }  // namespace pn532_spi


### PR DESCRIPTION
## Description:

Fixes an issue where the SPI communication is slightly different to the I2C one.

**Related issue (if applicable):** fixes esphome/issues#1654

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
