### PR TITLE
SPI gpio output

### DIFF
--- a/esphome/components/gpio/output/__init__.py
+++ b/esphome/components/gpio/output/__init__.py
@@ -22,3 +22,4 @@ def to_code(config):
 
     pin = yield cg.gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(pin))
+    cg.add_define("USE_GPIO_BINARY_OUT")

--- a/esphome/components/gpio/output/gpio_binary_output.h
+++ b/esphome/components/gpio/output/gpio_binary_output.h
@@ -18,6 +18,7 @@ class GPIOBinaryOutput : public output::BinaryOutput, public Component {
   }
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  GPIOPin *get_pin() { return pin_; }
 
  protected:
   void write_state(bool state) override { this->pin_->digital_write(state); }

--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -12,11 +12,19 @@ void ICACHE_RAM_ATTR HOT SPIComponent::disable() {
   if (this->hw_spi_ != nullptr) {
     this->hw_spi_->endTransaction();
   }
-  if (this->active_cs_) {
+
+  if (this->active_cs_ != nullptr) {
     ESP_LOGVV(TAG, "Disabling SPI Chip on pin %u...", this->active_cs_->get_pin());
     this->active_cs_->digital_write(true);
     this->active_cs_ = nullptr;
   }
+#ifdef USE_GPIO_BINARY_OUT
+  else if (this->active_cs_output_ != nullptr) {
+    ESP_LOGVV(TAG, "Disabling SPI Chip on CSOUPUT pin %u...", this->active_cs_output_->get_pin()->get_pin());
+    this->active_cs_output_->turn_on();
+    this->active_cs_output_ = nullptr;
+  }
+#endif
 }
 void SPIComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SPI bus...");

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -9,6 +9,7 @@
 #ifdef USE_GPIO_BINARY_OUT
 #include "esphome/components/gpio/output/gpio_binary_output.h"
 #endif
+
 namespace esphome {
 namespace spi {
 
@@ -230,9 +231,11 @@ class SPIComponent : public Component {
   GPIOPin *miso_{nullptr};
   GPIOPin *mosi_{nullptr};
   GPIOPin *active_cs_{nullptr};
-  esphome::gpio::GPIOBinaryOutput *active_cs_output_{nullptr};
   SPIClass *hw_spi_{nullptr};
   uint32_t wait_cycle_;
+#ifdef USE_GPIO_BINARY_OUT
+  esphome::gpio::GPIOBinaryOutput *active_cs_output_{nullptr};
+#endif
 };
 
 template<SPIBitOrder BIT_ORDER, SPIClockPolarity CLOCK_POLARITY, SPIClockPhase CLOCK_PHASE, SPIDataRate DATA_RATE>
@@ -243,7 +246,10 @@ class SPIDevice {
 
   void set_spi_parent(SPIComponent *parent) { parent_ = parent; }
   void set_cs_pin(GPIOPin *cs) { cs_ = cs; }
+
+#ifdef USE_GPIO_BINARY_OUT
   void set_cs_output_pin(esphome::gpio::GPIOBinaryOutput *cs_output) { this->cs_output_ = cs_output; }
+#endif
 
   void spi_setup() {
 #ifdef USE_GPIO_BINARY_OUT
@@ -315,7 +321,7 @@ class SPIDevice {
   SPIComponent *parent_{nullptr};
   GPIOPin *cs_{nullptr};
 #ifdef USE_GPIO_BINARY_OUT
-  gpio::GPIOBinaryOutput *cs_output_{nullptr};
+  esphome::gpio::GPIOBinaryOutput *cs_output_{nullptr};
 #endif
 };
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -235,10 +235,7 @@ wled:
 
 adalight:
 
-mcp23s08:
-  - id: 'mcp23s08_hub'
-    cs_pin: GPIO12
-    deviceaddress: 0
+
 
 mcp23s17:
   - id: 'mcp23s17_hub'
@@ -885,15 +882,6 @@ esp32_touch:
 
 binary_sensor:
   - platform: gpio
-    name: 'MCP23S08 Pin #1'
-    pin:
-      mcp23xxx: mcp23s08_hub
-      # Use pin number 1
-      number: 1
-      # One of INPUT or INPUT_PULLUP
-      mode: INPUT_PULLUP
-      inverted: False
-  - platform: gpio
     name: 'MCP23S17 Pin #1'
     pin:
       mcp23xxx: mcp23s17_hub
@@ -1493,14 +1481,6 @@ midea_dongle:
 
 switch:
   - platform: gpio
-    name: 'MCP23S08 Pin #0'
-    pin:
-      mcp23xxx: mcp23s08_hub
-      # Use pin number 0
-      number: 0
-      mode: OUTPUT
-      inverted: False
-  - platform: gpio
     name: 'MCP23S17 Pin #0'
     pin:
       mcp23xxx: mcp23s17_hub
@@ -2000,7 +1980,7 @@ tca9548a:
     multiplexer:
       id: multiplex0
       channel: 0
-    
+
 
 pcf8574:
   - id: 'pcf8574_hub'

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -58,6 +58,19 @@ mcp3008:
   - id: 'mcp3008_hub'
     cs_pin: GPIO12
 
+mcp23s08:
+  - id: 'mcp23s08_hub'
+    cs_pin: GPIO12
+    deviceaddress: 0
+
+output:
+  - platform: gpio
+    id: mcp0
+    pin:
+      mcp23xxx: mcp23s08_hub
+      number: 0
+      mode: OUTPUT
+
 sensor:
   - platform: homeassistant
     entity_id: sensor.hello_world
@@ -238,6 +251,16 @@ time:
         then:
           - logger.log: It's 16:00
 
+switch:
+  - platform: gpio
+    name: 'MCP23S08 Pin #0'
+    pin:
+      mcp23xxx: mcp23s08_hub
+      # Use pin number 0
+      number: 0
+      mode: OUTPUT
+      inverted: False
+
 esp32_touch:
   setup_mode: True
 
@@ -284,6 +307,16 @@ binary_sensor:
       name: 'WX08ZM Tablet Resource'
     battery_level:
       name: 'WX08ZM Battery Level'
+  - platform: gpio
+    name: 'MCP23S08 Pin #1'
+    pin:
+      mcp23xxx: mcp23s08_hub
+      # Use pin number 1
+      number: 1
+      # One of INPUT or INPUT_PULLUP
+      mode: INPUT_PULLUP
+      inverted: False
+
 
 esp32_ble_tracker:
   on_ble_advertise:

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -57,6 +57,8 @@ as3935_i2c:
 mcp3008:
   - id: 'mcp3008_hub'
     cs_pin: GPIO12
+  - id: 'mcp3008_hub_2'
+    cs_output_gpio: mcp0
 
 mcp23s08:
   - id: 'mcp23s08_hub'


### PR DESCRIPTION
# What does this implement/fix? 
With this change SPI can use the gpio output component as a cs pin. 


***The ``spi_device_schema`` still needs to be looked at to handle making cs a requirement***

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [X] ESP32
- [X ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:

```yaml
mcp23s08:
  - id: 'mcp23s08_hub'
    cs_pin: GPIO12
    deviceaddress: 0

output:
  - platform: gpio
    id: mcp0
    pin:
      mcp23xxx: mcp23s08_hub
      number: 0
      mode: OUTPUT

mcp3008:
  - id: 'mcp3008_hub'
    cs_output_gpio: mcp0

```

# Explain your changes
Allows using a gpio output pin as a cs pin in any SPI component. Especially useful for 8266 folks with a limited amount of PINs. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
