### PR TITLE
Do not use Serial2 for ESP32C3, too

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -136,7 +136,7 @@ void Logger::pre_setup() {
         break;
 #ifdef ARDUINO_ARCH_ESP32
       case UART_SELECTION_UART2:
-#if !CONFIG_IDF_TARGET_ESP32S2
+#if !CONFIG_IDF_TARGET_ESP32S2 && !CONFIG_IDF_TARGET_ESP32C3
         // FIXME: Validate in config that UART2 can't be set for ESP32-S2 (only has
         // UART0-UART1)
         this->hw_serial_ = &Serial2;


### PR DESCRIPTION
src/esphome/components/logger/logger.cpp: In member function 'void esphome::logger::Logger::pre_setup()':
src/esphome/components/logger/logger.cpp:142:29: error: 'Serial2' was not declared in this scope
         this->hw_serial_ = &Serial2;

# What does this implement/fix? 
Just fix the same for C3 like for S2 in https://github.com/esphome/esphome/pull/1433
Quick description 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
