### PR TITLE
Dont publish light state when using a flash

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -50,6 +50,8 @@ template<typename... Ts> class LightControlAction : public Action<Ts...> {
     call.set_effect(this->effect_.optional_value(x...));
     call.set_flash_length(this->flash_length_.optional_value(x...));
     call.set_transition_length(this->transition_length_.optional_value(x...));
+    if (this->flash_length_.has_value() && this->flash_length_.optional_value(x...) > 0)
+      call.set_publish(false);
     call.perform();
   }
 


### PR DESCRIPTION
# What does this implement/fix? 

A flash change of a light is temporary and therefore should not be published to the light state.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
