### PR TITLE
e131: fix issue 1579: limitation of maximum light count

### DIFF
--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -53,7 +53,7 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
 
   int output_offset = (universe - first_universe_) * get_lights_per_universe();
   // limit amount of lights per universe and received
-  int output_end = std::min(it->size(), std::min(output_offset + get_lights_per_universe(), packet.count - 1));
+  int output_end = std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + packet.count - 1));
   auto input_data = packet.values + 1;
 
   ESP_LOGV(TAG, "Applying data for '%s' on %d universe, for %d-%d.", get_name().c_str(), universe, output_offset,

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -53,7 +53,8 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
 
   int output_offset = (universe - first_universe_) * get_lights_per_universe();
   // limit amount of lights per universe and received
-  int output_end = std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + packet.count - 1));
+  int output_end =
+      std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + packet.count - 1));
   auto input_data = packet.values + 1;
 
   ESP_LOGV(TAG, "Applying data for '%s' on %d universe, for %d-%d.", get_name().c_str(), universe, output_offset,


### PR DESCRIPTION
# What does this implement/fix? 

issue esphome/issues#1579: limitation of light usable in e131 component

maximum light number was the received packet size minus one, not taking offset into account

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes esphome/issues#1579

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

none
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux
