### PR TITLE
Add support for recurring data in uart switch

### DIFF
--- a/esphome/components/uart/switch/__init__.py
+++ b/esphome/components/uart/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch, uart
-from esphome.const import CONF_DATA, CONF_ID, CONF_INVERTED
+from esphome.const import CONF_DATA, CONF_ID, CONF_INVERTED, CONF_SEND_EVERY
 from esphome.core import HexInt
 from .. import uart_ns, validate_raw_data
 
@@ -14,6 +14,7 @@ CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(UARTSwitch),
     cv.Required(CONF_DATA): validate_raw_data,
     cv.Optional(CONF_INVERTED): cv.invalid("UART switches do not support inverted mode!"),
+    cv.Optional(CONF_SEND_EVERY): cv.positive_time_period_milliseconds,
 }).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
 
 
@@ -27,3 +28,6 @@ def to_code(config):
     if isinstance(data, bytes):
         data = [HexInt(x) for x in data]
     cg.add(var.set_data(data))
+
+    if CONF_SEND_EVERY in config:
+        cg.add(var.set_send_every(config[CONF_SEND_EVERY]))

--- a/esphome/components/uart/switch/uart_switch.h
+++ b/esphome/components/uart/switch/uart_switch.h
@@ -9,13 +9,19 @@ namespace uart {
 
 class UARTSwitch : public switch_::Switch, public UARTDevice, public Component {
  public:
+  void loop() override;
+
   void set_data(const std::vector<uint8_t> &data) { data_ = data; }
+  void set_send_every(uint32_t send_every) { this->send_every_ = send_every; }
 
   void dump_config() override;
 
  protected:
+  void write_command_();
   void write_state(bool state) override;
   std::vector<uint8_t> data_;
+  uint32_t send_every_;
+  uint32_t last_transmission_;
 };
 
 }  // namespace uart

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1606,6 +1606,10 @@ switch:
   - platform: uart
     name: 'UART Bytes Output'
     data: [0xDE, 0xAD, 0xBE, 0xEF]
+  - platform: uart
+    name: 'UART Recurring Output'
+    data: [0xDE, 0xAD, 0xBE, 0xEF]
+    send_every: 1s
   - platform: template
     assumed_state: yes
     name: Stepper Switch


### PR DESCRIPTION
## Description:

This PR adds a `send_every` key on UART switches which allows the switch to stay on and send recurring data.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#986

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
