### PR TITLE
Receive long MQTT payload

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -25,9 +25,15 @@ void MQTTClientComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MQTT...");
   this->mqtt_client_.onMessage([this](char *topic, char *payload, AsyncMqttClientMessageProperties properties,
                                       size_t len, size_t index, size_t total) {
-    std::string payload_s(payload, len);
-    std::string topic_s(topic);
-    this->on_message(topic_s, payload_s);
+    // append new payload, may contain incomplete MQTT message
+    this->payload_s_.append(payload, len);
+
+    // MQTT fully received
+    if (len + index == total) {
+      std::string topic_s(topic);
+      this->on_message(topic_s, this->payload_s_);
+      this->payload_s_.clear();
+    }
   });
   this->mqtt_client_.onDisconnect([this](AsyncMqttClientDisconnectReason reason) {
     this->state_ = MQTT_CLIENT_DISCONNECTED;

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -35,7 +35,6 @@ void MQTTClientComponent::setup() {
     if (len + index == total) {
       this->on_message(topic, this->payload_buffer_);
       this->payload_buffer_.clear();
-      this->payload_buffer_.shrink_to_fit();
     }
   });
   this->mqtt_client_.onDisconnect([this](AsyncMqttClientDisconnectReason reason) {

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -250,6 +250,7 @@ class MQTTClientComponent : public Component {
   };
   std::string topic_prefix_{};
   MQTTMessage log_message_;
+  std::string payload_s_;
   int log_level_{ESPHOME_LOG_LEVEL};
 
   std::vector<MQTTSubscription> subscriptions_;

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -250,7 +250,7 @@ class MQTTClientComponent : public Component {
   };
   std::string topic_prefix_{};
   MQTTMessage log_message_;
-  std::string payload_s_;
+  std::string payload_buffer_;
   int log_level_{ESPHOME_LOG_LEVEL};
 
   std::vector<MQTTSubscription> subscriptions_;


### PR DESCRIPTION
# What does this implement/fix? 

MQTT fails when large message is delivered. Most noticeable with large JSON messages where JSON parsing then fails.

MQTT payload larger than TCP buffer will cause [AsyncMQTTClient to split payload contents into separate parts](https://github.com/marvinroger/async-mqtt-client/blob/master/docs/3.-Memory-management.md). 

The current ESPHome implementation assumes the whole payload will be delivered in one go 
https://github.com/esphome/esphome/blob/0f151a8f6bcf94d741b876d795c4a30648f924fe/esphome/components/mqtt/mqtt_client.cpp#L26-L31

This can be fixed by moving the payload_s variable to a class variable and only calling MQTTClientComponent::on_message(topic_s, payload_s) when the full payload is available.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

# Test Environment

- [x] ESP32
- [ ] ESP8266
- [x] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml - any standard MQTT setup will work 
mqtt:
  broker: !secret mqtt_broker
  username: !secret mqtt_username
  password: !secret mqtt_password
  on_json_message:
    - topic: test/data/
      then:
        logger.log: "JSON received"
```
Example long JSON message that causes error available here: https://pastebin.com/3DvKVeQR

**Logs:**
```
[18:37:06][D][main:174]: JSON received
[18:37:26][W][json:054]: Parsing JSON failed.
[18:37:26][W][json:054]: Parsing JSON failed.
```

# Explain your changes

ESPHome can't be used if large MQTT messages are sent. This has presented a problem in my project where large MQTT payloads are sent containing colour information for strings of neopixel lights arranged in a panel. The only alternative has been to chunk the MQTT payloads into smaller sections, which in turn causes problems with not being able to update the whole "frame" of pixels at one go.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
