### PR TITLE
BLE loop use

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -119,27 +119,28 @@ bool ESP32BLE::ble_setup_() {
   return true;
 }
 
-// void ESP32BLE::loop() {
-//   BLEEvent *ble_event = this->ble_events_.pop();
-//   while (ble_event != nullptr) {
-//     switch (ble_event->type_) {
-//       case ble_event->GATTS:
-//         this->real_gatts_event_handler_(ble_event->event_.gatts.gatts_event, ble_event->event_.gatts.gatts_if,
-//                                         &ble_event->event_.gatts.gatts_param);
-//         break;
-//       case ble_event->GAP:
-//         this->real_gap_event_handler_(ble_event->event_.gap.gap_event, &ble_event->event_.gap.gap_param);
-//         break;
-//       default:
-//         break;
-//     }
-//     delete ble_event;
-//     ble_event = this->ble_events_.pop();
-//   }
-// }
+void ESP32BLE::loop() {
+  BLEEvent *ble_event = this->ble_events_.pop();
+  while (ble_event != nullptr) {
+    switch (ble_event->type_) {
+      case ble_event->GATTS:
+        this->real_gatts_event_handler_(ble_event->event_.gatts.gatts_event, ble_event->event_.gatts.gatts_if,
+                                        &ble_event->event_.gatts.gatts_param);
+        break;
+      case ble_event->GAP:
+        this->real_gap_event_handler_(ble_event->event_.gap.gap_event, &ble_event->event_.gap.gap_param);
+        break;
+      default:
+        break;
+    }
+    delete ble_event;
+    ble_event = this->ble_events_.pop();
+  }
+}
 
 void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
-  global_ble->real_gap_event_handler_(event, param);
+  BLEEvent *new_event = new BLEEvent(event, param);
+  global_ble->ble_events_.push(new_event);
 }
 
 void ESP32BLE::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
@@ -152,7 +153,8 @@ void ESP32BLE::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap
 
 void ESP32BLE::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                    esp_ble_gatts_cb_param_t *param) {
-  global_ble->real_gatts_event_handler_(event, gatts_if, param);
+  BLEEvent *new_event = new BLEEvent(event, gatts_if, param);
+  global_ble->ble_events_.push(new_event);
 }
 
 void ESP32BLE::real_gatts_event_handler_(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -27,12 +27,9 @@ class ESP32BLE : public Component {
   void dump_config() override;
   float get_setup_priority() const override;
   void mark_failed() override;
-  bool can_proceed() override;
 
   bool has_server() { return this->server_ != nullptr; }
   bool has_client() { return false; }
-
-  bool is_ready() { return this->ready_; }
 
   void set_server(BLEServer *server) { this->server_ = server; }
 
@@ -45,10 +42,7 @@ class ESP32BLE : public Component {
   void real_gattc_event_handler_(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
   void real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
-  static void ble_core_task_(void *params);
-  static bool ble_setup_();
-
-  bool ready_{false};
+  bool ble_setup_();
 
   BLEServer *server_{nullptr};
   Queue<BLEEvent> ble_events_;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -23,7 +23,7 @@ typedef struct {
 class ESP32BLE : public Component {
  public:
   void setup() override;
-  // void loop() override;
+  void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
   void mark_failed() override;

--- a/esphome/components/esp32_ble/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble/ble_characteristic.cpp
@@ -13,10 +13,8 @@ static const char *TAG = "esp32_ble.characteristic";
 
 BLECharacteristic::BLECharacteristic(const ESPBTUUID uuid, uint32_t properties) : uuid_(uuid) {
   this->set_value_lock_ = xSemaphoreCreateBinary();
-  this->create_lock_ = xSemaphoreCreateBinary();
-
   xSemaphoreGive(this->set_value_lock_);
-  xSemaphoreGive(this->create_lock_);
+
   this->properties_ = (esp_gatt_char_prop_t) 0;
 
   this->set_broadcast_property((properties & PROPERTY_BROADCAST) != 0);
@@ -100,12 +98,11 @@ void BLECharacteristic::notify(bool notification) {
 
 void BLECharacteristic::add_descriptor(BLEDescriptor *descriptor) { this->descriptors_.push_back(descriptor); }
 
-bool BLECharacteristic::do_create(BLEService *service) {
+void BLECharacteristic::do_create(BLEService *service) {
   this->service_ = service;
   esp_attr_control_t control;
   control.auto_rsp = ESP_GATT_RSP_BY_APP;
 
-  xSemaphoreTake(this->create_lock_, portMAX_DELAY);
   ESP_LOGV(TAG, "Creating characteristic - %s", this->uuid_.to_string().c_str());
 
   esp_bt_uuid_t uuid = this->uuid_.get_uuid();
@@ -114,15 +111,39 @@ bool BLECharacteristic::do_create(BLEService *service) {
 
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "esp_ble_gatts_add_char failed: %d", err);
+    return;
+  }
+
+  this->state_ = CREATING;
+}
+
+bool BLECharacteristic::is_created() {
+  if (this->state_ == CREATED)
+    return true;
+
+  if (this->state_ != CREATING_DEPENDENTS)
     return false;
-  }
 
-  xSemaphoreWait(this->create_lock_, portMAX_DELAY);
-
+  bool created = true;
   for (auto *descriptor : this->descriptors_) {
-    descriptor->do_create(this);
+    created &= descriptor->is_created();
   }
-  return true;
+  if (created)
+    this->state_ = CREATED;
+  return this->state_ == CREATED;
+}
+
+bool BLECharacteristic::is_failed() {
+  if (this->state_ == FAILED)
+    return true;
+
+  bool failed = false;
+  for (auto *descriptor : this->descriptors_) {
+    failed |= descriptor->is_failed();
+  }
+  if (failed)
+    this->state_ = FAILED;
+  return this->state_ == FAILED;
 }
 
 void BLECharacteristic::set_broadcast_property(bool value) {
@@ -168,7 +189,12 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
     case ESP_GATTS_ADD_CHAR_EVT: {
       if (this->uuid_ == ESPBTUUID::from_uuid(param->add_char.char_uuid)) {
         this->handle_ = param->add_char.attr_handle;
-        xSemaphoreGive(this->create_lock_);
+
+        for (auto *descriptor : this->descriptors_) {
+          descriptor->do_create(this);
+        }
+
+        this->state_ = CREATING_DEPENDENTS;
       }
       break;
     }

--- a/esphome/components/esp32_ble/ble_characteristic.h
+++ b/esphome/components/esp32_ble/ble_characteristic.h
@@ -42,10 +42,10 @@ class BLECharacteristic {
 
   void notify(bool notification = true);
 
-  bool do_create(BLEService *service);
+  void do_create(BLEService *service);
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
 
-  void on_write(const std::function<void(const std::vector<uint8_t> &)> &func) { this->on_write_ = func; }
+  void on_write(const std::function<void(const std::vector<uint8_t> &)> &&func) { this->on_write_ = std::move(func); }
 
   void add_descriptor(BLEDescriptor *descriptor);
 
@@ -60,6 +60,9 @@ class BLECharacteristic {
   static const uint32_t PROPERTY_INDICATE = 1 << 4;
   static const uint32_t PROPERTY_WRITE_NR = 1 << 5;
 
+  bool is_created();
+  bool is_failed();
+
  protected:
   bool write_event_{false};
   BLEService *service_;
@@ -70,13 +73,20 @@ class BLECharacteristic {
   uint16_t value_read_offset_{0};
   std::vector<uint8_t> value_;
   SemaphoreHandle_t set_value_lock_;
-  SemaphoreHandle_t create_lock_;
 
   std::vector<BLEDescriptor *> descriptors_;
 
   std::function<void(const std::vector<uint8_t> &)> on_write_;
 
   esp_gatt_perm_t permissions_ = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
+
+  enum State : uint8_t {
+    FAILED = 0x00,
+    INIT,
+    CREATING,
+    CREATING_DEPENDENTS,
+    CREATED,
+  } state_{INIT};
 };
 
 }  // namespace esp32_ble

--- a/esphome/components/esp32_ble/ble_descriptor.h
+++ b/esphome/components/esp32_ble/ble_descriptor.h
@@ -16,22 +16,31 @@ class BLEDescriptor {
  public:
   BLEDescriptor(ESPBTUUID uuid, uint16_t max_len = 100);
   virtual ~BLEDescriptor();
-  bool do_create(BLECharacteristic *characteristic);
+  void do_create(BLECharacteristic *characteristic);
 
   void set_value(const std::string &value);
   void set_value(const uint8_t *data, size_t length);
 
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
 
+  bool is_created() { return this->state_ == CREATED; }
+  bool is_failed() { return this->state_ == FAILED; }
+
  protected:
   BLECharacteristic *characteristic_{nullptr};
   ESPBTUUID uuid_;
   uint16_t handle_{0xFFFF};
-  SemaphoreHandle_t create_lock_;
 
   esp_attr_value_t value_;
 
   esp_gatt_perm_t permissions_ = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
+
+  enum State : uint8_t {
+    FAILED = 0x00,
+    INIT,
+    CREATING,
+    CREATED,
+  } state_{INIT};
 };
 
 }  // namespace esp32_ble

--- a/esphome/components/esp32_ble/ble_server.cpp
+++ b/esphome/components/esp32_ble/ble_server.cpp
@@ -79,6 +79,7 @@ void BLEServer::loop() {
     case SETTING_UP_COMPONENT_SERVICES: {
       this->state_ = RUNNING;
       this->can_proceed_ = true;
+      ESP_LOGD(TAG, "BLE server setup successfully");
       break;
     }
   }

--- a/esphome/components/esp32_ble/ble_service.h
+++ b/esphome/components/esp32_ble/ble_service.h
@@ -33,26 +33,44 @@ class BLEService {
 
   BLEServer *get_server() { return this->server_; }
 
-  bool do_create(BLEServer *server);
+  void do_create(BLEServer *server);
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
 
   void start();
   void stop();
 
- protected:
-  bool errored_{false};
+  bool is_created();
+  bool is_failed();
 
+  bool is_running() { return this->running_state_ == RUNNING; }
+  bool is_starting() { return this->running_state_ == STARTING; }
+
+ protected:
   std::vector<BLECharacteristic *> characteristics_;
   BLECharacteristic *last_created_characteristic_{nullptr};
+  uint32_t created_characteristic_count_{0};
   BLEServer *server_;
   ESPBTUUID uuid_;
   uint16_t num_handles_;
   uint16_t handle_{0xFFFF};
   uint8_t inst_id_;
 
-  SemaphoreHandle_t create_lock_;
-  SemaphoreHandle_t start_lock_;
-  SemaphoreHandle_t stop_lock_;
+  bool do_create_characteristics_();
+
+  enum InitState : uint8_t {
+    FAILED = 0x00,
+    INIT,
+    CREATING,
+    CREATING_DEPENDENTS,
+    CREATED,
+  } init_state_{INIT};
+
+  enum RunningState : uint8_t {
+    STARTING,
+    RUNNING,
+    STOPPING,
+    STOPPED,
+  } running_state_{STOPPED};
 };
 
 }  // namespace esp32_ble

--- a/esphome/components/esp32_ble/queue.h
+++ b/esphome/components/esp32_ble/queue.h
@@ -68,9 +68,18 @@ class BLEEvent {
     this->event_.gattc.gattc_if = i;
     memcpy(&this->event_.gattc.gattc_param, p, sizeof(esp_ble_gattc_cb_param_t));
     // Need to also make a copy of notify event data.
-    if (e == ESP_GATTC_NOTIFY_EVT) {
-      memcpy(this->event_.gattc.notify_data, p->notify.value, p->notify.value_len);
-      this->event_.gattc.gattc_param.notify.value = this->event_.gattc.notify_data;
+    switch (e) {
+      case ESP_GATTC_NOTIFY_EVT:
+        memcpy(this->event_.gattc.data, p->notify.value, p->notify.value_len);
+        this->event_.gattc.gattc_param.notify.value = this->event_.gattc.data;
+        break;
+      case ESP_GATTC_READ_CHAR_EVT:
+      case ESP_GATTC_READ_DESCR_EVT:
+        memcpy(this->event_.gattc.data, p->read.value, p->read.value_len);
+        this->event_.gattc.gattc_param.read.value = this->event_.gattc.data;
+        break;
+      default:
+        break;
     }
     this->type_ = GATTC;
   };
@@ -92,7 +101,7 @@ class BLEEvent {
       esp_gattc_cb_event_t gattc_event;
       esp_gatt_if_t gattc_if;
       esp_ble_gattc_cb_param_t gattc_param;
-      uint8_t notify_data[64];
+      uint8_t data[64];
     } gattc;
 
     struct gatts_event {

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -21,11 +21,12 @@ class ESP32ImprovComponent : public Component, public esp32_ble::BLEServiceCompo
   void dump_config() override;
   void loop() override;
   void setup_service() override;
+  void setup_characteristics();
   void on_client_disconnect() override;
 
   float get_setup_priority() const override;
-  void start();
-  void end();
+  void start() override;
+  void stop() override;
   bool is_active() const { return this->state_ != improv::STATE_STOPPED; }
 
   void set_authorizer(binary_sensor::BinarySensor *authorizer) { this->authorizer_ = authorizer; }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -508,7 +508,7 @@ void WiFiComponent::check_connecting_finished() {
     }
 #ifdef USE_IMPROV
     if (this->is_esp32_improv_active_()) {
-      esp32_improv::global_improv_component->end();
+      esp32_improv::global_improv_component->stop();
     }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix? 

Replace the use of semaphores and blocking in ble setup with state machines so that the loop continues normally.

Also moves the ble events to use a queue and they get processed on the main loop.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
