### PR TITLE
fix dallas pin validation

### DIFF
--- a/esphome/components/dallas/__init__.py
+++ b/esphome/components/dallas/__init__.py
@@ -15,7 +15,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DallasComponent),
         cv.GenerateID(CONF_ONE_WIRE_ID): cv.declare_id(ESPOneWire),
-        cv.Required(CONF_PIN): pins.gpio_input_pin_schema,
+        cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
     }
 ).extend(cv.polling_component_schema("60s"))
 


### PR DESCRIPTION
# What does this implement/fix? 

Validates dallas data pin properly, it should not be allowed on port expander pins or input-only esp32 pins

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [x] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
