### PR TITLE
log "component took a long time" at warning

### DIFF
--- a/esphome/const.py
+++ b/esphome/const.py
@@ -309,6 +309,7 @@ CONF_LIGHTNING_ENERGY = "lightning_energy"
 CONF_LIGHTNING_THRESHOLD = "lightning_threshold"
 CONF_LOADED_INTEGRATIONS = "loaded_integrations"
 CONF_LOCAL = "local"
+CONF_LOG_LONG_LOOP_AT_WARNING_LEVEL = 'log_long_loop_at_warning_level'
 CONF_LOG_TOPIC = "log_topic"
 CONF_LOGGER = "logger"
 CONF_LOGS = "logs"

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -78,8 +78,14 @@ void Application::loop() {
 
   const uint32_t end = millis();
   if (end - start > 200) {
+    // FIXME: surely we can avoid duplicating these lines like this
+#ifdef ESPHOME_LOG_LONG_LOOP_AT_WARNING_LEVEL
     ESP_LOGW(TAG, "A component took a long time in a loop() cycle (%.2f s).", (end - start) / 1e3f);
     ESP_LOGW(TAG, "Components should block for at most 20-30ms in loop().");
+#else
+    ESP_LOGV(TAG, "A component took a long time in a loop() cycle (%.2f s).", (end - start) / 1e3f);
+    ESP_LOGV(TAG, "Components should block for at most 20-30ms in loop().");
+#endif
   }
 
   const uint32_t now = millis();

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -78,8 +78,8 @@ void Application::loop() {
 
   const uint32_t end = millis();
   if (end - start > 200) {
-    ESP_LOGV(TAG, "A component took a long time in a loop() cycle (%.2f s).", (end - start) / 1e3f);
-    ESP_LOGV(TAG, "Components should block for at most 20-30ms in loop().");
+    ESP_LOGW(TAG, "A component took a long time in a loop() cycle (%.2f s).", (end - start) / 1e3f);
+    ESP_LOGW(TAG, "Components should block for at most 20-30ms in loop().");
   }
 
   const uint32_t now = millis();

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -14,6 +14,7 @@ from esphome.const import (
     CONF_ESPHOME,
     CONF_INCLUDES,
     CONF_LIBRARIES,
+    CONF_LOG_LONG_LOOP_AT_WARNING_LEVEL,
     CONF_NAME,
     CONF_ON_BOOT,
     CONF_ON_LOOP,
@@ -201,6 +202,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Required(CONF_VERSION): cv.string_strict,
             }
         ),
+        cv.Optional(CONF_LOG_LONG_LOOP_AT_WARNING_LEVEL, default=False): cv.boolean,
         cv.Optional("esphome_core_version"): cv.invalid(
             "The esphome_core_version option has been "
             "removed in 1.13 - the esphome core source "
@@ -353,3 +355,6 @@ async def to_code(config):
     if CONF_PROJECT in config:
         cg.add_define("ESPHOME_PROJECT_NAME", config[CONF_PROJECT][CONF_NAME])
         cg.add_define("ESPHOME_PROJECT_VERSION", config[CONF_PROJECT][CONF_VERSION])
+
+    if config.get(CONF_LOG_LONG_LOOP_AT_WARNING_LEVEL, False):
+        cg.add_define("ESPHOME_LOG_LONG_LOOP_AT_WARNING_LEVEL")


### PR DESCRIPTION
# What does this implement/fix? 

I saw this message while logging at 'Very Verbose' and suggested on Discord that many component authors would never notice, because it's only logged at Verbose and up. Oxan said "I think upgrading that message to info or warning level isn't a bad idea".

After that, I also discovered that the whole reason I was seeing this log message was logging at Very Verbose, where dumping all the I2C communication actually causes the loop to run slow. So, at the current level, the message can be quite useless!

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** none that I am aware of

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none - I haven't checked how you generate changelogs, should I PR something for that?

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:

I used the setup from #2006 and added `delay(500);` to the end of `void CCS811Component::update()` in `/esphome/components/ccs811/ccs811.cpp`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
