### PR TITLE
Add support for the HRXL MaxSonar WR series sensors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,6 +49,7 @@ esphome/components/gpio/* @esphome/core
 esphome/components/gps/* @coogle
 esphome/components/havells_solar/* @sourabhjaiswal
 esphome/components/homeassistant/* @OttoWinter
+esphome/components/hrxl_maxsonar_wr/* @netmikey
 esphome/components/i2c/* @esphome/core
 esphome/components/improv/* @jesserockz
 esphome/components/inkbird_ibsth1_mini/* @fkirill

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
@@ -20,8 +20,7 @@ static const int MAX_DATA_LENGTH_BYTES = 6;
  * 1234 means a distance of 1,234 m.
  */
 void HrxlMaxsonarWrComponent::loop() {
-  this->flush();
-  String buffer;
+  std::string buffer;
   while (this->available() > 0) {
     uint8_t data;
     for (int i = 0; i < MAX_DATA_LENGTH_BYTES; i++) {
@@ -37,8 +36,8 @@ void HrxlMaxsonarWrComponent::loop() {
     }
 
     ESP_LOGV(TAG, "Read from serial: %s", buffer.c_str());
-    if (buffer.length() == (MAX_DATA_LENGTH_BYTES - 1) && buffer.startsWith("R")) {
-      int millimeters = buffer.substring(1).toInt();
+    if (buffer.length() == (MAX_DATA_LENGTH_BYTES - 1) && buffer[0] == 'R') {
+      int millimeters = atoi(buffer.substr(1).c_str());
       float meters = float(millimeters) / 1000.0;
       ESP_LOGV(TAG, "Distance from sensor: %u mm, %f m", millis, meters);
       this->publish_state(meters);
@@ -51,7 +50,7 @@ void HrxlMaxsonarWrComponent::loop() {
 void HrxlMaxsonarWrComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "HRXL MaxSonar WR Sensor:");
   LOG_SENSOR("  ", "Distance", this);
-  // As specified in the sensonr's data sheet
+  // As specified in the sensor's data sheet
   this->check_uart_settings(9600, 1, esphome::uart::UART_CONFIG_PARITY_NONE, 8);
 }
 

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
@@ -32,22 +32,21 @@ void HrxlMaxsonarWrComponent::loop() {
 
 void HrxlMaxsonarWrComponent::check_buffer_() {
   // The sensor seems to inject a rogue ASCII 255 byte from time to time. Get rid of that.
-  if (this->buffer_.back() == ASCII_NBSP) {
+  if (this->buffer_.back() == static_cast<char>(ASCII_NBSP)) {
     this->buffer_.pop_back();
     return;
   }
 
   // Stop reading at ASCII_CR. Also prevent the buffer from growing
   // indefinitely if no ASCII_CR is received after MAX_DATA_LENGTH_BYTES.
-  if (this->buffer_.back() == ASCII_CR || this->buffer_.length() >= MAX_DATA_LENGTH_BYTES) {
+  if (this->buffer_.back() == static_cast<char>(ASCII_CR) || this->buffer_.length() >= MAX_DATA_LENGTH_BYTES) {
     ESP_LOGV(TAG, "Read from serial: %s", this->buffer_.c_str());
 
     if (this->buffer_.length() == MAX_DATA_LENGTH_BYTES && this->buffer_[0] == 'R' &&
-        this->buffer_.back() == ASCII_CR) {
-
+        this->buffer_.back() == static_cast<char>(ASCII_CR)) {
       int millimeters = strtol(this->buffer_.substr(1, MAX_DATA_LENGTH_BYTES - 2).c_str(), nullptr, 10);
       float meters = float(millimeters) / 1000.0;
-      ESP_LOGV(TAG, "Distance from sensor: %lu mm, %f m", millis, meters);
+      ESP_LOGV(TAG, "Distance from sensor: %d mm, %f m", millimeters, meters);
       this->publish_state(meters);
     } else {
       ESP_LOGW(TAG, "Invalid data read from sensor: %s", this->buffer_.c_str());

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
@@ -9,7 +9,7 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace hrxlmaxsonarwr {
+namespace hrxl_maxsonar_wr {
 
 static const char *const TAG = "hrxl.maxsonar.wr.sensor";
 static const uint8_t ASCII_CR = 0x0D;
@@ -23,7 +23,7 @@ void HrxlMaxsonarWrComponent::loop() {
   uint8_t data;
   while (this->available() > 0) {
     if (this->read_byte(&data)) {
-      buffer += (char) data;
+      buffer_ += (char) data;
       this->check_buffer_();
     }
   }
@@ -32,23 +32,17 @@ void HrxlMaxsonarWrComponent::loop() {
 void HrxlMaxsonarWrComponent::check_buffer_() {
   // Stop reading at ASCII_CR. Also prevent the buffer from growing
   // indefinitely if no ASCII_CR is received after MAX_DATA_LENGTH_BYTES.
-  if (this->buffer.back() == ASCII_CR ||
-      this->buffer.length() >= MAX_DATA_LENGTH_BYTES) {
-
-    ESP_LOGV(TAG, "Read from serial: %s", this->buffer.c_str());
-
-    if (this->buffer.length() == MAX_DATA_LENGTH_BYTES &&
-        this->buffer[0] == 'R' &&
-        this->buffer.back() == ASCII_CR) {
-
-      int millimeters = atoi(this->buffer.substr(1, MAX_DATA_LENGTH_BYTES - 2).c_str());
+  if (this->buffer_.back() == ASCII_CR || this->buffer_.length() >= MAX_DATA_LENGTH_BYTES) {
+    ESP_LOGV(TAG, "Read from serial: %s", this->buffer_.c_str());
+    if (this->buffer_.length() == MAX_DATA_LENGTH_BYTES && this->buffer_[0] == 'R' && this->buffer_.back() == ASCII_CR) {
+      int millimeters = atoi(this->buffer_.substr(1, MAX_DATA_LENGTH_BYTES - 2).c_str());
       float meters = float(millimeters) / 1000.0;
       ESP_LOGV(TAG, "Distance from sensor: %u mm, %f m", millis, meters);
       this->publish_state(meters);
     } else {
-      ESP_LOGW(TAG, "Invalid data read from sensor: %s", this->buffer.c_str());
+      ESP_LOGW(TAG, "Invalid data read from sensor: %s", this->buffer_.c_str());
     }
-    this->buffer.clear();
+    this->buffer_.clear();
   }
 }
 
@@ -59,5 +53,5 @@ void HrxlMaxsonarWrComponent::dump_config() {
   this->check_uart_settings(9600, 1, esphome::uart::UART_CONFIG_PARITY_NONE, 8);
 }
 
-}  // namespace hrxlmaxsonarwr
-}  // namspace esphome
+}  // namespace hrxl_maxsonar_wr
+}  // namespace esphome

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
@@ -20,8 +20,8 @@ static const int MAX_DATA_LENGTH_BYTES = 6;
  * 1234 means a distance of 1,234 m.
  */
 void HrxlMaxsonarWrComponent::loop() {
-  std::string buffer;
   while (this->available() > 0) {
+    std::string buffer;
     uint8_t data;
     for (int i = 0; i < MAX_DATA_LENGTH_BYTES; i++) {
       if (this->read_byte(&data)) {

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.cpp
@@ -1,0 +1,59 @@
+// Official Datasheet:
+//   https://www.maxbotix.com/documents/HRXL-MaxSonar-WR_Datasheet.pdf
+//
+// This implementation is designed to work with the TTL Versions of the
+// MaxBotix HRXL MaxSonar WR sensor series. The sensor's TTL Pin (5) should be
+// wired to one of the ESP's input pins and configured as uart rx_pin.
+
+#include "hrxl_maxsonar_wr.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace hrxlmaxsonarwr {
+
+static const char *const TAG = "hrxl.maxsonar.wr.sensor";
+static const uint8_t ASCII_CR = 0x0D;
+static const int MAX_DATA_LENGTH_BYTES = 6;
+
+/**
+ * The sensor outputs something like "R1234\r" at a fixed rate of 6 Hz. Where
+ * 1234 means a distance of 1,234 m.
+ */
+void HrxlMaxsonarWrComponent::loop() {
+  this->flush();
+  String buffer;
+  while (this->available() > 0) {
+    uint8_t data;
+    for (int i = 0; i < MAX_DATA_LENGTH_BYTES; i++) {
+      if (this->read_byte(&data)) {
+        if (data == ASCII_CR) {
+          break;
+        } else {
+          buffer += (char) data;
+        }
+      } else {
+        break;
+      }
+    }
+
+    ESP_LOGV(TAG, "Read from serial: %s", buffer.c_str());
+    if (buffer.length() == (MAX_DATA_LENGTH_BYTES - 1) && buffer.startsWith("R")) {
+      int millimeters = buffer.substring(1).toInt();
+      float meters = float(millimeters) / 1000.0;
+      ESP_LOGV(TAG, "Distance from sensor: %u mm, %f m", millis, meters);
+      this->publish_state(meters);
+    } else {
+      ESP_LOGW(TAG, "Invalid data read from sensor: %s", buffer.c_str());
+    }
+  }
+}
+
+void HrxlMaxsonarWrComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "HRXL MaxSonar WR Sensor:");
+  LOG_SENSOR("  ", "Distance", this);
+  // As specified in the sensonr's data sheet
+  this->check_uart_settings(9600, 1, esphome::uart::UART_CONFIG_PARITY_NONE, 8);
+}
+
+}  // namespace hrxlmaxsonarwr
+}  // namspace esphome

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.h
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace hrxlmaxsonarwr {
+
+class HrxlMaxsonarWrComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
+  public:
+    // Nothing really public.
+
+    // ========== INTERNAL METHODS ==========
+    void loop() override;
+    void dump_config() override;
+
+  protected:
+    // Nothing.
+};
+
+}  // namespace hrxlmaxsonarwr
+}  // namespace esphome

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.h
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.h
@@ -16,7 +16,9 @@ class HrxlMaxsonarWrComponent : public sensor::Sensor, public Component, public 
     void dump_config() override;
 
   protected:
-    // Nothing.
+    void check_buffer_();
+
+    std::string buffer;
 };
 
 }  // namespace hrxlmaxsonarwr

--- a/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.h
+++ b/esphome/components/hrxl_maxsonar_wr/hrxl_maxsonar_wr.h
@@ -5,21 +5,21 @@
 #include "esphome/components/uart/uart.h"
 
 namespace esphome {
-namespace hrxlmaxsonarwr {
+namespace hrxl_maxsonar_wr {
 
 class HrxlMaxsonarWrComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
-  public:
-    // Nothing really public.
+ public:
+  // Nothing really public.
 
-    // ========== INTERNAL METHODS ==========
-    void loop() override;
-    void dump_config() override;
+  // ========== INTERNAL METHODS ==========
+  void loop() override;
+  void dump_config() override;
 
-  protected:
-    void check_buffer_();
+ protected:
+  void check_buffer_();
 
-    std::string buffer;
+  std::string buffer_;
 };
 
-}  // namespace hrxlmaxsonarwr
+}  // namespace hrxl_maxsonar_wr
 }  // namespace esphome

--- a/esphome/components/hrxl_maxsonar_wr/sensor.py
+++ b/esphome/components/hrxl_maxsonar_wr/sensor.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, uart
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_EMPTY,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_METER,
+    ICON_ARROW_EXPAND_VERTICAL,
+)
+
+CODEOWNERS = ["@netmikey"]
+DEPENDENCIES = ["uart"]
+
+hrxlmaxsonarwr_ns = cg.esphome_ns.namespace("hrxlmaxsonarwr")
+HrxlMaxsonarWrComponent = hrxlmaxsonarwr_ns.class_(
+    "HrxlMaxsonarWrComponent", sensor.Sensor, cg.Component, uart.UARTDevice
+)
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        UNIT_METER,
+        ICON_ARROW_EXPAND_VERTICAL,
+        3,
+        DEVICE_CLASS_EMPTY,
+        STATE_CLASS_MEASUREMENT,
+    )
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(HrxlMaxsonarWrComponent),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)
+    await uart.register_uart_device(var, config)

--- a/esphome/components/hrxl_maxsonar_wr/sensor.py
+++ b/esphome/components/hrxl_maxsonar_wr/sensor.py
@@ -12,7 +12,7 @@ from esphome.const import (
 CODEOWNERS = ["@netmikey"]
 DEPENDENCIES = ["uart"]
 
-hrxlmaxsonarwr_ns = cg.esphome_ns.namespace("hrxlmaxsonarwr")
+hrxlmaxsonarwr_ns = cg.esphome_ns.namespace("hrxl_maxsonar_wr")
 HrxlMaxsonarWrComponent = hrxlmaxsonarwr_ns.class_(
     "HrxlMaxsonarWrComponent", sensor.Sensor, cg.Component, uart.UARTDevice
 )

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -63,6 +63,15 @@ sensor:
   - platform: tuya
     id: tuya_sensor
     sensor_datapoint: 1
+  - platform: "hrxl_maxsonar_wr"
+    name: "Rainwater Tank Level"
+    filters:
+      - sliding_window_moving_average:
+          window_size: 12
+          send_every: 12
+      - or:
+        - throttle: "20min"
+        - delta: 0.02
 #
 # platform sensor.apds9960 requires component apds9960
 #


### PR DESCRIPTION
# What does this implement/fix? 

This adds support for the HRXL MaxSonar WR Series Ultrasonic Sensors by MaxBotix.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1308

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  rx_pin: 36
  baud_rate: 9600

sensor:
  - platform: "hrxl_maxsonar_wr"
    name: "Rainwater Tank"
    filters:
      - sliding_window_moving_average:
          window_size: 12
          send_every: 12
      - or:
        - throttle: "20min"
        - delta: 0.02
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
