### PR TITLE
Change wifi signal strength unit to dBm

### DIFF
--- a/esphome/components/wifi_signal/sensor.py
+++ b/esphome/components/wifi_signal/sensor.py
@@ -15,7 +15,9 @@ WiFiSignalSensor = wifi_signal_ns.class_(
 )
 
 CONFIG_SCHEMA = (
-    sensor.sensor_schema(UNIT_DECIBEL_MILLIWATT, ICON_EMPTY, 0, DEVICE_CLASS_SIGNAL_STRENGTH)
+    sensor.sensor_schema(
+        UNIT_DECIBEL_MILLIWATT, ICON_EMPTY, 0, DEVICE_CLASS_SIGNAL_STRENGTH
+    )
     .extend(
         {
             cv.GenerateID(): cv.declare_id(WiFiSignalSensor),

--- a/esphome/components/wifi_signal/sensor.py
+++ b/esphome/components/wifi_signal/sensor.py
@@ -5,7 +5,7 @@ from esphome.const import (
     CONF_ID,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     ICON_EMPTY,
-    UNIT_DECIBEL,
+    UNIT_DECIBEL_MILLIWATT,
 )
 
 DEPENDENCIES = ["wifi"]
@@ -15,7 +15,7 @@ WiFiSignalSensor = wifi_signal_ns.class_(
 )
 
 CONFIG_SCHEMA = (
-    sensor.sensor_schema(UNIT_DECIBEL, ICON_EMPTY, 0, DEVICE_CLASS_SIGNAL_STRENGTH)
+    sensor.sensor_schema(UNIT_DECIBEL_MILLIWATT, ICON_EMPTY, 0, DEVICE_CLASS_SIGNAL_STRENGTH)
     .extend(
         {
             cv.GenerateID(): cv.declare_id(WiFiSignalSensor),


### PR DESCRIPTION
# What does this implement/fix? 

This PR change WiFi signal unit to dBm as Wifi Signal Strength unit should be dBm and not dB

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1125
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: wifi_signal
    name: "WiFi Signal Strength"
```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

Wifi Signal Strength unit should be dBm and not dB

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
