### PR TITLE
fix path on windows escape

### DIFF
--- a/esphome/core.py
+++ b/esphome/core.py
@@ -339,7 +339,8 @@ class DocumentLocation:
 
     @property
     def as_line_directive(self):
-        return f'#line {self.line + 1} "{self.document}"'
+        document_path = str(self.document).replace('\\', '\\\\')
+        return f'#line {self.line + 1} "{document_path}"'
 
 
 class DocumentRange:


### PR DESCRIPTION
# What does this implement/fix? 

if doc name contains '\' for some reason this causes compilation to fail as the line directive get't malformed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [x] Windows
- [ ] Mac OS
- [ ] Linux

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
