### PR TITLE
Update total_pulses_ at every detected pulse

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -68,18 +68,17 @@ void ICACHE_RAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
     return;
   }
 
-  // Ignore the first detected pulse (we need at least two pulses to measure the width)
-  if (sensor->last_detected_edge_us_ != 0) {
-    // Check to see if we should filter this edge out
-    if ((now - sensor->last_detected_edge_us_) >= sensor->filter_us_) {
+  // Check to see if we should filter this edge out
+  if ((now - sensor->last_detected_edge_us_) >= sensor->filter_us_) {
+    // Ignore the first detected pulse (we need at least two pulses to measure the width)
+    if (sensor->last_detected_edge_us_ != 0) {
       // Don't measure the first valid pulse (we need at least two pulses to measure the width)
       if (sensor->last_valid_edge_us_ != 0) {
         sensor->pulse_width_us_ = (now - sensor->last_valid_edge_us_);
       }
-
-      sensor->total_pulses_++;
       sensor->last_valid_edge_us_ = now;
     }
+    sensor->total_pulses_++;
   }
 
   sensor->last_detected_edge_us_ = now;

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -23,7 +23,6 @@ void PulseMeterSensor::loop() {
   const uint32_t time_since_valid_edge_us = now - this->last_valid_edge_us_;
   if ((this->last_valid_edge_us_ != 0) && (time_since_valid_edge_us > this->timeout_us_)) {
     ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min", time_since_valid_edge_us / 1000000);
-    this->last_detected_edge_us_ = 0;
     this->last_valid_edge_us_ = 0;
     this->pulse_width_us_ = 0;
   }
@@ -70,15 +69,13 @@ void ICACHE_RAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
 
   // Check to see if we should filter this edge out
   if ((now - sensor->last_detected_edge_us_) >= sensor->filter_us_) {
-    // Ignore the first detected pulse (we need at least two pulses to measure the width)
-    if (sensor->last_detected_edge_us_ != 0) {
-      // Don't measure the first valid pulse (we need at least two pulses to measure the width)
-      if (sensor->last_valid_edge_us_ != 0) {
-        sensor->pulse_width_us_ = (now - sensor->last_valid_edge_us_);
-      }
-      sensor->last_valid_edge_us_ = now;
+    // Don't measure the first valid pulse (we need at least two pulses to measure the width)
+    if (sensor->last_valid_edge_us_ != 0) {
+      sensor->pulse_width_us_ = (now - sensor->last_valid_edge_us_);
     }
+
     sensor->total_pulses_++;
+    sensor->last_valid_edge_us_ = now;
   }
 
   sensor->last_detected_edge_us_ = now;


### PR DESCRIPTION
# What does this implement/fix? 

Instead of ignoring the first detected pulse after a timeout we should count all pulses.



## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2107

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [X] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
- platform: pulse_meter
  pin:
    number: D4
    inverted: True
  id: sensor_pulse_meter
  name: "${long_devicename} Current Usage"
  icon: "mdi:water-pump"
  unit_of_measurement: "L/min"
  timeout: 60s
  internal_filter: 10ms
  accuracy_decimals: 1
  total:
    id: sensor_pulse_meter_total
    name: "${long_devicename} Total Consumption"
    icon: "mdi:cube-outline"
    unit_of_measurement: "m3"
    accuracy_decimals: 3
    filters:
      - multiply: 0.001
```

# Explain your changes

See description in https://github.com/esphome/issues/issues/2107

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
