### PR TITLE
ESP32 ADC use esp-idf

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -1,8 +1,5 @@
 #include "adc_sensor.h"
 #include "esphome/core/log.h"
-#ifdef ARDUINO_ARCH_ESP32
-#include "driver/adc.h"
-#endif
 
 #ifdef USE_ADC_SENSOR_VCC
 ADC_MODE(ADC_VCC)
@@ -14,7 +11,7 @@ namespace adc {
 static const char *const TAG = "adc";
 
 #ifdef ARDUINO_ARCH_ESP32
-void ADCSensor::set_attenuation(adc_attenuation_t attenuation) { this->attenuation_ = attenuation; }
+void ADCSensor::set_attenuation(adc_atten_t attenuation) { this->attenuation_ = attenuation; }
 
 inline adc1_channel_t gpio_to_adc1(uint8_t pin) {
   switch (pin) {
@@ -76,6 +73,8 @@ void ADCSensor::dump_config() {
     case ADC_ATTEN_DB_11:
       ESP_LOGCONFIG(TAG, " Attenuation: 11db (max 3.9V)");
       break;
+    default:  // This is to satisfy the unused ADC_ATTEN_MAX
+      break;
   }
 #endif
   LOG_UPDATE_INTERVAL(this);
@@ -102,6 +101,8 @@ float ADCSensor::sample() {
       break;
     case ADC_ATTEN_DB_11:
       value_v *= 3.9;
+      break;
+    default:  // This is to satisfy the unused ADC_ATTEN_MAX
       break;
   }
   return value_v;

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -1,5 +1,8 @@
 #include "adc_sensor.h"
 #include "esphome/core/log.h"
+#ifdef ARDUINO_ARCH_ESP32
+#include "driver/adc.h"
+#endif
 
 #ifdef USE_ADC_SENSOR_VCC
 ADC_MODE(ADC_VCC)
@@ -12,6 +15,29 @@ static const char *const TAG = "adc";
 
 #ifdef ARDUINO_ARCH_ESP32
 void ADCSensor::set_attenuation(adc_attenuation_t attenuation) { this->attenuation_ = attenuation; }
+
+inline adc1_channel_t gpio_to_adc1(uint8_t pin) {
+  switch (pin) {
+    case 36:
+      return ADC1_CHANNEL_0;
+    case 37:
+      return ADC1_CHANNEL_1;
+    case 38:
+      return ADC1_CHANNEL_2;
+    case 39:
+      return ADC1_CHANNEL_3;
+    case 32:
+      return ADC1_CHANNEL_4;
+    case 33:
+      return ADC1_CHANNEL_5;
+    case 34:
+      return ADC1_CHANNEL_6;
+    case 35:
+      return ADC1_CHANNEL_7;
+    default:
+      return ADC1_CHANNEL_MAX;
+  }
+}
 #endif
 
 void ADCSensor::setup() {
@@ -21,7 +47,9 @@ void ADCSensor::setup() {
 #endif
 
 #ifdef ARDUINO_ARCH_ESP32
-  analogSetPinAttenuation(this->pin_, this->attenuation_);
+  adc1_config_channel_atten(gpio_to_adc1(pin_), attenuation_);
+  adc1_config_width(ADC_WIDTH_BIT_12);
+  adc_gpio_init(ADC_UNIT_1, (adc_channel_t) gpio_to_adc1(pin_));
 #endif
 }
 void ADCSensor::dump_config() {
@@ -36,16 +64,16 @@ void ADCSensor::dump_config() {
 #ifdef ARDUINO_ARCH_ESP32
   ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
   switch (this->attenuation_) {
-    case ADC_0db:
+    case ADC_ATTEN_DB_0:
       ESP_LOGCONFIG(TAG, " Attenuation: 0db (max 1.1V)");
       break;
-    case ADC_2_5db:
+    case ADC_ATTEN_DB_2_5:
       ESP_LOGCONFIG(TAG, " Attenuation: 2.5db (max 1.5V)");
       break;
-    case ADC_6db:
+    case ADC_ATTEN_DB_6:
       ESP_LOGCONFIG(TAG, " Attenuation: 6db (max 2.2V)");
       break;
-    case ADC_11db:
+    case ADC_ATTEN_DB_11:
       ESP_LOGCONFIG(TAG, " Attenuation: 11db (max 3.9V)");
       break;
   }
@@ -60,18 +88,19 @@ void ADCSensor::update() {
 }
 float ADCSensor::sample() {
 #ifdef ARDUINO_ARCH_ESP32
-  float value_v = analogRead(this->pin_) / 4095.0f;  // NOLINT
+  int raw = adc1_get_raw(gpio_to_adc1(pin_));
+  float value_v = raw / 4095.0f;
   switch (this->attenuation_) {
-    case ADC_0db:
+    case ADC_ATTEN_DB_0:
       value_v *= 1.1;
       break;
-    case ADC_2_5db:
+    case ADC_ATTEN_DB_2_5:
       value_v *= 1.5;
       break;
-    case ADC_6db:
+    case ADC_ATTEN_DB_6:
       value_v *= 2.2;
       break;
-    case ADC_11db:
+    case ADC_ATTEN_DB_11:
       value_v *= 3.9;
       break;
   }

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -6,6 +6,10 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/voltage_sampler/voltage_sampler.h"
 
+#ifdef ARDUINO_ARCH_ESP32
+#include "driver/adc.h"
+#endif
+
 namespace esphome {
 namespace adc {
 
@@ -13,7 +17,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
  public:
 #ifdef ARDUINO_ARCH_ESP32
   /// Set the attenuation for this pin. Only available on the ESP32.
-  void set_attenuation(adc_attenuation_t attenuation);
+  void set_attenuation(adc_atten_t attenuation);
 #endif
 
   /// Update adc values.
@@ -34,7 +38,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   uint8_t pin_;
 
 #ifdef ARDUINO_ARCH_ESP32
-  adc_atten_t attenuation_{};
+  adc_atten_t attenuation_{ADC_ATTEN_DB_0};
 #endif
 };
 

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -34,7 +34,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   uint8_t pin_;
 
 #ifdef ARDUINO_ARCH_ESP32
-  adc_attenuation_t attenuation_{ADC_0db};
+  adc_atten_t attenuation_{};
 #endif
 };
 

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -16,10 +16,10 @@ from esphome.const import (
 AUTO_LOAD = ["voltage_sampler"]
 
 ATTENUATION_MODES = {
-    "0db": cg.global_ns.ADC_0db,
-    "2.5db": cg.global_ns.ADC_2_5db,
-    "6db": cg.global_ns.ADC_6db,
-    "11db": cg.global_ns.ADC_11db,
+    "0db": cg.global_ns.ADC_ATTEN_DB_0,
+    "2.5db": cg.global_ns.ADC_ATTEN_DB_2_5,
+    "6db": cg.global_ns.ADC_ATTEN_DB_6,
+    "11db": cg.global_ns.ADC_ATTEN_DB_11,
 }
 
 


### PR DESCRIPTION
# What does this implement/fix? 

The arduino-esp32's adc functions are quite broken (TODO link) in newer framework versions. This PR migrates our adc code over to use esp-idf.

TODO:
- [ ] description links
- [ ] test

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2186

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
