### PR TITLE
tm1637 - support 6 character displays

### DIFF
--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -253,7 +253,7 @@ uint8_t TM1637Display::print(uint8_t start_pos, const char* str) {
         pos--;
       this->buffer_[pos] |= 0b10000000;
     } else {
-      if (pos >= 4) {
+      if (pos >= 6) {
         ESP_LOGE(TAG, "String is too long for the display!");
         break;
       }

--- a/esphome/components/tm1637/tm1637.h
+++ b/esphome/components/tm1637/tm1637.h
@@ -63,7 +63,7 @@ class TM1637Display : public PollingComponent {
   GPIOPin *clk_pin_;
   uint8_t intensity_;
   optional<tm1637_writer_t> writer_{};
-  uint8_t buffer_[4] = {0};
+  uint8_t buffer_[6] = {0};
 };
 
 }  // namespace tm1637


### PR DESCRIPTION
# What does this implement/fix? 

The TM1637 chip is capable of driving up to 6 digit displays, but the implementation was limited to 4 digits. This trivial patch allows all 6 digits to be used.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a
  
# Test Environment

- [X] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [X] Linux

# Explain your changes

I was unable to drive all 6 digits of my TM1637 LED display module and determined that the driver limits this to 4 digits. The chip supports a maximum of 6. (See https://www.mcielectronics.cl/website_MCI/static/documents/Datasheet_TM1637.pdf )

This simple change drives all 6 digits.

NOTE: Existing code that drives 4-digit displays will not be affected (in the same way that the current implementation also does not do anything special to cater for 2 or 3 digit displays)

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
