### PR TITLE
Expand uart invert feature to ESP8266

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -14,6 +14,7 @@ from esphome.const import (
     CONF_UART_ID,
     CONF_DATA,
     CONF_RX_BUFFER_SIZE,
+    CONF_INVERTED,
     CONF_INVERT,
     CONF_TRIGGER_ID,
     CONF_SEQUENCE,
@@ -65,6 +66,19 @@ def validate_rx_pin(value):
     if CORE.is_esp8266 and value[CONF_NUMBER] >= 16:
         raise cv.Invalid("Pins GPIO16 and GPIO17 cannot be used as RX pins on ESP8266.")
     return value
+
+
+def validate_invert_esp32(config):
+    if (
+        CORE.is_esp32
+        and CONF_TX_PIN in config
+        and CONF_RX_PIN in config
+        and config[CONF_TX_PIN][CONF_INVERTED] != config[CONF_RX_PIN][CONF_INVERTED]
+    ):
+        raise cv.Invalid(
+            "Different invert values for TX and RX pin are not (yet) supported for ESP32."
+        )
+    return config
 
 
 def _uart_declare_type(value):
@@ -162,6 +176,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN),
+    validate_invert_esp32,
 )
 
 

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -85,7 +85,7 @@ void ESP8266UartComponent::setup() {
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
     this->hw_serial_->swap();
     ESP8266UartComponent::serial0_in_use = true;
-  } else if ((tx_pin_ == nullptr || tx_pin_->get_pin() == 2) && rx_pin_ == nullptr) {
+  } else if ((tx_pin_ == nullptr || tx_pin_->get_pin() == 2) && (rx_pin_ == nullptr || rx_pin_->get_pin() == 8)) {
     this->hw_serial_ = &Serial1;
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
@@ -194,20 +194,14 @@ void ESP8266SoftwareSerial::setup(InternalGPIOPin *tx_pin, InternalGPIOPin *rx_p
     gpio_tx_pin_ = tx_pin;
     gpio_tx_pin_->setup();
     tx_pin_ = gpio_tx_pin_->to_isr();
-    tx_invert_ = gpio_tx_pin_->is_inverted();
-    tx_pin_.digital_write(!tx_invert_);
+    tx_pin_.digital_write(true);
   }
   if (rx_pin != nullptr) {
     gpio_rx_pin_ = rx_pin;
     gpio_rx_pin_->setup();
     rx_pin_ = gpio_rx_pin_->to_isr();
-    rx_invert_ = gpio_rx_pin_->is_inverted();
     rx_buffer_ = new uint8_t[this->rx_buffer_size_];  // NOLINT
-    if (rx_invert_) {
-      gpio_rx_pin_->attach_interrupt(ESP8266SoftwareSerial::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
-    } else {
-      gpio_rx_pin_->attach_interrupt(ESP8266SoftwareSerial::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
-    }
+    gpio_rx_pin_->attach_interrupt(ESP8266SoftwareSerial::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
   }
 }
 void IRAM_ATTR ESP8266SoftwareSerial::gpio_intr(ESP8266SoftwareSerial *arg) {
@@ -276,10 +270,10 @@ void IRAM_ATTR ESP8266SoftwareSerial::wait_(uint32_t *wait, const uint32_t &star
 }
 bool IRAM_ATTR ESP8266SoftwareSerial::read_bit_(uint32_t *wait, const uint32_t &start) {
   this->wait_(wait, start);
-  return this->rx_pin_.digital_read() ^ this->rx_invert_;
+  return this->rx_pin_.digital_read();
 }
 void IRAM_ATTR ESP8266SoftwareSerial::write_bit_(bool bit, uint32_t *wait, const uint32_t &start) {
-  this->tx_pin_.digital_write(bit ^ this->tx_invert_);
+  this->tx_pin_.digital_write(bit);
   this->wait_(wait, start);
 }
 uint8_t ESP8266SoftwareSerial::read_byte() {

--- a/esphome/components/uart/uart_component_esp8266.h
+++ b/esphome/components/uart/uart_component_esp8266.h
@@ -45,6 +45,8 @@ class ESP8266SoftwareSerial {
   ISRInternalGPIOPin tx_pin_;
   InternalGPIOPin *gpio_rx_pin_{nullptr};
   ISRInternalGPIOPin rx_pin_;
+  bool tx_invert_{false};
+  bool rx_invert_{false};
 };
 
 class ESP8266UartComponent : public UARTComponent, public Component {

--- a/esphome/components/uart/uart_component_esp8266.h
+++ b/esphome/components/uart/uart_component_esp8266.h
@@ -45,8 +45,6 @@ class ESP8266SoftwareSerial {
   ISRInternalGPIOPin tx_pin_;
   InternalGPIOPin *gpio_rx_pin_{nullptr};
   ISRInternalGPIOPin rx_pin_;
-  bool tx_invert_{false};
-  bool rx_invert_{false};
 };
 
 class ESP8266UartComponent : public UARTComponent, public Component {

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -227,7 +227,9 @@ spi:
 
 uart:
   - id: uart1
-    tx_pin: GPIO1
+    tx_pin:
+      number: GPIO1
+      inverted: yes
     rx_pin: GPIO3
     baud_rate: 115200
   - id: uart2


### PR DESCRIPTION
# What does this implement/fix? 

~Expands the ``invert`` option added for the ESP32 in #1586 to the ESP8266.~

Changes the ``invert`` option from #1586 to use the more idiomatic configuration using the full pin scheme. It also implements this feature for the ESP8266. 

~As the esp8266 arduino library only implements this for UART0, a combination of ``invert`` and ``tx_pin: GPIO2`` will fall back to using software UART.~

To also support different pin combinations, a the inverting behaviour is also implemented for ``ESP8266SoftwareSerial``.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Configuration change (this will require users to update their yaml configuration files to keep working) (on request of Otto, see below) 

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1117
  
# Test Environment

- [ ] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [X] Linux (Home Assistant on Home Assistant OS)
- [X] ADALM2000 logic analyzer/signal generator to verify incoming and outgoing signals

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  # UART0
  - id: uart0
    tx_pin: 
      number: GPIO1
      inverted: yes
    rx_pin: GPIO3
    baud_rate: 115200
  - id: not_uart1
    tx_pin: 
  # SoftwareSerial
  - id: sw
    tx_pin: GPIO5
    rx_pin: 
      number: GPIO4
      inverted: yes
    baud_rate: 115200

```

# Explain your changes

I needed to communicate over inverted lines, and this was only supported for the ESP32, I decided to implement it for the ESP8266 for my own needs. I think it might benefit others as well.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
