### PR TITLE
Always tick mdns in ethernet component

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -102,8 +102,6 @@ void EthernetComponent::loop() {
 
         this->dump_connect_params_();
         this->status_clear_warning();
-
-        network_tick_mdns();
       } else if (now - this->connect_begin_ > 15000) {
         ESP_LOGW(TAG, "Connecting via ethernet failed! Re-connecting...");
         this->start_connect_();
@@ -120,6 +118,8 @@ void EthernetComponent::loop() {
       }
       break;
   }
+
+  network_tick_mdns();
 }
 void EthernetComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Ethernet:");


### PR DESCRIPTION
# What does this implement/fix? 

Set the behavior of the ethernet component to mirror the wifi component
by always doing `network_tick_mdns` on each `loop()`.

The current implementation of `network_tick_mdns` is a noop for esp32,
meaning this function call will always do nothing as the ethernet
component is esp32-only.  Should any additional functionality be added
to this function for the esp32, this behavior is likely to be the most
correct, given the current configuration of the wifi component.

There is also an argument to be made to drop this call. If there is
never a case where esp32 specific functionality would be included in
`network_tick_mdns`, that may be a better change.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
