### PR TITLE
Fix Clang 11 finds

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,6 @@ Checks: >-
   -clang-analyzer-optin.*,
   -clang-analyzer-osx.*,
   -clang-analyzer-security.*,
-  -clang-diagnostic-fortify-source,
   -clang-diagnostic-shadow-field,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-goto,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,6 @@ Checks: >-
   -cert-oop57-cpp,
   -cert-str34-c,
   -clang-analyzer-core.CallAndMessage,
-  -clang-analyzer-deadcode.DeadStores,
   -clang-analyzer-optin.*,
   -clang-analyzer-osx.*,
   -clang-analyzer-security.*,

--- a/esphome/components/as3935_spi/as3935_spi.cpp
+++ b/esphome/components/as3935_spi/as3935_spi.cpp
@@ -33,7 +33,7 @@ void SPIAS3935Component::write_register(uint8_t reg, uint8_t mask, uint8_t bits,
 uint8_t SPIAS3935Component::read_register(uint8_t reg) {
   uint8_t value = 0;
   this->enable();
-  this->write_byte(reg |= SPI_READ_M);
+  this->write_byte(reg | SPI_READ_M);
   value = this->read_byte();
   // According to datsheet, the chip select must be written HIGH, LOW, HIGH
   // to correctly end the READ command.

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -67,7 +67,7 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
 
       data.length = raw[2];
       data.protocol = raw[3];
-      char next_byte[2];
+      char next_byte[3];
       for (uint8_t i = 0; i < data.length - 1; i++) {
         sprintf(next_byte, "%02X", raw[4 + i]);
         data.code += next_byte;
@@ -85,7 +85,7 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
 
       uint8_t buckets = raw[2] << 1;
       std::string str;
-      char next_byte[2];
+      char next_byte[3];
 
       for (uint32_t i = 0; i <= at; i++) {
         sprintf(next_byte, "%02X", raw[i]);


### PR DESCRIPTION
# What does this implement/fix? 

Some clang-tidy-11 checks are rather straight forward to address and make sense. This re-enables and fixes finds of two checks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
