### PR TITLE
Use core constants for sample duration on bh1750

### DIFF
--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -17,8 +17,8 @@ void BH1750Sensor::setup() {
     return;
   }
 
-  uint8_t mtreg_hi = (this->measurement_time_ >> 5) & 0b111;
-  uint8_t mtreg_lo = (this->measurement_time_ >> 0) & 0b11111;
+  uint8_t mtreg_hi = (this->measurement_duration_ >> 5) & 0b111;
+  uint8_t mtreg_lo = (this->measurement_duration_ >> 0) & 0b11111;
   this->write_bytes(BH1750_COMMAND_MT_REG_HI | mtreg_hi, nullptr, 0);
   this->write_bytes(BH1750_COMMAND_MT_REG_LO | mtreg_lo, nullptr, 0);
 }
@@ -77,7 +77,7 @@ void BH1750Sensor::read_data_() {
   }
 
   float lx = float(raw_value) / 1.2f;
-  lx *= 69.0f / this->measurement_time_;
+  lx *= 69.0f / this->measurement_duration_;
   ESP_LOGD(TAG, "'%s': Got illuminance=%.1flx", this->get_name().c_str(), lx);
   this->publish_state(lx);
   this->status_clear_warning();

--- a/esphome/components/bh1750/bh1750.h
+++ b/esphome/components/bh1750/bh1750.h
@@ -28,7 +28,7 @@ class BH1750Sensor : public sensor::Sensor, public PollingComponent, public i2c:
    * @param resolution The new resolution of the sensor.
    */
   void set_resolution(BH1750Resolution resolution);
-  void set_measurement_time(uint8_t measurement_time) { measurement_time_ = measurement_time; }
+  void set_measurement_duration(uint8_t measurement_duration) { measurement_duration_ = measurement_duration; }
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -41,7 +41,7 @@ class BH1750Sensor : public sensor::Sensor, public PollingComponent, public i2c:
   void read_data_();
 
   BH1750Resolution resolution_{BH1750_RESOLUTION_0P5_LX};
-  uint8_t measurement_time_;
+  uint8_t measurement_duration_;
 };
 
 }  // namespace bh1750

--- a/esphome/components/bh1750/sensor.py
+++ b/esphome/components/bh1750/sensor.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = (
                 min=31, max=254
             ),
             cv.Optional(CONF_MEASUREMENT_TIME): cv.Invalid(
-                "The 'measurement_time' option has been removed in 1.19.0"
+                "The 'measurement_time' option has been replaced with 'measurement_duration' in 1.19.0"
             ),
         }
     )

--- a/esphome/components/bh1750/sensor.py
+++ b/esphome/components/bh1750/sensor.py
@@ -36,7 +36,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MEASUREMENT_DURATION, default=69): cv.int_range(
                 min=31, max=254
             ),
-            cv.Optional(CONF_MEASUREMENT_TIME): cv.Invalid(
+            cv.Optional(CONF_MEASUREMENT_TIME): cv.invalid(
                 "The 'measurement_time' option has been replaced with 'measurement_duration' in 1.18.0"
             ),
         }

--- a/esphome/components/bh1750/sensor.py
+++ b/esphome/components/bh1750/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     DEVICE_CLASS_ILLUMINANCE,
     ICON_EMPTY,
     UNIT_LUX,
+    CONF_MEASUREMENT_DURATION,
 )
 
 DEPENDENCIES = ["i2c"]
@@ -23,7 +24,6 @@ BH1750Sensor = bh1750_ns.class_(
     "BH1750Sensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
 
-CONF_MEASUREMENT_TIME = "measurement_time"
 CONFIG_SCHEMA = (
     sensor.sensor_schema(UNIT_LUX, ICON_EMPTY, 1, DEVICE_CLASS_ILLUMINANCE)
     .extend(
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_RESOLUTION, default=0.5): cv.enum(
                 BH1750_RESOLUTIONS, float=True
             ),
-            cv.Optional(CONF_MEASUREMENT_TIME, default=69): cv.int_range(
+            cv.Optional(CONF_MEASUREMENT_DURATION, default=69): cv.int_range(
                 min=31, max=254
             ),
         }
@@ -49,4 +49,4 @@ def to_code(config):
     yield i2c.register_i2c_device(var, config)
 
     cg.add(var.set_resolution(config[CONF_RESOLUTION]))
-    cg.add(var.set_measurement_time(config[CONF_MEASUREMENT_TIME]))
+    cg.add(var.set_measurement_time(config[CONF_MEASUREMENT_DURATION]))

--- a/esphome/components/bh1750/sensor.py
+++ b/esphome/components/bh1750/sensor.py
@@ -24,6 +24,7 @@ BH1750Sensor = bh1750_ns.class_(
     "BH1750Sensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
 
+CONF_MEASUREMENT_TIME = "measurement_time"
 CONFIG_SCHEMA = (
     sensor.sensor_schema(UNIT_LUX, ICON_EMPTY, 1, DEVICE_CLASS_ILLUMINANCE)
     .extend(
@@ -34,6 +35,9 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_MEASUREMENT_DURATION, default=69): cv.int_range(
                 min=31, max=254
+            ),
+            cv.Optional(CONF_MEASUREMENT_TIME): cv.Invalid(
+                "The 'measurement_time' option has been removed in 1.19.0"
             ),
         }
     )
@@ -49,4 +53,4 @@ def to_code(config):
     yield i2c.register_i2c_device(var, config)
 
     cg.add(var.set_resolution(config[CONF_RESOLUTION]))
-    cg.add(var.set_measurement_time(config[CONF_MEASUREMENT_DURATION]))
+    cg.add(var.set_measurement_duration(config[CONF_MEASUREMENT_DURATION]))

--- a/esphome/components/bh1750/sensor.py
+++ b/esphome/components/bh1750/sensor.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = (
                 min=31, max=254
             ),
             cv.Optional(CONF_MEASUREMENT_TIME): cv.Invalid(
-                "The 'measurement_time' option has been replaced with 'measurement_duration' in 1.19.0"
+                "The 'measurement_time' option has been replaced with 'measurement_duration' in 1.18.0"
             ),
         }
     )

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -412,7 +412,7 @@ sensor:
     retain: False
     availability:
     state_topic: livingroom/custom_state_topic
-    measurement_time: 31
+    measurement_duration: 31
   - platform: bme280
     temperature:
       name: 'Outside Temperature'


### PR DESCRIPTION
# What does this implement/fix? 

Use of the core constant for "measurement duration"
This is a breaking change

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

from:
```yaml
# Example configuration entry
sensor:
  - platform: bh1750
    name: "BH1750 Illuminance"
    address: 0x23
    measurement_time: 69
    update_interval: 60s
```

to:
```yaml
# Example configuration entry
sensor:
  - platform: bh1750
    name: "BH1750 Illuminance"
    address: 0x23
    measurement_duration: 69
    update_interval: 60s
```

# Explain your changes

This will make future maintenance easier

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
