### PR TITLE
Shorten the ble name to prevent crash with long device names

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -91,7 +91,16 @@ bool ESP32BLE::ble_setup_() {
     }
   }
 
-  err = esp_ble_gap_set_device_name(App.get_name().c_str());
+  std::string name = App.get_name();
+  if (name.length() > 20) {
+    if (App.is_name_add_mac_suffix_enabled()) {
+      name.erase(name.begin() + 13, name.end() - 7);  // Remove characters between 13 and the mac address
+    } else {
+      name = name.substr(0, 20);
+    }
+  }
+
+  err = esp_ble_gap_set_device_name(name.c_str());
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "esp_ble_gap_set_device_name failed: %d", err);
     return false;

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -38,6 +38,7 @@ namespace esphome {
 class Application {
  public:
   void pre_setup(const std::string &name, const char *compilation_time, bool name_add_mac_suffix) {
+    this->name_add_mac_suffix_ = name_add_mac_suffix;
     if (name_add_mac_suffix) {
       this->name_ = name + "-" + get_mac_address().substr(6);
     } else {
@@ -96,6 +97,8 @@ class Application {
 
   /// Get the name of this Application set by set_name().
   const std::string &get_name() const { return this->name_; }
+
+  bool is_name_add_mac_suffix_enabled() const { return this->name_add_mac_suffix_; }
 
   const std::string &get_compilation_time() const { return this->compilation_time_; }
 
@@ -245,6 +248,7 @@ class Application {
 
   std::string name_;
   std::string compilation_time_;
+  bool name_add_mac_suffix_;
   uint32_t last_loop_{0};
   uint32_t loop_interval_{16};
   int dump_config_at_{-1};


### PR DESCRIPTION
# What does this implement/fix? 

There is a crash when the BLE name is longer than 29 characters. This PR shortens it to be maximum 20 characters and still has the MAC suffix if that is desired.

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
