### PR TITLE
Correct ADS1115 handling of multiple sensors in continuous mode

### DIFF
--- a/esphome/components/ads1115/ads1115.cpp
+++ b/esphome/components/ads1115/ads1115.cpp
@@ -107,17 +107,22 @@ float ADS1115Component::request_measurement(ADS1115Sensor *sensor) {
     }
     this->prev_config_ = config;
 
-    // about 1.6 ms with 860 samples per second
+    // about 1.2 ms with 860 samples per second
     delay(2);
 
-    uint32_t start = millis();
-    while (this->read_byte_16(ADS1115_REGISTER_CONFIG, &config) && (config >> 15) == 0) {
-      if (millis() - start > 100) {
-        ESP_LOGW(TAG, "Reading ADS1115 timed out");
-        this->status_set_warning();
-        return NAN;
+    // in continuous mode, conversion will always be running, rely on the delay
+    // to ensure conversion is taking place with the correct settings
+    // can we use the rdy pin to trigger when a conversion is done?
+    if (!this->continuous_mode_) {
+      uint32_t start = millis();
+      while (this->read_byte_16(ADS1115_REGISTER_CONFIG, &config) && (config >> 15) == 0) {
+        if (millis() - start > 100) {
+          ESP_LOGW(TAG, "Reading ADS1115 timed out");
+          this->status_set_warning();
+          return NAN;
+        }
+        yield();
       }
-      yield();
     }
   }
 

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -53,11 +53,11 @@ class ADS1115Component : public Component, public i2c::I2CDevice {
 class ADS1115Sensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
  public:
   ADS1115Sensor(ADS1115Component *parent) : parent_(parent) {}
-  void update() override;
+  void update() final;
   void set_multiplexer(ADS1115Multiplexer multiplexer) { multiplexer_ = multiplexer; }
   void set_gain(ADS1115Gain gain) { gain_ = gain; }
 
-  float sample() override;
+  float sample() final;
   uint8_t get_multiplexer() const { return multiplexer_; }
   uint8_t get_gain() const { return gain_; }
 

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -53,11 +53,11 @@ class ADS1115Component : public Component, public i2c::I2CDevice {
 class ADS1115Sensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
  public:
   ADS1115Sensor(ADS1115Component *parent) : parent_(parent) {}
-  void update() final;
+  void update() override;
   void set_multiplexer(ADS1115Multiplexer multiplexer) { multiplexer_ = multiplexer; }
   void set_gain(ADS1115Gain gain) { gain_ = gain; }
 
-  float sample() final;
+  float sample() override;
   uint8_t get_multiplexer() const { return multiplexer_; }
   uint8_t get_gain() const { return gain_; }
 


### PR DESCRIPTION
# What does this implement/fix? 

When running in continuous mode, the ADS1115 config register will always
return that it is currently taking a measurement.  When the config
register needs to be set, either on the first time a given sensor is
read or if a different sensor with a different mux has been read on the
same device since the last update, then this will cause this function to
timeout.  When only using a single sensor on the ADS1115, this will only
cause the first sample to fail, and all other samples will be able to
immediately read the sensor value.  However, when there is more than one
sensor mux setup with the same update frequency, then every sensor
reading will fail, as the config will attempt to be updated on each
update.

To fix this, when running in continuous mode, simply assume that a
conversion has taken place after a sufficient amount of time has passed.
Testing this empirically, this is sufficient to always get the correct
voltage from the ADC. I checked this by configuring two sensors, one
measuring 0V and the other measuring at 3.3V, and both sensors always
reported the correct values within expected tolerances.  Ideally, we may
be able to use the ALERT/RDY pin on the ADS1115 to detect when the
conversion is complete, however this would take some additional
configuration and handling of the gpio pin polling or interrupt setup.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

Fixes esphome/issues#892 (this was closed because it is stale)

There is some discussion in esphome/issues#892 about this problem, and
noting solutions similar to this, as well as the proposed fix using the
ready pin.  As noted in that issue, some of the issues mentioned there,
in particular regarding the CT clamp needing to poll the ADS1115 at
~kHz, will not be truly fixed by this, in particular because of the
inherent and necessary 2ms delay when changing mux channels (even with
an interrupt on the ready pin, this component will still need ~1.2ms to
register a new reading when running at 860 samples per second).
However, I feel like this is about as good as we can do given these
limitations and what this component is trying to accomplish. Some
documentation around the limitations here, as well as some information
in the CT clamp docs, may be helpful.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
esphome:
  name: ads115-test
  platform: ESP32
  board: esp32dev

logger:

api:

ota:
  password: !secret ota_password

wifi:
  # valid wifi config

i2c:
  # valid i2c config

ads1115:
  - address: 0x48
    continuous_mode: true

sensor:
  - platform: ads1115
    gain: 4.096
    multiplexer: "A0_GND"
    name: "ADC Channel 0"
  - platform: ads1115
    gain: 4.096
    multiplexer: "A1_GND"
    name: "ADC Channel 1"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).