### PR TITLE
Allow stepper speed 0 (for estop)

### DIFF
--- a/esphome/components/a4988/a4988.cpp
+++ b/esphome/components/a4988/a4988.cpp
@@ -26,23 +26,23 @@ void A4988::dump_config() {
   LOG_STEPPER(this);
 }
 void A4988::loop() {
-  bool at_target = this->has_reached_target();
+  bool should_stop = this->max_speed_ == 0.0f || this->has_reached_target();
   if (this->sleep_pin_ != nullptr) {
-    bool sleep_rising_edge = !sleep_pin_state_ & !at_target;
-    this->sleep_pin_->digital_write(!at_target);
-    this->sleep_pin_state_ = !at_target;
+    bool sleep_rising_edge = !sleep_pin_state_ & !should_stop;
+    this->sleep_pin_->digital_write(!should_stop);
+    this->sleep_pin_state_ = !should_stop;
     if (sleep_rising_edge) {
       delayMicroseconds(1000);
     }
   }
-  if (at_target) {
+  if (should_stop) {
     this->high_freq_.stop();
   } else {
     this->high_freq_.start();
   }
 
   int32_t dir = this->should_step_();
-  if (dir == 0)
+  if (dir == 0 || this->max_speed_ == 0.0f)
     return;
 
   this->dir_pin_->digital_write(dir == 1);

--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -59,8 +59,8 @@ def validate_speed(value):
         # pylint: disable=raise-missing-from
         raise cv.Invalid(f"Expected speed as floating point number, got {value}")
 
-    if value <= 0:
-        raise cv.Invalid("Speed must be larger than 0 steps/s!")
+    if value < 0:
+        raise cv.Invalid("Speed must be larger than or equal to 0 steps/s!")
 
     return value
 

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -15,7 +15,7 @@ void ULN2003::setup() {
 }
 void ULN2003::loop() {
   int dir = this->should_step_();
-  if (dir == 0 && this->has_reached_target()) {
+  if (this->max_speed_ == 0.0f || (dir == 0 && this->has_reached_target())) {
     this->high_freq_.stop();
 
     if (this->sleep_when_done_) {


### PR DESCRIPTION
# What does this implement/fix? 

Allows for setting stepper speed to 0. This does not change the target or current position but allows for emergency stopping and stopping immediately when the motor should not move anymore. (i.e. do not close shade if window is open, or add an e-stop button, etc.).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [x] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

N/A

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
