### PR TITLE
Move LightStateRTCState definition to .h file.

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -82,17 +82,6 @@ void LightState::dump_json(JsonObject &root) {
 }
 #endif
 
-struct LightStateRTCState {
-  bool state{false};
-  float brightness{1.0f};
-  float red{1.0f};
-  float green{1.0f};
-  float blue{1.0f};
-  float white{1.0f};
-  float color_temp{1.0f};
-  uint32_t effect{0};
-};
-
 void LightState::setup() {
   ESP_LOGCONFIG(TAG, "Setting up light '%s'...", this->get_name().c_str());
 

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -167,6 +167,17 @@ enum LightRestoreMode {
   LIGHT_ALWAYS_ON,
 };
 
+struct LightStateRTCState {
+  bool state{false};
+  float brightness{1.0f};
+  float red{1.0f};
+  float green{1.0f};
+  float blue{1.0f};
+  float white{1.0f};
+  float color_temp{1.0f};
+  uint32_t effect{0};
+};
+
 /** This class represents the communication layer between the front-end MQTT layer and the
  * hardware output layer.
  */


### PR DESCRIPTION
# What does this implement/fix? 

The definition for struct LightStateRTCState is currently unavailable for use from custom light code, because it resides in `light_state.cpp`  instead of `light_state.h`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

# Explain your changes

I am working on a light component, which implements a "disco mode". The idea is that I can push light state updates that are not saved, not published and that are executed immediately (instead of waiting for the next loop() for that light).

One feature related to this, is that after the disco mode is stopped, the light is restored to its state from before the disco state  changes. Easy enough if I can read the last known state from rtc memory, but the problem with that is that I cannot use the `LightStateRTCState` struct from my code.

A "solution" for now, is to define my own copy of the struct, and loading the data from rtc memory using that struct. This does work, but when the original `LightStateRTCState` gets modified, my copy won't get modified and restoring the last saved state from my code will likely start failing.

An alternative that I considered was calling `LightState::setup()`, since restore functionality is buried in there. This doesn't feel like the right solution to me though. The function of the setup function is, well... to setup the component. Not to update its state at random points during its lifetime.

BTW: The perfect solution would be when LightState provided `save()` and `restore()` as ready-to-use methods. That way it wouldn't even be a big issue when the struct definition wouldn't be living in an .h file. But that is something for a separate pull request I think.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
