### PR TITLE
Replace substitutions in substitutions first

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -136,4 +136,6 @@ def do_substitution_pass(config, command_line_substitutions):
             del substitutions[old]
 
     config[CONF_SUBSTITUTIONS] = substitutions
+    # Move substitutions to the first place to replace substitutions in them correctly
+    config.move_to_end(CONF_SUBSTITUTIONS, False)
     _substitute_item(substitutions, config, [])


### PR DESCRIPTION
# What does this implement/fix? 

With the configuration below or the one in https://github.com/esphome/issues/issues/1878 the name of wifi_info sensor would be `esp${num} Connected BSSID` instead of `esp02 Connected BSSID`.
The problem is that the config is a OrderedDict and the text sensor is coming before the substitutions. As the substitution `device` has also a substitution inside itself, we need to process them first before we replace them in the rest of the config.
Specially with packages, which will be evaluated first, the change is bigger that the substitutions object is not the first item in the ordered config dictionary.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1878

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
text_sensor:
  - platform: wifi_info
    bssid:
      name: ${device} Connected BSSID

substitutions:
  num: "02"
  device: esp${num}

esphome:
  name: ${device}
  platform: ESP8266
  board: esp01_1m

wifi:
  ssid: "test"
  password: "13aRfOK60jmF"

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Test1 Fallback Hotspot"
    password: "13aRfOK60jmF"

captive_portal:

# Enable logging
logger:

# Enable Home Assistant API
api:

ota:

```

# Explain your changes

I move the substitutions item to the first place in the config dictionary, so they will be processed first.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
