### PR TITLE
Support ESP8266 Arduino 3.0.0

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -237,7 +237,7 @@ optional<float> FilterOutValueFilter::new_value(float value) {
       return value;
   } else {
     int8_t accuracy = this->parent_->get_accuracy_decimals();
-    float accuracy_mult = pow(10.0, accuracy);
+    float accuracy_mult = powf(10.0f, accuracy);
     float rounded_filter_out = roundf(accuracy_mult * this->value_to_filter_out_);
     float rounded_value = roundf(accuracy_mult * value);
     if (rounded_filter_out == rounded_value)

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -237,7 +237,7 @@ optional<float> FilterOutValueFilter::new_value(float value) {
       return value;
   } else {
     int8_t accuracy = this->parent_->get_accuracy_decimals();
-    float accuracy_mult = pow10f(accuracy);
+    float accuracy_mult = pow(10.0, accuracy);
     float rounded_filter_out = roundf(accuracy_mult * this->value_to_filter_out_);
     float rounded_value = roundf(accuracy_mult * value);
     if (rounded_filter_out == rounded_value)

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -10,7 +10,7 @@
 #include <wpa2_enterprise.h>
 #endif
 
-#ifdef WIFI_IS_OFF_AT_BOOT // Identifies ESP8266 Arduino 3.0.0
+#ifdef WIFI_IS_OFF_AT_BOOT  // Identifies ESP8266 Arduino 3.0.0
 #define ARDUINO_ESP8266_RELEASE_3
 #endif
 
@@ -29,7 +29,6 @@ extern "C" {
 #define wifi_softap_set_dhcps_offer_option(offer, mode) dhcpSoftAP.set_dhcps_offer_option(offer, mode)
 #endif
 }
-
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -10,6 +10,10 @@
 #include <wpa2_enterprise.h>
 #endif
 
+#ifdef WIFI_IS_OFF_AT_BOOT // Identifies ESP8266 Arduino 3.0.0
+#define ARDUINO_ESP8266_RELEASE_3
+#endif
+
 extern "C" {
 #include "lwip/err.h"
 #include "lwip/dns.h"
@@ -18,7 +22,14 @@ extern "C" {
 #if LWIP_IPV6
 #include "lwip/netif.h"  // struct netif
 #endif
+#ifdef ARDUINO_ESP8266_RELEASE_3
+#include "LwipDhcpServer.h"
+#define wifi_softap_set_dhcps_lease(lease) dhcpSoftAP.set_dhcps_lease(lease)
+#define wifi_softap_set_dhcps_lease_time(time) dhcpSoftAP.set_dhcps_lease_time(time)
+#define wifi_softap_set_dhcps_offer_option(offer, mode) dhcpSoftAP.set_dhcps_offer_option(offer, mode)
+#endif
 }
+
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -648,6 +659,10 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
     ESP_LOGV(TAG, "Setting SoftAP info failed!");
     return false;
   }
+
+#ifdef ARDUINO_ESP8266_RELEASE_3
+  dhcpSoftAP.begin(&info);
+#endif
 
   struct dhcps_lease lease {};
   IPAddress start_address = info.ip.addr;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -28,6 +28,7 @@ ARDUINO_VERSION_ESP32 = {
 # See also https://github.com/platformio/platform-espressif8266/releases
 ARDUINO_VERSION_ESP8266 = {
     "dev": "https://github.com/platformio/platform-espressif8266.git",
+    "3.0.0": "platformio/espressif8266@3.0.0",
     "2.7.4": "platformio/espressif8266@2.6.2",
     "2.7.3": "platformio/espressif8266@2.6.1",
     "2.7.2": "platformio/espressif8266@2.6.0",

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -105,7 +105,7 @@ std::string truncate_string(const std::string &s, size_t length) {
 }
 
 std::string value_accuracy_to_string(float value, int8_t accuracy_decimals) {
-  auto multiplier = float(pow(10.0f, accuracy_decimals));
+  auto multiplier = float(powf(10.0f, accuracy_decimals));
   float value_rounded = roundf(value * multiplier) / multiplier;
   char tmp[32];  // should be enough, but we should maybe improve this at some point.
   dtostrf(value_rounded, 0, uint8_t(std::max(0, int(accuracy_decimals))), tmp);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -105,7 +105,7 @@ std::string truncate_string(const std::string &s, size_t length) {
 }
 
 std::string value_accuracy_to_string(float value, int8_t accuracy_decimals) {
-  auto multiplier = float(pow10(accuracy_decimals));
+  auto multiplier = float(pow(10.0f, accuracy_decimals));
   float value_rounded = roundf(value * multiplier) / multiplier;
   char tmp[32];  // should be enough, but we should maybe improve this at some point.
   dtostrf(value_rounded, 0, uint8_t(std::max(0, int(accuracy_decimals))), tmp);


### PR DESCRIPTION
# What does this implement/fix? 

This makes basic firmware compile with ESP8266 Arduino 3.0.0. Release 3.0.0 has quite some changes around WiFi. In a quick test it seems that both station mode and AP mode works with this set of changes already.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: test
  platform: ESP8266
  board: esp01_1m
  #arduino_version: espressif8266@3.0.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
