### PR TITLE
Remove explain changes section from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,19 +7,16 @@ Quick description and explanation of changes
 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)
+- [ ] Other
 
 **Related issue or feature (if applicable):** fixes <link to issue>
 
 **Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
-  
-# Test Environment
+
+## Test Environment
 
 - [ ] ESP32
 - [ ] ESP8266
-- [ ] Windows
-- [ ] Mac OS
-- [ ] Linux
 
 ## Example entry for `config.yaml`:
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # What does this implement/fix? 
 
-Quick description 
+Quick description and explanation of changes
 
 ## Types of changes
 
@@ -33,11 +33,6 @@ Quick description
 # Example config.yaml
 
 ```
-
-# Explain your changes
-
-Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
-Very important to fill if no issue linked
 
 ## Checklist:
   - [ ] The code change is tested and works locally.


### PR DESCRIPTION
# What does this implement/fix? 

The `explain changes` section feels somewhat duplicate with the first one (or at least in practice). Alternatively we could also reword it a little bit to make the distinction between the top section and this one more clear (personally, I like having the main text on top, and the lower parts be dedicated to checklists etc; otherwise your eyes have to move around to find the section where the important stuff is)

Feedback appreciated @jesserockz 