### PR TITLE
Fix on_multi_click min_length

### DIFF
--- a/esphome/components/binary_sensor/automation.cpp
+++ b/esphome/components/binary_sensor/automation.cpp
@@ -80,6 +80,10 @@ void binary_sensor::MultiClickTrigger::schedule_cooldown_() {
   this->cancel_timeout("is_not_valid");
 }
 void binary_sensor::MultiClickTrigger::schedule_is_valid_(uint32_t min_length) {
+  if (min_length == 0) {
+    this->is_valid_ = true;
+    return;
+  }
   this->is_valid_ = false;
   this->set_timeout("is_valid", min_length, [this]() {
     ESP_LOGV(TAG, "Multi Click: You can now %s the button.", this->parent_->state ? "RELEASE" : "PRESS");


### PR DESCRIPTION
# What does this implement/fix? 

Before this change there was a time when is_valid was still false even with the `min_length` being 0 because of the way the scheduler works.

Below is a log showing the is_valid callback executed 129ms after the touch starts (based on `last_execution`), and if you let go earlier than that then it is invalid.

```log
[15:29:20][VV][scheduler:152]: Running timeout 'is_valid' with interval=0 last_execution=8615 (now=8744)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
