### PR TITLE
Better logging for API connections.

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -37,19 +37,19 @@ APIConnection::APIConnection(AsyncClient *client, APIServer *parent)
   this->last_traffic_ = millis();
 }
 APIConnection::~APIConnection() { delete this->client_; }
-void APIConnection::on_error_(int8_t error) { 
-    ESP_LOGW(TAG, "Connection error %d (from lwIP) for %s", error, this->client_info_.c_str());
-    this->remove_ = true;
+void APIConnection::on_error_(int8_t error) {
+  ESP_LOGW(TAG, "Connection error %d (from lwIP) for %s", error, this->client_info_.c_str());
+  this->remove_ = true;
 }
 void APIConnection::on_disconnect_() {
-    if (! this->remove_) {
-      ESP_LOGI(TAG, "Client %s has disconnected", this->client_info_.c_str());
-    }
-    this->remove_ = true;
+  if (!this->remove_) {
+    ESP_LOGI(TAG, "Client %s has disconnected", this->client_info_.c_str());
+  }
+  this->remove_ = true;
 }
 void APIConnection::on_timeout_(uint32_t time) {
-    ESP_LOGW(TAG, "Received client timeout (from AsyncTCP) for %s.", this->client_info_.c_str());
-    this->on_fatal_error();
+  ESP_LOGW(TAG, "Received client timeout (from AsyncTCP) for %s.", this->client_info_.c_str());
+  this->on_fatal_error();
 }
 void APIConnection::on_data_(uint8_t *buf, size_t len) {
   if (len == 0 || buf == nullptr)

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -33,7 +33,7 @@ APIConnection::APIConnection(AsyncClient *client, APIServer *parent)
   this->recv_buffer_.reserve(32);
   this->client_info_ = this->client_->remoteIP().toString().c_str();
   this->client_info_ += ":";
-  this->client_info_ += to_string(this->client_->remotePort()).c_str();
+  this->client_info_ += to_string(this->client_->remotePort());
   this->last_traffic_ = millis();
 }
 APIConnection::~APIConnection() { delete this->client_; }
@@ -43,9 +43,9 @@ void APIConnection::on_error_(int8_t error) {
 }
 void APIConnection::on_disconnect_() {
   if (!this->remove_) {
+    this->remove_ = true;
     ESP_LOGI(TAG, "Client %s has disconnected", this->client_info_.c_str());
   }
-  this->remove_ = true;
 }
 void APIConnection::on_timeout_(uint32_t time) {
   ESP_LOGW(TAG, "Received client timeout (from AsyncTCP) for %s.", this->client_info_.c_str());
@@ -613,7 +613,7 @@ bool APIConnection::send_log_message(int level, const char *tag, const char *lin
 HelloResponse APIConnection::hello(const HelloRequest &msg) {
   this->client_info_ = msg.client_info + " (" + this->client_->remoteIP().toString().c_str();
   this->client_info_ += ":";
-  this->client_info_ += to_string(this->client_->remotePort()).c_str();
+  this->client_info_ += to_string(this->client_->remotePort());
   this->client_info_ += ")";
   ESP_LOGV(TAG, "Hello from client: '%s'", this->client_info_.c_str());
 

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -155,6 +155,7 @@ class APIConnection : public APIServerConnection {
   esp32_camera::CameraImageReader image_reader_;
 #endif
 
+  bool log_connect_{true};
   bool state_subscription_{false};
   int log_subscription_{ESPHOME_LOG_LEVEL_NONE};
   uint32_t last_traffic_;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -29,8 +29,6 @@ void APIServer::setup() {
         if (client == nullptr)
           return;
 
-        // can't print here because in lwIP thread
-        // ESP_LOGD(TAG, "New client connected from %s", client->remoteIP().toString().c_str());
         auto *a_this = (APIServer *) s;
         a_this->clients_.push_back(new APIConnection(client, a_this));
       },
@@ -74,6 +72,10 @@ void APIServer::loop() {
   this->clients_.erase(new_end, this->clients_.end());
 
   for (auto *client : this->clients_) {
+    if (client->log_connect_) {
+        ESP_LOGI(TAG, "New client connected from %s:%u", client->client_->remoteIP().toString().c_str(), client->client_->remotePort());
+        client->log_connect_ = false;
+    }
     client->loop();
   }
 

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -73,8 +73,9 @@ void APIServer::loop() {
 
   for (auto *client : this->clients_) {
     if (client->log_connect_) {
-        ESP_LOGI(TAG, "New client connected from %s:%u", client->client_->remoteIP().toString().c_str(), client->client_->remotePort());
-        client->log_connect_ = false;
+      ESP_LOGI(TAG, "New client connected from %s:%u", client->client_->remoteIP().toString().c_str(),
+               client->client_->remotePort());
+      client->log_connect_ = false;
     }
     client->loop();
   }


### PR DESCRIPTION
# What does this implement/fix? 

This fixes a couple of shortcomings in the api component connection logging.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

# Explain your changes

The following logging has been added to the api component:

**New client connections coming in**

In the original code, I saw that an attempt was done to log the client information at connect time. However, this code was commented out, because that piece of code ran in the lwIP thread, making the logging impossible.
I updated the code to log the incoming connection as soon as possible after handling the connect. Implementation-wise I set a boolean at connect time, which tells the api component to log the connect at its next `loop()` iteration.

Now, the incoming connection is logged:
```
[01:11:34][I][api:076]: New client connected from 192.168.100.135:49436
[01:11:34][D][api.connection:634]: Client 'ESPHome v1.18.0-dev (192.168.100.135:49436)' connected successfully!
```

I also included the message as logged by `api.connection`. One might say that this message is already enough. However, this message will only be logged when the API connection setup is completed. That message would not log for example a connection probe using `telnet <device IP> 6053`. The new logging will show this connection attempt however.

**Reasons for disconnecting an API client**

While debugging API client disconnect issues, I found that often no reason was logged for disconnecting an API client. Therefore, I updated the api component to have better logging for this. All disconnect routes now log a message, making it a lot easier to determine where in the code and for what reason the disconnect was triggered.

Example for the disconnect of the telnet from above (the most basic  disconnect case where the client closes the connection):
```
[01:13:52][I][api.connection:046]: Client 192.168.100.17:64360 has disconnected
```

This one is logged at the INFO level. Other disconnect reasons all have to do with some sort of problem (timeouts, unexpected data, the ESP device losing its WiFi connection, etc. etc.) Those reasons are all logged at the WARN level, since they indicate some kind of problem.

**Remote port for connected clients**

I added the remote port to the client information that is shown in the log messages.

Often, I have multiple connections open to the api server, from a single source IP address. Without a port number, these connections cannot be identified, and I cannot relate things that I see in the logs to an actual process on the client side.

Knowing a port number also makes it a lot easier to setup a sniffer to investigate the traffic that is being sent over the network for a specific client connection.

Examples for this can already be seen in the above examples.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
