### PR TITLE
Fix missing transition when turning lamp off.

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -94,9 +94,12 @@ class LightColorValues {
    * @return The linearly interpolated LightColorValues.
    */
   static LightColorValues lerp(const LightColorValues &start, const LightColorValues &end, float completion) {
+    // When turning off the light, make sure the brightness goes to zero.
+    auto end_brightness = end.get_state() == 0 ? 0 : end.get_brightness();
+
     LightColorValues v;
     v.set_state(esphome::lerp(completion, start.get_state(), end.get_state()));
-    v.set_brightness(esphome::lerp(completion, start.get_brightness(), end.get_brightness()));
+    v.set_brightness(esphome::lerp(completion, start.get_brightness(), end_brightness));
     v.set_red(esphome::lerp(completion, start.get_red(), end.get_red()));
     v.set_green(esphome::lerp(completion, start.get_green(), end.get_green()));
     v.set_blue(esphome::lerp(completion, start.get_blue(), end.get_blue()));


### PR DESCRIPTION
# What does this implement/fix? 

When turning on a light from Home Assistant with a (default) transition time, the light transitions to the desired light state over time by increasing its brightness. However, when turning it off, the light does not change during the transition period. After the transition period, it shuts down abruptly.

From a user perspective, this feels like the light is not reponding to the turn off command right away, but only after a little delay, because the light does not change at all.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Below you find the yaml that I am currently working with. I am writing a custom component, so this is not extremely useful for testing I'm afraid. However, the important bit is in there; the `default_transition_length: 1s`.

```yaml
light:
  - platform: custom
    lambda: |-
      auto bs2light = new esphome::rgbww::YeelightBedsideLampV2LightOutput(
          led_r, led_g, led_b, led_w, master1, master2);
      App.register_component(bs2light);
      return {bs2light};
    lights:
      - name: ${friendly_name} RGBW Light
        default_transition_length: 1s
```

# Explain your changes

The current behavior looks off to me. Here are some log lines that show the behavior that I observed.

When turning the light on, the brightness goes hand-in-hand with the state value:
```
[00:14:16][D][light:265]: 'Bedside Lamp Office RGBW Light' Setting:
[00:14:16][D][light:274]:   State: ON
[00:14:16][D][light:278]:   Brightness: 17%
[00:14:16][D][light:304]:   Transition Length: 1.0s
[00:14:16][VV][api.service:091]: send_light_state_response: LightStateResponse {
  key: 4065722751
  state: YES
  brightness: 0.168627
  red: 0
  green: 1
  blue: 1
  white: 0
  color_temperature: 588
  effect: 'None'
}
[00:14:16][VV][preferences:051]: SAVE 1: 0=0x00000001 1=0x3E2CACAD (Type=4065722751, CRC=0xDE98FAA1)
[00:14:16][D][yeelight_bs2:054]: B = State 0.000745, RGB 0.000000 1.000000 1.000000, BRI 0.000126, TEMP 588.000000
[00:14:16][D][yeelight_bs2:054]: B = State 0.002485, RGB 0.000000 1.000000 1.000000, BRI 0.000419, TEMP 588.000000
-----------8<---snip--------
[00:14:17][D][yeelight_bs2:054]: B = State 0.999978, RGB 0.000000 1.000000 1.000000, BRI 0.168624, TEMP 588.000000
[00:14:17][D][yeelight_bs2:054]: B = State 1.000000, RGB 0.000000 1.000000 1.000000, BRI 0.168627, TEMP 588.000000
```

However, when turning off the light, the brightness is kept as-is.
```
[00:14:18][D][light:265]: 'Bedside Lamp Office RGBW Light' Setting:
[00:14:18][D][light:274]:   State: OFF
[00:14:18][D][light:304]:   Transition Length: 1.0s
[00:14:18][VV][api.service:091]: send_light_state_response: LightStateResponse {
  key: 4065722751
  state: NO
  brightness: 0.168627
  red: 0
  green: 1
  blue: 1
  white: 0
  color_temperature: 588
  effect: 'None'
}
[00:14:18][VV][preferences:051]: SAVE 1: 0=0x00000000 1=0x3E2CACAD (Type=4065722751, CRC=0x9183467D)
[00:14:18][D][yeelight_bs2:054]: B = State 0.999255, RGB 0.000000 1.000000 1.000000, BRI 0.168627, TEMP 588.000000
[00:14:18][D][yeelight_bs2:054]: B = State 0.997730, RGB 0.000000 1.000000 1.000000, BRI 0.168627, TEMP 588.000000
[00:14:18][D][yeelight_bs2:054]: B = State 0.994615, RGB 0.000000 1.000000 1.000000, BRI 0.168627, TEMP 588.000000
-----------8<---snip--------
[00:14:19][D][yeelight_bs2:054]: B = State 0.000090, RGB 0.000000 1.000000 1.000000, BRI 0.168627, TEMP 588.000000
[00:14:19][D][yeelight_bs2:054]: B = State 0.000000, RGB 0.000000 1.000000 1.000000, BRI 0.168627, TEMP 588.000000
```

My fix simply makes sure that the brightness homes towards zero when the light's target state is OFF.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
