### PR TITLE
Added bottom segment to digit 9

### DIFF
--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -46,7 +46,7 @@ const uint8_t TM1637_ASCII_TO_RAW[] PROGMEM = {
     0b01011111,           // '6', ord 0x36
     0b01110000,           // '7', ord 0x37
     0b01111111,           // '8', ord 0x38
-    0b01110011,           // '9', ord 0x39
+    0b01111011,           // '9', ord 0x39
     0b01001000,           // ':', ord 0x3A
     0b01011000,           // ';', ord 0x3B
     TM1637_UNKNOWN_CHAR,  // '<', ord 0x3C


### PR DESCRIPTION
# What does this implement/fix? 

I just added the bottom segment to the 9 digit.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

# Explain your changes

Not sure if it was the way it was for a reason, but I'm pretty sure it's supposed to be:
```
 _  
|_|   
 _|   
```
not 
```
 _  
|_|   
  |   
```
as I've never seen it displayed like that on any digital time clock.

I've intentionally left some checkboxes unmarked, since this is an extremely small change.
Hopefully that's okay. Sorry if I missed something, and if I'm not doing this correctly, it's probably something you could  
change yourself, if you wanted to.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).