### PR TITLE
Update rgbww_light_output.h

### DIFF
--- a/esphome/components/rgbww/rgbww_light_output.h
+++ b/esphome/components/rgbww/rgbww_light_output.h
@@ -22,7 +22,7 @@ class RGBWWLightOutput : public light::LightOutput {
     auto traits = light::LightTraits();
     traits.set_supports_brightness(true);
     traits.set_supports_rgb(true);
-    traits.set_supports_rgb_white_value(true);
+    traits.set_supports_rgb_white_value(!color_interlock_);
     traits.set_supports_color_temperature(true);
     traits.set_supports_color_interlock(this->color_interlock_);
     traits.set_min_mireds(this->cold_white_temperature_);


### PR DESCRIPTION
Make set_supports_rgb_white_value dependent on the inverted value of color_interlock. When color_interlock is enabled RGB white value does nothing anyway and just clutters the home assistant interface. Now, if color_interlock is enabled, set_supports_rgb_white_value will be false.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
