### PR TITLE
Fix tuya fan speed send

### DIFF
--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -80,7 +80,7 @@ void TuyaFan::write_state() {
   }
   if (this->speed_id_.has_value()) {
     ESP_LOGV(TAG, "Setting speed: %d", this->fan_->speed);
-    this->parent_->set_datapoint_value(*this->speed_id_, this->fan_->speed);
+    this->parent_->set_datapoint_value(*this->speed_id_, this->fan_->speed - 1);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix? 

Fixes tuya fan speed send. I broke this when merging the fan speed count changes into the recent tuya improvements.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2166

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
