### PR TITLE
Automate building and publishing of esphome-lint docker image

### DIFF
--- a/.github/workflows/docker-lint-build.yml
+++ b/.github/workflows/docker-lint-build.yml
@@ -1,0 +1,36 @@
+name: Build and publish lint docker image
+
+# Only run when docker paths change
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'docker/Dockerfile.lint'
+      - 'requirements.txt'
+      - 'requirements_test.txt'
+      - 'platformio.ini'
+      - '.github/workflows/docker-lint-build.yml'
+
+jobs:
+  publish-docker-lint-iage:
+    name: Build docker containers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull for cache
+        run: |
+          docker pull "esphome/esphome-lint:latest" || true
+      - name: Build
+        run: |
+          docker build \
+            --cache-from "esphome/esphome-lint:latest" \
+            --file "docker/Dockerfile.lint" \
+            --tag "esphome/esphome-lint:latest" \
+            .
+      - name: Log in to docker hub
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
+      - run: |
+          docker push "esphome/esphome-lint:latest"


### PR DESCRIPTION
# What does this implement/fix? 

Before, I built the esphome/esphome-lint image myself on my machine. This PR automates building that image and publishing it whenever the files it depends on change on the dev branch.

Future work: we might want to version the lint image, so that if there's some breaking change with the lint image (hasn't happened in the past), we don't break outdated branches from PRs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
