### PR TITLE
Add the display.is_displaying_page condition

### DIFF
--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -131,11 +131,12 @@ def display_page_show_previous_to_code(config, action_id, template_arg, args):
 @automation.register_condition(
     "display.is_displaying_page",
     DisplayIsDisplayingPageCondition,
-    cv.Schema(
+    cv.maybe_simple_value(
         {
-            cv.Required(CONF_ID): cv.use_id(DisplayBuffer),
+            cv.GenerateID(CONF_ID): cv.use_id(DisplayBuffer),
             cv.Required(CONF_PAGE_ID): cv.use_id(DisplayPage),
-        }
+        },
+        key=CONF_PAGE_ID,
     ),
 )
 def display_is_displaying_page_to_code(config, condition_id, template_arg, args):

--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import core, automation
 from esphome.automation import maybe_simple_id
-from esphome.const import CONF_ID, CONF_LAMBDA, CONF_PAGES, CONF_ROTATION
+from esphome.const import CONF_ID, CONF_LAMBDA, CONF_PAGES, CONF_PAGE_ID, CONF_ROTATION
 from esphome.core import coroutine, coroutine_with_priority
 
 IS_PLATFORM_COMPONENT = True
@@ -18,6 +18,9 @@ DisplayPageShowNextAction = display_ns.class_(
 )
 DisplayPageShowPrevAction = display_ns.class_(
     "DisplayPageShowPrevAction", automation.Action
+)
+DisplayIsDisplayingPageCondition = display_ns.class_(
+    "DisplayIsDisplayingPageCondition", automation.Condition
 )
 
 DISPLAY_ROTATIONS = {
@@ -123,6 +126,25 @@ def display_page_show_next_to_code(config, action_id, template_arg, args):
 def display_page_show_previous_to_code(config, action_id, template_arg, args):
     paren = yield cg.get_variable(config[CONF_ID])
     yield cg.new_Pvariable(action_id, template_arg, paren)
+
+
+@automation.register_condition(
+    "display.is_displaying_page",
+    DisplayIsDisplayingPageCondition,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(DisplayBuffer),
+            cv.Required(CONF_PAGE_ID): cv.use_id(DisplayPage),
+        }
+    ),
+)
+def display_is_displaying_page_to_code(config, condition_id, template_arg, args):
+    paren = yield cg.get_variable(config[CONF_ID])
+    page = yield cg.get_variable(config[CONF_PAGE_ID])
+    var = cg.new_Pvariable(condition_id, template_arg, paren)
+    cg.add(var.set_page(page))
+
+    yield var
 
 
 @coroutine_with_priority(100.0)

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -296,6 +296,8 @@ class DisplayBuffer {
 
   void set_pages(std::vector<DisplayPage *> pages);
 
+  const DisplayPage *get_active_page() const { return this->page_; }
+
   /// Internal method to set the display rotation with.
   void set_rotation(DisplayRotation rotation);
 
@@ -446,6 +448,18 @@ template<typename... Ts> class DisplayPageShowPrevAction : public Action<Ts...> 
   void play(Ts... x) override { this->buffer_->show_prev_page(); }
 
   DisplayBuffer *buffer_;
+};
+
+template<typename... Ts> class DisplayIsDisplayingPageCondition : public Condition<Ts...> {
+ public:
+  DisplayIsDisplayingPageCondition(DisplayBuffer *parent) : parent_(parent) {}
+
+  void set_page(DisplayPage *page) { this->page_ = page; }
+  bool check(Ts... x) override { return this->parent_->get_active_page() == this->page_; }
+
+ protected:
+  DisplayBuffer *parent_;
+  DisplayPage *page_;
 };
 
 }  // namespace display

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1760,6 +1760,13 @@ interval:
           btn_left_state = ((uint32_t) id(btn_left)->get_value()  +  63 * (uint32_t)btn_left_state) >> 6;
 
           id(btn_left)->set_threshold(btn_left_state * 0.9);
+      - if:
+          condition:
+            display.is_displaying_page:
+              id: display1
+              page_id: page1
+          then:
+            - logger.log: 'Seeing page 1'
 
 color:
   - id: kbx_red


### PR DESCRIPTION
# What does this implement/fix? 

I have added
-  `const DisplayPage *get_active_page() const` to the `DisplayBuffer`
- a condition `display.is_displaying_page` with the `id` (display) and `page_id` (page) configuration, returning true if the specified page is currently displayed at the specified display

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1079
 
None yet, as I want to hear whether this is the correct way to do first.

# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  - platform: ili9341
    model: TFT 2.4
    id: 'tft'
    rotation: 180
    cs_pin: 22
    dc_pin: 21
    led_pin: 5

    pages:
      - id: page_1
        lambda: |-
          it.fill(COLOR_OFF);
          it.circle(120, 80, 10, COLOR_ON);
      - id: page_2
        lambda: |-
          it.fill(COLOR_OFF);
          it.circle(120, 240, 10, COLOR_ON);
  
interval:
  - interval: 2s
    then:
      - if:
          condition:
            display.is_displaying_page: page_1
          then:
            - display.page.show: page_2
          else:
            - if:
                condition:
                  display.is_displaying_page:
                    id: tft
                    page_id: page_2
                then:
                  - display.page.show: page_1
```

# Explain your changes

In order to develop a touch screen controlled gui (see #1542) using multiple pages on a tft display I needed a way to query whether a specific page is visible on the display so I can route the touch screen virtual buttons to the gui element I want to control.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

Thanks