### PR TITLE
Improved handling of "unknown" Tuya datapoints

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -398,6 +398,21 @@ void Tuya::send_local_time_() {
 }
 #endif
 
+void Tuya::set_datapoint_value(uint8_t datapoint_id, bool value) {
+  ESP_LOGD(TAG, "Setting datapoint %u to %u", datapoint_id, value);
+  optional<TuyaDatapoint> datapoint = this->get_datapoint_(datapoint_id);
+  if (!datapoint.has_value()) {
+    ESP_LOGE(TAG, "Attempt to set unknown datapoint %u", datapoint_id);
+  }
+  else if (datapoint->value_uint == value) {
+    ESP_LOGV(TAG, "Not sending unchanged value");
+    return;
+  }
+  std::vector<uint8_t> data;
+  data.push_back(value >> 0);
+  this->send_datapoint_command_(datapoint_id, TuyaDatapointType::BOOLEAN, data);
+}
+
 void Tuya::set_datapoint_value(uint8_t datapoint_id, uint32_t value) {
   ESP_LOGD(TAG, "Setting datapoint %u to %u", datapoint_id, value);
   optional<TuyaDatapoint> datapoint = this->get_datapoint_(datapoint_id);
@@ -433,7 +448,7 @@ void Tuya::set_datapoint_value(uint8_t datapoint_id, const std::string &value) {
   if (!datapoint.has_value()) {
     ESP_LOGE(TAG, "Attempt to set unknown datapoint %u", datapoint_id);
   }
-  if (datapoint->value_string == value) {
+  else if (datapoint->value_string == value) {
     ESP_LOGV(TAG, "Not sending unchanged value");
     return;
   }
@@ -441,7 +456,7 @@ void Tuya::set_datapoint_value(uint8_t datapoint_id, const std::string &value) {
   for (char const &c : value) {
     data.push_back(c);
   }
-  this->send_datapoint_command_(datapoint->id, datapoint->type, data);
+  this->send_datapoint_command_(datapoint_id, TuyaDatapointType::STRING, data);
 }
 
 optional<TuyaDatapoint> Tuya::get_datapoint_(uint8_t datapoint_id) {

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -75,6 +75,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void loop() override;
   void dump_config() override;
   void register_listener(uint8_t datapoint_id, const std::function<void(TuyaDatapoint)> &func);
+  void set_datapoint_value(uint8_t datapoint_id, bool value);
   void set_datapoint_value(uint8_t datapoint_id, uint32_t value);
   void set_datapoint_value(uint8_t datapoint_id, const std::string &value);
 #ifdef USE_TIME


### PR DESCRIPTION
# What does this implement/fix? 

This at least partially resolves issues with not being able to send data to the Tuya MCU if ESPHome has not received data for the same datapoint yet.  I have tested the changes for the boolean datapoints locally on a Feit dimmer, however I have not tested the changes for a string datapoint as I do not have a Tuya device that uses string datapoints.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** partially fixes esphome/issues#2149

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).
 