### PR TITLE
Allow HA addon to work with specified version

### DIFF
--- a/docker/rootfs/etc/services.d/esphome/run
+++ b/docker/rootfs/etc/services.d/esphome/run
@@ -23,4 +23,8 @@ if bashio::config.has_value 'relative_url'; then
 fi
 
 bashio::log.info "Starting ESPHome dashboard..."
-exec esphome dashboard /config/esphome --socket /var/run/esphome.sock --hassio
+if basio::config.has_value 'esphome_version'; then
+    exec esphome /config/esphome dashboard --socket /var/run/esphome.sock --hassio
+else
+    exec esphome dashboard /config/esphome --socket /var/run/esphome.sock --hassio
+fi


### PR DESCRIPTION
# What does this implement/fix? 

The command line order change meant that setting an `esphome_version` lower than 1.19.0 would break the addon

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
