### PR TITLE
Use built-in validation for altitude

### DIFF
--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -1,4 +1,3 @@
-import re
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c, sensor

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -28,10 +28,6 @@ CONF_AMBIENT_PRESSURE_COMPENSATION = "ambient_pressure_compensation"
 CONF_TEMPERATURE_OFFSET = "temperature_offset"
 
 
-def remove_altitude_suffix(value):
-    return re.sub(r"\s*(?:m(?:\s+a\.s\.l)?)|(?:MAM?SL)$", "", value)
-
-
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -47,7 +43,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_AUTOMATIC_SELF_CALIBRATION, default=True): cv.boolean,
             cv.Optional(CONF_ALTITUDE_COMPENSATION): cv.All(
-                remove_altitude_suffix,
+                cv.float_with_unit("altitude", "(m|m a.s.l.|m MAMSL|m MAML)"),
                 cv.int_range(min=0, max=0xFFFF, max_included=False),
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -42,7 +42,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_AUTOMATIC_SELF_CALIBRATION, default=True): cv.boolean,
             cv.Optional(CONF_ALTITUDE_COMPENSATION): cv.All(
-                cv.float_with_unit("altitude", "(m|m a.s.l.|m MAMSL|m MASL)"),
+                cv.float_with_unit("altitude", "(m|m a.s.l.|MAMSL|MASL)"),
                 cv.int_range(min=0, max=0xFFFF, max_included=False),
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -42,7 +42,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_AUTOMATIC_SELF_CALIBRATION, default=True): cv.boolean,
             cv.Optional(CONF_ALTITUDE_COMPENSATION): cv.All(
-                cv.float_with_unit("altitude", "(m|m a.s.l.|m MAMSL|m MAML)"),
+                cv.float_with_unit("altitude", "(m|m a.s.l.|m MAMSL|m MASL)"),
                 cv.int_range(min=0, max=0xFFFF, max_included=False),
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,


### PR DESCRIPTION
This improves the error location and message while being still backwards
compatible.

# What does this implement/fix? 

Quick description 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):**

- Noted in: https://github.com/esphome/issues/issues/1840

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: scd30
    co2:
      id: sensirion
      name: "Sensirion CO2"
      retain: False
      accuracy_decimals: 1
    temperature:
      name: "Sensirion Temperature"
      retain: False
      accuracy_decimals: 2
    humidity:
      name: "Sensirion Humidity"
      retain: False
      accuracy_decimals: 1
    altitude_compensation: 500m
    address: 0x61
    update_interval: 60s
```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
