### PR TITLE
Add support for the TLC5947 24-Channel, 12-Bit PWM LED Driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -126,6 +126,7 @@ esphome/components/tcl112/* @glmnet
 esphome/components/teleinfo/* @0hax
 esphome/components/thermostat/* @kbx81
 esphome/components/time/* @OttoWinter
+esphome/components/tlc5947/* @rnauber
 esphome/components/tm1637/* @glmnet
 esphome/components/tmp102/* @timsavage
 esphome/components/tof10120/* @wstrzalka

--- a/esphome/components/tlc5947/__init__.py
+++ b/esphome/components/tlc5947/__init__.py
@@ -1,0 +1,50 @@
+# this component is for the "TLC5947 24-Channel, 12-Bit PWM LED Driver" [https://www.ti.com/lit/ds/symlink/tlc5947.pdf],
+# which is used e.g. on [https://www.adafruit.com/product/1429]. The code is based on the components sm2135 and sm26716.
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.const import (
+    CONF_CLOCK_PIN,
+    CONF_DATA_PIN,
+    CONF_ID,
+    CONF_NUM_CHIPS,
+)
+
+CONF_LAT_PIN = "lat_pin"
+CONF_OE_PIN = "oe_pin"
+
+AUTO_LOAD = ["output"]
+CODEOWNERS = ["@rnauber"]
+
+tlc5947_ns = cg.esphome_ns.namespace("tlc5947")
+TLC5947 = tlc5947_ns.class_("TLC5947", cg.Component)
+
+MULTI_CONF = True
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(TLC5947),
+        cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_LAT_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_OE_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_NUM_CHIPS, default=1): cv.int_range(min=1, max=85),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    data = await cg.gpio_pin_expression(config[CONF_DATA_PIN])
+    cg.add(var.set_data_pin(data))
+    clock = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
+    cg.add(var.set_clock_pin(clock))
+    lat = await cg.gpio_pin_expression(config[CONF_LAT_PIN])
+    cg.add(var.set_lat_pin(lat))
+    if CONF_OE_PIN in config:
+        outenable = await cg.gpio_pin_expression(config[CONF_OE_PIN])
+        cg.add(var.set_outenable_pin(outenable))
+
+    cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))

--- a/esphome/components/tlc5947/output.py
+++ b/esphome/components/tlc5947/output.py
@@ -1,0 +1,28 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import output
+from esphome.const import CONF_CHANNEL, CONF_ID
+from . import TLC5947
+
+DEPENDENCIES = ["tlc5947"]
+CODEOWNERS = ["@rnauber"]
+
+Channel = TLC5947.class_("Channel", output.FloatOutput)
+
+CONF_TLC5947_ID = "tlc5947_id"
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.GenerateID(CONF_TLC5947_ID): cv.use_id(TLC5947),
+        cv.Required(CONF_ID): cv.declare_id(Channel),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await output.register_output(var, config)
+
+    parent = await cg.get_variable(config[CONF_TLC5947_ID])
+    cg.add(var.set_parent(parent))
+    cg.add(var.set_channel(config[CONF_CHANNEL]))

--- a/esphome/components/tlc5947/tlc5947.cpp
+++ b/esphome/components/tlc5947/tlc5947.cpp
@@ -13,7 +13,7 @@ void TLC5947::setup() {
   this->clock_pin_->digital_write(true);
   this->lat_pin_->setup();
   this->lat_pin_->digital_write(true);
-  if (this->outenable_pin_ != nullptr){
+  if (this->outenable_pin_ != nullptr) {
     this->outenable_pin_->setup();
     this->outenable_pin_->digital_write(false);
   }
@@ -38,7 +38,7 @@ void TLC5947::loop() {
 
   this->lat_pin_->digital_write(false);
 
-  //push the data out, MSB first, 12 bit word per channel, 24 channels per chip
+  // push the data out, MSB first, 12 bit word per channel, 24 channels per chip
   for (int32_t ch = N_CHANNELS_PER_CHIP * num_chips_ - 1; ch >= 0; ch--) {
     uint16_t word = pwm_amounts_[ch];
     for (uint8_t bit = 0; bit < 12; bit++) {
@@ -47,7 +47,7 @@ void TLC5947::loop() {
       word <<= 1;
 
       this->clock_pin_->digital_write(true);
-      this->clock_pin_->digital_write(true);//TWH0>12ns, so we should be fine using this as delay
+      this->clock_pin_->digital_write(true);  // TWH0>12ns, so we should be fine using this as delay
     }
   }
 
@@ -55,7 +55,7 @@ void TLC5947::loop() {
 
   // latch the values, so they will be applied
   this->lat_pin_->digital_write(true);
-  delayMicroseconds(1); // TWH1 > 30ns
+  delayMicroseconds(1);  // TWH1 > 30ns
   this->lat_pin_->digital_write(false);
 
   this->update_ = false;

--- a/esphome/components/tlc5947/tlc5947.cpp
+++ b/esphome/components/tlc5947/tlc5947.cpp
@@ -1,0 +1,65 @@
+#include "tlc5947.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace tlc5947 {
+
+static const char *const TAG = "tlc5947";
+
+void TLC5947::setup() {
+  this->data_pin_->setup();
+  this->data_pin_->digital_write(true);
+  this->clock_pin_->setup();
+  this->clock_pin_->digital_write(true);
+  this->lat_pin_->setup();
+  this->lat_pin_->digital_write(true);
+  if (this->outenable_pin_ != nullptr){
+    this->outenable_pin_->setup();
+    this->outenable_pin_->digital_write(false);
+  }
+
+  this->pwm_amounts_.resize(this->num_chips_ * N_CHANNELS_PER_CHIP, 0);
+
+  ESP_LOGCONFIG(TAG, "Done setting up TLC5947 output component.");
+}
+void TLC5947::dump_config() {
+  ESP_LOGCONFIG(TAG, "TLC5947:");
+  LOG_PIN("  Data Pin: ", this->data_pin_);
+  LOG_PIN("  Clock Pin: ", this->clock_pin_);
+  LOG_PIN("  LAT Pin: ", this->lat_pin_);
+  if (this->outenable_pin_ != nullptr)
+    LOG_PIN("  OE Pin: ", this->outenable_pin_);
+  ESP_LOGCONFIG(TAG, "  Number of chips: %u", this->num_chips_);
+}
+
+void TLC5947::loop() {
+  if (!this->update_)
+    return;
+
+  this->lat_pin_->digital_write(false);
+
+  //push the data out, MSB first, 12 bit word per channel, 24 channels per chip
+  for (int32_t ch = N_CHANNELS_PER_CHIP * num_chips_ - 1; ch >= 0; ch--) {
+    uint16_t word = pwm_amounts_[ch];
+    for (uint8_t bit = 0; bit < 12; bit++) {
+      this->clock_pin_->digital_write(false);
+      this->data_pin_->digital_write(word & 0x800);
+      word <<= 1;
+
+      this->clock_pin_->digital_write(true);
+      this->clock_pin_->digital_write(true);//TWH0>12ns, so we should be fine using this as delay
+    }
+  }
+
+  this->clock_pin_->digital_write(false);
+
+  // latch the values, so they will be applied
+  this->lat_pin_->digital_write(true);
+  delayMicroseconds(1); // TWH1 > 30ns
+  this->lat_pin_->digital_write(false);
+
+  this->update_ = false;
+}
+
+}  // namespace tlc5947
+}  // namespace esphome

--- a/esphome/components/tlc5947/tlc5947.h
+++ b/esphome/components/tlc5947/tlc5947.h
@@ -9,7 +9,6 @@
 namespace esphome {
 namespace tlc5947 {
 
-
 class TLC5947 : public Component {
  public:
   class Channel;
@@ -49,7 +48,7 @@ class TLC5947 : public Component {
  protected:
   void set_channel_value_(uint16_t channel, uint16_t value) {
     if (channel >= this->num_chips_ * N_CHANNELS_PER_CHIP)
-        return;
+      return;
     if (this->pwm_amounts_[channel] != value) {
       this->update_ = true;
     }

--- a/esphome/components/tlc5947/tlc5947.h
+++ b/esphome/components/tlc5947/tlc5947.h
@@ -1,0 +1,70 @@
+#pragma once
+// TLC5947 24-Channel, 12-Bit PWM LED Driver
+// https://www.ti.com/lit/ds/symlink/tlc5947.pdf
+
+#include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
+#include "esphome/components/output/float_output.h"
+
+namespace esphome {
+namespace tlc5947 {
+
+
+class TLC5947 : public Component {
+ public:
+  class Channel;
+
+  const uint8_t N_CHANNELS_PER_CHIP = 24;
+
+  void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }
+  void set_clock_pin(GPIOPin *clock_pin) { clock_pin_ = clock_pin; }
+  void set_lat_pin(GPIOPin *lat_pin) { lat_pin_ = lat_pin; }
+  void set_outenable_pin(GPIOPin *outenable_pin) { outenable_pin_ = outenable_pin; }
+  void set_num_chips(uint8_t num_chips) { num_chips_ = num_chips; }
+
+  void setup() override;
+
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  /// Send new values if they were updated.
+  void loop() override;
+
+  class Channel : public output::FloatOutput {
+   public:
+    void set_parent(TLC5947 *parent) { parent_ = parent; }
+    void set_channel(uint8_t channel) { channel_ = channel; }
+
+   protected:
+    void write_state(float state) override {
+      auto amount = static_cast<uint16_t>(state * 0xfff);
+      this->parent_->set_channel_value_(this->channel_, amount);
+    }
+
+    TLC5947 *parent_;
+    uint8_t channel_;
+  };
+
+ protected:
+  void set_channel_value_(uint16_t channel, uint16_t value) {
+    if (channel >= this->num_chips_ * N_CHANNELS_PER_CHIP)
+        return;
+    if (this->pwm_amounts_[channel] != value) {
+      this->update_ = true;
+    }
+    this->pwm_amounts_[channel] = value;
+  }
+
+  GPIOPin *data_pin_;
+  GPIOPin *clock_pin_;
+  GPIOPin *lat_pin_;
+  GPIOPin *outenable_pin_{nullptr};
+  uint8_t num_chips_;
+
+  std::vector<uint16_t> pwm_amounts_;
+  bool update_{true};
+};
+
+}  // namespace tlc5947
+}  // namespace esphome

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -30,10 +30,20 @@ binary_sensor:
     pin: GPIO0
     id: io0_button
 
+tlc5947:
+  data_pin: GPIO12
+  clock_pin: GPIO14
+  xlat_pin: GPIO15
+
 output:
   - platform: gpio
     pin: GPIO2
     id: built_in_led
+
+  - platform: tlc5947
+    id: output_red
+    channel: 0
+    max_power: 0.8
 
 esp32_ble:
 

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -33,7 +33,7 @@ binary_sensor:
 tlc5947:
   data_pin: GPIO12
   clock_pin: GPIO14
-  xlat_pin: GPIO15
+  lat_pin: GPIO15
 
 output:
   - platform: gpio


### PR DESCRIPTION
# What does this implement/fix? 

This patch adds support for the [TLC5947 24-Channel, 12-Bit PWM LED Driver](https://www.ti.com/lit/ds/symlink/tlc5947.pdf), which is used e.g. on this [Adafruit board ](https://www.adafruit.com/product/1429). The code is based on the components sm2135 and sm26716.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1337

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:


```yaml
# Example config.yaml

tlc5947:
  data_pin: GPIO12
  clock_pin: GPIO14
  xlat_pin: GPIO15

output:
  - platform: tlc5947
    id: output_red
    channel: 0
    max_power: 0.8


```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
