### PR TITLE
Handle lambdas with sensor id's made from substitutions

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -983,7 +983,7 @@ LAMBDA_ENTITY_ID_PROG = re.compile(r'id\(\s*([a-zA-Z0-9_]+\.[.a-zA-Z0-9_]+)\s*\)
 def lambda_(value):
     """Coerce this configuration option to a lambda."""
     if not isinstance(value, Lambda):
-        value = make_data_base(Lambda(string_strict(value)), value)
+        value = make_data_base(Lambda(string_strict(value)), None)
     entity_id_parts = re.split(LAMBDA_ENTITY_ID_PROG, value.value)
     if len(entity_id_parts) != 1:
         entity_ids = ' '.join("'{}'".format(entity_id_parts[i])

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1,5 +1,8 @@
 substitutions:
   devicename: test1
+  sensorname: my
+  textname: template
+  roomname: living_room
 
 esphome:
   name: test1
@@ -36,7 +39,7 @@ esphome:
           verify_ssl: false
           json:
             key: !lambda |-
-              return id(template_text).state;
+              return id(${textname}_text).state;
             greeting: 'Hello World'
       - http_request.send:
           method: PUT
@@ -121,7 +124,7 @@ mqtt:
                 int data = x["my_data"];
                 ESP_LOGD("main", "The data is: %d", data);
             - light.turn_on:
-                id: living_room_lights
+                id: ${roomname}_lights
                 brightness: !lambda |-
                   float brightness = 1.0;
                   if (x.containsKey("brightness"))
@@ -133,10 +136,10 @@ mqtt:
                     effect = x["effect"];
                   return effect;
             - light.control:
-                id: living_room_lights
-                brightness: !lambda 'return id(living_room_lights).current_values.get_brightness() + 0.5;'
+                id: ${roomname}_lights
+                brightness: !lambda 'return id(${roomname}_lights).current_values.get_brightness() + 0.5;'
             - light.dim_relative:
-                id: living_room_lights
+                id: ${roomname}_lights
                 relative_brightness: 5%
             - uart.write:
                 id: uart0
@@ -278,9 +281,9 @@ sensor:
       then:
         - lambda: |-
             ESP_LOGD("main", "Got value %f", x);
-            id(my_sensor).publish_state(42.0);
-            ESP_LOGI("main", "Value of my sensor: %f", id(my_sensor).state);
-            ESP_LOGI("main", "Raw Value of my sensor: %f", id(my_sensor).state);
+            id(${sensorname}_sensor).publish_state(42.0);
+            ESP_LOGI("main", "Value of my sensor: %f", id(${sensorname}_sensor).state);
+            ESP_LOGI("main", "Raw Value of my sensor: %f", id(${sensorname}_sensor).state);
     on_value_range:
       above: 5
       below: 10
@@ -307,7 +310,7 @@ sensor:
   - platform: ads1115
     multiplexer: 'A0_A1'
     gain: 1.024
-    id: my_sensor
+    id: ${sensorname}_sensor
     filters:
     state_topic: hi/me
     retain: false
@@ -946,12 +949,12 @@ binary_sensor:
     name: 'Garage Door Open'
     id: garage_door
     lambda: |-
-      if (isnan(id(my_sensor).state)) {
+      if (isnan(id(${sensorname}_sensor).state)) {
         // isnan checks if the ultrasonic sensor echo
         // has timed out, resulting in a NaN (not a number) state
         // in that case, return {} to indicate that we don't know.
         return {};
-      } else if (id(my_sensor).state > 30) {
+      } else if (id(${sensorname}_sensor).state > 30) {
         // Garage Door is open.
         return true;
       } else {
@@ -1244,7 +1247,7 @@ light:
               state = 0;
   - platform: rgb
     name: 'Living Room Lights'
-    id: living_room_lights
+    id: ${roomname}_lights
     red: pca_0
     green: pca_1
     blue: pca_2
@@ -1400,14 +1403,14 @@ climate:
     name: TCL112 Climate With Sensor
     supports_heat: True
     supports_cool: True
-    sensor: my_sensor
+    sensor: ${sensorname}_sensor
   - platform: tcl112
     name: TCL112 Climate
   - platform: coolix
     name: Coolix Climate With Sensor
     supports_heat: True
     supports_cool: True
-    sensor: my_sensor
+    sensor: ${sensorname}_sensor
   - platform: coolix
     name: Coolix Climate
   - platform: fujitsu_general
@@ -1967,10 +1970,10 @@ text_sensor:
     qos: 2
     on_value:
       - text_sensor.template.publish:
-          id: template_text
+          id: ${textname}_text
           state: Hello World
       - text_sensor.template.publish:
-          id: template_text
+          id: ${textname}_text
           state: |-
             return "Hello World2";
       - globals.set:
@@ -1981,7 +1984,7 @@ text_sensor:
           data: [0x10, 0x20, 0x30]
   - platform: template
     name: Template Text Sensor
-    id: template_text
+    id: ${textname}_text
   - platform: wifi_info
     ip_address:
       name: 'IP Address'
@@ -2023,4 +2026,4 @@ canbus:
               condition:
                 lambda: 'return x[0] == 0x11;'
               then:
-                light.toggle: living_room_lights
+                light.toggle: ${roomname}_lights


### PR DESCRIPTION
## Description:
This change fixes the validation crashes caused when the configuration includes a lambda referring to a sensor or binary_sensor id that is composed of a substitution. The changes to test1.yaml introduce substitutions for some of the various id's referenced in lambdas, both sensors and other components.

**Related issue (if applicable):** fixes [esphome/issues#1853](https://github.com/esphome/issues/issues/1853)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
