### PR TITLE
Fix servo detach chopped PWM

### DIFF
--- a/esphome/components/esp8266_pwm/esp8266_pwm.cpp
+++ b/esphome/components/esp8266_pwm/esp8266_pwm.cpp
@@ -37,6 +37,11 @@ void HOT ESP8266PWM::write_state(float state) {
   uint32_t duty_off = total_time_us - duty_on;
 
   if (duty_on == 0) {
+    // This is a hacky fix for servos: Servo PWM high time is maximum 2.4ms by default
+    // The frequency check is to affect this fix for servos mostly as the frequency is usually 50-300 hz
+    if (this->pin_->digital_read() && 50 <= this->frequency_ && this->frequency_ <= 300) {
+      delay(3);
+    }
     stopWaveform(this->pin_->get_pin());
     this->pin_->digital_write(this->pin_->is_inverted());
   } else if (duty_off == 0) {


### PR DESCRIPTION
# What does this implement/fix? 

Fixes an issue on ESP8266 PWM where on detaching servos, they will move to an unexpected position before detaching (quite frustrating indeed)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1347

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [x] ESP8266
- [x] Windows
- [ ] Mac OS
- [ ] Linux

# Explain your changes
Adds a delay for the current PWM pulse to complete. Unfortunately this check has to be done in esp8266_pwm as servo code is abstracted from float outputs.
Arduino ESP8266 does not suffer from this issue, they do it differently: `stopWaveForm` is a hard cut, thats why it does not work, however `startWaveForm` can be called and a "smooth" transition is done, so [what they do](https://github.com/esp8266/Arduino/blob/5ac64ffa27461161401971796150ef7f2b26a77d/libraries/Servo/src/Servo.cpp#L99) is calling `startWaveForm` to run one full pulse and then auto stop it, then delay for this to complete and finally `stopWaveForm` is called, the problem with this is that the delay is af ull servo frame (usually 20ms) so to implement it this way I'd have to code a `setTimeout` which will be may be more complex.

The fix as is will add at most a 3ms delay, but only if frequency is between 50 and 300hz which are what servos runs at, shouldn't affect other pwm uses as lights usually runs at at least 1000hz, etc.

If there are concerns about this being a breaking change, a config option can be added to enable this code too (and make it more complex may be too)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
