### PR TITLE
Fix error print in script/helpers.py

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -40,7 +40,7 @@ def build_all_include():
 def build_compile_commands():
     gcc_flags_json = os.path.join(root_path, ".gcc-flags.json")
     if not os.path.isfile(gcc_flags_json):
-        print("Could not find {} file which is required for clang-tidy.")
+        print("Could not find {} file which is required for clang-tidy.".format(gcc_flags_json))
         print(
             'Please run "pio init --ide atom" in the root esphome folder to generate that file.'
         )


### PR DESCRIPTION
This appears when pio environment hasn't been initialized e.g. when
calling ./script/clang-tidy.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
