### PR TITLE
ccs811: publish firmware version; log bootloader and HW version; fix a bug

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,7 @@ esphome/components/ble_client/* @buxtronix
 esphome/components/bme680_bsec/* @trvrnrth
 esphome/components/canbus/* @danielschramm @mvturnho
 esphome/components/captive_portal/* @OttoWinter
+esphome/components/ccs811/* @habbie
 esphome/components/climate/* @esphome/core
 esphome/components/climate_ir/* @glmnet
 esphome/components/color_temperature/* @jesserockz

--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -16,7 +16,7 @@ static const char *const TAG = "ccs811";
     return; \
   }
 
-#define CHECKED_IO(f) CHECK_TRUE(f, COMMUNICAITON_FAILED)
+#define CHECKED_IO(f) CHECK_TRUE(f, COMMUNICATION_FAILED)
 
 void CCS811Component::setup() {
   // page 9 programming guide - hwid is always 0x81
@@ -38,18 +38,50 @@ void CCS811Component::setup() {
   // set MEAS_MODE (page 5)
   uint8_t meas_mode = 0;
   uint32_t interval = this->get_update_interval();
-  if (interval <= 1000)
-    meas_mode = 1 << 4;
-  else if (interval <= 10000)
-    meas_mode = 2 << 4;
+  if (interval >= 60 * 1000)
+    meas_mode = 3 << 4;  // sensor takes a reading every 60 seconds
+  else if (interval >= 10 * 1000)
+    meas_mode = 2 << 4;  // sensor takes a reading every 10 seconds
+  else if (interval >= 1 * 1000)
+    meas_mode = 1 << 4;  // sensor takes a reading every second
   else
-    meas_mode = 3 << 4;
+    meas_mode = 4 << 4;  // sensor takes a reading every 250ms
 
   CHECKED_IO(this->write_byte(0x01, meas_mode))
 
   if (this->baseline_.has_value()) {
     // baseline available, write to sensor
     this->write_bytes(0x11, decode_uint16(*this->baseline_));
+  }
+
+  auto hardware_version_data = this->read_bytes<1>(0x21);
+  auto bootloader_version_data = this->read_bytes<2>(0x23);
+  auto application_version_data = this->read_bytes<2>(0x24);
+
+  uint8_t hardware_version = 0;
+  uint16_t bootloader_version = 0;
+  uint16_t application_version = 0;
+
+  if (hardware_version_data.has_value()) {
+    hardware_version = (*hardware_version_data)[0];
+  }
+
+  if (bootloader_version_data.has_value()) {
+    bootloader_version = encode_uint16((*bootloader_version_data)[0], (*bootloader_version_data)[1]);
+  }
+
+  if (application_version_data.has_value()) {
+    application_version = encode_uint16((*application_version_data)[0], (*application_version_data)[1]);
+  }
+
+  ESP_LOGD(TAG, "hardware_version=0x%x bootloader_version=0x%x application_version=0x%x\n", hardware_version,
+           bootloader_version, application_version);
+  if (this->version_ != nullptr) {
+    char version[20];  // "15.15.15 (0xffff)" is 17 chars, plus NUL, plus wiggle room
+    sprintf(version, "%d.%d.%d (0x%02x)", (application_version >> 12 & 15), (application_version >> 8 & 15),
+            (application_version >> 4 & 15), application_version);
+    ESP_LOGD(TAG, "publishing version state: %s", version);
+    this->version_->publish_state(version);
   }
 }
 void CCS811Component::update() {
@@ -117,6 +149,7 @@ void CCS811Component::dump_config() {
   LOG_UPDATE_INTERVAL(this)
   LOG_SENSOR("  ", "CO2 Sensor", this->co2_)
   LOG_SENSOR("  ", "TVOC Sensor", this->tvoc_)
+  LOG_TEXT_SENSOR("  ", "Firmware Version Sensor", this->version_)
   if (this->baseline_) {
     ESP_LOGCONFIG(TAG, "  Baseline: %04X", *this->baseline_);
   } else {
@@ -124,7 +157,7 @@ void CCS811Component::dump_config() {
   }
   if (this->is_failed()) {
     switch (this->error_code_) {
-      case COMMUNICAITON_FAILED:
+      case COMMUNICATION_FAILED:
         ESP_LOGW(TAG, "Communication failed! Is the sensor connected?");
         break;
       case INVALID_ID:

--- a/esphome/components/ccs811/ccs811.h
+++ b/esphome/components/ccs811/ccs811.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
 namespace esphome {
@@ -12,6 +13,7 @@ class CCS811Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_co2(sensor::Sensor *co2) { co2_ = co2; }
   void set_tvoc(sensor::Sensor *tvoc) { tvoc_ = tvoc; }
+  void set_version(text_sensor::TextSensor *version) { version_ = version; }
   void set_baseline(uint16_t baseline) { baseline_ = baseline; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
@@ -34,7 +36,7 @@ class CCS811Component : public PollingComponent, public i2c::I2CDevice {
 
   enum ErrorCode {
     UNKNOWN,
-    COMMUNICAITON_FAILED,
+    COMMUNICATION_FAILED,
     INVALID_ID,
     SENSOR_REPORTED_ERROR,
     APP_INVALID,
@@ -43,6 +45,7 @@ class CCS811Component : public PollingComponent, public i2c::I2CDevice {
 
   sensor::Sensor *co2_{nullptr};
   sensor::Sensor *tvoc_{nullptr};
+  text_sensor::TextSensor *version_{nullptr};
   optional<uint16_t> baseline_{};
   /// Input sensor for humidity reading.
   sensor::Sensor *humidity_{nullptr};


### PR DESCRIPTION
# What does this implement/fix? 

CCS811 modules have firmware, and many of them run version 1.0 or 1.1. The vendor has published 2.0.0 and 2.0.1 which are recommended over the 1.x versions. This PR adds logging of the HW revision, the bootloader version, and the loaded firmware version.

This PR fixes a typo in an enum.

This PR fixes a bug where the measurement interval on the CCS811 module was configured inappropriately in relation to the configured update interval in ESPHome, causing missed updates.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** I'm not aware of any.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/1336

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: ccs811
    eco2:
      name: "CCS811 eCO2 Value"
    tvoc:
      name: "CCS811 Total Volatile Organic Compound"
    version:
      name: "CCS811 Firmware Version"
    address: 0x5A
    update_interval: 5s

```

Compared to the example config in the docs, the `version` key is added. Unlike the other two sensors for ccs811, `version` is optional.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

I have not yet looked into the test framework. I will do that soon.

I did not test this with an actual HomeAssistant install yet. I'm not worried about it, but I'll do it soon. I may then find out that `ICON_RESTART` was a weird choice.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
