### PR TITLE
waveshare_epaper: Add support for 5.65" ACEP display

### DIFF
--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -308,7 +308,7 @@ class DisplayBuffer {
 
   virtual int get_width_internal() = 0;
 
-  void init_internal_(uint32_t buffer_length);
+  virtual void init_internal_(uint32_t buffer_length);
 
   void do_update_();
 

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -22,6 +22,9 @@ WaveshareEPaper = waveshare_epaper_ns.class_(
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper
 )
+WaveshareEPaperTypeF = waveshare_epaper_ns.class_(
+    "WaveshareEPaperTypeF", WaveshareEPaper
+)
 WaveshareEPaper2P7In = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P7In", WaveshareEPaper
 )
@@ -43,6 +46,7 @@ WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_(
 
 WaveshareEPaperTypeAModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeAModel")
 WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel")
+WaveshareEPaperTypeFModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeFModel")
 
 MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
@@ -55,6 +59,7 @@ MODELS = {
     "2.70in": ("b", WaveshareEPaper2P7In),
     "2.90in-b": ("b", WaveshareEPaper2P9InB),
     "4.20in": ("b", WaveshareEPaper4P2In),
+    "5.65in": ("f", WaveshareEPaperTypeFModel.WAVESHARE_ACEP_5_65_IN),
     "5.83in": ("b", WaveshareEPaper5P8In),
     "7.50in": ("b", WaveshareEPaper7P5In),
     "7.50inv2": ("b", WaveshareEPaper7P5InV2),
@@ -98,6 +103,9 @@ def to_code(config):
     elif model_type == "b":
         rhs = model.new()
         var = cg.Pvariable(config[CONF_ID], rhs, model)
+    elif model_type == "f":
+        rhs = WaveshareEPaperTypeF.new(model)
+        var = cg.Pvariable(config[CONF_ID], rhs, WaveshareEPaperTypeF)
     else:
         raise NotImplementedError()
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1035,7 +1035,7 @@ void WaveshareEPaperTypeF::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 void HOT WaveshareEPaperTypeF::send_display_size_(uint16_t width, uint16_t height) {
-  this->command(0x61); // 0x61: Set Display Resolution
+  this->command(0x61);  // 0x61: Set Display Resolution
   this->start_data_();
   this->write_byte(width >> 8);
   this->write_byte(width & 0xFF);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1046,14 +1046,19 @@ void WaveshareEPaperTypeF::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
+void HOT WaveshareEPaperTypeF::send_display_size_(uint16_t width, uint16_t height) {
+  this->command(0x61); // 0x61: Set Display Resolution
+  this->start_data_();
+  this->write_byte(width >> 8);
+  this->write_byte(width & 0xFF);
+  this->write_byte(height >> 8);
+  this->write_byte(height & 0xFF);
+  this->end_data_();
+}
 void HOT WaveshareEPaperTypeF::display() {
   uint32_t total_pixels = this->get_width_internal() * this->get_height_internal();
   ESP_LOGD(TAG, "Clean display");
-  this->command(0x61);  // Pixel dimensions (resolution)
-  this->data(0x02);
-  this->data(0x58);
-  this->data(0x01);
-  this->data(0xC0);
+  this->send_display_size_(this->get_width_internal(), this->get_height_internal());
   
   // "Clean" display to avoid/prevent ghosting
   this->command(0x10);
@@ -1077,11 +1082,7 @@ void HOT WaveshareEPaperTypeF::display() {
   
   ESP_LOGD(TAG, "Output buffer to display");
   
-  this->command(0x61);  // Pixel dimensions (resolution)
-  this->data(0x02);
-  this->data(0x58);
-  this->data(0x01);
-  this->data(0xC0);
+  this->send_display_size_(this->get_width_internal(), this->get_height_internal());
   
   // Send actual pixel buffer
   this->command(0x10);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -995,41 +995,35 @@ void WaveshareEPaperTypeF::initialize() {
   ESP_LOGD(TAG, "Init display");
   this->reset_();
   this->wait_until_busy_();
-  this->command(0x00);
-  this->data(0xEF);
+  this->command(0x00); // 0x00: Panel Settings
+  this->data(0xEF); // Scan up, shift right, DC/DC enabled
   this->data(0x08);
-  this->command(0x01);
-  this->data(0x37);
+  this->command(0x01); // 0x01: Power settings
+  this->data(0x37); // Use internal DC/DC for everything
   this->data(0x00);
   this->data(0x23);
   this->data(0x23);
-  this->command(0x03);
-  this->data(0x00);
-  this->command(0x06);
+  this->command(0x03); // 0x03: Power off sequence
+  this->data(0x00); // 0x00: 1 frame (default)
+  this->command(0x06); // 0x06: Booster soft start
   this->data(0xC7);
   this->data(0xC7);
   this->data(0x1D);
-  this->command(0x30);
-  this->data(0x3C);
-  this->command(0x40);
-  this->data(0x00);
-  this->command(0x50);
-  this->data(0x37);
-  this->command(0x60);
+  this->command(0x30); // 0x30: PLL control
+  this->data(0x3C); // 0x3C: 50Hz
+  this->command(0x41); // 0x41: Temperature sensor
+  this->data(0x00); // 0x00: Use internal temperature sensor
+  this->command(0x50); // 0x50: Border color, color LUT, VCOM + data interval
+  this->data(0x37); // White border, default LUT, default VCOM + data interval
+  this->command(0x60); // 0x60: Undocumented
   this->data(0x22);
-  this->command(0x61);  // Pixel dimensions (resolution)
-  this->data(0x02);
-  this->data(0x58);
-  this->data(0x01);
-  this->data(0xC0);
-  this->command(0xE3);
+  this->send_display_size_(this->get_width_internal(), this->get_height_internal());
+  this->command(0xE3); // 0xE3: Undocumented
   this->data(0xAA);
   
   delay(100); // NOLINT
   App.feed_wdt();
   
-  this->command(0x50);
-  this->data(0x37);
   ESP_LOGD(TAG, "Init display complete");
   
   App.feed_wdt();
@@ -1060,8 +1054,8 @@ void HOT WaveshareEPaperTypeF::display() {
   ESP_LOGD(TAG, "Clean display");
   this->send_display_size_(this->get_width_internal(), this->get_height_internal());
   
-  // "Clean" display to avoid/prevent ghosting
-  this->command(0x10);
+  // "Clean" display (fill with 0x7) to avoid/prevent ghosting
+  this->command(0x10); // 0x10: Start data transmission (for display)
   this->start_data_();
   uint32_t num_bytes = total_pixels / 2;
   for (size_t i = 0; i < num_bytes; i++) {
@@ -1070,11 +1064,11 @@ void HOT WaveshareEPaperTypeF::display() {
   }
   this->end_data_();
   
-  this->command(0x04);
+  this->command(0x04); // 0x04: Turn power ON
   this->wait_until_busy_();
-  this->command(0x12);
+  this->command(0x12); // 0x12: Refresh Display
   this->wait_until_busy_();
-  this->command(0x02);
+  this->command(0x02); // 0x02: Turn power OFF
   this->wait_until_idle_();
   App.feed_wdt();
   
@@ -1085,7 +1079,7 @@ void HOT WaveshareEPaperTypeF::display() {
   this->send_display_size_(this->get_width_internal(), this->get_height_internal());
   
   // Send actual pixel buffer
-  this->command(0x10);
+  this->command(0x10); // 0x10: Start data transmission (for display)
   this->start_data_();
   
   for (uint32_t pos = 0; pos < total_pixels; pos+= 2) {
@@ -1099,11 +1093,11 @@ void HOT WaveshareEPaperTypeF::display() {
   
   this->end_data_();
   
-  this->command(0x04);
+  this->command(0x04); // 0x04: Turn power ON
   this->wait_until_busy_();
-  this->command(0x12);
+  this->command(0x12); // 0x12: Refresh Display
   this->wait_until_busy_();
-  this->command(0x02);
+  this->command(0x02); // 0x02: Turn power OFF
   this->wait_until_idle_();
   App.feed_wdt();
   

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -992,7 +992,6 @@ void WaveshareEPaper7P5InV2::dump_config() {
 
 
 void WaveshareEPaperTypeF::initialize() {
-  ESP_LOGD(TAG, "Init display");
   this->reset_();
   this->wait_until_busy_();
   this->command(0x00); // 0x00: Panel Settings
@@ -1023,10 +1022,6 @@ void WaveshareEPaperTypeF::initialize() {
   
   delay(100); // NOLINT
   App.feed_wdt();
-  
-  ESP_LOGD(TAG, "Init display complete");
-  
-  App.feed_wdt();
 }
 void WaveshareEPaperTypeF::dump_config() {
   LOG_DISPLAY("", "Waveshare Advanced Color E-Paper", this);
@@ -1051,7 +1046,6 @@ void HOT WaveshareEPaperTypeF::send_display_size_(uint16_t width, uint16_t heigh
 }
 void HOT WaveshareEPaperTypeF::display() {
   uint32_t total_pixels = this->get_width_internal() * this->get_height_internal();
-  ESP_LOGD(TAG, "Clean display");
   this->send_display_size_(this->get_width_internal(), this->get_height_internal());
   
   // "Clean" display (fill with 0x7) to avoid/prevent ghosting
@@ -1073,8 +1067,6 @@ void HOT WaveshareEPaperTypeF::display() {
   App.feed_wdt();
   
   delay(200); // NOLINT
-  
-  ESP_LOGD(TAG, "Output buffer to display");
   
   this->send_display_size_(this->get_width_internal(), this->get_height_internal());
   
@@ -1103,7 +1095,6 @@ void HOT WaveshareEPaperTypeF::display() {
   
   delay(200); // NOLINT
   App.feed_wdt();
-  ESP_LOGD(TAG, "Output complete");
 }
 void WaveshareEPaperTypeF::fill(Color color) {
   const uint8_t fill = this->color_(color);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -990,37 +990,36 @@ void WaveshareEPaper7P5InV2::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-
 void WaveshareEPaperTypeF::initialize() {
   this->reset_();
   this->wait_until_busy_();
-  this->command(0x00); // 0x00: Panel Settings
-  this->data(0xEF); // Scan up, shift right, DC/DC enabled
+  this->command(0x00);  // 0x00: Panel Settings
+  this->data(0xEF);     // Scan up, shift right, DC/DC enabled
   this->data(0x08);
-  this->command(0x01); // 0x01: Power settings
-  this->data(0x37); // Use internal DC/DC for everything
+  this->command(0x01);  // 0x01: Power settings
+  this->data(0x37);     // Use internal DC/DC for everything
   this->data(0x00);
   this->data(0x23);
   this->data(0x23);
-  this->command(0x03); // 0x03: Power off sequence
-  this->data(0x00); // 0x00: 1 frame (default)
-  this->command(0x06); // 0x06: Booster soft start
+  this->command(0x03);  // 0x03: Power off sequence
+  this->data(0x00);     // 0x00: 1 frame (default)
+  this->command(0x06);  // 0x06: Booster soft start
   this->data(0xC7);
   this->data(0xC7);
   this->data(0x1D);
-  this->command(0x30); // 0x30: PLL control
-  this->data(0x3C); // 0x3C: 50Hz
-  this->command(0x41); // 0x41: Temperature sensor
-  this->data(0x00); // 0x00: Use internal temperature sensor
-  this->command(0x50); // 0x50: Border color, color LUT, VCOM + data interval
-  this->data(0x37); // White border, default LUT, default VCOM + data interval
-  this->command(0x60); // 0x60: Undocumented
+  this->command(0x30);  // 0x30: PLL control
+  this->data(0x3C);     // 0x3C: 50Hz
+  this->command(0x41);  // 0x41: Temperature sensor
+  this->data(0x00);     // 0x00: Use internal temperature sensor
+  this->command(0x50);  // 0x50: Border color, color LUT, VCOM + data interval
+  this->data(0x37);     // White border, default LUT, default VCOM + data interval
+  this->command(0x60);  // 0x60: Undocumented
   this->data(0x22);
   this->send_display_size_(this->get_width_internal(), this->get_height_internal());
-  this->command(0xE3); // 0xE3: Undocumented
+  this->command(0xE3);  // 0xE3: Undocumented
   this->data(0xAA);
-  
-  delay(100); // NOLINT
+
+  delay(100);  // NOLINT
   App.feed_wdt();
 }
 void WaveshareEPaperTypeF::dump_config() {
@@ -1047,9 +1046,9 @@ void HOT WaveshareEPaperTypeF::send_display_size_(uint16_t width, uint16_t heigh
 void HOT WaveshareEPaperTypeF::display() {
   uint32_t total_pixels = this->get_width_internal() * this->get_height_internal();
   this->send_display_size_(this->get_width_internal(), this->get_height_internal());
-  
+
   // "Clean" display (fill with 0x7) to avoid/prevent ghosting
-  this->command(0x10); // 0x10: Start data transmission (for display)
+  this->command(0x10);  // 0x10: Start data transmission (for display)
   this->start_data_();
   uint32_t num_bytes = total_pixels / 2;
   for (size_t i = 0; i < num_bytes; i++) {
@@ -1057,43 +1056,43 @@ void HOT WaveshareEPaperTypeF::display() {
     App.feed_wdt();
   }
   this->end_data_();
-  
-  this->command(0x04); // 0x04: Turn power ON
+
+  this->command(0x04);  // 0x04: Turn power ON
   this->wait_until_busy_();
-  this->command(0x12); // 0x12: Refresh Display
+  this->command(0x12);  // 0x12: Refresh Display
   this->wait_until_busy_();
-  this->command(0x02); // 0x02: Turn power OFF
+  this->command(0x02);  // 0x02: Turn power OFF
   this->wait_until_idle_();
   App.feed_wdt();
-  
-  delay(200); // NOLINT
-  
+
+  delay(200);  // NOLINT
+
   this->send_display_size_(this->get_width_internal(), this->get_height_internal());
-  
+
   // Send actual pixel buffer
-  this->command(0x10); // 0x10: Start data transmission (for display)
+  this->command(0x10);  // 0x10: Start data transmission (for display)
   this->start_data_();
-  
-  for (uint32_t pos = 0; pos < total_pixels; pos+= 2) {
+
+  for (uint32_t pos = 0; pos < total_pixels; pos += 2) {
     uint8_t out = this->get_index_value_(pos) << 4;
     if (pos < total_pixels - 1) {
-      out |= this->get_index_value_(pos+1);
+      out |= this->get_index_value_(pos + 1);
     }
     this->write_byte(out);
     App.feed_wdt();
   }
-  
+
   this->end_data_();
-  
-  this->command(0x04); // 0x04: Turn power ON
+
+  this->command(0x04);  // 0x04: Turn power ON
   this->wait_until_busy_();
-  this->command(0x12); // 0x12: Refresh Display
+  this->command(0x12);  // 0x12: Refresh Display
   this->wait_until_busy_();
-  this->command(0x02); // 0x02: Turn power OFF
+  this->command(0x02);  // 0x02: Turn power OFF
   this->wait_until_idle_();
   App.feed_wdt();
-  
-  delay(200); // NOLINT
+
+  delay(200);  // NOLINT
   App.feed_wdt();
 }
 void WaveshareEPaperTypeF::fill(Color color) {
@@ -1120,19 +1119,19 @@ uint8_t HOT WaveshareEPaperTypeF::color_(Color color) {
   } else if (color.raw_32 == COLOR_F_ORANGE.raw_32) {
     return 0x06;
   }
-  return 0x07; // "clean"
+  return 0x07;  // "clean"
 }
 void HOT WaveshareEPaperTypeF::draw_absolute_pixel_internal(int x, int y, Color color) {
   const uint8_t index = this->color_(color);
-  
+
   this->draw_absolute_pixel_internal(x, y, index);
 }
 void HOT WaveshareEPaperTypeF::draw_absolute_pixel_internal(int x, int y, uint8_t index) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
-  
+
   uint32_t pos = (x + y * this->get_width_internal());
-  
+
   const uint32_t pixel_bit_start = pos * pixel_storage_size_;
   const uint32_t pixel_bit_end = pixel_bit_start + pixel_storage_size_;
 
@@ -1146,7 +1145,7 @@ void HOT WaveshareEPaperTypeF::draw_absolute_pixel_internal(int x, int y, uint8_
 
   index_byte_start = (index_byte_start & ~mask) | ((index << byte_offset_start) & mask);
   this->buffer_[byte_location_start] = index_byte_start;
-  
+
   if (byte_location_start == byte_location_end) {  // Index is in the same byte
     return;
   }
@@ -1160,7 +1159,6 @@ void HOT WaveshareEPaperTypeF::draw_absolute_pixel_internal(int x, int y, uint8_
 
   this->buffer_[byte_location_end] = index_byte_end;
 }
-
 uint8_t HOT WaveshareEPaperTypeF::get_index_value_(uint32_t pos) {
   const uint32_t pixel_bit_start = pos * pixel_storage_size_;
   const uint32_t pixel_bit_end = pixel_bit_start + pixel_storage_size_;
@@ -1170,7 +1168,7 @@ uint8_t HOT WaveshareEPaperTypeF::get_index_value_(uint32_t pos) {
 
   uint8_t index_byte_start = this->buffer_[byte_location_start];
   const uint8_t byte_offset_start = pixel_bit_start % 8;
-  
+
   uint8_t mask = (1 << pixel_storage_size_) - 1;
 
   index_byte_start = (index_byte_start >> byte_offset_start);
@@ -1178,7 +1176,7 @@ uint8_t HOT WaveshareEPaperTypeF::get_index_value_(uint32_t pos) {
   if (byte_location_start == byte_location_end) {  // Index is in the same byte
     return index_byte_start & mask;
   }
-  
+
   const uint8_t byte_offset_end = pixel_bit_end % 8;
 
   uint8_t end_mask = mask >> (pixel_storage_size_ - byte_offset_end);
@@ -1205,7 +1203,6 @@ int WaveshareEPaperTypeF::get_height_internal() {
   }
   return 0;
 }
-
 uint32_t WaveshareEPaperTypeF::get_buffer_length_() {
   uint32_t total_pixels = this->get_width_internal() * this->get_height_internal();
   uint32_t screensize = total_pixels * this->pixel_storage_size_;
@@ -1228,7 +1225,7 @@ bool WaveshareEPaperTypeF::wait_until_idle_() {
     }
     delay(10);
   }
-  
+
   App.feed_wdt();
   return true;
 }
@@ -1246,7 +1243,7 @@ bool WaveshareEPaperTypeF::wait_until_busy_() {
     }
     delay(10);
   }
-  
+
   App.feed_wdt();
   return true;
 }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -314,6 +314,7 @@ class WaveshareEPaperTypeF : public WaveshareEPaper {
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   void draw_absolute_pixel_internal(int x, int y, uint8_t index);
   uint8_t get_index_value_(uint32_t pos);
+  void send_display_size_(uint16_t width, uint16_t height);
 
   int get_width_internal() override;
   int get_height_internal() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -311,7 +311,7 @@ class WaveshareEPaperTypeF : public WaveshareEPaper {
   uint8_t pixel_storage_size_ = 3;
 
   void draw_absolute_pixel_internal(int x, int y, Color color) override;  // NOLINT(readability-identifier-naming)
-  void draw_absolute_pixel_internal(int x, int y, uint8_t index);  // NOLINT(readability-identifier-naming)
+  void draw_absolute_pixel_internal(int x, int y, uint8_t index);         // NOLINT(readability-identifier-naming)
   uint8_t get_index_value_(uint32_t pos);
   void send_display_size_(uint16_t width, uint16_t height);  // NOLINT(readability-identifier-naming)
 
@@ -320,7 +320,7 @@ class WaveshareEPaperTypeF : public WaveshareEPaper {
   uint32_t get_buffer_length_() override;  // NOLINT(readability-identifier-naming)
 
   bool wait_until_idle_() override;  // NOLINT(readability-identifier-naming)
-  bool wait_until_busy_();  // NOLINT(readability-identifier-naming)
+  bool wait_until_busy_();           // NOLINT(readability-identifier-naming)
 
   WaveshareEPaperTypeFModel model_;
 };

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -270,7 +270,6 @@ class WaveshareEPaper7P5InV2 : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
-
 enum WaveshareEPaperTypeFModel {
   WAVESHARE_ACEP_5_65_IN = 0,
 };
@@ -282,7 +281,7 @@ static const Color COLOR_F_BLUE(0, 0, 255);
 static const Color COLOR_F_RED(255, 0, 0);
 static const Color COLOR_F_YELLOW(255, 255, 0);
 static const Color COLOR_F_ORANGE(255, 127, 0);
-static const Color COLOR_F_CLEAN(0x123456); // Anything that isn't one of the above will do.
+static const Color COLOR_F_CLEAN(0x123456);  // Anything that isn't one of the above will do.
 
 class WaveshareEPaperTypeF : public WaveshareEPaper {
  public:
@@ -294,7 +293,7 @@ class WaveshareEPaperTypeF : public WaveshareEPaper {
 
   void display() override;
 
-  virtual void fill(Color color) override;
+  void fill(Color color) override;
 
   void deep_sleep() override {
     if (this->reset_pin_ != nullptr) {
@@ -307,26 +306,24 @@ class WaveshareEPaperTypeF : public WaveshareEPaper {
   }
 
  protected:
-  virtual uint8_t color_(Color color);
-  
+  virtual uint8_t color_(Color color);  // NOLINT(readability-identifier-naming)
+
   uint8_t pixel_storage_size_ = 3;
-  
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
-  void draw_absolute_pixel_internal(int x, int y, uint8_t index);
+
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;  // NOLINT(readability-identifier-naming)
+  void draw_absolute_pixel_internal(int x, int y, uint8_t index);  // NOLINT(readability-identifier-naming)
   uint8_t get_index_value_(uint32_t pos);
-  void send_display_size_(uint16_t width, uint16_t height);
+  void send_display_size_(uint16_t width, uint16_t height);  // NOLINT(readability-identifier-naming)
 
   int get_width_internal() override;
   int get_height_internal() override;
-  uint32_t get_buffer_length_() override;
-  
-  bool wait_until_idle_() override;
-  bool wait_until_busy_();
+  uint32_t get_buffer_length_() override;  // NOLINT(readability-identifier-naming)
+
+  bool wait_until_idle_() override;  // NOLINT(readability-identifier-naming)
+  bool wait_until_busy_();  // NOLINT(readability-identifier-naming)
 
   WaveshareEPaperTypeFModel model_;
 };
-
-
 
 }  // namespace waveshare_epaper
 }  // namespace esphome

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -276,12 +276,12 @@ enum WaveshareEPaperTypeFModel {
 };
 
 static const Color COLOR_F_BLACK(0, 0, 0);
-static const Color COLOR_F_WHITE(1, 1, 1);
-static const Color COLOR_F_GREEN(0, 1, 0);
-static const Color COLOR_F_BLUE(0, 0, 1);
-static const Color COLOR_F_RED(1, 0, 0);
-static const Color COLOR_F_YELLOW(1, 1, 0);
-static const Color COLOR_F_ORANGE(1, 0.5, 0);
+static const Color COLOR_F_WHITE(255, 255, 255);
+static const Color COLOR_F_GREEN(0, 255, 0);
+static const Color COLOR_F_BLUE(0, 0, 255);
+static const Color COLOR_F_RED(255, 0, 0);
+static const Color COLOR_F_YELLOW(255, 255, 0);
+static const Color COLOR_F_ORANGE(255, 127, 0);
 static const Color COLOR_F_CLEAN(0x123456); // Anything that isn't one of the above will do.
 
 class WaveshareEPaperTypeF : public WaveshareEPaper {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -307,11 +307,13 @@ class WaveshareEPaperTypeF : public WaveshareEPaper {
   }
 
  protected:
-  uint32_t *buffer_{nullptr};
   virtual uint8_t color_(Color color);
   
-  void init_internal_(uint32_t buffer_length) override;
+  uint8_t pixel_storage_size_ = 3;
+  
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, uint8_t index);
+  uint8_t get_index_value_(uint32_t pos);
 
   int get_width_internal() override;
   int get_height_internal() override;

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -159,4 +159,12 @@ display:
     full_update_every: 30
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    cs_pin: GPIO23
+    dc_pin: GPIO23
+    busy_pin: GPIO23
+    reset_pin: GPIO23
+    model: 5.65in
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
 


### PR DESCRIPTION
# What does this implement/fix? 
Adds support for the 5.65" ACEP (Advanced Colo(u)r E-Paper) display to the waveshare_epaper component.  Implemented as a new type of model (Type F) in the hopes that it'll make it easier to support additional Type F ACEP displays if/when such displays are released.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1075
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: acepdisplay32
  platform: ESP32
  board: esp32doit-devkit-v1

# Configure SPI pins
spi:
  clk_pin: 13 #D5
  mosi_pin: 14 #D7

# Configure e-ink display
display:
  - platform: waveshare_epaper
    id: epaper
    cs_pin: 15 #D8
    dc_pin: 27 #D2
    busy_pin: 25 #D0
    reset_pin: 26 #D1
    model: 5.65in
    update_interval: 10min
    lambda: |-
       it.fill(esphome::waveshare_epaper::COLOR_F_WHITE);
       it.filled_rectangle(108, 50, 64, 348, esphome::waveshare_epaper::COLOR_F_BLACK);
       it.filled_rectangle(172, 50, 64, 348, esphome::waveshare_epaper::COLOR_F_GREEN);
       it.filled_rectangle(236, 50, 64, 348, esphome::waveshare_epaper::COLOR_F_BLUE);
       it.filled_rectangle(300, 50, 64, 348, esphome::waveshare_epaper::COLOR_F_RED);
       it.filled_rectangle(364, 50, 64, 348, esphome::waveshare_epaper::COLOR_F_YELLOW);
       it.filled_rectangle(428, 50, 64, 348, esphome::waveshare_epaper::COLOR_F_ORANGE);
```

# Explain your changes

In addition to supporting a new display, this should hopefully help set out what wider colour display support may look like.  The buffer implementation is based on the indexed buffer which forms part of the [displaybufferex](https://github.com/esphome/esphome/pull/1386) work by @SenexCrenshaw - but does not require that PR in any way.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
