### PR TITLE
Don't send Tuya commands while currently receiving a message

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -333,7 +333,7 @@ void Tuya::send_raw_command_(TuyaCommand command) {
 void Tuya::process_command_queue_() {
   uint32_t delay = millis() - this->last_command_timestamp_;
   // Left check of delay since last command in case theres ever a command sent by calling send_raw_command_ directly
-  if (delay > COMMAND_DELAY && !command_queue_.empty()) {
+  if (delay > COMMAND_DELAY && !this->command_queue_.empty() && this->rx_message_.empty()) {
     this->send_raw_command_(command_queue_.front());
     this->command_queue_.erase(command_queue_.begin());
   }


### PR DESCRIPTION
# What does this implement/fix? 

This simply adds a check to the command queue processing to prevent sending a command to the MCU while currently receiving a message from the MCU.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

fixes esphome/issues#1776

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.

