### PR TITLE
Improve external components error messages

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -109,7 +109,15 @@ def _compute_destination_path(key: str) -> Path:
     return base_dir / h.hexdigest()[:8]
 
 
-def _handle_git_response(ret):
+def _run_git_command(cmd):
+    try:
+        ret = subprocess.run(cmd, capture_output=True, check=False)
+    except FileNotFoundError as err:
+        raise cv.Invalid(
+            "git is not installed but required for external_components.\n"
+            "Please see https://git-scm.com/book/en/v2/Getting-Started-Installing-Git for installing git"
+        ) from err
+
     if ret.returncode != 0 and ret.stderr:
         err_str = ret.stderr.decode("utf-8")
         lines = [x.strip() for x in err_str.splitlines()]
@@ -118,46 +126,59 @@ def _handle_git_response(ret):
         raise cv.Invalid(err_str)
 
 
+def _process_git_config(config: dict, refresh) -> str:
+    key = f"{config[CONF_URL]}@{config.get(CONF_REF)}"
+    repo_dir = _compute_destination_path(key)
+    if not repo_dir.is_dir():
+        _LOGGER.info("Cloning %s", key)
+        _LOGGER.debug("Location: %s", repo_dir)
+        cmd = ["git", "clone", "--depth=1"]
+        if CONF_REF in config:
+            cmd += ["--branch", config[CONF_REF]]
+        cmd += ["--", config[CONF_URL], str(repo_dir)]
+        _run_git_command(cmd)
+
+    else:
+        # Check refresh needed
+        file_timestamp = Path(repo_dir / ".git" / "FETCH_HEAD")
+        # On first clone, FETCH_HEAD does not exists
+        if not file_timestamp.exists():
+            file_timestamp = Path(repo_dir / ".git" / "HEAD")
+        age = datetime.datetime.now() - datetime.datetime.fromtimestamp(
+            file_timestamp.stat().st_mtime
+        )
+        if age.seconds > refresh.total_seconds:
+            _LOGGER.info("Updating %s", key)
+            _LOGGER.debug("Location: %s", repo_dir)
+            # Stash local changes (if any)
+            _run_git_command(["git", "stash", "push", "--include-untracked"])
+            # Fetch remote ref
+            cmd = ["git", "fetch", "--", "origin"]
+            if CONF_REF in config:
+                cmd.append(config[CONF_REF])
+            _run_git_command(cmd)
+            # Hard reset to FETCH_HEAD (short-lived git ref corresponding to most recent fetch)
+            _run_git_command(["git", "reset", "--hard", "FETCH_HEAD"])
+
+    if (repo_dir / "esphome" / "components").is_dir():
+        components_dir = repo_dir / "esphome" / "components"
+    elif (repo_dir / "components").is_dir():
+        components_dir = repo_dir / "components"
+    else:
+        raise cv.Invalid(
+            "Could not find components folder for source. Please check the source contains a 'components' or 'esphome/components' folder"
+        )
+
+    return components_dir
+
+
 def _process_single_config(config: dict):
     conf = config[CONF_SOURCE]
     if conf[CONF_TYPE] == TYPE_GIT:
-        key = f"{conf[CONF_URL]}@{conf.get(CONF_REF)}"
-        repo_dir = _compute_destination_path(key)
-        if not repo_dir.is_dir():
-            cmd = ["git", "clone", "--depth=1"]
-            if CONF_REF in conf:
-                cmd += ["--branch", conf[CONF_REF]]
-            cmd += [conf[CONF_URL], str(repo_dir)]
-            ret = subprocess.run(cmd, capture_output=True, check=False)
-            _handle_git_response(ret)
-
-        else:
-            # Check refresh needed
-            file_timestamp = Path(repo_dir / ".git" / "FETCH_HEAD")
-            # On first clone, FETCH_HEAD does not exists
-            if not file_timestamp.exists():
-                file_timestamp = Path(repo_dir / ".git" / "HEAD")
-            age = datetime.datetime.now() - datetime.datetime.fromtimestamp(
-                file_timestamp.stat().st_mtime
+        with cv.prepend_path([CONF_SOURCE]):
+            components_dir = _process_git_config(
+                config[CONF_SOURCE], config[CONF_REFRESH]
             )
-            if age.seconds > config[CONF_REFRESH].total_seconds:
-                _LOGGER.info("Executing git pull %s", key)
-                cmd = ["git", "pull"]
-                ret = subprocess.run(
-                    cmd, cwd=repo_dir, capture_output=True, check=False
-                )
-                _handle_git_response(ret)
-
-        if (repo_dir / "esphome" / "components").is_dir():
-            components_dir = repo_dir / "esphome" / "components"
-        elif (repo_dir / "components").is_dir():
-            components_dir = repo_dir / "components"
-        else:
-            raise cv.Invalid(
-                "Could not find components folder for source. Please check the source contains a 'components' or 'esphome/components' folder",
-                [CONF_SOURCE],
-            )
-
     elif conf[CONF_TYPE] == TYPE_LOCAL:
         components_dir = Path(CORE.relative_config_path(conf[CONF_PATH]))
     else:


### PR DESCRIPTION
# What does this implement/fix? 

Improves error messages for `external_components` when git isn't installed.

Also changes the pull logic a bit to use a force pull (fetch + reset) instead, so that the pull is successful even with diverged history.

Fixes https://github.com/esphome/issues/issues/2110, fixes https://github.com/esphome/issues/issues/2208

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
