### PR TITLE
Time Based Cover: Fixed apparent race condition on ESP32 chips

### DIFF
--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -115,13 +115,13 @@ void TimeBasedCover::start_direction_(CoverOperation dir) {
 
   this->current_operation = dir;
 
-  this->stop_prev_trigger_();
-  trig->trigger();
-  this->prev_command_trigger_ = trig;
-
   const uint32_t now = millis();
   this->start_dir_time_ = now;
   this->last_recompute_time_ = now;
+
+  this->stop_prev_trigger_();
+  trig->trigger();
+  this->prev_command_trigger_ = trig;
 }
 void TimeBasedCover::recompute_position_() {
   if (this->current_operation == COVER_OPERATION_IDLE)


### PR DESCRIPTION
# What does this implement/fix? 

I has a situation where when the cover first started moving the current position would often jump to a seemingly random value at the start. It seemed that the `this->last_recompute_time_ = now;` line was not getting called before `recompute_position_` was getting called. Once I moved this code up before the trigger this stopped been an issue. I haven't looked into the triggering code but perhaps this is due to the dual code of the ESP32?

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32 (sonoff Dual R3)
- [ ] ESP8266

## Example entry for `config.yaml`:
The external component here was just the copy of time_based component that I made to fix this locally
```yaml
switch:
- platform: gpio
  pin: GPIO14
  interlock: &interlock [open_cover, close_cover]
  id: close_cover
- platform: gpio
  pin: GPIO27
  interlock: *interlock
  id: open_cover

external_components:
  - source:
      type: local
      path: components
      
cover:
- platform: time_based
  name: "Bedroom Shutters"
  id: bedroom_cover
  open_action:
    - switch.turn_on: open_cover
  open_duration: 33s
  close_action:
    - switch.turn_on: close_cover
  close_duration: 32s
  stop_action:
    - switch.turn_off: open_cover
    - switch.turn_off: close_cover```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
