### PR TITLE
Don't try compat parsing for "esphome version"

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -516,7 +516,7 @@ def parse_args(argv):
 
     deprecated_argv_suggestion = None
 
-    if ["dashboard", "config"] == argv[1:3]:
+    if ["dashboard", "config"] == argv[1:3] or ["version"] == argv[1:2]:
         # this is most likely meant in new-style arg format. do not try compat parsing
         pass
     else:


### PR DESCRIPTION
The compat version is the same as the regular version, so this only
resulted in a warning to run exactly the same command you're already
running.

Reported by @mmakaay in Discord.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
