### PR TITLE
Raise minimum python version to 3.7

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -638,10 +638,10 @@ def run_esphome(argv):
         _LOGGER.error("Missing configuration parameter, see esphome --help.")
         return 1
 
-    if sys.version_info < (3, 6, 0):
+    if sys.version_info < (3, 7, 0):
         _LOGGER.error(
-            "You're running ESPHome with Python <3.6. ESPHome is no longer compatible "
-            "with this Python version. Please reinstall ESPHome with Python 3.6+"
+            "You're running ESPHome with Python <3.7. ESPHome is no longer compatible "
+            "with this Python version. Please reinstall ESPHome with Python 3.7+"
         )
         return 1
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     zip_safe=False,
     platforms="any",
     test_suite="tests",
-    python_requires=">=3.6,<4.0",
+    python_requires=">=3.7,<4.0",
     install_requires=REQUIRES,
     keywords=["home", "automation"],
     entry_points={"console_scripts": ["esphome = esphome.__main__:main"]},


### PR DESCRIPTION
# What does this implement/fix? 

Breaking change. This PR raises the minimum python version to 3.7.

Python 3.7 will be required for some features I'm working on (#1657, #1630). The docker images already use 3.7, and most recent distributions ship with 3.7 or newer (exception: ubuntu bionic LTS, but those folks should upgrade to focal LTS)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [x] Windows
- [x] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
