### PR TITLE
Add support for IBS-TH1 External Sensor

### DIFF
--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -88,10 +88,10 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
   // Send temperature only if the value is set
-  if ( ! isnan(temperature) && this->temperature_ != nullptr) {
+  if (!isnan(temperature) && this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }
-  if ( ! isnan(ext_temperature) && this->ext_temperature_ != nullptr) {
+  if (!isnan(ext_temperature) && this->ext_temperature_ != nullptr) {
     this->ext_temperature_->publish_state(ext_temperature);
   }
   if (this->humidity_ != nullptr) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -88,10 +88,10 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
   // if (this->temperature_ != nullptr) {
-  if (temperature.has_value() && this->temperature_ != nullptr) {
+  if (this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }
-  if (ext_temperature.has_value() && this->ext_temperature_ != nullptr) {
+  if (this->ext_temperature_ != nullptr) {
     this->ext_temperature_->publish_state(ext_temperature);
   }
   if (this->humidity_ != nullptr) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -67,11 +67,14 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   // when data[2] == 0 temperature is from internal sensor (IBS-TH1 or IBS-TH1 Mini)
   // when data[2] == 1 temperature is from external sensor (IBS-TH1 only)
 
+  // Create empty variables to pass automatic checks
   auto temperature = NAN;
   auto ext_temperature = NAN;
 
+  // Read bluetooth data into variable
   auto measured_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
 
+  // Set temperature or ext_temperature based on which sensor is in use
   if (mnfData.data[2] == 0) {
     temperature = measured_temperature;
   } else if (mnfData.data[2] == 1) {
@@ -84,7 +87,7 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   auto battery_level = mnfData.data[5];
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
-  // if (this->temperature_ != nullptr) {
+  // Send temperature only if the value is set
   if ( ! isnan(temperature) && this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -88,10 +88,10 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
   // if (this->temperature_ != nullptr) {
-  if (this->temperature.has_value() && this->temperature_ != nullptr) {
+  if (temperature.has_value() && this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }
-  if (this->ext_temperature.has_value() && this->ext_temperature_ != nullptr) {
+  if (ext_temperature.has_value() && this->ext_temperature_ != nullptr) {
     this->ext_temperature_->publish_state(ext_temperature);
   }
   if (this->humidity_ != nullptr) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "inkbird_ibsth1_mini";
 void InkbirdIBSTH1_MINI::dump_config() {
   ESP_LOGCONFIG(TAG, "Inkbird IBS TH1 MINI");
   LOG_SENSOR("  ", "Temperature", this->temperature_);
-  LOG_SENSOR("  ", "External Temperature", this->ext_temperature_);
+  LOG_SENSOR("  ", "External Temperature", this->external_temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
@@ -69,16 +69,16 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
 
   // Create empty variables to pass automatic checks
   auto temperature = NAN;
-  auto ext_temperature = NAN;
+  auto external_temperature = NAN;
 
   // Read bluetooth data into variable
   auto measured_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
 
-  // Set temperature or ext_temperature based on which sensor is in use
+  // Set temperature or external_temperature based on which sensor is in use
   if (mnfData.data[2] == 0) {
     temperature = measured_temperature;
   } else if (mnfData.data[2] == 1) {
-    ext_temperature = measured_temperature;
+    external_temperature = measured_temperature;
   } else {
     ESP_LOGVV(TAG, "parse_device(): unknown sensor type");
     return false;
@@ -91,8 +91,8 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   if (!isnan(temperature) && this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }
-  if (!isnan(ext_temperature) && this->ext_temperature_ != nullptr) {
-    this->ext_temperature_->publish_state(ext_temperature);
+  if (!isnan(external_temperature) && this->external_temperature_ != nullptr) {
+    this->external_temperature_->publish_state(external_temperature);
   }
   if (this->humidity_ != nullptr) {
     this->humidity_->publish_state(humidity);

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -81,9 +81,6 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
     return false;
   }
 
-  // auto ext_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
-  // auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
-
   auto battery_level = mnfData.data[5];
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
@@ -91,7 +88,7 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   if ( ! isnan(temperature) && this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }
-  if (this->ext_temperature_ != nullptr) {
+  if ( ! isnan(ext_temperature) && this->ext_temperature_ != nullptr) {
     this->ext_temperature_->publish_state(ext_temperature);
   }
   if (this->humidity_ != nullptr) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -67,8 +67,8 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   // when data[2] == 0 temperature is from internal sensor (IBS-TH1 or IBS-TH1 Mini)
   // when data[2] == 1 temperature is from external sensor (IBS-TH1 only)
 
-  auto temperature = 100.0f;
-  auto ext_temperature = 100.0f;
+  // auto temperature = 100.0f;
+  // auto ext_temperature = 100.0f;
 
   if (mnfData.data[2] == 0) {
     auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -73,9 +73,9 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   auto measured_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
 
   if (mnfData.data[2] == 0) {
-    temperature = this->measured_temperature;
+    temperature = measured_temperature;
   } else if (mnfData.data[2] == 1) {
-    ext_temperature = this->measured_temperature;
+    ext_temperature = measured_temperature;
   } else {
     ESP_LOGVV(TAG, "parse_device(): unknown sensor type");
     return false;

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -67,6 +67,9 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   // when data[2] == 0 temperature is from internal sensor (IBS-TH1 or IBS-TH1 Mini)
   // when data[2] == 1 temperature is from external sensor (IBS-TH1 only)
 
+  auto temperature = nullptr;
+  auto ext_temperature = nullptr;
+
   if (mnfData.data[2] == 0) {
     auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
   } else if (mnfData.data[2] == 1) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -67,8 +67,8 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   // when data[2] == 0 temperature is from internal sensor (IBS-TH1 or IBS-TH1 Mini)
   // when data[2] == 1 temperature is from external sensor (IBS-TH1 only)
 
-  auto temperature = nullptr;
-  auto ext_temperature = nullptr;
+  auto temperature = 100.0f;
+  auto ext_temperature = 100.0f;
 
   if (mnfData.data[2] == 0) {
     auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -67,15 +67,15 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   // when data[2] == 0 temperature is from internal sensor (IBS-TH1 or IBS-TH1 Mini)
   // when data[2] == 1 temperature is from external sensor (IBS-TH1 only)
 
-  // auto temperature = 100.0f;
-  // auto ext_temperature = 100.0f;
+  auto temperature = NAN;
+  auto ext_temperature = NAN;
 
   auto measured_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
 
   if (mnfData.data[2] == 0) {
-    auto temperature = this->measured_temperature;
+    this->temperature = this->measured_temperature;
   } else if (mnfData.data[2] == 1) {
-    auto ext_temperature = this->measured_temperature;
+    this->ext_temperature = this->measured_temperature;
   } else {
     ESP_LOGVV(TAG, "parse_device(): unknown sensor type");
     return false;

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -70,25 +70,28 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   // auto temperature = 100.0f;
   // auto ext_temperature = 100.0f;
 
+  auto measured_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+
   if (mnfData.data[2] == 0) {
-    auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+    auto temperature = this->measured_temperature;
   } else if (mnfData.data[2] == 1) {
-    auto ext_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+    auto ext_temperature = this->measured_temperature;
   } else {
     ESP_LOGVV(TAG, "parse_device(): unknown sensor type");
     return false;
   }
 
-  auto ext_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
-  auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+  // auto ext_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+  // auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
 
   auto battery_level = mnfData.data[5];
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
-  if (this->temperature_ != nullptr) {
+  // if (this->temperature_ != nullptr) {
+  if (this->temperature.has_value() && this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }
-  if (this->ext_temperature_ != nullptr) {
+  if (this->ext_temperature.has_value() && this->ext_temperature_ != nullptr) {
     this->ext_temperature_->publish_state(ext_temperature);
   }
   if (this->humidity_ != nullptr) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -11,6 +11,7 @@ static const char *const TAG = "inkbird_ibsth1_mini";
 void InkbirdIBSTH1_MINI::dump_config() {
   ESP_LOGCONFIG(TAG, "Inkbird IBS TH1 MINI");
   LOG_SENSOR("  ", "Temperature", this->temperature_);
+  LOG_SENSOR("  ", "External Temperature", this->ext_temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
@@ -54,7 +55,7 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
     ESP_LOGVV(TAG, "parse_device(): manufacturer data element length is expected to be of length 7");
     return false;
   }
-  if ((mnfData.data[2] != 0) || (mnfData.data[6] != 8)) {
+  if (mnfData.data[6] != 8) {
     ESP_LOGVV(TAG, "parse_device(): unexpected data");
     return false;
   }
@@ -63,12 +64,26 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   // data[5] is a battery level
   // data[0] and data[1] is humidity * 100 (in pct)
   // uuid is a temperature * 100 (in Celcius)
+  // when data[2] == 0 temperature is from internal sensor (IBS-TH1 or IBS-TH1 Mini)
+  // when data[2] == 1 temperature is from external sensor (IBS-TH1 only)
+
+  if (mnfData.data[2] == 0) {
+    auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+  } else if (mnfData.data[2] == 1) {
+    auto ext_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+  } else {
+    ESP_LOGVV(TAG, "parse_device(): unknown sensor type");
+    return false;
+  }
+
   auto battery_level = mnfData.data[5];
-  auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
   if (this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
+  }
+  if (this->ext_temperature_ != nullptr) {
+    this->ext_temperature_->publish_state(ext_temperature);
   }
   if (this->humidity_ != nullptr) {
     this->humidity_->publish_state(humidity);

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -73,9 +73,9 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   auto measured_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
 
   if (mnfData.data[2] == 0) {
-    this->temperature = this->measured_temperature;
+    temperature = this->measured_temperature;
   } else if (mnfData.data[2] == 1) {
-    this->ext_temperature = this->measured_temperature;
+    ext_temperature = this->measured_temperature;
   } else {
     ESP_LOGVV(TAG, "parse_device(): unknown sensor type");
     return false;

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -79,6 +79,9 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
     return false;
   }
 
+  auto ext_temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+  auto temperature = mnfData.uuid.get_uuid().uuid.uuid16 / 100.0f;
+
   auto battery_level = mnfData.data[5];
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -88,7 +88,7 @@ bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &devi
   auto humidity = ((mnfData.data[1] << 8) + mnfData.data[0]) / 100.0f;
 
   // if (this->temperature_ != nullptr) {
-  if (this->temperature_ != nullptr) {
+  if ( ! isnan(temperature) && this->temperature_ != nullptr) {
     this->temperature_->publish_state(temperature);
   }
   if (this->ext_temperature_ != nullptr) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
@@ -18,12 +18,14 @@ class InkbirdIBSTH1_MINI : public Component, public esp32_ble_tracker::ESPBTDevi
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
+  void set_ext_temperature(sensor::Sensor *ext_temperature) { ext_temperature_ = ext_temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
 
  protected:
   uint64_t address_;
   sensor::Sensor *temperature_{nullptr};
+  sensor::Sensor *ext_temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
 };

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
@@ -18,14 +18,14 @@ class InkbirdIBSTH1_MINI : public Component, public esp32_ble_tracker::ESPBTDevi
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
-  void set_ext_temperature(sensor::Sensor *ext_temperature) { ext_temperature_ = ext_temperature; }
+  void set_external_temperature(sensor::Sensor *external_temperature) { external_temperature_ = external_temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
 
  protected:
   uint64_t address_;
   sensor::Sensor *temperature_{nullptr};
-  sensor::Sensor *ext_temperature_{nullptr};
+  sensor::Sensor *external_temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
 };

--- a/esphome/components/inkbird_ibsth1_mini/sensor.py
+++ b/esphome/components/inkbird_ibsth1_mini/sensor.py
@@ -19,7 +19,7 @@ from esphome.const import (
 CODEOWNERS = ["@fkirill"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 
-CONF_EXT_TEMPERATURE = ["external_temperature"]
+CONF_EXT_TEMPERATURE = "external_temperature"
 
 inkbird_ibsth1_mini_ns = cg.esphome_ns.namespace("inkbird_ibsth1_mini")
 InkbirdUBSTH1_MINI = inkbird_ibsth1_mini_ns.class_(

--- a/esphome/components/inkbird_ibsth1_mini/sensor.py
+++ b/esphome/components/inkbird_ibsth1_mini/sensor.py
@@ -19,7 +19,7 @@ from esphome.const import (
 CODEOWNERS = ["@fkirill"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 
-CONF_EXT_TEMPERATURE = "external_temperature"
+CONF_EXT_TEMPERATURE = "ext_temperature"
 
 inkbird_ibsth1_mini_ns = cg.esphome_ns.namespace("inkbird_ibsth1_mini")
 InkbirdUBSTH1_MINI = inkbird_ibsth1_mini_ns.class_(

--- a/esphome/components/inkbird_ibsth1_mini/sensor.py
+++ b/esphome/components/inkbird_ibsth1_mini/sensor.py
@@ -19,7 +19,7 @@ from esphome.const import (
 CODEOWNERS = ["@fkirill"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 
-CONF_EXT_TEMPERATURE = "ext_temperature"
+CONF_EXTERNAL_TEMPERATURE = "external_temperature"
 
 inkbird_ibsth1_mini_ns = cg.esphome_ns.namespace("inkbird_ibsth1_mini")
 InkbirdUBSTH1_MINI = inkbird_ibsth1_mini_ns.class_(
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = (
                 DEVICE_CLASS_TEMPERATURE,
                 STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_EXT_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_EXTERNAL_TEMPERATURE): sensor.sensor_schema(
                 UNIT_CELSIUS,
                 ICON_EMPTY,
                 1,
@@ -76,9 +76,9 @@ async def to_code(config):
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature(sens))
-    if CONF_EXT_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_EXT_TEMPERATURE])
-        cg.add(var.set_ext_temperature(sens))
+    if CONF_EXTERNAL_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_EXTERNAL_TEMPERATURE])
+        cg.add(var.set_external_temperature(sens))
     if CONF_HUMIDITY in config:
         sens = await sensor.new_sensor(config[CONF_HUMIDITY])
         cg.add(var.set_humidity(sens))

--- a/esphome/components/inkbird_ibsth1_mini/sensor.py
+++ b/esphome/components/inkbird_ibsth1_mini/sensor.py
@@ -19,6 +19,8 @@ from esphome.const import (
 CODEOWNERS = ["@fkirill"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 
+CONF_EXT_TEMPERATURE = ["external_temperature"]
+
 inkbird_ibsth1_mini_ns = cg.esphome_ns.namespace("inkbird_ibsth1_mini")
 InkbirdUBSTH1_MINI = inkbird_ibsth1_mini_ns.class_(
     "InkbirdIBSTH1_MINI", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
@@ -30,6 +32,13 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(InkbirdUBSTH1_MINI),
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                UNIT_CELSIUS,
+                ICON_EMPTY,
+                1,
+                DEVICE_CLASS_TEMPERATURE,
+                STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_EXT_TEMPERATURE): sensor.sensor_schema(
                 UNIT_CELSIUS,
                 ICON_EMPTY,
                 1,
@@ -67,6 +76,9 @@ async def to_code(config):
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature(sens))
+    if CONF_EXT_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_EXT_TEMPERATURE])
+        cg.add(var.set_ext_temperature(sens))
     if CONF_HUMIDITY in config:
         sens = await sensor.new_sensor(config[CONF_HUMIDITY])
         cg.add(var.set_humidity(sens))


### PR DESCRIPTION
# What does this implement/fix? 

IBS-TH1 Mini was already implemented. This update will add support for non mini models and external sensor with full backwards combability. 
IBS-TH1 and IBS-TH1 Mini send the exact same payload with internal sensors. IBS-TH1 identifies data from the external sensor with a flipped bit (mnfData.data[2] in code)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1289

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
      - platform: inkbird_ibsth1_mini
        mac_address: 38:81:D7:0A:9C:11
        temperature:
          name: "Inkbird IBS-TH1 Temperature"
        ext_temperature:
          name: "Inkburd IBS-TH1 External Temperature"
        humidity:
          name: "Inkbird IBS-TH1 Humidity"
        battery_level:
          name: "Inkbird IBS-TH1 Battery Level"
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
