### PR TITLE
CLI user experience improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
           echo "::add-matcher::.github/workflows/matchers/python.json"
-      - run: esphome tests/${{ matrix.test }}.yaml compile
+      - run: esphome compile tests/${{ matrix.test }}.yaml
 
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
           echo "::add-matcher::.github/workflows/matchers/python.json"
-      - run: esphome tests/${{ matrix.test }}.yaml compile
+      - run: esphome compile tests/${{ matrix.test }}.yaml
 
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
           echo "::add-matcher::.github/workflows/matchers/python.json"
-      - run: esphome tests/${{ matrix.test }}.yaml compile
+      - run: esphome compile tests/${{ matrix.test }}.yaml
 
   pytest:
     runs-on: ubuntu-latest

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "run",
             "type": "shell",
-            "command": "python3 -m esphome config dashboard",
+            "command": "python3 -m esphome dashboard config",
             "problemMatcher": []
         }
     ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /config
 # in every docker command twice
 ENTRYPOINT ["esphome"]
 # When no arguments given, start the dashboard in the workdir
-CMD ["/config", "dashboard"]
+CMD ["dashboard", "/config"]

--- a/docker/rootfs/etc/services.d/esphome/run
+++ b/docker/rootfs/etc/services.d/esphome/run
@@ -23,4 +23,4 @@ if bashio::config.has_value 'relative_url'; then
 fi
 
 bashio::log.info "Starting ESPHome dashboard..."
-exec esphome /config/esphome dashboard --socket /var/run/esphome.sock --hassio
+exec esphome dashboard /config/esphome --socket /var/run/esphome.sock --hassio

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -473,6 +473,12 @@ def parse_args(argv):
         "configuration", help="Your YAML configuration file.", nargs="*"
     )
 
+    mqtt_options = argparse.ArgumentParser(add_help=False)
+    mqtt_options.add_argument("--topic", help="Manually set the MQTT topic.")
+    mqtt_options.add_argument("--username", help="Manually set the MQTT username.")
+    mqtt_options.add_argument("--password", help="Manually set the MQTT password.")
+    mqtt_options.add_argument("--client-id", help="Manually set the MQTT client id.")
+
     subparsers = parser.add_subparsers(
         help="Command to run:", dest="command", metavar="command"
     )
@@ -498,14 +504,10 @@ def parse_args(argv):
     )
 
     parser_logs = subparsers.add_parser(
-        "logs", help="Validate the configuration and show all logs."
+        "logs",
+        help="Validate the configuration and show all logs.",
+        parents=[mqtt_options],
     )
-    parser_logs.add_argument(
-        "--topic", help="Manually set the MQTT topic to subscribe to."
-    )
-    parser_logs.add_argument("--username", help="Manually set the MQTT username.")
-    parser_logs.add_argument("--password", help="Manually set the MQTT password.")
-    parser_logs.add_argument("--client-id", help="Manually set the MQTT client id.")
     parser_logs.add_argument(
         "--serial-port",
         help="Manually specify the serial port/address to use, for example /dev/ttyUSB0.",
@@ -514,6 +516,7 @@ def parse_args(argv):
     parser_run = subparsers.add_parser(
         "run",
         help="Validate the configuration, create a binary, upload it, and start logs.",
+        parents=[mqtt_options],
     )
     parser_run.add_argument(
         "--upload-port",
@@ -522,22 +525,12 @@ def parse_args(argv):
     parser_run.add_argument(
         "--no-logs", help="Disable starting logs.", action="store_true"
     )
-    parser_run.add_argument(
-        "--topic", help="Manually set the MQTT topic to subscribe to."
-    )
-    parser_run.add_argument("--username", help="Manually set the MQTT username.")
-    parser_run.add_argument("--password", help="Manually set the MQTT password.")
-    parser_run.add_argument("--client-id", help="Manually set the MQTT client id.")
 
     parser_clean = subparsers.add_parser(
-        "clean-mqtt", help="Helper to clear retained messages from an MQTT topic."
+        "clean-mqtt",
+        help="Helper to clear retained messages from an MQTT topic.",
+        parents=[mqtt_options],
     )
-    parser_clean.add_argument(
-        "--topic", help="Manually set the MQTT topic to subscribe to."
-    )
-    parser_clean.add_argument("--username", help="Manually set the MQTT username.")
-    parser_clean.add_argument("--password", help="Manually set the MQTT password.")
-    parser_clean.add_argument("--client-id", help="Manually set the MQTT client id.")
 
     subparsers.add_parser(
         "wizard",

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -475,6 +475,7 @@ def parse_args(argv):
 
     subparsers = parser.add_subparsers(help="Commands", dest="command")
     subparsers.required = True
+
     subparsers.add_parser("config", help="Validate the configuration and spit it out.")
 
     parser_compile = subparsers.add_parser(
@@ -487,16 +488,15 @@ def parse_args(argv):
     )
 
     parser_upload = subparsers.add_parser(
-        "upload", help="Validate the configuration " "and upload the latest binary."
+        "upload", help="Validate the configuration and upload the latest binary."
     )
     parser_upload.add_argument(
         "--upload-port",
-        help="Manually specify the upload port to use. "
-        "For example /dev/cu.SLAB_USBtoUART.",
+        help="Manually specify the upload port to use. For example /dev/cu.SLAB_USBtoUART.",
     )
 
     parser_logs = subparsers.add_parser(
-        "logs", help="Validate the configuration " "and show all MQTT logs."
+        "logs", help="Validate the configuration and show all MQTT logs."
     )
     parser_logs.add_argument("--topic", help="Manually set the topic to subscribe to.")
     parser_logs.add_argument("--username", help="Manually set the username.")
@@ -504,19 +504,16 @@ def parse_args(argv):
     parser_logs.add_argument("--client-id", help="Manually set the client id.")
     parser_logs.add_argument(
         "--serial-port",
-        help="Manually specify a serial port to use"
-        "For example /dev/cu.SLAB_USBtoUART.",
+        help="Manually specify a serial port to useFor example /dev/cu.SLAB_USBtoUART.",
     )
 
     parser_run = subparsers.add_parser(
         "run",
-        help="Validate the configuration, create a binary, "
-        "upload it, and start MQTT logs.",
+        help="Validate the configuration, create a binary, upload it, and start MQTT logs.",
     )
     parser_run.add_argument(
         "--upload-port",
-        help="Manually specify the upload port/ip to use. "
-        "For example /dev/cu.SLAB_USBtoUART.",
+        help="Manually specify the upload port/ip to use. For example /dev/cu.SLAB_USBtoUART.",
     )
     parser_run.add_argument(
         "--no-logs", help="Disable starting MQTT logs.", action="store_true"
@@ -533,7 +530,7 @@ def parse_args(argv):
     parser_run.add_argument("--client-id", help="Manually set the client id for logs.")
 
     parser_clean = subparsers.add_parser(
-        "clean-mqtt", help="Helper to clear an MQTT topic from " "retain messages."
+        "clean-mqtt", help="Helper to clear an MQTT topic from retain messages."
     )
     parser_clean.add_argument("--topic", help="Manually set the topic to subscribe to.")
     parser_clean.add_argument("--username", help="Manually set the username.")
@@ -542,8 +539,7 @@ def parse_args(argv):
 
     subparsers.add_parser(
         "wizard",
-        help="A helpful setup wizard that will guide "
-        "you through setting up esphome.",
+        help="A helpful setup wizard that will guide you through setting up esphome.",
     )
 
     subparsers.add_parser(
@@ -554,37 +550,39 @@ def parse_args(argv):
 
     subparsers.add_parser("clean", help="Delete all temporary build files.")
 
-    dashboard = subparsers.add_parser(
+    parser_dashboard = subparsers.add_parser(
         "dashboard", help="Create a simple web server for a dashboard."
     )
-    dashboard.add_argument(
+    parser_dashboard.add_argument(
         "--port",
         help="The HTTP port to open connections on. Defaults to 6052.",
         type=int,
         default=6052,
     )
-    dashboard.add_argument(
+    parser_dashboard.add_argument(
         "--username",
-        help="The optional username to require " "for authentication.",
+        help="The optional username to require for authentication.",
         type=str,
         default="",
     )
-    dashboard.add_argument(
+    parser_dashboard.add_argument(
         "--password",
-        help="The optional password to require " "for authentication.",
+        help="The optional password to require for authentication.",
         type=str,
         default="",
     )
-    dashboard.add_argument(
+    parser_dashboard.add_argument(
         "--open-ui", help="Open the dashboard UI in a browser.", action="store_true"
     )
-    dashboard.add_argument("--hassio", help=argparse.SUPPRESS, action="store_true")
-    dashboard.add_argument(
+    parser_dashboard.add_argument(
+        "--hassio", help=argparse.SUPPRESS, action="store_true"
+    )
+    parser_dashboard.add_argument(
         "--socket", help="Make the dashboard serve under a unix socket", type=str
     )
 
-    vscode = subparsers.add_parser("vscode", help=argparse.SUPPRESS)
-    vscode.add_argument("--ace", action="store_true")
+    parser_vscode = subparsers.add_parser("vscode", help=argparse.SUPPRESS)
+    parser_vscode.add_argument("--ace", action="store_true")
 
     subparsers.add_parser("update-all", help=argparse.SUPPRESS)
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -487,9 +487,7 @@ def parse_args(argv):
     #
     # Disable argparse's built-in help option and add it manually to prevent this
     # parser from printing the help messagefor the old format when invoked with -h.
-    compat_parser = argparse.ArgumentParser(
-        parents=[options_parser], add_help=False, exit_on_error=False
-    )
+    compat_parser = argparse.ArgumentParser(parents=[options_parser], add_help=False)
     compat_parser.add_argument("-h", "--help")
     compat_parser.add_argument("configuration", nargs="*")
     compat_parser.add_argument(
@@ -508,6 +506,12 @@ def parse_args(argv):
             "dashboard",
         ],
     )
+
+    # on Python 3.9+ we can simply set exit_on_error=False in the constructor
+    def _raise(x):
+        raise argparse.ArgumentError(None, x)
+
+    compat_parser.error = _raise
 
     try:
         result, unparsed = compat_parser.parse_known_args(argv[1:])

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -304,7 +304,7 @@ def command_compile(args, config):
 
 def command_upload(args, config):
     port = choose_upload_log_host(
-        default=args.upload_port,
+        default=args.device,
         check_default=None,
         show_ota=True,
         show_mqtt=False,
@@ -319,7 +319,7 @@ def command_upload(args, config):
 
 def command_logs(args, config):
     port = choose_upload_log_host(
-        default=args.serial_port,
+        default=args.device,
         check_default=None,
         show_ota=False,
         show_mqtt=True,
@@ -337,7 +337,7 @@ def command_run(args, config):
         return exit_code
     _LOGGER.info("Successfully compiled program.")
     port = choose_upload_log_host(
-        default=args.upload_port,
+        default=args.device,
         check_default=None,
         show_ota=True,
         show_mqtt=False,
@@ -350,7 +350,7 @@ def command_run(args, config):
     if args.no_logs:
         return 0
     port = choose_upload_log_host(
-        default=args.upload_port,
+        default=args.device,
         check_default=port,
         show_ota=False,
         show_mqtt=True,
@@ -408,7 +408,7 @@ def command_update_all(args):
         print("-" * twidth)
         print()
         rc = run_external_process(
-            "esphome", "--dashboard", f, "run", "--no-logs", "--upload-port", "OTA"
+            "esphome", "--dashboard", f, "run", "--no-logs", "--device", "OTA"
         )
         if rc == 0:
             print_bar("[{}] {}".format(color(Fore.BOLD_GREEN, "SUCCESS"), f))
@@ -499,8 +499,8 @@ def parse_args(argv):
         "upload", help="Validate the configuration and upload the latest binary."
     )
     parser_upload.add_argument(
-        "--upload-port",
-        help="Manually specify the upload port/address to use, for example /dev/ttyUSB0.",
+        "--device",
+        help="Manually specify the serial port/address to use, for example /dev/ttyUSB0.",
     )
 
     parser_logs = subparsers.add_parser(
@@ -509,7 +509,7 @@ def parse_args(argv):
         parents=[mqtt_options],
     )
     parser_logs.add_argument(
-        "--serial-port",
+        "--device",
         help="Manually specify the serial port/address to use, for example /dev/ttyUSB0.",
     )
 
@@ -519,8 +519,8 @@ def parse_args(argv):
         parents=[mqtt_options],
     )
     parser_run.add_argument(
-        "--upload-port",
-        help="Manually specify the upload port/address to use, for example /dev/ttyUSB0.",
+        "--device",
+        help="Manually specify the serial port/address to use, for example /dev/ttyUSB0.",
     )
     parser_run.add_argument(
         "--no-logs", help="Disable starting logs.", action="store_true"

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -455,10 +455,10 @@ POST_CONFIG_ACTIONS = {
 def parse_args(argv):
     parser = argparse.ArgumentParser(description=f"ESPHome v{const.__version__}")
     parser.add_argument(
-        "-v", "--verbose", help="Enable verbose esphome logs.", action="store_true"
+        "-v", "--verbose", help="Enable verbose ESPHome logs.", action="store_true"
     )
     parser.add_argument(
-        "-q", "--quiet", help="Disable all esphome logs.", action="store_true"
+        "-q", "--quiet", help="Disable all ESPHome logs.", action="store_true"
     )
     parser.add_argument("--dashboard", help=argparse.SUPPRESS, action="store_true")
     parser.add_argument(
@@ -473,7 +473,9 @@ def parse_args(argv):
         "configuration", help="Your YAML configuration file.", nargs="*"
     )
 
-    subparsers = parser.add_subparsers(help="Commands", dest="command")
+    subparsers = parser.add_subparsers(
+        help="Command to run:", dest="command", metavar="command"
+    )
     subparsers.required = True
 
     subparsers.add_parser("config", help="Validate the configuration and spit it out.")
@@ -492,61 +494,61 @@ def parse_args(argv):
     )
     parser_upload.add_argument(
         "--upload-port",
-        help="Manually specify the upload port to use. For example /dev/cu.SLAB_USBtoUART.",
+        help="Manually specify the upload port/address to use, for example /dev/ttyUSB0.",
     )
 
     parser_logs = subparsers.add_parser(
-        "logs", help="Validate the configuration and show all MQTT logs."
+        "logs", help="Validate the configuration and show all logs."
     )
-    parser_logs.add_argument("--topic", help="Manually set the topic to subscribe to.")
-    parser_logs.add_argument("--username", help="Manually set the username.")
-    parser_logs.add_argument("--password", help="Manually set the password.")
-    parser_logs.add_argument("--client-id", help="Manually set the client id.")
+    parser_logs.add_argument(
+        "--topic", help="Manually set the MQTT topic to subscribe to."
+    )
+    parser_logs.add_argument("--username", help="Manually set the MQTT username.")
+    parser_logs.add_argument("--password", help="Manually set the MQTT password.")
+    parser_logs.add_argument("--client-id", help="Manually set the MQTT client id.")
     parser_logs.add_argument(
         "--serial-port",
-        help="Manually specify a serial port to useFor example /dev/cu.SLAB_USBtoUART.",
+        help="Manually specify the serial port/address to use, for example /dev/ttyUSB0.",
     )
 
     parser_run = subparsers.add_parser(
         "run",
-        help="Validate the configuration, create a binary, upload it, and start MQTT logs.",
+        help="Validate the configuration, create a binary, upload it, and start logs.",
     )
     parser_run.add_argument(
         "--upload-port",
-        help="Manually specify the upload port/ip to use. For example /dev/cu.SLAB_USBtoUART.",
+        help="Manually specify the upload port/address to use, for example /dev/ttyUSB0.",
     )
     parser_run.add_argument(
-        "--no-logs", help="Disable starting MQTT logs.", action="store_true"
+        "--no-logs", help="Disable starting logs.", action="store_true"
     )
     parser_run.add_argument(
-        "--topic", help="Manually set the topic to subscribe to for logs."
+        "--topic", help="Manually set the MQTT topic to subscribe to."
     )
-    parser_run.add_argument(
-        "--username", help="Manually set the MQTT username for logs."
-    )
-    parser_run.add_argument(
-        "--password", help="Manually set the MQTT password for logs."
-    )
-    parser_run.add_argument("--client-id", help="Manually set the client id for logs.")
+    parser_run.add_argument("--username", help="Manually set the MQTT username.")
+    parser_run.add_argument("--password", help="Manually set the MQTT password.")
+    parser_run.add_argument("--client-id", help="Manually set the MQTT client id.")
 
     parser_clean = subparsers.add_parser(
-        "clean-mqtt", help="Helper to clear an MQTT topic from retain messages."
+        "clean-mqtt", help="Helper to clear retained messages from an MQTT topic."
     )
-    parser_clean.add_argument("--topic", help="Manually set the topic to subscribe to.")
-    parser_clean.add_argument("--username", help="Manually set the username.")
-    parser_clean.add_argument("--password", help="Manually set the password.")
-    parser_clean.add_argument("--client-id", help="Manually set the client id.")
+    parser_clean.add_argument(
+        "--topic", help="Manually set the MQTT topic to subscribe to."
+    )
+    parser_clean.add_argument("--username", help="Manually set the MQTT username.")
+    parser_clean.add_argument("--password", help="Manually set the MQTT password.")
+    parser_clean.add_argument("--client-id", help="Manually set the MQTT client id.")
 
     subparsers.add_parser(
         "wizard",
-        help="A helpful setup wizard that will guide you through setting up esphome.",
+        help="A helpful setup wizard that will guide you through setting up ESPHome.",
     )
 
     subparsers.add_parser(
         "mqtt-fingerprint", help="Get the SSL fingerprint from a MQTT broker."
     )
 
-    subparsers.add_parser("version", help="Print the esphome version and exit.")
+    subparsers.add_parser("version", help="Print the ESPHome version and exit.")
 
     subparsers.add_parser("clean", help="Delete all temporary build files.")
 
@@ -581,10 +583,10 @@ def parse_args(argv):
         "--socket", help="Make the dashboard serve under a unix socket", type=str
     )
 
-    parser_vscode = subparsers.add_parser("vscode", help=argparse.SUPPRESS)
+    parser_vscode = subparsers.add_parser("vscode")
     parser_vscode.add_argument("--ace", action="store_true")
 
-    subparsers.add_parser("update-all", help=argparse.SUPPRESS)
+    subparsers.add_parser("update-all")
 
     return parser.parse_args(argv[1:])
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -276,7 +276,7 @@ class EsphomeLogsHandler(EsphomeCommandWebSocket):
             "--dashboard",
             config_file,
             "logs",
-            "--serial-port",
+            "--device",
             json_message["port"],
         ]
 
@@ -289,7 +289,7 @@ class EsphomeUploadHandler(EsphomeCommandWebSocket):
             "--dashboard",
             config_file,
             "run",
-            "--upload-port",
+            "--device",
             json_message["port"],
         ]
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -62,7 +62,7 @@ class DashboardSettings:
             self.using_password = bool(password)
         if self.using_password:
             self.password_hash = password_hash(password)
-        self.config_dir = args.configuration[0]
+        self.config_dir = args.configuration
 
     @property
     def relative_url(self):
@@ -274,8 +274,8 @@ class EsphomeLogsHandler(EsphomeCommandWebSocket):
         return [
             "esphome",
             "--dashboard",
-            config_file,
             "logs",
+            config_file,
             "--device",
             json_message["port"],
         ]
@@ -287,8 +287,8 @@ class EsphomeUploadHandler(EsphomeCommandWebSocket):
         return [
             "esphome",
             "--dashboard",
-            config_file,
             "run",
+            config_file,
             "--device",
             json_message["port"],
         ]
@@ -297,40 +297,40 @@ class EsphomeUploadHandler(EsphomeCommandWebSocket):
 class EsphomeCompileHandler(EsphomeCommandWebSocket):
     def build_command(self, json_message):
         config_file = settings.rel_path(json_message["configuration"])
-        return ["esphome", "--dashboard", config_file, "compile"]
+        return ["esphome", "--dashboard", "compile", config_file]
 
 
 class EsphomeValidateHandler(EsphomeCommandWebSocket):
     def build_command(self, json_message):
         config_file = settings.rel_path(json_message["configuration"])
-        return ["esphome", "--dashboard", config_file, "config"]
+        return ["esphome", "--dashboard", "config", config_file]
 
 
 class EsphomeCleanMqttHandler(EsphomeCommandWebSocket):
     def build_command(self, json_message):
         config_file = settings.rel_path(json_message["configuration"])
-        return ["esphome", "--dashboard", config_file, "clean-mqtt"]
+        return ["esphome", "--dashboard", "clean-mqtt", config_file]
 
 
 class EsphomeCleanHandler(EsphomeCommandWebSocket):
     def build_command(self, json_message):
         config_file = settings.rel_path(json_message["configuration"])
-        return ["esphome", "--dashboard", config_file, "clean"]
+        return ["esphome", "--dashboard", "clean", config_file]
 
 
 class EsphomeVscodeHandler(EsphomeCommandWebSocket):
     def build_command(self, json_message):
-        return ["esphome", "--dashboard", "-q", "dummy", "vscode"]
+        return ["esphome", "--dashboard", "-q", "vscode", "dummy"]
 
 
 class EsphomeAceEditorHandler(EsphomeCommandWebSocket):
     def build_command(self, json_message):
-        return ["esphome", "--dashboard", "-q", settings.config_dir, "vscode", "--ace"]
+        return ["esphome", "--dashboard", "-q", "vscode", settings.config_dir, "--ace"]
 
 
 class EsphomeUpdateAllHandler(EsphomeCommandWebSocket):
     def build_command(self, json_message):
-        return ["esphome", "--dashboard", settings.config_dir, "update-all"]
+        return ["esphome", "--dashboard", "update-all", settings.config_dir]
 
 
 class SerialPortRequestHandler(BaseHandler):

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
 
 set -x
 
-esphome tests/test1.yaml compile
-esphome tests/test2.yaml compile
-esphome tests/test3.yaml compile
-esphome tests/test4.yaml compile
+esphome compile tests/test1.yaml
+esphome compile tests/test2.yaml
+esphome compile tests/test3.yaml
+esphome compile tests/test4.yaml


### PR DESCRIPTION
# What does this implement/fix? 

Improve CLI user experience by improving help messages, using consistent parameter naming, and swapping configuration/command arguments (as is commonly used by e.g. git and pip).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1183
  
# Test Environment

- [ ] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

# Explain your changes
The first commit is just some code cleanup in preparation of the later commits (to reduce noise in their diffs).

The second commit is hopefully pretty non-controversial improvement and clean-up of the command line help messages.

The third commit is some code cleanup to avoid duplicating the MQTT arguments for every subcommand.

The fourth commit replaces the `--upload-port` argument for the `upload` and `run` commands, and the `--serial-port` argument for the `logs` command with a common `--device` argument. The different name for an option that does exactly the same is somewhat tiresome, as it means switching between the commands isn't simply a matter of changing the command option, but you also need to edit the command line. I'm not too sold on the `--device` argument name, so if someone can think of something better I'll happily change it. This is a breaking change, but I don't think it'll affect many users. If needed I can make it backward-compatible by also accepting the previous options.

The fifth commit swaps the argument order of the command and configuration file (e.g. `esphome file.yaml run` is now `esphome run file.yaml`). In my opinion this is a more natural command order. It's also the order commonly used by lots of other tools (e.g. git and pip), so users might be used to this order. The last commit adds backward-compatibility for the old argument order.

Furthermore, swapping these commands allows better validation of the passed configuration file. E.g. the logs command did accept more than one config file, but that was pointless, since it'll only connect to one host at a time; while the version command required a configuration file to be passed but didn't do anything with it. 

However, this is a somewhat breaking change and I recognize it might be somewhat controversial. If there's no consensus for this change, I'll drop it from this pull request so that the other three commits can still be merged.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
