### PR TITLE
Fix WDT loopTask reboots due to esp32_ble_tracker.

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -72,7 +72,7 @@ void ESP32BLETracker::loop_process_scan_result() {
     xSemaphoreGive(this->scan_result_lock_);
     return;
   }
-  
+
   // If not, then fetch the next result from the processing queue.
   auto next_result = this->scan_result_buffer_[process_index];
   this->scan_process_index_ = (process_index + 1) % SCAN_RESULT_BUFSZ;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -71,7 +71,7 @@ void ESP32BLETracker::loop_process_scan_result() {
   if (process_index == result_index) {
     xSemaphoreGive(this->scan_result_lock_);
     return;
-  } 
+  }
   
   // If not, then fetch the next result from the processing queue.
   auto next_result = this->scan_result_buffer_[process_index];

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -10,7 +10,7 @@
 #include <esp_gap_ble_api.h>
 #include <esp_bt_defs.h>
 
-#define SCAN_RESULT_BUFSZ 16
+static const uint8_t SCAN_RESULT_BUFSZ = 16;
 
 namespace esphome {
 namespace esp32_ble_tracker {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -149,9 +149,6 @@ class ESP32BLETracker : public Component {
   void dump_config() override;
 
   void loop() override;
-  void loop_start_next_scan();
-  void loop_process_scan_result();
-  void loop_log_errors();
 
   void register_listener(ESPBTDeviceListener *listener) {
     listener->set_parent(this);
@@ -173,6 +170,11 @@ class ESP32BLETracker : public Component {
   void gap_scan_set_param_complete(const esp_ble_gap_cb_param_t::ble_scan_param_cmpl_evt_param &param);
   /// Called when a `ESP_GAP_BLE_SCAN_START_COMPLETE_EVT` event is received.
   void gap_scan_start_complete(const esp_ble_gap_cb_param_t::ble_scan_start_cmpl_evt_param &param);
+
+  // Components of the main loop() method.
+  void loop_start_next_scan();
+  void loop_process_scan_result();
+  void loop_log_errors();
 
   /// Vector of addresses that have already been printed in print_bt_device_info
   std::vector<uint64_t> already_discovered_;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -10,6 +10,8 @@
 #include <esp_gap_ble_api.h>
 #include <esp_bt_defs.h>
 
+#define SCAN_RESULT_BUFSZ 16
+
 namespace esphome {
 namespace esp32_ble_tracker {
 
@@ -147,6 +149,9 @@ class ESP32BLETracker : public Component {
   void dump_config() override;
 
   void loop() override;
+  void loop_start_next_scan();
+  void loop_process_scan_result();
+  void loop_log_errors();
 
   void register_listener(ESPBTDeviceListener *listener) {
     listener->set_parent(this);
@@ -182,7 +187,8 @@ class ESP32BLETracker : public Component {
   SemaphoreHandle_t scan_result_lock_;
   SemaphoreHandle_t scan_end_lock_;
   size_t scan_result_index_{0};
-  esp_ble_gap_cb_param_t::ble_scan_result_evt_param scan_result_buffer_[16];
+  size_t scan_process_index_{0};
+  esp_ble_gap_cb_param_t::ble_scan_result_evt_param scan_result_buffer_[SCAN_RESULT_BUFSZ];
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
 };


### PR DESCRIPTION
# What does this implement/fix? 

When enabling `esp32_ble_tracker`, my device is getting a lot of reboots, because the loop() method of the component takes too long to complete. This triggers the watchdog to reboot the device.

This commit makes the component do less work per loop() cycle, to keep the watchdog happy.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** 

* I ran into this, while working on a feature in a repo of mine: https://github.com/mmakaay/esphome-xiaomi_bslamp2/issues/18
* This might fix ESPHome issue: https://github.com/esphome/issues/issues/1731
  (not the brownout issues of course, but I do see WDT loopTask reboots as well)
  
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [X] ESP32 (specifically a single core ESP32-WROOM-32D)
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [X] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esp32_ble_tracker:
```

# Explain your changes

The loop() method of the esp32_ble_tracker module uses too much time.
To fix this, the main change that I did was to not loop over, parse and process all discovered devices in one loop() cycle, but to process one discovered device per loop() cycle. The scan result buffer (which holds 16 scan results) is no longer treated as a stack that must be emptied, but instead a circular buffer with two indvidual pointers: one pointer to the last added item and one pointer to the last processed item.

After this change, my device didn't suffocate in a reboot loop, and started to report discovered bluetooth devices.

Some other things could be done to bring the time per loop() cycle down even further, but this looked like the major issue to me. Therefore, I didn't go for additional micro-optimizations. Let's do those when they are actually required.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
