### PR TITLE
Avoid unnecessary waits to stabilize the VOC algorithm

### DIFF
--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -220,7 +220,8 @@ void SGP40Component::update() {
 
   uint32_t voc_index = this->measure_voc_index_();
 
-  if (this->samples_read_++ < this->samples_to_stabalize_) {
+  if (this->samples_read_ < this->samples_to_stabalize_) {
+    this->samples_read_++;
     ESP_LOGD(TAG, "Sensor has not collected enough samples yet. (%d/%d) VOC index is: %u", this->samples_read_,
              this->samples_to_stabalize_, voc_index);
     return;


### PR DESCRIPTION
Currently the SGP40 integration waits for 90 samples read until
stabilization is deemed successful. However, after that the samples_read
variable continous to get incremented. This ultimately leads to an
overflow pretty quickly since samples_read is only uint8_t. This in
turn leads to another 90 samples read until values get sent out.

Only increment samples_read during initialization time.

# What does this implement/fix? 

Quick description 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: sgp40
    name: "VOC"
    unit_of_measurement: "idx"
    update_interval: 60s
```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
