### PR TITLE
catch 0.0 in float set_level pre-adjustment

### DIFF
--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -31,6 +31,10 @@ void FloatOutput::set_level(float state) {
 #endif
   if (this->is_inverted())
     state = 1.0f - state;
+  if (state == 0.0f) {  // regardless of min_power_, 0.0 means off
+    this->write_state(state);
+    return;
+  }
   float adjusted_value = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
   this->write_state(adjusted_value);
 }


### PR DESCRIPTION
# What does this implement/fix? 

When using min_power on a float output, makes sure that off means off, not min_power.
Full issue description in attached related issue.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [https://github.com/esphome/issues/issues/2237](https://github.com/esphome/issues/issues/2237)

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: esp8266_pwm
    id: output_led
    pin: D4
    min_power: 0.50


light:
  - platform: monochromatic
    name: 'Test_LED'
    output: output_led
    default_transition_length: 0s
    gamma_correct: 0.0        #disabled to demonstrate this more easily
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
