### PR TITLE
Fix independent white/rgb control when color interlock disabled

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -193,7 +193,8 @@ class LightColorValues {
   void as_rgbw(float *red, float *green, float *blue, float *white, float gamma = 0,
                bool color_interlock = false) const {
     this->as_rgb(red, green, blue, gamma, color_interlock);
-    *white = gamma_correct(this->state_ * this->brightness_ * this->white_, gamma);
+    *white = (color_interlock) ? gamma_correct(this->state_ * this->brightness_ * this->white_, gamma) : 
+                                 gamma_correct(this->state_ * this->white_, gamma);
   }
 
   /// Convert these light color values to an RGBWW representation with the given parameters.
@@ -204,7 +205,9 @@ class LightColorValues {
     const float color_temp = clamp(this->color_temperature_, color_temperature_cw, color_temperature_ww);
     const float ww_fraction = (color_temp - color_temperature_cw) / (color_temperature_ww - color_temperature_cw);
     const float cw_fraction = 1.0f - ww_fraction;
-    const float white_level = gamma_correct(this->state_ * this->brightness_ * this->white_, gamma);
+
+    const float white_level = (color_interlock) ? gamma_correct(this->state_ * this->brightness_ * this->white_, gamma) : 
+                                                  gamma_correct(this->state_ * this->white_, gamma);
     *cold_white = white_level * cw_fraction;
     *warm_white = white_level * ww_fraction;
     if (!constant_brightness) {


### PR DESCRIPTION
# What does this implement/fix? 

On release 1.16.2, even with color_interlock = false now, there is no way to turn on only the white LEDs.
This:
![image](https://user-images.githubusercontent.com/3387157/116185476-8769c480-a6d6-11eb-8986-5c28ff25598b.png)
results in no light output.
This:
![image](https://user-images.githubusercontent.com/3387157/116185511-9781a400-a6d6-11eb-834c-a3249da80488.png)
results in both the white and RGB lights being on, which on some of my bulbs, causes them to overheat and reboot! Not to mention, can look ugly mixing the RGB 'white' in with the white LEDs. So there needs to be a way to turn on just the white LEDs.

This fix allows RGB and White brightness to be controlled separately, when color_interlock is false (behavior when color_interlock = true should not be affected).


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** 
Fixes https://github.com/esphome/issues/issues/1531 which was closed without fixing.
  
# Test Environment

- [ ] ESP8266

# Explain your changes

Changes in a couple places:
- Modifies changes from #925 , only happen when color_interlock=true
-  Modifies changes from [967](https://github.com/esphome/esphome/commit/177617e6e34a54c095bbb15f7b62c33839869f19#diff-01de44b4905d62d99d036aa9ce05a22a3e067075265fd02252d67a40cc412863) only happens when color_interlock = true
- Probably the trickiest change - in startup, if interlock isn't enabled, and the recovery of previous paramters was not successful, set RGB brightness to 0 (so as not to boot into full RGB and white brightness).

## Checklist:
Tested locally. Shouldn't need documentation update but can write that up if needed.
