### PR TITLE
Add option to suffix name with mac address

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -37,8 +37,8 @@ namespace esphome {
 
 class Application {
  public:
-  void pre_setup(const std::string &name, const char *compilation_time, bool name_mac_suffix) {
-    if (name_mac_suffix) {
+  void pre_setup(const std::string &name, const char *compilation_time, bool name_add_mac_suffix) {
+    if (name_add_mac_suffix) {
       this->name_ = name + "_" + get_mac_address().substr(6);
     } else {
       this->name_ = name;

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -37,8 +37,12 @@ namespace esphome {
 
 class Application {
  public:
-  void pre_setup(const std::string &name, const char *compilation_time) {
-    this->name_ = name;
+  void pre_setup(const std::string &name, const char *compilation_time, bool name_mac_suffix) {
+    if (name_mac_suffix) {
+      this->name_ = name + "_" + get_mac_address().substr(6);
+    } else {
+      this->name_ = name;
+    }
     this->compilation_time_ = compilation_time;
     global_preferences.begin();
   }

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -45,6 +45,8 @@ LoopTrigger = cg.esphome_ns.class_(
 
 VERSION_REGEX = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[ab]\d+)?$")
 
+CONF_NAME_MAC_SUFFIX = "name_mac_suffix"
+
 
 def validate_board(value):
     if CORE.is_esp8266:
@@ -173,6 +175,7 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_INCLUDES, default=[]): cv.ensure_list(valid_include),
         cv.Optional(CONF_LIBRARIES, default=[]): cv.ensure_list(cv.string_strict),
+        cv.Optional(CONF_NAME_MAC_SUFFIX, default=False): cv.boolean,
         cv.Optional("esphome_core_version"): cv.invalid(
             "The esphome_core_version option has been "
             "removed in 1.13 - the esphome core source "
@@ -289,7 +292,11 @@ def _add_automations(config):
 def to_code(config):
     cg.add_global(cg.global_ns.namespace("esphome").using)
     cg.add(
-        cg.App.pre_setup(config[CONF_NAME], cg.RawExpression('__DATE__ ", " __TIME__'))
+        cg.App.pre_setup(
+            config[CONF_NAME],
+            cg.RawExpression('__DATE__ ", " __TIME__'),
+            config[CONF_NAME_MAC_SUFFIX],
+        )
     )
 
     CORE.add_job(_add_automations, config)

--- a/esphome/core_config.py
+++ b/esphome/core_config.py
@@ -45,7 +45,7 @@ LoopTrigger = cg.esphome_ns.class_(
 
 VERSION_REGEX = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[ab]\d+)?$")
 
-CONF_NAME_MAC_SUFFIX = "name_mac_suffix"
+CONF_NAME_ADD_MAC_SUFFIX = "name_add_mac_suffix"
 
 
 def validate_board(value):
@@ -175,7 +175,7 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_INCLUDES, default=[]): cv.ensure_list(valid_include),
         cv.Optional(CONF_LIBRARIES, default=[]): cv.ensure_list(cv.string_strict),
-        cv.Optional(CONF_NAME_MAC_SUFFIX, default=False): cv.boolean,
+        cv.Optional(CONF_NAME_ADD_MAC_SUFFIX, default=False): cv.boolean,
         cv.Optional("esphome_core_version"): cv.invalid(
             "The esphome_core_version option has been "
             "removed in 1.13 - the esphome core source "
@@ -295,7 +295,7 @@ def to_code(config):
         cg.App.pre_setup(
             config[CONF_NAME],
             cg.RawExpression('__DATE__ ", " __TIME__'),
-            config[CONF_NAME_MAC_SUFFIX],
+            config[CONF_NAME_ADD_MAC_SUFFIX],
         )
     )
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: test1
+  name_add_mac_suffix: true
   platform: ESP32
   board: nodemcu-32s
   on_boot:


### PR DESCRIPTION
# What does this implement/fix? 

## This is an advanced option meant for use by makers or manufacturers selling devices with ESPHome preinstalled and configured

Add option to suffix name with mac address

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** #1598

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1058
  
# Test Environment

- [x] ESP32
- [x] ESP8266
- [ ] Windows
- [x] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: test_device
  name_add_mac_suffix: true
```

# Explain your changes

While this allows compile once, flash many. It "breaks" OTA because ESPHome will not be able to find the device using the device name in the yaml file via mDNS.

Using this config option, the device will have `App.get_name()` return `test_device_123456` which affects the network hostname and the unique id for entities when added to Home Assistant

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
