### PR TITLE
Inkplate 6 Optimizations

### DIFF
--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -567,7 +567,7 @@ void Inkplate6::clean_fast_(uint8_t c, uint8_t rep) {
       hscan_start_(send);
       GPIO.out_w1ts = send | clock;
       GPIO.out_w1tc = clock;
-      for (int j = 0, jm =  this->get_width_internal() / 8; j < jm; j++) {
+      for (int j = 0, jm = this->get_width_internal() / 8; j < jm; j++) {
         GPIO.out_w1ts = clock;
         GPIO.out_w1tc = clock;
         GPIO.out_w1ts = clock;


### PR DESCRIPTION
# What does this implement/fix? 

The Inkplate 6 driver uses a bit-banged parallel protocol to update the display.  Right now, the inner loops involve a decent amount of calculation, both explicit and from things like indirect function calls.  This PR just lifts most of that out of the inner loops.  The result is a very significant speedup in the update rate for relatively little changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

# Explain your changes

The speedup in updating is huge and has a noticeable impact on the display.  Without the changes, you can see the full update scan repeatedly moving across the display.  With it, it's just a brief flicker.  Anecdotally, the partial update also seems to have less ghosting effects.

From my testing, the average of three updates:
|        | Partial Update | B/W Full Update | Greyscale Full Update |
| ------ | -------------- | --------------- | --------------------- |
| Before | 1253ms         | 4995ms          | 7459ms                |
| After  | 382ms          | 970ms           | 1488ms                |

There's probably more that could be done to make the update faster, but for the small amount of changes required, the gain from this is significant.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
