### PR TITLE
Send Celsius temperature unit in MQTT discovery message

### DIFF
--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -60,6 +60,8 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
   root["max_temp"] = traits.get_visual_max_temperature();
   // temp_step
   root["temp_step"] = traits.get_visual_temperature_step();
+  // temperature units are always coerced to Celsius internally
+  root["temp_unit"] = "C";
 
   if (traits.supports_preset(CLIMATE_PRESET_AWAY)) {
     // away_mode_command_topic


### PR DESCRIPTION
# What does this implement/fix? 

When HomeAssistant is configured to Imperial units, the temperature readings of the climate component are misinterpreted as Fahrenheit, when in reality they are always forced to Celsius internally by ESPHome. This fix sends the explicit temperature unit definition of "C" in the MQTT discovery message.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes esphome/issues#2077

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [X] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes
This change just forces the temperature unit to Celsius on the HA side to match what ESPHome is sending, so it can be properly interpreted if HA is configured in Imperial units.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
