### PR TITLE
Switch docker images to debian

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up env variables
         run: |
-          base_version="2.8.0"
+          base_version="3.0.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"
@@ -45,7 +45,7 @@ jobs:
         run: |
           docker pull "${BUILD_TO}:dev" || true
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - run: |
           docker build \
             --build-arg "BUILD_FROM=${BUILD_FROM}" \

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -174,7 +174,7 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Set up env variables
         run: |
-          base_version="2.8.0"
+          base_version="3.0.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"
@@ -193,7 +193,7 @@ jobs:
         run: |
           docker pull "${BUILD_TO}:dev" || true
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - run: |
           docker build \
             --build-arg "BUILD_FROM=${BUILD_FROM}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Set up env variables
         run: |
-          base_version="2.8.0"
+          base_version="3.0.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"
@@ -221,7 +221,7 @@ jobs:
         run: |
           docker pull "${BUILD_TO}:${CACHE_TAG}" || true
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - run: |
           docker build \
             --build-arg "BUILD_FROM=${BUILD_FROM}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:2.8.0
+ARG BUILD_FROM=esphome/esphome-base-amd64:3.0.0
 FROM ${BUILD_FROM}
 
 # First install requirements to leverage caching when requirements don't change

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:2.8.0
+FROM esphome/esphome-base-amd64:3.0.0
 
 COPY . .
 

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM esphome/esphome-lint-base:2.8.0
+FROM esphome/esphome-lint-base:3.0.0
 
 COPY requirements.txt requirements_test.txt docker/platformio_install_deps.py  platformio.ini /
 RUN \


### PR DESCRIPTION
# What does this implement/fix? 

See also https://github.com/esphome/esphome-docker-base/releases/tag/v3.0.0

debian buster base image builds work now. This PR upgrades the base image to 3.0.0.

debian's advantage is that the aarch64 builds also work the latest distribution, and uses python 3.7 (on ubuntu bionic was 3.6)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
