### PR TITLE
Update rgbww_light_output.h

### DIFF
--- a/esphome/components/rgbww/rgbww_light_output.h
+++ b/esphome/components/rgbww/rgbww_light_output.h
@@ -46,8 +46,8 @@ class RGBWWLightOutput : public light::LightOutput {
   output::FloatOutput *blue_;
   output::FloatOutput *cold_white_;
   output::FloatOutput *warm_white_;
-  float cold_white_temperature_;
-  float warm_white_temperature_;
+  int cold_white_temperature_;
+  int warm_white_temperature_;
   bool constant_brightness_;
   bool color_interlock_{false};
 };


### PR DESCRIPTION
Changed cold_white_temperature and warm_white temperature from a float to an integer. This makes home assisting show it correctly in the color temperature slider. If it is set to float home assistant show something like 470.8390000283847829304845 in the slider which provides an ugly ui and color temperature to as a decimal is invalid anyway.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
