### PR TITLE
Fix ethernet component hostname handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ __pycache__/
 # Intellij Idea
 .idea
 
+# Vim
+*.swp
+
 # Hide some OS X stuff
 .DS_Store
 .AppleDouble

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -84,21 +84,21 @@ void EthernetComponent::loop() {
   const uint32_t now = millis();
 
   switch (this->state_) {
-    case EthernetComponentState::Stopped:
+    case EthernetComponentState::STOPPED:
       if (this->started_) {
         ESP_LOGI(TAG, "Starting ethernet connection");
-        this->state_ = EthernetComponentState::Connecting;
+        this->state_ = EthernetComponentState::CONNECTING;
         this->start_connect_();
       }
       break;
-    case EthernetComponentState::Connecting:
+    case EthernetComponentState::CONNECTING:
       if (!this->started_) {
         ESP_LOGI(TAG, "Stopped ethernet connection");
-        this->state_ = EthernetComponentState::Stopped;
+        this->state_ = EthernetComponentState::STOPPED;
       } else if (this->connected_) {
         // connection established
         ESP_LOGI(TAG, "Connected via Ethernet!");
-        this->state_ = EthernetComponentState::Connected;
+        this->state_ = EthernetComponentState::CONNECTED;
 
         this->dump_connect_params_();
         this->status_clear_warning();
@@ -109,13 +109,13 @@ void EthernetComponent::loop() {
         this->start_connect_();
       }
       break;
-    case EthernetComponentState::Connected:
+    case EthernetComponentState::CONNECTED:
       if (!this->started_) {
         ESP_LOGI(TAG, "Stopped ethernet connection");
-        this->state_ = EthernetComponentState::Stopped;
+        this->state_ = EthernetComponentState::STOPPED;
       } else if (!this->connected_) {
         ESP_LOGW(TAG, "Connection via Ethernet lost! Re-connecting...");
-        this->state_ = EthernetComponentState::Connecting;
+        this->state_ = EthernetComponentState::CONNECTING;
         this->start_connect_();
       }
       break;
@@ -225,7 +225,7 @@ void EthernetComponent::eth_phy_power_enable_(bool enable) {
   delay(1);
   global_eth_component->orig_power_enable_fun_(enable);
 }
-bool EthernetComponent::is_connected() { return this->state_ == EthernetComponentState::Connected; }
+bool EthernetComponent::is_connected() { return this->state_ == EthernetComponentState::CONNECTED; }
 void EthernetComponent::dump_connect_params_() {
   tcpip_adapter_ip_info_t ip;
   tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &ip);

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -27,9 +27,9 @@ struct ManualIP {
 };
 
 enum class EthernetComponentState {
-  Stopped,
-  Connecting,
-  Connected,
+  STOPPED,
+  CONNECTING,
+  CONNECTED,
 };
 
 class EthernetComponent : public Component {

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -27,9 +27,9 @@ struct ManualIP {
 };
 
 enum class EthernetComponentState {
-    Stopped,
-    Connecting,
-    Connected,
+  Stopped,
+  Connecting,
+  Connected,
 };
 
 class EthernetComponent : public Component {

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -73,7 +73,7 @@ class EthernetComponent : public Component {
 
   bool started_{false};
   bool connected_{false};
-  EthernetComponentState state_{EthernetComponentState::Stopped};
+  EthernetComponentState state_{EthernetComponentState::STOPPED};
   uint32_t connect_begin_;
   eth_config_t eth_config;
   eth_phy_power_enable_func orig_power_enable_fun_;

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -26,6 +26,12 @@ struct ManualIP {
   IPAddress dns2;  ///< The second DNS server. 0.0.0.0 for default.
 };
 
+enum class EthernetComponentState {
+    Stopped,
+    Connecting,
+    Connected,
+};
+
 class EthernetComponent : public Component {
  public:
   EthernetComponent();
@@ -65,9 +71,9 @@ class EthernetComponent : public Component {
   eth_clock_mode_t clk_mode_{ETH_CLOCK_GPIO0_IN};
   optional<ManualIP> manual_ip_{};
 
-  bool initialized_{false};
+  bool started_{false};
   bool connected_{false};
-  bool last_connected_{false};
+  EthernetComponentState state_{EthernetComponentState::Stopped};
   uint32_t connect_begin_;
   eth_config_t eth_config;
   eth_phy_power_enable_func orig_power_enable_fun_;


### PR DESCRIPTION
# What does this implement/fix? 

Previously, the ethernet component would try to setup and connect before
`esp_eth_enable` is called, which can be called right after
`esp_eth_init` is called.  The rest of the logic in `start_connect_`,
for example setting up the hostname and dhcp information, should wait
until after the ETH_START event is received.  This would result in the
first connection attempt always failing (as `esp_eth_enable` would only
be called on the second run through `start_connect_`) and once
connected, would fail to set the hostname correctly.

This PR correctly runs `esp_eth_enable` and `esp_eth_init` in the
`setup` for the component.  This allows the ethernet component to
connect on the first attempt, saving 15 sec (the connection timeout) on
component startup.

This PR adds some additional state tracking to the ethernet component to
be able to know when the start event has been received and start the
connection once the eth_start event is received, and also track the
connection status through this state machine.  This makes the state more
explicit, rather than using `last_connected_` and `connected_` to track
state.

With this PR, because of the now correct setup, the hostname is
correctly set.  This could have been seen earlier by error checking the
return from `tcpip_adapter_set_hostname`, as this would fail on the
first call, before the esp_eth_enable.  Error checking is added to the
call to set the hostname, to catch further problems with this.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

Fixes esphome/issues#2184

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
esphome:
  name: testdevice
  platform: ESP32
  board: wesp32

ethernet:
  type: LAN8720
  mdc_pin: GPIO16
  mdio_pin: GPIO17
  clk_mode: GPIO0_IN
  domain: !secret my_domain

logger:

api:

ota:
  password: !secret ota_password
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Ran test yaml on wesp32 device, saw that device would connect correctly
on the first attempt without requiring a re-try on the ethernet
connection, and once connected, had the correct hostname. Disconnected
and re-connected the ethernet cable to observe the state correctly
transition between connecting and connected.
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
