### PR TITLE
Fix fan speed restore issue on boot

### DIFF
--- a/esphome/components/binary/fan/binary_fan.cpp
+++ b/esphome/components/binary/fan/binary_fan.cpp
@@ -56,7 +56,8 @@ void BinaryFan::loop() {
   }
 }
 
-// We need a higher priority than the FanState component to make sure that the traits are set when that component sets itself up.
+// We need a higher priority than the FanState component to make sure that the traits are set 
+// when that component sets itself up.
 float BinaryFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
 
 }  // namespace binary

--- a/esphome/components/binary/fan/binary_fan.cpp
+++ b/esphome/components/binary/fan/binary_fan.cpp
@@ -58,7 +58,7 @@ void BinaryFan::loop() {
 
 // We need a higher priority than the FanState component to make sure that the traits are set
 // when that component sets itself up.
-float BinaryFan::get_setup_priority() const { return fan::FanState::get_global_setup_priority() + 1.0f; }
+float BinaryFan::get_setup_priority() const { return fan_->get_setup_priority() + 1.0f; }
 
 }  // namespace binary
 }  // namespace esphome

--- a/esphome/components/binary/fan/binary_fan.cpp
+++ b/esphome/components/binary/fan/binary_fan.cpp
@@ -56,9 +56,9 @@ void BinaryFan::loop() {
   }
 }
 
-// We need a higher priority than the FanState component to make sure that the traits are set 
+// We need a higher priority than the FanState component to make sure that the traits are set
 // when that component sets itself up.
-float BinaryFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
+float BinaryFan::get_setup_priority() const { return fan::FanState::get_global_setup_priority() + 1.0f; }
 
 }  // namespace binary
 }  // namespace esphome

--- a/esphome/components/binary/fan/binary_fan.cpp
+++ b/esphome/components/binary/fan/binary_fan.cpp
@@ -55,7 +55,9 @@ void BinaryFan::loop() {
     ESP_LOGD(TAG, "Setting reverse direction: %s", ONOFF(enable));
   }
 }
-float BinaryFan::get_setup_priority() const { return setup_priority::DATA; }
+
+// We need a higher priority than the FanState component to make sure that the traits are set when that component sets itself up.
+float BinaryFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
 
 }  // namespace binary
 }  // namespace esphome

--- a/esphome/components/fan/fan_state.cpp
+++ b/esphome/components/fan/fan_state.cpp
@@ -39,8 +39,7 @@ void FanState::setup() {
   call.set_direction(recovered.direction);
   call.perform();
 }
-float FanState::get_global_setup_priority() { return setup_priority::HARDWARE - 1.0f; }
-float FanState::get_setup_priority() const { return get_global_setup_priority(); }
+float FanState::get_setup_priority() const { return setup_priority::DATA - 1.0f; }
 uint32_t FanState::hash_base() { return 418001110UL; }
 
 void FanStateCall::perform() const {

--- a/esphome/components/fan/fan_state.cpp
+++ b/esphome/components/fan/fan_state.cpp
@@ -39,7 +39,8 @@ void FanState::setup() {
   call.set_direction(recovered.direction);
   call.perform();
 }
-float FanState::get_setup_priority() const { return FAN_STATE_SETUP_PRIORITY; }
+float FanState::get_global_setup_priority() { return setup_priority::HARDWARE - 1.0f; }
+float FanState::get_setup_priority() const { return get_global_setup_priority(); }
 uint32_t FanState::hash_base() { return 418001110UL; }
 
 void FanStateCall::perform() const {

--- a/esphome/components/fan/fan_state.cpp
+++ b/esphome/components/fan/fan_state.cpp
@@ -39,7 +39,7 @@ void FanState::setup() {
   call.set_direction(recovered.direction);
   call.perform();
 }
-float FanState::get_setup_priority() const { return setup_priority::HARDWARE - 1.0f; }
+float FanState::get_setup_priority() const { return FAN_STATE_SETUP_PRIORITY; }
 uint32_t FanState::hash_base() { return 418001110UL; }
 
 void FanStateCall::perform() const {

--- a/esphome/components/fan/fan_state.h
+++ b/esphome/components/fan/fan_state.h
@@ -65,8 +65,6 @@ class FanStateCall {
   optional<FanDirection> direction_{};
 };
 
-static const float FAN_STATE_SETUP_PRIORITY = setup_priority::HARDWARE - 1.0f;
-
 class FanState : public Nameable, public Component {
  public:
   FanState() = default;
@@ -96,6 +94,7 @@ class FanState : public Nameable, public Component {
   FanStateCall make_call();
 
   void setup() override;
+  static float get_global_setup_priority();
   float get_setup_priority() const override;
 
  protected:

--- a/esphome/components/fan/fan_state.h
+++ b/esphome/components/fan/fan_state.h
@@ -65,6 +65,8 @@ class FanStateCall {
   optional<FanDirection> direction_{};
 };
 
+static const float FAN_STATE_SETUP_PRIORITY = setup_priority::HARDWARE - 1.0f;
+
 class FanState : public Nameable, public Component {
  public:
   FanState() = default;

--- a/esphome/components/fan/fan_state.h
+++ b/esphome/components/fan/fan_state.h
@@ -94,7 +94,6 @@ class FanState : public Nameable, public Component {
   FanStateCall make_call();
 
   void setup() override;
-  static float get_global_setup_priority();
   float get_setup_priority() const override;
 
  protected:

--- a/esphome/components/speed/fan/speed_fan.cpp
+++ b/esphome/components/speed/fan/speed_fan.cpp
@@ -57,9 +57,9 @@ void SpeedFan::loop() {
   }
 }
 
-// We need a higher priority than the FanState component to make sure that the traits are set 
+// We need a higher priority than the FanState component to make sure that the traits are set
 // when that component sets itself up.
-float SpeedFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
+float SpeedFan::get_setup_priority() const { return fan::FanState::get_global_setup_priority() + 1.0f; }
 
 }  // namespace speed
 }  // namespace esphome

--- a/esphome/components/speed/fan/speed_fan.cpp
+++ b/esphome/components/speed/fan/speed_fan.cpp
@@ -59,7 +59,7 @@ void SpeedFan::loop() {
 
 // We need a higher priority than the FanState component to make sure that the traits are set
 // when that component sets itself up.
-float SpeedFan::get_setup_priority() const { return fan::FanState::get_global_setup_priority() + 1.0f; }
+float SpeedFan::get_setup_priority() const { return fan_->get_setup_priority() + 1.0f; }
 
 }  // namespace speed
 }  // namespace esphome

--- a/esphome/components/speed/fan/speed_fan.cpp
+++ b/esphome/components/speed/fan/speed_fan.cpp
@@ -56,7 +56,9 @@ void SpeedFan::loop() {
     ESP_LOGD(TAG, "Setting reverse direction: %s", ONOFF(enable));
   }
 }
-float SpeedFan::get_setup_priority() const { return setup_priority::DATA; }
+
+// We need a higher priority than the FanState component to make sure that the traits are set when that component sets itself up.
+float SpeedFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
 
 }  // namespace speed
 }  // namespace esphome

--- a/esphome/components/speed/fan/speed_fan.cpp
+++ b/esphome/components/speed/fan/speed_fan.cpp
@@ -57,7 +57,8 @@ void SpeedFan::loop() {
   }
 }
 
-// We need a higher priority than the FanState component to make sure that the traits are set when that component sets itself up.
+// We need a higher priority than the FanState component to make sure that the traits are set 
+// when that component sets itself up.
 float SpeedFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
 
 }  // namespace speed

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -84,7 +84,8 @@ void TuyaFan::write_state() {
   }
 }
 
-// We need a higher priority than the FanState component to make sure that the traits are set when that component sets itself up.
+// We need a higher priority than the FanState component to make sure that the traits are set 
+// when that component sets itself up.
 float TuyaFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
 
 }  // namespace tuya

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -86,7 +86,7 @@ void TuyaFan::write_state() {
 
 // We need a higher priority than the FanState component to make sure that the traits are set
 // when that component sets itself up.
-float TuyaFan::::get_setup_priority() const { return fan_->get_setup_priority() + 1.0f; }
+float TuyaFan::get_setup_priority() const { return fan_->get_setup_priority() + 1.0f; }
 
 }  // namespace tuya
 }  // namespace esphome

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -84,5 +84,8 @@ void TuyaFan::write_state() {
   }
 }
 
+// We need a higher priority than the FanState component to make sure that the traits are set when that component sets itself up.
+float TuyaFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
+
 }  // namespace tuya
 }  // namespace esphome

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -84,9 +84,9 @@ void TuyaFan::write_state() {
   }
 }
 
-// We need a higher priority than the FanState component to make sure that the traits are set 
+// We need a higher priority than the FanState component to make sure that the traits are set
 // when that component sets itself up.
-float TuyaFan::get_setup_priority() const { return fan::FAN_STATE_SETUP_PRIORITY + 1.0f; }
+float TuyaFan::get_setup_priority() const { return fan::FanState::get_global_setup_priority() + 1.0f; }
 
 }  // namespace tuya
 }  // namespace esphome

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -86,7 +86,7 @@ void TuyaFan::write_state() {
 
 // We need a higher priority than the FanState component to make sure that the traits are set
 // when that component sets itself up.
-float TuyaFan::get_setup_priority() const { return fan::FanState::get_global_setup_priority() + 1.0f; }
+float TuyaFan::::get_setup_priority() const { return fan_->get_setup_priority() + 1.0f; }
 
 }  // namespace tuya
 }  // namespace esphome

--- a/esphome/components/tuya/fan/tuya_fan.h
+++ b/esphome/components/tuya/fan/tuya_fan.h
@@ -11,6 +11,7 @@ class TuyaFan : public Component {
  public:
   TuyaFan(Tuya *parent, fan::FanState *fan, int speed_count) : parent_(parent), fan_(fan), speed_count_(speed_count) {}
   void setup() override;
+  float get_setup_priority() const override;
   void dump_config() override;
   void set_speed_id(uint8_t speed_id) { this->speed_id_ = speed_id; }
   void set_switch_id(uint8_t switch_id) { this->switch_id_ = switch_id; }


### PR DESCRIPTION
# What does this implement/fix? 

This fixes the "Fan speed not restored from preference on boot esphome/issues#2097" issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes [Issue #2097](https://github.com/esphome/issues/issues/2097)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A
  
# Test Environment

- [x] ESP32
- [ ] ESP8266
- [ ] Windows
- [x] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: ledc
    pin: 19
    id: fan_speed

fan:
  - platform: speed
    name: "sz_fan"
    id: sz_fan
    output: fan_speed
```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
The root cause is the setup priority of the components based on FanState, which used to be DATA instead of HARDWARE, which is less than the priority of FanState itself (HARDWARE - 1). I have introduced a constant FAN_STATE_SETUP_PRIORITY on which all get_setup_priority() implementations are based now. So this issue cannot be reintroduced. I have also updated the priorities for binary fan and Tuya fan (but note that I have only tested the changes with speed fan!).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
