### PR TITLE
Don't disable light effect state when switched off

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -135,10 +135,12 @@ void LightState::setup() {
   call.perform();
 }
 void LightState::loop() {
-  // Apply effect (if any)
-  auto *effect = this->get_active_effect_();
-  if (effect != nullptr) {
-    effect->apply();
+  // Apply effect (if any and light is on)
+  if (this->current_values.is_on()) {
+    auto *effect = this->get_active_effect_();
+    if (effect != nullptr) {
+      effect->apply();
+    }
   }
 
   // Apply transformer (if any)
@@ -536,19 +538,6 @@ LightColorValues LightCall::validate_() {
   if (this->has_transition_() && !supports_transition) {
     ESP_LOGW(TAG, "'%s' - Light does not support transitions!", name);
     this->transition_length_.reset();
-  }
-
-  // If not a flash and turning the light off, then disable the light
-  // Do not use light color values directly, so that effects can set 0% brightness
-  // Reason: When user turns off the light in frontend, the effect should also stop
-  if (!this->has_flash_() && !this->state_.value_or(v.is_on())) {
-    if (this->has_effect_()) {
-      ESP_LOGW(TAG, "'%s' - Cannot start an effect when turning off!", name);
-      this->effect_.reset();
-    } else if (this->parent_->active_effect_index_ != 0) {
-      // Auto turn off effect
-      this->effect_ = 0;
-    }
   }
 
   // Disable saving for flashes


### PR DESCRIPTION
## Description:

I really don't like that a light remembers all of its state (color, brightness, ..) except the current effect when you switch it off.  
If you switch if off and then back on currently it sets the effect to "None".

My change works for me. (Tested it with most of the included addressable effects and a lambda effect)

But I don't know enough of ESPHome to be sure that there are no bad side effects of my approach. Maybe it would be a good idea to somehow call LightEffect::stop and then LightEffect::start later but I don't think one can do that without saving more state. And: I don't really think it is needed.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/976



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).


