### PR TITLE
Autorepeat filter for the binary sensors

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -163,6 +163,10 @@ def delayed_off_filter_to_code(config, filter_id):
 CONF_TIME_OFF = "time_off"
 CONF_TIME_ON = "time_on"
 
+DEFAULT_DELAY = "1s"
+DEFAULT_TIME_OFF = "100ms"
+DEFAULT_TIME_ON = "900ms"
+
 
 @FILTER_REGISTRY.register(
     "autorepeat",
@@ -171,23 +175,31 @@ CONF_TIME_ON = "time_on"
         cv.ensure_list(
             {
                 cv.Optional(
-                    CONF_DELAY, default="1s"
+                    CONF_DELAY, default=DEFAULT_DELAY
                 ): cv.positive_time_period_milliseconds,
                 cv.Optional(
-                    CONF_TIME_OFF, default="100ms"
+                    CONF_TIME_OFF, default=DEFAULT_TIME_OFF
                 ): cv.positive_time_period_milliseconds,
                 cv.Optional(
-                    CONF_TIME_ON, default="900ms"
+                    CONF_TIME_ON, default=DEFAULT_TIME_ON
                 ): cv.positive_time_period_milliseconds,
             }
         ),
-        cv.Length(min=1),
     ),
 )
 def autorepeat_filter_to_code(config, filter_id):
     timings = []
-    for conf in config:
-        timings.append((conf[CONF_DELAY], conf[CONF_TIME_OFF], conf[CONF_TIME_ON]))
+    if len(config) > 0:
+        for conf in config:
+            timings.append((conf[CONF_DELAY], conf[CONF_TIME_OFF], conf[CONF_TIME_ON]))
+    else:
+        timings.append(
+            (
+                cv.time_period_str_unit(DEFAULT_DELAY).total_milliseconds,
+                cv.time_period_str_unit(DEFAULT_TIME_OFF).total_milliseconds,
+                cv.time_period_str_unit(DEFAULT_TIME_ON).total_milliseconds,
+            )
+        )
     var = cg.new_Pvariable(filter_id, timings)
     yield cg.register_component(var, {})
     yield var

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -66,6 +66,33 @@ class InvertFilter : public Filter {
   optional<bool> new_value(bool value, bool is_initial) override;
 };
 
+struct AutorepeatFilterTiming {
+  AutorepeatFilterTiming(uint32_t delay, uint32_t off, uint32_t on) {
+    this->delay = delay;
+    this->time_off = off;
+    this->time_on = on;
+  }
+  uint32_t delay;
+  uint32_t time_off;
+  uint32_t time_on;
+};
+
+class AutorepeatFilter : public Filter, public Component {
+ public:
+  explicit AutorepeatFilter(const std::vector<AutorepeatFilterTiming> &timings);
+
+  optional<bool> new_value(bool value, bool is_initial) override;
+
+  float get_setup_priority() const override;
+
+ protected:
+  void next_timing_();
+  void next_value_(bool val);
+
+  std::vector<AutorepeatFilterTiming> timings_;
+  uint8_t active_timing_{0};
+};
+
 class LambdaFilter : public Filter {
  public:
   explicit LambdaFilter(const std::function<optional<bool>(bool)> &f);

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -86,6 +86,20 @@ binary_sensor:
   - platform: tuya
     id: tuya_binary_sensor
     sensor_datapoint: 1
+  - platform: template
+    id: ar1
+    lambda: 'return {};'
+    filters:
+      - autorepeat:
+        - delay: 2s
+          time_off: 100ms
+          time_on: 900ms
+        - delay: 4s
+          time_off: 100ms
+          time_on: 400ms
+    on_state:
+      then:
+        - lambda: 'ESP_LOGI("ar1:", "%d", x);'
 
 climate:
   - platform: tuya


### PR DESCRIPTION
# What does this implement/fix? 

A common autorepeat filter able to produce binary sensor changes according to a timing description

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1093
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
binary_sensor:
  - platform: ...
    # ...
    filters:
      - autorepeat:
        - delay: 1s
          time_off: 100ms
          time_on: 900ms
        - delay: 5s
          time_off: 100ms
          time_on: 400ms
```

# Explain your changes

Developing a touch screen GUI I wanted to have the possibility to implement an autorepeat for the (virtual) buttons so I can for example conveniently implement a date/time set widget.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
