### PR TITLE
Support custom build_flags for bme680_bsec

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -60,5 +60,5 @@ def to_code(config):
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
     )
 
-    cg.add_build_flag("-DUSING_BSEC")
+    cg.add_define("USING_BSEC")
     cg.add_library("BSEC Software Library", "1.6.1480")

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -1,4 +1,4 @@
-#ifdef USING_BSEC
+
 
 #include "bme680_bsec.h"
 #include "esphome/core/log.h"
@@ -7,7 +7,7 @@
 
 namespace esphome {
 namespace bme680_bsec {
-
+#ifdef USING_BSEC
 static const char *TAG = "bme680_bsec.sensor";
 
 static const std::string IAQ_ACCURACY_STATES[4] = {"Stabilizing", "Uncertain", "Calibrating", "Calibrated"};
@@ -391,8 +391,6 @@ void BME680BSECComponent::save_state_(uint8_t accuracy) {
 
   ESP_LOGI(TAG, "Saved state");
 }
-
+#endif
 }  // namespace bme680_bsec
 }  // namespace esphome
-
-#endif

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -1,4 +1,4 @@
-#ifdef USING_BSEC
+
 
 #pragma once
 
@@ -7,11 +7,15 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/preferences.h"
-#include <bsec.h>
 #include <map>
+
+#ifdef USING_BSEC
+#include <bsec.h>
+#endif
 
 namespace esphome {
 namespace bme680_bsec {
+#ifdef USING_BSEC
 
 enum IAQMode {
   IAQ_MODE_STATIC = 0,
@@ -99,8 +103,6 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   sensor::Sensor *co2_equivalent_sensor_;
   sensor::Sensor *breath_voc_equivalent_sensor_;
 };
-
+#endif
 }  // namespace bme680_bsec
 }  // namespace esphome
-
-#endif


### PR DESCRIPTION
# What does this implement/fix? 
This is needed for folks who set ``build_flags`` in yaml files brought in under ``packages:``
Quick description 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>


# Test Environment

- [X] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

# Explain your changes
For users with ``build_flags`` included through ``packages:`` ``USING_BSEC`` is not added to ``build_flags``. This simple change moves ``USING_BSEC`` to a define and still keeps ``bsec.h`` out of the mix. Things compile as expected. Below is the error.

**Note** The real fix might be figuring out why ``-DUSING_BSEC`` i'snt being added to ``build_flags`` but as of now this is broke for some users.

```
src/main.cpp:90:1: error: 'bme680_bsec' does not name a type
 bme680_bsec::BME680BSECComponent *bme680_bsec_bme680bseccomponent;
 ^
config/shared/esp_thermostat_nextion_common_config.yaml: In function 'void setup()':
config/shared/esp_thermostat_nextion_common_config.yaml:2281:3: error: 'bme680_bsec_bme680bseccomponent' was not declared in this scope
config/shared/esp_thermostat_nextion_common_config.yaml:2281:41: error: 'bme680_bsec' does not name a type
config/shared/esp_thermostat_nextion_common_config.yaml:675:49: error: 'bme680_bsec' has not been declared
config/shared/esp_thermostat_nextion_common_config.yaml:676:52: error: 'bme680_bsec' has not been declared
```
## Checklist:
  - [X ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
