### PR TITLE
fix substitution losing track of document range

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -4,6 +4,7 @@ import re
 import esphome.config_validation as cv
 from esphome import core
 from esphome.const import CONF_SUBSTITUTIONS
+from esphome.yaml_util import ESPHomeDataBase, make_data_base
 
 CODEOWNERS = ['@esphome/core']
 _LOGGER = logging.getLogger(__name__)
@@ -68,7 +69,11 @@ def _expand_substitutions(substitutions, value, path):
         value = value[:i] + sub
         i = len(value)
         value += tail
-    return value
+
+    assert isinstance(orig_value, ESPHomeDataBase)
+    # even though string can get larger or smaller, the range should point
+    # to original document marks
+    return make_data_base(value, orig_value)
 
 
 def _substitute_item(substitutions, item, path):

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -76,8 +76,8 @@ def _expand_substitutions(substitutions, value, path):
         # even though string can get larger or smaller, the range should point
         # to original document marks
         return make_data_base(value, orig_value)
-    else:
-        return value
+
+    return value
 
 
 def _substitute_item(substitutions, item, path):

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -70,10 +70,14 @@ def _expand_substitutions(substitutions, value, path):
         i = len(value)
         value += tail
 
-    assert isinstance(orig_value, ESPHomeDataBase)
-    # even though string can get larger or smaller, the range should point
-    # to original document marks
-    return make_data_base(value, orig_value)
+    # orig_value can also already be a lambda with esp_range info, and only
+    # a plain string is sent in orig_value
+    if isinstance(orig_value, ESPHomeDataBase):
+        # even though string can get larger or smaller, the range should point
+        # to original document marks
+        return make_data_base(value, orig_value)
+    else:
+        return value
 
 
 def _substitute_item(substitutions, item, path):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -983,7 +983,7 @@ LAMBDA_ENTITY_ID_PROG = re.compile(r'id\(\s*([a-zA-Z0-9_]+\.[.a-zA-Z0-9_]+)\s*\)
 def lambda_(value):
     """Coerce this configuration option to a lambda."""
     if not isinstance(value, Lambda):
-        value = make_data_base(Lambda(string_strict(value)), None)
+        value = make_data_base(Lambda(string_strict(value)), value)
     entity_id_parts = re.split(LAMBDA_ENTITY_ID_PROG, value.value)
     if len(entity_id_parts) != 1:
         entity_ids = ' '.join("'{}'".format(entity_id_parts[i])

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -983,7 +983,7 @@ LAMBDA_ENTITY_ID_PROG = re.compile(r'id\(\s*([a-zA-Z0-9_]+\.[.a-zA-Z0-9_]+)\s*\)
 def lambda_(value):
     """Coerce this configuration option to a lambda."""
     if not isinstance(value, Lambda):
-        value = make_data_base(Lambda(string_strict(value)), value)
+        value = make_data_base(Lambda(string_strict(value)), None)
     entity_id_parts = re.split(LAMBDA_ENTITY_ID_PROG, value.value)
     if len(entity_id_parts) != 1:
         entity_ids = ' '.join("'{}'".format(entity_id_parts[i])

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1,5 +1,8 @@
 substitutions:
   devicename: test1
+  sensorname: my
+  textname: template
+  roomname: living_room
 
 esphome:
   name: test1
@@ -36,7 +39,7 @@ esphome:
           verify_ssl: false
           json:
             key: !lambda |-
-              return id(template_text).state;
+              return id(${textname}_text).state;
             greeting: 'Hello World'
       - http_request.send:
           method: PUT
@@ -121,7 +124,7 @@ mqtt:
                 int data = x["my_data"];
                 ESP_LOGD("main", "The data is: %d", data);
             - light.turn_on:
-                id: living_room_lights
+                id: ${roomname}_lights
                 brightness: !lambda |-
                   float brightness = 1.0;
                   if (x.containsKey("brightness"))
@@ -133,10 +136,10 @@ mqtt:
                     effect = x["effect"];
                   return effect;
             - light.control:
-                id: living_room_lights
-                brightness: !lambda 'return id(living_room_lights).current_values.get_brightness() + 0.5;'
+                id: ${roomname}_lights
+                brightness: !lambda 'return id(${roomname}_lights).current_values.get_brightness() + 0.5;'
             - light.dim_relative:
-                id: living_room_lights
+                id: ${roomname}_lights
                 relative_brightness: 5%
             - uart.write:
                 id: uart0
@@ -278,9 +281,9 @@ sensor:
       then:
         - lambda: |-
             ESP_LOGD("main", "Got value %f", x);
-            id(my_sensor).publish_state(42.0);
-            ESP_LOGI("main", "Value of my sensor: %f", id(my_sensor).state);
-            ESP_LOGI("main", "Raw Value of my sensor: %f", id(my_sensor).state);
+            id(${sensorname}_sensor).publish_state(42.0);
+            ESP_LOGI("main", "Value of my sensor: %f", id(${sensorname}_sensor).state);
+            ESP_LOGI("main", "Raw Value of my sensor: %f", id(${sensorname}_sensor).state);
     on_value_range:
       above: 5
       below: 10
@@ -307,7 +310,7 @@ sensor:
   - platform: ads1115
     multiplexer: 'A0_A1'
     gain: 1.024
-    id: my_sensor
+    id: ${sensorname}_sensor
     filters:
     state_topic: hi/me
     retain: false
@@ -946,12 +949,12 @@ binary_sensor:
     name: 'Garage Door Open'
     id: garage_door
     lambda: |-
-      if (isnan(id(my_sensor).state)) {
+      if (isnan(id(${sensorname}_sensor).state)) {
         // isnan checks if the ultrasonic sensor echo
         // has timed out, resulting in a NaN (not a number) state
         // in that case, return {} to indicate that we don't know.
         return {};
-      } else if (id(my_sensor).state > 30) {
+      } else if (id(${sensorname}_sensor).state > 30) {
         // Garage Door is open.
         return true;
       } else {
@@ -1244,7 +1247,7 @@ light:
               state = 0;
   - platform: rgb
     name: 'Living Room Lights'
-    id: living_room_lights
+    id: ${roomname}_lights
     red: pca_0
     green: pca_1
     blue: pca_2
@@ -1400,14 +1403,14 @@ climate:
     name: TCL112 Climate With Sensor
     supports_heat: True
     supports_cool: True
-    sensor: my_sensor
+    sensor: ${sensorname}_sensor
   - platform: tcl112
     name: TCL112 Climate
   - platform: coolix
     name: Coolix Climate With Sensor
     supports_heat: True
     supports_cool: True
-    sensor: my_sensor
+    sensor: ${sensorname}_sensor
   - platform: coolix
     name: Coolix Climate
   - platform: fujitsu_general
@@ -1976,10 +1979,10 @@ text_sensor:
     qos: 2
     on_value:
       - text_sensor.template.publish:
-          id: template_text
+          id: ${textname}_text
           state: Hello World
       - text_sensor.template.publish:
-          id: template_text
+          id: ${textname}_text
           state: |-
             return "Hello World2";
       - globals.set:
@@ -1990,7 +1993,7 @@ text_sensor:
           data: [0x10, 0x20, 0x30]
   - platform: template
     name: Template Text Sensor
-    id: template_text
+    id: ${textname}_text
   - platform: wifi_info
     ip_address:
       name: 'IP Address'
@@ -2032,4 +2035,4 @@ canbus:
               condition:
                 lambda: 'return x[0] == 0x11;'
               then:
-                light.toggle: living_room_lights
+                light.toggle: ${roomname}_lights


### PR DESCRIPTION
## Description:

Substitutions does that, but the yaml loader injects data on base types (dicts, list, and also str, int, etc) this data is used to know where it comes from for displaying good message error: e.g. you typed wrong a var name in line 23.

Substitutions where clearing out this data and then ESPHome crashed when tried to track this data, so now this should fix the crash and also point errors better.

Picked up test1.yaml from @mtl010957 which now performs many checks on lambda substitutions,  thanks!

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1853
closes https://github.com/esphome/esphome/pull/1545

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
