### PR TITLE
change lcd clear() to clear the buffer

### DIFF
--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -104,9 +104,7 @@ void HOT LCDDisplay::display() {
   }
 }
 void LCDDisplay::update() {
-  for (uint8_t i = 0; i < this->rows_ * this->columns_; i++)
-    this->buffer_[i] = ' ';
-
+  this->clear();
   this->call_writer();
   this->display();
 }
@@ -149,9 +147,8 @@ void LCDDisplay::printf(const char *format, ...) {
     this->print(0, 0, buffer);
 }
 void LCDDisplay::clear() {
-  // clear display, also sets DDRAM address to 0 (home)
-  this->command_(LCD_DISPLAY_COMMAND_CLEAR_DISPLAY);
-  delay(2);
+  for (uint8_t i = 0; i < this->rows_ * this->columns_; i++)
+    this->buffer_[i] = ' ';
 }
 #ifdef USE_TIME
 void LCDDisplay::strftime(uint8_t column, uint8_t row, const char *format, time::ESPTime time) {


### PR DESCRIPTION
# What does this implement/fix? 

There's currently no way to clear the display from outside the update method.  The clear() method clears the lcd, but not the buffer.  This changes that to match expectations.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuraiton files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
