### PR TITLE
Fix color_brightness missing in addressable_set

### DIFF
--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -177,6 +177,7 @@ LIGHT_ADDRESSABLE_SET_ACTION_SCHEMA = cv.Schema(
         cv.Optional(CONF_GREEN): cv.templatable(cv.percentage),
         cv.Optional(CONF_BLUE): cv.templatable(cv.percentage),
         cv.Optional(CONF_WHITE): cv.templatable(cv.percentage),
+        cv.Optional(CONF_COLOR_BRIGHTNESS): cv.templatable(cv.percentage),
     }
 )
 
@@ -217,6 +218,11 @@ async def light_addressable_set_to_code(config, action_id, template_arg, args):
             config[CONF_WHITE], args, cg.uint8, to_exp=rgbw_to_exp
         )
         cg.add(var.set_white(templ))
+    if CONF_COLOR_BRIGHTNESS in config:
+        templ = await cg.templatable(
+            config[CONF_COLOR_BRIGHTNESS], args, cg.uint8, to_exp=rgbw_to_exp
+        )
+        cg.add(var.set_color_brightness(templ))
     return var
 
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -32,6 +32,7 @@ esphome:
           green: !lambda 'return 255;'
           blue: 0%
           white: 100%
+          color_brightness: 50%
       - http_request.get:
           url: https://esphome.io
           headers:
@@ -1458,6 +1459,7 @@ light:
                 red: 100%
                 green: 100%
                 blue: 0%
+                color_brightness: !lambda return 255;
             - delay: 100ms
             - light.addressable_set:
                 id: addr1


### PR DESCRIPTION
# What does this implement/fix? 

Fixes https://github.com/esphome/issues/issues/2266

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
