### PR TITLE
Add min/max filters

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -72,6 +72,8 @@ SensorPublishAction = sensor_ns.class_('SensorPublishAction', automation.Action)
 # Filters
 Filter = sensor_ns.class_('Filter')
 MedianFilter = sensor_ns.class_('MedianFilter', Filter)
+MinFilter = sensor_ns.class_('MinFilter', Filter)
+MaxFilter = sensor_ns.class_('MaxFilter', Filter)
 SlidingWindowMovingAverageFilter = sensor_ns.class_('SlidingWindowMovingAverageFilter', Filter)
 ExponentialMovingAverageFilter = sensor_ns.class_('ExponentialMovingAverageFilter', Filter)
 LambdaFilter = sensor_ns.class_('LambdaFilter', Filter)
@@ -161,6 +163,32 @@ MEDIAN_SCHEMA = cv.All(cv.Schema({
 
 @FILTER_REGISTRY.register('median', MedianFilter, MEDIAN_SCHEMA)
 def median_filter_to_code(config, filter_id):
+    yield cg.new_Pvariable(filter_id, config[CONF_WINDOW_SIZE], config[CONF_SEND_EVERY],
+                           config[CONF_SEND_FIRST_AT])
+
+
+MIN_SCHEMA = cv.All(cv.Schema({
+    cv.Optional(CONF_WINDOW_SIZE, default=5): cv.positive_not_null_int,
+    cv.Optional(CONF_SEND_EVERY, default=5): cv.positive_not_null_int,
+    cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.positive_not_null_int,
+}), validate_send_first_at)
+
+
+@FILTER_REGISTRY.register('min', MinFilter, MIN_SCHEMA)
+def min_filter_to_code(config, filter_id):
+    yield cg.new_Pvariable(filter_id, config[CONF_WINDOW_SIZE], config[CONF_SEND_EVERY],
+                           config[CONF_SEND_FIRST_AT])
+
+
+MAX_SCHEMA = cv.All(cv.Schema({
+    cv.Optional(CONF_WINDOW_SIZE, default=5): cv.positive_not_null_int,
+    cv.Optional(CONF_SEND_EVERY, default=5): cv.positive_not_null_int,
+    cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.positive_not_null_int,
+}), validate_send_first_at)
+
+
+@FILTER_REGISTRY.register('max', MaxFilter, MAX_SCHEMA)
+def max_filter_to_code(config, filter_id):
     yield cg.new_Pvariable(filter_id, config[CONF_WINDOW_SIZE], config[CONF_SEND_EVERY],
                            config[CONF_SEND_FIRST_AT])
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -76,6 +76,66 @@ class MedianFilter : public Filter {
   size_t window_size_;
 };
 
+/** Simple min filter.
+ *
+ * Takes the min of the last <send_every> values and pushes it out every <send_every>.
+ */
+class MinFilter : public Filter {
+ public:
+  /** Construct a MinFilter.
+   *
+   * @param window_size The number of values that the min should be returned from.
+   * @param send_every After how many sensor values should a new one be pushed out.
+   * @param send_first_at After how many values to forward the very first value. Defaults to the first value
+   *   on startup being published on the first *raw* value, so with no filter applied. Must be less than or equal to
+   *   send_every.
+   */
+  explicit MinFilter(size_t window_size, size_t send_every, size_t send_first_at);
+
+  optional<float> new_value(float value) override;
+
+  void set_send_every(size_t send_every);
+  void set_window_size(size_t window_size);
+
+  uint32_t expected_interval(uint32_t input) override;
+
+ protected:
+  std::deque<float> queue_;
+  size_t send_every_;
+  size_t send_at_;
+  size_t window_size_;
+};
+
+/** Simple max filter.
+ *
+ * Takes the max of the last <send_every> values and pushes it out every <send_every>.
+ */
+class MaxFilter : public Filter {
+ public:
+  /** Construct a MaxFilter.
+   *
+   * @param window_size The number of values that the max should be returned from.
+   * @param send_every After how many sensor values should a new one be pushed out.
+   * @param send_first_at After how many values to forward the very first value. Defaults to the first value
+   *   on startup being published on the first *raw* value, so with no filter applied. Must be less than or equal to
+   *   send_every.
+   */
+  explicit MaxFilter(size_t window_size, size_t send_every, size_t send_first_at);
+
+  optional<float> new_value(float value) override;
+
+  void set_send_every(size_t send_every);
+  void set_window_size(size_t window_size);
+
+  uint32_t expected_interval(uint32_t input) override;
+
+ protected:
+  std::deque<float> queue_;
+  size_t send_every_;
+  size_t send_at_;
+  size_t window_size_;
+};
+
 /** Simple sliding window moving average filter.
  *
  * Essentially just takes takes the average of the last window_size values and pushes them out

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -262,6 +262,14 @@ sensor:
           window_size: 5
           send_every: 5
           send_first_at: 3
+      - min:
+          window_size: 5
+          send_every: 5
+          send_first_at: 3
+      - max:
+          window_size: 5
+          send_every: 5
+          send_first_at: 3
       - sliding_window_moving_average:
           window_size: 15
           send_every: 15


### PR DESCRIPTION
# What does this implement/fix? 

Adds new sensor filters to calculate the moving min or max over the data. This filter works similarly to the `median` filter, but it uses `std::min_element()` and `std::max_element()` to get the extrema values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1032
  
# Test Environment

- [x] ESP32
- [x] ESP8266
- [ ] Windows
- [x] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: wifi_signal
    # ...
    filters:
      - min:
          window_size: 7
          send_every: 4
          send_first_at: 3
```

```yaml
# Example config.yaml
sensor:
  - platform: wifi_signal
    # ...
    filters:
      - max:
          window_size: 7
          send_every: 4
          send_first_at: 3
```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.

While there isn't an issue for it, I have seen this sort of filter requested on the ESPHome subreddit. I have also needed it for mic adc input, and I know it could be useful for other adc sensors which can have quick spikes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
