### PR TITLE
remote_receiver use config parent receiver for registering dumpers

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -176,7 +176,9 @@ validate_binary_sensor = cv.validate_registry_entry(
 TRIGGER_REGISTRY = SimpleRegistry()
 DUMPER_REGISTRY = Registry(
     {
-        cv.GenerateID(CONF_RECEIVER_ID): cv.use_id(RemoteReceiverBase),
+        cv.Optional(CONF_RECEIVER_ID): cv.invalid(
+            "This has been removed in ESPHome 1.20.0 and the dumper attaches directly to the parent receiver."
+        ),
     }
 )
 
@@ -228,8 +230,6 @@ async def build_dumpers(config):
     dumpers = []
     for conf in config:
         dumper = await cg.build_registry_entry(DUMPER_REGISTRY, conf)
-        receiver = await cg.get_variable(conf[CONF_RECEIVER_ID])
-        cg.add(receiver.register_dumper(dumper))
         dumpers.append(dumper)
     return dumpers
 

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -54,7 +54,10 @@ async def to_code(config):
     else:
         var = cg.new_Pvariable(config[CONF_ID], pin)
 
-    await remote_base.build_dumpers(config[CONF_DUMP])
+    dumpers = await remote_base.build_dumpers(config[CONF_DUMP])
+    for dumper in dumpers:
+        cg.add(var.register_dumper(dumper))
+
     await remote_base.build_triggers(config)
     await cg.register_component(var, config)
 


### PR DESCRIPTION
# What does this implement/fix? 

The `dumpers` attached to a remote_receiver had a weird config schema that took a `RemoteReceiverBase` ID as part of the schema. This was not really needed as the config was a child of the receiver and could be automatically determined by the to_code methods. 

This became an issue when using multiple `remote_receivers` in a single device eg. RF and IR with dumpers as they try to use an ID of a receiver and there were multiple choices so users got a config validation error.

While this is a breaking change, it is an undocumented config option/feature for the dump config and so should not have a major impact.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2215

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
