### PR TITLE
Bump NeoPixelBus-esphome from 2.6.2 to upstream NeoPixelBus 2.6.4

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -205,4 +205,4 @@ async def to_code(config):
     cg.add(var.set_pixel_order(getattr(ESPNeoPixelOrder, config[CONF_TYPE])))
 
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
-    cg.add_library("NeoPixelBus-esphome", "2.6.2")
+    cg.add_library("NeoPixelBus", "2.6.4")

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ lib_deps =
     ArduinoJson-esphomelib@5.13.3
     ESPAsyncWebServer-esphome@1.2.7
     FastLED@3.3.2
-    NeoPixelBus-esphome@2.6.2
+    NeoPixelBus@2.6.4
     1655@1.0.2  ; TinyGPSPlus (has name conflict)
     6865@1.0.0  ; TM1651 Battery Display
     6306@1.0.3  ; HM3301


### PR DESCRIPTION
Now that the clang-tidy problem is fixed in upstream NeoPixelBus let's
use upstream directly.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
