### PR TITLE
Support multiple configuration directories for update-all subcommand

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -394,7 +394,7 @@ def command_update_all(args):
     import click
 
     success = {}
-    files = list_yaml_files(args.configuration[0])
+    files = list_yaml_files(args.configuration)
     twidth = 60
 
     def print_bar(middle_text):
@@ -676,7 +676,7 @@ def parse_args(argv):
 
     parser_update = subparsers.add_parser("update-all")
     parser_update.add_argument(
-        "configuration", help="Your YAML configuration file directory.", nargs=1
+        "configuration", help="Your YAML configuration file directories.", nargs="+"
     )
 
     return parser.parse_args(argv[1:])

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -284,7 +284,6 @@ def command_vscode(args):
 
     logging.disable(logging.INFO)
     logging.disable(logging.WARNING)
-    CORE.config_path = args.configuration
     vscode.read_config(args)
 
 
@@ -669,9 +668,7 @@ def parse_args(argv):
     )
 
     parser_vscode = subparsers.add_parser("vscode")
-    parser_vscode.add_argument(
-        "configuration", help="Your YAML configuration file.", nargs=1
-    )
+    parser_vscode.add_argument("configuration", help="Your YAML configuration file.")
     parser_vscode.add_argument("--ace", action="store_true")
 
     parser_update = subparsers.add_parser("update-all")

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -98,7 +98,7 @@ class DashboardSettings:
         return os.path.join(self.config_dir, *args)
 
     def list_yaml_files(self):
-        return util.list_yaml_files(self.config_dir)
+        return util.list_yaml_files([self.config_dir])
 
 
 settings = DashboardSettings()

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -247,17 +247,24 @@ class OrderedDict(collections.OrderedDict):
         return dict(self).__repr__()
 
 
-def list_yaml_files(folder):
-    files = filter_yaml_files([os.path.join(folder, p) for p in os.listdir(folder)])
+def list_yaml_files(folders):
+    files = filter_yaml_files(
+        [os.path.join(folder, p) for folder in folders for p in os.listdir(folder)]
+    )
     files.sort()
     return files
 
 
 def filter_yaml_files(files):
-    files = [f for f in files if os.path.splitext(f)[1] == ".yaml"]
-    files = [f for f in files if os.path.basename(f) != "secrets.yaml"]
-    files = [f for f in files if not os.path.basename(f).startswith(".")]
-    return files
+    return [
+        f
+        for f in files
+        if (
+            os.path.splitext(f)[1] == ".yaml"
+            and os.path.basename(f) != "secrets.yaml"
+            and not os.path.basename(f).startswith(".")
+        )
+    ]
 
 
 class SerialPort:

--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -67,7 +67,7 @@ def read_config(args):
         CORE.ace = args.ace
         f = data["file"]
         if CORE.ace:
-            CORE.config_path = os.path.join(args.configuration[0], f)
+            CORE.config_path = os.path.join(args.configuration, f)
         else:
             CORE.config_path = data["file"]
         vs = VSCodeResult()


### PR DESCRIPTION
# What does this implement/fix? 

Support multiple configuration directories for update-all subcommand, just like e.g. `config` or `compile` accept multiple configuration files.

Also some code cleanup for the `vscode` subcommand, which unnecessarily used a list that could only contain 1 item. 

~~Note that this conflicts with the first change in #1924 (I'll rebase this PR once that one is merged).~~ Done.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** see also discussion in #1924

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
