### PR TITLE
Fix typo in test3.yaml

### DIFF
--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1097,27 +1097,27 @@ fingerprint_grow:
   new_password: 0xA65B9840
   on_finger_scan_matched:
     - homeassistant.event:
-        event: esphome.${devicename}_fingerprint_grow_finger_scan_matched
+        event: esphome.${device_name}_fingerprint_grow_finger_scan_matched
         data:
           finger_id: !lambda 'return finger_id;'
           confidence: !lambda 'return confidence;'
   on_finger_scan_unmatched:
     - homeassistant.event:
-        event: esphome.${devicename}_fingerprint_grow_finger_scan_unmatched
+        event: esphome.${device_name}_fingerprint_grow_finger_scan_unmatched
   on_enrollment_scan:
     - homeassistant.event:
-        event: esphome.${devicename}_fingerprint_grow_enrollment_scan
+        event: esphome.${device_name}_fingerprint_grow_enrollment_scan
         data:
           finger_id: !lambda 'return finger_id;'
           scan_num: !lambda 'return scan_num;'
   on_enrollment_done:
     - homeassistant.event:
-        event: esphome.${devicename}_fingerprint_grow_node_enrollment_done
+        event: esphome.${device_name}_fingerprint_grow_node_enrollment_done
         data:
           finger_id: !lambda 'return finger_id;'
   on_enrollment_failed:
     - homeassistant.event:
-        event: esphome.${devicename}_fingerprint_grow_enrollment_failed
+        event: esphome.${device_name}_fingerprint_grow_enrollment_failed
         data:
           finger_id: !lambda 'return finger_id;'
   uart_id: uart6


### PR DESCRIPTION
# What does this implement/fix? 

Compiling test3.yaml currently throws warnings as `$devicename` should be `$device_name`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
