### PR TITLE
Add stepper.set_acceleration and stepper.set_deceleration to stepper component

### DIFF
--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -21,6 +21,8 @@ Stepper = stepper_ns.class_("Stepper")
 SetTargetAction = stepper_ns.class_("SetTargetAction", automation.Action)
 ReportPositionAction = stepper_ns.class_("ReportPositionAction", automation.Action)
 SetSpeedAction = stepper_ns.class_("SetSpeedAction", automation.Action)
+SetAccelerationAction = stepper_ns.class_("SetAccelerationAction", automation.Action)
+SetDecelerationAction = stepper_ns.class_("SetDecelerationAction", automation.Action)
 
 
 def validate_acceleration(value):
@@ -140,6 +142,42 @@ async def stepper_set_speed_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_SPEED], args, cg.int32)
     cg.add(var.set_speed(template_))
+    return var
+
+
+@automation.register_action(
+    "stepper.set_acceleration",
+    SetAccelerationAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(Stepper),
+            cv.Required(CONF_ACCELERATION): cv.templatable(validate_acceleration),
+        }
+    ),
+)
+async def stepper_set_acceleration_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_ACCELERATION], args, cg.int32)
+    cg.add(var.set_acceleration(template_))
+    return var
+
+
+@automation.register_action(
+    "stepper.set_deceleration",
+    SetDecelerationAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(Stepper),
+            cv.Required(CONF_DECELERATION): cv.templatable(validate_acceleration),
+        }
+    ),
+)
+async def stepper_set_deceleration_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_DECELERATION], args, cg.int32)
+    cg.add(var.set_deceleration(template_))
     return var
 
 

--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -140,7 +140,7 @@ async def stepper_report_position_to_code(config, action_id, template_arg, args)
 async def stepper_set_speed_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_SPEED], args, cg.int32)
+    template_ = await cg.templatable(config[CONF_SPEED], args, cg.float_)
     cg.add(var.set_speed(template_))
     return var
 
@@ -158,7 +158,7 @@ async def stepper_set_speed_to_code(config, action_id, template_arg, args):
 async def stepper_set_acceleration_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_ACCELERATION], args, cg.int32)
+    template_ = await cg.templatable(config[CONF_ACCELERATION], args, cg.float_)
     cg.add(var.set_acceleration(template_))
     return var
 
@@ -176,7 +176,7 @@ async def stepper_set_acceleration_to_code(config, action_id, template_arg, args
 async def stepper_set_deceleration_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_DECELERATION], args, cg.int32)
+    template_ = await cg.templatable(config[CONF_DECELERATION], args, cg.float_)
     cg.add(var.set_deceleration(template_))
     return var
 

--- a/esphome/components/stepper/stepper.h
+++ b/esphome/components/stepper/stepper.h
@@ -77,5 +77,35 @@ template<typename... Ts> class SetSpeedAction : public Action<Ts...> {
   Stepper *parent_;
 };
 
+template<typename... Ts> class SetAccelerationAction : public Action<Ts...> {
+ public:
+  explicit SetAccelerationAction(Stepper *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(float, acceleration);
+
+  void play(Ts... x) override {
+    float acceleration = this->acceleration_.value(x...);
+    this->parent_->set_acceleration(acceleration);
+  }
+
+ protected:
+  Stepper *parent_;
+};
+
+template<typename... Ts> class SetDecelerationAction : public Action<Ts...> {
+ public:
+  explicit SetDecelerationAction(Stepper *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(float, deceleration);
+
+  void play(Ts... x) override {
+    float deceleration = this->deceleration_.value(x...);
+    this->parent_->set_deceleration(deceleration);
+  }
+
+ protected:
+  Stepper *parent_;
+};
+
 }  // namespace stepper
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 

Adds set_acceleration and set_deceleration actions to the stepper component, basically exact same implementation as "stepper.set_speed".

I have a stepper motor powered blind that I send different speeds to, based on the time of day and room occupancy, and it is nice to also control the accel/decel based on the speed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [https://github.com/esphome/feature-requests/issues/580](https://github.com/esphome/feature-requests/issues/580)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1288

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
close_action:
      - if:
          condition:
              switch.is_on: quietmode
          then:
              - stepper.set_speed:
                  id: secondaryStepper
                  speed: 300 steps/s
              - stepper.set_acceleration:
                  id: secondaryStepper
                  acceleration: 60 steps/s^2
              - stepper.set_deceleration:
                  id: secondaryStepper
                  deceleration: 60 steps/s^2
      - stepper.set_target:
          id: secondaryStepper
          target: 23200

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
