### PR TITLE
Configure clang-format for consistent pointer alignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,7 +49,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true

--- a/esphome/components/addressable_light/addressable_light_display.cpp
+++ b/esphome/components/addressable_light/addressable_light_display.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace addressable_light {
 
-static const char* TAG = "addressable_light.display";
+static const char *TAG = "addressable_light.display";
 
 int AddressableLightDisplay::get_width_internal() { return this->width_; }
 int AddressableLightDisplay::get_height_internal() { return this->height_; }
@@ -24,7 +24,7 @@ void AddressableLightDisplay::update() {
 void AddressableLightDisplay::display() {
   bool dirty = false;
   uint8_t old_r, old_g, old_b, old_w;
-  Color* c;
+  Color *c;
 
   for (uint32_t offset = 0; offset < this->addressable_light_buffer_.size(); offset++) {
     c = &(this->addressable_light_buffer_[offset]);

--- a/esphome/components/b_parasite/b_parasite.cpp
+++ b/esphome/components/b_parasite/b_parasite.cpp
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace b_parasite {
 
-static const char* TAG = "b_parasite";
+static const char *TAG = "b_parasite";
 
 void BParasite::dump_config() {
   ESP_LOGCONFIG(TAG, "b_parasite");
@@ -16,25 +16,25 @@ void BParasite::dump_config() {
   LOG_SENSOR("  ", "Soil Moisture", this->soil_moisture_);
 }
 
-bool BParasite::parse_device(const esp32_ble_tracker::ESPBTDevice& device) {
+bool BParasite::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   if (device.address_uint64() != address_) {
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
   }
   ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str().c_str());
-  const auto& service_datas = device.get_service_datas();
+  const auto &service_datas = device.get_service_datas();
   if (service_datas.size() != 1) {
     ESP_LOGE(TAG, "Unexpected service_datas size (%d)", service_datas.size());
     return false;
   }
-  const auto& service_data = service_datas[0];
+  const auto &service_data = service_datas[0];
 
   ESP_LOGVV(TAG, "Service data:");
   for (const uint8_t byte : service_data.data) {
     ESP_LOGVV(TAG, "0x%02x", byte);
   }
 
-  const auto& data = service_data.data;
+  const auto &data = service_data.data;
 
   // Counter for deduplicating messages.
   uint8_t counter = data[1] & 0x0f;

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace dfplayer {
 
-static const char* TAG = "dfplayer";
+static const char *TAG = "dfplayer";
 
 void DFPlayer::play_folder(uint16_t folder, uint16_t file) {
   if (folder < 100 && file < 256) {

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace fingerprint_grow {
 
-static const char* TAG = "fingerprint_grow";
+static const char *TAG = "fingerprint_grow";
 
 // Based on Adafruit's library: https://github.com/adafruit/Adafruit-Fingerprint-Sensor-Library
 

--- a/esphome/components/fujitsu_general/fujitsu_general.cpp
+++ b/esphome/components/fujitsu_general/fujitsu_general.cpp
@@ -8,7 +8,7 @@ namespace fujitsu_general {
 #define SET_NIBBLE(message, nibble, value) (message[nibble / 2] |= (value & 0b00001111) << ((nibble % 2) ? 0 : 4))
 #define GET_NIBBLE(message, nibble) ((message[nibble / 2] >> ((nibble % 2) ? 0 : 4)) & 0b00001111)
 
-static const char* TAG = "fujitsu_general.climate";
+static const char *TAG = "fujitsu_general.climate";
 
 // Common header
 const uint8_t FUJITSU_GENERAL_COMMON_LENGTH = 6;
@@ -202,7 +202,7 @@ void FujitsuGeneralClimate::transmit_off_() {
   this->power_ = false;
 }
 
-void FujitsuGeneralClimate::transmit_(uint8_t const* message, uint8_t length) {
+void FujitsuGeneralClimate::transmit_(uint8_t const *message, uint8_t length) {
   ESP_LOGV(TAG, "Transmit message length %d", length);
 
   auto transmit = this->transmitter_->transmit();
@@ -231,7 +231,7 @@ void FujitsuGeneralClimate::transmit_(uint8_t const* message, uint8_t length) {
   transmit.perform();
 }
 
-uint8_t FujitsuGeneralClimate::checksum_state_(uint8_t const* message) {
+uint8_t FujitsuGeneralClimate::checksum_state_(uint8_t const *message) {
   uint8_t checksum = 0;
   for (uint8_t i = 7; i < FUJITSU_GENERAL_STATE_MESSAGE_LENGTH - 1; ++i) {
     checksum += message[i];
@@ -239,7 +239,7 @@ uint8_t FujitsuGeneralClimate::checksum_state_(uint8_t const* message) {
   return 256 - checksum;
 }
 
-uint8_t FujitsuGeneralClimate::checksum_util_(uint8_t const* message) { return 255 - message[5]; }
+uint8_t FujitsuGeneralClimate::checksum_util_(uint8_t const *message) { return 255 - message[5]; }
 
 bool FujitsuGeneralClimate::on_receive(remote_base::RemoteReceiveData data) {
   ESP_LOGV(TAG, "Received IR message");

--- a/esphome/components/fujitsu_general/fujitsu_general.h
+++ b/esphome/components/fujitsu_general/fujitsu_general.h
@@ -66,13 +66,13 @@ class FujitsuGeneralClimate : public climate_ir::ClimateIR {
   bool on_receive(remote_base::RemoteReceiveData data) override;
 
   /// Transmit message as IR pulses
-  void transmit_(uint8_t const* message, uint8_t length);
+  void transmit_(uint8_t const *message, uint8_t length);
 
   /// Calculate checksum for a state message
-  uint8_t checksum_state_(uint8_t const* message);
+  uint8_t checksum_state_(uint8_t const *message);
 
   /// Calculate cecksum for a util message
-  uint8_t checksum_util_(uint8_t const* message);
+  uint8_t checksum_util_(uint8_t const *message);
 
   // true if currently on - fujitsus transmit an on flag on when the remote moves from off to on
   bool power_{false};

--- a/esphome/components/max31855/max31855.cpp
+++ b/esphome/components/max31855/max31855.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace max31855 {
 
-static const char* TAG = "max31855";
+static const char *TAG = "max31855";
 
 void MAX31855Sensor::update() {
   this->enable();

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace max31865 {
 
-static const char* TAG = "max31865";
+static const char *TAG = "max31865";
 
 void MAX31865Sensor::update() {
   // Check new faults since last measurement
@@ -176,7 +176,7 @@ const uint16_t MAX31865Sensor::read_register_16_(uint8_t reg) {
   return value;
 }
 
-float MAX31865Sensor::calc_temperature_(const float& rtd_ratio) {
+float MAX31865Sensor::calc_temperature_(const float &rtd_ratio) {
   // Based loosely on Adafruit's library: https://github.com/adafruit/Adafruit_MAX31865
   // Mainly based on formulas provided by Analog:
   // http://www.analog.com/media/en/technical-documentation/application-notes/AN709_0.pdf

--- a/esphome/components/max31865/max31865.h
+++ b/esphome/components/max31865/max31865.h
@@ -51,7 +51,7 @@ class MAX31865Sensor : public sensor::Sensor,
   void write_register_(uint8_t reg, uint8_t value);
   const uint8_t read_register_(uint8_t reg);
   const uint16_t read_register_16_(uint8_t reg);
-  float calc_temperature_(const float& rtd_ratio);
+  float calc_temperature_(const float &rtd_ratio);
 };
 
 }  // namespace max31865

--- a/esphome/components/nfc/ndef_record.cpp
+++ b/esphome/components/nfc/ndef_record.cpp
@@ -3,7 +3,7 @@
 namespace esphome {
 namespace nfc {
 
-static const char* TAG = "nfc.ndef_record";
+static const char *TAG = "nfc.ndef_record";
 
 uint32_t NdefRecord::get_encoded_size() {
   uint32_t size = 2;

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace rtttl {
 
-static const char* TAG = "rtttl";
+static const char *TAG = "rtttl";
 
 static const uint32_t DOUBLE_NOTE_GAP_MS = 10;
 

--- a/esphome/components/sgp40/sensirion_voc_algorithm.cpp
+++ b/esphome/components/sgp40/sensirion_voc_algorithm.cpp
@@ -224,7 +224,7 @@ static fix16_t fix16_exp(fix16_t in_value) {
   static const uint8_t NUM_EXP_VALUES = 4;
   static const fix16_t EXP_POS_VALUES[4] = {F16(2.7182818), F16(1.1331485), F16(1.0157477), F16(1.0019550)};
   static const fix16_t EXP_NEG_VALUES[4] = {F16(0.3678794), F16(0.8824969), F16(0.9844964), F16(0.9980488)};
-  const fix16_t* exp_values;
+  const fix16_t *exp_values;
 
   fix16_t res, arg;
   uint16_t i;
@@ -253,35 +253,35 @@ static fix16_t fix16_exp(fix16_t in_value) {
   return res;
 }
 
-static void voc_algorithm_init_instances(VocAlgorithmParams* params);
-static void voc_algorithm_mean_variance_estimator_init(VocAlgorithmParams* params);
-static void voc_algorithm_mean_variance_estimator_init_instances(VocAlgorithmParams* params);
-static void voc_algorithm_mean_variance_estimator_set_parameters(VocAlgorithmParams* params, fix16_t std_initial,
+static void voc_algorithm_init_instances(VocAlgorithmParams *params);
+static void voc_algorithm_mean_variance_estimator_init(VocAlgorithmParams *params);
+static void voc_algorithm_mean_variance_estimator_init_instances(VocAlgorithmParams *params);
+static void voc_algorithm_mean_variance_estimator_set_parameters(VocAlgorithmParams *params, fix16_t std_initial,
                                                                  fix16_t tau_mean_variance_hours,
                                                                  fix16_t gating_max_duration_minutes);
-static void voc_algorithm_mean_variance_estimator_set_states(VocAlgorithmParams* params, fix16_t mean, fix16_t std,
+static void voc_algorithm_mean_variance_estimator_set_states(VocAlgorithmParams *params, fix16_t mean, fix16_t std,
                                                              fix16_t uptime_gamma);
-static fix16_t voc_algorithm_mean_variance_estimator_get_std(VocAlgorithmParams* params);
-static fix16_t voc_algorithm_mean_variance_estimator_get_mean(VocAlgorithmParams* params);
-static void voc_algorithm_mean_variance_estimator_calculate_gamma(VocAlgorithmParams* params,
+static fix16_t voc_algorithm_mean_variance_estimator_get_std(VocAlgorithmParams *params);
+static fix16_t voc_algorithm_mean_variance_estimator_get_mean(VocAlgorithmParams *params);
+static void voc_algorithm_mean_variance_estimator_calculate_gamma(VocAlgorithmParams *params,
                                                                   fix16_t voc_index_from_prior);
-static void voc_algorithm_mean_variance_estimator_process(VocAlgorithmParams* params, fix16_t sraw,
+static void voc_algorithm_mean_variance_estimator_process(VocAlgorithmParams *params, fix16_t sraw,
                                                           fix16_t voc_index_from_prior);
-static void voc_algorithm_mean_variance_estimator_sigmoid_init(VocAlgorithmParams* params);
-static void voc_algorithm_mean_variance_estimator_sigmoid_set_parameters(VocAlgorithmParams* params, fix16_t l,
+static void voc_algorithm_mean_variance_estimator_sigmoid_init(VocAlgorithmParams *params);
+static void voc_algorithm_mean_variance_estimator_sigmoid_set_parameters(VocAlgorithmParams *params, fix16_t l,
                                                                          fix16_t x0, fix16_t k);
-static fix16_t voc_algorithm_mean_variance_estimator_sigmoid_process(VocAlgorithmParams* params, fix16_t sample);
-static void voc_algorithm_mox_model_init(VocAlgorithmParams* params);
-static void voc_algorithm_mox_model_set_parameters(VocAlgorithmParams* params, fix16_t sraw_std, fix16_t sraw_mean);
-static fix16_t voc_algorithm_mox_model_process(VocAlgorithmParams* params, fix16_t sraw);
-static void voc_algorithm_sigmoid_scaled_init(VocAlgorithmParams* params);
-static void voc_algorithm_sigmoid_scaled_set_parameters(VocAlgorithmParams* params, fix16_t offset);
-static fix16_t voc_algorithm_sigmoid_scaled_process(VocAlgorithmParams* params, fix16_t sample);
-static void voc_algorithm_adaptive_lowpass_init(VocAlgorithmParams* params);
-static void voc_algorithm_adaptive_lowpass_set_parameters(VocAlgorithmParams* params);
-static fix16_t voc_algorithm_adaptive_lowpass_process(VocAlgorithmParams* params, fix16_t sample);
+static fix16_t voc_algorithm_mean_variance_estimator_sigmoid_process(VocAlgorithmParams *params, fix16_t sample);
+static void voc_algorithm_mox_model_init(VocAlgorithmParams *params);
+static void voc_algorithm_mox_model_set_parameters(VocAlgorithmParams *params, fix16_t sraw_std, fix16_t sraw_mean);
+static fix16_t voc_algorithm_mox_model_process(VocAlgorithmParams *params, fix16_t sraw);
+static void voc_algorithm_sigmoid_scaled_init(VocAlgorithmParams *params);
+static void voc_algorithm_sigmoid_scaled_set_parameters(VocAlgorithmParams *params, fix16_t offset);
+static fix16_t voc_algorithm_sigmoid_scaled_process(VocAlgorithmParams *params, fix16_t sample);
+static void voc_algorithm_adaptive_lowpass_init(VocAlgorithmParams *params);
+static void voc_algorithm_adaptive_lowpass_set_parameters(VocAlgorithmParams *params);
+static fix16_t voc_algorithm_adaptive_lowpass_process(VocAlgorithmParams *params, fix16_t sample);
 
-void voc_algorithm_init(VocAlgorithmParams* params) {
+void voc_algorithm_init(VocAlgorithmParams *params) {
   params->mVoc_Index_Offset = F16(VOC_ALGORITHM_VOC_INDEX_OFFSET_DEFAULT);
   params->mTau_Mean_Variance_Hours = F16(VOC_ALGORITHM_TAU_MEAN_VARIANCE_HOURS);
   params->mGating_Max_Duration_Minutes = F16(VOC_ALGORITHM_GATING_MAX_DURATION_MINUTES);
@@ -292,7 +292,7 @@ void voc_algorithm_init(VocAlgorithmParams* params) {
   voc_algorithm_init_instances(params);
 }
 
-static void voc_algorithm_init_instances(VocAlgorithmParams* params) {
+static void voc_algorithm_init_instances(VocAlgorithmParams *params) {
   voc_algorithm_mean_variance_estimator_init(params);
   voc_algorithm_mean_variance_estimator_set_parameters(
       params, params->mSraw_Std_Initial, params->mTau_Mean_Variance_Hours, params->mGating_Max_Duration_Minutes);
@@ -305,17 +305,17 @@ static void voc_algorithm_init_instances(VocAlgorithmParams* params) {
   voc_algorithm_adaptive_lowpass_set_parameters(params);
 }
 
-void voc_algorithm_get_states(VocAlgorithmParams* params, int32_t* state0, int32_t* state1) {
+void voc_algorithm_get_states(VocAlgorithmParams *params, int32_t *state0, int32_t *state1) {
   *state0 = voc_algorithm_mean_variance_estimator_get_mean(params);
   *state1 = voc_algorithm_mean_variance_estimator_get_std(params);
 }
 
-void voc_algorithm_set_states(VocAlgorithmParams* params, int32_t state0, int32_t state1) {
+void voc_algorithm_set_states(VocAlgorithmParams *params, int32_t state0, int32_t state1) {
   voc_algorithm_mean_variance_estimator_set_states(params, state0, state1, F16(VOC_ALGORITHM_PERSISTENCE_UPTIME_GAMMA));
   params->mSraw = state0;
 }
 
-void voc_algorithm_set_tuning_parameters(VocAlgorithmParams* params, int32_t voc_index_offset,
+void voc_algorithm_set_tuning_parameters(VocAlgorithmParams *params, int32_t voc_index_offset,
                                          int32_t learning_time_hours, int32_t gating_max_duration_minutes,
                                          int32_t std_initial) {
   params->mVoc_Index_Offset = (fix16_from_int(voc_index_offset));
@@ -325,7 +325,7 @@ void voc_algorithm_set_tuning_parameters(VocAlgorithmParams* params, int32_t voc
   voc_algorithm_init_instances(params);
 }
 
-void voc_algorithm_process(VocAlgorithmParams* params, int32_t sraw, int32_t* voc_index) {
+void voc_algorithm_process(VocAlgorithmParams *params, int32_t sraw, int32_t *voc_index) {
   if ((params->mUptime <= F16(VOC_ALGORITHM_INITIAL_BLACKOUT))) {
     params->mUptime = (params->mUptime + F16(VOC_ALGORITHM_SAMPLING_INTERVAL));
   } else {
@@ -352,16 +352,16 @@ void voc_algorithm_process(VocAlgorithmParams* params, int32_t sraw, int32_t* vo
   *voc_index = (fix16_cast_to_int((params->mVoc_Index + F16(0.5))));
 }
 
-static void voc_algorithm_mean_variance_estimator_init(VocAlgorithmParams* params) {
+static void voc_algorithm_mean_variance_estimator_init(VocAlgorithmParams *params) {
   voc_algorithm_mean_variance_estimator_set_parameters(params, F16(0.), F16(0.), F16(0.));
   voc_algorithm_mean_variance_estimator_init_instances(params);
 }
 
-static void voc_algorithm_mean_variance_estimator_init_instances(VocAlgorithmParams* params) {
+static void voc_algorithm_mean_variance_estimator_init_instances(VocAlgorithmParams *params) {
   voc_algorithm_mean_variance_estimator_sigmoid_init(params);
 }
 
-static void voc_algorithm_mean_variance_estimator_set_parameters(VocAlgorithmParams* params, fix16_t std_initial,
+static void voc_algorithm_mean_variance_estimator_set_parameters(VocAlgorithmParams *params, fix16_t std_initial,
                                                                  fix16_t tau_mean_variance_hours,
                                                                  fix16_t gating_max_duration_minutes) {
   params->m_Mean_Variance_Estimator__Gating_Max_Duration_Minutes = gating_max_duration_minutes;
@@ -385,7 +385,7 @@ static void voc_algorithm_mean_variance_estimator_set_parameters(VocAlgorithmPar
   params->m_Mean_Variance_Estimator___Gating_Duration_Minutes = F16(0.);
 }
 
-static void voc_algorithm_mean_variance_estimator_set_states(VocAlgorithmParams* params, fix16_t mean, fix16_t std,
+static void voc_algorithm_mean_variance_estimator_set_states(VocAlgorithmParams *params, fix16_t mean, fix16_t std,
                                                              fix16_t uptime_gamma) {
   params->m_Mean_Variance_Estimator___Mean = mean;
   params->m_Mean_Variance_Estimator___Std = std;
@@ -393,15 +393,15 @@ static void voc_algorithm_mean_variance_estimator_set_states(VocAlgorithmParams*
   params->m_Mean_Variance_Estimator___Initialized = true;
 }
 
-static fix16_t voc_algorithm_mean_variance_estimator_get_std(VocAlgorithmParams* params) {
+static fix16_t voc_algorithm_mean_variance_estimator_get_std(VocAlgorithmParams *params) {
   return params->m_Mean_Variance_Estimator___Std;
 }
 
-static fix16_t voc_algorithm_mean_variance_estimator_get_mean(VocAlgorithmParams* params) {
+static fix16_t voc_algorithm_mean_variance_estimator_get_mean(VocAlgorithmParams *params) {
   return (params->m_Mean_Variance_Estimator___Mean + params->m_Mean_Variance_Estimator___Sraw_Offset);
 }
 
-static void voc_algorithm_mean_variance_estimator_calculate_gamma(VocAlgorithmParams* params,
+static void voc_algorithm_mean_variance_estimator_calculate_gamma(VocAlgorithmParams *params,
                                                                   fix16_t voc_index_from_prior) {
   fix16_t uptime_limit;
   fix16_t sigmoid_gamma_mean;
@@ -469,7 +469,7 @@ static void voc_algorithm_mean_variance_estimator_calculate_gamma(VocAlgorithmPa
   }
 }
 
-static void voc_algorithm_mean_variance_estimator_process(VocAlgorithmParams* params, fix16_t sraw,
+static void voc_algorithm_mean_variance_estimator_process(VocAlgorithmParams *params, fix16_t sraw,
                                                           fix16_t voc_index_from_prior) {
   fix16_t delta_sgp;
   fix16_t c;
@@ -514,18 +514,18 @@ static void voc_algorithm_mean_variance_estimator_process(VocAlgorithmParams* pa
   }
 }
 
-static void voc_algorithm_mean_variance_estimator_sigmoid_init(VocAlgorithmParams* params) {
+static void voc_algorithm_mean_variance_estimator_sigmoid_init(VocAlgorithmParams *params) {
   voc_algorithm_mean_variance_estimator_sigmoid_set_parameters(params, F16(0.), F16(0.), F16(0.));
 }
 
-static void voc_algorithm_mean_variance_estimator_sigmoid_set_parameters(VocAlgorithmParams* params, fix16_t l,
+static void voc_algorithm_mean_variance_estimator_sigmoid_set_parameters(VocAlgorithmParams *params, fix16_t l,
                                                                          fix16_t x0, fix16_t k) {
   params->m_Mean_Variance_Estimator___Sigmoid__L = l;
   params->m_Mean_Variance_Estimator___Sigmoid__K = k;
   params->m_Mean_Variance_Estimator___Sigmoid__X0 = x0;
 }
 
-static fix16_t voc_algorithm_mean_variance_estimator_sigmoid_process(VocAlgorithmParams* params, fix16_t sample) {
+static fix16_t voc_algorithm_mean_variance_estimator_sigmoid_process(VocAlgorithmParams *params, fix16_t sample) {
   fix16_t x;
 
   x = (fix16_mul(params->m_Mean_Variance_Estimator___Sigmoid__K,
@@ -539,30 +539,30 @@ static fix16_t voc_algorithm_mean_variance_estimator_sigmoid_process(VocAlgorith
   }
 }
 
-static void voc_algorithm_mox_model_init(VocAlgorithmParams* params) {
+static void voc_algorithm_mox_model_init(VocAlgorithmParams *params) {
   voc_algorithm_mox_model_set_parameters(params, F16(1.), F16(0.));
 }
 
-static void voc_algorithm_mox_model_set_parameters(VocAlgorithmParams* params, fix16_t sraw_std, fix16_t sraw_mean) {
+static void voc_algorithm_mox_model_set_parameters(VocAlgorithmParams *params, fix16_t sraw_std, fix16_t sraw_mean) {
   params->m_Mox_Model__Sraw_Std = sraw_std;
   params->m_Mox_Model__Sraw_Mean = sraw_mean;
 }
 
-static fix16_t voc_algorithm_mox_model_process(VocAlgorithmParams* params, fix16_t sraw) {
+static fix16_t voc_algorithm_mox_model_process(VocAlgorithmParams *params, fix16_t sraw) {
   return (fix16_mul((fix16_div((sraw - params->m_Mox_Model__Sraw_Mean),
                                (-(params->m_Mox_Model__Sraw_Std + F16(VOC_ALGORITHM_SRAW_STD_BONUS))))),
                     F16(VOC_ALGORITHM_VOC_INDEX_GAIN)));
 }
 
-static void voc_algorithm_sigmoid_scaled_init(VocAlgorithmParams* params) {
+static void voc_algorithm_sigmoid_scaled_init(VocAlgorithmParams *params) {
   voc_algorithm_sigmoid_scaled_set_parameters(params, F16(0.));
 }
 
-static void voc_algorithm_sigmoid_scaled_set_parameters(VocAlgorithmParams* params, fix16_t offset) {
+static void voc_algorithm_sigmoid_scaled_set_parameters(VocAlgorithmParams *params, fix16_t offset) {
   params->m_Sigmoid_Scaled__Offset = offset;
 }
 
-static fix16_t voc_algorithm_sigmoid_scaled_process(VocAlgorithmParams* params, fix16_t sample) {
+static fix16_t voc_algorithm_sigmoid_scaled_process(VocAlgorithmParams *params, fix16_t sample) {
   fix16_t x;
   fix16_t shift;
 
@@ -583,11 +583,11 @@ static fix16_t voc_algorithm_sigmoid_scaled_process(VocAlgorithmParams* params, 
   }
 }
 
-static void voc_algorithm_adaptive_lowpass_init(VocAlgorithmParams* params) {
+static void voc_algorithm_adaptive_lowpass_init(VocAlgorithmParams *params) {
   voc_algorithm_adaptive_lowpass_set_parameters(params);
 }
 
-static void voc_algorithm_adaptive_lowpass_set_parameters(VocAlgorithmParams* params) {
+static void voc_algorithm_adaptive_lowpass_set_parameters(VocAlgorithmParams *params) {
   params->m_Adaptive_Lowpass__A1 =
       F16((VOC_ALGORITHM_SAMPLING_INTERVAL / (VOC_ALGORITHM_LP_TAU_FAST + VOC_ALGORITHM_SAMPLING_INTERVAL)));
   params->m_Adaptive_Lowpass__A2 =
@@ -595,7 +595,7 @@ static void voc_algorithm_adaptive_lowpass_set_parameters(VocAlgorithmParams* pa
   params->m_Adaptive_Lowpass___Initialized = false;
 }
 
-static fix16_t voc_algorithm_adaptive_lowpass_process(VocAlgorithmParams* params, fix16_t sample) {
+static fix16_t voc_algorithm_adaptive_lowpass_process(VocAlgorithmParams *params, fix16_t sample) {
   fix16_t abs_delta;
   fix16_t f1;
   fix16_t tau_a;

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace sim800l {
 
-static const char* TAG = "sim800l";
+static const char *TAG = "sim800l";
 
 const char ASCII_CR = 0x0D;
 const char ASCII_LF = 0x0A;

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace tm1637 {
 
-const char* TAG = "display.tm1637";
+const char *TAG = "display.tm1637";
 const uint8_t TM1637_I2C_COMM1 = 0x40;
 const uint8_t TM1637_I2C_COMM2 = 0xC0;
 const uint8_t TM1637_I2C_COMM3 = 0x80;
@@ -136,7 +136,7 @@ void TM1637Display::dump_config() {
 }
 
 void TM1637Display::update() {
-  for (uint8_t& i : this->buffer_)
+  for (uint8_t &i : this->buffer_)
     i = 0;
   if (this->writer_.has_value())
     (*this->writer_)(*this);
@@ -227,7 +227,7 @@ bool TM1637Display::send_byte_(uint8_t b) {
   return ack;
 }
 
-uint8_t TM1637Display::print(uint8_t start_pos, const char* str) {
+uint8_t TM1637Display::print(uint8_t start_pos, const char *str) {
   ESP_LOGV(TAG, "Print at %d: %s", start_pos, str);
   uint8_t pos = start_pos;
   for (; *str != '\0'; str++) {
@@ -263,8 +263,8 @@ uint8_t TM1637Display::print(uint8_t start_pos, const char* str) {
   }
   return pos - start_pos;
 }
-uint8_t TM1637Display::print(const char* str) { return this->print(0, str); }
-uint8_t TM1637Display::printf(uint8_t pos, const char* format, ...) {
+uint8_t TM1637Display::print(const char *str) { return this->print(0, str); }
+uint8_t TM1637Display::printf(uint8_t pos, const char *format, ...) {
   va_list arg;
   va_start(arg, format);
   char buffer[64];
@@ -274,7 +274,7 @@ uint8_t TM1637Display::printf(uint8_t pos, const char* format, ...) {
     return this->print(pos, buffer);
   return 0;
 }
-uint8_t TM1637Display::printf(const char* format, ...) {
+uint8_t TM1637Display::printf(const char *format, ...) {
   va_list arg;
   va_start(arg, format);
   char buffer[64];
@@ -286,14 +286,14 @@ uint8_t TM1637Display::printf(const char* format, ...) {
 }
 
 #ifdef USE_TIME
-uint8_t TM1637Display::strftime(uint8_t pos, const char* format, time::ESPTime time) {
+uint8_t TM1637Display::strftime(uint8_t pos, const char *format, time::ESPTime time) {
   char buffer[64];
   size_t ret = time.strftime(buffer, sizeof(buffer), format);
   if (ret > 0)
     return this->print(pos, buffer);
   return 0;
 }
-uint8_t TM1637Display::strftime(const char* format, time::ESPTime time) { return this->strftime(0, format, time); }
+uint8_t TM1637Display::strftime(const char *format, time::ESPTime time) { return this->strftime(0, format, time); }
 #endif
 
 }  // namespace tm1637


### PR DESCRIPTION
# What does this implement/fix? 

See https://github.com/esphome/esphome/pull/1884#discussion_r649064270

clang-format was incorrectly configured, and tried to derive the pointer alignment. Disable the option to use `PointerAlignment: Right`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
