### PR TITLE
Update dashboard to 20210617.0

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -716,9 +716,6 @@ class LogoutHandler(BaseHandler):
         self.redirect("./login")
 
 
-_STATIC_FILE_HASHES = {}
-
-
 def get_base_frontend_path():
     if ENV_DEV not in os.environ:
         import esphome_dashboard
@@ -741,19 +738,22 @@ def get_static_path(*args):
     return os.path.join(get_base_frontend_path(), "static", *args)
 
 
+@functools.lru_cache(maxsize=None)
 def get_static_file_url(name):
+    base = f"./static/{name}"
+
+    if ENV_DEV in os.environ:
+        return base
+
     # Module imports can't deduplicate if stuff added to url
     if name == "js/esphome/index.js":
-        return f"./static/{name}"
+        import esphome_dashboard
+        return base.replace('index.js', esphome_dashboard.entrypoint())
 
-    if name in _STATIC_FILE_HASHES:
-        hash_ = _STATIC_FILE_HASHES[name]
-    else:
-        path = get_static_path(name)
-        with open(path, "rb") as f_handle:
-            hash_ = hashlib.md5(f_handle.read()).hexdigest()[:8]
-        _STATIC_FILE_HASHES[name] = hash_
-    return f"./static/{name}?hash={hash_}"
+    path = get_static_path(name)
+    with open(path, "rb") as f_handle:
+        hash_ = hashlib.md5(f_handle.read()).hexdigest()[:8]
+    return f"{base}?hash={hash_}"
 
 
 def make_app(debug=get_bool_env(ENV_DEV)):
@@ -819,9 +819,6 @@ def make_app(debug=get_bool_env(ENV_DEV)):
         ],
         **app_settings,
     )
-
-    if debug:
-        _STATIC_FILE_HASHES.clear()
 
     return app
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -748,7 +748,8 @@ def get_static_file_url(name):
     # Module imports can't deduplicate if stuff added to url
     if name == "js/esphome/index.js":
         import esphome_dashboard
-        return base.replace('index.js', esphome_dashboard.entrypoint())
+
+        return base.replace("index.js", esphome_dashboard.entrypoint())
 
     path = get_static_path(name)
     with open(path, "rb") as f_handle:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ ifaddr==0.1.7
 platformio==5.1.1
 esptool==2.8
 click==7.1.2
-esphome-dashboard==20210617.0
+esphome-dashboard==20210617.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ ifaddr==0.1.7
 platformio==5.1.1
 esptool==2.8
 click==7.1.2
-esphome-dashboard==20210615.0
+esphome-dashboard==20210617.0


### PR DESCRIPTION
# What does this implement/fix? 

Bump the dashboard with improved cache busting.

We saw some issues where the old legacy `esphome.js` was being loaded, attaching duplicate click handlers. In the updated dashboard this is no longer possible because:

 - the legacy `esphome.js` is now included in the main build
 - entrypoint of the main build has a hash in the filename to bust cache

https://github.com/esphome/dashboard/releases/tag/20210617.0
https://github.com/esphome/dashboard/releases/tag/20210617.1

Fixes https://github.com/esphome/issues/issues/2135
Fixes https://github.com/esphome/issues/issues/2138

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
