### PR TITLE
Number and Template Number updates

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -570,11 +570,11 @@ bool APIConnection::send_number_info(number::Number *number) {
   msg.object_id = number->get_object_id();
   msg.name = number->get_name();
   msg.unique_id = get_default_unique_id("number", number);
-  msg.icon = number->get_icon();
+  msg.icon = number->traits.get_icon();
 
-  msg.min_value = number->get_min_value();
-  msg.max_value = number->get_max_value();
-  msg.step = number->get_step();
+  msg.min_value = number->traits.get_min_value();
+  msg.max_value = number->traits.get_max_value();
+  msg.step = number->traits.get_step();
 
   return this->send_list_entities_number_response(msg);
 }

--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -3,10 +3,6 @@
 
 #ifdef USE_NUMBER
 
-#ifdef USE_DEEP_SLEEP
-#include "esphome/components/deep_sleep/deep_sleep_component.h"
-#endif
-
 namespace esphome {
 namespace mqtt {
 
@@ -20,7 +16,7 @@ void MQTTNumberComponent::setup() {
   this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &state) {
     auto val = parse_float(state);
     if (!val.has_value()) {
-      ESP_LOGE(TAG, "Can't convert '%s' to number!", state.c_str());
+      ESP_LOGW(TAG, "Can't convert '%s' to number!", state.c_str());
       return;
     }
     auto call = this->number_->make_call();
@@ -39,8 +35,15 @@ std::string MQTTNumberComponent::component_type() const { return "number"; }
 
 std::string MQTTNumberComponent::friendly_name() const { return this->number_->get_name(); }
 void MQTTNumberComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) {
-  if (!this->number_->get_icon().empty())
-    root["icon"] = this->number_->get_icon();
+  const auto &traits = number_->traits;
+  // https://www.home-assistant.io/integrations/number.mqtt/
+  if (!traits.get_icon().empty())
+    root["icon"] = traits.get_icon();
+  root["min_value"] = traits.get_min_value();
+  root["max_value"] = traits.get_max_value();
+  root["step"] = traits.get_step();
+
+  config.command_topic = true;
 }
 bool MQTTNumberComponent::send_initial_state() {
   if (this->number_->has_state()) {
@@ -51,8 +54,9 @@ bool MQTTNumberComponent::send_initial_state() {
 }
 bool MQTTNumberComponent::is_internal() { return this->number_->is_internal(); }
 bool MQTTNumberComponent::publish_state(float value) {
-  int8_t accuracy = this->number_->get_accuracy_decimals();
-  return this->publish(this->get_state_topic_(), value_accuracy_to_string(value, accuracy));
+  char buffer[64];
+  snprintf(buffer, sizeof(buffer), "%f", value);
+  return this->publish(this->get_state_topic_(), buffer);
 }
 
 }  // namespace mqtt

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -8,67 +8,38 @@ static const char *const TAG = "number";
 
 void NumberCall::perform() {
   ESP_LOGD(TAG, "'%s' - Setting", this->parent_->get_name().c_str());
-  if (this->value_.has_value()) {
-    auto value = *this->value_;
-    uint8_t accuracy = this->parent_->get_accuracy_decimals();
-    float min_value = this->parent_->get_min_value();
-    if (value < min_value) {
-      ESP_LOGW(TAG, "  Value %s must not be less than minimum %s", value_accuracy_to_string(value, accuracy).c_str(),
-               value_accuracy_to_string(min_value, accuracy).c_str());
-      this->value_.reset();
-      return;
-    }
-    float max_value = this->parent_->get_max_value();
-    if (value > max_value) {
-      ESP_LOGW(TAG, "  Value %s must not be larger than maximum %s", value_accuracy_to_string(value, accuracy).c_str(),
-               value_accuracy_to_string(max_value, accuracy).c_str());
-      this->value_.reset();
-      return;
-    }
-    ESP_LOGD(TAG, "  Value: %s", value_accuracy_to_string(*this->value_, accuracy).c_str());
-    this->parent_->set(*this->value_);
+  if (!this->value_.has_value() || isnan(*this->value_)) {
+    ESP_LOGW(TAG, "No value set for NumberCall");
+    return;
   }
+
+  const auto &traits = this->parent_->traits;
+  auto value = *this->value_;
+
+  float min_value = traits.get_min_value();
+  if (value < min_value) {
+    ESP_LOGW(TAG, "  Value %f must not be less than minimum %f", value, min_value);
+    return;
+  }
+  float max_value = traits.get_max_value();
+  if (value > max_value) {
+    ESP_LOGW(TAG, "  Value %f must not be greater than maximum %f", value, max_value);
+    return;
+  }
+  ESP_LOGD(TAG, "  Value: %f", *this->value_);
+  this->parent_->control(*this->value_);
 }
-
-NumberCall &NumberCall::set_value(float value) {
-  this->value_ = value;
-  return *this;
-}
-
-const optional<float> &NumberCall::get_value() const { return this->value_; }
-
-NumberCall Number::make_call() { return NumberCall(this); }
 
 void Number::publish_state(float state) {
   this->has_state_ = true;
   this->state = state;
-  ESP_LOGD(TAG, "'%s': Sending state %.5f", this->get_name().c_str(), state);
+  ESP_LOGD(TAG, "'%s': Sending state %f", this->get_name().c_str(), state);
   this->state_callback_.call(state);
 }
-
-uint32_t Number::update_interval() { return 0; }
-Number::Number(const std::string &name) : Nameable(name), state(NAN) {}
-Number::Number() : Number("") {}
 
 void Number::add_on_state_callback(std::function<void(float)> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
-void Number::set_icon(const std::string &icon) { this->icon_ = icon; }
-std::string Number::get_icon() { return *this->icon_; }
-int8_t Number::get_accuracy_decimals() {
-  // use printf %g to find number of digits based on step
-  char buf[32];
-  sprintf(buf, "%.5g", this->step_);
-  std::string str{buf};
-  size_t dot_pos = str.find('.');
-  if (dot_pos == std::string::npos)
-    return 0;
-
-  return str.length() - dot_pos - 1;
-}
-float Number::get_state() const { return this->state; }
-
-bool Number::has_state() const { return this->has_state_; }
 
 uint32_t Number::hash_base() { return 2282307003UL; }
 

--- a/esphome/components/template/number/__init__.py
+++ b/esphome/components/template/number/__init__.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 from esphome.components import number
 from esphome.const import (
     CONF_ID,
+    CONF_INITIAL_VALUE,
     CONF_LAMBDA,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
@@ -35,6 +36,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Exclusive(CONF_LAMBDA, "lambda-optimistic"): cv.returning_lambda,
             cv.Exclusive(CONF_OPTIMISTIC, "lambda-optimistic"): cv.boolean,
             cv.Optional(CONF_SET_ACTION): automation.validate_automation(single=True),
+            cv.Optional(CONF_INITIAL_VALUE): cv.float_,
         }
     ).extend(cv.polling_component_schema("60s")),
     validate_min_max,
@@ -65,3 +67,6 @@ async def to_code(config):
         await automation.build_automation(
             var.get_set_trigger(), [(float, "x")], config[CONF_SET_ACTION]
         )
+
+    if CONF_INITIAL_VALUE in config:
+        cg.add(var.set_initial_value(config[CONF_INITIAL_VALUE]))

--- a/esphome/components/template/number/__init__.py
+++ b/esphome/components/template/number/__init__.py
@@ -44,7 +44,13 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await number.register_number(var, config)
+    await number.register_number(
+        var,
+        config,
+        min_value=config[CONF_MIN_VALUE],
+        max_value=config[CONF_MAX_VALUE],
+        step=config[CONF_STEP],
+    )
 
     if CONF_LAMBDA in config:
         template_ = await cg.process_lambda(
@@ -57,7 +63,3 @@ async def to_code(config):
         )
 
     cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
-
-    cg.add(var.set_min_value(config[CONF_MIN_VALUE]))
-    cg.add(var.set_max_value(config[CONF_MAX_VALUE]))
-    cg.add(var.set_step(config[CONF_STEP]))

--- a/esphome/components/template/number/__init__.py
+++ b/esphome/components/template/number/__init__.py
@@ -32,8 +32,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MAX_VALUE): cv.float_,
             cv.Required(CONF_MIN_VALUE): cv.float_,
             cv.Required(CONF_STEP): cv.positive_float,
-            cv.Optional(CONF_LAMBDA): cv.returning_lambda,
-            cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
+            cv.Exclusive(CONF_LAMBDA, "lambda-optimistic"): cv.returning_lambda,
+            cv.Exclusive(CONF_OPTIMISTIC, "lambda-optimistic"): cv.boolean,
             cv.Optional(CONF_SET_ACTION): automation.validate_automation(single=True),
         }
     ).extend(cv.polling_component_schema("60s")),
@@ -57,9 +57,11 @@ async def to_code(config):
             config[CONF_LAMBDA], [], return_type=cg.optional.template(float)
         )
         cg.add(var.set_template(template_))
+
+    elif CONF_OPTIMISTIC in config:
+        cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
+
     if CONF_SET_ACTION in config:
         await automation.build_automation(
             var.get_set_trigger(), [(float, "x")], config[CONF_SET_ACTION]
         )
-
-    cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))

--- a/esphome/components/template/number/template_number.cpp
+++ b/esphome/components/template/number/template_number.cpp
@@ -6,21 +6,39 @@ namespace template_ {
 
 static const char *const TAG = "template.number";
 
+void TemplateNumber::setup() {
+  if (this->f_.has_value() || !this->optimistic_)
+    return;
+
+  this->pref_ = global_preferences.make_preference<float>(this->get_object_id_hash());
+  float value;
+  if (!this->pref_.load(&value)) {
+    if (!isnan(this->initial_value_))
+      value = this->initial_value_;
+    else
+      value = this->traits.get_min_value();
+  }
+  this->publish_state(value);
+}
+
 void TemplateNumber::update() {
   if (!this->f_.has_value())
     return;
 
   auto val = (*this->f_)();
-  if (val.has_value()) {
-    this->publish_state(*val);
-  }
+  if (!val.has_value())
+    return;
+
+  this->publish_state(*val);
 }
 
 void TemplateNumber::control(float value) {
   this->set_trigger_->trigger(value);
 
-  if (this->optimistic_)
+  if (this->optimistic_) {
     this->publish_state(value);
+    this->pref_.save(&value);
+  }
 }
 void TemplateNumber::dump_config() {
   LOG_NUMBER("", "Template Number", this);

--- a/esphome/components/template/number/template_number.cpp
+++ b/esphome/components/template/number/template_number.cpp
@@ -6,8 +6,6 @@ namespace template_ {
 
 static const char *const TAG = "template.number";
 
-TemplateNumber::TemplateNumber() : set_trigger_(new Trigger<float>()) {}
-
 void TemplateNumber::update() {
   if (!this->f_.has_value())
     return;
@@ -18,22 +16,17 @@ void TemplateNumber::update() {
   }
 }
 
-void TemplateNumber::set(float value) {
+void TemplateNumber::control(float value) {
   this->set_trigger_->trigger(value);
 
   if (this->optimistic_)
     this->publish_state(value);
 }
-float TemplateNumber::get_setup_priority() const { return setup_priority::HARDWARE; }
-void TemplateNumber::set_template(std::function<optional<float>()> &&f) { this->f_ = f; }
 void TemplateNumber::dump_config() {
   LOG_NUMBER("", "Template Number", this);
   ESP_LOGCONFIG(TAG, "  Optimistic: %s", YESNO(this->optimistic_));
   LOG_UPDATE_INTERVAL(this);
 }
-
-void TemplateNumber::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-Trigger<float> *TemplateNumber::get_set_trigger() const { return this->set_trigger_; };
 
 }  // namespace template_
 }  // namespace esphome

--- a/esphome/components/template/number/template_number.h
+++ b/esphome/components/template/number/template_number.h
@@ -3,6 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
 
 namespace esphome {
 namespace template_ {
@@ -11,18 +12,23 @@ class TemplateNumber : public number::Number, public PollingComponent {
  public:
   void set_template(std::function<optional<float>()> &&f) { this->f_ = f; }
 
+  void setup() override;
   void update() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
   Trigger<float> *get_set_trigger() const { return set_trigger_; }
   void set_optimistic(bool optimistic) { optimistic_ = optimistic; }
+  void set_initial_value(float initial_value) { initial_value_ = initial_value; }
 
  protected:
   void control(float value) override;
   bool optimistic_{false};
+  float initial_value_{NAN};
   Trigger<float> *set_trigger_ = new Trigger<float>();
   optional<std::function<optional<float>()>> f_;
+
+  ESPPreferenceObject pref_;
 };
 
 }  // namespace template_

--- a/esphome/components/template/number/template_number.h
+++ b/esphome/components/template/number/template_number.h
@@ -9,20 +9,19 @@ namespace template_ {
 
 class TemplateNumber : public number::Number, public PollingComponent {
  public:
-  TemplateNumber();
-  void set_template(std::function<optional<float>()> &&f);
+  void set_template(std::function<optional<float>()> &&f) { this->f_ = f; }
 
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  Trigger<float> *get_set_trigger() const;
-  void set_optimistic(bool optimistic);
+  Trigger<float> *get_set_trigger() const { return set_trigger_; }
+  void set_optimistic(bool optimistic) { optimistic_ = optimistic; }
 
  protected:
-  void set(float value) override;
+  void control(float value) override;
   bool optimistic_{false};
-  Trigger<float> *set_trigger_;
+  Trigger<float> *set_trigger_ = new Trigger<float>();
   optional<std::function<optional<float>()>> f_;
 };
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -614,8 +614,9 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
 std::string WebServer::number_json(number::Number *obj, float value) {
   return json::build_json([obj, value](JsonObject &root) {
     root["id"] = "number-" + obj->get_object_id();
-    std::string state = value_accuracy_to_string(value, obj->get_accuracy_decimals());
-    root["state"] = state;
+    char buffer[64];
+    snprintf(buffer, sizeof(buffer), "%f", value);
+    root["state"] = buffer;
     root["value"] = value;
   });
 }


### PR DESCRIPTION
# What does this implement/fix? 

This PR adds RTC/flash saving and loading of the `template` number platform as well as an `initial_value` config option for the first time its run without a stored value.
Also some of the static data has moved from the `number` itself to a `traits` member.

As a **breaking change** (and what seems to make sense to me) the `lambda` and `optimistic` config keys are now exclusive and cannot be used together. (I feel like this should apply to all template platforms - another PR maybe).
*Please let me know if this should not be the case*

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1314

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
