### PR TITLE
a4988 wait 1ms when coming out of sleep

### DIFF
--- a/esphome/components/a4988/a4988.cpp
+++ b/esphome/components/a4988/a4988.cpp
@@ -11,6 +11,7 @@ void A4988::setup() {
   if (this->sleep_pin_ != nullptr) {
     this->sleep_pin_->setup();
     this->sleep_pin_->digital_write(false);
+    this->sleep_pin_state_ = false;
   }
   this->step_pin_->setup();
   this->step_pin_->digital_write(false);
@@ -27,7 +28,12 @@ void A4988::dump_config() {
 void A4988::loop() {
   bool at_target = this->has_reached_target();
   if (this->sleep_pin_ != nullptr) {
+    bool sleep_rising_edge = !sleep_pin_state_ & !at_target;
     this->sleep_pin_->digital_write(!at_target);
+    this->sleep_pin_state_ = !at_target;
+    if (sleep_rising_edge) {
+      delayMicroseconds(1000);
+    }
   }
   if (at_target) {
     this->high_freq_.stop();

--- a/esphome/components/a4988/a4988.h
+++ b/esphome/components/a4988/a4988.h
@@ -21,6 +21,7 @@ class A4988 : public stepper::Stepper, public Component {
   GPIOPin *step_pin_;
   GPIOPin *dir_pin_;
   GPIOPin *sleep_pin_{nullptr};
+  bool sleep_pin_state_;
   HighFrequencyLoopRequester high_freq_;
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

Adds a 1ms pause to the a4988 when coming out of sleep, before starting to step.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

# Explain your changes

As specified on page 10 of the a4988 datasheet: [https://www.allegromicro.com/-/media/files/datasheets/a4988-datasheet.ashx](https://www.allegromicro.com/-/media/files/datasheets/a4988-datasheet.ashx) under **Sleep Mode**, 

> "When emerging from Sleep mode, in order to allow the charge pump to stabilize, provide a delay of 1 ms before issuing a Step command."

This fix adds a boolean to assist in tracking the rising edge of the sleep pin (coming out of sleep mode), and if so, adds a 1000 μs delay before continuing on with the a4988 loop.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
