### PR TITLE
I2c raw cmds with multiplexer

### DIFF
--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -199,13 +199,13 @@ void I2CDevice::raw_begin_transmission() { // NOLINT
 #endif
   this->parent_->raw_begin_transmission(this->address_);
 }
-bool I2CDevice::raw_end_transmission(bool send_stop = true) { // NOLINT
+bool I2CDevice::raw_end_transmission(bool send_stop) { // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif
   return this->parent_->raw_end_transmission(this->address_, send_stop);
 }
-void raw_write(const uint8_t *data, uint8_t len) { // NOLINT
+void I2CDevice::raw_write(const uint8_t *data, uint8_t len) { // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -193,11 +193,35 @@ void I2CDevice::check_multiplexer_() {
 }
 #endif
 
+void I2CDevice::raw_begin_transmission() { // NOLINT
+#ifdef USE_I2C_MULTIPLEXER
+  this->check_multiplexer_();
+#endif
+  this->parent_->raw_begin_transmission(this->address_);
+}
+bool I2CDevice::raw_end_transmission(bool send_stop = true) { // NOLINT
+#ifdef USE_I2C_MULTIPLEXER
+  this->check_multiplexer_();
+#endif
+  return this->parent_->raw_end_transmission(this->address_, send_stop);
+}
+void raw_write(const uint8_t *data, uint8_t len) { // NOLINT
+#ifdef USE_I2C_MULTIPLEXER
+  this->check_multiplexer_();
+#endif
+  this->parent_->raw_write(this->address_, data, len);
+}
 bool I2CDevice::read_bytes(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif
   return this->parent_->read_bytes(this->address_, a_register, data, len, conversion);
+}
+bool I2CDevice::read_bytes_raw(uint8_t *data, uint8_t len) { // NOLINT
+#ifdef USE_I2C_MULTIPLEXER
+  this->check_multiplexer_();
+#endif
+  return this->parent_->read_bytes_raw(this->address_, data, len);    
 }
 bool I2CDevice::read_byte(uint8_t a_register, uint8_t *data, uint32_t conversion) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
@@ -210,6 +234,12 @@ bool I2CDevice::write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len
   this->check_multiplexer_();
 #endif
   return this->parent_->write_bytes(this->address_, a_register, data, len);
+}
+bool I2CDevice::write_bytes_raw(const uint8_t *data, uint8_t len) { // NOLINT
+#ifdef USE_I2C_MULTIPLEXER
+  this->check_multiplexer_();
+#endif
+  return this->parent_->write_bytes_raw(this->address_, data, len);
 }
 bool I2CDevice::write_byte(uint8_t a_register, uint8_t data) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -193,19 +193,19 @@ void I2CDevice::check_multiplexer_() {
 }
 #endif
 
-void I2CDevice::raw_begin_transmission() { // NOLINT
+void I2CDevice::raw_begin_transmission() {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif
   this->parent_->raw_begin_transmission(this->address_);
 }
-bool I2CDevice::raw_end_transmission(bool send_stop) { // NOLINT
+bool I2CDevice::raw_end_transmission(bool send_stop) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif
   return this->parent_->raw_end_transmission(this->address_, send_stop);
 }
-void I2CDevice::raw_write(const uint8_t *data, uint8_t len) { // NOLINT
+void I2CDevice::raw_write(const uint8_t *data, uint8_t len) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif
@@ -217,11 +217,11 @@ bool I2CDevice::read_bytes(uint8_t a_register, uint8_t *data, uint8_t len, uint3
 #endif
   return this->parent_->read_bytes(this->address_, a_register, data, len, conversion);
 }
-bool I2CDevice::read_bytes_raw(uint8_t *data, uint8_t len) { // NOLINT
+bool I2CDevice::read_bytes_raw(uint8_t *data, uint8_t len) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif
-  return this->parent_->read_bytes_raw(this->address_, data, len);    
+  return this->parent_->read_bytes_raw(this->address_, data, len);
 }
 bool I2CDevice::read_byte(uint8_t a_register, uint8_t *data, uint32_t conversion) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
@@ -235,7 +235,7 @@ bool I2CDevice::write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len
 #endif
   return this->parent_->write_bytes(this->address_, a_register, data, len);
 }
-bool I2CDevice::write_bytes_raw(const uint8_t *data, uint8_t len) { // NOLINT
+bool I2CDevice::write_bytes_raw(const uint8_t *data, uint8_t len) {  // NOLINT
 #ifdef USE_I2C_MULTIPLEXER
   this->check_multiplexer_();
 #endif

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -24,7 +24,7 @@ namespace i2c {
  * I2CComponents, each with different SDA and SCL pins and use `set_parent` on all I2CDevices that use
  * the non-first I2C bus.
  */
-class I2CComponent : public Component {
+celass I2CComponent : public Component {
  public:
   I2CComponent();
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }
@@ -178,15 +178,13 @@ class I2CDevice {
   I2CRegister reg(uint8_t a_register) { return {this, a_register}; }
 
   /// Begin a write transmission.
-  void raw_begin_transmission() { this->parent_->raw_begin_transmission(this->address_); };
+  void raw_begin_transmission();
 
   /// End a write transmission, return true if successful.
-  bool raw_end_transmission(bool send_stop = true) {
-    return this->parent_->raw_end_transmission(this->address_, send_stop);
-  };
+  bool raw_end_transmission(bool send_stop = true);
 
   /// Write len amount of bytes from data. begin_transmission_ must be called before this.
-  void raw_write(const uint8_t *data, uint8_t len) { this->parent_->raw_write(this->address_, data, len); };
+  void raw_write(const uint8_t *data, uint8_t len);
 
   /** Read len amount of bytes from a register into data. Optionally with a conversion time after
    * writing the register value to the bus.
@@ -198,7 +196,7 @@ class I2CDevice {
    * @return If the operation was successful.
    */
   bool read_bytes(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
-  bool read_bytes_raw(uint8_t *data, uint8_t len) { return this->parent_->read_bytes_raw(this->address_, data, len); }
+  bool read_bytes_raw(uint8_t *data, uint8_t len);
 
   template<size_t N> optional<std::array<uint8_t, N>> read_bytes(uint8_t a_register) {
     std::array<uint8_t, N> res;
@@ -246,9 +244,7 @@ class I2CDevice {
    * @return If the operation was successful.
    */
   bool write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len);
-  bool write_bytes_raw(const uint8_t *data, uint8_t len) {
-    return this->parent_->write_bytes_raw(this->address_, data, len);
-  }
+  bool write_bytes_raw(const uint8_t *data, uint8_t len);
 
   /** Write a vector of data to a register.
    *

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -24,7 +24,7 @@ namespace i2c {
  * I2CComponents, each with different SDA and SCL pins and use `set_parent` on all I2CDevices that use
  * the non-first I2C bus.
  */
-celass I2CComponent : public Component {
+class I2CComponent : public Component {
  public:
   I2CComponent();
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }

--- a/esphome/components/mcp4725/mcp4725.cpp
+++ b/esphome/components/mcp4725/mcp4725.cpp
@@ -9,9 +9,9 @@ static const char *TAG = "mcp4725";
 void MCP4725::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MCP4725 (0x%02X)...", this->address_);
 
-  this->raw_begin_transmission(this->address_);
+  this->raw_begin_transmission();
 
-  if (!this->raw_end_transmission(this->address_)) {
+  if (!this->raw_end_transmission()) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
 

--- a/esphome/components/mcp4725/mcp4725.cpp
+++ b/esphome/components/mcp4725/mcp4725.cpp
@@ -9,9 +9,9 @@ static const char *TAG = "mcp4725";
 void MCP4725::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MCP4725 (0x%02X)...", this->address_);
 
-  this->parent_->raw_begin_transmission(this->address_);
+  this->raw_begin_transmission(this->address_);
 
-  if (!this->parent_->raw_end_transmission(this->address_)) {
+  if (!this->raw_end_transmission(this->address_)) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
 

--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
@@ -10,8 +10,8 @@ void I2CSSD1306::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2C SSD1306...");
   this->init_reset_();
 
-  this->raw_begin_transmission(this->address_);
-  if (!this->raw_end_transmission(this->address_)) {
+  this->raw_begin_transmission();
+  if (!this->raw_end_transmission()) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
     return;

--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
@@ -10,8 +10,8 @@ void I2CSSD1306::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2C SSD1306...");
   this->init_reset_();
 
-  this->parent_->raw_begin_transmission(this->address_);
-  if (!this->parent_->raw_end_transmission(this->address_)) {
+  this->raw_begin_transmission(this->address_);
+  if (!this->raw_end_transmission(this->address_)) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
     return;

--- a/esphome/components/ssd1327_i2c/ssd1327_i2c.cpp
+++ b/esphome/components/ssd1327_i2c/ssd1327_i2c.cpp
@@ -10,8 +10,8 @@ void I2CSSD1327::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2C SSD1327...");
   this->init_reset_();
 
-  this->parent_->raw_begin_transmission(this->address_);
-  if (!this->parent_->raw_end_transmission(this->address_)) {
+  this->raw_begin_transmission(this->address_);
+  if (!this->raw_end_transmission(this->address_)) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
     return;

--- a/esphome/components/ssd1327_i2c/ssd1327_i2c.cpp
+++ b/esphome/components/ssd1327_i2c/ssd1327_i2c.cpp
@@ -10,8 +10,8 @@ void I2CSSD1327::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2C SSD1327...");
   this->init_reset_();
 
-  this->raw_begin_transmission(this->address_);
-  if (!this->raw_end_transmission(this->address_)) {
+  this->raw_begin_transmission();
+  if (!this->raw_end_transmission()) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
     return;


### PR DESCRIPTION
# What does this implement/fix? 

* Missing I<sup>2</sup>C multiplexer support for the various raw data transfer commands from the `I2CDevice` class.
* Compatibility of a few components with I2C multiplexing.
 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

This is the configuration that did not work without these fixes:

```yaml
# Example config.yaml
i2c:
  id: i2c0

tca9548a:
  - address: 0x70
    id: multiplex0
    i2c_id: i2c0

display:
  - platform: ssd1306_i2c
    model: "SSD1306 128x64"
    multiplexer:
      id: multiplex0
      channel: 0
  - platform: ssd1306_i2c
    model: "SSD1306 128x64"
    multiplexer:
      id: multiplex0
      channel: 1
```

# Explain your changes

I2C multiplexing support was added to the I2CDevice class, but it was missing for the following methods:
* `raw_begin_transmission()`
* `raw_end_transmission()`
* `read_bytes_raw()`
* `write_bytes_raw()`

Therefore, I added multiplexing support to these.

Additionally, a fix was done for a few components (`mcp4725`, `ssd1306_i2c` and `ssd1327_i2c`) that directly called `raw_begin_transmission()` and `raw_end_transmission()` on their parent I2C component, instead of using the equivalent methods that are readily available in their base `I2CDevice` class. They use these in the `setup()` method to check if they can connect to the I2C device.
By calling the parent (i.e. the multiplexer in this scenario) directly, the code that sets the correct multiplexer channel for the device is never called. As a result, the connection check code will be talking to a random channel on the multiplexer.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
