### PR TITLE
Allow RC522 components to have multiple configurations

### DIFF
--- a/esphome/components/rc522/__init__.py
+++ b/esphome/components/rc522/__init__.py
@@ -7,7 +7,6 @@ from esphome.core import coroutine
 
 CODEOWNERS = ["@glmnet"]
 AUTO_LOAD = ["binary_sensor"]
-MULTI_CONF = True
 
 CONF_RC522_ID = "rc522_id"
 

--- a/esphome/components/rc522_i2c/__init__.py
+++ b/esphome/components/rc522_i2c/__init__.py
@@ -6,7 +6,7 @@ from esphome.const import CONF_ID
 CODEOWNERS = ["@glmnet"]
 DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["rc522"]
-
+MULTI_CONF = True
 
 rc522_i2c_ns = cg.esphome_ns.namespace("rc522_i2c")
 RC522I2C = rc522_i2c_ns.class_("RC522I2C", rc522.RC522, i2c.I2CDevice)

--- a/esphome/components/rc522_spi/__init__.py
+++ b/esphome/components/rc522_spi/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ID
 CODEOWNERS = ["@glmnet"]
 DEPENDENCIES = ["spi"]
 AUTO_LOAD = ["rc522"]
+MULTI_CONF = True
 
 rc522_spi_ns = cg.esphome_ns.namespace("rc522_spi")
 RC522Spi = rc522_spi_ns.class_("RC522Spi", rc522.RC522, spi.SPIDevice)

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1982,10 +1982,15 @@ rc522_spi:
         ESP_LOGD("main", "Found tag %s", x.c_str());
 
 rc522_i2c:
-  update_interval: 1s
-  on_tag:
-    - lambda: |-
-        ESP_LOGD("main", "Found tag %s", x.c_str());
+  - update_interval: 1s
+    on_tag:
+      - lambda: |-
+          ESP_LOGD("main", "Found tag %s", x.c_str());
+
+  - update_interval: 1s
+    on_tag:
+      - lambda: |-
+          ESP_LOGD("main", "Found tag %s", x.c_str());
 
 gps:
   uart_id: uart0


### PR DESCRIPTION
# What does this implement/fix? 

This allows `rc522_spi` and `rc522_i2c` to have multiple configurations - i.e multiple readers 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
