### PR TITLE
Improve climate mode code docs

### DIFF
--- a/esphome/components/climate/climate_mode.h
+++ b/esphome/components/climate/climate_mode.h
@@ -13,7 +13,7 @@ enum ClimateMode : uint8_t {
   CLIMATE_MODE_HEAT_COOL = 1,
   /// The climate device is set to cool to reach the a target temperature
   CLIMATE_MODE_COOL = 2,
-  /// The climate device is set to cool to reach the a target temperature
+  /// The climate device is set to heat to reach the a target temperature
   CLIMATE_MODE_HEAT = 3,
   /// The climate device only has the fan enabled, no heating or cooling is taking place
   CLIMATE_MODE_FAN_ONLY = 4,

--- a/esphome/components/climate/climate_mode.h
+++ b/esphome/components/climate/climate_mode.h
@@ -7,19 +7,22 @@ namespace climate {
 
 /// Enum for all modes a climate device can be in.
 enum ClimateMode : uint8_t {
-  /// The climate device is off (not in auto, heat or cool mode)
+  /// The climate device is off
   CLIMATE_MODE_OFF = 0,
-  /// The climate device is set to automatically change the heating/cooling cycle
+  /// The climate device is set to heat/cool to reach the target temperature.
   CLIMATE_MODE_HEAT_COOL = 1,
-  /// The climate device is manually set to cool mode (not in auto mode!)
+  /// The climate device is set to cool to reach the a target temperature
   CLIMATE_MODE_COOL = 2,
-  /// The climate device is manually set to heat mode (not in auto mode!)
+  /// The climate device is set to cool to reach the a target temperature
   CLIMATE_MODE_HEAT = 3,
-  /// The climate device is manually set to fan only mode
+  /// The climate device only has the fan enabled, no heating or cooling is taking place
   CLIMATE_MODE_FAN_ONLY = 4,
-  /// The climate device is manually set to dry mode
+  /// The climate device is set to dry/humidity mode
   CLIMATE_MODE_DRY = 5,
-  /// The climate device is manually set to heat-cool mode
+  /** The climate device is adjusting the temperatre dynamically.
+   * For example, the target temperature can be adjusted based on a schedule, or learned behavior.
+   * The target temperature can't be adjusted when in this mode.
+   */
   CLIMATE_MODE_AUTO = 6
 };
 
@@ -27,15 +30,15 @@ enum ClimateMode : uint8_t {
 enum ClimateAction : uint8_t {
   /// The climate device is off (inactive or no power)
   CLIMATE_ACTION_OFF = 0,
-  /// The climate device is actively cooling (usually in cool or auto mode)
+  /// The climate device is actively cooling
   CLIMATE_ACTION_COOLING = 2,
-  /// The climate device is actively heating (usually in heat or auto mode)
+  /// The climate device is actively heating
   CLIMATE_ACTION_HEATING = 3,
   /// The climate device is idle (monitoring climate but no action needed)
   CLIMATE_ACTION_IDLE = 4,
-  /// The climate device is drying (either mode DRY or AUTO)
+  /// The climate device is drying
   CLIMATE_ACTION_DRYING = 5,
-  /// The climate device is in fan only mode (either mode FAN_ONLY or AUTO)
+  /// The climate device is in fan only mode
   CLIMATE_ACTION_FAN = 6,
 };
 

--- a/esphome/components/climate/climate_mode.h
+++ b/esphome/components/climate/climate_mode.h
@@ -11,9 +11,9 @@ enum ClimateMode : uint8_t {
   CLIMATE_MODE_OFF = 0,
   /// The climate device is set to heat/cool to reach the target temperature.
   CLIMATE_MODE_HEAT_COOL = 1,
-  /// The climate device is set to cool to reach the a target temperature
+  /// The climate device is set to cool to reach the target temperature
   CLIMATE_MODE_COOL = 2,
-  /// The climate device is set to heat to reach the a target temperature
+  /// The climate device is set to heat to reach the target temperature
   CLIMATE_MODE_HEAT = 3,
   /// The climate device only has the fan enabled, no heating or cooling is taking place
   CLIMATE_MODE_FAN_ONLY = 4,


### PR DESCRIPTION
# What does this implement/fix? 

Related to #1994

ESPHome's climate model was created before the HA climate entity remodel, and made different assumptions about the configured mode.

<table>
<tr>
	<td>Mode
	<td>Old Meaning
	<td>New Meaning
<tr>
	<td><code>COOL</code>
	<td>Force the device to cool at 100%
	<td>Device cools to reach a target temperature (but must not heat)
<tr>
	<td><code>HEAT</code>
	<td>Force the device to heat at 100%
	<td>Device heats to reach a target temperature (but must not cool)
</table>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
