### PR TITLE
Add cover toggle support

### DIFF
--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -59,6 +59,7 @@ validate_cover_operation = cv.enum(COVER_OPERATIONS, upper=True)
 OpenAction = cover_ns.class_("OpenAction", automation.Action)
 CloseAction = cover_ns.class_("CloseAction", automation.Action)
 StopAction = cover_ns.class_("StopAction", automation.Action)
+ToggleAction = cover_ns.class_("ToggleAction", automation.Action)
 ControlAction = cover_ns.class_("ControlAction", automation.Action)
 CoverPublishAction = cover_ns.class_("CoverPublishAction", automation.Action)
 CoverIsOpenCondition = cover_ns.class_("CoverIsOpenCondition", Condition)
@@ -117,6 +118,12 @@ async def cover_close_to_code(config, action_id, template_arg, args):
 async def cover_stop_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
+
+
+@automation.register_action("cover.toggle", ToggleAction, COVER_ACTION_SCHEMA)
+def cover_toggle_to_code(config, action_id, template_arg, args):
+    paren = yield cg.get_variable(config[CONF_ID])
+    yield cg.new_Pvariable(action_id, template_arg, paren)
 
 
 COVER_CONTROL_ACTION_SCHEMA = cv.Schema(

--- a/esphome/components/cover/automation.h
+++ b/esphome/components/cover/automation.h
@@ -37,6 +37,16 @@ template<typename... Ts> class StopAction : public Action<Ts...> {
   Cover *cover_;
 };
 
+template<typename... Ts> class ToggleAction : public Action<Ts...> {
+ public:
+  explicit ToggleAction(Cover *cover) : cover_(cover) {}
+
+  void play(Ts... x) override { this->cover_->toggle(); }
+
+ protected:
+  Cover *cover_;
+};
+
 template<typename... Ts> class ControlAction : public Action<Ts...> {
  public:
   explicit ControlAction(Cover *cover) : cover_(cover) {}

--- a/esphome/components/cover/automation.h
+++ b/esphome/components/cover/automation.h
@@ -41,7 +41,7 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
  public:
   explicit ToggleAction(Cover *cover) : cover_(cover) {}
 
-  void play(Ts... x) override { this->cover_->toggle(); }
+  void play(Ts... x) override { this->cover_->make_call().set_command_toggle().perform(); }
 
  protected:
   Cover *cover_;

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -122,7 +122,6 @@ void CoverCall::validate_() {
     }
   }
   if (this->toggle_.has_value()) {
-    auto toggle = *this->toggle_;
     if (!traits.get_supports_toggle()) {
       ESP_LOGW(TAG, "'%s' - This cover device does not support toggle!", this->parent_->get_name().c_str());
       this->toggle_.reset();

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -80,7 +80,8 @@ void CoverCall::perform() {
   if (this->toggle_) {
     ESP_LOGD(TAG, "  Command: TOGGLE");
     if (this->parent_->current_operation == CoverOperation::COVER_OPERATION_IDLE) {
-      if (this->parent_->is_fully_closed() || this->parent_->last_operation == CoverOperation::COVER_OPERATION_CLOSING) {
+      if (this->parent_->is_fully_closed() ||
+          this->parent_->last_operation == CoverOperation::COVER_OPERATION_CLOSING) {
         this->parent_->last_operation = CoverOperation::COVER_OPERATION_OPENING;
         this->position_ = COVER_OPEN;
       } else {

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -164,11 +164,6 @@ void Cover::stop() {
   call.set_command_stop();
   call.perform();
 }
-void Cover::toggle() {
-  auto call = this->make_call();
-  call.set_command_toggle();
-  call.perform();
-}
 void Cover::add_on_state_callback(std::function<void()> &&f) { this->state_callback_.add(std::move(f)); }
 void Cover::publish_state(bool save) {
   this->position = clamp(this->position, 0.0f, 1.0f);

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -77,22 +77,6 @@ CoverCall &CoverCall::set_tilt(float tilt) {
 void CoverCall::perform() {
   ESP_LOGD(TAG, "'%s' - Setting", this->parent_->get_name().c_str());
   auto traits = this->parent_->get_traits();
-  if (this->toggle_) {
-    ESP_LOGD(TAG, "  Command: TOGGLE");
-    if (this->parent_->current_operation == CoverOperation::COVER_OPERATION_IDLE) {
-      if (this->parent_->is_fully_closed() ||
-          this->parent_->last_operation == CoverOperation::COVER_OPERATION_CLOSING) {
-        this->parent_->last_operation = CoverOperation::COVER_OPERATION_OPENING;
-        this->position_ = COVER_OPEN;
-      } else {
-        this->parent_->last_operation = CoverOperation::COVER_OPERATION_CLOSING;
-        this->position_ = COVER_CLOSED;
-      }
-    } else {
-      this->stop_ = true;
-    }
-    this->toggle_ = false;
-  }
   this->validate_();
   if (this->stop_) {
     ESP_LOGD(TAG, "  Command: STOP");
@@ -107,10 +91,14 @@ void CoverCall::perform() {
   if (this->tilt_.has_value()) {
     ESP_LOGD(TAG, "  Tilt: %.0f%%", *this->tilt_ * 100.0f);
   }
+  if (this->toggle_.has_value()) {
+    ESP_LOGD(TAG, "  Command: TOGGLE");
+  }
   this->parent_->control(*this);
 }
 const optional<float> &CoverCall::get_position() const { return this->position_; }
 const optional<float> &CoverCall::get_tilt() const { return this->tilt_; }
+const optional<bool> &CoverCall::get_toggle() const { return this->toggle_; }
 void CoverCall::validate_() {
   auto traits = this->parent_->get_traits();
   if (this->position_.has_value()) {
@@ -133,6 +121,13 @@ void CoverCall::validate_() {
       this->tilt_ = clamp(tilt, 0.0f, 1.0f);
     }
   }
+  if (this->toggle_.has_value()) {
+    auto toggle = *this->toggle_;
+    if (!traits.get_supports_toggle()) {
+      ESP_LOGW(TAG, "'%s' - This cover device does not support toggle!", this->parent_->get_name().c_str());
+      this->toggle_.reset();
+    }
+  }
   if (this->stop_) {
     if (this->position_.has_value()) {
       ESP_LOGW(TAG, "Cannot set position when stopping a cover!");
@@ -141,6 +136,10 @@ void CoverCall::validate_() {
     if (this->tilt_.has_value()) {
       ESP_LOGW(TAG, "Cannot set tilt when stopping a cover!");
       this->tilt_.reset();
+    }
+    if (this->toggle_.has_value()) {
+      ESP_LOGW(TAG, "Cannot set toggle when stopping a cover!");
+      this->toggle_.reset();
     }
   }
 }

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -52,13 +52,14 @@ class CoverCall {
   const optional<float> &get_position() const;
   bool get_stop() const;
   const optional<float> &get_tilt() const;
+  const optional<bool> &get_toggle() const;
 
  protected:
   void validate_();
 
   Cover *parent_;
   bool stop_{false};
-  bool toggle_{false};
+  optional<bool> toggle_{};
   optional<float> position_{};
   optional<float> tilt_{};
 };
@@ -113,8 +114,6 @@ class Cover : public Nameable {
 
   /// The current operation of the cover (idle, opening, closing).
   CoverOperation current_operation{COVER_OPERATION_IDLE};
-  /// The last operation of the cover (opening, closing), needed for toggle action.
-  CoverOperation last_operation{COVER_OPERATION_OPENING};
   /** The position of the cover from 0.0 (fully closed) to 1.0 (fully open).
    *
    * For binary covers this is always equals to 0.0 or 1.0 (see also COVER_OPEN and

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -29,7 +29,7 @@ class CoverCall {
  public:
   CoverCall(Cover *parent);
 
-  /// Set the command as a string, "STOP", "OPEN", "CLOSE".
+  /// Set the command as a string, "STOP", "OPEN", "CLOSE", "TOGGLE".
   CoverCall &set_command(const char *command);
   /// Set the command to open the cover.
   CoverCall &set_command_open();
@@ -37,6 +37,8 @@ class CoverCall {
   CoverCall &set_command_close();
   /// Set the command to stop the cover.
   CoverCall &set_command_stop();
+  /// Set the command to toggle the cover.
+  CoverCall &set_command_toggle();
   /// Set the call to a certain target position.
   CoverCall &set_position(float position);
   /// Set the call to a certain target tilt.
@@ -110,6 +112,8 @@ class Cover : public Nameable {
 
   /// The current operation of the cover (idle, opening, closing).
   CoverOperation current_operation{COVER_OPERATION_IDLE};
+  /// The last operation of the cover (opening, closing), needed for toggle action.
+  CoverOperation last_operation{COVER_OPERATION_OPENING};
   /** The position of the cover from 0.0 (fully closed) to 1.0 (fully open).
    *
    * For binary covers this is always equals to 0.0 or 1.0 (see also COVER_OPEN and
@@ -139,6 +143,11 @@ class Cover : public Nameable {
    */
   ESPDEPRECATED("stop() is deprecated, use make_call().set_command_stop() instead.", "2021.9")
   void stop();
+  /** Toggle the cover.
+   *
+   * This is a legacy method and may be removed later, please use `.make_call()` instead.
+   */
+  void toggle();
 
   void add_on_state_callback(std::function<void()> &&f);
 

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -58,6 +58,7 @@ class CoverCall {
 
   Cover *parent_;
   bool stop_{false};
+  bool toggle_{false};
   optional<float> position_{};
   optional<float> tilt_{};
 };

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -59,9 +59,9 @@ class CoverCall {
 
   Cover *parent_;
   bool stop_{false};
-  optional<bool> toggle_{};
   optional<float> position_{};
   optional<float> tilt_{};
+  optional<bool> toggle_{};
 };
 
 /// Struct used to store the restored state of a cover
@@ -147,6 +147,7 @@ class Cover : public Nameable {
    *
    * This is a legacy method and may be removed later, please use `.make_call()` instead.
    */
+  ESPDEPRECATED("stop() is deprecated, use make_call().set_command_toggle() instead.", "2021.9")
   void toggle();
 
   void add_on_state_callback(std::function<void()> &&f);

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -143,12 +143,6 @@ class Cover : public Nameable {
    */
   ESPDEPRECATED("stop() is deprecated, use make_call().set_command_stop() instead.", "2021.9")
   void stop();
-  /** Toggle the cover.
-   *
-   * This is a legacy method and may be removed later, please use `.make_call()` instead.
-   */
-  ESPDEPRECATED("stop() is deprecated, use make_call().set_command_toggle() instead.", "2021.9")
-  void toggle();
 
   void add_on_state_callback(std::function<void()> &&f);
 

--- a/esphome/components/cover/cover_traits.h
+++ b/esphome/components/cover/cover_traits.h
@@ -13,11 +13,14 @@ class CoverTraits {
   void set_supports_position(bool supports_position) { this->supports_position_ = supports_position; }
   bool get_supports_tilt() const { return this->supports_tilt_; }
   void set_supports_tilt(bool supports_tilt) { this->supports_tilt_ = supports_tilt; }
+  bool get_supports_toggle() const { return this->supports_toggle_; }
+  void set_supports_toggle(bool supports_toggle) { this->supports_toggle_ = supports_toggle; }
 
  protected:
   bool is_assumed_state_{false};
   bool supports_position_{false};
   bool supports_tilt_{false};
+  bool supports_toggle_{false};
 };
 
 }  // namespace cover

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -66,12 +66,12 @@ void TimeBasedCover::control(const CoverCall &call) {
       this->start_direction_(COVER_OPERATION_IDLE);
       this->publish_state();
     } else {
-      if (this->last_operation_ == COVER_OPERATION_OPENING) {
-        this->target_position_ = COVER_CLOSED;
-        this->start_direction_(COVER_OPERATION_CLOSING);
-      } else {
+      if (this->position == COVER_CLOSED || this->last_operation_ == COVER_OPERATION_CLOSING) {
         this->target_position_ = COVER_OPEN;
         this->start_direction_(COVER_OPERATION_OPENING);
+      } else {
+        this->target_position_ = COVER_CLOSED;
+        this->start_direction_(COVER_OPERATION_CLOSING);
       }
     }
   }

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -45,6 +45,7 @@ class TimeBasedCover : public cover::Cover, public Component {
   float target_position_{0};
   bool has_built_in_endstop_{false};
   bool assumed_state_{false};
+  cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
 }  // namespace time_based

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -724,6 +724,12 @@ binary_sensor:
     id: r0_sensor
     name: 'R0 Sensor'
     component_name: page0.r0
+  - platform: template
+    id: 'cover_toggle'
+    on_press:
+      then:
+        - cover.toggle: time_based_cover
+
 globals:
   - id: my_global_string
     type: std::string
@@ -1013,6 +1019,7 @@ cover:
     max_duration: 10min
   - platform: time_based
     name: Time Based Cover
+    id: time_based_cover
     stop_action:
       - switch.turn_on: gpio_switch1
     open_action:


### PR DESCRIPTION
# What does this implement/fix? 

Adds support for cover operation with single push button, cycling through the states close/stop/open/stop... with
each button press.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1189
  
# Test Environment

- [x] ESP32
- [x] ESP8266
- [ ] Windows
- [x] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

cover:
  - platform: time_based
    id: cover_1
    open_duration: 10s
    close_duration: 10s
binary_sensor:
  - platform: template
    id: switch_1
    on_press:
      then:
        - cover.toggle: cover_1
```

# Explain your changes

The toggle action allows the cover to be operated with a single push button. Cycling through the sequence 
close/stop/open/stop... Opening the cover when fully closed, closing the cover when fully opened.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).