### PR TITLE
Improve error checking: too many component id candidates

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -320,6 +320,8 @@ def command_config(args, config):
 def command_vscode(args):
     from esphome import vscode
 
+    logging.disable(logging.INFO)
+    logging.disable(logging.WARNING)
     CORE.config_path = args.configuration[0]
     vscode.read_config(args)
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -389,15 +389,21 @@ def do_id_pass(result):  # type: (Config) -> None
                 )
 
         if id.id is None and id.type is not None:
+            matches = []
             for v in declare_ids:
                 if v[0] is None or not isinstance(v[0].type, MockObjClass):
                     continue
                 inherits = v[0].type.inherits_from(id.type)
                 if inherits:
-                    id.id = v[0].id
-                    break
-            else:
+                    matches.append(v[0].id)
+
+            if len(matches) == 0:
                 result.add_str_error(f"Couldn't resolve ID for type '{id.type}'", path)
+            elif len(matches) == 1:
+                id.id = matches[0]
+            elif len(matches) > 1:
+                result.add_str_error(
+                    f"Too many candidates found for '{path[-1]}' type '{id.type}' Some are '{matches[0]}' and '{matches[1]}'", path)
 
 
 def recursive_check_replaceme(value):

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -144,9 +144,13 @@ mqtt:
             - uart.write:
                 id: uart0
                 data: Hello World
-            - uart.write: [0x00, 0x20, 0x30]
-            - uart.write: !lambda |-
-                return {};
+            - uart.write:
+                id: uart0
+                data: [0x00, 0x20, 0x30]
+            - uart.write:
+                id: uart0
+                data: !lambda |-
+                  return {};
 
 i2c:
   sda: 21
@@ -469,7 +473,7 @@ sensor:
       name: 'HLW8012 Power'
       id: hlw8012_power
     energy:
-      name: "HLW8012 Energy"
+      name: 'HLW8012 Energy'
       id: hlw8012_energy
     update_interval: 15s
     current_resistor: 0.001 ohm
@@ -583,6 +587,7 @@ sensor:
     reference_resistance: '430 Ω'
     rtd_nominal_resistance: '100 Ω'
   - platform: mhz19
+    uart_id: uart0
     co2:
       name: 'MH-Z19 CO2 Value'
     temperature:
@@ -648,25 +653,27 @@ sensor:
     name: Pulse Width
     pin: GPIO12
   - platform: senseair
+    uart_id: uart0
     co2:
       name: 'SenseAir CO2 Value'
     update_interval: 15s
   - platform: sm300d2
+    uart_id: uart0
     co2:
-      name: "SM300D2 CO2 Value"
+      name: 'SM300D2 CO2 Value'
     formaldehyde:
-      name: "SM300D2 Formaldehyde Value"    
+      name: 'SM300D2 Formaldehyde Value'
     tvoc:
-      name: "SM300D2 TVOC Value"
+      name: 'SM300D2 TVOC Value'
     pm_2_5:
-      name: "SM300D2 PM2.5 Value"
+      name: 'SM300D2 PM2.5 Value'
     pm_10_0:
-      name: "SM300D2 PM10 Value"
+      name: 'SM300D2 PM10 Value'
     temperature:
-      name: "SM300D2 Temperature Value"
+      name: 'SM300D2 Temperature Value'
     humidity:
-      name: "SM300D2 Humidity Value"   
-    update_interval: 60s    
+      name: 'SM300D2 Humidity Value'
+    update_interval: 60s
   - platform: sht3xd
     temperature:
       name: 'Living Room Temperature 8'
@@ -785,6 +792,7 @@ sensor:
             root["key"] = id(the_sensor).state;
             root["greeting"] = "Hello World";
   - platform: sds011
+    uart_id: uart0
     pm_2_5:
       name: 'SDS011 PM2.5'
     pm_10_0:
@@ -834,6 +842,7 @@ sensor:
       name: 'AQI'
       calculation_type: 'CAQI'
   - platform: teleinfo
+    uart_id: uart0
     tags:
       - tag_name: 'HCHC'
         sensor:
@@ -1007,6 +1016,7 @@ binary_sensor:
           id: gpio_19
           frequency: !lambda 'return 500.0;'
   - platform: pn532
+    pn532_id: pn532_bs
     uid: 74-10-37-94
     name: 'PN532 NFC Tag'
   - platform: rdm6300
@@ -1518,7 +1528,7 @@ switch:
     turn_on_action:
       remote_transmitter.transmit_samsung36:
         address: 0x0400
-        command: 0x000E00FF      
+        command: 0x000E00FF
   - platform: template
     name: Sony
     turn_on_action:
@@ -1653,12 +1663,15 @@ switch:
           id: my_switch
           state: !lambda 'return false;'
   - platform: uart
+    uart_id: uart0
     name: 'UART String Output'
     data: 'DataToSend'
   - platform: uart
+    uart_id: uart0
     name: 'UART Bytes Output'
     data: [0xDE, 0xAD, 0xBE, 0xEF]
   - platform: uart
+    uart_id: uart0
     name: 'UART Recurring Output'
     data: [0xDE, 0xAD, 0xBE, 0xEF]
     send_every: 1s
@@ -1774,6 +1787,7 @@ display:
     lambda: |-
       it.print("1234");
   - platform: nextion
+    uart_id: uart0
     lambda: |-
       it.set_component_value("gauge", 50);
       it.set_component_text("textview", "Hello World!");
@@ -1901,6 +1915,7 @@ status_led:
   pin: GPIO2
 
 pn532_spi:
+  id: pn532_bs
   cs_pin: GPIO23
   update_interval: 1s
   on_tag:
@@ -1913,6 +1928,7 @@ pn532_spi:
 pn532_i2c:
 
 rdm6300:
+  uart_id: uart0
 
 rc522_spi:
   cs_pin: GPIO23
@@ -1928,6 +1944,7 @@ rc522_i2c:
         ESP_LOGD("main", "Found tag %s", x.c_str());
 
 gps:
+  uart_id: uart0
 
 time:
   - platform: sntp

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -197,10 +197,6 @@ uart:
     rx_pin: GPIO3
     baud_rate: 115200
 
-  - id: adalight_uart
-    rx_pin: GPIO3
-    baud_rate: 115200
-
 ota:
   safe_mode: True
   port: 3286
@@ -814,7 +810,6 @@ light:
     effects:
       - wled:
       - adalight:
-          uart_id: adalight_uart
       - e131:
           universe: 1
   - platform: hbridge


### PR DESCRIPTION
# What does this implement/fix? 

Still more yaml validation, I want community feedback to push this one, it will break (or fix) current configurations, in fact tests don't pass as is.

![image](https://user-images.githubusercontent.com/96162/109556881-2054d880-7ab6-11eb-84b9-2d02df7f71e0.png)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [x] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

This will ensure that when you omit specifying a component id on a component which accepts id `cv.use_id` there is only one valid option, otherwise it will complain with the message in the screenshot and fail validation.

Other option could be issuing just a warning (need to add warning outputs mechanism) 

I guess this can prevent a few mistakes here and there, note that in the case of the image, without this check, ESPHome will accept this configuration and assign `output_cw` to `warm_white` because it's the first float output defined. This will result off course in an unexpected behavior.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
