### PR TITLE
1.18.0b2

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -136,7 +136,11 @@ void Logger::pre_setup() {
         break;
 #ifdef ARDUINO_ARCH_ESP32
       case UART_SELECTION_UART2:
+#if !CONFIG_IDF_TARGET_ESP32S2
+        // FIXME: Validate in config that UART2 can't be set for ESP32-S2 (only has
+        // UART0-UART1)
         this->hw_serial_ = &Serial2;
+#endif
         break;
 #endif
     }

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -261,7 +261,11 @@ class WiFiComponent : public Component {
 #endif
 
 #ifdef ARDUINO_ARCH_ESP32
+#if ESP_IDF_VERSION_MAJOR >= 4
+  void wifi_event_callback_(arduino_event_id_t event, arduino_event_info_t info);
+#else
   void wifi_event_callback_(system_event_id_t event, system_event_info_t info);
+#endif
   void wifi_scan_done_callback_();
 #endif
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 18
-PATCH_VERSION = "0b1"
+PATCH_VERSION = "0b2"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Writing the first 90 percent of a computer program takes 90 percent of the time. The remaining ten percent also takes 90 percent of the time and the final touches also take 90 percent of the time."_

~ N.J. Rubenking
- docs: Fixed datasheet link for RC522 [docs#1144](https://github.com/esphome/esphome-docs/pull/1144)
- docs: Added receive for Fujitsu ACs [docs#1037](https://github.com/esphome/esphome-docs/pull/1037)
- docs: Update allowed characters for node names [docs#1072](https://github.com/esphome/esphome-docs/pull/1072)
- docs: Update docs: Add references to alternative ICs to HLW8012 and CSE7766 [docs#902](https://github.com/esphome/esphome-docs/pull/902)
- docs: Update pulse_counter.rst [docs#1089](https://github.com/esphome/esphome-docs/pull/1089)
- docs: Remove deprecated board_flash_mode from configuration example [docs#1149](https://github.com/esphome/esphome-docs/pull/1149)
- docs: Update deep_sleep.rst [docs#1152](https://github.com/esphome/esphome-docs/pull/1152)
- docs: Utalize pip3 for commands [docs#1143](https://github.com/esphome/esphome-docs/pull/1143)
- docs: FAQ page: Converting from "I" to "we" wording [docs#1103](https://github.com/esphome/esphome-docs/pull/1103)
- docs: thermostat min/max temperature clarification [docs#1057](https://github.com/esphome/esphome-docs/pull/1057)
- docs: Added compatibility notes [docs#1033](https://github.com/esphome/esphome-docs/pull/1033)
- docs: Specify format for BSSID entries. [docs#1046](https://github.com/esphome/esphome-docs/pull/1046)
- docs: add font to usage example [docs#1050](https://github.com/esphome/esphome-docs/pull/1050)
- docs: Fix missed merge conflict [docs#1155](https://github.com/esphome/esphome-docs/pull/1155)
- docs: Sample codeblock has incorrect variables [docs#1156](https://github.com/esphome/esphome-docs/pull/1156)
- docs: Replaced set_password with new_password [docs#1157](https://github.com/esphome/esphome-docs/pull/1157)
- docs: pulse counter: Show how calculations are made [docs#861](https://github.com/esphome/esphome-docs/pull/861)
- esphome: Fix build issues for idf 4.2 (Support ESP32-S2) [esphome#1433](https://github.com/esphome/esphome/pull/1433)
