### PR TITLE
Add support for ESP32-C3 in esp-hal

### DIFF
--- a/esphome/core/esphal.cpp
+++ b/esphome/core/esphal.cpp
@@ -29,9 +29,15 @@ GPIOPin::GPIOPin(uint8_t pin, uint8_t mode, bool inverted)
       gpio_mask_(pin < 16 ? (1UL << pin) : 1)
 #endif
 #ifdef ARDUINO_ARCH_ESP32
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+          gpio_set_(pin < 32 ? &GPIO.out_w1ts.val : &GPIO.out_w1tc.val),
+      gpio_clear_(&GPIO.out_w1tc.val),
+      gpio_read_(&GPIO.in.val),
+#else
           gpio_set_(pin < 32 ? &GPIO.out_w1ts : &GPIO.out1_w1ts.val),
       gpio_clear_(pin < 32 ? &GPIO.out_w1tc : &GPIO.out1_w1tc.val),
       gpio_read_(pin < 32 ? &GPIO.in : &GPIO.in1.val),
+#endif
       gpio_mask_(pin < 32 ? (1UL << pin) : (1UL << (pin - 32)))
 #endif
 {
@@ -194,11 +200,15 @@ void ICACHE_RAM_ATTR ISRInternalGPIOPin::clear_interrupt() {
   GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, this->gpio_mask_);
 #endif
 #ifdef ARDUINO_ARCH_ESP32
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+  GPIO.status_w1tc.val = this->gpio_mask_;
+#else
   if (this->pin_ < 32) {
     GPIO.status_w1tc = this->gpio_mask_;
   } else {
     GPIO.status1_w1tc.intr_st = this->gpio_mask_;
   }
+#endif
 #endif
 }
 


### PR DESCRIPTION
# What does this implement/fix? 
Fixes some compile errors with esp32-c3 build.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esp_c3
  platform: ESP32
  board: nodemcu-32s
  platformio_options:
    board_build.mcu: esp32c3
    platform: https://github.com/Jason2866/platform-espressif32.git#feature/arduino-c3
    platform_packages: framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#master
```



# Explain your changes
https://github.com/esphome/feature-requests/issues/1217

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
