### PR TITLE
Remove double scheduling from addressable lights

### DIFF
--- a/esphome/components/adalight/adalight_light_effect.cpp
+++ b/esphome/components/adalight/adalight_light_effect.cpp
@@ -44,6 +44,7 @@ void AdalightLightEffect::blank_all_leds_(light::AddressableLight &it) {
   for (int led = it.size(); led-- > 0;) {
     it[led].set(Color::BLACK);
   }
+  it.schedule_show();
 }
 
 void AdalightLightEffect::apply(light::AddressableLight &it, const Color &current_color) {
@@ -133,6 +134,7 @@ AdalightLightEffect::Frame AdalightLightEffect::parse_frame_(light::AddressableL
     it[led].set(Color(led_data[0], led_data[1], led_data[2], white));
   }
 
+  it.schedule_show();
   return CONSUMED;
 }
 

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -84,6 +84,7 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
       break;
   }
 
+  it->schedule_show();
   return true;
 }
 

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -20,13 +20,12 @@ void FastLEDLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "  Num LEDs: %u", this->num_leds_);
   ESP_LOGCONFIG(TAG, "  Max refresh rate: %u", *this->max_refresh_rate_);
 }
-void FastLEDLightOutput::loop() {
-  if (!this->should_show_())
-    return;
-
-  uint32_t now = micros();
+void FastLEDLightOutput::write_state(light::LightState *state) {
   // protect from refreshing too often
+  uint32_t now = micros();
   if (*this->max_refresh_rate_ != 0 && (now - this->last_refresh_) < *this->max_refresh_rate_) {
+    // try again next loop iteration, so that this change won't get lost
+    this->schedule_show();
     return;
   }
   this->last_refresh_ = now;

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -213,7 +213,7 @@ class FastLEDLightOutput : public light::AddressableLight {
   }
   void setup() override;
   void dump_config() override;
-  void loop() override;
+  void write_state(light::LightState *state) override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
   void clear_effect_data() override {

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -12,8 +12,7 @@ void AddressableLight::call_setup() {
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
   this->set_interval(5000, [this]() {
     const char *name = this->state_parent_ == nullptr ? "" : this->state_parent_->get_name().c_str();
-    ESP_LOGVV(TAG, "Addressable Light '%s' (effect_active=%s next_show=%s)", name, YESNO(this->effect_active_),
-              YESNO(this->next_show_));
+    ESP_LOGVV(TAG, "Addressable Light '%s' (effect_active=%s)", name, YESNO(this->effect_active_));
     for (int i = 0; i < this->size(); i++) {
       auto color = this->get(i);
       ESP_LOGVV(TAG, "  [%2d] Color: R=%3u G=%3u B=%3u W=%3u", i, color.get_red_raw(), color.get_green_raw(),
@@ -36,7 +35,7 @@ Color esp_color_from_light_color_values(LightColorValues val) {
   return Color(r, g, b, w);
 }
 
-void AddressableLight::write_state(LightState *state) {
+void AddressableLight::update_state(LightState *state) {
   auto val = state->current_values;
   auto max_brightness = to_uint8_scale(val.get_brightness() * val.get_state());
   this->correction_.set_local_brightness(max_brightness);

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -51,6 +51,7 @@ class AddressableLight : public LightOutput, public Component {
       amnt = this->size();
     this->range(amnt, this->size()) = this->range(0, -amnt);
   }
+  // Indicates whether an effect that directly updates the output buffer is active to prevent overwriting
   bool is_effect_active() const { return this->effect_active_; }
   void set_effect_active(bool effect_active) { this->effect_active_ = effect_active; }
   std::unique_ptr<LightTransformer> create_default_transition() override;

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -53,7 +53,6 @@ class AddressableLight : public LightOutput, public Component {
   }
   bool is_effect_active() const { return this->effect_active_; }
   void set_effect_active(bool effect_active) { this->effect_active_ = effect_active; }
-  void write_state(LightState *state) override;
   std::unique_ptr<LightTransformer> create_default_transition() override;
   void set_correction(float red, float green, float blue, float white = 1.0f) {
     this->correction_.set_max_brightness(
@@ -63,7 +62,8 @@ class AddressableLight : public LightOutput, public Component {
     this->correction_.calculate_gamma_table(state->get_gamma_correct());
     this->state_parent_ = state;
   }
-  void schedule_show() { this->next_show_ = true; }
+  void update_state(LightState *state) override;
+  void schedule_show() { this->state_parent_->next_write_ = true; }
 
 #ifdef USE_POWER_SUPPLY
   void set_power_supply(power_supply::PowerSupply *power_supply) { this->power_.set_parent(power_supply); }
@@ -74,9 +74,7 @@ class AddressableLight : public LightOutput, public Component {
  protected:
   friend class AddressableLightTransformer;
 
-  bool should_show_() const { return this->effect_active_ || this->next_show_; }
   void mark_shown_() {
-    this->next_show_ = false;
 #ifdef USE_POWER_SUPPLY
     for (auto c : *this) {
       if (c.get().is_on()) {
@@ -90,7 +88,6 @@ class AddressableLight : public LightOutput, public Component {
   virtual ESPColorView get_view_internal(int32_t index) const = 0;
 
   bool effect_active_{false};
-  bool next_show_{true};
   ESPColorCorrection correction_{};
 #ifdef USE_POWER_SUPPLY
   power_supply::PowerSupplyRequester power_;

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -63,6 +63,7 @@ class AddressableLambdaLightEffect : public AddressableLightEffect {
       this->last_run_ = now;
       this->f_(it, current_color, this->initial_run_);
       this->initial_run_ = false;
+      it.schedule_show();
     }
   }
 
@@ -87,6 +88,7 @@ class AddressableRainbowLightEffect : public AddressableLightEffect {
       var = hsv;
       hue += add;
     }
+    it.schedule_show();
   }
   void set_speed(uint32_t speed) { this->speed_ = speed; }
   void set_width(uint16_t width) { this->width_ = width; }
@@ -134,6 +136,7 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
         new_color.b = c.b;
       }
     }
+    it.schedule_show();
   }
 
  protected:
@@ -170,6 +173,8 @@ class AddressableScanEffect : public AddressableLightEffect {
       }
       this->last_move_ = now;
     }
+
+    it.schedule_show();
   }
 
  protected:
@@ -210,6 +215,7 @@ class AddressableTwinkleEffect : public AddressableLightEffect {
         continue;
       addressable[pos].set_effect_data(1);
     }
+    addressable.schedule_show();
   }
   void set_twinkle_probability(float twinkle_probability) { this->twinkle_probability_ = twinkle_probability; }
   void set_progress_interval(uint32_t progress_interval) { this->progress_interval_ = progress_interval; }
@@ -257,6 +263,7 @@ class AddressableRandomTwinkleEffect : public AddressableLightEffect {
       const uint8_t color = random_uint32() & 0b111;
       it[pos].set_effect_data(0b1000 | color);
     }
+    it.schedule_show();
   }
   void set_twinkle_probability(float twinkle_probability) { this->twinkle_probability_ = twinkle_probability; }
   void set_progress_interval(uint32_t progress_interval) { this->progress_interval_ = progress_interval; }
@@ -301,6 +308,7 @@ class AddressableFireworksEffect : public AddressableLightEffect {
         it[pos] = current_color;
       }
     }
+    it.schedule_show();
   }
   void set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
   void set_spark_probability(float spark_probability) { this->spark_probability_ = spark_probability; }
@@ -335,6 +343,7 @@ class AddressableFlickerEffect : public AddressableLightEffect {
       // slowly fade back to "real" value
       var = (var.get() * inv_intensity) + (current_color * intensity);
     }
+    it.schedule_show();
   }
   void set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
   void set_intensity(float intensity) { this->intensity_ = to_uint8_scale(intensity); }

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -154,24 +154,24 @@ class AddressableScanEffect : public AddressableLightEffect {
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
   void set_scan_width(uint32_t scan_width) { this->scan_width_ = scan_width; }
   void apply(AddressableLight &it, const Color &current_color) override {
-    it.all() = Color::BLACK;
+    const uint32_t now = millis();
+    if (now - this->last_move_ < this->move_interval_)
+      return;
 
+    if (direction_) {
+      this->at_led_++;
+      if (this->at_led_ == it.size() - this->scan_width_)
+        this->direction_ = false;
+    } else {
+      this->at_led_--;
+      if (this->at_led_ == 0)
+        this->direction_ = true;
+    }
+    this->last_move_ = now;
+
+    it.all() = Color::BLACK;
     for (auto i = 0; i < this->scan_width_; i++) {
       it[this->at_led_ + i] = current_color;
-    }
-
-    const uint32_t now = millis();
-    if (now - this->last_move_ > this->move_interval_) {
-      if (direction_) {
-        this->at_led_++;
-        if (this->at_led_ == it.size() - this->scan_width_)
-          this->direction_ = false;
-      } else {
-        this->at_led_--;
-        if (this->at_led_ == 0)
-          this->direction_ = true;
-      }
-      this->last_move_ = now;
     }
 
     it.schedule_show();

--- a/esphome/components/light/light_output.h
+++ b/esphome/components/light/light_output.h
@@ -19,6 +19,13 @@ class LightOutput {
 
   virtual void setup_state(LightState *state) {}
 
+  /// Called on every update of the current values of the associated LightState,
+  /// can optionally be used to do processing of this change.
+  virtual void update_state(LightState *state) {}
+
+  /// Called from loop() every time the light state has changed, and should
+  /// should write the new state to hardware. Every call to write_state() is
+  /// preceded by (at least) one call to update_state().
   virtual void write_state(LightState *state) = 0;
 };
 

--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -82,10 +82,7 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight {
     this->controller_->Begin();
   }
 
-  void loop() override {
-    if (!this->should_show_())
-      return;
-
+  void write_state(light::LightState *state) override {
     this->mark_shown_();
     this->controller_->Dirty();
 

--- a/esphome/components/partition/light_partition.h
+++ b/esphome/components/partition/light_partition.h
@@ -50,13 +50,11 @@ class PartitionLightOutput : public light::AddressableLight {
     }
   }
   light::LightTraits get_traits() override { return this->segments_[0].get_src()->get_traits(); }
-  void loop() override {
-    if (this->should_show_()) {
-      for (auto seg : this->segments_) {
-        seg.get_src()->schedule_show();
-      }
-      this->mark_shown_();
+  void write_state(light::LightState *state) override {
+    for (auto seg : this->segments_) {
+      seg.get_src()->schedule_show();
     }
+    this->mark_shown_();
   }
 
  protected:

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -42,6 +42,7 @@ void WLEDLightEffect::blank_all_leds_(light::AddressableLight &it) {
   for (int led = it.size(); led-- > 0;) {
     it[led].set(Color::BLACK);
   }
+  it.schedule_show();
 }
 
 void WLEDLightEffect::apply(light::AddressableLight &it, const Color &current_color) {
@@ -134,6 +135,7 @@ bool WLEDLightEffect::parse_frame_(light::AddressableLight &it, const uint8_t *p
     blank_at_ = millis() + DEFAULT_BLANK_TIME;
   }
 
+  it.schedule_show();
   return true;
 }
 


### PR DESCRIPTION
# What does this implement/fix? 

For non-addressable lights, a light call is processed like this:
1. `LightCall.perform()` sets either `LightState.transformer` (if a transition/flash is used) or `LightState.next_write_` (otherwise)
2. On the next loop, `LightState.loop()`:
	* Applies the active effect (which can perform another call to change the state and set `next_write_`)
	* Applies the active transformer (which returns values to change the state and set `next_write_`)
	* Calls `LightOutput.write_state()` if `next_write_` is set...
	* ...which in turn writes the state to the hardware

However, for addressable lights, effects and transitions it's a bit more complicated:
1. `LightCall.perform()` sets `LightState.transformer` (if a transition/flash is used) or `LightState.next_write_` (otherwise)
2. On the next loop, `LightState.loop()`:
	* Applies the active effect (which updates the output buffer)
	* Applies the active transformer (which updates the output buffer)
	* Calls `LightOutput.write_state()` if `next_write_` is set... (only happens if no transition is used)
	* ...which in turn writes the state to the output buffer and sets `LightOutput.next_show_`
3. On the next loop, `LightOutput.loop()`
	* Writes the output buffer to the hardware if an effect is active or `next_show_` is set

Aside from unnecessary delay in performing the user's request, this also has the problem that scripts like this don't work as expected:
```yaml
script:
   - id: addressable_delay_test
     then:
     - light.turn_on:
         id: lightstrip
         brightness: 40%
         red: 100%
         green: 0%
         blue: 0%
         transition_length: 0s
     - light.addressable_set:
         id: lightstrip
         range_from: 0
         range_to: 3
         red: 0%
         green: 100%
         blue: 0%
```
Instead of setting the first 4 LEDs to green, this turns the whole strip to red. This happens because `light.addressable_set`
writes directly to the output buffer between step 1 and 2 above, and the `write_state()` call overwrites this again. 

This PR changes the processing so that any state change is always directly written to the output buffer for addressable lights:
1. `LightCall.perform()`:
        * If a transition/flash is used, sets `LightState.transformer`
	* Otherwise, sets `LightState.next_write_` and `LightOutput.update_state()`, which for addressable lights writes the state to the output buffer
2. On the next loop, `LightState.loop()`:
	* Applies the active effect (which either performs another call, or updates the output buffer directly, in which case it also sets `next_write_`)
	* Applies the active transformer (which either returns values, in which case `next_write_` is set and `LightOutput.update_state()` is called, or writes to the output buffer directly, in which case it also sets `next_write_`)
	* Calls `LightOutput.write_state()` if `next_write_` is set...
	* ...which in turn writes the output buffer to the hardware

In short, the new contract is that `LightState` sets `next_write_` when the current values are updated through or a call, effect or transformer, and then calls `update_state()` as well, so that the new values can be written to the output buffer. If an effect or transformer writes directly to the output buffer, it is his responsibility to take care of setting `next_write_` (using `AddressableLight.schedule_show()`).

Most of the code change is to make the addressable effects call `schedule_show()` when they write to the output buffer. 
A smaller change would be to always set `next_write_` in `LightState.loop()` if an effect is active and leave the effects
unchanged, but that would mean that the output buffer is written to the hardware in every `loop()` call when an effect is
active, even if nothing changed. This eliminates that unnecessary work. 

I've left the rate limiting in the FastLED light output in place, though I think it's no longer necessary anymore, as the light
platform now ensures `write_state()` is only called when things have actually changed, and built-in effects are internally
rate limited. However, maybe you can get unreasonable refresh rates with "external" effects such as WLED.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<details>

```yaml
light:
   - platform: fastled_clockless
     id: lightstrip
     chipset: WS2812B
     pin: D2
     num_leds: 8
     rgb_order: GRB
     name: "Stairs lighting"
     restore_mode: ALWAYS_OFF
     gamma_correct: 1.5
     color_correct: [100%, 80%, 95%]
     effects:
     - pulse:
         name: Pulse
     - addressable_scan:
         name: Scan
         move_interval: 250ms
         scan_width: 1

script:
   - id: addressable_delay_test
     then:
     - light.turn_on:
         id: lightstrip
         brightness: 40%
         red: 100%
         green: 0%
         blue: 0%
         transition_length: 0s
     - light.addressable_set:
         id: lightstrip
         range_from: 0
         range_to: 2
         red: 0%
         green: 100%
         blue: 0%
     - light.addressable_set:
         id: lightstrip
         range_from: 2
         range_to: 3
         red: 0%
         green: 0%
         blue: 100%
```
</details>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
