### PR TITLE
Fix and extend Teleinfo functionality for Linky Standard mode.

### DIFF
--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -1,5 +1,6 @@
 #include "teleinfo.h"
 #include "esphome/core/log.h"
+#include <time.h>
 
 namespace esphome {
 namespace teleinfo {
@@ -19,6 +20,45 @@ static int get_field(char *dest, char *buf_start, char *buf_end, int sep) {
   dest[len] = '\0';
 
   return len;
+}
+// Convert a Linky timestamp to a Unix epoche time
+// Linky timestamp example: "E210519075608"
+// Format: SYYMMDDhhmmss
+// S = season is 'E' (été = summer) or 'H' (hiver = winter), upcase = Linky is synced
+static long linkyTimestampToEpoche(std::string linky_timestamp) {
+  struct tm tm;
+  time_t t;
+  
+  // create a parsable representation of the timestamp (separators between parts)
+  std::string parsable_timestamp = linky_timestamp.substr(1);
+  for(int i=10; i>0; i-=2){
+    parsable_timestamp.insert(i, "-");
+  }
+  ESP_LOGD(TAG, "--> parsable_timestamp: %s", &(parsable_timestamp[0]));
+
+  // read season, lowercase means unsynced time, but we ignore this
+  char season = toupper(linky_timestamp[0]);
+  ESP_LOGD(TAG, "--> season: %c", season);
+
+  // parse time into tm struct
+  if (strptime(&(parsable_timestamp[0]), "%y-%m-%d-%H-%M-%S", &tm) == NULL) {
+    ESP_LOGE(TAG, "Invalid Linky timestamp: %s", &(linky_timestamp[0]));
+    return 0;
+  }
+  ESP_LOGD(TAG, "--> parsed timestamp - year: %d; month: %d; day: %d; hour: %d; minute: %d; second: %d", tm.tm_year, tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+  // convert tm struct to unix epoche
+  // and correct timezone and daylight saving to get UTC
+  // "Time" integration MUST be added in ESPHome node config, otherwise _timezone is 0
+  t = mktime(&tm) - _timezone - (season=='E' ? 3600 : 0);
+  if (t < 0){
+    ESP_LOGE(TAG, "Could not convert Linky timestamp: %s", &(linky_timestamp[0]));
+    return 0;
+  }
+  ESP_LOGD(TAG, "--> _timezone: %d", _timezone);
+  ESP_LOGD(TAG, "--> epoche: %d", t);
+
+  return (long) t;
 }
 /* TeleInfo methods */
 bool TeleInfo::check_crc_(const char *grp, const char *grp_end) {
@@ -64,7 +104,9 @@ bool TeleInfo::read_chars_until_(bool drop, uint8_t c) {
 
   return false;
 }
-void TeleInfo::setup() { state_ = OFF; }
+void TeleInfo::setup() { 
+  state_ = OFF;
+}
 void TeleInfo::update() {
   if (state_ == OFF) {
     buf_index_ = 0;
@@ -97,22 +139,24 @@ void TeleInfo::loop() {
       /* Each frame is composed of multiple groups starting by 0xa(Line Feed) and ending by
        * 0xd ('\r').
        *
-       * Historical mode: each group contains tag, data and a CRC separated by 0x20 (Space)
+       * HISTORICAL mode: each group contains tag, data and a CRC separated by 0x20 (Space)
        * 0xa | Tag | 0x20 | Data | 0x20 | CRC | 0xd
        *     ^^^^^^^^^^^^^^^^^^^^
-       * Checksum is computed on the above in historical mode.
        *
-       * Standard mode: each group contains tag, data and a CRC separated by 0x9 (\t)
+       * STANDARD mode: each group contains tag, timestamp (optional), data and a CRC separated by 0x9 (\t)
        * 0xa | Tag | 0x9 | Data | 0x9 | CRC | 0xd
        *     ^^^^^^^^^^^^^^^^^^^^^^^^^
-       * Checksum is computed on the above in standard mode.
+       * 0xa | Tag | 0x9 | Timestamp | 0x9 | Data | 0x9 | CRC | 0xd
+       *     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       *
+       * Checksums (CRC) are computed over the underlined part in the above groups.
        */
       while ((buf_finger = static_cast<char *>(memchr(buf_finger, (int) 0xa, buf_index_ - 1))) &&
              ((buf_finger - buf_) < buf_index_)) {
-        /* Point to the first char of the group after 0xa */
+        // Point to the first char of the group after 0xa
         buf_finger += 1;
 
-        /* Group len */
+        // Group len
         grp_end = static_cast<char *>(memchr(buf_finger, 0xd, buf_end - buf_finger));
         if (!grp_end) {
           ESP_LOGE(TAG, "No group found");
@@ -122,43 +166,74 @@ void TeleInfo::loop() {
         if (!check_crc_(buf_finger, grp_end))
           break;
 
-        /* Get tag */
+        // Get tag
         field_len = get_field(tag_, buf_finger, grp_end, separator_);
         if (!field_len || field_len >= MAX_TAG_SIZE) {
-          ESP_LOGE(TAG, "Invalid tag.");
+          ESP_LOGE(TAG, "Invalid tag field");
           break;
         }
-
-        /* Advance buf_finger to after the tag and the separator. */
+        ESP_LOGD(TAG, "--> tag field: %s", tag_);
+        // Advance buf_finger to after the tag and the separator.
         buf_finger += field_len + 1;
 
-        /* Get value (after next separator) */
-        field_len = get_field(val_, buf_finger, grp_end, separator_);
-        if (!field_len || field_len >= MAX_VAL_SIZE) {
-          ESP_LOGE(TAG, "Invalid Value");
-          break;
+        // count the number of data fields
+        // (historical mode: always 1, standard mode: 1 or 2)
+        int data_field_cnt = std::count(buf_finger, grp_end, separator_);
+        ESP_LOGD(TAG, "--> data field count: %d", data_field_cnt);
+
+        // if two data fields found: first field is a Linky timestamp
+        timestamp_[0] = '\0';
+        if(data_field_cnt>1) {
+          // Get timestamp (after next separator) */
+          field_len = get_field(timestamp_, buf_finger, grp_end, separator_);
+          if (!field_len || field_len >= MAX_TIMESTAMP_SIZE) {
+            ESP_LOGE(TAG, "Invalid timestamp field");
+            break;
+          }
+          ESP_LOGD(TAG, "--> timestamp field: %s", timestamp_);
+          // Advance buf_finger to end of field
+          buf_finger += field_len + 1;
         }
 
-        /* Advance buf_finger to end of group */
+        // next field is always the value field
+        // Get value (after next separator)
+        field_len = get_field(val_, buf_finger, grp_end, separator_);
+        if (field_len >= MAX_VAL_SIZE) {
+          ESP_LOGE(TAG, "Invalid value field");
+          break;
+        }
+        ESP_LOGD(TAG, "--> value field: %s", val_);
+        // Advance buf_finger to end of group
         buf_finger += field_len + 1 + 1 + 1;
 
-        publish_value_(std::string(tag_), std::string(val_));
+        publish_value_(std::string(tag_), std::string(timestamp_), std::string(val_));
       }
       state_ = OFF;
       break;
   }
 }
-void TeleInfo::publish_value_(std::string tag, std::string val) {
+void TeleInfo::publish_value_(std::string tag, std::string timestamp, std::string val) {
   /* It will return 0 if tag is not a float. */
-  auto newval = parse_float(val);
   for (auto element : teleinfo_sensors_)
-    if (tag == element->tag)
-      element->sensor->publish_state(*newval);
+    if (tag == element->tag){
+      std::string device_class = element->sensor->get_device_class();
+      if( device_class.compare("timestamp") == 0 && timestamp[0]!='\0'){
+        // for a sensor with device_class "timestamp" we use the Linky timestamp field (if we got one)
+        float newval = (float)linkyTimestampToEpoche(timestamp);
+        ESP_LOGD(TAG, "--> device class \"timestamp\", epoche received: %f", newval);
+        element->sensor->publish_state(newval);
+      } else {
+        // for a sensor with any other device_class (or when Linky timestamp field is missing) we use the value field
+        auto newval = parse_float(val);
+        element->sensor->publish_state(*newval);
+      }
+    }
 }
 void TeleInfo::dump_config() {
   ESP_LOGCONFIG(TAG, "TeleInfo:");
-  for (auto element : teleinfo_sensors_)
+  for (auto element : teleinfo_sensors_) {
     LOG_SENSOR("  ", element->tag, element->sensor);
+  }
   this->check_uart_settings(baud_rate_, 1, uart::UART_CONFIG_PARITY_EVEN, 7);
 }
 TeleInfo::TeleInfo(bool historical_mode) {

--- a/esphome/components/teleinfo/teleinfo.h
+++ b/esphome/components/teleinfo/teleinfo.h
@@ -7,12 +7,13 @@
 namespace esphome {
 namespace teleinfo {
 /*
- * 198 bytes should be enough to contain a full session in historical mode with
- * three phases. But go with 1024 just to be sure.
+ * A three phase Linky in Standard mode sends about 1350 bytes for a full transmission. Historical mode sends much less.
+ * We go with 2048 just to be sure.
  */
 static const uint8_t MAX_TAG_SIZE = 64;
+static const uint16_t MAX_TIMESTAMP_SIZE = 14;
 static const uint16_t MAX_VAL_SIZE = 256;
-static const uint16_t MAX_BUF_SIZE = 1024;
+static const uint16_t MAX_BUF_SIZE = 2048;
 
 struct TeleinfoSensorElement {
   const char *tag;
@@ -36,6 +37,7 @@ class TeleInfo : public PollingComponent, public uart::UARTDevice {
   char buf_[MAX_BUF_SIZE];
   uint32_t buf_index_{0};
   char tag_[MAX_TAG_SIZE];
+  char timestamp_[MAX_TIMESTAMP_SIZE];
   char val_[MAX_VAL_SIZE];
   enum State {
     OFF,
@@ -45,7 +47,7 @@ class TeleInfo : public PollingComponent, public uart::UARTDevice {
   } state_{OFF};
   bool read_chars_until_(bool drop, uint8_t c);
   bool check_crc_(const char *grp, const char *grp_end);
-  void publish_value_(std::string tag, std::string val);
+  void publish_value_(std::string tag, std::string timestamp, std::string val);
 };
 }  // namespace teleinfo
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 

Component Teleinfo:
* Fixes and extensions
* Now fully supports Linky Standard mode

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** 
replaces https://github.com/esphome/esphome/pull/1802
fixes https://github.com/esphome/issues/issues/2060

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 
https://github.com/esphome/esphome-docs/pull/1197
  
# Test Environment

- [ ] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml
esphome:
  name: teleinfo_standard_example
  platform: ESP8266
  board: d1_mini

wifi:
  ssid:     !secret my_wlan_sid
  password: !secret my_wlan_pwd

logger:
  baud_rate: 0

api:

ota:

uart:
  id: uart_bus
  rx_pin: GPIO3
  baud_rate: 9600
  parity: EVEN
  data_bits: 7

sensor:
  - platform: teleinfo
    update_interval: 15s
    historical_mode: false
    tags:
      - tag_name: "EAST"
        sensor:
          name: "Linky: Consumption"
          unit_of_measurement: "Wh"
          icon: mdi:home-analytics
      - tag_name: "SMAXSN"
        sensor:
          # read value of tag
          name: "Linky: Max. power today"
          device_class: "power"
          unit_of_measurement: "VA"
      - tag_name: "SMAXSN"
        sensor:
          # read Linky timestamp of same tag as above
          name: "Linky: Time of max. power today"
          device_class: "timestamp"
          unit_of_measurement: ""

```

# Explain your changes

* Fixes "buffer full" problem on three phase Linky in standard mode. In this configuration Linky creates over 1300 bytes of data per frame, which is more than the reserverd 1024. PR sets this value to 2048. See: https://github.com/esphome/issues/issues/2060
* Standard mode provides a set of tags that does not only contain a value but also a timestamp, which is relevant data. I.e. it contains the exact time of highest load. This PR allows to read out the timestamp AND/OR the value of a tag (not only the value). The timestamp is read by associating a sensor with a tag and setting the data_class of the sensor to "timestamp". 
* Without the PR the component is broken for all tags in Standard mode that also contain a timestamp (returns zero values for all such tags.)


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
