### PR TITLE
midea_ac: fix presets implementation

### DIFF
--- a/esphome/components/midea_ac/midea_climate.cpp
+++ b/esphome/components/midea_ac/midea_climate.cpp
@@ -100,7 +100,7 @@ bool MideaAC::allow_preset(climate::ClimatePreset preset) const {
         ESP_LOGD(TAG, "BOOST preset is only available in HEAT or COOL mode");
       }
       break;
-    case climate::CLIMATE_PRESET_HOME:
+    case climate::CLIMATE_PRESET_NONE:
       return true;
     default:
       break;

--- a/esphome/components/midea_ac/midea_climate.cpp
+++ b/esphome/components/midea_ac/midea_climate.cpp
@@ -191,7 +191,7 @@ climate::ClimateTraits MideaAC::traits() {
   if (traits_swing_both_)
     traits.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
   traits.set_supported_presets({
-      climate::CLIMATE_PRESET_HOME,
+      climate::CLIMATE_PRESET_NONE,
   });
   if (traits_preset_eco_)
     traits.add_supported_preset(climate::CLIMATE_PRESET_ECO);

--- a/esphome/components/midea_ac/midea_frame.cpp
+++ b/esphome/components/midea_ac/midea_frame.cpp
@@ -98,6 +98,7 @@ optional<climate::ClimatePreset> PropertiesFrame::get_preset() const {
 }
 
 void PropertiesFrame::set_preset(climate::ClimatePreset preset) {
+  this->clear_presets();
   switch (preset) {
     case climate::CLIMATE_PRESET_ECO:
       this->set_eco_mode(true);
@@ -113,14 +114,21 @@ void PropertiesFrame::set_preset(climate::ClimatePreset preset) {
   }
 }
 
+void PropertiesFrame::clear_presets() {
+  this->set_eco_mode(false);
+  this->set_sleep_mode(false);
+  this->set_turbo_mode(false);
+  this->set_freeze_protection_mode(false);
+}
+
 bool PropertiesFrame::is_custom_preset() const { return this->get_freeze_protection_mode(); }
 
 const std::string &PropertiesFrame::get_custom_preset() const { return midea_ac::MIDEA_FREEZE_PROTECTION_PRESET; };
 
 void PropertiesFrame::set_custom_preset(const std::string &preset) {
-  if (preset == MIDEA_FREEZE_PROTECTION_PRESET) {
+  this->clear_presets();
+  if (preset == MIDEA_FREEZE_PROTECTION_PRESET)
     this->set_freeze_protection_mode(true);
-  }
 }
 
 bool PropertiesFrame::is_custom_fan_mode() const {

--- a/esphome/components/midea_ac/midea_frame.cpp
+++ b/esphome/components/midea_ac/midea_frame.cpp
@@ -93,7 +93,7 @@ optional<climate::ClimatePreset> PropertiesFrame::get_preset() const {
   } else if (this->get_turbo_mode()) {
     return climate::CLIMATE_PRESET_BOOST;
   } else {
-    return climate::CLIMATE_PRESET_HOME;
+    return climate::CLIMATE_PRESET_NONE;
   }
 }
 

--- a/esphome/components/midea_ac/midea_frame.cpp
+++ b/esphome/components/midea_ac/midea_frame.cpp
@@ -86,15 +86,13 @@ void PropertiesFrame::set_mode(climate::ClimateMode mode) {
 }
 
 optional<climate::ClimatePreset> PropertiesFrame::get_preset() const {
-  if (this->get_eco_mode()) {
+  if (this->get_eco_mode())
     return climate::CLIMATE_PRESET_ECO;
-  } else if (this->get_sleep_mode()) {
+  if (this->get_sleep_mode())
     return climate::CLIMATE_PRESET_SLEEP;
-  } else if (this->get_turbo_mode()) {
+  if (this->get_turbo_mode())
     return climate::CLIMATE_PRESET_BOOST;
-  } else {
-    return climate::CLIMATE_PRESET_NONE;
-  }
+  return climate::CLIMATE_PRESET_NONE;
 }
 
 void PropertiesFrame::set_preset(climate::ClimatePreset preset) {

--- a/esphome/components/midea_ac/midea_frame.h
+++ b/esphome/components/midea_ac/midea_frame.h
@@ -115,6 +115,7 @@ class PropertiesFrame : public midea_dongle::BaseFrame {
   /* PRESET */
   optional<climate::ClimatePreset> get_preset() const;
   void set_preset(climate::ClimatePreset preset);
+  void clear_presets();
 
   bool is_custom_preset() const;
   const std::string &get_custom_preset() const;


### PR DESCRIPTION
# What does this implement/fix? 

Fix presets implementation in `midea_ac` component

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
