### PR TITLE
Support library override using named library with repository

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -408,19 +408,29 @@ class Define:
 
 
 class Library:
-    def __init__(self, name, version):
+    def __init__(self, name, version, repository=None):
         self.name = name
         self.version = version
+        self.repository = repository
+
+    def __str__(self):
+        return self.as_lib_dep
 
     @property
     def as_lib_dep(self):
+        if self.repository is not None:
+            if self.name is not None:
+                return f"{self.name}={self.repository}"
+            else:
+                return self.repository
+
         if self.version is None:
             return self.name
         return f"{self.name}@{self.version}"
 
     @property
     def as_tuple(self):
-        return self.name, self.version
+        return self.name, self.version, self.repository
 
     def __hash__(self):
         return hash(self.as_tuple)
@@ -632,10 +642,23 @@ class EsphomeCore:
                 "Library {} must be instance of Library, not {}"
                 "".format(library, type(library))
             )
-        _LOGGER.debug("Adding library: %s", library)
         for other in self.libraries[:]:
             if other.name != library.name:
                 continue
+            if other.repository is not None:
+                if library.repository is None or other.repository == library.repository:
+                    # Other is using a/the same repository, takes precendence
+                    break
+                else:
+                    raise ValueError(
+                        "Adding named Library with repository failed! Libraries {} and {} "
+                        "requested with conflicting repositories!"
+                        "".format(library, other)
+                    )
+            elif library.repository is not None:
+                self.libraries.remove(other)
+                continue
+
             if library.version is None:
                 # Other requirement is more specific
                 break
@@ -652,6 +675,7 @@ class EsphomeCore:
                 "".format(library, other)
             )
         else:
+            _LOGGER.debug("Adding library: %s", library)
             self.libraries.append(library)
         return library
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -421,8 +421,7 @@ class Library:
         if self.repository is not None:
             if self.name is not None:
                 return f"{self.name}={self.repository}"
-            else:
-                return self.repository
+            return self.repository
 
         if self.version is None:
             return self.name
@@ -649,12 +648,11 @@ class EsphomeCore:
                 if library.repository is None or other.repository == library.repository:
                     # Other is using a/the same repository, takes precendence
                     break
-                else:
-                    raise ValueError(
-                        "Adding named Library with repository failed! Libraries {} and {} "
-                        "requested with conflicting repositories!"
-                        "".format(library, other)
-                    )
+                raise ValueError(
+                    "Adding named Library with repository failed! Libraries {} and {} "
+                    "requested with conflicting repositories!"
+                    "".format(library, other)
+                )
             elif library.repository is not None:
                 self.libraries.remove(other)
                 continue

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -653,7 +653,9 @@ class EsphomeCore:
                     "requested with conflicting repositories!"
                     "".format(library, other)
                 )
-            elif library.repository is not None:
+
+            if library.repository is not None:
+                # This is more specific since its using a repository
                 self.libraries.remove(other)
                 continue
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -332,6 +332,14 @@ async def to_code(config):
         if "@" in lib:
             name, vers = lib.split("@", 1)
             cg.add_library(name, vers)
+        elif "://" in lib:
+            # Repository...
+            if "=" in lib:
+                name, repo = lib.split("=", 1)
+                cg.add_library(name, None, repo)
+            else:
+                cg.add_library(None, None, lib)
+
         else:
             cg.add_library(lib, None)
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -543,13 +543,13 @@ def add_global(expression: Union[SafeExpType, Statement]):
     CORE.add_global(expression)
 
 
-def add_library(name: str, version: Optional[str]):
+def add_library(name: str, version: Optional[str], repository: Optional[str] = None):
     """Add a library to the codegen library storage.
 
     :param name: The name of the library (for example 'AsyncTCP')
     :param version: The version of the library, may be None.
     """
-    CORE.add_library(Library(name, version))
+    CORE.add_library(Library(name, version, repository))
 
 
 def add_build_flag(build_flag: str):

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -444,16 +444,24 @@ class TestDefine:
 
 class TestLibrary:
     @pytest.mark.parametrize(
-        "name, value, prop, expected",
+        "name, version, repository, prop, expected",
         (
-            ("mylib", None, "as_lib_dep", "mylib"),
-            ("mylib", None, "as_tuple", ("mylib", None)),
-            ("mylib", "1.2.3", "as_lib_dep", "mylib@1.2.3"),
-            ("mylib", "1.2.3", "as_tuple", ("mylib", "1.2.3")),
+            ("mylib", None, None, "as_lib_dep", "mylib"),
+            ("mylib", None, None, "as_tuple", ("mylib", None, None)),
+            ("mylib", "1.2.3", None, "as_lib_dep", "mylib@1.2.3"),
+            ("mylib", "1.2.3", None, "as_tuple", ("mylib", "1.2.3", None)),
+            ("mylib", None, "file:///test", "as_lib_dep", "mylib=file:///test"),
+            (
+                "mylib",
+                None,
+                "file:///test",
+                "as_tuple",
+                ("mylib", None, "file:///test"),
+            ),
         ),
     )
-    def test_properties(self, name, value, prop, expected):
-        target = core.Library(name, value)
+    def test_properties(self, name, version, repository, prop, expected):
+        target = core.Library(name, version, repository)
 
         actual = getattr(target, prop)
 
@@ -465,6 +473,7 @@ class TestLibrary:
             ("__eq__", core.Library(name="libfoo", version="1.2.3"), True),
             ("__eq__", core.Library(name="libfoo", version="1.2.4"), False),
             ("__eq__", core.Library(name="libbar", version="1.2.3"), False),
+            ("__eq__", core.Library(name="libbar", version=None, repository="file:///test"), False),
             ("__eq__", 1000, NotImplemented),
             ("__eq__", "1000", NotImplemented),
             ("__eq__", True, NotImplemented),


### PR DESCRIPTION
Platformio support custom name in `lib_deps` (see [1]). Use this feature
to allow to override libraries requested by built-in components (e.g.
ESPAsyncWebServer-esphome).

This allows to use a custom version of ESPAsyncWebServer-esphome from a
remote or local repository, by using e.g.:

```
esphome:
  libraries:
    - ESPAsyncWebServer-esphome=file:///workspaces/esphome/ESPAsyncWebServer
    #or
    - ESPAsyncWebServer-esphome=https://github.com/user/ESPAsyncWebServer#my-branch
```

This tries to represent libraries similar to how the pio lib install
command is structured (see [2]).

[1] https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-deps
[2] https://docs.platformio.org/en/latest/core/userguide/lib/cmd_install.html#cmd-lib-install

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  libraries:
    - ESPAsyncWebServer-esphome=https://github.com/agners/ESPAsyncWebServer#fix-compile-on-riscv

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
