### PR TITLE
Support raw datapoints for tuya components

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -240,6 +240,7 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
   switch (datapoint.type) {
     case TuyaDatapointType::RAW:
       datapoint.value_raw = std::vector<uint8_t>(data, data + data_len);
+      ESP_LOGD(TAG, "Datapoint %u update to %s", datapoint.id, hexencode(datapoint.value_raw).c_str());
       break;
     case TuyaDatapointType::BOOLEAN:
       if (data_len != 1) {
@@ -247,6 +248,7 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
         return;
       }
       datapoint.value_bool = data[0];
+      ESP_LOGD(TAG, "Datapoint %u update to %s", datapoint.id, ONOFF(datapoint.value_bool));
       break;
     case TuyaDatapointType::INTEGER:
       if (data_len != 4) {
@@ -254,9 +256,11 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
         return;
       }
       datapoint.value_uint = encode_uint32(data[0], data[1], data[2], data[3]);
+      ESP_LOGD(TAG, "Datapoint %u update to %d", datapoint.id, datapoint.value_int);
       break;
     case TuyaDatapointType::STRING:
       datapoint.value_string = std::string(reinterpret_cast<const char *>(data), data_len);
+      ESP_LOGD(TAG, "Datapoint %u update to %s", datapoint.id, datapoint.value_string.c_str());
       break;
     case TuyaDatapointType::ENUM:
       if (data_len != 1) {
@@ -264,6 +268,7 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
         return;
       }
       datapoint.value_enum = data[0];
+      ESP_LOGD(TAG, "Datapoint %u update to %d", datapoint.id, datapoint.value_enum);
       break;
     case TuyaDatapointType::BITMASK:
       switch (data_len) {
@@ -280,12 +285,12 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
           ESP_LOGW(TAG, "Datapoint %u has bad bitmask len %zu", datapoint.id, data_len);
           return;
       }
+      ESP_LOGD(TAG, "Datapoint %u update to %#08X", datapoint.id, datapoint.value_bitmask);
       break;
     default:
-      ESP_LOGW(TAG, "Datapoint %u has unknown type 0x%02hhX", datapoint.id, datapoint.type);
+      ESP_LOGW(TAG, "Datapoint %u has unknown type %#02hhX", datapoint.id, datapoint.type);
       return;
   }
-  ESP_LOGD(TAG, "Datapoint %u update to %u", datapoint.id, datapoint.value_uint);
 
   // Update internal datapoints
   bool found = false;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -31,7 +31,9 @@ void Tuya::dump_config() {
     return;
   }
   for (auto &info : this->datapoints_) {
-    if (info.type == TuyaDatapointType::BOOLEAN)
+    if (info.type == TuyaDatapointType::RAW)
+      ESP_LOGCONFIG(TAG, "  Datapoint %u: raw (value: %s)", info.id, hexencode(info.value_raw).c_str());
+    else if (info.type == TuyaDatapointType::BOOLEAN)
       ESP_LOGCONFIG(TAG, "  Datapoint %u: switch (value: %s)", info.id, ONOFF(info.value_bool));
     else if (info.type == TuyaDatapointType::INTEGER)
       ESP_LOGCONFIG(TAG, "  Datapoint %u: int value (value: %d)", info.id, info.value_int);
@@ -236,6 +238,9 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
   datapoint.len = data_len;
 
   switch (datapoint.type) {
+    case TuyaDatapointType::RAW:
+      datapoint.value_raw = std::vector<uint8_t>(data, data + data_len);
+      break;
     case TuyaDatapointType::BOOLEAN:
       if (data_len != 1) {
         ESP_LOGW(TAG, "Datapoint %u has bad boolean len %zu", datapoint.id, data_len);

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -32,6 +32,7 @@ struct TuyaDatapoint {
     uint32_t value_bitmask;
   };
   std::string value_string;
+  std::vector<uint8_t> value_raw;
 };
 
 struct TuyaDatapointListener {


### PR DESCRIPTION
# What does this implement/fix? 

**This PR is based on #1491 which should be merged first, so currently marked as a draft.**

This adds support for raw datapoints of tuya devices.

This is required base work for future improvements of the tuya climate component to evaluate heating/cooling schedules.
The tuya climate component currently has no way of knowing the temperature setpoint in automatic mode (only the manual setpoint is exposed as a datapoint). Having the schedule available will allow finding the currently active target temperature.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A
  
# Test Environment

- [ ] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [X] Linux (Home Assistant Addon)

# Explain your changes

See above.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
