### PR TITLE
allow default option for typed_schema

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1347,7 +1347,7 @@ def extract_keys(schema):
 def typed_schema(schemas, **kwargs):
     """Create a schema that has a key to distinguish between schemas"""
     key = kwargs.pop("key", CONF_TYPE)
-    default_schema_option = kwargs.pop("default", None)
+    default_schema_option = kwargs.pop("default_type", None)
     key_validator = one_of(*schemas, **kwargs)
 
     def validator(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1346,8 +1346,8 @@ def extract_keys(schema):
 @jschema_typed
 def typed_schema(schemas, **kwargs):
     """Create a schema that has a key to distinguish between schemas"""
-    key = kwargs.pop('key', CONF_TYPE)
-    default_schema_option = kwargs.pop('default', None)
+    key = kwargs.pop("key", CONF_TYPE)
+    default_schema_option = kwargs.pop("default", None)
     key_validator = one_of(*schemas, **kwargs)
 
     def validator(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1346,16 +1346,18 @@ def extract_keys(schema):
 @jschema_typed
 def typed_schema(schemas, **kwargs):
     """Create a schema that has a key to distinguish between schemas"""
-    key = kwargs.pop("key", CONF_TYPE)
+    key = kwargs.pop('key', CONF_TYPE)
+    default_schema_option = kwargs.pop('default', None)
     key_validator = one_of(*schemas, **kwargs)
 
     def validator(value):
         if not isinstance(value, dict):
             raise Invalid("Value must be dict")
-        if key not in value:
-            raise Invalid("type not specified!")
+        schema_option = value.pop(key, default_schema_option)
+        if schema_option is None:
+            raise Invalid(key + " not specified!")
         value = value.copy()
-        key_v = key_validator(value.pop(key))
+        key_v = key_validator(schema_option)
         value = schemas[key_v](value)
         value[key] = key_v
         return value

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1353,10 +1353,10 @@ def typed_schema(schemas, **kwargs):
     def validator(value):
         if not isinstance(value, dict):
             raise Invalid("Value must be dict")
+        value = value.copy()
         schema_option = value.pop(key, default_schema_option)
         if schema_option is None:
             raise Invalid(key + " not specified!")
-        value = value.copy()
         key_v = key_validator(schema_option)
         value = schemas[key_v](value)
         value[key] = key_v


### PR DESCRIPTION
# What does this implement/fix? 

Quick description 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [x] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
N/A (only change of validation code)

# Explain your changes

I have added an option to the typed_schema function to specify a default sub-schema to choose if the specified "key" (like type) is not contained in the yaml. This default is optional, i.e., if the key is missing and no default is specified, an error will be raised as before. So this change is fully backward compatible.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
