### PR TITLE
midea_ac: Fix turbo boost mode. Preset PRESET_BOOST.

### DIFF
--- a/esphome/components/midea_ac/midea_frame.h
+++ b/esphome/components/midea_ac/midea_frame.h
@@ -102,8 +102,11 @@ class PropertiesFrame : public midea_dongle::BaseFrame {
   void set_sleep_mode(bool state) { this->set_bytemask_(20, 0x01, state); }
 
   /* TURBO MODE */
-  bool get_turbo_mode() const { return this->pbuf_[18] & 0x20; }
-  void set_turbo_mode(bool state) { this->set_bytemask_(18, 0x20, state); }
+  bool get_turbo_mode() const { return this->pbuf_[18] & 0x20 || this->pbuf_[20] & 0x02; }
+  void set_turbo_mode(bool state) {
+    this->set_bytemask_(18, 0x20, state);
+    this->set_bytemask_(20, 0x02, state);
+  }
 
   /* FREEZE PROTECTION */
   bool get_freeze_protection_mode() const { return this->pbuf_[31] & 0x80; }


### PR DESCRIPTION
# What does this implement/fix? 

Fix TurboBoost mode (PRESET_BOOST). 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
