### PR TITLE
Support custom fan modes in mqtt_climate

### DIFF
--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -91,7 +91,7 @@ class ClimateTraits {
   ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
   void set_supports_fan_mode_diffuse(bool supported) { set_fan_mode_support_(CLIMATE_FAN_DIFFUSE, supported); }
   bool supports_fan_mode(ClimateFanMode fan_mode) const { return supported_fan_modes_.count(fan_mode); }
-  bool get_supports_fan_modes() const { return !supported_fan_modes_.empty(); }
+  bool get_supports_fan_modes() const { return !supported_fan_modes_.empty() || !supported_custom_fan_modes_.empty(); }
   const std::set<ClimateFanMode> get_supported_fan_modes() const { return supported_fan_modes_; }
 
   void set_supported_custom_fan_modes(std::set<std::string> supported_custom_fan_modes) {

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -97,6 +97,8 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
       fan_modes.add("focus");
     if (traits.supports_fan_mode(CLIMATE_FAN_DIFFUSE))
       fan_modes.add("diffuse");
+    for (const auto &fan_mode : traits.get_supported_custom_fan_modes())
+      fan_modes.add(fan_mode);
   }
 
   if (traits.get_supports_swing_modes()) {
@@ -291,36 +293,39 @@ bool MQTTClimateComponent::publish_state_() {
   }
 
   if (traits.get_supports_fan_modes()) {
-    const char *payload = "";
-    switch (this->device_->fan_mode.value()) {
-      case CLIMATE_FAN_ON:
-        payload = "on";
-        break;
-      case CLIMATE_FAN_OFF:
-        payload = "off";
-        break;
-      case CLIMATE_FAN_AUTO:
-        payload = "auto";
-        break;
-      case CLIMATE_FAN_LOW:
-        payload = "low";
-        break;
-      case CLIMATE_FAN_MEDIUM:
-        payload = "medium";
-        break;
-      case CLIMATE_FAN_HIGH:
-        payload = "high";
-        break;
-      case CLIMATE_FAN_MIDDLE:
-        payload = "middle";
-        break;
-      case CLIMATE_FAN_FOCUS:
-        payload = "focus";
-        break;
-      case CLIMATE_FAN_DIFFUSE:
-        payload = "diffuse";
-        break;
-    }
+    std::string payload;
+    if (this->device_->fan_mode.has_value())
+      switch (this->device_->fan_mode.value()) {
+        case CLIMATE_FAN_ON:
+          payload = "on";
+          break;
+        case CLIMATE_FAN_OFF:
+          payload = "off";
+          break;
+        case CLIMATE_FAN_AUTO:
+          payload = "auto";
+          break;
+        case CLIMATE_FAN_LOW:
+          payload = "low";
+          break;
+        case CLIMATE_FAN_MEDIUM:
+          payload = "medium";
+          break;
+        case CLIMATE_FAN_HIGH:
+          payload = "high";
+          break;
+        case CLIMATE_FAN_MIDDLE:
+          payload = "middle";
+          break;
+        case CLIMATE_FAN_FOCUS:
+          payload = "focus";
+          break;
+        case CLIMATE_FAN_DIFFUSE:
+          payload = "diffuse";
+          break;
+      }
+    if (this->device_->custom_fan_mode.has_value())
+      payload = this->device_->custom_fan_mode.value();
     if (!this->publish(this->get_fan_mode_state_topic(), payload))
       success = false;
   }


### PR DESCRIPTION
# What does this implement/fix? 

Support custom fan modes for MQTT connections. Include in discovery and publish (subscribe already works).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP8266

Tested with the following variations in the climate device:
* Supports both standard and custom fan modes
* Only supports standard fan modes
* Only supports custom fan modes
* Doesn't support any fan modes

Tested that all fan modes appear in HA. Tested changing to both types of fan modes.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).