### PR TITLE
fixes #858 - esphome crashes with neolightbus and RMT

### DIFF
--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -68,7 +68,8 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight {
   void add_leds(uint16_t count_pixels) { this->add_leds(new NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(count_pixels)); }
   void add_leds(NeoPixelBus<T_COLOR_FEATURE, T_METHOD> *controller) {
     this->controller_ = controller;
-    this->controller_->Begin();
+    // controller gets initialised in setup() - avoid calling twice (crashes with RMT)
+    // this->controller_->Begin();
   }
 
   // ========== INTERNAL METHODS ==========


### PR DESCRIPTION
# What does this implement/fix? 

Quick description 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/858

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
NA
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [x] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: test
  platform: ESP32
  board: nodemcu-32s

light:
  - platform: neopixelbus
    type: GRBW
    variant: SK6812
    method: ESP32_RMT_0
    pin: GPIO22
    num_leds: 42
    name: "NeoPixel Light 0"
  - platform: neopixelbus
    type: GRBW
    variant: SK6812
    method: ESP32_RMT_1
    pin: GPIO23
    num_leds: 42
    name: "NeoPixel Light 1"
```

# Explain your changes

Currently neopixelbus crashes on boot when using RMT (as seen in the issue). Without RMT is not possible to use more than one light in the ESP32.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
