### PR TITLE
Bump NeoPixelBus-esphome to 2.6.2

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -205,4 +205,4 @@ def to_code(config):
     cg.add(var.set_pixel_order(getattr(ESPNeoPixelOrder, config[CONF_TYPE])))
 
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
-    cg.add_library("NeoPixelBus-esphome", "2.5.7")
+    cg.add_library("NeoPixelBus-esphome", "2.6.2")


### PR DESCRIPTION
# What does this implement/fix? 

Quick description 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1481 and https://github.com/esphome/issues/issues/1600
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

# Explain your changes

Update the library ´NeoPixelBus-esphome´ to the current version 2.6.2 to fix usage on ESP32.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
