### PR TITLE
mqtt_client: Added MQTTClientComponent::unsubscribe()

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -347,6 +347,26 @@ void MQTTClientComponent::subscribe_json(const std::string &topic, mqtt_json_cal
   this->subscriptions_.push_back(subscription);
 }
 
+void MQTTClientComponent::unsubscribe(const std::string &topic) {
+  uint16_t ret = this->mqtt_client_.unsubscribe(topic.c_str());
+  yield();
+  if (ret != 0) {
+    ESP_LOGV(TAG, "unsubscribe(topic='%s')", topic.c_str());
+  } else {
+    delay(5);
+    ESP_LOGV(TAG, "Unsubscribe failed for topic='%s'. Will retry later.", topic.c_str());
+    this->status_momentary_warning("unsubscribe", 1000);
+  }
+
+  auto it = subscriptions_.begin();
+  while (it != subscriptions_.end()) {
+	if (it->topic == topic)
+	  it = subscriptions_.erase(it);
+	else
+	  ++it;
+  }
+}
+
 // Publish
 bool MQTTClientComponent::publish(const std::string &topic, const std::string &payload, uint8_t qos, bool retain) {
   return this->publish(topic, payload.data(), payload.size(), qos, retain);

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -360,10 +360,10 @@ void MQTTClientComponent::unsubscribe(const std::string &topic) {
 
   auto it = subscriptions_.begin();
   while (it != subscriptions_.end()) {
-	if (it->topic == topic)
-	  it = subscriptions_.erase(it);
-	else
-	  ++it;
+    if (it->topic == topic)
+      it = subscriptions_.erase(it);
+    else
+      ++it;
   }
 }
 

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -354,7 +354,7 @@ void MQTTClientComponent::unsubscribe(const std::string &topic) {
     ESP_LOGV(TAG, "unsubscribe(topic='%s')", topic.c_str());
   } else {
     delay(5);
-    ESP_LOGV(TAG, "Unsubscribe failed for topic='%s'. Will retry later.", topic.c_str());
+    ESP_LOGV(TAG, "Unsubscribe failed for topic='%s'.", topic.c_str());
     this->status_momentary_warning("unsubscribe", 1000);
   }
 

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -161,10 +161,10 @@ class MQTTClientComponent : public Component {
 
   /** Unsubscribe from an MQTT topic.
    *
-   * @param topic The topic to unsubscribe from. Must match the topic in the original subscribe or subscribe_json call exactly.
+   * @param topic The topic to unsubscribe from.
+   * Must match the topic in the original subscribe or subscribe_json call exactly.
    */
   void unsubscribe(const std::string &topic);
-
 
   /** Publish a MQTTMessage
    *

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -159,6 +159,13 @@ class MQTTClientComponent : public Component {
    */
   void subscribe_json(const std::string &topic, mqtt_json_callback_t callback, uint8_t qos = 0);
 
+  /** Unsubscribe from an MQTT topic.
+   *
+   * @param topic The topic to unsubscribe from. Must match the topic in the original subscribe or subscribe_json call exactly.
+   */
+  void unsubscribe(const std::string &topic);
+
+
   /** Publish a MQTTMessage
    *
    * @param message The message.

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -161,6 +161,8 @@ class MQTTClientComponent : public Component {
 
   /** Unsubscribe from an MQTT topic.
    *
+   * If multiple existing subscriptions to the same topic exist, all of them will be removed.
+   *
    * @param topic The topic to unsubscribe from.
    * Must match the topic in the original subscribe or subscribe_json call exactly.
    */


### PR DESCRIPTION
# What does this implement/fix? 

Added an `unsubscribe()` method to the `MQTTClientComponent` class.

I required this for my project which deals with a lot of changing MQTT topics.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a
  
# Test Environment

- [ ] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [X] Linux

# Explain your changes

The `MQTTClientComponent` has a `subscribe()` method but no `unsubscribe()` method. There is already an `unsubscribe()` method in the underlying `AsyncMqttClient` class, so this addition is merely a further wrapper method.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
