### PR TITLE
Introduce clamp as a template function

### DIFF
--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -94,7 +94,7 @@ void LgIrClimate::transmit_state() {
       // remote_state |= FAN_MODE_AUTO_DRY;
     }
     if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_HEAT) {
-      auto temp = (uint8_t) roundf(clamp(this->target_temperature, TEMP_MIN, TEMP_MAX));
+      auto temp = (uint8_t) roundf(clamp<float>(this->target_temperature, TEMP_MIN, TEMP_MAX));
       remote_state |= ((temp - 15) << TEMP_SHIFT);
     }
   }

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -84,7 +84,7 @@ void CoolixClimate::transmit_state() {
     }
     if (this->mode != climate::CLIMATE_MODE_OFF) {
       if (this->mode != climate::CLIMATE_MODE_FAN_ONLY) {
-        auto temp = (uint8_t) roundf(clamp(this->target_temperature, COOLIX_TEMP_MIN, COOLIX_TEMP_MAX));
+        auto temp = (uint8_t) roundf(clamp<float>(this->target_temperature, COOLIX_TEMP_MIN, COOLIX_TEMP_MAX));
         remote_state |= COOLIX_TEMP_MAP[temp - COOLIX_TEMP_MIN];
       } else {
         remote_state |= COOLIX_FAN_TEMP_CODE;

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -135,7 +135,7 @@ uint8_t DaikinClimate::temperature_() {
     case climate::CLIMATE_MODE_DRY:
       return 0xc0;
     default:
-      uint8_t temperature = (uint8_t) roundf(clamp(this->target_temperature, DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX));
+      uint8_t temperature = (uint8_t) roundf(clamp<float>(this->target_temperature, DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX));
       return temperature << 1;
   }
 }

--- a/esphome/components/fan/fan_helpers.cpp
+++ b/esphome/components/fan/fan_helpers.cpp
@@ -6,7 +6,7 @@ namespace fan {
 
 FanSpeed speed_level_to_enum(int speed_level, int supported_speed_levels) {
   const auto speed_ratio = static_cast<float>(speed_level) / (supported_speed_levels + 1);
-  const auto legacy_level = static_cast<int>(clamp(ceilf(speed_ratio * 3), 1, 3));
+  const auto legacy_level = clamp<int>(static_cast<int>(ceilf(speed_ratio * 3)), 1, 3);
   return static_cast<FanSpeed>(legacy_level - 1);
 }
 

--- a/esphome/components/fan/fan_state.cpp
+++ b/esphome/components/fan/fan_state.cpp
@@ -54,7 +54,7 @@ void FanStateCall::perform() const {
   }
   if (this->speed_.has_value()) {
     const int speed_count = this->state_->get_traits().supported_speed_count();
-    this->state_->speed = static_cast<int>(clamp(*this->speed_, 1, speed_count));
+    this->state_->speed = clamp(*this->speed_, 1, speed_count);
   }
 
   FanStateRTCState saved{};

--- a/esphome/components/fujitsu_general/fujitsu_general.cpp
+++ b/esphome/components/fujitsu_general/fujitsu_general.cpp
@@ -110,7 +110,7 @@ void FujitsuGeneralClimate::transmit_state() {
 
   // Set temperature
   uint8_t temperature_clamped =
-      (uint8_t) roundf(clamp(this->target_temperature, FUJITSU_GENERAL_TEMP_MIN, FUJITSU_GENERAL_TEMP_MAX));
+      (uint8_t) roundf(clamp<float>(this->target_temperature, FUJITSU_GENERAL_TEMP_MIN, FUJITSU_GENERAL_TEMP_MAX));
   uint8_t temperature_offset = temperature_clamped - FUJITSU_GENERAL_TEMP_MIN;
   SET_NIBBLE(remote_state, FUJITSU_GENERAL_TEMPERATURE_NIBBLE, temperature_offset);
 

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -42,8 +42,8 @@ void MitsubishiClimate::transmit_state() {
       break;
   }
 
-  remote_state[7] =
-      (uint8_t) roundf(clamp(this->target_temperature, MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) - MITSUBISHI_TEMP_MIN);
+  remote_state[7] = (uint8_t) roundf(clamp<float>(this->target_temperature, MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) -
+                                     MITSUBISHI_TEMP_MIN);
 
   ESP_LOGV(TAG, "Sending Mitsubishi target temp: %.1f state: %02X mode: %02X temp: %02X", this->target_temperature,
            remote_state[5], remote_state[6], remote_state[7]);

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -130,7 +130,7 @@ void SSD1306::update() {
 }
 void SSD1306::set_brightness(float brightness) {
   // validation
-  this->brightness_ = clamp(brightness, 0, 1);
+  this->brightness_ = clamp(brightness, 0.0F, 1.0F);
   // now write the new brightness level to the display
   this->command(SSD1306_COMMAND_SET_CONTRAST);
   this->command(int(SSD1306_MAX_CONTRAST * (this->brightness_)));

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -126,7 +126,7 @@ void SSD1322::update() {
   this->display();
 }
 void SSD1322::set_brightness(float brightness) {
-  this->brightness_ = clamp(brightness, 0, 1);
+  this->brightness_ = clamp(brightness, 0.0F, 1.0F);
   // now write the new brightness level to the display
   this->command(SSD1322_SETCONTRAST);
   this->data(int(SSD1322_MAX_CONTRAST * (this->brightness_)));

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -100,7 +100,7 @@ void SSD1327::update() {
 }
 void SSD1327::set_brightness(float brightness) {
   // validation
-  this->brightness_ = clamp(brightness, 0, 1);
+  this->brightness_ = clamp(brightness, 0.0F, 1.0F);
   // now write the new brightness level to the display
   this->command(SSD1327_SETCONTRAST);
   this->command(int(SSD1327_MAX_CONTRAST * (this->brightness_)));

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -97,7 +97,7 @@ void SSD1331::update() {
 }
 void SSD1331::set_brightness(float brightness) {
   // validation
-  this->brightness_ = clamp(brightness, 0, 1);
+  this->brightness_ = clamp(brightness, 0.0F, 1.0F);
   // now write the new brightness level to the display
   this->command(SSD1331_CONTRASTA);  // 0x81
   this->command(int(SSD1331_MAX_CONTRASTA * (this->brightness_)));

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -287,13 +287,16 @@ void HighFrequencyLoopRequester::stop() {
 }
 bool HighFrequencyLoopRequester::is_high_frequency() { return high_freq_num_requests > 0; }
 
-float clamp(float val, float min, float max) {
+template<typename T> T clamp(const T val, const T min, const T max) {
   if (val < min)
     return min;
   if (val > max)
     return max;
   return val;
 }
+template float clamp(float, float, float);
+template int clamp(int, int, int);
+
 float lerp(float completion, float start, float end) { return start + (end - start) * completion; }
 
 bool str_startswith(const std::string &full, const std::string &start) { return full.rfind(start, 0) == 0; }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -80,7 +80,7 @@ class HighFrequencyLoopRequester {
  * @param max The maximum value.
  * @return val clamped in between min and max.
  */
-float clamp(float val, float min, float max);
+template<typename T> T clamp(T val, T min, T max);
 
 /** Linearly interpolate between end start and end by completion.
  *


### PR DESCRIPTION
This allows to avoid some unnecessary type conversion in
fan_helpers/fan_state. Use the float variant explicitly where necessary
or float constants to make sure the correct variant is used.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (cleanup)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
