### PR TITLE
Add support for waveshare_epaper 1.54v2

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -46,6 +46,7 @@ WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel"
 
 MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
+    "1.54inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN_V2),
     "2.13in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN),
     "2.13in-ttgo": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN),
     "2.13in-ttgo-b1": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B1),
@@ -67,7 +68,7 @@ def validate_full_update_every_only_type_a(value):
     if MODELS[value[CONF_MODEL]][0] != "a":
         raise cv.Invalid(
             "The 'full_update_every' option is only available for models "
-            "'1.54in', '2.13in', '2.90in', and '2.90inV2'."
+            "'1.54in', '1.54inV2', '2.13in', '2.90in', and '2.90inV2'."
         )
     return value
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -210,6 +210,9 @@ void WaveshareEPaperTypeA::dump_config() {
     case WAVESHARE_EPAPER_1_54_IN:
       ESP_LOGCONFIG(TAG, "  Model: 1.54in");
       break;
+    case WAVESHARE_EPAPER_1_54_IN_V2:
+      ESP_LOGCONFIG(TAG, "  Model: 1.54inV2");
+      break;
     case WAVESHARE_EPAPER_2_13_IN:
       ESP_LOGCONFIG(TAG, "  Model: 2.13in");
       break;
@@ -334,7 +337,7 @@ void HOT WaveshareEPaperTypeA::display() {
 
   // COMMAND DISPLAY UPDATE CONTROL 2
   this->command(0x22);
-  if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2) {
+  if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ == WAVESHARE_EPAPER_1_54_IN_V2) {
     this->data(full_update ? 0xF7 : 0xFF);
   } else if (this->model_ == TTGO_EPAPER_2_13_IN_B73) {
     this->data(0xC7);
@@ -352,6 +355,8 @@ void HOT WaveshareEPaperTypeA::display() {
 int WaveshareEPaperTypeA::get_width_internal() {
   switch (this->model_) {
     case WAVESHARE_EPAPER_1_54_IN:
+      return 200;
+    case WAVESHARE_EPAPER_1_54_IN_V2:
       return 200;
     case WAVESHARE_EPAPER_2_13_IN:
       return 128;
@@ -371,6 +376,8 @@ int WaveshareEPaperTypeA::get_width_internal() {
 int WaveshareEPaperTypeA::get_height_internal() {
   switch (this->model_) {
     case WAVESHARE_EPAPER_1_54_IN:
+      return 200;
+    case WAVESHARE_EPAPER_1_54_IN_V2:
       return 200;
     case WAVESHARE_EPAPER_2_13_IN:
       return 250;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -86,7 +86,7 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   void display() override;
 
   void deep_sleep() override {
-    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ ==WAVESHARE_EPAPER_1_54_IN_V2) {
+    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ == WAVESHARE_EPAPER_1_54_IN_V2) {
       // COMMAND DEEP SLEEP MODE
       this->command(0x10);
       this->data(0x01);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -66,6 +66,7 @@ class WaveshareEPaper : public PollingComponent,
 
 enum WaveshareEPaperTypeAModel {
   WAVESHARE_EPAPER_1_54_IN = 0,
+  WAVESHARE_EPAPER_1_54_IN_V2,
   WAVESHARE_EPAPER_2_13_IN,
   WAVESHARE_EPAPER_2_9_IN,
   WAVESHARE_EPAPER_2_9_IN_V2,
@@ -85,7 +86,7 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   void display() override;
 
   void deep_sleep() override {
-    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2) {
+    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ ==WAVESHARE_EPAPER_1_54_IN_V2) {
       // COMMAND DEEP SLEEP MODE
       this->command(0x10);
       this->data(0x01);


### PR DESCRIPTION
# What does this implement/fix? 

Add support for the _*1.54inv2*_ `waveshare_epaper` display.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1032

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1205
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [x] Mac OS
- [x] Linux

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
spi:
  clk_pin: 13
  mosi_pin: 14

display:
  - platform: waveshare_epaper
    id: epaper
    cs_pin: 15
    dc_pin: 27
    busy_pin: 25
    reset_pin: 26
    model: 1.54inv2
    full_update_every: 30
    lambda: |-
      it.print(0, 0, id(font1), "Hello World!");

```

# Explain your changes

V1 of this board works differently than the V2 board, which has been available for over a year at this point.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
