### PR TITLE
Correct Native API Wire Format Documentation

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -46,6 +46,7 @@ service APIConnection {
 // The Home Assistant protocol is structured as a simple
 // TCP socket with short binary messages encoded in the protocol buffers format
 // First, a message in this protocol has a specific format:
+//  * A zero byte.
 //  * VarInt denoting the size of the message object. (type is not part of this)
 //  * VarInt denoting the type of message.
 //  * The message object encoded as a ProtoBuf message


### PR DESCRIPTION
## Description:
Messages start with a 0 byte preamble, see 
https://github.com/esphome/esphome/blob/96ab6b51b89282c4c8f5b890440c27e75cddb5ba/esphome/components/api/api_connection.cpp#L47
[aioesphomeapi transmit](https://github.com/esphome/aioesphomeapi/blob/33ad17f99c5f7f1f8301ae6483177e9ec23bd6ab/aioesphomeapi/connection.py#L207)
This is not documented in the protocol description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
