### PR TITLE
Bme680 sec sample rate

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -10,7 +10,6 @@ AUTO_LOAD = ["sensor", "text_sensor"]
 CONF_BME680_BSEC_ID = "bme680_bsec_id"
 CONF_TEMPERATURE_OFFSET = "temperature_offset"
 CONF_IAQ_MODE = "iaq_mode"
-CONF_SAMPLE_RATE = "sample_rate"
 CONF_STATE_SAVE_INTERVAL = "state_save_interval"
 
 bme680_bsec_ns = cg.esphome_ns.namespace("bme680_bsec")
@@ -21,11 +20,6 @@ IAQ_MODE_OPTIONS = {
     "MOBILE": IAQMode.IAQ_MODE_MOBILE,
 }
 
-SampleRate = bme680_bsec_ns.enum("SampleRate")
-SAMPLE_RATE_OPTIONS = {
-    "LP": SampleRate.SAMPLE_RATE_LP,
-    "ULP": SampleRate.SAMPLE_RATE_ULP,
-}
 
 BME680BSECComponent = bme680_bsec_ns.class_(
     "BME680BSECComponent", cg.Component, i2c.I2CDevice
@@ -37,9 +31,6 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_TEMPERATURE_OFFSET, default=0): cv.temperature,
         cv.Optional(CONF_IAQ_MODE, default="STATIC"): cv.enum(
             IAQ_MODE_OPTIONS, upper=True
-        ),
-        cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
-            SAMPLE_RATE_OPTIONS, upper=True
         ),
         cv.Optional(
             CONF_STATE_SAVE_INTERVAL, default="6hours"
@@ -55,10 +46,9 @@ def to_code(config):
 
     cg.add(var.set_temperature_offset(config[CONF_TEMPERATURE_OFFSET]))
     cg.add(var.set_iaq_mode(config[CONF_IAQ_MODE]))
-    cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
     cg.add(
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
     )
 
-    cg.add_define("USING_BSEC")
+    cg.add_define("USE_BSEC")
     cg.add_library("BSEC Software Library", "1.6.1480")

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -38,7 +38,7 @@ void BME680BSECComponent::setup() {
     return;
   }
 
-  if (this->iaq_sensor_sample_rate_ == SAMPLE_RATE_ULP) {
+  if (this->iaq_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP) {
     const uint8_t bsec_config[] = {
 #include "config/generic_33v_300s_28d/bsec_iaq.txt"
     };

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -43,14 +43,14 @@ void BME680BSECComponent::setup() {
 #include "config/generic_33v_300s_28d/bsec_iaq.txt"
     };
     this->set_config_(bsec_config);
-    this->update_subscription_(BSEC_SAMPLE_RATE_ULP);
   } else {
     const uint8_t bsec_config[] = {
 #include "config/generic_33v_3s_28d/bsec_iaq.txt"
     };
     this->set_config_(bsec_config);
-    this->update_subscription_(BSEC_SAMPLE_RATE_LP);
   }
+
+  this->update_subscription_();
 
   if (this->bsec_status_ != BSEC_OK) {
     this->mark_failed();

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -78,7 +78,6 @@ void BME680BSECComponent::update_subscription_(float sample_rate) {
   }
 
   if (this->co2_equivalent_sensor_) {
-    ESP_LOGD(TAG, "co2_equivalent_sensor_ %f %f", sample_rate, co2_equivalent_sensor_sample_rate_);
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_CO2_EQUIVALENT;
     virtual_sensors[num_virtual_sensors].sample_rate = co2_equivalent_sensor_sample_rate_;
     num_virtual_sensors++;
@@ -145,22 +144,25 @@ void BME680BSECComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  State Save Interval: %ims", this->state_save_interval_ms_);
 
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
-  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->temperature_sensor_sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s",
+                this->temperature_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP ? "ULP" : "LP");
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
-  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->pressure_sensor_sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->pressure_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP ? "ULP" : "LP");
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
-  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->humidity_sensor_sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->humidity_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP ? "ULP" : "LP");
   LOG_SENSOR("  ", "Gas Resistance", this->gas_resistance_sensor_);
-  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->gas_resistance_sensor_sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s",
+                this->gas_resistance_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP ? "ULP" : "LP");
   LOG_SENSOR("  ", "IAQ", this->iaq_sensor_);
-  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->iaq_sensor_sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->iaq_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP ? "ULP" : "LP");
   LOG_SENSOR("  ", "Numeric IAQ Accuracy", this->iaq_accuracy_sensor_);
   LOG_TEXT_SENSOR("  ", "IAQ Accuracy", this->iaq_accuracy_text_sensor_);
   LOG_SENSOR("  ", "CO2 Equivalent", this->co2_equivalent_sensor_);
-  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", this->co2_equivalent_sensor_sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s",
+                this->co2_equivalent_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP ? "ULP" : "LP");
   LOG_SENSOR("  ", "Breath VOC Equivalent", this->breath_voc_equivalent_sensor_);
   ESP_LOGCONFIG(TAG, "    Sample Rate: %s",
-                this->breath_voc_equivalent_sensor_sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+                this->breath_voc_equivalent_sensor_sample_rate_ == BSEC_SAMPLE_RATE_ULP ? "ULP" : "LP");
 }
 
 float BME680BSECComponent::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -84,35 +84,30 @@ void BME680BSECComponent::update_subscription_() {
   }
 
   if (this->breath_voc_equivalent_sensor_) {
-    ESP_LOGD(TAG, "breath_voc_equivalent_sensor_ %f %f", sample_rate, breath_voc_equivalent_sensor_sample_rate_);
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_BREATH_VOC_EQUIVALENT;
     virtual_sensors[num_virtual_sensors].sample_rate = breath_voc_equivalent_sensor_sample_rate_;
     num_virtual_sensors++;
   }
 
   if (this->pressure_sensor_) {
-    ESP_LOGD(TAG, "pressure_sensor_ %f %f", sample_rate, pressure_sensor_sample_rate_);
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_RAW_PRESSURE;
     virtual_sensors[num_virtual_sensors].sample_rate = pressure_sensor_sample_rate_;
     num_virtual_sensors++;
   }
 
   if (this->gas_resistance_sensor_) {
-    ESP_LOGD(TAG, "gas_resistance_sensor_ %f %f", sample_rate, gas_resistance_sensor_sample_rate_);
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_RAW_GAS;
     virtual_sensors[num_virtual_sensors].sample_rate = gas_resistance_sensor_sample_rate_;
     num_virtual_sensors++;
   }
 
   if (this->temperature_sensor_) {
-    ESP_LOGD(TAG, "temperature_sensor_ %f %f", sample_rate, temperature_sensor_sample_rate_);
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE;
     virtual_sensors[num_virtual_sensors].sample_rate = temperature_sensor_sample_rate_;
     num_virtual_sensors++;
   }
 
   if (this->humidity_sensor_) {
-    ESP_LOGD(TAG, "humidity_sensor_ %f %f", sample_rate, humidity_sensor_sample_rate_);
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY;
     virtual_sensors[num_virtual_sensors].sample_rate = humidity_sensor_sample_rate_;
     num_virtual_sensors++;

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -65,7 +65,7 @@ void BME680BSECComponent::set_config_(const uint8_t *config) {
   this->bsec_status_ = bsec_set_configuration(config, BSEC_MAX_PROPERTY_BLOB_SIZE, work_buffer, sizeof(work_buffer));
 }
 
-void BME680BSECComponent::update_subscription_(float sample_rate) {
+void BME680BSECComponent::update_subscription_() {
   bsec_sensor_configuration_t virtual_sensors[BSEC_NUMBER_OUTPUTS];
   int num_virtual_sensors = 0;
 

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -35,39 +35,44 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
 
   void set_state_save_interval(uint32_t interval) { this->state_save_interval_ms_ = interval; }
 
-  void set_temperature_sensor(sensor::Sensor *temperature_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor, SampleRate temperature_sensor_sample_rate) {
     temperature_sensor_ = temperature_sensor;
-    temperature_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+    temperature_sensor_sample_rate_ =
+        temperature_sensor_sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
-  void set_pressure_sensor(sensor::Sensor *pressure_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor, SampleRate pressure_sensor_sample_rate) {
     pressure_sensor_ = pressure_sensor;
-    pressure_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+    pressure_sensor_sample_rate_ =
+        pressure_sensor_sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
-  void set_humidity_sensor(sensor::Sensor *humidity_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+  void set_humidity_sensor(sensor::Sensor *humidity_sensor, SampleRate humidity_sensor_sample_rate) {
     humidity_sensor_ = humidity_sensor;
-    humidity_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+    humidity_sensor_sample_rate_ =
+        humidity_sensor_sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
-  void set_gas_resistance_sensor(sensor::Sensor *gas_resistance_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+  void set_gas_resistance_sensor(sensor::Sensor *gas_resistance_sensor, SampleRate gas_resistance_sensor_sample_rate) {
     gas_resistance_sensor_ = gas_resistance_sensor;
-    gas_resistance_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+    gas_resistance_sensor_sample_rate_ =
+        gas_resistance_sensor_sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
-  void set_iaq_sensor(sensor::Sensor *iaq_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+  void set_iaq_sensor(sensor::Sensor *iaq_sensor, SampleRate iaq_sensor_sample_rate) {
     iaq_sensor_ = iaq_sensor;
-    iaq_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+    iaq_sensor_sample_rate_ = iaq_sensor_sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
   void set_iaq_accuracy_text_sensor(text_sensor::TextSensor *iaq_accuracy_text_sensor) {
     iaq_accuracy_text_sensor_ = iaq_accuracy_text_sensor;
   }
   void set_iaq_accuracy_sensor(sensor::Sensor *iaq_accuracy_sensor) { iaq_accuracy_sensor_ = iaq_accuracy_sensor; }
-  void set_co2_equivalent_sensor(sensor::Sensor *co2_equivalent_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+  void set_co2_equivalent_sensor(sensor::Sensor *co2_equivalent_sensor, SampleRate co2_equivalent_sensor_sample_rate) {
     co2_equivalent_sensor_ = co2_equivalent_sensor;
-    co2_equivalent_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+    co2_equivalent_sensor_sample_rate_ =
+        co2_equivalent_sensor_sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
   void set_breath_voc_equivalent_sensor(sensor::Sensor *breath_voc_equivalent_sensor,
-                                        esphome::bme680_bsec::SampleRate sample_rate) {
+                                        SampleRate breath_voc_equivalent_sensor_sample_rate) {
     breath_voc_equivalent_sensor_ = breath_voc_equivalent_sensor;
     breath_voc_equivalent_sensor_sample_rate_ =
-        sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+        breath_voc_equivalent_sensor_sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
 
   static BME680BSECComponent *instance;
@@ -111,20 +116,20 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   IAQMode iaq_mode_{IAQ_MODE_STATIC};
 
   sensor::Sensor *temperature_sensor_;
-  float temperature_sensor_sample_rate_{SAMPLE_RATE_LP};
+  float temperature_sensor_sample_rate_;
   sensor::Sensor *pressure_sensor_;
-  float pressure_sensor_sample_rate_{SAMPLE_RATE_LP};
+  float pressure_sensor_sample_rate_;
   sensor::Sensor *humidity_sensor_;
-  float humidity_sensor_sample_rate_{SAMPLE_RATE_LP};
+  float humidity_sensor_sample_rate_;
   sensor::Sensor *gas_resistance_sensor_;
-  float gas_resistance_sensor_sample_rate_{SAMPLE_RATE_ULP};
+  float gas_resistance_sensor_sample_rate_;
   sensor::Sensor *iaq_sensor_;
-  float iaq_sensor_sample_rate_{SAMPLE_RATE_ULP};
+  float iaq_sensor_sample_rate_;
   text_sensor::TextSensor *iaq_accuracy_text_sensor_;
   sensor::Sensor *co2_equivalent_sensor_;
-  float co2_equivalent_sensor_sample_rate_{SAMPLE_RATE_ULP};
+  float co2_equivalent_sensor_sample_rate_;
   sensor::Sensor *breath_voc_equivalent_sensor_;
-  float breath_voc_equivalent_sensor_sample_rate_{SAMPLE_RATE_ULP};
+  float breath_voc_equivalent_sensor_sample_rate_;
   sensor::Sensor *iaq_accuracy_sensor_;
 };
 #endif

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -87,7 +87,7 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
 
  protected:
   void set_config_(const uint8_t *config);
-  void update_subscription_(float sample_rate);
+  void update_subscription_();
 
   void run_();
   void read_(bsec_bme_settings_t bme680_settings);

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -3,19 +3,20 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/preferences.h"
 #include <map>
 
-#ifdef USING_BSEC
+#ifdef USE_BSEC
 #include <bsec.h>
 #endif
 
 namespace esphome {
 namespace bme680_bsec {
-#ifdef USING_BSEC
+#ifdef USE_BSEC
 
 enum IAQMode {
   IAQ_MODE_STATIC = 0,
@@ -31,25 +32,42 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
  public:
   void set_temperature_offset(float offset) { this->temperature_offset_ = offset; }
   void set_iaq_mode(IAQMode iaq_mode) { this->iaq_mode_ = iaq_mode; }
-  void set_sample_rate(SampleRate sample_rate) { this->sample_rate_ = sample_rate; }
+
   void set_state_save_interval(uint32_t interval) { this->state_save_interval_ms_ = interval; }
 
-  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
-  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
-  void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
-  void set_gas_resistance_sensor(sensor::Sensor *gas_resistance_sensor) {
-    gas_resistance_sensor_ = gas_resistance_sensor;
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+    temperature_sensor_ = temperature_sensor;
+    temperature_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
-  void set_iaq_sensor(sensor::Sensor *iaq_sensor) { iaq_sensor_ = iaq_sensor; }
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+    pressure_sensor_ = pressure_sensor;
+    pressure_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+  }
+  void set_humidity_sensor(sensor::Sensor *humidity_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+    humidity_sensor_ = humidity_sensor;
+    humidity_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+  }
+  void set_gas_resistance_sensor(sensor::Sensor *gas_resistance_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+    gas_resistance_sensor_ = gas_resistance_sensor;
+    gas_resistance_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+  }
+  void set_iaq_sensor(sensor::Sensor *iaq_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
+    iaq_sensor_ = iaq_sensor;
+    iaq_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+  }
   void set_iaq_accuracy_text_sensor(text_sensor::TextSensor *iaq_accuracy_text_sensor) {
     iaq_accuracy_text_sensor_ = iaq_accuracy_text_sensor;
   }
   void set_iaq_accuracy_sensor(sensor::Sensor *iaq_accuracy_sensor) { iaq_accuracy_sensor_ = iaq_accuracy_sensor; }
-  void set_co2_equivalent_sensor(sensor::Sensor *co2_equivalent_sensor) {
+  void set_co2_equivalent_sensor(sensor::Sensor *co2_equivalent_sensor, esphome::bme680_bsec::SampleRate sample_rate) {
     co2_equivalent_sensor_ = co2_equivalent_sensor;
+    co2_equivalent_sensor_sample_rate_ = sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
-  void set_breath_voc_equivalent_sensor(sensor::Sensor *breath_voc_equivalent_sensor) {
+  void set_breath_voc_equivalent_sensor(sensor::Sensor *breath_voc_equivalent_sensor,
+                                        esphome::bme680_bsec::SampleRate sample_rate) {
     breath_voc_equivalent_sensor_ = breath_voc_equivalent_sensor;
+    breath_voc_equivalent_sensor_sample_rate_ =
+        sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
   }
 
   static BME680BSECComponent *instance;
@@ -91,17 +109,23 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
 
   float temperature_offset_{0};
   IAQMode iaq_mode_{IAQ_MODE_STATIC};
-  SampleRate sample_rate_{SAMPLE_RATE_LP};
 
   sensor::Sensor *temperature_sensor_;
+  float temperature_sensor_sample_rate_{SAMPLE_RATE_LP};
   sensor::Sensor *pressure_sensor_;
+  float pressure_sensor_sample_rate_{SAMPLE_RATE_LP};
   sensor::Sensor *humidity_sensor_;
+  float humidity_sensor_sample_rate_{SAMPLE_RATE_LP};
   sensor::Sensor *gas_resistance_sensor_;
+  float gas_resistance_sensor_sample_rate_{SAMPLE_RATE_ULP};
   sensor::Sensor *iaq_sensor_;
+  float iaq_sensor_sample_rate_{SAMPLE_RATE_ULP};
   text_sensor::TextSensor *iaq_accuracy_text_sensor_;
-  sensor::Sensor *iaq_accuracy_sensor_;
   sensor::Sensor *co2_equivalent_sensor_;
+  float co2_equivalent_sensor_sample_rate_{SAMPLE_RATE_ULP};
   sensor::Sensor *breath_voc_equivalent_sensor_;
+  float breath_voc_equivalent_sensor_sample_rate_{SAMPLE_RATE_ULP};
+  sensor::Sensor *iaq_accuracy_sensor_;
 };
 #endif
 }  // namespace bme680_bsec

--- a/esphome/components/bme680_bsec/sensor.py
+++ b/esphome/components/bme680_bsec/sensor.py
@@ -35,6 +35,7 @@ CONF_IAQ_ACCURACY = "iaq_accuracy"
 CONF_CO2_EQUIVALENT = "co2_equivalent"
 CONF_BREATH_VOC_EQUIVALENT = "breath_voc_equivalent"
 CONF_SAMPLE_RATE = "sample_rate"
+CONFIG_IAQ_SAMPLE_RATE = "iaq_sample_rate"
 UNIT_IAQ = "IAQ"
 ICON_ACCURACY = "mdi:checkbox-marked-circle-outline"
 ICON_TEST_TUBE = "mdi:test-tube"
@@ -59,6 +60,9 @@ TYPES = {
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
+        cv.Optional(CONFIG_IAQ_SAMPLE_RATE, default="ULP"): cv.enum(
+            SAMPLE_RATE_OPTIONS, upper=True
+        ),
         cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
             UNIT_CELSIUS, ICON_THERMOMETER, 1, DEVICE_CLASS_TEMPERATURE
         ).extend(
@@ -88,42 +92,18 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_GAS_RESISTANCE): sensor.sensor_schema(
             UNIT_OHM, ICON_GAS_CYLINDER, 0, DEVICE_CLASS_EMPTY
-        ).extend(
-            {
-                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
-                    SAMPLE_RATE_OPTIONS, upper=True
-                )
-            },
         ),
         cv.Optional(CONF_IAQ): sensor.sensor_schema(
             UNIT_IAQ, ICON_GAUGE, 0, DEVICE_CLASS_EMPTY
-        ).extend(
-            {
-                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
-                    SAMPLE_RATE_OPTIONS, upper=True
-                )
-            },
         ),
         cv.Optional(CONF_IAQ_ACCURACY): sensor.sensor_schema(
             UNIT_EMPTY, ICON_ACCURACY, 0, DEVICE_CLASS_EMPTY
         ),
         cv.Optional(CONF_CO2_EQUIVALENT): sensor.sensor_schema(
             UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
-        ).extend(
-            {
-                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
-                    SAMPLE_RATE_OPTIONS, upper=True
-                )
-            },
         ),
         cv.Optional(CONF_BREATH_VOC_EQUIVALENT): sensor.sensor_schema(
             UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
-        ).extend(
-            {
-                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
-                    SAMPLE_RATE_OPTIONS, upper=True
-                )
-            },
         ),
     }
 )
@@ -138,7 +118,7 @@ def setup_conf(config, key, hub, funcName):
         if CONF_SAMPLE_RATE in conf:
             cg.add(func(var, conf[CONF_SAMPLE_RATE]))
         else:
-            cg.add(func(var))
+            cg.add(func(var, config[CONFIG_IAQ_SAMPLE_RATE]))
 
 
 def to_code(config):

--- a/esphome/components/bme680_bsec/sensor.py
+++ b/esphome/components/bme680_bsec/sensor.py
@@ -22,7 +22,11 @@ from esphome.const import (
     ICON_WATER_PERCENT,
 )
 from esphome.core import coroutine
-from . import BME680BSECComponent, CONF_BME680_BSEC_ID
+from . import (
+    BME680BSECComponent,
+    CONF_BME680_BSEC_ID,
+    bme680_bsec_ns,
+)
 
 DEPENDENCIES = ["bme680_bsec"]
 
@@ -30,9 +34,16 @@ CONF_IAQ = "iaq"
 CONF_IAQ_ACCURACY = "iaq_accuracy"
 CONF_CO2_EQUIVALENT = "co2_equivalent"
 CONF_BREATH_VOC_EQUIVALENT = "breath_voc_equivalent"
+CONF_SAMPLE_RATE = "sample_rate"
 UNIT_IAQ = "IAQ"
 ICON_ACCURACY = "mdi:checkbox-marked-circle-outline"
 ICON_TEST_TUBE = "mdi:test-tube"
+
+SampleRate = bme680_bsec_ns.enum("SampleRate")
+SAMPLE_RATE_OPTIONS = {
+    "LP": SampleRate.SAMPLE_RATE_LP,
+    "ULP": SampleRate.SAMPLE_RATE_ULP,
+}
 
 TYPES = {
     CONF_TEMPERATURE: "set_temperature_sensor",
@@ -50,27 +61,69 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
         cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
             UNIT_CELSIUS, ICON_THERMOMETER, 1, DEVICE_CLASS_TEMPERATURE
+        ).extend(
+            {
+                cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
+                    SAMPLE_RATE_OPTIONS, upper=True
+                )
+            },
         ),
         cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
             UNIT_HECTOPASCAL, ICON_GAUGE, 1, DEVICE_CLASS_PRESSURE
+        ).extend(
+            {
+                cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
+                    SAMPLE_RATE_OPTIONS, upper=True
+                )
+            },
         ),
         cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
             UNIT_PERCENT, ICON_WATER_PERCENT, 1, DEVICE_CLASS_HUMIDITY
+        ).extend(
+            {
+                cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
+                    SAMPLE_RATE_OPTIONS, upper=True
+                )
+            },
         ),
         cv.Optional(CONF_GAS_RESISTANCE): sensor.sensor_schema(
             UNIT_OHM, ICON_GAS_CYLINDER, 0, DEVICE_CLASS_EMPTY
+        ).extend(
+            {
+                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
+                    SAMPLE_RATE_OPTIONS, upper=True
+                )
+            },
         ),
         cv.Optional(CONF_IAQ): sensor.sensor_schema(
             UNIT_IAQ, ICON_GAUGE, 0, DEVICE_CLASS_EMPTY
+        ).extend(
+            {
+                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
+                    SAMPLE_RATE_OPTIONS, upper=True
+                )
+            },
         ),
         cv.Optional(CONF_IAQ_ACCURACY): sensor.sensor_schema(
             UNIT_EMPTY, ICON_ACCURACY, 0, DEVICE_CLASS_EMPTY
         ),
         cv.Optional(CONF_CO2_EQUIVALENT): sensor.sensor_schema(
             UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
+        ).extend(
+            {
+                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
+                    SAMPLE_RATE_OPTIONS, upper=True
+                )
+            },
         ),
         cv.Optional(CONF_BREATH_VOC_EQUIVALENT): sensor.sensor_schema(
             UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
+        ).extend(
+            {
+                cv.Optional(CONF_SAMPLE_RATE, default="ULP"): cv.enum(
+                    SAMPLE_RATE_OPTIONS, upper=True
+                )
+            },
         ),
     }
 )
@@ -82,7 +135,10 @@ def setup_conf(config, key, hub, funcName):
         conf = config[key]
         var = yield sensor.new_sensor(conf)
         func = getattr(hub, funcName)
-        cg.add(func(var))
+        if CONF_SAMPLE_RATE in conf:
+            cg.add(func(var, conf[CONF_SAMPLE_RATE]))
+        else:
+            cg.add(func(var))
 
 
 def to_code(config):

--- a/esphome/components/bme680_bsec/sensor.py
+++ b/esphome/components/bme680_bsec/sensor.py
@@ -35,7 +35,7 @@ CONF_IAQ_ACCURACY = "iaq_accuracy"
 CONF_CO2_EQUIVALENT = "co2_equivalent"
 CONF_BREATH_VOC_EQUIVALENT = "breath_voc_equivalent"
 CONF_SAMPLE_RATE = "sample_rate"
-CONFIG_IAQ_SAMPLE_RATE = "iaq_sample_rate"
+CONFIG_GAS_SAMPLE_RATE = "gas_sample_rate"
 UNIT_IAQ = "IAQ"
 ICON_ACCURACY = "mdi:checkbox-marked-circle-outline"
 ICON_TEST_TUBE = "mdi:test-tube"
@@ -60,7 +60,7 @@ TYPES = {
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
-        cv.Optional(CONFIG_IAQ_SAMPLE_RATE, default="ULP"): cv.enum(
+        cv.Optional(CONFIG_GAS_SAMPLE_RATE, default="ULP"): cv.enum(
             SAMPLE_RATE_OPTIONS, upper=True
         ),
         cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
@@ -118,7 +118,7 @@ def setup_conf(config, key, hub, funcName):
         if CONF_SAMPLE_RATE in conf:
             cg.add(func(var, conf[CONF_SAMPLE_RATE]))
         else:
-            cg.add(func(var, config[CONFIG_IAQ_SAMPLE_RATE]))
+            cg.add(func(var, config[CONFIG_GAS_SAMPLE_RATE]))
 
 
 def to_code(config):

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -234,28 +234,6 @@ sensor:
     id: freezer_temp_source
     reference_voltage: 3.19
     number: 0
-  - platform: bme680_bsec
-    temperature:
-      id: bme680_temp
-      sample_rate: LP
-    humidity:
-      id: bme680_humidity
-      sample_rate: LP
-    pressure:
-      id: bme680_pressure
-      sample_rate: LP
-    gas_resistance:
-      id: bme680_gas_resistance
-      sample_rate: ULP
-    iaq:
-      id: bme680_iaq
-      sample_rate: ULP
-    co2_equivalent:
-      id: bme680_co2_equivalent
-      sample_rate: ULP
-    breath_voc_equivalent:
-      id: bme680_breath_voc_equivalent
-      sample_rate: ULP
 
 time:
   - platform: homeassistant
@@ -380,9 +358,6 @@ text_sensor:
     id: ha_hello_world2
   - platform: ble_scanner
     name: Scanner
-  - platform: bme680_bsec
-    iaq_accuracy:
-      id: bme680_bsec_text
 
 script:
   - id: my_script

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -58,9 +58,6 @@ mcp3008:
   - id: 'mcp3008_hub'
     cs_pin: GPIO12
 
-bme680_bsec:
-  address: 0x76
-
 sensor:
   - platform: homeassistant
     entity_id: sensor.hello_world

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -58,6 +58,9 @@ mcp3008:
   - id: 'mcp3008_hub'
     cs_pin: GPIO12
 
+bme680_bsec:
+  address: 0x76
+
 sensor:
   - platform: homeassistant
     entity_id: sensor.hello_world
@@ -231,6 +234,29 @@ sensor:
     id: freezer_temp_source
     reference_voltage: 3.19
     number: 0
+  - platform: bme680_bsec
+    temperature:
+      id: bme680_temp
+      sample_rate: LP
+    humidity:
+      id: bme680_humidity
+      sample_rate: LP
+    pressure:
+      id: bme680_pressure
+      sample_rate: LP
+    gas_resistance:
+      id: bme680_gas_resistance
+      sample_rate: ULP
+    iaq:
+      id: bme680_iaq
+      sample_rate: ULP
+    co2_equivalent:
+      id: bme680_co2_equivalent
+      sample_rate: ULP
+    breath_voc_equivalent:
+      id: bme680_breath_voc_equivalent
+      sample_rate: ULP
+
 time:
   - platform: homeassistant
     on_time:
@@ -354,6 +380,9 @@ text_sensor:
     id: ha_hello_world2
   - platform: ble_scanner
     name: Scanner
+  - platform: bme680_bsec
+    iaq_accuracy:
+      id: bme680_bsec_text
 
 script:
   - id: my_script


### PR DESCRIPTION
# What does this implement/fix? 
Moved sample_rate from the parent config to per sensor
Fixed USE name - This was causing warnings in the build log
Added tests

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Configuration change (this will require users to update their yaml configuration files to keep working)
  
# Test Environment

- [X] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:

```yaml
- platform: bme680_bsec
    temperature:
      id: bme680_temp
      sample_rate: LP
    humidity:
      id: bme680_humidity
      sample_rate: LP
    pressure:
      id: bme680_pressure
      sample_rate: LP
    gas_resistance:
      id: bme680_gas_resistance
      sample_rate: ULP
    iaq:
      id: bme680_iaq
      sample_rate: ULP
    co2_equivalent:
      id: bme680_co2_equivalent
      sample_rate: ULP
    breath_voc_equivalent:
      id: bme680_breath_voc_equivalent
      sample_rate: ULP
```

# Explain your changes
Currently only one sample rate is used. This PR allows each sensor to have its own allowing for each to have its own update interval. sample_rate has been removed from the parent component which is a breaking change.

Tests have been added as well.

Added Docs
https://github.com/esphome/esphome-docs/pull/1099

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

