### PR TITLE
SPI transfer fix. Use write when no miso pin is set

### DIFF
--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -184,7 +184,7 @@ class SPIComponent : public Component {
   GPIOPin *active_cs_{nullptr};
   SPIClass *hw_spi_{nullptr};
   uint32_t wait_cycle_;
-};  // namespace spi
+};
 
 template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE, SPIDataRate DATA_RATE>
 class SPIDevice {


### PR DESCRIPTION
## Description:
transfer crashes on 8266 devices if a miso pin is not set. ESP32 chips are OK. 

I would say dont use transfer when write should be used. This PR changes it so ESP32 and 8266 devices dont need to set miso for transfer to work. It will choose related write functions if miso is not set. I tested this and it works as expected

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
