### PR TITLE
Compat argv parsing improvements

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -514,14 +514,26 @@ def parse_args(argv):
 
     compat_parser.error = _raise
 
-    try:
-        result, unparsed = compat_parser.parse_known_args(argv[1:])
-        last_option = len(argv) - len(unparsed) - 1 - len(result.configuration)
-        argv = argv[0:last_option] + [result.command] + result.configuration + unparsed
-        deprecated_argv_suggestion = argv
-    except argparse.ArgumentError:
-        # This is not an old-style command line, so we don't have to do anything.
-        deprecated_argv_suggestion = None
+    deprecated_argv_suggestion = None
+
+    if ["dashboard", "config"] == argv[1:3]:
+        # this is most likely meant in new-style arg format. do not try compat parsing
+        pass
+    else:
+        try:
+            result, unparsed = compat_parser.parse_known_args(argv[1:])
+            last_option = len(argv) - len(unparsed) - 1 - len(result.configuration)
+            unparsed = [
+                "--device" if arg in ("--upload-port", "--serial-port") else arg
+                for arg in unparsed
+            ]
+            argv = (
+                argv[0:last_option] + [result.command] + result.configuration + unparsed
+            )
+            deprecated_argv_suggestion = argv
+        except argparse.ArgumentError:
+            # This is not an old-style command line, so we don't have to do anything.
+            pass
 
     # And continue on with regular parsing
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
# What does this implement/fix? 

A new esphome cli args syntax was introduced in #1805 - to prevent a hard breaking change compat parsing for old-style args was added.

There were two cases where this was not ideal:

```
# New style trying to start dashboard in local config folder
$ esphome dashboard config
WARNING Calling ESPHome with the configuration before the command is deprecated and will be removed in the future. 
WARNING Please instead use:
WARNING    esphome config dashboard
INFO Reading configuration dashboard...
ERROR Error while reading config: Invalid YAML syntax:

Error reading file dashboard: [Errno 2] No such file or directory: 'dashboard'


# Old style trying to upload, but --upload-port was replaced with --device
$ esphome config/test.yaml run --upload-port OTA
usage: esphome [-h] [-v] [-q] [-s key value] command ...
esphome: error: unrecognized arguments: --upload-port OTA
```

This PR fixes those two cases:

```
$ esphome dashboard config
INFO Starting dashboard web server on port 6052 and configuration dir config...
# ...
$ esphome config/test.yaml run --upload-port OTA
WARNING Calling ESPHome with the configuration before the command is deprecated and will be removed in the future. 
WARNING Please instead use:
WARNING    esphome run config/test.yaml --device OTA
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
