### PR TITLE
Use size_t for length parameter

### DIFF
--- a/esphome/core/preferences.cpp
+++ b/esphome/core/preferences.cpp
@@ -252,9 +252,9 @@ bool ESPPreferenceObject::load_internal_() {
 
   char key[32];
   sprintf(key, "%u", this->offset_);
-  uint32_t len = (this->length_words_ + 1) * 4;
+  size_t len = (this->length_words_ + 1) * 4;
 
-  uint32_t actual_len;
+  size_t actual_len;
   esp_err_t err = nvs_get_blob(global_preferences.nvs_handle_, key, nullptr, &actual_len);
   if (err) {
     ESP_LOGV(TAG, "nvs_get_blob('%s'): %s - the key might not be set yet", key, esp_err_to_name(err));


### PR DESCRIPTION
The function uses this signature:
  esp_err_t nvs_get_blob(nvs_handle handle, const char* key, void* out_value, size_t* length);

So we can avoid those errors/warnings.

```
Compiling .pioenvs/esp_demo_s2/src/esphome/core/preferences.cpp.o
src/esphome/core/preferences.cpp: In member function 'bool esphome::ESPPreferenceObject::load_internal_()':
src/esphome/core/preferences.cpp:258:78: error: invalid conversion from 'uint32_t*' {aka 'long unsigned int*'} to 'size_t*' {aka 'unsigned int*'} [-fpermissive]
   esp_err_t err = nvs_get_blob(global_preferences.nvs_handle_, key, nullptr, &actual_len);
                                                                              ^~~~~~~~~~~
In file included from src/esphome/core/preferences.cpp:12:
/.../.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32c3/include/nvs_flash/include/nvs.h:455:87: note:   initializing argument 4 of 'esp_err_t nvs_get_blob(nvs_handle_t, const char*, void*, size_t*)'
 esp_err_t nvs_get_blob(nvs_handle_t handle, const char* key, void* out_value, size_t* length);
                                                                               ~~~~~~~~^~~~~~
src/esphome/core/preferences.cpp:267:72: error: invalid conversion from 'uint32_t*' {aka 'long unsigned int*'} to 'size_t*' {aka 'unsigned int*'} [-fpermissive]
   err = nvs_get_blob(global_preferences.nvs_handle_, key, this->data_, &len);
                                                                        ^~~~
In file included from src/esphome/core/preferences.cpp:12:
/.../.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32c3/include/nvs_flash/include/nvs.h:455:87: note:   initializing argument 4 of 'esp_err_t nvs_get_blob(nvs_handle_t, const char*, void*, size_t*)'
 esp_err_t nvs_get_blob(nvs_handle_t handle, const char* key, void* out_value, size_t* length);
                                                                               ~~~~~~~~^
```
# What does this implement/fix? 
Found while I tried C3 build: https://github.com/esphome/feature-requests/issues/1217


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
