### PR TITLE
Sensor Average Filter Fix Floating Pointer Error Accumulating

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -148,10 +148,10 @@ void SlidingWindowMovingAverageFilter::set_window_size(size_t window_size) { thi
 optional<float> SlidingWindowMovingAverageFilter::new_value(float value) {
   if (!isnan(value)) {
     if (this->queue_.size() == this->window_size_) {
-      this->sum_ -= this->queue_.front();
-      this->queue_.pop();
+      this->sum_ -= this->queue_[0];
+      this->queue_.pop_front();
     }
-    this->queue_.push(value);
+    this->queue_.push_back(value);
     this->sum_ += value;
   }
   float average;
@@ -161,8 +161,16 @@ optional<float> SlidingWindowMovingAverageFilter::new_value(float value) {
     average = this->sum_ / this->queue_.size();
   ESP_LOGVV(TAG, "SlidingWindowMovingAverageFilter(%p)::new_value(%f) -> %f", this, value, average);
 
-  if (++this->send_at_ >= this->send_every_) {
-    this->send_at_ = 0;
+  if (++this->send_at_ % this->send_every_ == 0) {
+    if (this->send_at_ >= 10000) {
+      // Recalculate to prevent floating point error accumulating
+      this->sum_ = 0;
+      for (auto v : this->queue_)
+        this->sum_ += v;
+      average = this->sum_ / this->queue_.size();
+      this->send_at_ = 0;
+    }
+
     ESP_LOGVV(TAG, "SlidingWindowMovingAverageFilter(%p)::new_value(%f) SENDING", this, value);
     return average;
   }

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -162,7 +162,7 @@ class SlidingWindowMovingAverageFilter : public Filter {
 
  protected:
   float sum_{0.0};
-  std::queue<float> queue_;
+  std::deque<float> queue_;
   size_t send_every_;
   size_t send_at_;
   size_t window_size_;


### PR DESCRIPTION
# What does this implement/fix? 

A few days ago I noticed a brightness sensor was publishing values like `-0.1 lx`. Turns out the device has an uptime of over 7 months and I assume the floating point error accumulated over time.

This PR recalculates the sum over the array every so often (arbitrarily chosen after 10000 values, which should be enough).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** non

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none
  
# Test Environment

- [x] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: bh1750
    name: $name BH1750
    update_interval: 5s
    measurement_time: 31
    resolution: 4.0
    filters:
      - sliding_window_moving_average:
          window_size: 24
          send_every: 12
```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.

Fixes aforementioned (minor) issue.


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
