### PR TITLE
1.17.2

### DIFF
--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -68,7 +68,8 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight {
   void add_leds(uint16_t count_pixels) { this->add_leds(new NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(count_pixels)); }
   void add_leds(NeoPixelBus<T_COLOR_FEATURE, T_METHOD> *controller) {
     this->controller_ = controller;
-    this->controller_->Begin();
+    // controller gets initialised in setup() - avoid calling twice (crashes with RMT)
+    // this->controller_->Begin();
   }
 
   // ========== INTERNAL METHODS ==========

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 17
-PATCH_VERSION = "1"
+PATCH_VERSION = "2"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Programming is like sex: one mistake and you’re providing support for a lifetime."_

~ Michael Sinz
- esphome: fixes #858 - esphome crashes with neolightbus and RMT [esphome#1667](https://github.com/esphome/esphome/pull/1667)
- docs: Fix abundant apostrophes [docs#1137](https://github.com/esphome/esphome-docs/pull/1137)
- docs: Add output part to binary light example [docs#1061](https://github.com/esphome/esphome-docs/pull/1061)
