### PR TITLE
Bump base image to 3.4.0

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up env variables
         run: |
-          base_version="3.3.0"
+          base_version="3.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up env variables
         run: |
-          base_version="3.1.0"
+          base_version="3.3.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     # cpp lint job runs with esphome-lint docker image so that clang-format-*
     # doesn't have to be installed
-    container: esphome/esphome-lint:1.0
+    container: esphome/esphome-lint:1.1
     steps:
       - uses: actions/checkout@v2
       # Set up the pio project so that the cpp checks know how files are compiled
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     # cpp lint job runs with esphome-lint docker image so that clang-format-*
     # doesn't have to be installed
-    container: esphome/esphome-lint:1.0
+    container: esphome/esphome-lint:1.1
     # Split clang-tidy check into 4 jobs. Each one will check 1/4th of the .cpp files
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-lint-build.yml
+++ b/.github/workflows/docker-lint-build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set TAG
         run: |
-          echo "TAG=1.0" >> $GITHUB_ENV
+          echo "TAG=1.1" >> $GITHUB_ENV
       - name: Pull for cache
         run: |
           docker pull "esphome/esphome-lint:latest" || true

--- a/.github/workflows/docker-lint-build.yml
+++ b/.github/workflows/docker-lint-build.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'docker/Dockerfile.lint'
       - 'requirements.txt'
+      - 'requirements_optional.txt'
       - 'requirements_test.txt'
       - 'platformio.ini'
       - '.github/workflows/docker-lint-build.yml'

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -175,7 +175,7 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Set up env variables
         run: |
-          base_version="3.1.0"
+          base_version="3.3.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     # cpp lint job runs with esphome-lint docker image so that clang-format-*
     # doesn't have to be installed
-    container: esphome/esphome-lint:1.0
+    container: esphome/esphome-lint:1.1
     steps:
       - uses: actions/checkout@v2
       # Set up the pio project so that the cpp checks know how files are compiled
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     # cpp lint job runs with esphome-lint docker image so that clang-format-*
     # doesn't have to be installed
-    container: esphome/esphome-lint:1.0
+    container: esphome/esphome-lint:1.1
     # Split clang-tidy check into 4 jobs. Each one will check 1/4th of the .cpp files
     strategy:
       fail-fast: false

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -175,7 +175,7 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Set up env variables
         run: |
-          base_version="3.3.0"
+          base_version="3.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Set up env variables
         run: |
-          base_version="3.3.0"
+          base_version="3.4.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     # cpp lint job runs with esphome-lint docker image so that clang-format-*
     # doesn't have to be installed
-    container: esphome/esphome-lint:1.0
+    container: esphome/esphome-lint:1.1
     steps:
       - uses: actions/checkout@v2
       # Set up the pio project so that the cpp checks know how files are compiled
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     # cpp lint job runs with esphome-lint docker image so that clang-format-*
     # doesn't have to be installed
-    container: esphome/esphome-lint:1.0
+    container: esphome/esphome-lint:1.1
     # Split clang-tidy check into 4 jobs. Each one will check 1/4th of the .cpp files
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Set up env variables
         run: |
-          base_version="3.1.0"
+          base_version="3.3.0"
 
           if [[ "${{ matrix.build_type }}" == "hassio" ]]; then
             build_from="esphome/esphome-hassio-base-${{ matrix.arch }}:${base_version}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:3.1.0
+ARG BUILD_FROM=esphome/esphome-base-amd64:3.3.0
 FROM ${BUILD_FROM}
 
 # First install requirements to leverage caching when requirements don't change
-COPY requirements.txt docker/platformio_install_deps.py platformio.ini /
+COPY requirements.txt requirements_optional.txt docker/platformio_install_deps.py platformio.ini /
 RUN \
-    pip3 install --no-cache-dir -r /requirements.txt \
+    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
     && /platformio_install_deps.py /platformio.ini
 
 # Then copy esphome and install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=esphome/esphome-base-amd64:3.3.0
+ARG BUILD_FROM=esphome/esphome-base-amd64:3.4.0
 FROM ${BUILD_FROM}
 
 # First install requirements to leverage caching when requirements don't change

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:3.1.0
+FROM esphome/esphome-base-amd64:3.3.0
 
 COPY . .
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM esphome/esphome-base-amd64:3.3.0
+FROM esphome/esphome-base-amd64:3.4.0
 
 COPY . .
 

--- a/docker/Dockerfile.hassio
+++ b/docker/Dockerfile.hassio
@@ -2,9 +2,9 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 # First install requirements to leverage caching when requirements don't change
-COPY requirements.txt docker/platformio_install_deps.py platformio.ini /
+COPY requirements.txt requirements_optional.txt docker/platformio_install_deps.py platformio.ini /
 RUN \
-    pip3 install --no-cache-dir -r /requirements.txt \
+    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
     && /platformio_install_deps.py /platformio.ini
 
 # Copy root filesystem

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM esphome/esphome-lint-base:3.3.0
+FROM esphome/esphome-lint-base:3.4.0
 
 COPY requirements.txt requirements_optional.txt requirements_test.txt docker/platformio_install_deps.py  platformio.ini /
 RUN \

--- a/docker/Dockerfile.lint
+++ b/docker/Dockerfile.lint
@@ -1,8 +1,8 @@
-FROM esphome/esphome-lint-base:3.1.0
+FROM esphome/esphome-lint-base:3.3.0
 
-COPY requirements.txt requirements_test.txt docker/platformio_install_deps.py  platformio.ini /
+COPY requirements.txt requirements_optional.txt requirements_test.txt docker/platformio_install_deps.py  platformio.ini /
 RUN \
-    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_test.txt \
+    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt -r /requirements_test.txt \
     && /platformio_install_deps.py /platformio.ini
 
 VOLUME ["/esphome"]

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,0 +1,2 @@
+pillow>4.0.0
+cryptography>=2.0.0,<4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,6 @@
 pylint==2.8.2
 flake8==3.9.2
 black==21.5b1
-pillow>4.0.0
-cryptography>=2.0.0,<4
 pexpect==4.8.0
 pre-commit
 

--- a/script/setup
+++ b/script/setup
@@ -4,7 +4,7 @@
 set -e
 
 cd "$(dirname "$0")/.."
-pip3 install -r requirements.txt -r requirements_test.txt
+pip3 install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
 pip3 install -e .
 
 pre-commit install


### PR DESCRIPTION
# What does this implement/fix? 

Bump the docker base image 3.3.0: https://github.com/esphome/esphome-docker-base/releases/tag/v3.3.0

Due to the removal of `python3-pil`, also creates `requirements_optional.txt` containing optional python dependencies to install:
- these are _not_ required for esphome install (especially for cryptography, installation is hard)
- but the docker images _do_ bundle these.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to keep working)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
  
# Test Environment

- [ ] ESP32
- [ ] ESP8266
- [ ] Windows
- [ ] Mac OS
- [ ] Linux

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

# Explain your changes

Describe your changes here to communicate to the maintainers **why we should accept this pull request**.
Very important to fill if no issue linked

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
