### PR TITLE
Bump ESPAsyncWebServer-esphome to 1.3.0

### DIFF
--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -25,5 +25,5 @@ async def to_code(config):
 
     if CORE.is_esp32:
         cg.add_library("FS", None)
-    # https://github.com/OttoWinter/ESPAsyncWebServer/blob/master/library.json
-    cg.add_library("ESPAsyncWebServer-esphome", "1.2.7")
+    # https://github.com/esphome/ESPAsyncWebServer/blob/master/library.json
+    cg.add_library("ESPAsyncWebServer-esphome", "1.3.0")

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -26,4 +26,4 @@ async def to_code(config):
     if CORE.is_esp32:
         cg.add_library("FS", None)
     # https://github.com/esphome/ESPAsyncWebServer/blob/master/library.json
-    cg.add_library("ESPAsyncWebServer-esphome", "1.3.0")
+    cg.add_library("esphome/ESPAsyncWebServer-esphome", "1.3.0")

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ include_dir = include
 lib_deps =
     AsyncMqttClient-esphome@0.8.4
     ArduinoJson-esphomelib@5.13.3
-    ESPAsyncWebServer-esphome@1.2.7
+    esphome/ESPAsyncWebServer-esphome@1.3.0
     FastLED@3.3.2
     NeoPixelBus-esphome@2.6.2
     1655@1.0.2  ; TinyGPSPlus (has name conflict)


### PR DESCRIPTION
# What does this implement/fix? 

The latest release 1.3.0 contains fixes for the latest Arduino SDK
relesae (2.0.0-rc1) as well as a use-after-free fix when trying
to free unused headers on a http request.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2257

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
