### PR TITLE
Fix safe mode ota flashing under certain configurations

### DIFF
--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -32,7 +32,8 @@ def to_code(config):
     yield cg.register_component(var, config)
 
     if config[CONF_SAFE_MODE]:
-        condition = var.should_enter_safe_mode(config[CONF_NUM_ATTEMPTS], config[CONF_REBOOT_TIMEOUT])
+        condition = var.should_enter_safe_mode(config[CONF_NUM_ATTEMPTS],
+                                               config[CONF_REBOOT_TIMEOUT])
         cg.add(RawExpression(f"if ({condition}) return"))
 
     if CORE.is_esp8266:

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -1,3 +1,4 @@
+from esphome.cpp_generator import RawExpression
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
@@ -31,7 +32,8 @@ def to_code(config):
     yield cg.register_component(var, config)
 
     if config[CONF_SAFE_MODE]:
-        cg.add(var.start_safe_mode(config[CONF_NUM_ATTEMPTS], config[CONF_REBOOT_TIMEOUT]))
+        condition = var.start_safe_mode(config[CONF_NUM_ATTEMPTS], config[CONF_REBOOT_TIMEOUT])
+        cg.add(RawExpression(f"if ({condition}) return"))
 
     if CORE.is_esp8266:
         cg.add_library('Update', None)

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -32,7 +32,7 @@ def to_code(config):
     yield cg.register_component(var, config)
 
     if config[CONF_SAFE_MODE]:
-        condition = var.start_safe_mode(config[CONF_NUM_ATTEMPTS], config[CONF_REBOOT_TIMEOUT])
+        condition = var.should_enter_safe_mode(config[CONF_NUM_ATTEMPTS], config[CONF_REBOOT_TIMEOUT])
         cg.add(RawExpression(f"if ({condition}) return"))
 
     if CORE.is_esp8266:

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -355,7 +355,7 @@ void OTAComponent::set_auth_password(const std::string &password) { this->passwo
 float OTAComponent::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
 uint16_t OTAComponent::get_port() const { return this->port_; }
 void OTAComponent::set_port(uint16_t port) { this->port_ = port; }
-bool OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
+bool OTAComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
   this->has_safe_mode_ = true;
   this->safe_mode_start_time_ = millis();
   this->safe_mode_enable_time_ = enable_time;

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -355,7 +355,7 @@ void OTAComponent::set_auth_password(const std::string &password) { this->passwo
 float OTAComponent::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
 uint16_t OTAComponent::get_port() const { return this->port_; }
 void OTAComponent::set_port(uint16_t port) { this->port_ = port; }
-void OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
+bool OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
   this->has_safe_mode_ = true;
   this->safe_mode_start_time_ = millis();
   this->safe_mode_enable_time_ = enable_time;
@@ -380,12 +380,11 @@ void OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
 
     ESP_LOGI(TAG, "Waiting for OTA attempt.");
 
-    while (true) {
-      App.loop();
-    }
+    return true;
   } else {
     // increment counter
     this->write_rtc_(this->safe_mode_rtc_value_ + 1);
+    return false;
   }
 }
 void OTAComponent::write_rtc_(uint32_t val) { this->rtc_.save(&val); }

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -47,7 +47,7 @@ class OTAComponent : public Component {
   /// Manually set the port OTA should listen on.
   void set_port(uint16_t port);
 
-  bool start_safe_mode(uint8_t num_attempts, uint32_t enable_time);
+  bool should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_time);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -47,7 +47,7 @@ class OTAComponent : public Component {
   /// Manually set the port OTA should listen on.
   void set_port(uint16_t port);
 
-  void start_safe_mode(uint8_t num_attempts, uint32_t enable_time);
+  bool start_safe_mode(uint8_t num_attempts, uint32_t enable_time);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)


### PR DESCRIPTION
## Description:

Instead of the ota safe mode function having:
```cpp
while(true) {
  App.loop();
}
```
We just return from the `setup()` function, which stops the registering of any more components and goes into the regular Arduino `loop()`

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
