### PR TITLE
auto_detect check was backwards

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -32,19 +32,19 @@ void DHT::dump_config() {
 
 void DHT::update() {
   float temperature, humidity;
-  bool error;
+  bool success;
   if (this->model_ == DHT_MODEL_AUTO_DETECT) {
     this->model_ = DHT_MODEL_DHT22;
-    error = this->read_sensor_(&temperature, &humidity, false);
-    if (error) {
+    success = this->read_sensor_(&temperature, &humidity, false);
+    if (!success) {
       this->model_ = DHT_MODEL_DHT11;
       return;
     }
   } else {
-    error = this->read_sensor_(&temperature, &humidity, true);
+    success = this->read_sensor_(&temperature, &humidity, true);
   }
 
-  if (error) {
+  if (success) {
     ESP_LOGD(TAG, "Got Temperature=%.1f°C Humidity=%.1f%%", temperature, humidity);
 
     if (this->temperature_sensor_ != nullptr)


### PR DESCRIPTION
## Description:
Auto detect would always fail on the correct model. read_sensor_ returns true on a good read. The original code used the return as an error not success.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
