### PR TITLE
Replace CLIMATE_MODE_AUTO with CLIMATE_MODE_HEAT_COOL in most cases

### DIFF
--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -21,7 +21,7 @@ void BangBangClimate::setup() {
     restore->to_call(this).perform();
   } else {
     // restore from defaults, change_away handles those for us
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     this->change_away_(false);
   }
 }
@@ -50,7 +50,7 @@ climate::ClimateTraits BangBangClimate::traits() {
   return traits;
 }
 void BangBangClimate::compute_state_() {
-  if (this->mode != climate::CLIMATE_MODE_AUTO) {
+  if (this->mode != climate::CLIMATE_MODE_HEAT_COOL) {
     // in non-auto mode, switch directly to appropriate action
     //  - HEAT mode -> HEATING action
     //  - COOL mode -> COOLING action

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -41,7 +41,7 @@ void BangBangClimate::control(const climate::ClimateCall &call) {
 climate::ClimateTraits BangBangClimate::traits() {
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(true);
-  traits.set_supports_auto_mode(true);
+  traits.set_supports_heat_cool_mode(true);
   traits.set_supports_cool_mode(this->supports_cool_);
   traits.set_supports_heat_mode(this->supports_heat_);
   traits.set_supports_two_point_target_temperature(true);

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -159,7 +159,7 @@ struct ClimateDeviceRestoreState {
  *
  * The entire state of the climate device is encoded in public properties of the base class (current_temperature,
  * mode etc). These are read-only for the user and rw for integrations. The reason these are public
- * is for simple access to them from lambdas `if (id(my_climate).mode == climate::CLIMATE_MODE_AUTO) ...`
+ * is for simple access to them from lambdas `if (id(my_climate).mode == climate::CLIMATE_MODE_HEAT_COOL) ...`
  */
 class Climate : public Nameable {
  public:

--- a/esphome/components/climate/climate_traits.cpp
+++ b/esphome/components/climate/climate_traits.cpp
@@ -8,6 +8,8 @@ bool ClimateTraits::supports_mode(ClimateMode mode) const {
   switch (mode) {
     case CLIMATE_MODE_OFF:
       return true;
+    case CLIMATE_MODE_HEAT_COOL:
+      return this->supports_heat_cool_mode_;
     case CLIMATE_MODE_AUTO:
       return this->supports_auto_mode_;
     case CLIMATE_MODE_COOL:
@@ -31,6 +33,9 @@ void ClimateTraits::set_supports_two_point_target_temperature(bool supports_two_
   supports_two_point_target_temperature_ = supports_two_point_target_temperature;
 }
 void ClimateTraits::set_supports_auto_mode(bool supports_auto_mode) { supports_auto_mode_ = supports_auto_mode; }
+void ClimateTraits::set_supports_heat_cool_mode(bool supports_heat_cool_mode) {
+  supports_heat_cool_mode_ = supports_heat_cool_mode;
+}
 void ClimateTraits::set_supports_cool_mode(bool supports_cool_mode) { supports_cool_mode_ = supports_cool_mode; }
 void ClimateTraits::set_supports_heat_mode(bool supports_heat_mode) { supports_heat_mode_ = supports_heat_mode; }
 void ClimateTraits::set_supports_fan_only_mode(bool supports_fan_only_mode) {

--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -46,6 +46,7 @@ class ClimateTraits {
   bool get_supports_two_point_target_temperature() const;
   void set_supports_two_point_target_temperature(bool supports_two_point_target_temperature);
   void set_supports_auto_mode(bool supports_auto_mode);
+  void set_supports_heat_cool_mode(bool supports_heat_cool_mode);
   void set_supports_cool_mode(bool supports_cool_mode);
   void set_supports_heat_mode(bool supports_heat_mode);
   void set_supports_fan_only_mode(bool supports_fan_only_mode);
@@ -100,6 +101,7 @@ class ClimateTraits {
   bool supports_current_temperature_{false};
   bool supports_two_point_target_temperature_{false};
   bool supports_auto_mode_{false};
+  bool supports_heat_cool_mode_{false};
   bool supports_cool_mode_{false};
   bool supports_heat_mode_{false};
   bool supports_fan_only_mode_{false};

--- a/esphome/components/climate_ir/climate_ir.cpp
+++ b/esphome/components/climate_ir/climate_ir.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "climate_ir";
 climate::ClimateTraits ClimateIR::traits() {
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(this->sensor_ != nullptr);
-  traits.set_supports_auto_mode(true);
+  traits.set_supports_heat_cool_mode(true);
   traits.set_supports_cool_mode(this->supports_cool_);
   traits.set_supports_heat_mode(this->supports_heat_);
   traits.set_supports_dry_mode(this->supports_dry_);

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -39,7 +39,7 @@ void LgIrClimate::transmit_state() {
     send_swing_cmd_ = false;
     remote_state |= COMMAND_SWING;
   } else {
-    if (mode_before_ == climate::CLIMATE_MODE_OFF && this->mode == climate::CLIMATE_MODE_AUTO) {
+    if (mode_before_ == climate::CLIMATE_MODE_OFF && this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
       remote_state |= COMMAND_ON_AI;
     } else if (mode_before_ == climate::CLIMATE_MODE_OFF && this->mode != climate::CLIMATE_MODE_OFF) {
       remote_state |= COMMAND_ON;
@@ -52,7 +52,7 @@ void LgIrClimate::transmit_state() {
         case climate::CLIMATE_MODE_HEAT:
           remote_state |= COMMAND_HEAT;
           break;
-        case climate::CLIMATE_MODE_AUTO:
+        case climate::CLIMATE_MODE_HEAT_COOL:
           remote_state |= COMMAND_AUTO;
           break;
         case climate::CLIMATE_MODE_DRY:
@@ -89,7 +89,7 @@ void LgIrClimate::transmit_state() {
       }
     }
 
-    if (this->mode == climate::CLIMATE_MODE_AUTO) {
+    if (this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
       this->fan_mode = climate::CLIMATE_FAN_AUTO;
       // remote_state |= FAN_MODE_AUTO_DRY;
     }
@@ -128,7 +128,7 @@ bool LgIrClimate::on_receive(remote_base::RemoteReceiveData data) {
   if ((remote_state & COMMAND_MASK) == COMMAND_ON) {
     this->mode = climate::CLIMATE_MODE_COOL;
   } else if ((remote_state & COMMAND_MASK) == COMMAND_ON_AI) {
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
   }
 
   if ((remote_state & COMMAND_MASK) == COMMAND_OFF) {
@@ -138,7 +138,7 @@ bool LgIrClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->swing_mode == climate::CLIMATE_SWING_OFF ? climate::CLIMATE_SWING_VERTICAL : climate::CLIMATE_SWING_OFF;
   } else {
     if ((remote_state & COMMAND_MASK) == COMMAND_AUTO)
-      this->mode = climate::CLIMATE_MODE_AUTO;
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     else if ((remote_state & COMMAND_MASK) == COMMAND_DRY_FAN)
       this->mode = climate::CLIMATE_MODE_DRY;
     else if ((remote_state & COMMAND_MASK) == COMMAND_HEAT) {
@@ -152,7 +152,7 @@ bool LgIrClimate::on_receive(remote_base::RemoteReceiveData data) {
       this->target_temperature = ((remote_state & TEMP_MASK) >> TEMP_SHIFT) + 15;
 
     // Fan Speed
-    if (this->mode == climate::CLIMATE_MODE_AUTO) {
+    if (this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
       this->fan_mode = climate::CLIMATE_FAN_AUTO;
     } else if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_HEAT ||
                this->mode == climate::CLIMATE_MODE_DRY) {

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -70,7 +70,7 @@ void CoolixClimate::transmit_state() {
       case climate::CLIMATE_MODE_HEAT:
         remote_state |= COOLIX_HEAT;
         break;
-      case climate::CLIMATE_MODE_AUTO:
+      case climate::CLIMATE_MODE_HEAT_COOL:
         remote_state |= COOLIX_AUTO;
         break;
       case climate::CLIMATE_MODE_FAN_ONLY:
@@ -89,7 +89,7 @@ void CoolixClimate::transmit_state() {
       } else {
         remote_state |= COOLIX_FAN_TEMP_CODE;
       }
-      if (this->mode == climate::CLIMATE_MODE_AUTO || this->mode == climate::CLIMATE_MODE_DRY) {
+      if (this->mode == climate::CLIMATE_MODE_HEAT_COOL || this->mode == climate::CLIMATE_MODE_DRY) {
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
         remote_state |= COOLIX_FAN_MODE_AUTO_DRY;
       } else {
@@ -197,7 +197,7 @@ bool CoolixClimate::on_receive(remote_base::RemoteReceiveData data) {
     if ((remote_state & COOLIX_MODE_MASK) == COOLIX_HEAT)
       this->mode = climate::CLIMATE_MODE_HEAT;
     else if ((remote_state & COOLIX_MODE_MASK) == COOLIX_AUTO)
-      this->mode = climate::CLIMATE_MODE_AUTO;
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     else if ((remote_state & COOLIX_MODE_MASK) == COOLIX_DRY_FAN) {
       if ((remote_state & COOLIX_FAN_MASK) == COOLIX_FAN_MODE_AUTO_DRY)
         this->mode = climate::CLIMATE_MODE_DRY;
@@ -207,7 +207,7 @@ bool CoolixClimate::on_receive(remote_base::RemoteReceiveData data) {
       this->mode = climate::CLIMATE_MODE_COOL;
 
     // Fan Speed
-    if ((remote_state & COOLIX_FAN_AUTO) == COOLIX_FAN_AUTO || this->mode == climate::CLIMATE_MODE_AUTO ||
+    if ((remote_state & COOLIX_FAN_AUTO) == COOLIX_FAN_AUTO || this->mode == climate::CLIMATE_MODE_HEAT_COOL ||
         this->mode == climate::CLIMATE_MODE_DRY)
       this->fan_mode = climate::CLIMATE_FAN_AUTO;
     else if ((remote_state & COOLIX_FAN_MIN) == COOLIX_FAN_MIN)

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -77,7 +77,7 @@ uint8_t DaikinClimate::operation_mode_() {
     case climate::CLIMATE_MODE_HEAT:
       operating_mode |= DAIKIN_MODE_HEAT;
       break;
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       operating_mode |= DAIKIN_MODE_AUTO;
       break;
     case climate::CLIMATE_MODE_FAN_ONLY:
@@ -131,7 +131,7 @@ uint8_t DaikinClimate::temperature_() {
   switch (this->mode) {
     case climate::CLIMATE_MODE_FAN_ONLY:
       return 0x32;
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
     case climate::CLIMATE_MODE_DRY:
       return 0xc0;
     default:
@@ -160,7 +160,7 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
         this->mode = climate::CLIMATE_MODE_HEAT;
         break;
       case DAIKIN_MODE_AUTO:
-        this->mode = climate::CLIMATE_MODE_AUTO;
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
       case DAIKIN_MODE_FAN:
         this->mode = climate::CLIMATE_MODE_FAN_ONLY;

--- a/esphome/components/fujitsu_general/fujitsu_general.cpp
+++ b/esphome/components/fujitsu_general/fujitsu_general.cpp
@@ -133,7 +133,7 @@ void FujitsuGeneralClimate::transmit_state() {
     case climate::CLIMATE_MODE_FAN_ONLY:
       SET_NIBBLE(remote_state, FUJITSU_GENERAL_MODE_NIBBLE, FUJITSU_GENERAL_MODE_FAN);
       break;
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
     default:
       SET_NIBBLE(remote_state, FUJITSU_GENERAL_MODE_NIBBLE, FUJITSU_GENERAL_MODE_AUTO);
       break;
@@ -344,7 +344,7 @@ bool FujitsuGeneralClimate::on_receive(remote_base::RemoteReceiveData data) {
       case FUJITSU_GENERAL_MODE_AUTO:
       default:
         // TODO: CLIMATE_MODE_10C is missing from esphome
-        this->mode = climate::CLIMATE_MODE_AUTO;
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
     }
 

--- a/esphome/components/hitachi_ac344/hitachi_ac344.cpp
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.cpp
@@ -12,7 +12,7 @@ void set_bits(uint8_t *const dst, const uint8_t offset, const uint8_t nbits, con
   uint8_t mask = UINT8_MAX >> (8 - ((nbits > 8) ? 8 : nbits));
   // Calculate the mask & clear the space for the data.
   // Clear the destination bits.
-  *dst &= ~(uint8_t)(mask << offset);
+  *dst &= ~(uint8_t) (mask << offset);
   // Merge in the data.
   *dst |= ((data & mask) << offset);
 }
@@ -155,7 +155,7 @@ void HitachiClimate::transmit_state() {
     case climate::CLIMATE_MODE_HEAT:
       set_mode_(HITACHI_AC344_MODE_HEAT);
       break;
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       set_mode_(HITACHI_AC344_MODE_AUTO);
       break;
     case climate::CLIMATE_MODE_FAN_ONLY:
@@ -251,7 +251,7 @@ bool HitachiClimate::parse_mode_(const uint8_t remote_state[]) {
         this->mode = climate::CLIMATE_MODE_HEAT;
         break;
       case HITACHI_AC344_MODE_AUTO:
-        this->mode = climate::CLIMATE_MODE_AUTO;
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
       case HITACHI_AC344_MODE_FAN:
         this->mode = climate::CLIMATE_MODE_FAN_ONLY;

--- a/esphome/components/hitachi_ac344/hitachi_ac344.cpp
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.cpp
@@ -12,7 +12,7 @@ void set_bits(uint8_t *const dst, const uint8_t offset, const uint8_t nbits, con
   uint8_t mask = UINT8_MAX >> (8 - ((nbits > 8) ? 8 : nbits));
   // Calculate the mask & clear the space for the data.
   // Clear the destination bits.
-  *dst &= ~(uint8_t) (mask << offset);
+  *dst &= ~(uint8_t)(mask << offset);
   // Merge in the data.
   *dst |= ((data & mask) << offset);
 }

--- a/esphome/components/midea_ac/midea_climate.cpp
+++ b/esphome/components/midea_ac/midea_climate.cpp
@@ -167,7 +167,7 @@ climate::ClimateTraits MideaAC::traits() {
   traits.set_visual_min_temperature(17);
   traits.set_visual_max_temperature(30);
   traits.set_visual_temperature_step(0.5);
-  traits.set_supports_auto_mode(true);
+  traits.set_supports_heat_cool_mode(true);
   traits.set_supports_cool_mode(true);
   traits.set_supports_dry_mode(true);
   traits.set_supports_heat_mode(true);

--- a/esphome/components/midea_ac/midea_frame.cpp
+++ b/esphome/components/midea_ac/midea_frame.cpp
@@ -44,7 +44,7 @@ climate::ClimateMode PropertiesFrame::get_mode() const {
     return climate::CLIMATE_MODE_OFF;
   switch (this->pbuf_[12] >> 5) {
     case MIDEA_MODE_AUTO:
-      return climate::CLIMATE_MODE_AUTO;
+      return climate::CLIMATE_MODE_HEAT_COOL;
     case MIDEA_MODE_COOL:
       return climate::CLIMATE_MODE_COOL;
     case MIDEA_MODE_DRY:
@@ -61,7 +61,7 @@ climate::ClimateMode PropertiesFrame::get_mode() const {
 void PropertiesFrame::set_mode(climate::ClimateMode mode) {
   uint8_t m;
   switch (mode) {
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       m = MIDEA_MODE_AUTO;
       break;
     case climate::CLIMATE_MODE_COOL:

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -33,7 +33,7 @@ void MitsubishiClimate::transmit_state() {
     case climate::CLIMATE_MODE_HEAT:
       remote_state[6] = MITSUBISHI_HEAT;
       break;
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       remote_state[6] = MITSUBISHI_AUTO;
       break;
     case climate::CLIMATE_MODE_OFF:

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -20,7 +20,7 @@ void PIDClimate::setup() {
     restore->to_call(this).perform();
   } else {
     // restore from defaults, change_away handles those for us
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     this->target_temperature = this->default_target_temperature_;
   }
 }
@@ -31,7 +31,7 @@ void PIDClimate::control(const climate::ClimateCall &call) {
     this->target_temperature = *call.get_target_temperature();
 
   // If switching to non-auto mode, set output immediately
-  if (this->mode != climate::CLIMATE_MODE_AUTO)
+  if (this->mode != climate::CLIMATE_MODE_HEAT_COOL)
     this->handle_non_auto_mode_();
 
   this->publish_state();
@@ -121,14 +121,14 @@ void PIDClimate::update_pid_() {
         // keep autotuner instance so that subsequent dump_configs will print the long result message.
       } else {
         value = res.output;
-        if (mode != climate::CLIMATE_MODE_AUTO) {
+        if (mode != climate::CLIMATE_MODE_HEAT_COOL) {
           ESP_LOGW(TAG, "For PID autotuner you need to set AUTO (also called heat/cool) mode!");
         }
       }
     }
   }
 
-  if (this->mode != climate::CLIMATE_MODE_AUTO) {
+  if (this->mode != climate::CLIMATE_MODE_HEAT_COOL) {
     this->handle_non_auto_mode_();
   } else {
     this->write_output_(value);

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -39,7 +39,7 @@ void PIDClimate::control(const climate::ClimateCall &call) {
 climate::ClimateTraits PIDClimate::traits() {
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(true);
-  traits.set_supports_auto_mode(true);
+  traits.set_supports_heat_cool_mode(true);
   traits.set_supports_two_point_target_temperature(false);
   traits.set_supports_cool_mode(this->supports_cool_());
   traits.set_supports_heat_mode(this->supports_heat_());

--- a/esphome/components/tcl112/tcl112.cpp
+++ b/esphome/components/tcl112/tcl112.cpp
@@ -47,7 +47,7 @@ void Tcl112Climate::transmit_state() {
 
   // Set mode
   switch (this->mode) {
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       remote_state[6] &= 0xF0;
       remote_state[6] |= TCL112_AUTO;
       break;
@@ -204,7 +204,7 @@ bool Tcl112Climate::on_receive(remote_base::RemoteReceiveData data) {
         this->mode = climate::CLIMATE_MODE_FAN_ONLY;
         break;
       case TCL112_AUTO:
-        this->mode = climate::CLIMATE_MODE_AUTO;
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
     }
   }

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -227,7 +227,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
 
-    auto_mode_available = CONF_HEAT_ACTION in config and CONF_COOL_ACTION in config
+    heat_cool_mode_available = CONF_HEAT_ACTION in config and CONF_COOL_ACTION in config
     two_points_available = CONF_HEAT_ACTION in config and (
         CONF_COOL_ACTION in config or CONF_FAN_ONLY_ACTION in config
     )
@@ -258,10 +258,10 @@ async def to_code(config):
         var.get_idle_action_trigger(), [], config[CONF_IDLE_ACTION]
     )
 
-    if auto_mode_available is True:
-        cg.add(var.set_supports_auto(True))
+    if heat_cool_mode_available is True:
+        cg.add(var.set_supports_heat_cool(True))
     else:
-        cg.add(var.set_supports_auto(False))
+        cg.add(var.set_supports_heat_cool(False))
 
     if CONF_COOL_ACTION in config:
         await automation.build_automation(

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -79,6 +79,7 @@ climate::ClimateTraits ThermostatClimate::traits() {
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(true);
   traits.set_supports_auto_mode(this->supports_auto_);
+  traits.set_supports_heat_cool_mode(this->supports_heat_cool_);
   traits.set_supports_cool_mode(this->supports_cool_);
   traits.set_supports_dry_mode(this->supports_dry_);
   traits.set_supports_fan_only_mode(this->supports_fan_only_);
@@ -130,7 +131,6 @@ climate::ClimateAction ThermostatClimate::compute_action_() {
       case climate::CLIMATE_MODE_OFF:
         target_action = climate::CLIMATE_ACTION_OFF;
         break;
-      case climate::CLIMATE_MODE_AUTO:
       case climate::CLIMATE_MODE_HEAT_COOL:
       case climate::CLIMATE_MODE_COOL:
       case climate::CLIMATE_MODE_HEAT:
@@ -435,6 +435,9 @@ ThermostatClimate::ThermostatClimate()
       swing_mode_vertical_trigger_(new Trigger<>()) {}
 void ThermostatClimate::set_hysteresis(float hysteresis) { this->hysteresis_ = hysteresis; }
 void ThermostatClimate::set_sensor(sensor::Sensor *sensor) { this->sensor_ = sensor; }
+void ThermostatClimate::set_supports_heat_cool(bool supports_heat_cool) {
+  this->supports_heat_cool_ = supports_heat_cool;
+}
 void ThermostatClimate::set_supports_auto(bool supports_auto) { this->supports_auto_ = supports_auto; }
 void ThermostatClimate::set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
 void ThermostatClimate::set_supports_dry(bool supports_dry) { this->supports_dry_ = supports_dry; }
@@ -522,6 +525,7 @@ void ThermostatClimate::dump_config() {
   }
   ESP_LOGCONFIG(TAG, "  Hysteresis: %.1f°C", this->hysteresis_);
   ESP_LOGCONFIG(TAG, "  Supports AUTO: %s", YESNO(this->supports_auto_));
+  ESP_LOGCONFIG(TAG, "  Supports HEAT/COOL: %s", YESNO(this->supports_heat_cool_));
   ESP_LOGCONFIG(TAG, "  Supports COOL: %s", YESNO(this->supports_cool_));
   ESP_LOGCONFIG(TAG, "  Supports DRY: %s", YESNO(this->supports_dry_));
   ESP_LOGCONFIG(TAG, "  Supports FAN_ONLY: %s", YESNO(this->supports_fan_only_));

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -21,7 +21,7 @@ void ThermostatClimate::setup() {
     restore->to_call(this).perform();
   } else {
     // restore from defaults, change_away handles temps for us
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     this->change_away_(false);
   }
   // refresh the climate action based on the restored settings
@@ -131,6 +131,7 @@ climate::ClimateAction ThermostatClimate::compute_action_() {
         target_action = climate::CLIMATE_ACTION_OFF;
         break;
       case climate::CLIMATE_MODE_AUTO:
+      case climate::CLIMATE_MODE_HEAT_COOL:
       case climate::CLIMATE_MODE_COOL:
       case climate::CLIMATE_MODE_HEAT:
         if (this->supports_cool_) {
@@ -321,7 +322,7 @@ void ThermostatClimate::switch_to_mode_(climate::ClimateMode mode) {
     case climate::CLIMATE_MODE_OFF:
       trig = this->off_mode_trigger_;
       break;
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       // trig = this->auto_mode_trigger_;
       break;
     case climate::CLIMATE_MODE_COOL:
@@ -339,7 +340,7 @@ void ThermostatClimate::switch_to_mode_(climate::ClimateMode mode) {
     default:
       // we cannot report an invalid mode back to HA (even if it asked for one)
       //  and must assume some valid value
-      mode = climate::CLIMATE_MODE_AUTO;
+      mode = climate::CLIMATE_MODE_HEAT_COOL;
       // trig = this->auto_mode_trigger_;
   }
   assert(trig != nullptr);

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -29,6 +29,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   void set_hysteresis(float hysteresis);
   void set_sensor(sensor::Sensor *sensor);
   void set_supports_auto(bool supports_auto);
+  void set_supports_heat_cool(bool supports_heat_cool);
   void set_supports_cool(bool supports_cool);
   void set_supports_dry(bool supports_dry);
   void set_supports_fan_only(bool supports_fan_only);
@@ -113,6 +114,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// A false value for any given attribute means that the controller has no such action
   /// (for example a thermostat, where only heating and not-heating is possible).
   bool supports_auto_{false};
+  bool supports_heat_cool_{false};
   bool supports_cool_{false};
   bool supports_dry_{false};
   bool supports_fan_only_{false};

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -80,7 +80,7 @@ void ToshibaClimate::transmit_state() {
       mode = TOSHIBA_MODE_COOL;
       break;
 
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
     default:
       mode = TOSHIBA_MODE_AUTO;
   }
@@ -190,7 +190,7 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
     case TOSHIBA_MODE_AUTO:
     default:
       /* Note: Dry and Fan-only modes are reported as Auto, as they are not supported yet */
-      this->mode = climate::CLIMATE_MODE_AUTO;
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
   }
 
   /* Get the target temperature */

--- a/esphome/components/tuya/climate/tuya_climate.cpp
+++ b/esphome/components/tuya/climate/tuya_climate.cpp
@@ -13,7 +13,7 @@ void TuyaClimate::setup() {
       this->mode = climate::CLIMATE_MODE_OFF;
       if (datapoint.value_bool) {
         if (this->supports_heat_ && this->supports_cool_) {
-          this->mode = climate::CLIMATE_MODE_AUTO;
+          this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         } else if (this->supports_heat_) {
           this->mode = climate::CLIMATE_MODE_HEAT;
         } else if (this->supports_cool_) {

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -48,7 +48,7 @@ void WhirlpoolClimate::transmit_state() {
     this->powered_on_assumed = powered_on;
   }
   switch (this->mode) {
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       // set fan auto
       // set temp auto temp
       // set sleep false
@@ -78,7 +78,7 @@ void WhirlpoolClimate::transmit_state() {
 
   // Temperature
   auto temp = (uint8_t) roundf(clamp(this->target_temperature, this->temperature_min_(), this->temperature_max_()));
-  remote_state[3] |= (uint8_t)(temp - this->temperature_min_()) << 4;
+  remote_state[3] |= (uint8_t) (temp - this->temperature_min_()) << 4;
 
   // Fan speed
   switch (this->fan_mode.value()) {
@@ -239,7 +239,7 @@ bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->mode = climate::CLIMATE_MODE_FAN_ONLY;
         break;
       case WHIRLPOOL_AUTO:
-        this->mode = climate::CLIMATE_MODE_AUTO;
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
     }
   }

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -78,7 +78,7 @@ void WhirlpoolClimate::transmit_state() {
 
   // Temperature
   auto temp = (uint8_t) roundf(clamp(this->target_temperature, this->temperature_min_(), this->temperature_max_()));
-  remote_state[3] |= (uint8_t) (temp - this->temperature_min_()) << 4;
+  remote_state[3] |= (uint8_t)(temp - this->temperature_min_()) << 4;
 
   // Fan speed
   switch (this->fan_mode.value()) {

--- a/esphome/components/yashima/yashima.cpp
+++ b/esphome/components/yashima/yashima.cpp
@@ -82,7 +82,7 @@ const uint32_t YASHIMA_CARRIER_FREQUENCY = 38000;
 climate::ClimateTraits YashimaClimate::traits() {
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(this->sensor_ != nullptr);
-  traits.set_supports_auto_mode(true);
+  traits.set_supports_heat_cool_mode(true);
   traits.set_supports_cool_mode(this->supports_cool_);
   traits.set_supports_heat_mode(this->supports_heat_);
   traits.set_supports_two_point_target_temperature(false);

--- a/esphome/components/yashima/yashima.cpp
+++ b/esphome/components/yashima/yashima.cpp
@@ -139,7 +139,7 @@ void YashimaClimate::transmit_state_() {
 
   // Set mode
   switch (this->mode) {
-    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
       remote_state[0] |= YASHIMA_MODE_AUTO_BYTE0;
       remote_state[5] |= YASHIMA_MODE_AUTO_BYTE5;
       break;


### PR DESCRIPTION
# What does this implement/fix? 

A missed change in #1471 meant the value for AUTO 6 was sent via protobuf but HA doesnt understand it yet.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
- fixes esphome/issues#2137
- fixes esphome/issues#2139
- fixes esphome/issues#2140
- fixes esphome/issues#2143

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
