### PR TITLE
buffer allocation and TRUEFALSE templates

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -319,3 +319,18 @@ template<typename T> class Parented {
 uint32_t fnv1_hash(const std::string &str);
 
 }  // namespace esphome
+
+template<typename T> T *new_buffer(size_t length) {
+  T *buffer;
+#ifdef ARDUINO_ARCH_ESP32
+  if (psramFound()) {
+    buffer = (T *) ps_malloc(length);
+  } else {
+    buffer = new T[length];
+  }
+#else
+  buffer = new T[length];
+#endif
+
+  return buffer;
+}  // namespace esphome

--- a/esphome/core/log.h
+++ b/esphome/core/log.h
@@ -160,5 +160,6 @@ int esp_idf_log_vprintf_(const char *format, va_list args);  // NOLINT
       ((byte) &0x08 ? '1' : '0'), ((byte) &0x04 ? '1' : '0'), ((byte) &0x02 ? '1' : '0'), ((byte) &0x01 ? '1' : '0')
 #define YESNO(b) ((b) ? "YES" : "NO")
 #define ONOFF(b) ((b) ? "ON" : "OFF")
+#define TRUEFALSE(b) ((b) ? "TRUE" : "FALSE")
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 
``new_buffer`` - I have been using PSRAM where I can and this template helps a lot. By default it will use PSRAM if it is available. I didn't include a ``delete_buffer`` since this wasn't deemed useful. 

``TRUEFALSE(bool)`` - self explanatory helper

Quick description 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [X] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
``new_buffer`` gives a standard way of allocating a buffer space and will use PSRAM when available. This gives the ESP32 some extra breathing room especially considering the bigger displays and features being added to esphome. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
