### PR TITLE
Added / to default glyphs

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -72,7 +72,7 @@ def validate_truetype_file(value):
 
 
 DEFAULT_GLYPHS = (
-    ' !"%()+,-.:0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz°'
+    ' !"%()+,-.:/0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz°'
 )
 CONF_RAW_DATA_ID = "raw_data_id"
 


### PR DESCRIPTION
# What does this implement/fix? 

Add the '/' character to the standard glyphs. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

The standard glyph set includes the ° degree sign for displaying temperatures on a display, but not the / character for displaying like velocity, acceleration or wind speeds. This character should therefore be included in the standard set.

## Checklist:
  - [*] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
