### PR TITLE
[Teleinfo] do not stop parsing frame if there is only a CRC error on …

### DIFF
--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -90,6 +90,7 @@ void TeleInfo::loop() {
       char *grp_end;
       char *buf_end;
       int field_len;
+      bool crc_error;
 
       buf_finger = buf_;
       buf_end = buf_ + buf_index_;
@@ -119,8 +120,10 @@ void TeleInfo::loop() {
           break;
         }
 
+        crc_error = false;
+
         if (!check_crc_(buf_finger, grp_end))
-          break;
+          crc_error = true;
 
         /* Get tag */
         field_len = get_field(tag_, buf_finger, grp_end, separator_);
@@ -142,7 +145,8 @@ void TeleInfo::loop() {
         /* Advance buf_finger to end of group */
         buf_finger += field_len + 1 + 1 + 1;
 
-        publish_value_(std::string(tag_), std::string(val_));
+	if (!crc_error)
+          publish_value_(std::string(tag_), std::string(val_));
       }
       state_ = OFF;
       break;

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -122,7 +122,7 @@ void TeleInfo::loop() {
         if (!check_crc_(buf_finger, grp_end))
           continue;
 
-	/* Get tag */
+        /* Get tag */
         field_len = get_field(tag_, buf_finger, grp_end, separator_);
         if (!field_len || field_len >= MAX_TAG_SIZE) {
           ESP_LOGE(TAG, "Invalid tag.");

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -141,7 +141,7 @@ void TeleInfo::loop() {
           buf_finger += field_len + 1 + 1 + 1;
 
           publish_value_(std::string(tag_), std::string(val_));
-	}
+        }
       }
       state_ = OFF;
       break;

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -119,7 +119,7 @@ void TeleInfo::loop() {
           break;
         }
 
-        if (!check_crc_(buf_finger, grp_end)) {
+        if (check_crc_(buf_finger, grp_end)) {
           /* Get tag */
           field_len = get_field(tag_, buf_finger, grp_end, separator_);
           if (!field_len || field_len >= MAX_TAG_SIZE) {

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -145,7 +145,7 @@ void TeleInfo::loop() {
         /* Advance buf_finger to end of group */
         buf_finger += field_len + 1 + 1 + 1;
 
-	if (!crc_error)
+        if (!crc_error)
           publish_value_(std::string(tag_), std::string(val_));
       }
       state_ = OFF;

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -119,29 +119,30 @@ void TeleInfo::loop() {
           break;
         }
 
-        if (check_crc_(buf_finger, grp_end)) {
-          /* Get tag */
-          field_len = get_field(tag_, buf_finger, grp_end, separator_);
-          if (!field_len || field_len >= MAX_TAG_SIZE) {
-            ESP_LOGE(TAG, "Invalid tag.");
-            break;
-          }
+        if (!check_crc_(buf_finger, grp_end))
+          continue;
 
-          /* Advance buf_finger to after the tag and the separator. */
-          buf_finger += field_len + 1;
-
-          /* Get value (after next separator) */
-          field_len = get_field(val_, buf_finger, grp_end, separator_);
-          if (!field_len || field_len >= MAX_VAL_SIZE) {
-            ESP_LOGE(TAG, "Invalid Value");
-            break;
-          }
-
-          /* Advance buf_finger to end of group */
-          buf_finger += field_len + 1 + 1 + 1;
-
-          publish_value_(std::string(tag_), std::string(val_));
+	/* Get tag */
+        field_len = get_field(tag_, buf_finger, grp_end, separator_);
+        if (!field_len || field_len >= MAX_TAG_SIZE) {
+          ESP_LOGE(TAG, "Invalid tag.");
+          break;
         }
+
+        /* Advance buf_finger to after the tag and the separator. */
+        buf_finger += field_len + 1;
+
+        /* Get value (after next separator) */
+        field_len = get_field(val_, buf_finger, grp_end, separator_);
+        if (!field_len || field_len >= MAX_VAL_SIZE) {
+          ESP_LOGE(TAG, "Invalid Value");
+          break;
+        }
+
+        /* Advance buf_finger to end of group */
+        buf_finger += field_len + 1 + 1 + 1;
+
+        publish_value_(std::string(tag_), std::string(val_));
       }
       state_ = OFF;
       break;


### PR DESCRIPTION
…a group

# What does this implement/fix? 

teleinfo stops parsing frame as soon as there is an error in the frame. This fix allow teleinfo to continue parsing the frame if there is only a crc error on a group : the bad crc value is ignored (publish_value_ is not done) and the parsing of the frame continue to try to find other valid values.
This avoid to loose the complete frame information if only one group is corrupted. I tested this and have very more realtime data because all post crc error data are not lost.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
Exemple provided in teleinfo documentation on esphome website is accurate to test this PR.
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
