### PR TITLE
Fix component_tests config

### DIFF
--- a/script/component_test
+++ b/script/component_test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+set -x
+
+pytest tests/component_tests

--- a/script/fulltest
+++ b/script/fulltest
@@ -10,4 +10,5 @@ script/ci-custom.py
 script/lint-python
 script/lint-cpp
 script/unit_test
+script/component_test
 script/test

--- a/tests/component_tests/conftest.py
+++ b/tests/component_tests/conftest.py
@@ -1,5 +1,13 @@
 """Fixtures for component tests."""
 
+import sys
+from pathlib import Path
+
+# Add package root to python path
+here = Path(__file__).parent
+package_root = here.parent.parent
+sys.path.insert(0, package_root.as_posix())
+
 import pytest
 
 from esphome.core import CORE


### PR DESCRIPTION
# What does this implement/fix? 

This is a fix for the component_tests.
They were not executed and didn't work.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

# Explain your changes

I'm planning to develop a new component and I'd like to add some tests for it.
Unluckily this in not possible as the component_tests don't work.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
