### PR TITLE
Climate modes COOL and HEAT are auto modes

### DIFF
--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -20,7 +20,6 @@ void PIDClimate::setup() {
     restore->to_call(this).perform();
   } else {
     // restore from defaults, change_away handles those for us
-    // restore from defaults, change_away handles those for us
     if (supports_heat_() && supports_cool_())
       this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     else if (supports_cool_())

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -41,11 +41,13 @@ climate::ClimateTraits PIDClimate::traits() {
   traits.set_supports_current_temperature(true);
   traits.set_supports_two_point_target_temperature(false);
 
-  traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL});
+  traits.set_supported_modes({climate::CLIMATE_MODE_OFF});
   if (supports_cool_())
     traits.add_supported_mode(climate::CLIMATE_MODE_COOL);
   if (supports_heat_())
     traits.add_supported_mode(climate::CLIMATE_MODE_HEAT);
+  if (supports_heat_() && supports_cool_())
+    traits.add_supported_mode(climate::CLIMATE_MODE_HEAT_COOL);
 
   traits.set_supports_action(true);
   return traits;
@@ -95,11 +97,7 @@ void PIDClimate::handle_non_auto_mode_() {
   // in non-auto mode, switch directly to appropriate action
   //  - HEAT mode / COOL mode -> Output at ±100%
   //  - OFF mode -> Output at 0%
-  if (this->mode == climate::CLIMATE_MODE_HEAT) {
-    this->write_output_(1.0);
-  } else if (this->mode == climate::CLIMATE_MODE_COOL) {
-    this->write_output_(-1.0);
-  } else if (this->mode == climate::CLIMATE_MODE_OFF) {
+  if (this->mode == climate::CLIMATE_MODE_OFF) {
     this->write_output_(0.0);
   } else {
     assert(false);
@@ -132,7 +130,7 @@ void PIDClimate::update_pid_() {
     }
   }
 
-  if (this->mode != climate::CLIMATE_MODE_HEAT_COOL) {
+  if (this->mode == climate::CLIMATE_MODE_OFF) {
     this->handle_non_auto_mode_();
   } else {
     this->write_output_(value);

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -95,7 +95,6 @@ void PIDClimate::write_output_(float value) {
 }
 void PIDClimate::handle_non_auto_mode_() {
   // in non-auto mode, switch directly to appropriate action
-  //  - HEAT mode / COOL mode -> Output at ±100%
   //  - OFF mode -> Output at 0%
   if (this->mode == climate::CLIMATE_MODE_OFF) {
     this->write_output_(0.0);

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -20,7 +20,13 @@ void PIDClimate::setup() {
     restore->to_call(this).perform();
   } else {
     // restore from defaults, change_away handles those for us
-    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+    // restore from defaults, change_away handles those for us
+    if (supports_heat_() && supports_cool_())
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+    else if (supports_cool_())
+      this->mode = climate::CLIMATE_MODE_COOL;
+    else if (supports_heat_())
+      this->mode = climate::CLIMATE_MODE_HEAT;
     this->target_temperature = this->default_target_temperature_;
   }
 }


### PR DESCRIPTION
# What does this implement/fix? 

If only a heat (or cool) mode is defined, the hvac mode heat_cool should not even be visible in Home assistant
If hvac mode is set to only heat (or cool), the heater should be regulated based on the temperature instead of always on

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1750

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
