### PR TITLE
waveshare_epaper: add support for ttgo t5 b74 variant display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -50,6 +50,7 @@ MODELS = {
     "2.13in-ttgo": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN),
     "2.13in-ttgo-b1": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B1),
     "2.13in-ttgo-b73": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B73),
+    "2.13in-ttgo-b74": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B74),
     "2.90in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN),
     "2.90inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN_V2),
     "2.70in": ("b", WaveshareEPaper2P7In),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -163,6 +163,18 @@ void WaveshareEPaper::on_safe_shutdown() { this->deep_sleep(); }
 // ========================================================
 
 void WaveshareEPaperTypeA::initialize() {
+  if (this->model_ == TTGO_EPAPER_2_13_IN_B74)
+  {
+     this->reset_pin_->digital_write(0);
+     delay(10);
+     this->reset_pin_->digital_write(1);
+     delay(10);
+     this->wait_until_idle_();
+
+     this->command(0x12); // SWRESET
+     this->wait_until_idle_();
+  }
+
   // COMMAND DRIVER OUTPUT CONTROL
   this->command(0x01);
   this->data(this->get_height_internal() - 1);
@@ -193,6 +205,7 @@ void WaveshareEPaperTypeA::initialize() {
     case TTGO_EPAPER_2_13_IN_B1:
       this->data(0x01);  // x increase, y decrease : as in demo code
       break;
+    case TTGO_EPAPER_2_13_IN_B74:
     case WAVESHARE_EPAPER_2_9_IN_V2:
       this->data(0x03);  // from top left to bottom right
       // RAM content option for Display Update
@@ -218,6 +231,9 @@ void WaveshareEPaperTypeA::dump_config() {
       break;
     case TTGO_EPAPER_2_13_IN_B73:
       ESP_LOGCONFIG(TAG, "  Model: 2.13in (TTGO B73)");
+      break;
+    case TTGO_EPAPER_2_13_IN_B74:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13in (TTGO B74)");
       break;
     case TTGO_EPAPER_2_13_IN_B1:
       ESP_LOGCONFIG(TAG, "  Model: 2.13in (TTGO B1)");
@@ -253,6 +269,9 @@ void HOT WaveshareEPaperTypeA::display() {
         case TTGO_EPAPER_2_13_IN_B73:
           this->write_lut_(full_update ? FULL_UPDATE_LUT_TTGO_B73 : PARTIAL_UPDATE_LUT_TTGO_B73, LUT_SIZE_TTGO_B73);
           break;
+        case TTGO_EPAPER_2_13_IN_B74:
+          // there is no LUT
+          break;
         case TTGO_EPAPER_2_13_IN_B1:
           this->write_lut_(full_update ? FULL_UPDATE_LUT_TTGO_B1 : PARTIAL_UPDATE_LUT_TTGO_B1, LUT_SIZE_TTGO_B1);
           break;
@@ -286,7 +305,12 @@ void HOT WaveshareEPaperTypeA::display() {
       this->data((this->get_height_internal() - 1) >> 8);
 
       break;
+    case TTGO_EPAPER_2_13_IN_B74:
+      //BorderWaveform
+      this->command(0x3C);
+      this->data(full_update ? 0x05 : 0x80);
 
+      // fall through
     default:
       // COMMAND SET RAM X ADDRESS START END POSITION
       this->command(0x44);
@@ -338,6 +362,9 @@ void HOT WaveshareEPaperTypeA::display() {
     this->data(full_update ? 0xF7 : 0xFF);
   } else if (this->model_ == TTGO_EPAPER_2_13_IN_B73) {
     this->data(0xC7);
+  } else if (this->model_ == TTGO_EPAPER_2_13_IN_B74) {
+    //this->data(0xC7);
+    this->data(full_update ? 0xF7 : 0xFF);
   } else {
     this->data(0xC4);
   }
@@ -358,6 +385,7 @@ int WaveshareEPaperTypeA::get_width_internal() {
     case TTGO_EPAPER_2_13_IN:
       return 128;
     case TTGO_EPAPER_2_13_IN_B73:
+    case TTGO_EPAPER_2_13_IN_B74:
       return 128;
     case TTGO_EPAPER_2_13_IN_B1:
       return 128;
@@ -377,6 +405,7 @@ int WaveshareEPaperTypeA::get_height_internal() {
     case TTGO_EPAPER_2_13_IN:
       return 250;
     case TTGO_EPAPER_2_13_IN_B73:
+    case TTGO_EPAPER_2_13_IN_B74:
       return 250;
     case TTGO_EPAPER_2_13_IN_B1:
       return 250;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -305,7 +305,7 @@ void HOT WaveshareEPaperTypeA::display() {
 
       break;
     case TTGO_EPAPER_2_13_IN_B74:
-      //BorderWaveform
+      // BorderWaveform
       this->command(0x3C);
       this->data(full_update ? 0x05 : 0x80);
 
@@ -362,7 +362,7 @@ void HOT WaveshareEPaperTypeA::display() {
   } else if (this->model_ == TTGO_EPAPER_2_13_IN_B73) {
     this->data(0xC7);
   } else if (this->model_ == TTGO_EPAPER_2_13_IN_B74) {
-    //this->data(0xC7);
+    // this->data(0xC7);
     this->data(full_update ? 0xF7 : 0xFF);
   } else {
     this->data(0xC4);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -163,16 +163,15 @@ void WaveshareEPaper::on_safe_shutdown() { this->deep_sleep(); }
 // ========================================================
 
 void WaveshareEPaperTypeA::initialize() {
-  if (this->model_ == TTGO_EPAPER_2_13_IN_B74)
-  {
-     this->reset_pin_->digital_write(false);
-     delay(10);
-     this->reset_pin_->digital_write(true);
-     delay(10);
-     this->wait_until_idle_();
+  if (this->model_ == TTGO_EPAPER_2_13_IN_B74) {
+    this->reset_pin_->digital_write(false);
+    delay(10);
+    this->reset_pin_->digital_write(true);
+    delay(10);
+    this->wait_until_idle_();
 
-     this->command(0x12); // SWRESET
-     this->wait_until_idle_();
+    this->command(0x12);  // SWRESET
+    this->wait_until_idle_();
   }
 
   // COMMAND DRIVER OUTPUT CONTROL

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -165,9 +165,9 @@ void WaveshareEPaper::on_safe_shutdown() { this->deep_sleep(); }
 void WaveshareEPaperTypeA::initialize() {
   if (this->model_ == TTGO_EPAPER_2_13_IN_B74)
   {
-     this->reset_pin_->digital_write(0);
+     this->reset_pin_->digital_write(false);
      delay(10);
-     this->reset_pin_->digital_write(1);
+     this->reset_pin_->digital_write(true);
      delay(10);
      this->wait_until_idle_();
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -72,6 +72,7 @@ enum WaveshareEPaperTypeAModel {
   TTGO_EPAPER_2_13_IN,
   TTGO_EPAPER_2_13_IN_B73,
   TTGO_EPAPER_2_13_IN_B1,
+  TTGO_EPAPER_2_13_IN_B74,
 };
 
 class WaveshareEPaperTypeA : public WaveshareEPaper {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3068843/121070324-db37f500-c7ce-11eb-93ae-6d767bdba6b4.png)

# What does this implement/fix? 

This patch adds support for ttgo t5 b74 variant 2.13" e-ink display.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1220
  
# Test Environment

- [X] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [X] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: ttgo-t5-display
  platform: ESP32
  board: featheresp32


wifi:
  ssid: "testnet"
  password: "password"

time:
  - platform: sntp
    id: ntp

font:
  - file: 'IBMPlexMono-Bold.ttf'
    id: din_big
    size: 50

spi:
  clk_pin: 18
  mosi_pin: 23
  # miso_pin unused

display:
  - platform: waveshare_epaper
    cs_pin: 5
    dc_pin: 17
    busy_pin: 4
    reset_pin: 16
    model: 2.13in-ttgo-b74
    update_interval: 1s
    full_update_every: 30
    rotation: 270
    lambda: |-
      it.strftime(125, 14, id(din_big), TextAlign::TOP_CENTER, "%H:%M:%S", id(ntp).now());


```

# Explain your changes


The GxGDEM0213B74 is similar to the b73 variant, although it
does not use a LUT waveform when doing full or partial updates,
and adds a command for the border waveform.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

