### PR TITLE
Fix white value transition for addressable lights

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -68,10 +68,7 @@ void AddressableLight::write_state(LightState *state) {
 
     // our transition will handle brightness, disable brightness in correction.
     this->correction_.set_local_brightness(255);
-    uint8_t orig_w = target_color.w;
     target_color *= static_cast<uint8_t>(roundf(end_values.get_brightness() * end_values.get_state() * 255.0f));
-    // w is not scaled by brightness
-    target_color.w = orig_w;
 
     float denom = (1.0f - new_smoothed);
     float alpha = denom == 0.0f ? 0.0f : (new_smoothed - prev_smoothed) / denom;


### PR DESCRIPTION
# What does this implement/fix? 

The transition for the white value of addressable lights didn't take brightness into account (after #1895), so the transition would go to the wrong value, and then jump to the correct value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
  - platform: neopixelbus
    name: "Addressable (NeoPixelBus RGBW)"
    type: RGBW
    variant: SK6812
    pin: GPIO3
    num_leds: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
