### PR TITLE
Bump hypothesis from 5.21.0 to 5.49.0

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,4 +11,4 @@ pytest==6.2.3
 pytest-cov==2.11.1
 pytest-mock==3.5.1
 asyncmock==0.4.2
-hypothesis==5.21.0
+hypothesis==5.49.0

--- a/tests/unit_tests/strategies.py
+++ b/tests/unit_tests/strategies.py
@@ -4,7 +4,7 @@ import hypothesis.strategies._internal.core as st
 from hypothesis.strategies._internal.strategies import SearchStrategy
 
 
-@st.defines_strategy_with_reusable_values
+@st.defines_strategy(force_reusable_values=True)
 def mac_addr_strings():
     # type: () -> SearchStrategy[Text]
     """A strategy for MAC address strings.


### PR DESCRIPTION
# What does this implement/fix?

Updates hypothesis to the latest release of the 5.0 series.

Updates the use of hypothesis internal strategy definition call after
hypothesis 5.32.1.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2021

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

The esphome test suite uses an internal API of hypothesis, so this change updates the call to be compatible with newer versions, and in turn updates the dependency.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
