### PR TITLE
Fixed lolin32 lite key

### DIFF
--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -538,7 +538,7 @@ ESP32_BOARD_PINS = {
     "iotbusio": {},
     "iotbusproteus": {},
     "lolin32": {"LED": 5},
-    "lolin32-lite": {"LED": 22},
+    "lolin32_lite": {"LED": 22},
     "lolin_d32": {"LED": 5, "_VBAT": 35},
     "lolin_d32_pro": {"LED": 5, "_VBAT": 35},
     "lopy": {


### PR DESCRIPTION
# What does this implement/fix? 

Lolin 32 lite is wrongly using the key `lolin32-lite` while [platformio](https://docs.platformio.org/en/latest/boards/espressif32/lolin32.html#board-espressif32-lolin32) specifies it as `lolin32_lite`. This simple change allows the use of lolin32 lite boards as expected from the listed known boards. Without this fix it results in the error `Error: Unknown board ID 'lolin32-lite'`. This was also raised in  [#2064](https://github.com/esphome/issues/issues/2064).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/2064>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: livingroom
  platform: ESP32
  board: lolin32_lite
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
