### PR TITLE
Add optional lambda to BLESensor for raw data parsing

### DIFF
--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
             cv.Required(CONF_CHARACTERISTIC_UUID): esp32_ble_tracker.bt_uuid,
             cv.Optional(CONF_DESCRIPTOR_UUID): esp32_ble_tracker.bt_uuid,
-            cv.Optional(CONF_LAMBDA): cv.lambda_,
+            cv.Optional(CONF_LAMBDA): cv.returning_lambda,
             cv.Optional(CONF_NOTIFY, default=False): cv.boolean,
             cv.Optional(CONF_ON_NOTIFY): automation.validate_automation(
                 {

--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -84,7 +84,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
       }
       if (param->read.handle == this->handle) {
         this->status_clear_warning();
-        this->publish_state(this->parse_data(param));
+        this->publish_state(this->parse_data(param->read.value, param->read.value_len));
       }
       break;
     }
@@ -93,7 +93,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
         break;
       ESP_LOGV(TAG, "[%s] ESP_GATTC_NOTIFY_EVT: handle=0x%x, value=0x%x", this->get_name().c_str(),
                param->notify.handle, param->notify.value[0]);
-      this->publish_state(this->parse_data(param));
+      this->publish_state(this->parse_data(param->notify.value, param->notify.value_len));
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
@@ -105,12 +105,12 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
   }
 }
 
-float BLESensor::parse_data(esp_ble_gattc_cb_param_t *param) {
+float BLESensor::parse_data(uint8_t *value, uint16_t value_len) {
   if (this->data_to_value_func_.has_value()) {
-    std::vector<uint8_t> data(param->read.value, param->read.value + param->read.value_len);
+    std::vector<uint8_t> data(value, value + value_len);
     return (*this->data_to_value_func_)(data);
   } else {
-    return param->read.value[0];
+    return value[0];
   }
 }
 

--- a/esphome/components/ble_client/sensor/ble_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_sensor.h
@@ -13,6 +13,8 @@ namespace ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
+using data_to_value_t = std::function<float(std::vector<uint8_t>)>;
+
 class BLESensor : public sensor::Sensor, public PollingComponent, public BLEClientNode {
  public:
   void loop() override;
@@ -30,11 +32,14 @@ class BLESensor : public sensor::Sensor, public PollingComponent, public BLEClie
   void set_descr_uuid16(uint16_t uuid) { this->descr_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_descr_uuid32(uint32_t uuid) { this->descr_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
   void set_descr_uuid128(uint8_t *uuid) { this->descr_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
+  void set_data_to_value(data_to_value_t &&lambda_) { this->data_to_value_func_ = lambda_; }
   void set_enable_notify(bool notify) { this->notify_ = notify; }
   uint16_t handle;
 
  protected:
   uint32_t hash_base() override;
+  float parse_data(esp_ble_gattc_cb_param_t *param);
+  optional<data_to_value_t> data_to_value_func_{};
   bool notify_;
   espbt::ESPBTUUID service_uuid_;
   espbt::ESPBTUUID char_uuid_;

--- a/esphome/components/ble_client/sensor/ble_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_sensor.h
@@ -38,7 +38,7 @@ class BLESensor : public sensor::Sensor, public PollingComponent, public BLEClie
 
  protected:
   uint32_t hash_base() override;
-  float parse_data(esp_ble_gattc_cb_param_t *param);
+  float parse_data(uint8_t *value, uint16_t value_len);
   optional<data_to_value_t> data_to_value_func_{};
   bool notify_;
   espbt::ESPBTUUID service_uuid_;

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -271,6 +271,9 @@ sensor:
     descriptor_uuid: 'ffe2'
     notify: true
     update_interval: never
+    lambda: |-
+      ESP_LOGD("main", "Length of data is %i", x.size());
+      return x[0];
     on_notify:
       then:
         - lambda: |-


### PR DESCRIPTION
# What does this implement/fix? 

This expands on the recently merged BLE GATT client functionality, which only used the first byte of each data message. Since many BLE devices use messages with more than one byte of payload and a wide variety of data encodings, converting these with a user-defined lambda seems the most practical way forward. This pull request introduces such a lambda function as an optional configuration parameter, with fallback to the current way of using just the first data payload byte.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/556#issuecomment-845488558

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1210
  
# Test Environment

- [X] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

esp32_ble_tracker:

ble_client:
  - mac_address: F5:FF:58:7E:04:73
    id: smartgadget_0473

sensor:
  - platform: ble_client
    ble_client_id: smartgadget_0473
    name: "RH_0473"
    service_uuid: '00001234-B38D-4985-720E-0F993A68EE41'
    characteristic_uuid: '00001235-B38D-4985-720E-0F993A68EE41'
    device_class: "humidity"
    lambda: !lambda |-
      return *((float*)(&x[0]));

```

# Explain your changes

see above

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
