### PR TITLE
Add --ca-cert option to subcommands logs and clean-mqtt

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -247,9 +247,16 @@ def show_logs(config, args, port):
         return run_logs(config, port)
     if get_port_type(port) == "MQTT" and "mqtt" in config:
         from esphome import mqtt
+        import os
+
+        ca_cert= args.ca_cert
+        if ca_cert is not None: 
+            if not os.path.isabs(args.ca_cert) : 
+                ca_cert = os.path.join(os.getcwd(), ca_cert)
 
         return mqtt.show_logs(
-            config, args.topic, args.username, args.password, args.client_id
+            config, args.topic, args.username, args.password, args.client_id,
+            ca_cert
         )
 
     raise EsphomeError("No remote or local logging method configured (api/mqtt/logger)")
@@ -545,6 +552,10 @@ def parse_args(argv):
         help="Manually specify a serial port to use"
         "For example /dev/cu.SLAB_USBtoUART.",
     )
+    parser_logs.add_argument(
+        "--ca-cert",
+        help="If using self signed certificate for MQTT"
+        "Pass, ca cert file path, like ../mqtt/certs/ca.crt")
 
     parser_run = subparsers.add_parser(
         "run",

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -124,7 +124,8 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None,
             client_id, ca_cert)
 
 
-def clear_topic(config, topic, username=None, password=None, client_id=None):
+def clear_topic(config, topic, username=None, password=None, client_id=None,
+        ca_cert=None):
     if topic is None:
         discovery_prefix = config[CONF_MQTT].get(CONF_DISCOVERY_PREFIX, "homeassistant")
         name = config[CONF_ESPHOME][CONF_NAME]
@@ -145,7 +146,8 @@ def clear_topic(config, topic, username=None, password=None, client_id=None):
             return
         client.publish(msg.topic, None, retain=True)
 
-    return initialize(config, [topic], on_message, username, password, client_id)
+    return initialize(config, [topic], on_message, username, password,
+            client_id, ca_cert)
 
 
 # From marvinroger/async-mqtt-client -> scripts/get-fingerprint/get-fingerprint.py

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -28,7 +28,8 @@ from esphome.util import safe_print
 _LOGGER = logging.getLogger(__name__)
 
 
-def initialize(config, subscriptions, on_message, username, password, client_id):
+def initialize(config, subscriptions, on_message, username, password, client_id,
+        ca_cert=None):
     def on_connect(client, userdata, flags, return_code):
         _LOGGER.info("Connected to MQTT broker!")
         for topic in subscriptions:
@@ -74,7 +75,7 @@ def initialize(config, subscriptions, on_message, username, password, client_id)
         else:
             tls_version = ssl.PROTOCOL_SSLv23
         client.tls_set(
-            ca_certs=None,
+            ca_certs=ca_cert,
             certfile=None,
             keyfile=None,
             cert_reqs=ssl.CERT_REQUIRED,
@@ -96,7 +97,8 @@ def initialize(config, subscriptions, on_message, username, password, client_id)
     return 0
 
 
-def show_logs(config, topic=None, username=None, password=None, client_id=None):
+def show_logs(config, topic=None, username=None, password=None, client_id=None,
+        ca_cert=None):
     if topic is not None:
         pass  # already have topic
     elif CONF_MQTT in config:
@@ -118,7 +120,8 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None):
         message = time_ + payload
         safe_print(message)
 
-    return initialize(config, [topic], on_message, username, password, client_id)
+    return initialize(config, [topic], on_message, username, password,
+            client_id, ca_cert)
 
 
 def clear_topic(config, topic, username=None, password=None, client_id=None):


### PR DESCRIPTION
# What does this implement/fix? 

This change allow users of mqtt configured using self signed certificates, to interact from esphome cli for reading logs and clearing mqtt topics in a secure way. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:

No change required

# Explain your changes

This PR  provides a new CLI option for subcomands logs and clean-mqtt, making possible to send custom CA certificate avoiding `SSL:CERTIFICATE_VERIFY_FAILED` error:

```
esphome my-device.yaml clean-mqtt --ca-cert mosquito-ssl/ssl/ca.crt
esphome my-device.yaml logs --ca-cert mosquito-ssl/ssl/ca.crt
```
If no `--ca-cert` option is sent, and MQTT service uses and unknown SSL certificate, commands behave as always

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
