### PR TITLE
Fix error when using %% in printf format.

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -209,14 +209,12 @@ def validate_printf(value):
     cfmt = """\
     (                                  # start of capture group 1
     %                                  # literal "%"
-    (?:                                # first option
     (?:[-+0 #]{0,5})                   # optional flags
     (?:\d+|\*)?                        # width
     (?:\.(?:\d+|\*))?                  # precision
     (?:h|l|ll|w|I|I32|I64)?            # size
     [cCdiouxXeEfgGaAnpsSZ]             # type
-    ) |                                # OR
-    %%)                                # literal "%%"
+    ) 
     """  # noqa
     matches = re.findall(cfmt, value[CONF_FORMAT], flags=re.X)
     if len(matches) != len(value[CONF_ARGS]):


### PR DESCRIPTION
# What does this implement/fix? 

It's not possible to include an escaped `%` in the log message formatting of the logger module.
If you use something like `("%f%%", percentage)` in the code, you will get the error:

  `Found 2 printf-patterns (%f, %%), but 1 args were given!`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Here's a simple example that will trigger the error.
binary_sensor:
  - platform: status
    name: "Printf test"
    on_state:
      then:
        - logger.log:
            format: "We're at %f%%"
            args: [ "42.73'"]
```

# Explain your changes

For printf formatting, a check is done to see if the number of
arguments matches the number of printf formatting placeholders.

The escape code `%%` that is used for representing a literal `%`
is also counted as a placeholder, but no argument will be provided
for that one ever.

This commit fixes this behavior by omitting the `%%` from the regular expression that is used to lookup the placeholders.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
