### PR TITLE
Correctly invert esp32 RMT TX

### DIFF
--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -41,6 +41,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   bool initialized_{false};
   std::vector<rmt_item32_t> rmt_temp_;
   esp_err_t error_code_{ESP_OK};
+  bool inverted_{false};
 #endif
   uint8_t carrier_duty_percent_{50};
 };

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -50,6 +50,7 @@ void RemoteTransmitterComponent::configure_rmt() {
   } else {
     c.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
     c.tx_config.idle_level = RMT_IDLE_LEVEL_HIGH;
+    this->inverted_ = true;
   }
 
   esp_err_t error = rmt_config(&c);
@@ -95,10 +96,10 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
       val -= item;
 
       if (rmt_i % 2 == 0) {
-        rmt_item.level0 = static_cast<uint32_t>(level);
+        rmt_item.level0 = static_cast<uint32_t>(level ^ this->inverted_);
         rmt_item.duration0 = static_cast<uint32_t>(item);
       } else {
-        rmt_item.level1 = static_cast<uint32_t>(level);
+        rmt_item.level1 = static_cast<uint32_t>(level ^ this->inverted_);
         rmt_item.duration1 = static_cast<uint32_t>(item);
         this->rmt_temp_.push_back(rmt_item);
       }


### PR DESCRIPTION
# What does this implement/fix? 

Invert rmt.level if an esp32 is using an inverted output as a transmitter.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [https://github.com/esphome/issues/issues/2240](https://github.com/esphome/issues/issues/2240)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# ESP32

remote_transmitter:
  pin:
    number: GPIO17
    inverted: True
  carrier_duty_percent: 100%

climate:
  - platform: coolix
    name: "Transmitting AC"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
