### PR TITLE
Fix PID climate breaks when restoring old modes

### DIFF
--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -37,7 +37,7 @@ void PIDClimate::control(const climate::ClimateCall &call) {
 
   // If switching to off mode, set output immediately
   if (this->mode == climate::CLIMATE_MODE_OFF)
-    this->handle_non_auto_mode_();
+    this->write_output_(0.0f);
 
   this->publish_state();
 }

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -98,15 +98,6 @@ void PIDClimate::write_output_(float value) {
   }
   this->pid_computed_callback_.call();
 }
-void PIDClimate::handle_non_auto_mode_() {
-  // in non-auto mode, switch directly to appropriate action
-  //  - OFF mode -> Output at 0%
-  if (this->mode == climate::CLIMATE_MODE_OFF) {
-    this->write_output_(0.0);
-  } else {
-    assert(false);
-  }
-}
 void PIDClimate::update_pid_() {
   float value;
   if (isnan(this->current_temperature) || isnan(this->target_temperature)) {
@@ -135,7 +126,7 @@ void PIDClimate::update_pid_() {
   }
 
   if (this->mode == climate::CLIMATE_MODE_OFF) {
-    this->handle_non_auto_mode_();
+    this->write_output_(0.0);
   } else {
     this->write_output_(value);
   }

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -56,7 +56,6 @@ class PIDClimate : public climate::Climate, public Component {
   bool supports_heat_() const { return this->heat_output_ != nullptr; }
 
   void write_output_(float value);
-  void handle_non_auto_mode_();
 
   /// The sensor used for getting the current temperature
   sensor::Sensor *sensor_;


### PR DESCRIPTION
# What does this implement/fix? 

Fixes https://github.com/esphome/issues/issues/2264

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
