### PR TITLE
Workaround to reduce the stack usage

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -489,10 +489,11 @@ class EsphomeCore:
         self.component_ids = set()
         # Whether ESPHome was started in verbose mode
         self.verbose = False
-        # Regexp to search for stack usage reduction workaround
+        # Regexps to search for stack usage reduction workaround
         self.stack_reduction_re = re.compile(
             r"(= new display::Font)|(\([a-zA-Z_\d ]*\{[a-zA-Z_\d, {}]*\)\;)|(\[\=\]\()"
         )
+        self.stack_reduction_not_re = re.compile(r"^\s*[a-zA-Z_:\d]+ [a-zA-Z_:\d]+ =")
 
     def reset(self):
         self.dashboard = False
@@ -717,6 +718,8 @@ class EsphomeCore:
         return id in self.variables
 
     def reduce_stack_usage(self, stmt):
+        if self.stack_reduction_not_re.search(stmt) is not None:
+            return stmt
         if self.stack_reduction_re.search(stmt) is not None:
             return "[&]() __attribute__((noinline)) {" + stmt + "}();"
         return stmt

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -489,6 +489,10 @@ class EsphomeCore:
         self.component_ids = set()
         # Whether ESPHome was started in verbose mode
         self.verbose = False
+        # Regexp to search for stack usage reduction workaround
+        self.stack_reduction_re = re.compile(
+            r"(= new display::Font)|(\([a-zA-Z_\d ]*\{[a-zA-Z_\d, {}]*\)\;)|(\[\=\]\()"
+        )
 
     def reset(self):
         self.dashboard = False
@@ -712,6 +716,11 @@ class EsphomeCore:
     def has_id(self, id):
         return id in self.variables
 
+    def reduce_stack_usage(self, stmt):
+        if self.stack_reduction_re.search(stmt) is not None:
+            return "[&]() __attribute__((noinline)) {" + stmt + "}();"
+        return stmt
+
     @property
     def cpp_main_section(self):
         from esphome.cpp_generator import statement
@@ -719,6 +728,7 @@ class EsphomeCore:
         main_code = []
         for exp in self.main_statements:
             text = str(statement(exp))
+            text = self.reduce_stack_usage(text)
             text = text.rstrip()
             main_code.append(text)
         return "\n".join(main_code) + "\n\n"

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -491,7 +491,7 @@ class EsphomeCore:
         self.verbose = False
         # Regexps to search for stack usage reduction workaround
         self.stack_reduction_re = re.compile(
-            r"(= new display::Font)|(\([a-zA-Z_\d ]*\{[a-zA-Z_\d, {}]*\)\;)|(\[\=\]\()"
+            r"(\([a-zA-Z_\d ]*\{[a-zA-Z_\d, {}]*\)\;)|(\[\=\]\()"
         )
         self.stack_reduction_not_re = re.compile(r"^\s*[a-zA-Z_:\d]+ [a-zA-Z_:\d]+ =")
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -318,6 +318,7 @@ async def to_code(config):
     cg.add_build_flag("-Wno-unused-variable")
     cg.add_build_flag("-Wno-unused-but-set-variable")
     cg.add_build_flag("-Wno-sign-compare")
+    cg.add_build_flag("-Wstack-usage=512")
     if config.get(CONF_ESP8266_RESTORE_FROM_FLASH, False):
         cg.add_define("USE_ESP8266_PREFERENCES_FLASH")
 


### PR DESCRIPTION
# What does this implement/fix? 

A proof of concept of the way to lower the stack usage of `setup()`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes esphome/issues#1960
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

# Explain your changes

This is a demonstration of an admittedly ugly workaround for excessive stack usage in `setup()`. Doing googling and some trial and error I found that the following way can be used to force a piece of code to localize its stack usage by basically forcing it out to an own function

```cpp
[&]() __attribute__((noinline)) {
  int table[1000];
  f(table, 1000);
}();
```

My quite complicated project started with the stack usage of `setup()` of 14544 bytes. Adjusting `CONFIG_ARDUINO_LOOP_STACK_SIZE` for the whole thing not to crash caused it to run out of memory, manifesting as occasional crashes and reproducible inability to do OTA updates.

The workaround is activated for the three constructs
- the font creation (brought the `setup()` to 12720 bytes with largest lambda 1888)
- a crude attempt to catch initializer lists without catching anything that hurts (9408 bytes)
- the lambdas containing `[=](` (8944 bytes)

That means that the total, i.e. `setup()` plus largest font creation lambda is now 10832 bytes, a saving of 3.7 kB. Still needs adjusting the `sdkconfig.h` but saves a bit.

I am of course not calling for merging it, it is just a proof of concept and maybe a help for users affected.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
