### PR TITLE
Add support for more EZO sensor commands

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -9,6 +9,15 @@ static const char *TAG = "ezo.sensor";
 static const uint16_t EZO_STATE_WAIT = 1;
 static const uint16_t EZO_STATE_SEND_TEMP = 2;
 static const uint16_t EZO_STATE_WAIT_TEMP = 4;
+static const uint16_t EZO_STATE_SEND_PROBE_TYPE = 8;
+static const uint16_t EZO_STATE_WAIT_PROBE_TYPE = 16;
+static const uint16_t EZO_STATE_SEND_CALIBRATION = 32;
+static const uint16_t EZO_STATE_WAIT_CALIBRATION = 64;
+
+static const uint16_t CAL_SINGLE = 0;
+static const uint16_t CAL_LOW = 1;
+static const uint16_t CAL_MEDIUM = 2;
+static const uint16_t CAL_HIGH = 3;
 
 void EZOSensor::dump_config() {
   LOG_SENSOR("", "EZO", this);
@@ -32,6 +41,7 @@ void EZOSensor::update() {
 
 void EZOSensor::loop() {
   uint8_t buf[20];
+  int len;
   if (!(this->state_ & EZO_STATE_WAIT)) {
     if (this->state_ & EZO_STATE_SEND_TEMP) {
       int len = sprintf((char *) buf, "T,%0.3f", this->tempcomp_);
@@ -39,6 +49,28 @@ void EZOSensor::loop() {
       this->state_ = EZO_STATE_WAIT | EZO_STATE_WAIT_TEMP;
       this->start_time_ = millis();
       this->wait_time_ = 300;
+    }
+    if (this->state_ & EZO_STATE_SEND_PROBE_TYPE ) {
+      int len = sprintf((char *) buf, "K,%0.3f", this->probe_type_);
+      this->write_bytes_raw(buf, len);
+      this->state_ = EZO_STATE_WAIT | EZO_STATE_WAIT_PROBE_TYPE;
+      this->start_time_ = millis();
+      this->wait_time_ = 300;
+    }
+    if (this->state_ & EZO_STATE_SEND_CALIBRATION) {
+      if (this->calibration_type_ == CAL_SINGLE) {
+        len = sprintf((char *) buf, "Cal,%0.3f", this->calibration_value_);
+      } else if (this->calibration_type_ == CAL_LOW) {
+        len = sprintf((char *) buf, "Cal,low,%0.3f", this->calibration_value_);
+      } else if (this->calibration_type_ == CAL_MEDIUM) {
+        len = sprintf((char *) buf, "Cal,mid,%0.3f", this->calibration_value_);
+      } else {
+        len = sprintf((char *) buf, "Cal,high,%0.3f", this->calibration_value_);
+      }
+      this->write_bytes_raw(buf, len);
+      this->state_ = EZO_STATE_WAIT | EZO_STATE_WAIT_CALIBRATION;
+      this->start_time_ = millis();
+      this->wait_time_ = 300;   
     }
     return;
   }
@@ -81,6 +113,24 @@ void EZOSensor::set_tempcomp_value(float temp) {
   this->tempcomp_ = temp;
   this->state_ |= EZO_STATE_SEND_TEMP;
 }
+
+void EZOSensor::set_probe_type(float probe_type) {
+  this->probe_type_ = probe_type;
+  this->state_ |= EZO_STATE_SEND_PROBE_TYPE;
+}
+
+void EZOSensor::set_calibration_single(float value) {
+  this->calibration_value_ = value;
+  this->calibration_type_ = CAL_SINGLE;
+  this->state_ |= EZO_STATE_SEND_CALIBRATION;
+}
+
+void EZOSensor::set_calibration_point(int point, float value) {
+  this->calibration_value_ = value;
+  this->calibration_type_ = point;
+  this->state_ |= EZO_STATE_SEND_CALIBRATION;
+}
+
 
 }  // namespace ezo
 }  // namespace esphome

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -50,7 +50,7 @@ void EZOSensor::loop() {
       this->start_time_ = millis();
       this->wait_time_ = 300;
     }
-    if (this->state_ & EZO_STATE_SEND_PROBE_TYPE ) {
+    if (this->state_ & EZO_STATE_SEND_PROBE_TYPE) {
       int len = sprintf((char *) buf, "K,%0.3f", this->probe_type_);
       this->write_bytes_raw(buf, len);
       this->state_ = EZO_STATE_WAIT | EZO_STATE_WAIT_PROBE_TYPE;
@@ -70,7 +70,7 @@ void EZOSensor::loop() {
       this->write_bytes_raw(buf, len);
       this->state_ = EZO_STATE_WAIT | EZO_STATE_WAIT_CALIBRATION;
       this->start_time_ = millis();
-      this->wait_time_ = 300;   
+      this->wait_time_ = 300;
     }
     return;
   }
@@ -130,7 +130,6 @@ void EZOSensor::set_calibration_point(int point, float value) {
   this->calibration_type_ = point;
   this->state_ |= EZO_STATE_SEND_CALIBRATION;
 }
-
 
 }  // namespace ezo
 }  // namespace esphome

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -16,12 +16,18 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   float get_setup_priority() const override { return setup_priority::DATA; };
 
   void set_tempcomp_value(float temp);
+  void set_probe_type(float probe_type);
+  void set_calibration_single(float value);
+  void set_calibration_point(int point, float value);
 
  protected:
   unsigned long start_time_ = 0;
   unsigned long wait_time_ = 0;
   uint16_t state_ = 0;
   float tempcomp_;
+  float probe_type_;
+  float calibration_value_;
+  uint16_t calibration_type_;
 };
 
 }  // namespace ezo


### PR DESCRIPTION
# What does this implement/fix? 

Add support for calibrating EZO probes and for setting probe type (relevant for EC probe). Calibration can happen using a single value or multi-point calibration (support varies across probe types)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

# Test Environment

- [ ] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

# Explain your changes

There have been various debates to support more commands (specifically calibration) on these sensors since this needs to happen every couple of months. Currently support for EZO commands was limited to temperature compensation. This PR adds support for:
- Setting the probe type (relevant for EC probes)
- Single-point calibration
- Multi-point calibration

Note that this is my first time writing C++ code. So happy to get feedback.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

