### PR TITLE
Add Arduino ESP32 version mapping

### DIFF
--- a/esphome/const.py
+++ b/esphome/const.py
@@ -16,6 +16,7 @@ ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789_-"
 # See also https://github.com/platformio/platform-espressif32/releases
 ARDUINO_VERSION_ESP32 = {
     "dev": "https://github.com/platformio/platform-espressif32.git",
+    "1.0.6": "platformio/espressif32@3.2.0",
     "1.0.5": "platformio/espressif32@3.1.1",
     "1.0.4": "platformio/espressif32@3.0.0",
     "1.0.3": "platformio/espressif32@1.10.0",


### PR DESCRIPTION
# What does this implement/fix? 

See also https://github.com/platformio/platform-espressif32/releases/tag/v3.2.0

Arduino framework 1.0.6 was released: https://github.com/espressif/arduino-esp32/releases/tag/1.0.6 for the `arduino_version` variable (no guarantee for actually compiling though, this is just the mapping)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

See above

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
