### PR TITLE
Remove superfluous polling on ADS1115

### DIFF
--- a/esphome/components/ads1115/ads1115.cpp
+++ b/esphome/components/ads1115/ads1115.cpp
@@ -64,11 +64,6 @@ void ADS1115Component::setup() {
     return;
   }
   this->prev_config_ = config;
-
-  for (auto *sensor : this->sensors_) {
-    this->set_interval(sensor->get_name(), sensor->update_interval(),
-                       [this, sensor] { this->request_measurement(sensor); });
-  }
 }
 void ADS1115Component::dump_config() {
   ESP_LOGCONFIG(TAG, "Setting up ADS1115...");


### PR DESCRIPTION
# What does this implement/fix? 

The `setup()` of the ADS1115 component would setup an update interval,
in addition to the one that would be setup by the polling component.
These calls would simply request a measurement but not update the value.
This additional call is removed by this change.  The ADS1115 continues
to function as expected using the polling setup by the PollingComponent.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: ads115-test
  platform: ESP32
  board: esp32dev

logger:

api:

ota:
  password: !secret ota_password

wifi:
  # valid wifi config

i2c:
  # valid i2c config

ads1115:
  - address: 0x48

sensor:
  - platform: ads1115
    gain: 4.096
    multiplexer: "A0_GND"
    name: "ADC Channel 0"
  - platform: ads1115
    gain: 4.096
    multiplexer: "A1_GND"
    name: "ADC Channel 1"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Added some logging to `ADS1115Sensor::request_measurement` and checked that it would only fire when the polling updates would take place.
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).