### PR TITLE
Fix sensor.sensor_schema interface changed

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -185,7 +185,7 @@ def sensor_schema(
     unit_of_measurement_: str,
     icon_: str,
     accuracy_decimals_: int,
-    device_class_: Optional[str] = None,
+    device_class_: Optional[str] = DEVICE_CLASS_EMPTY,
 ) -> cv.Schema:
     schema = SENSOR_SCHEMA
     if unit_of_measurement_ != UNIT_EMPTY:
@@ -206,7 +206,7 @@ def sensor_schema(
                 ): accuracy_decimals,
             }
         )
-    if device_class_ is not None:
+    if device_class_ != DEVICE_CLASS_EMPTY:
         schema = schema.extend(
             {cv.Optional(CONF_DEVICE_CLASS, default=device_class_): device_class}
         )

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -1,4 +1,5 @@
 import math
+from typing import Optional
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
@@ -180,8 +181,12 @@ SENSOR_SCHEMA = cv.MQTT_COMPONENT_SCHEMA.extend(
 )
 
 
-def sensor_schema(unit_of_measurement_, icon_, accuracy_decimals_, device_class_):
-    # type: (str, str, int, str) -> cv.Schema
+def sensor_schema(
+    unit_of_measurement_: str,
+    icon_: str,
+    accuracy_decimals_: int,
+    device_class_: Optional[str] = None,
+) -> cv.Schema:
     schema = SENSOR_SCHEMA
     if unit_of_measurement_ != UNIT_EMPTY:
         schema = schema.extend(
@@ -201,7 +206,7 @@ def sensor_schema(unit_of_measurement_, icon_, accuracy_decimals_, device_class_
                 ): accuracy_decimals,
             }
         )
-    if device_class_ != DEVICE_CLASS_EMPTY:
+    if device_class_ is not None:
         schema = schema.extend(
             {cv.Optional(CONF_DEVICE_CLASS, default=device_class_): device_class}
         )


### PR DESCRIPTION
# What does this implement/fix? 

Looks like #1533 removed the default value for this function, thus causing older integrations to fail at the call site. We should really try to keep this interface stable, as other out-of-tree integrations might depend on it.

See also #1313

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
