### PR TITLE
Climate IR LG -keep previous temp and fan if swing

### DIFF
--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -139,24 +139,24 @@ bool LgIrClimate::on_receive(remote_base::RemoteReceiveData data) {
     } else {
       this->mode = climate::CLIMATE_MODE_COOL;
     }
-  }
 
-  // Temperature
-  if (this->mode == climate::CLIMATE_MODE_COOL)
-    this->target_temperature = ((remote_state & TEMP_MASK) >> TEMP_SHIFT) + 15;
+    // Temperature
+    if (this->mode == climate::CLIMATE_MODE_COOL)
+      this->target_temperature = ((remote_state & TEMP_MASK) >> TEMP_SHIFT) + 15;
 
-  // Fan Speed
-  if (this->mode == climate::CLIMATE_MODE_AUTO) {
-    this->fan_mode = climate::CLIMATE_FAN_AUTO;
-  } else if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_DRY) {
-    if ((remote_state & FAN_MASK) == FAN_AUTO)
+    // Fan Speed
+    if (this->mode == climate::CLIMATE_MODE_AUTO) {
       this->fan_mode = climate::CLIMATE_FAN_AUTO;
-    else if ((remote_state & FAN_MASK) == FAN_MIN)
-      this->fan_mode = climate::CLIMATE_FAN_LOW;
-    else if ((remote_state & FAN_MASK) == FAN_MED)
-      this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-    else if ((remote_state & FAN_MASK) == FAN_MAX)
-      this->fan_mode = climate::CLIMATE_FAN_HIGH;
+    } else if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_DRY) {
+      if ((remote_state & FAN_MASK) == FAN_AUTO)
+        this->fan_mode = climate::CLIMATE_FAN_AUTO;
+      else if ((remote_state & FAN_MASK) == FAN_MIN)
+        this->fan_mode = climate::CLIMATE_FAN_LOW;
+      else if ((remote_state & FAN_MASK) == FAN_MED)
+        this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+      else if ((remote_state & FAN_MASK) == FAN_MAX)
+        this->fan_mode = climate::CLIMATE_FAN_HIGH;
+    }
   }
   this->publish_state();
 


### PR DESCRIPTION
Swing IR command does not carry CLIMATE_FAN or TEMP within itself, so previous states sould be kept. Tested with actual LG IR remote controller.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
