### PR TITLE
Ct clamp nan

### DIFF
--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -20,7 +20,9 @@ void CTClampSensor::dump_config() {
 void CTClampSensor::update() {
   // Latch that an update is requested and attempts to preform update if no other clamp is being sampled.
   this->update_requested_ = true;
-  if (CTClampSensor::mutex) return;
+  if (CTClampSensor::mutex) {
+    return;
+  }
   CTClampSensor::mutex = true;
   this->update_requested_ = false;
 

--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -40,7 +40,10 @@ void CTClampSensor::update() {
 
     float dc = this->sample_sum_ / this->num_samples_;
     float var = (this->sample_squared_sum_ / this->num_samples_) - dc * dc;
-    float ac = std::sqrt(var);
+    float ac = 0;
+    if (var > 0) {
+      ac = std::sqrt(var);
+    }
     ESP_LOGD(TAG, "'%s' - Raw AC Value: %.3fA (from %d samples)", this->name_.c_str(), ac, this->num_samples_);
     this->publish_state(ac);
     mutex = false;

--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -7,7 +7,7 @@ namespace esphome {
 namespace ct_clamp {
 
 static const char *const TAG = "ct_clamp";
-static bool mutex = false;
+bool CTClampSensor::mutex = false;
 
 void CTClampSensor::setup() {}
 
@@ -20,8 +20,8 @@ void CTClampSensor::dump_config() {
 void CTClampSensor::update() {
   // Latch that an update is requested and attempts to preform update if no other clamp is being sampled.
   this->update_requested_ = true;
-  if (mutex) return;
-  mutex = true;
+  if (CTClampSensor::mutex) return;
+  CTClampSensor::mutex = true;
   this->update_requested_ = false;
 
   // Request a high loop() execution interval during sampling phase.
@@ -46,7 +46,7 @@ void CTClampSensor::update() {
     }
     ESP_LOGD(TAG, "'%s' - Raw AC Value: %.3fA (from %d samples)", this->name_.c_str(), ac, this->num_samples_);
     this->publish_state(ac);
-    mutex = false;
+    CTClampSensor::mutex = false;
   });
 
   // Set sampling values

--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -7,7 +7,7 @@ namespace esphome {
 namespace ct_clamp {
 
 static const char *const TAG = "ct_clamp";
-bool CTClampSensor::mutex = false;
+bool CTClampSensor::mutex = false; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 void CTClampSensor::setup() {}
 

--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -36,7 +36,7 @@ void CTClampSensor::update() {
     float dc = this->sample_sum_ / this->num_samples_;
     float var = (this->sample_squared_sum_ / this->num_samples_) - dc * dc;
     float ac = std::sqrt(var);
-    ESP_LOGD(TAG, "'%s' - Raw AC Value: %.3fA", this->name_.c_str(), ac);
+    ESP_LOGD(TAG, "'%s' - Raw AC Value: %.3fA (from %d samples)", this->name_.c_str(), ac, this->num_samples_);
     this->publish_state(ac);
   });
 

--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -42,7 +42,7 @@ class CTClampSensor : public sensor::Sensor, public PollingComponent {
    *   3) Sum of sample squared
    * https://en.wikipedia.org/wiki/Root_mean_square
    */
-  static bool mutex;
+  static bool mutex; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
   float sample_sum_ = 0.0f;
   float sample_squared_sum_ = 0.0f;
   uint32_t num_samples_ = 0;

--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -42,7 +42,7 @@ class CTClampSensor : public sensor::Sensor, public PollingComponent {
    *   3) Sum of sample squared
    * https://en.wikipedia.org/wiki/Root_mean_square
    */
-
+  static bool mutex;
   float sample_sum_ = 0.0f;
   float sample_squared_sum_ = 0.0f;
   uint32_t num_samples_ = 0;

--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -35,17 +35,19 @@ class CTClampSensor : public sensor::Sensor, public PollingComponent {
    *
    * Diagram: https://learn.openenergymonitor.org/electricity-monitoring/ct-sensors/interface-with-arduino
    *
-   * This is automatically calculated with an exponential moving average/digital low pass filter.
-   *
-   * 0.5 is a good initial approximation to start with for most ESP8266 setups.
+   * The current clamp only measures AC, so any DC component is an unwanted artifact from the
+   * sampling circuit. The AC component is essentially the same as the calculating the Standard-Deviation,
+   * which can be done by cumulating 3 values per sample:
+   *   1) Number of samples
+   *   2) Sum of samples
+   *   3) Sum of sample squared
+   * https://en.wikipedia.org/wiki/Root_mean_square
    */
-  float offset_ = 0.5f;
 
   float sample_sum_ = 0.0f;
+  float sample_squared_sum_ = 0.0f;
   uint32_t num_samples_ = 0;
   bool is_sampling_ = false;
-  /// Calibrate offset value once at boot
-  bool is_calibrating_offset_ = false;
 };
 
 }  // namespace ct_clamp

--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -25,7 +25,6 @@ class CTClampSensor : public sensor::Sensor, public PollingComponent {
  protected:
   /// High Frequency loop() requester used during sampling phase.
   HighFrequencyLoopRequester high_freq_;
-
   /// Duration in ms of the sampling phase.
   uint32_t sample_duration_;
   /// The sampling source to read values from.
@@ -47,6 +46,7 @@ class CTClampSensor : public sensor::Sensor, public PollingComponent {
   float sample_sum_ = 0.0f;
   float sample_squared_sum_ = 0.0f;
   uint32_t num_samples_ = 0;
+  bool update_requested_ = false;
   bool is_sampling_ = false;
 };
 


### PR DESCRIPTION
# What does this implement/fix? 
Fixes NAN values from AC calculation sneaking in. Protects square root from negative values.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
