### PR TITLE
Bump NeoPixelBus from 2.5.7 to 2.6.1

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -181,4 +181,4 @@ def to_code(config):
     cg.add(var.set_pixel_order(getattr(ESPNeoPixelOrder, config[CONF_TYPE])))
 
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
-    cg.add_library('NeoPixelBus-esphome', '2.5.7')
+    cg.add_library('NeoPixelBus-esphome', '2.6.1')

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ lib_deps =
     ArduinoJson-esphomelib@5.13.3
     ESPAsyncWebServer-esphome@1.2.7
     FastLED@3.3.2
-    NeoPixelBus-esphome@2.5.7
+    NeoPixelBus-esphome@2.6.1
     ESPAsyncTCP-esphome@1.2.3
     1655@1.0.2  ; TinyGPSPlus (has name conflict)
     6865@1.0.0  ; TM1651 Battery Display


### PR DESCRIPTION
## Description:
Bump NeoPixelBus version to 2.6.1

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1481

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
