### PR TITLE
SPI Improvements

### DIFF
--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -38,7 +38,7 @@ void SPIComponent::setup() {
 #ifdef ARDUINO_ARCH_ESP8266
   if (clk_pin == 6 && miso_pin == 7 && mosi_pin == 8) {
     // pass
-  } else if (clk_pin == 14 && miso_pin == 12 && mosi_pin == 13) {
+  } else if (clk_pin == 14 && (!has_miso || miso_pin == 12) && (!has_mosi || mosi_pin == 13)) {
     // pass
   } else {
     use_hw_spi = false;

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -99,6 +99,30 @@ class SPIComponent : public Component {
   }
 
   template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
+  void write_byte16(const uint16_t data) {
+    if (this->hw_spi_ != nullptr) {
+      this->hw_spi_->write16(data);
+      return;
+    }
+
+    this->write_byte<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data >> 8);
+    this->write_byte<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data);
+  }
+
+  template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
+  void write_array16(const uint16_t *data, size_t length) {
+    if (this->hw_spi_ != nullptr) {
+      for (size_t i = 0; i < length; i++) {
+        this->hw_spi_->write16(data[i]);
+      }
+      return;
+    }
+    for (size_t i = 0; i < length; i++) {
+      this->write_byte16<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data[i]);
+    }
+  }
+
+  template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE>
   void write_array(const uint8_t *data, size_t length) {
     if (this->hw_spi_ != nullptr) {
       auto *data_c = const_cast<uint8_t *>(data);
@@ -206,6 +230,14 @@ class SPIDevice {
 
   void write_byte(uint8_t data) {
     return this->parent_->template write_byte<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data);
+  }
+
+  void write_byte16(uint8_t data) {
+    return this->parent_->template write_byte16<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data);
+  }
+
+  void write_array16(const uint16_t *data, size_t length) {
+    this->parent_->template write_array16<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data, length);
   }
 
   void write_array(const uint8_t *data, size_t length) {


### PR DESCRIPTION
On the 8266 hardware SPI was only enabled when all 4 (clk,cs,miso,mosi) were enabled. This changes it so hardware SPI is enabled when miso or mosi is enabled.

Added in write_byte16 and write_array16. The hardware SPI package already had this. Just extending it to the SPI component

# What does this implement/fix? 

Quick description 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [X] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
