### PR TITLE
Fixed transfer_byte to write_byte for 8266

### DIFF
--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -407,7 +407,7 @@ void HOT ST7735::senddata_(const uint8_t *data_bytes, uint8_t num_data_bytes) {
   this->cs_->digital_write(false);
   this->enable();
   for (uint8_t i = 0; i < num_data_bytes; i++) {
-    this->transfer_byte(pgm_read_byte(data_bytes++));  // write byte - SPI library
+    this->write_byte(pgm_read_byte(data_bytes++));  // write byte - SPI library
   }
   this->cs_->digital_write(true);
   this->disable();


### PR DESCRIPTION
## Description:
Changed transfer_byte to write_byte 

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1824

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
