### PR TITLE
Fix parity bit calculation for ESP8266SoftwareSerial

### DIFF
--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -242,9 +242,9 @@ void ICACHE_RAM_ATTR HOT ESP8266SoftwareSerial::write_byte(uint8_t data) {
   bool parity_bit = false;
   bool need_parity_bit = true;
   if (this->parity_ == UART_CONFIG_PARITY_EVEN)
-    parity_bit = true;
-  else if (this->parity_ == UART_CONFIG_PARITY_ODD)
     parity_bit = false;
+  else if (this->parity_ == UART_CONFIG_PARITY_ODD)
+    parity_bit = true;
   else
     need_parity_bit = false;
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the parity bit computation for ESP8266SoftwareSerial. An even number of 1-bits should result in a 0 bit for even parity and 1 bit for odd parity.
https://en.wikipedia.org/wiki/Parity_bit

This could be a breaking change for any clients that are relying on the current broken behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1355
  
# Test Environment

- [ ] ESP32
- [x] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

The existing computation for the parity bit is backwards. A 0 data value, with no bits set, should result in a even parity bit of 0.

Current even parity calculation: true^0^0^0...=1
Correct even parity calculation: false^0^0^0...=0

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
