### PR TITLE
Warn if underscore character is used in hostname

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -882,7 +882,8 @@ def hostname(value):
         if c in "_" and not warned_underscore:
             _LOGGER.warning(
                 "'%s': Using the '_' (underscore) character in the hostname is discouraged "
-                "as it can cause problems with some DHCP and local name services.",
+                "as it can cause problems with some DHCP and local name services. "
+                "To rename an existing device see https://esphome.io/components/esphome.html#changing-esphome-node-name",
                 value,
             )
             warned_underscore = True

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -883,7 +883,7 @@ def hostname(value):
             _LOGGER.warning(
                 "'%s': Using the '_' (underscore) character in the hostname is discouraged "
                 "as it can cause problems with some DHCP and local name services. "
-                "To rename an existing device see https://esphome.io/components/esphome.html#changing-esphome-node-name",
+                "For more information, see https://esphome.io/guides/faq.html#why-shouldn-t-i-use-underscores-in-my-device-name",
                 value,
             )
             warned_underscore = True

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -873,11 +873,19 @@ def validate_bytes(value):
 
 def hostname(value):
     value = string(value)
+    warned_underscore = False
     if len(value) > 63:
         raise Invalid("Hostnames can only be 63 characters long")
     for c in value:
-        if not (c.isalnum() or c in "-"):
+        if not (c.isalnum() or c in "-_"):
             raise Invalid("Hostname can only have alphanumeric characters and -")
+        if c in "_" and not warned_underscore:
+            _LOGGER.warning(
+                "'%s': Using the '_' (underscore) character in the hostname is discouraged "
+                "as it can cause problems with some DHCP and local name services.",
+                value,
+            )
+            warned_underscore = True
     return value
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -876,8 +876,8 @@ def hostname(value):
     if len(value) > 63:
         raise Invalid("Hostnames can only be 63 characters long")
     for c in value:
-        if not (c.isalnum() or c in "_-"):
-            raise Invalid("Hostname can only have alphanumeric characters and _ or -")
+        if not (c.isalnum() or c in "-"):
+            raise Invalid("Hostname can only have alphanumeric characters and -")
     return value
 
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -6,7 +6,7 @@ ESP_PLATFORM_ESP32 = "ESP32"
 ESP_PLATFORM_ESP8266 = "ESP8266"
 ESP_PLATFORMS = [ESP_PLATFORM_ESP32, ESP_PLATFORM_ESP8266]
 
-ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-"
+ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 
 # Lookup table from ESP32 arduino framework version to latest platformio
 # package with that version

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -6,7 +6,7 @@ ESP_PLATFORM_ESP32 = "ESP32"
 ESP_PLATFORM_ESP8266 = "ESP8266"
 ESP_PLATFORMS = [ESP_PLATFORM_ESP32, ESP_PLATFORM_ESP8266]
 
-ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-"
 
 # Lookup table from ESP32 arduino framework version to latest platformio
 # package with that version

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -158,7 +158,7 @@ def valid_project_name(value: str):
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_NAME): cv.valid_name,
+        cv.Required(CONF_NAME): cv.hostname,
         cv.Required(CONF_PLATFORM): cv.one_of("ESP8266", "ESP32", upper=True),
         cv.Required(CONF_BOARD): validate_board,
         cv.Optional(CONF_COMMENT): cv.string,

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -27,7 +27,7 @@ def test_alphanumeric__invalid(value):
         config_validation.alphanumeric(value)
 
 
-@given(value=text(alphabet=string.ascii_lowercase + string.digits + "-_"))
+@given(value=text(alphabet=string.ascii_lowercase + string.digits + "-"))
 def test_valid_name__valid(value):
     actual = config_validation.valid_name(value)
 

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -27,7 +27,7 @@ def test_alphanumeric__invalid(value):
         config_validation.alphanumeric(value)
 
 
-@given(value=text(alphabet=string.ascii_lowercase + string.digits + "-"))
+@given(value=text(alphabet=string.ascii_lowercase + string.digits + "-_"))
 def test_valid_name__valid(value):
     actual = config_validation.valid_name(value)
 
@@ -38,6 +38,19 @@ def test_valid_name__valid(value):
 def test_valid_name__invalid(value):
     with pytest.raises(Invalid):
         config_validation.valid_name(value)
+
+
+@pytest.mark.parametrize("value", ("foo", "bar123", "foo-bar"))
+def test_hostname__valid(value):
+    actual = config_validation.hostname(value)
+
+    assert actual == value
+
+
+@pytest.mark.parametrize("value", ("foo bar", "foo_bar", "foo#bar"))
+def test_hostname__invalid(value):
+    with pytest.raises(Invalid):
+        config_validation.hostname(value)
 
 
 @given(one_of(integers(), text()))

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -47,10 +47,19 @@ def test_hostname__valid(value):
     assert actual == value
 
 
-@pytest.mark.parametrize("value", ("foo bar", "foo_bar", "foo#bar"))
+@pytest.mark.parametrize("value", ("foo bar", "foobar ", "foo#bar"))
 def test_hostname__invalid(value):
     with pytest.raises(Invalid):
         config_validation.hostname(value)
+
+
+def test_hostname__warning(caplog):
+    actual = config_validation.hostname("foo_bar")
+    assert actual == "foo_bar"
+    assert (
+        "Using the '_' (underscore) character in the hostname is discouraged"
+        in caplog.text
+    )
 
 
 @given(one_of(integers(), text()))


### PR DESCRIPTION
# What does this implement/fix? 
Warns about underscores in hostnames to prevent DHCP/DNS problems.

 - Underscores in device names can cause strange DNS problems that are hard for users to trace, [example1](https://github.com/esphome/issues/issues/1123), [example2](https://community.home-assistant.io/t/nodes-created-from-esphome-not-showing-a-entities-in-home-assist/228807).

 - According to [RFC1912](https://datatracker.ietf.org/doc/html/rfc1912), underscores are not allowed in hostnames.

This PR causes the compile to raise an warning when the user tries to use an underscore in a hostname.

It is not a breaking change because it is just a warning. If the user choose to rename, they will have to remove & re-add the device in HA, the warning links to instructions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** 
Partial fix for https://github.com/esphome/issues/issues/1123

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 
https://github.com/esphome/esphome-docs/pull/1366

## Test Environment
- [ ] ESP32
- [ ] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
(The [documentation](https://esphome.io/components/esphome.html#configuration-variables) is already correct as it does not state that underscores are allowed)