### PR TITLE
Improve DHT read timings

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -94,11 +94,17 @@ bool HOT ICACHE_RAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, 
       delayMicroseconds(40);
     } else if (this->model_ == DHT_MODEL_DHT22_TYPE2) {
       delayMicroseconds(2000);
+    } else if (this->model_ == DHT_MODEL_AM2302) {
+      delayMicroseconds(1000);
     } else {
       delayMicroseconds(800);
     }
     this->pin_->pin_mode(INPUT_PULLUP);
-    delayMicroseconds(40);
+
+    // Host pull up 20-40us then DHT response 80us
+    // Start waiting for initial rising edge at the center when we
+    // expect the DHT response (30us+40us)
+    delayMicroseconds(70);
 
     uint8_t bit = 7;
     uint8_t byte = 0;
@@ -116,8 +122,6 @@ bool HOT ICACHE_RAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, 
           break;
         }
       }
-      if (error_code != 0)
-        break;
 
       start_time = micros();
       uint32_t end_time = start_time;
@@ -132,8 +136,6 @@ bool HOT ICACHE_RAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, 
           break;
         }
       }
-      if (error_code != 0)
-        break;
 
       if (i < 0)
         continue;


### PR DESCRIPTION
# What does this implement/fix? 

Make sure that the initial rising edge is properly detected even if
timing is somewhat off.

Set MCU start signal to 1ms for AM2302.

Also removes two superfluous breaks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** might fix https://github.com/esphome/issues/issues/2102

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

sensor:
  - platform: dht
    pin: 2
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    update_interval: 2s
    model: dht11
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
