### PR TITLE
Fixed CustomComponentConstructor::get_component()

### DIFF
--- a/esphome/components/custom_component/custom_component.h
+++ b/esphome/components/custom_component/custom_component.h
@@ -16,7 +16,7 @@ class CustomComponentConstructor {
     }
   }
 
-  const Component *get_component(int i) const { return this->components_[i]; }
+  Component *get_component(int i) const { return this->components_[i]; }
 
  protected:
   std::vector<Component *> components_;

--- a/esphome/components/custom_component/custom_component.h
+++ b/esphome/components/custom_component/custom_component.h
@@ -16,7 +16,7 @@ class CustomComponentConstructor {
     }
   }
 
-  Component *get_component(int i) { return this->components_[i]; }
+  const Component *get_component(int i) const { return this->components_[i]; }
 
  protected:
   std::vector<Component *> components_;


### PR DESCRIPTION
# What does this implement/fix? 

The function `CustomComponentConstructor::get_component()` was not actually usable due to const qualifier constraints.

Calling it would result in a compiler error:

> error: passing 'const esphome::custom_component::CustomComponentConstructor' as 'this' argument of 'esphome::Component* esphome::custom_component::CustomComponentConstructor::get_component(int)' discards qualifiers [-fpermissive]

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** none

# Test Environment

- [X] ESP8266
- [X] Linux

## Example entry for `config.yaml`:
```yaml
esphome:
  name: demo
  platform: ESP8266
  board: esp01_1m

custom_component:
  - id: demo_component
    lambda: |-
      auto demo_component = new Component();
      return {demo_component};

light:
  - platform: fastled_clockless
    chipset: WS2812B
    pin: GPIO2
    num_leds: 16
    rgb_order: GRB
    name: "Demo"
    id: demo
    effects:
      - addressable_lambda:
          name: "Demo"
          update_interval: 50ms
          lambda: |-
            const Component *comp;
            comp = id(demo_component).get_component(0);

```

# Explain your changes

The function get_component cannot ever be used as it stands.

Making the function `const` fixes the issue.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
