### PR TITLE
Add calibration of rtc for deep sleep.

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -88,7 +88,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 #endif
 
 #ifdef ARDUINO_ARCH_ESP8266
-  ESP.deepSleep((uint64)(*this->sleep_duration_/(system_rtc_clock_cali_proc()/27307.0)));
+  ESP.deepSleep((uint64)(*this->sleep_duration_ / (system_rtc_clock_cali_proc() / 27307.0)));
 #endif
 }
 float DeepSleepComponent::get_setup_priority() const { return setup_priority::LATE; }

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -1,3 +1,7 @@
+#ifdef ARDUINO_ARCH_ESP8266
+#include <user_interface.h>
+#endif
+
 #include "deep_sleep_component.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
@@ -84,7 +88,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 #endif
 
 #ifdef ARDUINO_ARCH_ESP8266
-  ESP.deepSleep(*this->sleep_duration_);
+  ESP.deepSleep((uint64)(*this->sleep_duration_/(system_rtc_clock_cali_proc()/27307.0)));
 #endif
 }
 float DeepSleepComponent::get_setup_priority() const { return setup_priority::LATE; }


### PR DESCRIPTION
# What does this implement/fix? 

This change improves the accuracy of the deep sleep wakeup. The rtc clock is wildly inaccurate but a little calibration before sleeping can improve this. Before this change on my test devices they were waking up 18 seconds early (in a 5 minute sleep), with this change they wake up 1-2 seconds early.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

The change improves the timing of the deep sleep component. The is a function in the ESP sdk can can be used to estimate how much drift can be expected with the rtc clock which is wildly inaccurate.  Using this function in the sleep time calcualtion can achieve far more accurate sleep durations (still affected by temperature changes during the sleep, but nothing can be done about that).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
