### PR TITLE
Fixes new auto mode COOL and HEAT after #1994

### DIFF
--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -35,8 +35,8 @@ void PIDClimate::control(const climate::ClimateCall &call) {
   if (call.get_target_temperature().has_value())
     this->target_temperature = *call.get_target_temperature();
 
-  // If switching to non-auto mode, set output immediately
-  if (this->mode != climate::CLIMATE_MODE_HEAT_COOL)
+  // If switching to off mode, set output immediately
+  if (this->mode == climate::CLIMATE_MODE_OFF)
     this->handle_non_auto_mode_();
 
   this->publish_state();


### PR DESCRIPTION
# What does this implement/fix? 

#1994 broke PID Climate when using COOL or HEAT only mode

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
