### PR TITLE
Added Waveshare 2.90inch V2 e-ink display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -27,6 +27,7 @@ MODELS = {
     '2.13in-ttgo': ('a', WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN),
     '2.13in-ttgo-b73': ('a', WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B73),
     '2.90in': ('a', WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN),
+    '2.90inv2': ('a', WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN_V2),
     '2.70in': ('b', WaveshareEPaper2P7In),
     '2.90in-b': ('b', WaveshareEPaper2P9InB),
     '4.20in': ('b', WaveshareEPaper4P2In),
@@ -41,7 +42,7 @@ def validate_full_update_every_only_type_a(value):
         return value
     if MODELS[value[CONF_MODEL]][0] != 'a':
         raise cv.Invalid("The 'full_update_every' option is only available for models "
-                         "'1.54in', '2.13in' and '2.90in'.")
+                         "'1.54in', '2.13in', '2.90in', and '2.90inV2'.")
     return value
 
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -178,6 +178,13 @@ void WaveshareEPaperTypeA::initialize() {
   // COMMAND DATA ENTRY MODE SETTING
   this->command(0x11);
   this->data(0x03);  // from top left to bottom right
+
+  if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2) {
+    // RAM content option for Display Update
+    this->command(0x21);
+    this->data(0x00);
+    this->data(0x80);
+  }
 }
 void WaveshareEPaperTypeA::dump_config() {
   LOG_DISPLAY("", "Waveshare E-Paper", this);
@@ -197,6 +204,9 @@ void WaveshareEPaperTypeA::dump_config() {
     case WAVESHARE_EPAPER_2_9_IN:
       ESP_LOGCONFIG(TAG, "  Model: 2.9in");
       break;
+    case WAVESHARE_EPAPER_2_9_IN_V2:
+      ESP_LOGCONFIG(TAG, "  Model: 2.9inV2");
+      break;
   }
   ESP_LOGCONFIG(TAG, "  Full Update Every: %u", this->full_update_every_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
@@ -205,14 +215,15 @@ void WaveshareEPaperTypeA::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 void HOT WaveshareEPaperTypeA::display() {
+  bool full_update = this->at_update_ == 0;
+  bool prev_full_update = this->at_update_ == 1;
+
   if (!this->wait_until_idle_()) {
     this->status_set_warning();
     return;
   }
 
   if (this->full_update_every_ >= 2) {
-    bool prev_full_update = this->at_update_ == 1;
-    bool full_update = this->at_update_ == 0;
     if (full_update != prev_full_update) {
       if (this->model_ == TTGO_EPAPER_2_13_IN) {
         this->write_lut_(full_update ? FULL_UPDATE_LUT_TTGO : PARTIAL_UPDATE_LUT_TTGO, LUT_SIZE_TTGO);
@@ -258,7 +269,12 @@ void HOT WaveshareEPaperTypeA::display() {
 
   // COMMAND DISPLAY UPDATE CONTROL 2
   this->command(0x22);
-  this->data(0xC4);
+  if (this->model_ != WAVESHARE_EPAPER_2_9_IN_V2) {
+    this->data(0xC4);
+  } else {
+    this->data(full_update ? 0xF7 : 0xFF);
+  }
+
   // COMMAND MASTER ACTIVATION
   this->command(0x20);
   // COMMAND TERMINATE FRAME READ WRITE
@@ -278,6 +294,8 @@ int WaveshareEPaperTypeA::get_width_internal() {
       return 128;
     case WAVESHARE_EPAPER_2_9_IN:
       return 128;
+    case WAVESHARE_EPAPER_2_9_IN_V2:
+      return 128;
   }
   return 0;
 }
@@ -292,6 +310,8 @@ int WaveshareEPaperTypeA::get_height_internal() {
     case TTGO_EPAPER_2_13_IN_B73:
       return 250;
     case WAVESHARE_EPAPER_2_9_IN:
+      return 296;
+    case WAVESHARE_EPAPER_2_9_IN_V2:
       return 296;
   }
   return 0;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -269,10 +269,10 @@ void HOT WaveshareEPaperTypeA::display() {
 
   // COMMAND DISPLAY UPDATE CONTROL 2
   this->command(0x22);
-  if (this->model_ != WAVESHARE_EPAPER_2_9_IN_V2) {
-    this->data(0xC4);
-  } else {
+  if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2) {
     this->data(full_update ? 0xF7 : 0xFF);
+  } else {
+    this->data(0xC4);
   }
 
   // COMMAND MASTER ACTIVATION

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -83,13 +83,13 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   void display() override;
 
   void deep_sleep() override {
-    if (this->model_ != WAVESHARE_EPAPER_2_9_IN_V2) {
-      // COMMAND DEEP SLEEP MODE
-      this->command(0x10);
-    } else {
+    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2) {
       // COMMAND DEEP SLEEP MODE
       this->command(0x10);
       this->data(0x01);
+    } else {
+      // COMMAND DEEP SLEEP MODE
+      this->command(0x10);
     }
     this->wait_until_idle_();
   }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -67,6 +67,7 @@ enum WaveshareEPaperTypeAModel {
   WAVESHARE_EPAPER_1_54_IN = 0,
   WAVESHARE_EPAPER_2_13_IN,
   WAVESHARE_EPAPER_2_9_IN,
+  WAVESHARE_EPAPER_2_9_IN_V2,
   TTGO_EPAPER_2_13_IN,
   TTGO_EPAPER_2_13_IN_B73,
 };
@@ -82,8 +83,14 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   void display() override;
 
   void deep_sleep() override {
-    // COMMAND DEEP SLEEP MODE
-    this->command(0x10);
+    if (this->model_ != WAVESHARE_EPAPER_2_9_IN_V2) {
+      // COMMAND DEEP SLEEP MODE
+      this->command(0x10);
+    } else {
+      // COMMAND DEEP SLEEP MODE
+      this->command(0x10);
+      this->data(0x01);
+    }
     this->wait_until_idle_();
   }
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1812,6 +1812,15 @@ display:
     full_update_every: 30
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    cs_pin: GPIO23
+    dc_pin: GPIO23
+    busy_pin: GPIO23
+    reset_pin: GPIO23
+    model: 2.90inv2
+    full_update_every: 30
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: st7789v
     cs_pin: GPIO5
     dc_pin: GPIO16


### PR DESCRIPTION
## Description:
Added support for Waveshare 2.90inch Version 2 e-ink display

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1010

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
