### PR TITLE
1.18.0b3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -85,6 +85,7 @@ esphome/components/sgp40/* @SenexCrenshaw
 esphome/components/sht4x/* @sjtrny
 esphome/components/shutdown/* @esphome/core
 esphome/components/sim800l/* @glmnet
+esphome/components/sm2135/* @BoukeHaarsma23
 esphome/components/spi/* @esphome/core
 esphome/components/ssd1322_base/* @kbx81
 esphome/components/ssd1322_spi/* @kbx81

--- a/esphome/components/async_tcp/__init__.py
+++ b/esphome/components/async_tcp/__init__.py
@@ -8,8 +8,8 @@ CODEOWNERS = ["@OttoWinter"]
 @coroutine_with_priority(200.0)
 def to_code(config):
     if CORE.is_esp32:
-        # https://github.com/OttoWinter/AsyncTCP/blob/master/library.json
-        cg.add_library("AsyncTCP-esphome", "1.1.1")
+        # https://github.com/esphome/AsyncTCP/blob/master/library.json
+        cg.add_library("esphome/AsyncTCP-esphome", "1.2.2")
     elif CORE.is_esp8266:
         # https://github.com/OttoWinter/ESPAsyncTCP
         cg.add_library("ESPAsyncTCP-esphome", "1.2.3")

--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -17,8 +17,8 @@ void BH1750Sensor::setup() {
     return;
   }
 
-  uint8_t mtreg_hi = (this->measurement_time_ >> 5) & 0b111;
-  uint8_t mtreg_lo = (this->measurement_time_ >> 0) & 0b11111;
+  uint8_t mtreg_hi = (this->measurement_duration_ >> 5) & 0b111;
+  uint8_t mtreg_lo = (this->measurement_duration_ >> 0) & 0b11111;
   this->write_bytes(BH1750_COMMAND_MT_REG_HI | mtreg_hi, nullptr, 0);
   this->write_bytes(BH1750_COMMAND_MT_REG_LO | mtreg_lo, nullptr, 0);
 }
@@ -77,7 +77,7 @@ void BH1750Sensor::read_data_() {
   }
 
   float lx = float(raw_value) / 1.2f;
-  lx *= 69.0f / this->measurement_time_;
+  lx *= 69.0f / this->measurement_duration_;
   ESP_LOGD(TAG, "'%s': Got illuminance=%.1flx", this->get_name().c_str(), lx);
   this->publish_state(lx);
   this->status_clear_warning();

--- a/esphome/components/bh1750/bh1750.h
+++ b/esphome/components/bh1750/bh1750.h
@@ -28,7 +28,7 @@ class BH1750Sensor : public sensor::Sensor, public PollingComponent, public i2c:
    * @param resolution The new resolution of the sensor.
    */
   void set_resolution(BH1750Resolution resolution);
-  void set_measurement_time(uint8_t measurement_time) { measurement_time_ = measurement_time; }
+  void set_measurement_duration(uint8_t measurement_duration) { measurement_duration_ = measurement_duration; }
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -41,7 +41,7 @@ class BH1750Sensor : public sensor::Sensor, public PollingComponent, public i2c:
   void read_data_();
 
   BH1750Resolution resolution_{BH1750_RESOLUTION_0P5_LX};
-  uint8_t measurement_time_;
+  uint8_t measurement_duration_;
 };
 
 }  // namespace bh1750

--- a/esphome/components/bh1750/sensor.py
+++ b/esphome/components/bh1750/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     DEVICE_CLASS_ILLUMINANCE,
     ICON_EMPTY,
     UNIT_LUX,
+    CONF_MEASUREMENT_DURATION,
 )
 
 DEPENDENCIES = ["i2c"]
@@ -32,8 +33,11 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_RESOLUTION, default=0.5): cv.enum(
                 BH1750_RESOLUTIONS, float=True
             ),
-            cv.Optional(CONF_MEASUREMENT_TIME, default=69): cv.int_range(
+            cv.Optional(CONF_MEASUREMENT_DURATION, default=69): cv.int_range(
                 min=31, max=254
+            ),
+            cv.Optional(CONF_MEASUREMENT_TIME): cv.invalid(
+                "The 'measurement_time' option has been replaced with 'measurement_duration' in 1.18.0"
             ),
         }
     )
@@ -49,4 +53,4 @@ def to_code(config):
     yield i2c.register_i2c_device(var, config)
 
     cg.add(var.set_resolution(config[CONF_RESOLUTION]))
-    cg.add(var.set_measurement_time(config[CONF_MEASUREMENT_TIME]))
+    cg.add(var.set_measurement_duration(config[CONF_MEASUREMENT_DURATION]))

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -1,0 +1,33 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.const import (
+    CONF_CLOCK_PIN,
+    CONF_DATA_PIN,
+    CONF_ID,
+)
+
+AUTO_LOAD = ["output"]
+CODEOWNERS = ["@BoukeHaarsma23"]
+
+sm2135_ns = cg.esphome_ns.namespace("sm2135")
+SM2135 = sm2135_ns.class_("SM2135", cg.Component)
+
+MULTI_CONF = True
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(SM2135),
+        cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+
+    data = yield cg.gpio_pin_expression(config[CONF_DATA_PIN])
+    cg.add(var.set_data_pin(data))
+    clock = yield cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
+    cg.add(var.set_clock_pin(clock))

--- a/esphome/components/sm2135/output.py
+++ b/esphome/components/sm2135/output.py
@@ -1,0 +1,28 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import output
+from esphome.const import CONF_CHANNEL, CONF_ID
+from . import SM2135
+
+DEPENDENCIES = ["sm2135"]
+CODEOWNERS = ["@BoukeHaarsma23"]
+
+Channel = SM2135.class_("Channel", output.FloatOutput)
+
+CONF_SM2135_ID = "sm2135_id"
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.GenerateID(CONF_SM2135_ID): cv.use_id(SM2135),
+        cv.Required(CONF_ID): cv.declare_id(Channel),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield output.register_output(var, config)
+
+    parent = yield cg.get_variable(config[CONF_SM2135_ID])
+    cg.add(var.set_parent(parent))
+    cg.add(var.set_channel(config[CONF_CHANNEL]))

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -1,0 +1,81 @@
+#include "sm2135.h"
+#include "esphome/core/log.h"
+
+// Tnx to the work of https://github.com/arendst (Tasmota) for making the initial version of the driver
+
+namespace esphome {
+namespace sm2135 {
+
+static const char *TAG = "sm2135";
+
+static const uint8_t SM2135_ADDR_MC = 0xC0;  // Max current register
+static const uint8_t SM2135_ADDR_CH = 0xC1;  // RGB or CW channel select register
+static const uint8_t SM2135_ADDR_R = 0xC2;   // Red color
+static const uint8_t SM2135_ADDR_G = 0xC3;   // Green color
+static const uint8_t SM2135_ADDR_B = 0xC4;   // Blue color
+static const uint8_t SM2135_ADDR_C = 0xC5;   // Cold
+static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
+
+static const uint8_t SM2135_RGB = 0x00;  // RGB channel
+static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
+
+static const uint8_t SM2135_10MA = 0x00;
+static const uint8_t SM2135_15MA = 0x01;
+static const uint8_t SM2135_20MA = 0x02;  // RGB max current (Chip default)
+static const uint8_t SM2135_25MA = 0x03;
+static const uint8_t SM2135_30MA = 0x04;  // CW max current (Chip default)
+static const uint8_t SM2135_35MA = 0x05;
+static const uint8_t SM2135_40MA = 0x06;
+static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
+static const uint8_t SM2135_50MA = 0x08;
+static const uint8_t SM2135_55MA = 0x09;
+static const uint8_t SM2135_60MA = 0x0A;
+
+static const uint8_t SM2135_CURRENT = (SM2135_20MA << 4) | SM2135_10MA;
+
+void SM2135::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
+  this->data_pin_->setup();
+  this->data_pin_->digital_write(true);
+  this->clock_pin_->setup();
+  this->clock_pin_->digital_write(true);
+  this->pwm_amounts_.resize(5, 0);
+}
+void SM2135::dump_config() {
+  ESP_LOGCONFIG(TAG, "SM2135:");
+  LOG_PIN("  Data Pin: ", this->data_pin_);
+  LOG_PIN("  Clock Pin: ", this->clock_pin_);
+}
+
+void SM2135::loop() {
+  if (!this->update_)
+    return;
+
+  uint8_t data[6];
+  if (this->update_channel_ == 3 || this->update_channel_ == 4) {
+    // No color so must be Cold/Warm
+    data[0] = SM2135_ADDR_MC;
+    data[1] = SM2135_CURRENT;
+    data[2] = SM2135_CW;
+    this->write_buffer_(data, 3);
+    delay(1);
+    data[0] = SM2135_ADDR_C;
+    data[1] = this->pwm_amounts_[4];  // Warm
+    data[2] = this->pwm_amounts_[3];  // Cold
+    this->write_buffer_(data, 3);
+  } else {
+    // Color
+    data[0] = SM2135_ADDR_MC;
+    data[1] = SM2135_CURRENT;
+    data[2] = SM2135_RGB;
+    data[3] = this->pwm_amounts_[1];  // Green
+    data[4] = this->pwm_amounts_[0];  // Red
+    data[5] = this->pwm_amounts_[2];  // Blue
+    this->write_buffer_(data, 6);
+  }
+
+  this->update_ = false;
+}
+
+}  // namespace sm2135
+}  // namespace esphome

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
+#include "esphome/components/output/float_output.h"
+
+namespace esphome {
+namespace sm2135 {
+
+class SM2135 : public Component {
+ public:
+  class Channel;
+
+  void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }
+  void set_clock_pin(GPIOPin *clock_pin) { clock_pin_ = clock_pin; }
+
+  void setup() override;
+
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  /// Send new values if they were updated.
+  void loop() override;
+
+  class Channel : public output::FloatOutput {
+   public:
+    void set_parent(SM2135 *parent) { parent_ = parent; }
+    void set_channel(uint8_t channel) { channel_ = channel; }
+
+   protected:
+    void write_state(float state) override {
+      auto amount = static_cast<uint8_t>(state * 0xff);
+      this->parent_->set_channel_value_(this->channel_, amount);
+    }
+
+    SM2135 *parent_;
+    uint8_t channel_;
+  };
+
+ protected:
+  void set_channel_value_(uint8_t channel, uint8_t value) {
+    if (this->pwm_amounts_[channel] != value) {
+      this->update_ = true;
+      this->update_channel_ = channel;
+    }
+    this->pwm_amounts_[channel] = value;
+  }
+  void write_bit_(bool value) {
+    this->clock_pin_->digital_write(false);
+    this->data_pin_->digital_write(value);
+    this->clock_pin_->digital_write(true);
+  }
+
+  void write_byte_(uint8_t data) {
+    for (uint8_t mask = 0x80; mask; mask >>= 1) {
+      this->write_bit_(data & mask);
+    }
+    this->clock_pin_->digital_write(false);
+    this->data_pin_->digital_write(true);
+    this->clock_pin_->digital_write(true);
+  }
+
+  void write_buffer_(uint8_t *buffer, uint8_t size) {
+    this->data_pin_->digital_write(false);
+    for (uint32_t i = 0; i < size; i++) {
+      this->write_byte_(buffer[i]);
+    }
+    this->clock_pin_->digital_write(false);
+    this->clock_pin_->digital_write(true);
+    this->data_pin_->digital_write(true);
+  }
+
+  GPIOPin *data_pin_;
+  GPIOPin *clock_pin_;
+  uint8_t update_channel_;
+  std::vector<uint8_t> pwm_amounts_;
+  bool update_{true};
+};
+
+}  // namespace sm2135
+}  // namespace esphome

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 18
-PATCH_VERSION = "0b2"
+PATCH_VERSION = "0b3"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@ include_dir = include
 
 [common]
 lib_deps =
-    AsyncTCP-esphome@1.1.1
+    esphome/AsyncTCP-esphome@1.2.2
     AsyncMqttClient-esphome@0.8.4
     ArduinoJson-esphomelib@5.13.3
     ESPAsyncWebServer-esphome@1.2.7

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -413,7 +413,7 @@ sensor:
     retain: False
     availability:
     state_topic: livingroom/custom_state_topic
-    measurement_time: 31
+    measurement_duration: 31
   - platform: bme280
     temperature:
       name: 'Outside Temperature'

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -586,6 +586,10 @@ script:
     then:
       - lambda: 'ESP_LOGD("main", "Hello World!");'
 
+sm2135:
+  data_pin: GPIO12
+  clock_pin: GPIO14
+
 switch:
   - platform: template
     name: 'mpr121_toggle'
@@ -828,6 +832,21 @@ output:
     pin: GPIO5
     id: my_slow_pwm
     period: 15s
+  - platform: sm2135
+    id: sm2135_0
+    channel: 0
+  - platform: sm2135
+    id: sm2135_1
+    channel: 1
+  - platform: sm2135
+    id: sm2135_2
+    channel: 2
+  - platform: sm2135
+    id: sm2135_3
+    channel: 3
+  - platform: sm2135
+    id: sm2135_4
+    channel: 4
 
 mcp23017:
   id: mcp23017_hub


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"In C++ it’s harder to shoot yourself in the foot, but when you do, you blow off your whole leg."_

~ Bjarne Stroustrup
- esphome: Upgrade the version of AsyncTCP-esphome to v1.2.2 [esphome#1762](https://github.com/esphome/esphome/pull/1762)
- esphome: Use core constants for sample duration on bh1750 [esphome#1764](https://github.com/esphome/esphome/pull/1764) (breaking-change)
- docs: Fix docs for inkplate [docs#1158](https://github.com/esphome/esphome-docs/pull/1158)
- docs: Fixed wrong link in i2c_id [docs#1163](https://github.com/esphome/esphome-docs/pull/1163)
- docs: Explain where to upload .ttf font files [docs#1133](https://github.com/esphome/esphome-docs/pull/1133)
- esphome: Add sm2135 component [esphome#1736](https://github.com/esphome/esphome/pull/1736) (new-integration)
- docs: Add sm2135 component [docs#1127](https://github.com/esphome/esphome-docs/pull/1127)
