### PR TITLE
Color brightness fixes

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -32,19 +32,26 @@ LightCall &LightCall::parse_color_json(JsonObject &root) {
 
   if (root.containsKey("color")) {
     JsonObject &color = root["color"];
+    // HA also encodes brightness information in the r, g, b values, so extract that and set it as color brightness.
+    float max_rgb = 0.0f;
     if (color.containsKey("r")) {
-      this->set_red(float(color["r"]) / 255.0f);
+      float r = float(color["r"]) / 255.0f;
+      max_rgb = fmaxf(max_rgb, r);
+      this->set_red(r);
     }
     if (color.containsKey("g")) {
-      this->set_green(float(color["g"]) / 255.0f);
+      float g = float(color["g"]) / 255.0f;
+      max_rgb = fmaxf(max_rgb, g);
+      this->set_green(g);
     }
     if (color.containsKey("b")) {
-      this->set_blue(float(color["b"]) / 255.0f);
+      float b = float(color["b"]) / 255.0f;
+      max_rgb = fmaxf(max_rgb, b);
+      this->set_blue(b);
     }
-  }
-
-  if (root.containsKey("color_brightness")) {
-    this->set_color_brightness(float(root["color_brightness"]) / 255.0f);
+    if (color.containsKey("r") || color.containsKey("g") || color.containsKey("b")) {
+      this->set_color_brightness(max_rgb);
+    }
   }
 
   if (root.containsKey("white_value")) {

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -418,7 +418,7 @@ LightCall &LightCall::set_brightness_if_supported(float brightness) {
 }
 LightCall &LightCall::set_color_brightness_if_supported(float brightness) {
   if (this->parent_->get_traits().get_supports_rgb_white_value())
-    this->set_brightness(brightness);
+    this->set_color_brightness(brightness);
   return *this;
 }
 LightCall &LightCall::set_red_if_supported(float red) {

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -135,12 +135,11 @@ class LightColorValues {
       root["brightness"] = uint8_t(this->get_brightness() * 255);
     if (traits.get_supports_rgb()) {
       JsonObject &color = root.createNestedObject("color");
-      color["r"] = uint8_t(this->get_red() * 255);
-      color["g"] = uint8_t(this->get_green() * 255);
-      color["b"] = uint8_t(this->get_blue() * 255);
+      color["r"] = uint8_t(this->get_color_brightness() * this->get_red() * 255);
+      color["g"] = uint8_t(this->get_color_brightness() * this->get_green() * 255);
+      color["b"] = uint8_t(this->get_color_brightness() * this->get_blue() * 255);
     }
     if (traits.get_supports_rgb_white_value()) {
-      root["color_brightness"] = uint8_t(this->get_color_brightness() * 255);
       root["white_value"] = uint8_t(this->get_white() * 255);
     }
     if (traits.get_supports_color_temperature())

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -18,6 +18,7 @@ LightCall LightState::make_call() { return LightCall(this); }
 struct LightStateRTCState {
   bool state{false};
   float brightness{1.0f};
+  float color_brightness{1.0f};
   float red{1.0f};
   float green{1.0f};
   float blue{1.0f};
@@ -65,6 +66,7 @@ void LightState::setup() {
 
   call.set_state(recovered.state);
   call.set_brightness_if_supported(recovered.brightness);
+  call.set_color_brightness_if_supported(recovered.color_brightness);
   call.set_red_if_supported(recovered.red);
   call.set_green_if_supported(recovered.green);
   call.set_blue_if_supported(recovered.blue);
@@ -244,6 +246,7 @@ void LightState::save_remote_values_() {
   LightStateRTCState saved;
   saved.state = this->remote_values.is_on();
   saved.brightness = this->remote_values.get_brightness();
+  saved.color_brightness = this->remote_values.get_color_brightness();
   saved.red = this->remote_values.get_red();
   saved.green = this->remote_values.get_green();
   saved.blue = this->remote_values.get_blue();


### PR DESCRIPTION
# What does this implement/fix? 

Some minor fixes for the new color brightness I noticed while working on the color mode stuff.

~Draft PR for now as I haven't tested this beyond compilation.~ Tested, though I don't have a HA with MQTT setup, so I haven't tested that specific interaction -- but that's broken before this PR as well due to the HA colormodel changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
