### PR TITLE
More Tuya MCU robustness

### DIFF
--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -107,6 +107,7 @@ class Tuya : public Component, public uart::UARTDevice {
   int gpio_status_ = -1;
   int gpio_reset_ = -1;
   uint32_t last_command_timestamp_ = 0;
+  uint32_t last_rx_char_timestamp_ = 0;
   std::string product_ = "";
   std::vector<TuyaDatapointListener> listeners_;
   std::vector<TuyaDatapoint> datapoints_;


### PR DESCRIPTION
- Apply receive timeout as an inter character receive interval timeout,
otherwise command sending may hang indefinitely.
- relax COMMAND_DELAY. There doesn't seem to be evidence that even the
poorly performant Feit/Holtek MCU requires such a conservative
inter-command delay. 50ms is a long time if doing transitions.

# What does this implement/fix? 

The recent Tuya fixes have taken care of the lion share of the problems, however the current code can deadlock
if a RX character is dropped. This adds a very generous inter-character timeout (uses the existing 300ms RECEIVE_TIMEOUT), to proceed with sending commands if a short-read occurs.

This also relaxes the COMMAND_DELAY. It isn't clear that such a prolonged delay was ever necessary. It was more of
a hack when this component was overall in much worse shape. I am using this with the infamous Feit BR-DIM with
its very underwhelming MCU and have had no problems.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable): 
- esphome/esphome#2065

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
