### PR TITLE
Add TAG to all compile units

### DIFF
--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -7,6 +7,8 @@
 namespace esphome {
 namespace esp32_ble {
 
+static const char *const TAG = "esp32_ble";
+
 BLEAdvertising::BLEAdvertising() {
   this->advertising_data_.set_scan_rsp = false;
   this->advertising_data_.include_name = true;

--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -5,6 +5,8 @@
 namespace esphome {
 namespace esp32_ble {
 
+static const char *const TAG = "esp32_ble";
+
 ESPBTUUID::ESPBTUUID() : uuid_() {}
 ESPBTUUID ESPBTUUID::from_uint16(uint16_t uuid) {
   ESPBTUUID ret;


### PR DESCRIPTION
When using `static` a TAG is only valid in the current compile unit. For
some reason it seems that the current ESP8266/ESP32 compiler use the
instance from ble.cpp, but it seems that this causes issues with newer
compiler leading to compile time errors like this:
```
In file included from /root/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-log.h:164,
                 from /root/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:71,
                 from /root/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:36,
                 from src/esphome/core/esphal.h:3,
                 from src/esphome/core/helpers.h:10,
                 from src/esphome/components/esp32_ble/ble_uuid.h:3,
                 from src/esphome/components/esp32_ble/ble_advertising.cpp:5:
src/esphome/components/esp32_ble/ble_advertising.cpp: In member function 'void esphome::esp32_ble::BLEAdvertising::start()':
src/esphome/components/esp32_ble/ble_advertising.cpp:64:14: error: 'TAG' was not declared in this scope
     ESP_LOGE(TAG, "esp_ble_gap_config_adv_data failed (Advertising): %d", err);
              ^~~
```

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32-C3
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
