### PR TITLE
Generate protobuf code closer to formatted files

### DIFF
--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -89,7 +89,7 @@ enum ClimateAction : uint32_t {
 
 class HelloRequest : public ProtoMessage {
  public:
-  std::string client_info{};  // NOLINT
+  std::string client_info{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -98,9 +98,9 @@ class HelloRequest : public ProtoMessage {
 };
 class HelloResponse : public ProtoMessage {
  public:
-  uint32_t api_version_major{0};  // NOLINT
-  uint32_t api_version_minor{0};  // NOLINT
-  std::string server_info{};      // NOLINT
+  uint32_t api_version_major{0};
+  uint32_t api_version_minor{0};
+  std::string server_info{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -110,7 +110,7 @@ class HelloResponse : public ProtoMessage {
 };
 class ConnectRequest : public ProtoMessage {
  public:
-  std::string password{};  // NOLINT
+  std::string password{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -119,7 +119,7 @@ class ConnectRequest : public ProtoMessage {
 };
 class ConnectResponse : public ProtoMessage {
  public:
-  bool invalid_password{false};  // NOLINT
+  bool invalid_password{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -163,13 +163,13 @@ class DeviceInfoRequest : public ProtoMessage {
 };
 class DeviceInfoResponse : public ProtoMessage {
  public:
-  bool uses_password{false};       // NOLINT
-  std::string name{};              // NOLINT
-  std::string mac_address{};       // NOLINT
-  std::string esphome_version{};   // NOLINT
-  std::string compilation_time{};  // NOLINT
-  std::string model{};             // NOLINT
-  bool has_deep_sleep{false};      // NOLINT
+  bool uses_password{false};
+  std::string name{};
+  std::string mac_address{};
+  std::string esphome_version{};
+  std::string compilation_time{};
+  std::string model{};
+  bool has_deep_sleep{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -200,12 +200,12 @@ class SubscribeStatesRequest : public ProtoMessage {
 };
 class ListEntitiesBinarySensorResponse : public ProtoMessage {
  public:
-  std::string object_id{};              // NOLINT
-  uint32_t key{0};                      // NOLINT
-  std::string name{};                   // NOLINT
-  std::string unique_id{};              // NOLINT
-  std::string device_class{};           // NOLINT
-  bool is_status_binary_sensor{false};  // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string device_class{};
+  bool is_status_binary_sensor{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -216,9 +216,9 @@ class ListEntitiesBinarySensorResponse : public ProtoMessage {
 };
 class BinarySensorStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};            // NOLINT
-  bool state{false};          // NOLINT
-  bool missing_state{false};  // NOLINT
+  uint32_t key{0};
+  bool state{false};
+  bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -228,14 +228,14 @@ class BinarySensorStateResponse : public ProtoMessage {
 };
 class ListEntitiesCoverResponse : public ProtoMessage {
  public:
-  std::string object_id{};        // NOLINT
-  uint32_t key{0};                // NOLINT
-  std::string name{};             // NOLINT
-  std::string unique_id{};        // NOLINT
-  bool assumed_state{false};      // NOLINT
-  bool supports_position{false};  // NOLINT
-  bool supports_tilt{false};      // NOLINT
-  std::string device_class{};     // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool assumed_state{false};
+  bool supports_position{false};
+  bool supports_tilt{false};
+  std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -246,11 +246,11 @@ class ListEntitiesCoverResponse : public ProtoMessage {
 };
 class CoverStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};                            // NOLINT
-  enums::LegacyCoverState legacy_state{};     // NOLINT
-  float position{0.0f};                       // NOLINT
-  float tilt{0.0f};                           // NOLINT
-  enums::CoverOperation current_operation{};  // NOLINT
+  uint32_t key{0};
+  enums::LegacyCoverState legacy_state{};
+  float position{0.0f};
+  float tilt{0.0f};
+  enums::CoverOperation current_operation{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -260,14 +260,14 @@ class CoverStateResponse : public ProtoMessage {
 };
 class CoverCommandRequest : public ProtoMessage {
  public:
-  uint32_t key{0};                             // NOLINT
-  bool has_legacy_command{false};              // NOLINT
-  enums::LegacyCoverCommand legacy_command{};  // NOLINT
-  bool has_position{false};                    // NOLINT
-  float position{0.0f};                        // NOLINT
-  bool has_tilt{false};                        // NOLINT
-  float tilt{0.0f};                            // NOLINT
-  bool stop{false};                            // NOLINT
+  uint32_t key{0};
+  bool has_legacy_command{false};
+  enums::LegacyCoverCommand legacy_command{};
+  bool has_position{false};
+  float position{0.0f};
+  bool has_tilt{false};
+  float tilt{0.0f};
+  bool stop{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -277,14 +277,14 @@ class CoverCommandRequest : public ProtoMessage {
 };
 class ListEntitiesFanResponse : public ProtoMessage {
  public:
-  std::string object_id{};           // NOLINT
-  uint32_t key{0};                   // NOLINT
-  std::string name{};                // NOLINT
-  std::string unique_id{};           // NOLINT
-  bool supports_oscillation{false};  // NOLINT
-  bool supports_speed{false};        // NOLINT
-  bool supports_direction{false};    // NOLINT
-  int32_t supported_speed_count{0};  // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool supports_oscillation{false};
+  bool supports_speed{false};
+  bool supports_direction{false};
+  int32_t supported_speed_count{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -295,12 +295,12 @@ class ListEntitiesFanResponse : public ProtoMessage {
 };
 class FanStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};                  // NOLINT
-  bool state{false};                // NOLINT
-  bool oscillating{false};          // NOLINT
-  enums::FanSpeed speed{};          // NOLINT
-  enums::FanDirection direction{};  // NOLINT
-  int32_t speed_level{0};           // NOLINT
+  uint32_t key{0};
+  bool state{false};
+  bool oscillating{false};
+  enums::FanSpeed speed{};
+  enums::FanDirection direction{};
+  int32_t speed_level{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -310,17 +310,17 @@ class FanStateResponse : public ProtoMessage {
 };
 class FanCommandRequest : public ProtoMessage {
  public:
-  uint32_t key{0};                  // NOLINT
-  bool has_state{false};            // NOLINT
-  bool state{false};                // NOLINT
-  bool has_speed{false};            // NOLINT
-  enums::FanSpeed speed{};          // NOLINT
-  bool has_oscillating{false};      // NOLINT
-  bool oscillating{false};          // NOLINT
-  bool has_direction{false};        // NOLINT
-  enums::FanDirection direction{};  // NOLINT
-  bool has_speed_level{false};      // NOLINT
-  int32_t speed_level{0};           // NOLINT
+  uint32_t key{0};
+  bool has_state{false};
+  bool state{false};
+  bool has_speed{false};
+  enums::FanSpeed speed{};
+  bool has_oscillating{false};
+  bool oscillating{false};
+  bool has_direction{false};
+  enums::FanDirection direction{};
+  bool has_speed_level{false};
+  int32_t speed_level{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -330,17 +330,17 @@ class FanCommandRequest : public ProtoMessage {
 };
 class ListEntitiesLightResponse : public ProtoMessage {
  public:
-  std::string object_id{};                 // NOLINT
-  uint32_t key{0};                         // NOLINT
-  std::string name{};                      // NOLINT
-  std::string unique_id{};                 // NOLINT
-  bool supports_brightness{false};         // NOLINT
-  bool supports_rgb{false};                // NOLINT
-  bool supports_white_value{false};        // NOLINT
-  bool supports_color_temperature{false};  // NOLINT
-  float min_mireds{0.0f};                  // NOLINT
-  float max_mireds{0.0f};                  // NOLINT
-  std::vector<std::string> effects{};      // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool supports_brightness{false};
+  bool supports_rgb{false};
+  bool supports_white_value{false};
+  bool supports_color_temperature{false};
+  float min_mireds{0.0f};
+  float max_mireds{0.0f};
+  std::vector<std::string> effects{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -351,15 +351,15 @@ class ListEntitiesLightResponse : public ProtoMessage {
 };
 class LightStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};                // NOLINT
-  bool state{false};              // NOLINT
-  float brightness{0.0f};         // NOLINT
-  float red{0.0f};                // NOLINT
-  float green{0.0f};              // NOLINT
-  float blue{0.0f};               // NOLINT
-  float white{0.0f};              // NOLINT
-  float color_temperature{0.0f};  // NOLINT
-  std::string effect{};           // NOLINT
+  uint32_t key{0};
+  bool state{false};
+  float brightness{0.0f};
+  float red{0.0f};
+  float green{0.0f};
+  float blue{0.0f};
+  float white{0.0f};
+  float color_temperature{0.0f};
+  std::string effect{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -370,25 +370,25 @@ class LightStateResponse : public ProtoMessage {
 };
 class LightCommandRequest : public ProtoMessage {
  public:
-  uint32_t key{0};                    // NOLINT
-  bool has_state{false};              // NOLINT
-  bool state{false};                  // NOLINT
-  bool has_brightness{false};         // NOLINT
-  float brightness{0.0f};             // NOLINT
-  bool has_rgb{false};                // NOLINT
-  float red{0.0f};                    // NOLINT
-  float green{0.0f};                  // NOLINT
-  float blue{0.0f};                   // NOLINT
-  bool has_white{false};              // NOLINT
-  float white{0.0f};                  // NOLINT
-  bool has_color_temperature{false};  // NOLINT
-  float color_temperature{0.0f};      // NOLINT
-  bool has_transition_length{false};  // NOLINT
-  uint32_t transition_length{0};      // NOLINT
-  bool has_flash_length{false};       // NOLINT
-  uint32_t flash_length{0};           // NOLINT
-  bool has_effect{false};             // NOLINT
-  std::string effect{};               // NOLINT
+  uint32_t key{0};
+  bool has_state{false};
+  bool state{false};
+  bool has_brightness{false};
+  float brightness{0.0f};
+  bool has_rgb{false};
+  float red{0.0f};
+  float green{0.0f};
+  float blue{0.0f};
+  bool has_white{false};
+  float white{0.0f};
+  bool has_color_temperature{false};
+  float color_temperature{0.0f};
+  bool has_transition_length{false};
+  uint32_t transition_length{0};
+  bool has_flash_length{false};
+  uint32_t flash_length{0};
+  bool has_effect{false};
+  std::string effect{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -399,15 +399,15 @@ class LightCommandRequest : public ProtoMessage {
 };
 class ListEntitiesSensorResponse : public ProtoMessage {
  public:
-  std::string object_id{};            // NOLINT
-  uint32_t key{0};                    // NOLINT
-  std::string name{};                 // NOLINT
-  std::string unique_id{};            // NOLINT
-  std::string icon{};                 // NOLINT
-  std::string unit_of_measurement{};  // NOLINT
-  int32_t accuracy_decimals{0};       // NOLINT
-  bool force_update{false};           // NOLINT
-  std::string device_class{};         // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  std::string unit_of_measurement{};
+  int32_t accuracy_decimals{0};
+  bool force_update{false};
+  std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -418,9 +418,9 @@ class ListEntitiesSensorResponse : public ProtoMessage {
 };
 class SensorStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};            // NOLINT
-  float state{0.0f};          // NOLINT
-  bool missing_state{false};  // NOLINT
+  uint32_t key{0};
+  float state{0.0f};
+  bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -430,12 +430,12 @@ class SensorStateResponse : public ProtoMessage {
 };
 class ListEntitiesSwitchResponse : public ProtoMessage {
  public:
-  std::string object_id{};    // NOLINT
-  uint32_t key{0};            // NOLINT
-  std::string name{};         // NOLINT
-  std::string unique_id{};    // NOLINT
-  std::string icon{};         // NOLINT
-  bool assumed_state{false};  // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool assumed_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -446,8 +446,8 @@ class ListEntitiesSwitchResponse : public ProtoMessage {
 };
 class SwitchStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};    // NOLINT
-  bool state{false};  // NOLINT
+  uint32_t key{0};
+  bool state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -457,8 +457,8 @@ class SwitchStateResponse : public ProtoMessage {
 };
 class SwitchCommandRequest : public ProtoMessage {
  public:
-  uint32_t key{0};    // NOLINT
-  bool state{false};  // NOLINT
+  uint32_t key{0};
+  bool state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -468,11 +468,11 @@ class SwitchCommandRequest : public ProtoMessage {
 };
 class ListEntitiesTextSensorResponse : public ProtoMessage {
  public:
-  std::string object_id{};  // NOLINT
-  uint32_t key{0};          // NOLINT
-  std::string name{};       // NOLINT
-  std::string unique_id{};  // NOLINT
-  std::string icon{};       // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -482,9 +482,9 @@ class ListEntitiesTextSensorResponse : public ProtoMessage {
 };
 class TextSensorStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};            // NOLINT
-  std::string state{};        // NOLINT
-  bool missing_state{false};  // NOLINT
+  uint32_t key{0};
+  std::string state{};
+  bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -495,8 +495,8 @@ class TextSensorStateResponse : public ProtoMessage {
 };
 class SubscribeLogsRequest : public ProtoMessage {
  public:
-  enums::LogLevel level{};  // NOLINT
-  bool dump_config{false};  // NOLINT
+  enums::LogLevel level{};
+  bool dump_config{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -505,10 +505,10 @@ class SubscribeLogsRequest : public ProtoMessage {
 };
 class SubscribeLogsResponse : public ProtoMessage {
  public:
-  enums::LogLevel level{};  // NOLINT
-  std::string tag{};        // NOLINT
-  std::string message{};    // NOLINT
-  bool send_failed{false};  // NOLINT
+  enums::LogLevel level{};
+  std::string tag{};
+  std::string message{};
+  bool send_failed{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -525,8 +525,8 @@ class SubscribeHomeassistantServicesRequest : public ProtoMessage {
 };
 class HomeassistantServiceMap : public ProtoMessage {
  public:
-  std::string key{};    // NOLINT
-  std::string value{};  // NOLINT
+  std::string key{};
+  std::string value{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -535,11 +535,11 @@ class HomeassistantServiceMap : public ProtoMessage {
 };
 class HomeassistantServiceResponse : public ProtoMessage {
  public:
-  std::string service{};                                 // NOLINT
-  std::vector<HomeassistantServiceMap> data{};           // NOLINT
-  std::vector<HomeassistantServiceMap> data_template{};  // NOLINT
-  std::vector<HomeassistantServiceMap> variables{};      // NOLINT
-  bool is_event{false};                                  // NOLINT
+  std::string service{};
+  std::vector<HomeassistantServiceMap> data{};
+  std::vector<HomeassistantServiceMap> data_template{};
+  std::vector<HomeassistantServiceMap> variables{};
+  bool is_event{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -556,7 +556,7 @@ class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
 };
 class SubscribeHomeAssistantStateResponse : public ProtoMessage {
  public:
-  std::string entity_id{};  // NOLINT
+  std::string entity_id{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -565,8 +565,8 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
 };
 class HomeAssistantStateResponse : public ProtoMessage {
  public:
-  std::string entity_id{};  // NOLINT
-  std::string state{};      // NOLINT
+  std::string entity_id{};
+  std::string state{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -582,7 +582,7 @@ class GetTimeRequest : public ProtoMessage {
 };
 class GetTimeResponse : public ProtoMessage {
  public:
-  uint32_t epoch_seconds{0};  // NOLINT
+  uint32_t epoch_seconds{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -591,8 +591,8 @@ class GetTimeResponse : public ProtoMessage {
 };
 class ListEntitiesServicesArgument : public ProtoMessage {
  public:
-  std::string name{};            // NOLINT
-  enums::ServiceArgType type{};  // NOLINT
+  std::string name{};
+  enums::ServiceArgType type{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -602,9 +602,9 @@ class ListEntitiesServicesArgument : public ProtoMessage {
 };
 class ListEntitiesServicesResponse : public ProtoMessage {
  public:
-  std::string name{};                                // NOLINT
-  uint32_t key{0};                                   // NOLINT
-  std::vector<ListEntitiesServicesArgument> args{};  // NOLINT
+  std::string name{};
+  uint32_t key{0};
+  std::vector<ListEntitiesServicesArgument> args{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -614,15 +614,15 @@ class ListEntitiesServicesResponse : public ProtoMessage {
 };
 class ExecuteServiceArgument : public ProtoMessage {
  public:
-  bool bool_{false};                        // NOLINT
-  int32_t legacy_int{0};                    // NOLINT
-  float float_{0.0f};                       // NOLINT
-  std::string string_{};                    // NOLINT
-  int32_t int_{0};                          // NOLINT
-  std::vector<bool> bool_array{};           // NOLINT
-  std::vector<int32_t> int_array{};         // NOLINT
-  std::vector<float> float_array{};         // NOLINT
-  std::vector<std::string> string_array{};  // NOLINT
+  bool bool_{false};
+  int32_t legacy_int{0};
+  float float_{0.0f};
+  std::string string_{};
+  int32_t int_{0};
+  std::vector<bool> bool_array{};
+  std::vector<int32_t> int_array{};
+  std::vector<float> float_array{};
+  std::vector<std::string> string_array{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -633,8 +633,8 @@ class ExecuteServiceArgument : public ProtoMessage {
 };
 class ExecuteServiceRequest : public ProtoMessage {
  public:
-  uint32_t key{0};                             // NOLINT
-  std::vector<ExecuteServiceArgument> args{};  // NOLINT
+  uint32_t key{0};
+  std::vector<ExecuteServiceArgument> args{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -644,10 +644,10 @@ class ExecuteServiceRequest : public ProtoMessage {
 };
 class ListEntitiesCameraResponse : public ProtoMessage {
  public:
-  std::string object_id{};  // NOLINT
-  uint32_t key{0};          // NOLINT
-  std::string name{};       // NOLINT
-  std::string unique_id{};  // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -657,9 +657,9 @@ class ListEntitiesCameraResponse : public ProtoMessage {
 };
 class CameraImageResponse : public ProtoMessage {
  public:
-  uint32_t key{0};     // NOLINT
-  std::string data{};  // NOLINT
-  bool done{false};    // NOLINT
+  uint32_t key{0};
+  std::string data{};
+  bool done{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -670,8 +670,8 @@ class CameraImageResponse : public ProtoMessage {
 };
 class CameraImageRequest : public ProtoMessage {
  public:
-  bool single{false};  // NOLINT
-  bool stream{false};  // NOLINT
+  bool single{false};
+  bool stream{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -680,20 +680,20 @@ class CameraImageRequest : public ProtoMessage {
 };
 class ListEntitiesClimateResponse : public ProtoMessage {
  public:
-  std::string object_id{};                                       // NOLINT
-  uint32_t key{0};                                               // NOLINT
-  std::string name{};                                            // NOLINT
-  std::string unique_id{};                                       // NOLINT
-  bool supports_current_temperature{false};                      // NOLINT
-  bool supports_two_point_target_temperature{false};             // NOLINT
-  std::vector<enums::ClimateMode> supported_modes{};             // NOLINT
-  float visual_min_temperature{0.0f};                            // NOLINT
-  float visual_max_temperature{0.0f};                            // NOLINT
-  float visual_temperature_step{0.0f};                           // NOLINT
-  bool supports_away{false};                                     // NOLINT
-  bool supports_action{false};                                   // NOLINT
-  std::vector<enums::ClimateFanMode> supported_fan_modes{};      // NOLINT
-  std::vector<enums::ClimateSwingMode> supported_swing_modes{};  // NOLINT
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool supports_current_temperature{false};
+  bool supports_two_point_target_temperature{false};
+  std::vector<enums::ClimateMode> supported_modes{};
+  float visual_min_temperature{0.0f};
+  float visual_max_temperature{0.0f};
+  float visual_temperature_step{0.0f};
+  bool supports_away{false};
+  bool supports_action{false};
+  std::vector<enums::ClimateFanMode> supported_fan_modes{};
+  std::vector<enums::ClimateSwingMode> supported_swing_modes{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -704,16 +704,16 @@ class ListEntitiesClimateResponse : public ProtoMessage {
 };
 class ClimateStateResponse : public ProtoMessage {
  public:
-  uint32_t key{0};                       // NOLINT
-  enums::ClimateMode mode{};             // NOLINT
-  float current_temperature{0.0f};       // NOLINT
-  float target_temperature{0.0f};        // NOLINT
-  float target_temperature_low{0.0f};    // NOLINT
-  float target_temperature_high{0.0f};   // NOLINT
-  bool away{false};                      // NOLINT
-  enums::ClimateAction action{};         // NOLINT
-  enums::ClimateFanMode fan_mode{};      // NOLINT
-  enums::ClimateSwingMode swing_mode{};  // NOLINT
+  uint32_t key{0};
+  enums::ClimateMode mode{};
+  float current_temperature{0.0f};
+  float target_temperature{0.0f};
+  float target_temperature_low{0.0f};
+  float target_temperature_high{0.0f};
+  bool away{false};
+  enums::ClimateAction action{};
+  enums::ClimateFanMode fan_mode{};
+  enums::ClimateSwingMode swing_mode{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 
@@ -723,21 +723,21 @@ class ClimateStateResponse : public ProtoMessage {
 };
 class ClimateCommandRequest : public ProtoMessage {
  public:
-  uint32_t key{0};                          // NOLINT
-  bool has_mode{false};                     // NOLINT
-  enums::ClimateMode mode{};                // NOLINT
-  bool has_target_temperature{false};       // NOLINT
-  float target_temperature{0.0f};           // NOLINT
-  bool has_target_temperature_low{false};   // NOLINT
-  float target_temperature_low{0.0f};       // NOLINT
-  bool has_target_temperature_high{false};  // NOLINT
-  float target_temperature_high{0.0f};      // NOLINT
-  bool has_away{false};                     // NOLINT
-  bool away{false};                         // NOLINT
-  bool has_fan_mode{false};                 // NOLINT
-  enums::ClimateFanMode fan_mode{};         // NOLINT
-  bool has_swing_mode{false};               // NOLINT
-  enums::ClimateSwingMode swing_mode{};     // NOLINT
+  uint32_t key{0};
+  bool has_mode{false};
+  enums::ClimateMode mode{};
+  bool has_target_temperature{false};
+  float target_temperature{0.0f};
+  bool has_target_temperature_low{false};
+  float target_temperature_low{0.0f};
+  bool has_target_temperature_high{false};
+  float target_temperature_high{0.0f};
+  bool has_away{false};
+  bool away{false};
+  bool has_fan_mode{false};
+  enums::ClimateFanMode fan_mode{};
+  bool has_swing_mode{false};
+  enums::ClimateSwingMode swing_mode{};
   void encode(ProtoWriteBuffer buffer) const override;
   void dump_to(std::string &out) const override;
 

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -139,7 +139,8 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
   ESP_LOGVV(TAG, "send_homeassistant_service_response: %s", msg.dump().c_str());
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
+    const SubscribeHomeAssistantStateResponse &msg) {
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
   return this->send_message_<SubscribeHomeAssistantStateResponse>(msg, 39);
 }
@@ -424,7 +425,8 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(
+    const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -139,8 +139,7 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
   ESP_LOGVV(TAG, "send_homeassistant_service_response: %s", msg.dump().c_str());
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
-    const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
   return this->send_message_<SubscribeHomeAssistantStateResponse>(msg, 39);
 }
@@ -425,8 +424,7 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(
-    const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -40,7 +40,16 @@ d = descriptor.FileDescriptorSet.FromString(content)
 
 
 def indent_list(text, padding="  "):
-    return [padding + line for line in text.splitlines()]
+    lines = []
+    for line in text.splitlines():
+        if line == "":
+            p = ""
+        elif line.startswith("#ifdef") or line.startswith("#endif"):
+            p = ""
+        else:
+            p = padding
+        lines.append(p + line)
+    return lines
 
 
 def indent(text, padding="  "):
@@ -103,7 +112,7 @@ class TypeInfo:
 
     @property
     def class_member(self) -> str:
-        return f"{self.cpp_type} {self.field_name}{{{self.default_value}}};  // NOLINT"
+        return f"{self.cpp_type} {self.field_name}{{{self.default_value}}};"
 
     @property
     def decode_varint_content(self) -> str:
@@ -432,7 +441,7 @@ class SInt64Type(TypeInfo):
     decode_varint = "value.as_sint64()"
     encode_func = "encode_sin64"
 
-    def dump(self):
+    def dump(self, name):
         o = f'sprintf(buffer, "%ll", {name});\n'
         o += f"out.append(buffer);"
         return o
@@ -515,9 +524,9 @@ class RepeatedTypeInfo(TypeInfo):
     @property
     def encode_content(self):
         return f"""\
-        for (auto {'' if self._ti_is_bool else '&'}it : this->{self.field_name}) {{
-          buffer.{self._ti.encode_func}({self.number}, it, true);
-        }}"""
+for (auto {'' if self._ti_is_bool else '&'}it : this->{self.field_name}) {{
+  buffer.{self._ti.encode_func}({self.number}, it, true);
+}}"""
 
     @property
     def dump_content(self):
@@ -536,12 +545,14 @@ def build_enum_type(desc):
         out += f"  {v.name} = {v.number},\n"
     out += "};\n"
 
-    cpp = f"template<>\n"
-    cpp += f"const char *proto_enum_to_string<enums::{name}>(enums::{name} value) {{\n"
+    cpp = f"template<>"
+    cpp = f"template<> const char *proto_enum_to_string<enums::{name}>(enums::{name} value) {{\n"
     cpp += f"  switch (value) {{\n"
     for v in desc.value:
-        cpp += f'    case enums::{v.name}: return "{v.name}";\n'
-    cpp += f'    default: return "UNKNOWN";\n'
+        cpp += f"    case enums::{v.name}:\n"
+        cpp += f'      return "{v.name}";\n'
+    cpp += f"    default:\n"
+    cpp += f'      return "UNKNOWN";\n'
     cpp += f"  }}\n"
     cpp += f"}}\n"
 
@@ -620,21 +631,35 @@ def build_message_type(desc):
         prot = "bool decode_64bit(uint32_t field_id, Proto64bit value) override;"
         protected_content.insert(0, prot)
 
-    o = f"void {desc.name}::encode(ProtoWriteBuffer buffer) const {{\n"
-    o += indent("\n".join(encode)) + "\n"
+    o = f"void {desc.name}::encode(ProtoWriteBuffer buffer) const {{"
+    if encode:
+        if len(encode) == 1 and len(encode[0]) + len(o) + 3 < 120:
+            o += f" {encode[0]} "
+        else:
+            o += "\n"
+            o += indent("\n".join(encode)) + "\n"
     o += "}\n"
     cpp += o
     prot = "void encode(ProtoWriteBuffer buffer) const override;"
     public_content.append(prot)
 
-    o = f"void {desc.name}::dump_to(std::string &out) const {{\n"
+    o = f"void {desc.name}::dump_to(std::string &out) const {{"
     if dump:
-        o += f"  char buffer[64];\n"
-        o += f'  out.append("{desc.name} {{\\n");\n'
-        o += indent("\n".join(dump)) + "\n"
-        o += f'  out.append("}}");\n'
+        if len(dump) == 1 and len(dump[0]) + len(o) + 3 < 120:
+            o += f" {dump[0]} "
+        else:
+            o += "\n"
+            o += f"  char buffer[64];\n"
+            o += f'  out.append("{desc.name} {{\\n");\n'
+            o += indent("\n".join(dump)) + "\n"
+            o += f'  out.append("}}");\n'
     else:
-        o += f'  out.append("{desc.name} {{}}");\n'
+        o2 = f'out.append("{desc.name} {{}}");'
+        if len(o) + len(o2) + 3 < 120:
+            o += f" {o2} "
+        else:
+            o += "\n"
+            o += f"  {o2}\n"
     o += "}\n"
     cpp += o
     prot = "void dump_to(std::string &out) const override;"
@@ -643,8 +668,11 @@ def build_message_type(desc):
     out = f"class {desc.name} : public ProtoMessage {{\n"
     out += " public:\n"
     out += indent("\n".join(public_content)) + "\n"
+    out += "\n"
     out += " protected:\n"
-    out += indent("\n".join(protected_content)) + "\n"
+    out += indent("\n".join(protected_content))
+    if len(protected_content) > 0:
+        out += "\n"
     out += "};\n"
     return out, cpp
 
@@ -814,13 +842,13 @@ cases.sort()
 hpp += " protected:\n"
 hpp += f"  bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;\n"
 out = f"bool {class_name}::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {{\n"
-out += f"  switch(msg_type) {{\n"
+out += f"  switch (msg_type) {{\n"
 for i, case in cases:
     c = f"case {i}: {{\n"
     c += indent(case) + "\n"
     c += f"}}"
     out += indent(c, "    ") + "\n"
-out += "    default: \n"
+out += "    default:\n"
 out += "      return false;\n"
 out += "  }\n"
 out += "  return true;\n"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -523,10 +523,10 @@ class RepeatedTypeInfo(TypeInfo):
 
     @property
     def encode_content(self):
-        return f"""\
-for (auto {'' if self._ti_is_bool else '&'}it : this->{self.field_name}) {{
-  buffer.{self._ti.encode_func}({self.number}, it, true);
-}}"""
+        o = f"for (auto {'' if self._ti_is_bool else '&'}it : this->{self.field_name}) {{\n"
+        o += f"  buffer.{self._ti.encode_func}({self.number}, it, true);\n"
+        o += f"}}"
+        return o
 
     @property
     def dump_content(self):
@@ -545,7 +545,6 @@ def build_enum_type(desc):
         out += f"  {v.name} = {v.number},\n"
     out += "};\n"
 
-    cpp = f"template<>"
     cpp = f"template<> const char *proto_enum_to_string<enums::{name}>(enums::{name} value) {{\n"
     cpp += f"  switch (value) {{\n"
     for v in desc.value:


### PR DESCRIPTION
# What does this implement/fix? 

This just modifies the proto generation code so that it generates the cpp/h code more closely to the files that get formatted with `clang-format`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
