### PR TITLE
Ensure wifi is in at least station mode before starting improv

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -79,7 +79,8 @@ void WiFiComponent::setup() {
   }
 #ifdef USE_IMPROV
   if (esp32_improv::global_improv_component != nullptr)
-    esp32_improv::global_improv_component->start();
+    if (this->wifi_mode_(true, {}))
+      esp32_improv::global_improv_component->start();
 #endif
   this->wifi_apply_hostname_();
 #if defined(ARDUINO_ARCH_ESP32) && defined(USE_MDNS)
@@ -143,11 +144,11 @@ void WiFiComponent::loop() {
     }
 
 #ifdef USE_IMPROV
-    if (esp32_improv::global_improv_component != nullptr) {
-      if (!this->is_connected()) {
-        esp32_improv::global_improv_component->start();
-      }
-    }
+    if (esp32_improv::global_improv_component != nullptr)
+      if (!this->is_connected())
+        if (this->wifi_mode_(true, {}))
+          esp32_improv::global_improv_component->start();
+
 #endif
 
     if (!this->has_ap() && this->reboot_timeout_ != 0) {


### PR DESCRIPTION
# What does this implement/fix? 

It is possible to have `wifi` but not setup the adapter, which causes improv to crash when saving.

```yaml
wifi:
  networks:
```

This would set up the component, but not set up station mode or ap mode.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
