### PR TITLE
Extend 'uart:' with 'invert:' for esp32

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
 from esphome.const import CONF_BAUD_RATE, CONF_ID, CONF_RX_PIN, CONF_TX_PIN, CONF_UART_ID, \
-    CONF_DATA, CONF_RX_BUFFER_SIZE
+    CONF_DATA, CONF_RX_BUFFER_SIZE, CONF_INVERT
 from esphome.core import CORE, coroutine
 
 CODEOWNERS = ['@esphome/core']
@@ -47,6 +47,8 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
     cv.Optional(CONF_TX_PIN): pins.output_pin,
     cv.Optional(CONF_RX_PIN): validate_rx_pin,
     cv.Optional(CONF_RX_BUFFER_SIZE, default=256): cv.validate_bytes,
+    cv.SplitDefault(CONF_INVERT, esp32=False): cv.All(cv.only_on_esp32,
+                                                      cv.boolean),
     cv.Optional(CONF_STOP_BITS, default=1): cv.one_of(1, 2, int=True),
     cv.Optional(CONF_DATA_BITS, default=8): cv.int_range(min=5, max=8),
     cv.Optional(CONF_PARITY, default="NONE"): cv.enum(UART_PARITY_OPTIONS, upper=True)
@@ -65,6 +67,8 @@ def to_code(config):
     if CONF_RX_PIN in config:
         cg.add(var.set_rx_pin(config[CONF_RX_PIN]))
     cg.add(var.set_rx_buffer_size(config[CONF_RX_BUFFER_SIZE]))
+    if CONF_INVERT in config:
+        cg.add(var.set_invert(config[CONF_INVERT]))
     cg.add(var.set_stop_bits(config[CONF_STOP_BITS]))
     cg.add(var.set_data_bits(config[CONF_DATA_BITS]))
     cg.add(var.set_parity(config[CONF_PARITY]))

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -90,6 +90,7 @@ class UARTComponent : public Component, public Stream {
   void set_tx_pin(uint8_t tx_pin) { this->tx_pin_ = tx_pin; }
   void set_rx_pin(uint8_t rx_pin) { this->rx_pin_ = rx_pin; }
   void set_rx_buffer_size(size_t rx_buffer_size) { this->rx_buffer_size_ = rx_buffer_size; }
+  void set_invert(bool invert) { this->invert_ = invert; }
   void set_stop_bits(uint8_t stop_bits) { this->stop_bits_ = stop_bits; }
   void set_data_bits(uint8_t data_bits) { this->data_bits_ = data_bits; }
   void set_parity(UARTParityOptions parity) { this->parity_ = parity; }
@@ -106,6 +107,7 @@ class UARTComponent : public Component, public Stream {
   optional<uint8_t> tx_pin_;
   optional<uint8_t> rx_pin_;
   size_t rx_buffer_size_;
+  bool invert_;
   uint32_t baud_rate_;
   uint8_t stop_bits_;
   uint8_t data_bits_;

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -90,7 +90,9 @@ class UARTComponent : public Component, public Stream {
   void set_tx_pin(uint8_t tx_pin) { this->tx_pin_ = tx_pin; }
   void set_rx_pin(uint8_t rx_pin) { this->rx_pin_ = rx_pin; }
   void set_rx_buffer_size(size_t rx_buffer_size) { this->rx_buffer_size_ = rx_buffer_size; }
+#ifdef ARDUINO_ARCH_ESP32
   void set_invert(bool invert) { this->invert_ = invert; }
+#endif
   void set_stop_bits(uint8_t stop_bits) { this->stop_bits_ = stop_bits; }
   void set_data_bits(uint8_t data_bits) { this->data_bits_ = data_bits; }
   void set_parity(UARTParityOptions parity) { this->parity_ = parity; }
@@ -107,7 +109,9 @@ class UARTComponent : public Component, public Stream {
   optional<uint8_t> tx_pin_;
   optional<uint8_t> rx_pin_;
   size_t rx_buffer_size_;
+#ifdef ARDUINO_ARCH_ESP32
   bool invert_;
+#endif
   uint32_t baud_rate_;
   uint8_t stop_bits_;
   uint8_t data_bits_;

--- a/esphome/components/uart/uart_esp32.cpp
+++ b/esphome/components/uart/uart_esp32.cpp
@@ -80,7 +80,7 @@ void UARTComponent::setup() {
   }
   int8_t tx = this->tx_pin_.has_value() ? *this->tx_pin_ : -1;
   int8_t rx = this->rx_pin_.has_value() ? *this->rx_pin_ : -1;
-  this->hw_serial_->begin(this->baud_rate_, get_config(), rx, tx);
+  this->hw_serial_->begin(this->baud_rate_, get_config(), rx, tx, this->invert_);
   this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
 }
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -169,6 +169,7 @@ uart:
     data_bits: 8
     stop_bits: 1
     rx_buffer_size: 512
+    invert: false
 
   - id: adalight_uart
     tx_pin: GPIO25


### PR DESCRIPTION
# What does this implement/fix? 

This allows to configure the uart data lines to be logically inverted.
Only possible in hardware for ESP32.
ESP8266 does not support inverting in hardware.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

**Related issue or feature (if applicable):** fixes [#1145](https://github.com/esphome/feature-requests/issues/1145)
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation:** esphome/esphome-docs#1039
  
# Test Environment
- [x] ESP32

## Example entry for `config.yaml`:
```yaml
uart:
  - rx_pin: GPIO21
    baud_rate: 115200
    id: p1_bus    
    invert: true
```

# Explain your changes

Sometimes uart peripherals have inverted logic levels (see linked issue).
This enables us to use those peripherals without hardware changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
