### PR TITLE
Support for A9G GPS/2G Chips

### DIFF
--- a/esphome/components/a9g/__init__.py
+++ b/esphome/components/a9g/__init__.py
@@ -1,0 +1,68 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+
+from esphome import pins
+from esphome.components import uart
+from esphome.components import sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    UNIT_DEGREES,
+    ICON_EMPTY,
+    DEVICE_CLASS_EMPTY,
+)
+
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["sensor"]
+
+CODEOWNERS = ["@coogle"]
+
+a9g_ns = cg.esphome_ns.namespace("a9g")
+a9g = a9g_ns.class_("A9G", cg.Component, uart.UARTDevice)
+# a9gListener = a9g_ns.class_("a9gListener")
+
+CONF_A9G_ID = "a9g_id"
+CONF_POWER_ON_PIN = "power_on_pin"
+CONF_POWER_OFF_PIN = "power_off_pin"
+CONF_WAKE_PIN = "wake_pin"
+CONF_LOW_POWER_PIN = "low_power_pin"
+
+MULTI_CONF = True
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(a9g),
+            cv.Optional(CONF_LATITUDE): sensor.sensor_schema(
+                UNIT_DEGREES, ICON_EMPTY, 6, DEVICE_CLASS_EMPTY
+            ),
+            cv.Optional(CONF_LONGITUDE): sensor.sensor_schema(
+                UNIT_DEGREES, ICON_EMPTY, 6, DEVICE_CLASS_EMPTY
+            ),
+            cv.Optional(CONF_POWER_ON_PIN, default=16): pins.output_pin,
+            cv.Optional(CONF_POWER_OFF_PIN, default=15): pins.output_pin,
+            cv.Optional(CONF_WAKE_PIN, default=13): pins.input_pin,
+            cv.Optional(CONF_LOW_POWER_PIN, default=2): pins.output_pin,
+        }
+    )
+    .extend(cv.polling_component_schema("20s"))
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    if CONF_LATITUDE in config:
+        sens = await sensor.new_sensor(config[CONF_LATITUDE])
+        cg.add(var.set_latitude_sensor(sens))
+
+    if CONF_LONGITUDE in config:
+        sens = await sensor.new_sensor(config[CONF_LONGITUDE])
+        cg.add(var.set_longitude_sensor(sens))
+
+
+def validate(config, item_config):
+    uart.validate_device("a9g", config, item_config, require_tx=True)

--- a/esphome/components/a9g/a9g.cpp
+++ b/esphome/components/a9g/a9g.cpp
@@ -1,0 +1,159 @@
+#include "a9g.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace a9g {
+
+static const char *TAG = "a9g";
+
+void A9G::setup() {
+
+    pinMode(this->a9g_power_on_pin_, OUTPUT);
+    pinMode(this->a9g_power_off_pin_, OUTPUT);
+    pinMode(this->a9g_low_power_pin_, OUTPUT);
+
+    digitalWrite(this->a9g_power_on_pin_, HIGH);
+    digitalWrite(this->a9g_power_off_pin_, LOW);
+    digitalWrite(this->a9g_low_power_pin_, HIGH);
+
+    ESP_LOGD(TAG, "Powering on A9G...");
+    delay(2000);
+
+    digitalWrite(this->a9g_power_on_pin_, LOW);
+    delay(3000);
+    digitalWrite(this->a9g_power_on_pin_, HIGH);
+    delay(5000);
+
+    this->send_command("AT+GPS=1");
+
+    this->a9g_initialized_ = true;
+}
+
+bool A9G::send_command(const char *command) {
+    this->send_command(command, NULL, 0);
+    return true;
+}
+
+bool A9G::send_command(const char *command, uint8_t *response, size_t length) {
+    uint8_t newline[2] = {0x0D, 0x0A};
+    long int time = millis();
+    size_t bytesRead = 0;
+
+    while (this->available()) this->read();
+
+    this->write_str(command);
+    this->write_array(newline, sizeof(newline));
+    this->flush();
+
+    if (response == nullptr)
+    {
+        return true;
+    }
+
+    while ((time + 200) > millis())
+    {
+        while (this->available() && (bytesRead < length)) {
+            uint8_t c = this->read();
+            response[bytesRead] = c;
+            bytesRead++;
+        }
+    }
+
+    return true;
+}
+
+A9GCoordinate* A9G::parse_location_response(uint8_t *response) {
+    A9GCoordinate *coordinates;
+    char lat[12], lon[12];
+
+    coordinates = (A9GCoordinate *)malloc(sizeof(A9GCoordinate));
+    coordinates->latitude = -100;
+    coordinates->longitude = -100;
+
+    if (strlen((const char *)response) < 17)
+    {
+        return coordinates;
+    }
+
+    if (strncmp("AT+LOCATION=2\r\n\r\n", (const char *)response, 17) == 0)
+    {
+        if (strlen((const char *)response) >= 38)
+        {
+            for(int idx = 17; idx < strlen((const char *) response); idx++) {
+                char c = response[idx];
+
+                if (c == ',') {
+                    size_t lat_size = idx - 17;
+
+                    if (lat_size + 1 <= sizeof(lat)) {
+                        int idx2;
+                        size_t lon_size;
+                        
+
+                        ESP_LOGD(TAG, "Latitude Str Size: %d", lat_size);
+                        strncpy(&lat[0], (const char *)&response[17], lat_size);
+
+                        for(idx2 = idx; 
+                            (idx2 < strlen((const char *)response)) && (response[idx2] != '\r'); 
+                            idx2++);
+
+                        lon_size = idx2 - idx -1;
+
+                        ESP_LOGD(TAG, "Longitude Str Size: %d", lon_size);
+
+                        strncpy(&lon[0], (const char *)&response[idx + 1], lon_size);
+
+                        coordinates->latitude = strtof(&lat[0], NULL);
+                        coordinates->longitude = strtof(&lon[0], NULL);
+
+                        return coordinates;
+                    }
+                    else
+                    {
+                        ESP_LOGD(TAG, "Could not parse latitude (invalid string size)");
+                    }
+                }
+            }
+        }
+        else
+        {
+            ESP_LOGD(TAG, "Invalid length, cannot parse latitude and logitude");
+        }
+    }
+    return coordinates;
+}
+
+void A9G::update() {
+    uint8_t readBuffer[100];
+    A9GCoordinate *coordinates;
+    
+    if (!this->a9g_initialized_)
+    {
+        return;
+    }
+
+    this->send_command("AT+LOCATION=2", &readBuffer[0], sizeof(readBuffer));
+
+    coordinates = this->parse_location_response(&readBuffer[0]);
+    
+    if ((coordinates->latitude != -100) && (coordinates->longitude != -100)) {
+        this->latitude_ = coordinates->latitude;
+        this->longitude_ = coordinates->longitude;
+
+        if (this->latitude_sensor_ != nullptr)
+            this->latitude_sensor_->publish_state(this->latitude_);
+
+        if (this->longitude_sensor_ != nullptr)
+            this->longitude_sensor_->publish_state(this->longitude_);
+    }
+
+    free(coordinates);
+
+}
+
+void A9G::loop() {
+
+}
+
+} // namespace a9g
+} // namespace esphome

--- a/esphome/components/a9g/a9g.cpp
+++ b/esphome/components/a9g/a9g.cpp
@@ -68,7 +68,7 @@ A9GCoordinate* A9G::parse_location_response(uint8_t *response) {
 
     coordinates = (A9GCoordinate *)malloc(sizeof(A9GCoordinate));
     coordinates->latitude = -100;
-    coordinates->longitude = -100;
+    coordinates->longitude = -200;
 
     if (strlen((const char *)response) < 17)
     {
@@ -136,7 +136,7 @@ void A9G::update() {
 
     coordinates = this->parse_location_response(&readBuffer[0]);
     
-    if ((coordinates->latitude != -100) && (coordinates->longitude != -100)) {
+    if ((coordinates->latitude != -100) && (coordinates->longitude != -200)) {
         this->latitude_ = coordinates->latitude;
         this->longitude_ = coordinates->longitude;
 

--- a/esphome/components/a9g/a9g.h
+++ b/esphome/components/a9g/a9g.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome {
+namespace a9g {
+
+typedef struct A9GCoordinate {
+    float latitude;
+    float longitude;
+} A9GCoordinate;
+
+class A9G : public PollingComponent, public uart::UARTDevice {
+  public:
+    void set_latitude_sensor(sensor::Sensor *latitude_sensor) { latitude_sensor_ = latitude_sensor; }
+    void set_longitude_sensor(sensor::Sensor *longitude_sensor) { longitude_sensor_ = longitude_sensor; }
+
+    float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+    void set_power_on_pin(uint8_t power_on_pin) { a9g_power_on_pin_ = power_on_pin; }
+    void set_power_off_pin(uint8_t power_off_pin) { a9g_power_off_pin_ = power_off_pin; }
+    void set_wake_pin(uint8_t wake_pin) { a9g_wake_pin_ = wake_pin; }
+    void set_low_power_pin(uint8_t low_power_pin) { a9g_low_power_pin_ = low_power_pin; }
+
+    bool send_command(const char *command, uint8_t *response, size_t length);
+    bool send_command(const char *command);
+    A9GCoordinate* parse_location_response(uint8_t *response);
+
+    void loop() override;
+    void update() override;
+    void setup() override;
+  
+  protected:
+    float latitude_ = -1;
+    float longitude_ = -1;
+
+    uint8_t a9g_power_on_pin_;
+    uint8_t a9g_power_off_pin_;
+    uint8_t a9g_wake_pin_;
+    uint8_t a9g_low_power_pin_; 
+
+    bool a9g_initialized_ = false;
+
+    sensor::Sensor *latitude_sensor_{nullptr};
+    sensor::Sensor *longitude_sensor_{nullptr};
+};
+
+} // end of namespace a9g
+} // end of namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 

This is the initial implementation of support in ESPHome for A9G chips, specifically for boards like this (although 
any properly wired A9G chip should do the trick):

https://www.ebay.com/itm/164284777533

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
Docs TBD:

# Test Environment

- [ ] ESP32
- [X ] ESP8266
- [ ] Windows
- [ X] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:
  rx_pin: 14
  tx_pin: 12
  baud_rate: 115200
  id: a9g_uart

a9g:
  uart_id: a9g_uart
  latitude:
    name: "RV Latitude"
  longitude:
    name: "RV Longitude"
```

# Explain your changes

The existing GPS component is based on NEMA protocols, and the A9G chip requires some other stuff to happen in order for things to work properly. This is the initial implementation which supports extracting GPS coordinates but I plan on adding the ability to send text messages using the chip as well via a ESPHome service. 

Before I go through the trouble of adding docs and tests, etc. I wanted to get the PR out to see if this was a welcome contribution.

## Checklist:
  - [X ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
 
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
