### PR TITLE
Validate color temperature values for RGBWW/CWWW lights

### DIFF
--- a/esphome/components/cwww/light.py
+++ b/esphome/components/cwww/light.py
@@ -14,15 +14,18 @@ CWWWLightOutput = cwww_ns.class_("CWWWLightOutput", light.LightOutput)
 
 CONF_CONSTANT_BRIGHTNESS = "constant_brightness"
 
-CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
-    {
-        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(CWWWLightOutput),
-        cv.Required(CONF_COLD_WHITE): cv.use_id(output.FloatOutput),
-        cv.Required(CONF_WARM_WHITE): cv.use_id(output.FloatOutput),
-        cv.Required(CONF_COLD_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
-        cv.Required(CONF_WARM_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
-        cv.Optional(CONF_CONSTANT_BRIGHTNESS, default=False): cv.boolean,
-    }
+CONFIG_SCHEMA = cv.All(
+    light.RGB_LIGHT_SCHEMA.extend(
+        {
+            cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(CWWWLightOutput),
+            cv.Required(CONF_COLD_WHITE): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_WARM_WHITE): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_COLD_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
+            cv.Required(CONF_WARM_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
+            cv.Optional(CONF_CONSTANT_BRIGHTNESS, default=False): cv.boolean,
+        }
+    ),
+    light.validate_color_temperature_channels,
 )
 
 

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -16,6 +16,8 @@ from esphome.const import (
     CONF_ON_TURN_OFF,
     CONF_ON_TURN_ON,
     CONF_TRIGGER_ID,
+    CONF_COLD_WHITE_COLOR_TEMPERATURE,
+    CONF_WARM_WHITE_COLOR_TEMPERATURE,
 )
 from esphome.core import coroutine_with_priority
 from .automation import light_control_to_code  # noqa
@@ -102,6 +104,18 @@ ADDRESSABLE_LIGHT_SCHEMA = RGB_LIGHT_SCHEMA.extend(
         cv.Optional(CONF_POWER_SUPPLY): cv.use_id(power_supply.PowerSupply),
     }
 )
+
+
+def validate_color_temperature_channels(value):
+    if (
+        value[CONF_COLD_WHITE_COLOR_TEMPERATURE]
+        >= value[CONF_WARM_WHITE_COLOR_TEMPERATURE]
+    ):
+        raise cv.Invalid(
+            "Color temperature of the cold white channel must be colder than that of the warm white channel.",
+            path=[CONF_COLD_WHITE_COLOR_TEMPERATURE],
+        )
+    return value
 
 
 async def setup_light_core_(light_var, output_var, config):

--- a/esphome/components/rgbww/light.py
+++ b/esphome/components/rgbww/light.py
@@ -18,19 +18,22 @@ RGBWWLightOutput = rgbww_ns.class_("RGBWWLightOutput", light.LightOutput)
 CONF_CONSTANT_BRIGHTNESS = "constant_brightness"
 CONF_COLOR_INTERLOCK = "color_interlock"
 
-CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
-    {
-        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(RGBWWLightOutput),
-        cv.Required(CONF_RED): cv.use_id(output.FloatOutput),
-        cv.Required(CONF_GREEN): cv.use_id(output.FloatOutput),
-        cv.Required(CONF_BLUE): cv.use_id(output.FloatOutput),
-        cv.Required(CONF_COLD_WHITE): cv.use_id(output.FloatOutput),
-        cv.Required(CONF_WARM_WHITE): cv.use_id(output.FloatOutput),
-        cv.Required(CONF_COLD_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
-        cv.Required(CONF_WARM_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
-        cv.Optional(CONF_CONSTANT_BRIGHTNESS, default=False): cv.boolean,
-        cv.Optional(CONF_COLOR_INTERLOCK, default=False): cv.boolean,
-    }
+CONFIG_SCHEMA = cv.All(
+    light.RGB_LIGHT_SCHEMA.extend(
+        {
+            cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(RGBWWLightOutput),
+            cv.Required(CONF_RED): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_GREEN): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_BLUE): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_COLD_WHITE): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_WARM_WHITE): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_COLD_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
+            cv.Required(CONF_WARM_WHITE_COLOR_TEMPERATURE): cv.color_temperature,
+            cv.Optional(CONF_CONSTANT_BRIGHTNESS, default=False): cv.boolean,
+            cv.Optional(CONF_COLOR_INTERLOCK, default=False): cv.boolean,
+        }
+    ),
+    light.validate_color_temperature_channels,
 )
 
 


### PR DESCRIPTION
# What does this implement/fix? 

Check if the color temperature of the cold white channel is colder (less) than the warm white channel.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
light:
# This will now give an error
  - platform: cwww
    id: light_cwww
    name: "CWWW"
    cold_white: pwm1
    warm_white: pwm2
    cold_white_color_temperature: 1000 K
    warm_white_color_temperature: 5000 K
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
