### PR TITLE
Modbus sensor

### DIFF
--- a/esphome/components/modbus_sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_sensor/modbus_sensor.cpp
@@ -19,7 +19,7 @@ void ModbusSensor::set_sensor_length(uint8_t length) {
 void ModbusSensor::on_modbus_data(const std::vector<uint8_t> &data) {
   // Skip if data size doesn't mach the expected size
   if (data.size() != this->response_size_) {
-    ESP_LOGV(TAG, "Skip data - size %d - expected size: %d", data.size(), this->response_size_);
+    ESP_LOGV(TAG, "Skip data - size %lu - expected size: %d", data.size(), this->response_size_);
     return;
   }
 

--- a/esphome/components/modbus_sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_sensor/modbus_sensor.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace modbus_sensor {
 
-static const char *TAG = "modbus_sensor";
+static const char *TAG = "modbus.sensor";
 
 void ModbusSensor::set_sensor_length(uint8_t length) {
   sensors_length_.push_back(length);

--- a/esphome/components/modbus_sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_sensor/modbus_sensor.cpp
@@ -62,7 +62,7 @@ void ModbusSensor::dump_config() {
     } else if (this->registers_[i].register_type == REGISTER_TYPE_32BIT_REVERSED) {
       register_type = "32bit_reversed";
     } else {
-          register_type = "";
+      register_type = "";
     }
     ESP_LOGCONFIG(TAG, "  Sensor %d:", i);
     ESP_LOGCONFIG(TAG, "    Register type: %s", register_type);

--- a/esphome/components/modbus_sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_sensor/modbus_sensor.cpp
@@ -6,15 +6,13 @@ namespace modbus_sensor {
 
 static const char *TAG = "modbus_sensor";
 
-
 void ModbusSensor::set_sensor_length(uint8_t length) {
   sensors_length_.push_back(length);
   this->response_size_ = 0;
-  for (int i = 0 ; i < this->sensors_.size(); i++) {
+  for (int i = 0; i < this->sensors_.size(); i++) {
     this->response_size_ += this->sensors_length_[i] * 2;
   }
 }
-
 
 void ModbusSensor::on_modbus_data(const std::vector<uint8_t> &data) {
   // Skip if data size doesn't mach the expected size
@@ -35,12 +33,12 @@ void ModbusSensor::on_modbus_data(const std::vector<uint8_t> &data) {
 
   uint16_t value;
   uint16_t start = 0;
-  for (uint16_t i = 0 ; i < this->sensors_.size(); i++) {
-    if ( this->sensors_length_[i] == 1 ) {
+  for (uint16_t i = 0; i < this->sensors_.size(); i++) {
+    if (this->sensors_length_[i] == 1) {
       value = get_16bit_value(start);
       this->sensors_[i]->publish_state(value);
     }
-    else if ( this->sensors_length_[i] == 2 ) {
+    else if (this->sensors_length_[i] == 2) {
       if (this->sensors_reverse_order_[i]) {
         value = get_32bit_value_reverse(start);
       } else {
@@ -51,7 +49,6 @@ void ModbusSensor::on_modbus_data(const std::vector<uint8_t> &data) {
 
     start += this->sensors_length_[i] * 2;
   }
-
 }
 
 void ModbusSensor::dump_config() {
@@ -59,8 +56,8 @@ void ModbusSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "  Address: %d", this->address_);
   ESP_LOGCONFIG(TAG, "  Register: %d", this->register_);
   const char *reverse_order;
-  for (uint16_t i = 0 ; i < this->sensors_.size(); i++) {
-    if ( this->sensors_reverse_order_[i] ) {
+  for (uint16_t i = 0; i < this->sensors_.size(); i++) {
+    if (this->sensors_reverse_order_[i]) {
       reverse_order = "true";
     } else {
       reverse_order = "false";

--- a/esphome/components/modbus_sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_sensor/modbus_sensor.cpp
@@ -56,7 +56,20 @@ void ModbusSensor::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void ModbusSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "ModbusSensor:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "  Address: %d", this->address_);
+  ESP_LOGCONFIG(TAG, "  Register: %d", this->register_);
+  const char *reverse_order;
+  for (uint16_t i = 0 ; i < this->sensors_.size(); i++) {
+    if ( this->sensors_reverse_order_[i] ) {
+      reverse_order = "true";
+    } else {
+      reverse_order = "false";
+    }
+    ESP_LOGCONFIG(TAG, "  Sensor %d:", i);
+    ESP_LOGCONFIG(TAG, "    Lenght: %d", this->sensors_length_[i]);
+    ESP_LOGCONFIG(TAG, "    Reverse order: %s", reverse_order);
+    LOG_SENSOR("  ", "  Name: ", this->sensors_[i]);
+  }
 }
 
 }  // namespace modbus_sensor

--- a/esphome/components/modbus_sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_sensor/modbus_sensor.cpp
@@ -37,8 +37,7 @@ void ModbusSensor::on_modbus_data(const std::vector<uint8_t> &data) {
     if (this->sensors_length_[i] == 1) {
       value = get_16bit_value(start);
       this->sensors_[i]->publish_state(value);
-    }
-    else if (this->sensors_length_[i] == 2) {
+    } else if (this->sensors_length_[i] == 2) {
       if (this->sensors_reverse_order_[i]) {
         value = get_32bit_value_reverse(start);
       } else {

--- a/esphome/components/modbus_sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_sensor/modbus_sensor.cpp
@@ -1,0 +1,63 @@
+#include "modbus_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace modbus_sensor {
+
+static const char *TAG = "modbus_sensor";
+
+
+void ModbusSensor::set_sensor_length(uint8_t length) {
+  sensors_length_.push_back(length);
+  this->response_size_ = 0;
+  for (int i = 0 ; i < this->sensors_.size(); i++) {
+    this->response_size_ += this->sensors_length_[i] * 2;
+  }
+}
+
+
+void ModbusSensor::on_modbus_data(const std::vector<uint8_t> &data) {
+  // Skip if data size doesn't mach the expected size
+  if (data.size() != this->response_size_) {
+    ESP_LOGV(TAG, "Skip data - size %d - expected size: %d", data.size(), this->response_size_);
+    return;
+  }
+
+  auto get_16bit_value = [&](size_t i) -> uint16_t {
+    return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
+  };
+  auto get_32bit_value = [&](size_t i) -> uint32_t {
+    return (uint32_t(get_16bit_value(i + 2)) << 16) | (uint32_t(get_16bit_value(i + 0)) << 0);
+  };
+  auto get_32bit_value_reverse = [&](size_t i) -> uint32_t {
+    return (uint32_t(get_16bit_value(i + 0)) << 16) | (uint32_t(get_16bit_value(i + 2)) << 0);
+  };
+
+  uint16_t value;
+  uint16_t start = 0;
+  for (uint16_t i = 0 ; i < this->sensors_.size(); i++) {
+    if ( this->sensors_length_[i] == 1 ) {
+      value = get_16bit_value(start);
+      this->sensors_[i]->publish_state(value);
+    }
+    else if ( this->sensors_length_[i] == 2 ) {
+      if (this->sensors_reverse_order_[i]) {
+        value = get_32bit_value_reverse(start);
+      } else {
+        value = get_32bit_value(start);
+      }
+      this->sensors_[i]->publish_state(value);
+    }
+
+    start += this->sensors_length_[i] * 2;
+  }
+
+}
+
+void ModbusSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "ModbusSensor:");
+  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+}
+
+}  // namespace modbus_sensor
+}  // namespace esphome

--- a/esphome/components/modbus_sensor/modbus_sensor.h
+++ b/esphome/components/modbus_sensor/modbus_sensor.h
@@ -9,25 +9,34 @@ namespace modbus_sensor {
 
 static const uint8_t READ_REGISTERS_FUNCTION = 0x04;
 
+enum RegisterType {
+  REGISTER_TYPE_16BIT,
+  REGISTER_TYPE_32BIT,
+  REGISTER_TYPE_32BIT_REVERSED
+};
+
+struct Register
+{
+  sensor::Sensor *sensor;
+  RegisterType register_type;
+};
+
 class ModbusSensor : public PollingComponent, public modbus::ModbusDevice {
  public:
-  void set_sensor(sensor::Sensor *sensor) { sensors_.push_back(sensor); }
-  void set_sensor_reverse_order(bool reverse_order) { sensors_reverse_order_.push_back(reverse_order); }
-  void set_register(uint16_t register_address) { this->register_ = register_address; }
+  void set_register_address(uint16_t register_address) { this->register_address_ = register_address; }
   void set_register_count(uint16_t register_count) { this->register_count_ = register_count; }
-  void update() override { this->send(READ_REGISTERS_FUNCTION, register_, register_count_); }
+  void update() override { this->send(READ_REGISTERS_FUNCTION, register_address_, register_count_); }
 
-  void set_sensor_length(uint8_t length);
+  void set_sensor(sensor::Sensor *sensor, RegisterType register_type);
   void on_modbus_data(const std::vector<uint8_t> &data) override;
   void dump_config() override;
 
  protected:
-  std::vector<sensor::Sensor *> sensors_;
+  std::vector<Register> registers_;
   std::vector<uint8_t> sensors_length_;
   std::vector<bool> sensors_reverse_order_;
-  uint16_t register_;
-  uint16_t register_count_;
-  uint16_t response_size_;
+  uint16_t register_address_;
+  uint16_t register_count_ = 0;
 };
 
 }  // namespace modbus_sensor

--- a/esphome/components/modbus_sensor/modbus_sensor.h
+++ b/esphome/components/modbus_sensor/modbus_sensor.h
@@ -9,14 +9,9 @@ namespace modbus_sensor {
 
 static const uint8_t READ_REGISTERS_FUNCTION = 0x04;
 
-enum RegisterType {
-  REGISTER_TYPE_16BIT,
-  REGISTER_TYPE_32BIT,
-  REGISTER_TYPE_32BIT_REVERSED
-};
+enum RegisterType { REGISTER_TYPE_16BIT, REGISTER_TYPE_32BIT, REGISTER_TYPE_32BIT_REVERSED };
 
-struct Register
-{
+struct Register {
   sensor::Sensor *sensor;
   RegisterType register_type;
 };

--- a/esphome/components/modbus_sensor/modbus_sensor.h
+++ b/esphome/components/modbus_sensor/modbus_sensor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/modbus/modbus.h"
+
+namespace esphome {
+namespace modbus_sensor {
+
+static const uint8_t READ_REGISTERS_FUNCTION = 0x04;
+
+class ModbusSensor : public PollingComponent, public modbus::ModbusDevice {
+  public:
+    void set_sensor(sensor::Sensor *sensor) { sensors_.push_back(sensor); }
+    void set_sensor_reverse_order(bool reverse_order) { sensors_reverse_order_.push_back(reverse_order); }
+    void set_register(uint16_t register_address) { this->register_ = register_address; }
+    void set_register_count(uint16_t register_count) { this->register_count_ = register_count; }
+    void update() override { this->send(READ_REGISTERS_FUNCTION, register_, register_count_); }
+
+    void set_sensor_length(uint8_t length);
+    void on_modbus_data(const std::vector<uint8_t> &data) override;
+    void dump_config() override;
+
+  protected:
+    std::vector<sensor::Sensor*> sensors_;
+    std::vector<uint8_t> sensors_length_;
+    std::vector<bool> sensors_reverse_order_;
+    uint16_t register_;
+    uint16_t register_count_;
+    uint16_t response_size_;
+};
+
+}  // namespace modbus_sensor
+}  // namespace esphome

--- a/esphome/components/modbus_sensor/modbus_sensor.h
+++ b/esphome/components/modbus_sensor/modbus_sensor.h
@@ -10,24 +10,24 @@ namespace modbus_sensor {
 static const uint8_t READ_REGISTERS_FUNCTION = 0x04;
 
 class ModbusSensor : public PollingComponent, public modbus::ModbusDevice {
-  public:
-    void set_sensor(sensor::Sensor *sensor) { sensors_.push_back(sensor); }
-    void set_sensor_reverse_order(bool reverse_order) { sensors_reverse_order_.push_back(reverse_order); }
-    void set_register(uint16_t register_address) { this->register_ = register_address; }
-    void set_register_count(uint16_t register_count) { this->register_count_ = register_count; }
-    void update() override { this->send(READ_REGISTERS_FUNCTION, register_, register_count_); }
+public:
+  void set_sensor(sensor::Sensor *sensor) { sensors_.push_back(sensor); }
+  void set_sensor_reverse_order(bool reverse_order) { sensors_reverse_order_.push_back(reverse_order); }
+  void set_register(uint16_t register_address) { this->register_ = register_address; }
+  void set_register_count(uint16_t register_count) { this->register_count_ = register_count; }
+  void update() override { this->send(READ_REGISTERS_FUNCTION, register_, register_count_); }
 
-    void set_sensor_length(uint8_t length);
-    void on_modbus_data(const std::vector<uint8_t> &data) override;
-    void dump_config() override;
+  void set_sensor_length(uint8_t length);
+  void on_modbus_data(const std::vector<uint8_t> &data) override;
+  void dump_config() override;
 
-  protected:
-    std::vector<sensor::Sensor*> sensors_;
-    std::vector<uint8_t> sensors_length_;
-    std::vector<bool> sensors_reverse_order_;
-    uint16_t register_;
-    uint16_t register_count_;
-    uint16_t response_size_;
+protected:
+  std::vector<sensor::Sensor*> sensors_;
+  std::vector<uint8_t> sensors_length_;
+  std::vector<bool> sensors_reverse_order_;
+  uint16_t register_;
+  uint16_t register_count_;
+  uint16_t response_size_;
 };
 
 }  // namespace modbus_sensor

--- a/esphome/components/modbus_sensor/modbus_sensor.h
+++ b/esphome/components/modbus_sensor/modbus_sensor.h
@@ -10,7 +10,7 @@ namespace modbus_sensor {
 static const uint8_t READ_REGISTERS_FUNCTION = 0x04;
 
 class ModbusSensor : public PollingComponent, public modbus::ModbusDevice {
-public:
+ public:
   void set_sensor(sensor::Sensor *sensor) { sensors_.push_back(sensor); }
   void set_sensor_reverse_order(bool reverse_order) { sensors_reverse_order_.push_back(reverse_order); }
   void set_register(uint16_t register_address) { this->register_ = register_address; }
@@ -21,7 +21,7 @@ public:
   void on_modbus_data(const std::vector<uint8_t> &data) override;
   void dump_config() override;
 
-protected:
+ protected:
   std::vector<sensor::Sensor*> sensors_;
   std::vector<uint8_t> sensors_length_;
   std::vector<bool> sensors_reverse_order_;

--- a/esphome/components/modbus_sensor/modbus_sensor.h
+++ b/esphome/components/modbus_sensor/modbus_sensor.h
@@ -22,7 +22,7 @@ class ModbusSensor : public PollingComponent, public modbus::ModbusDevice {
   void dump_config() override;
 
  protected:
-  std::vector<sensor::Sensor*> sensors_;
+  std::vector<sensor::Sensor *> sensors_;
   std::vector<uint8_t> sensors_length_;
   std::vector<bool> sensors_reverse_order_;
   uint16_t register_;

--- a/esphome/components/modbus_sensor/sensor.py
+++ b/esphome/components/modbus_sensor/sensor.py
@@ -1,8 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, modbus
-from esphome.const import CONF_ID, CONF_LENGTH, CONF_SENSORS, \
-    DEVICE_CLASS_EMPTY, ICON_EMPTY, UNIT_EMPTY
+from esphome.const import CONF_ID, CONF_SENSORS, DEVICE_CLASS_EMPTY, ICON_EMPTY, UNIT_EMPTY
 
 
 modbus_sensor_ns = cg.esphome_ns.namespace('modbus_sensor')

--- a/esphome/components/modbus_sensor/sensor.py
+++ b/esphome/components/modbus_sensor/sensor.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, modbus
+from esphome.const import CONF_ID, CONF_LENGTH, CONF_SENSORS, DEVICE_CLASS_EMPTY, ICON_EMPTY, UNIT_EMPTY
+
+
+AUTO_LOAD = ['modbus']
+
+CONF_REGISTER = 'register'
+CONF_REVERSE_ORDER = ' reverse_order'
+
+modbus_sensor_ns = cg.esphome_ns.namespace('modbus_sensor')
+ModbusSensor = modbus_sensor_ns.class_('ModbusSensor', cg.PollingComponent, modbus.ModbusDevice)
+
+
+REGISTER_SCHEMA = cv.Schema({
+    cv.Optional(CONF_LENGTH, default=1): cv.int_range(min=1, max=2),
+    cv.Optional(CONF_REVERSE_ORDER, default=False): cv.boolean,
+}).extend(sensor.sensor_schema(UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY))
+
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(ModbusSensor),
+    cv.Required(CONF_REGISTER): cv.hex_uint16_t,
+    cv.Required(CONF_SENSORS): cv.All(cv.ensure_list(REGISTER_SCHEMA), cv.Length(min=1)),
+}).extend(cv.polling_component_schema('60s')).extend(modbus.modbus_device_schema(0x01))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield modbus.register_modbus_device(var, config)
+    cg.add(var.set_register(config[CONF_REGISTER]))
+    register_count = 0
+    for sensor_config in config[CONF_SENSORS]:
+        register_count += sensor_config[CONF_LENGTH]
+        sens = yield sensor.new_sensor(sensor_config)
+        cg.add(var.set_sensor(sens))
+        cg.add(var.set_sensor_length(sensor_config[CONF_LENGTH]))
+        cg.add(var.set_sensor_reverse_order(sensor_config[CONF_REVERSE_ORDER]))
+    cg.add(var.set_register_count(register_count))

--- a/esphome/components/modbus_sensor/sensor.py
+++ b/esphome/components/modbus_sensor/sensor.py
@@ -5,24 +5,32 @@ from esphome.const import CONF_ID, CONF_LENGTH, CONF_SENSORS, \
     DEVICE_CLASS_EMPTY, ICON_EMPTY, UNIT_EMPTY
 
 
-AUTO_LOAD = ['modbus']
-
-CONF_REGISTER = 'register'
-CONF_REVERSE_ORDER = 'reverse_order'
-
 modbus_sensor_ns = cg.esphome_ns.namespace('modbus_sensor')
 ModbusSensor = modbus_sensor_ns.class_('ModbusSensor', cg.PollingComponent, modbus.ModbusDevice)
 
+AUTO_LOAD = ['modbus']
+
+CONF_REGISTER_ADDRESS = 'register_address'
+CONF_REGISTER_TYPE = 'register_type'
+CONF_REVERSE_ORDER = 'reverse_order'
+
+
+RegisterType = modbus_sensor_ns.enum('RegisterType')
+REGISTER_TYPES = {
+    '16bit': RegisterType.REGISTER_TYPE_16BIT,
+    '32bit': RegisterType.REGISTER_TYPE_32BIT,
+    '32bit_reversed': RegisterType.REGISTER_TYPE_32BIT_REVERSED,
+}
+
 
 REGISTER_SCHEMA = cv.Schema({
-    cv.Optional(CONF_LENGTH, default=1): cv.int_range(min=1, max=2),
-    cv.Optional(CONF_REVERSE_ORDER, default=False): cv.boolean,
+    cv.Optional(CONF_REGISTER_TYPE, default='16bit'): cv.enum(REGISTER_TYPES),
 }).extend(sensor.sensor_schema(UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY))
 
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(ModbusSensor),
-    cv.Required(CONF_REGISTER): cv.hex_uint16_t,
+    cv.Required(CONF_REGISTER_ADDRESS): cv.hex_uint16_t,
     cv.Required(CONF_SENSORS): cv.All(cv.ensure_list(REGISTER_SCHEMA), cv.Length(min=1)),
 }).extend(cv.polling_component_schema('60s')).extend(modbus.modbus_device_schema(0x01))
 
@@ -31,12 +39,7 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     yield modbus.register_modbus_device(var, config)
-    cg.add(var.set_register(config[CONF_REGISTER]))
-    register_count = 0
+    cg.add(var.set_register_address(config[CONF_REGISTER_ADDRESS]))
     for sensor_config in config[CONF_SENSORS]:
-        register_count += sensor_config[CONF_LENGTH]
         sens = yield sensor.new_sensor(sensor_config)
-        cg.add(var.set_sensor(sens))
-        cg.add(var.set_sensor_length(sensor_config[CONF_LENGTH]))
-        cg.add(var.set_sensor_reverse_order(sensor_config[CONF_REVERSE_ORDER]))
-    cg.add(var.set_register_count(register_count))
+        cg.add(var.set_sensor(sens, sensor_config[CONF_REGISTER_TYPE]))

--- a/esphome/components/modbus_sensor/sensor.py
+++ b/esphome/components/modbus_sensor/sensor.py
@@ -7,7 +7,7 @@ from esphome.const import CONF_ID, CONF_LENGTH, CONF_SENSORS, DEVICE_CLASS_EMPTY
 AUTO_LOAD = ['modbus']
 
 CONF_REGISTER = 'register'
-CONF_REVERSE_ORDER = ' reverse_order'
+CONF_REVERSE_ORDER = 'reverse_order'
 
 modbus_sensor_ns = cg.esphome_ns.namespace('modbus_sensor')
 ModbusSensor = modbus_sensor_ns.class_('ModbusSensor', cg.PollingComponent, modbus.ModbusDevice)

--- a/esphome/components/modbus_sensor/sensor.py
+++ b/esphome/components/modbus_sensor/sensor.py
@@ -1,7 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, modbus
-from esphome.const import CONF_ID, CONF_LENGTH, CONF_SENSORS, DEVICE_CLASS_EMPTY, ICON_EMPTY, UNIT_EMPTY
+from esphome.const import CONF_ID, CONF_LENGTH, CONF_SENSORS, \
+    DEVICE_CLASS_EMPTY, ICON_EMPTY, UNIT_EMPTY
 
 
 AUTO_LOAD = ['modbus']


### PR DESCRIPTION
# What does this implement/fix? 

A generic modbus sensor that can be configured to read a lot of currently unsupported modbus devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
This configuration mimics the already existing pzemac component.
```yaml
# Example config.yaml
uart:
  rx_pin: GPIO16
  tx_pin: GPIO17
  baud_rate: 9600

sensor:
  - platform: modbus_sensor
    address: 1
    register: 0
    sensors:
      - name: voltage
        unit_of_measurement: V
        device_class: voltage
        accuracy_decimals: 1
        filters:
          multiply: 0.1
      - name: current
        register_type: 32bit
        unit_of_measurement: A
        device_class: current
        accuracy_decimals: 3
        filters:
          multiply: 0.001
      - name: power
        register_type: 32bit
        unit_of_measurement: W
        device_class: power
        accuracy_decimals: 1
        filters:
          multiply: 0.1
      - name: energy
        register_type: 32bit
        unit_of_measurement: Wh
        device_class: energy
        accuracy_decimals: 0
      - name: frequency
        unit_of_measurement: Hz
        accuracy_decimals: 1
        filters:
          multiply: 0.1
      - name: power_factor
        device_class: power_factor
        accuracy_decimals: 2
        filters:
          multiply: 0.01
```

# Explain your changes

I wrote this component for my own use.  
If you think it may be useful to someone else out there, I'll try to improve it and add some documentation.
I'll use it as a test bench for the next step: a component for the Eastron SDM family (SDM120, SDM220, SD630)
There's already some effort ( #745 ) but unluckily it supports the only sensor that I don't need !  ;-) 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
