### PR TITLE
Add cover feedback signals

### DIFF
--- a/esphome/components/time_based/cover.py
+++ b/esphome/components/time_based/cover.py
@@ -16,6 +16,7 @@ time_based_ns = cg.esphome_ns.namespace("time_based")
 TimeBasedCover = time_based_ns.class_("TimeBasedCover", cover.Cover, cg.Component)
 
 CONF_HAS_BUILT_IN_ENDSTOP = "has_built_in_endstop"
+CONF_USE_FEEDBACK = "use_feedback"
 
 CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
     {
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
         cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_HAS_BUILT_IN_ENDSTOP, default=False): cv.boolean,
         cv.Optional(CONF_ASSUMED_STATE, default=True): cv.boolean,
+        cv.Optional(CONF_USE_FEEDBACK, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -52,3 +54,4 @@ async def to_code(config):
 
     cg.add(var.set_has_built_in_endstop(config[CONF_HAS_BUILT_IN_ENDSTOP]))
     cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))
+    cg.add(var.set_use_feedback(config[CONF_USE_FEEDBACK]))

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -22,7 +22,11 @@ void TimeBasedCover::setup() {
   }
 }
 void TimeBasedCover::loop() {
-  if (this->current_operation == COVER_OPERATION_IDLE)
+  auto current_operation = this->use_feedback_
+    ? this->current_operation_feedback
+    : this->current_operation;
+
+  if (current_operation == COVER_OPERATION_IDLE)
     return;
 
   const uint32_t now = millis();
@@ -124,12 +128,16 @@ void TimeBasedCover::start_direction_(CoverOperation dir) {
   this->last_recompute_time_ = now;
 }
 void TimeBasedCover::recompute_position_() {
-  if (this->current_operation == COVER_OPERATION_IDLE)
+  auto current_operation = this->use_feedback_
+    ? this->current_operation_feedback
+    : this->current_operation;
+
+  if (current_operation == COVER_OPERATION_IDLE)
     return;
 
   float dir;
   float action_dur;
-  switch (this->current_operation) {
+  switch (current_operation) {
     case COVER_OPERATION_OPENING:
       dir = 1.0f;
       action_dur = this->open_duration_;
@@ -146,6 +154,13 @@ void TimeBasedCover::recompute_position_() {
   this->position += dir * (now - this->last_recompute_time_) / action_dur;
   this->position = clamp(this->position, 0.0f, 1.0f);
 
+  this->last_recompute_time_ = now;
+}
+void TimeBasedCover::feedback(cover::CoverOperation op) {
+  this->current_operation_feedback = op;
+
+  const uint32_t now = millis();
+  this->start_dir_time_ = now;
   this->last_recompute_time_ = now;
 }
 

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -22,6 +22,9 @@ class TimeBasedCover : public cover::Cover, public Component {
   cover::CoverTraits get_traits() override;
   void set_has_built_in_endstop(bool value) { this->has_built_in_endstop_ = value; }
   void set_assumed_state(bool value) { this->assumed_state_ = value; }
+  void set_use_feedback(bool value) { this->use_feedback_ = value; }
+
+  void feedback(cover::CoverOperation op);
 
  protected:
   void control(const cover::CoverCall &call) override;
@@ -45,6 +48,9 @@ class TimeBasedCover : public cover::Cover, public Component {
   float target_position_{0};
   bool has_built_in_endstop_{false};
   bool assumed_state_{false};
+  bool use_feedback_{false};
+
+  cover::CoverOperation current_operation_feedback{cover::CoverOperation::COVER_OPERATION_IDLE};
 };
 
 }  // namespace time_based


### PR DESCRIPTION
# What does this implement/fix? 

Fix wrong position computation when a cover doesn't move as soon as the command is sent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/feature-requests/issues/778>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [x] ESP8266
- [ ] Windows
- [x] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
 switch:
   - platform: gpio
     pin: GPIO15
     name: "Relay #1"
     internal: true
     id: relay1
     interlock: &interlock_group [relay1, relay2]
     interlock_wait_time: 1s
     on_turn_on:
       then:
         - lambda: |-
             id(rolladen).feedback(COVER_OPERATION_CLOSING);
     on_turn_off:
       then:
         - lambda: |-
             id(rolladen).feedback(COVER_OPERATION_IDLE);

   - platform: gpio
     pin: GPIO4
     name: "Relay #2"
     internal: true
     id: relay2
     interlock: *interlock_group
     interlock_wait_time: 1s
     on_turn_on:
       then:
         - lambda: |-
             id(rolladen).feedback(COVER_OPERATION_OPENING);
     on_turn_off:
       then:
         - lambda: |-
             id(rolladen).feedback(COVER_OPERATION_IDLE);

 cover:
   - platform: time_based
     name: "My cover"
     id: rolladen
     device_class: shutter
     use_feedback: true

     open_action:
       - switch.turn_on: relay2
     open_duration: 25s

     close_action:
       - switch.turn_on: relay1
     close_duration: 22s

     stop_action:
       - switch.turn_off: relay1
       - switch.turn_off: relay2
```

# Explain your changes

Add a configuration parameter that enables the cover to use actual relay status to compute the moving position instead of assuming that the cover is moving.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
