### PR TITLE
Revert "Bump AsyncTCP-esphome to 1.2.1."

### DIFF
--- a/esphome/components/async_tcp/__init__.py
+++ b/esphome/components/async_tcp/__init__.py
@@ -9,7 +9,7 @@ CODEOWNERS = ["@OttoWinter"]
 def to_code(config):
     if CORE.is_esp32:
         # https://github.com/OttoWinter/AsyncTCP/blob/master/library.json
-        cg.add_library("AsyncTCP-esphome", "1.2.1")
+        cg.add_library("AsyncTCP-esphome", "1.1.1")
     elif CORE.is_esp8266:
         # https://github.com/OttoWinter/ESPAsyncTCP
         cg.add_library("ESPAsyncTCP-esphome", "1.2.3")

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@ include_dir = include
 
 [common]
 lib_deps =
-    AsyncTCP-esphome@1.2.1
+    AsyncTCP-esphome@1.1.1
     AsyncMqttClient-esphome@0.8.4
     ArduinoJson-esphomelib@5.13.3
     ESPAsyncWebServer-esphome@1.2.7


### PR DESCRIPTION
Reverts esphome/esphome#1693

cc @mmakaay

Unfortunately this is giving client disconnects:

I've only checked with an ESP32-WROOM-32D, I'm not sure what the last D is, but the issue is introduced in the library bump

HA Error:

```
2021-04-21 13:16:50 INFO (MainThread) [aioesphomeapi.connection] test-esp32.local: Error while reading incoming messages: Error while receiving data: 0 bytes read on a total of 1 expected bytes
2021-04-21 13:16:50 DEBUG (MainThread) [aioesphomeapi.connection] test-esp32.local: Closed socket
2021-04-21 13:16:50 INFO (MainThread) [homeassistant.components.esphome] Disconnected from ESPHome API for test-esp32.local
```

ESPHome logs (via OTA, it does not disconnect too often but seems to happen too)
```
[10:17:55][D][api.connection:617]: Client 'Home Assistant 2021.5.0.dev0 (10.0.1.147)' connected successfully!
[10:18:01][D][api:067]: Disconnecting Home Assistant 2021.5.0.dev0 (10.0.1.147)
[10:18:04][D][api.connection:617]: Client 'Home Assistant 2021.5.0.dev0 (10.0.1.147)' connected successfully!
[10:18:10][D][api:067]: Disconnecting Home Assistant 2021.5.0.dev0 (10.0.1.147)
[10:18:13][D][api.connection:617]: Client 'Home Assistant 2021.5.0.dev0 (10.0.1.147)' connected successfully!
[10:18:19][D][api:067]: Disconnecting Home Assistant 2021.5.0.dev0 (10.0.1.147)
[10:18:22][D][api.connection:617]: Client 'Home Assistant 2021.5.0.dev0 (10.0.1.147)' connected successfully!
[10:18:28][D][api:067]: Disconnecting Home Assistant 2021.5.0.dev0 (10.0.1.147)
[10:18:31][D][api.connection:617]: Client 'Home Assistant 2021.5.0.dev0 (10.0.1.147)' connected successfully!
ERROR Error while reading incoming messages: Error while receiving data: [WinError 10053] An established connection was aborted by 
the software in your host machine
WARNING Disconnected from API: Error while receiving data: [WinError 10053] An established connection was aborted by the software in your host machine
INFO Connecting to test-esp32.local:6053 (10.0.1.103)
WARNING Couldn't connect to API (Timeout while waiting for message response!). Trying to reconnect in 1 seconds
INFO Connecting to test-esp32.local:6053 (10.0.1.103)
INFO Successfully connected to test-esp32.local
[10:18:45][D][api:067]: Disconnecting Home Assistant 2021.5.0.dev0 (10.0.1.147)
[10:18:48][D][api.connection:617]: Client 'Home Assistant 2021.5.0.dev0 (10.0.1.147)' connected successfully!
[10:18:54][D][api:067]: Disconnecting Home Assistant 2021.5.0.dev0 (10.0.1.147)
[10:18:57][D][api.connection:617]: Client 'Home Assistant 2021.5.0.dev0 (10.0.1.147)' connected successfully!
[10:19:03][D][api:067]: Disconnecting Home Assistant 2021.5.0.dev0 (10.0.1.147)
```

