### PR TITLE
[duty_cycle] initialize two missing variables

### DIFF
--- a/esphome/components/duty_cycle/duty_cycle_sensor.cpp
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.cpp
@@ -13,6 +13,8 @@ void DutyCycleSensor::setup() {
   this->store_.pin = this->pin_->to_isr();
   this->store_.last_level = this->pin_->digital_read();
   this->last_update_ = micros();
+  this->store_.on_time = 0;
+  this->store_.last_interrupt = micros();
 
   this->pin_->attach_interrupt(DutyCycleSensorStore::gpio_intr, &this->store_, CHANGE);
 }

--- a/esphome/components/duty_cycle/duty_cycle_sensor.cpp
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.cpp
@@ -13,7 +13,6 @@ void DutyCycleSensor::setup() {
   this->store_.pin = this->pin_->to_isr();
   this->store_.last_level = this->pin_->digital_read();
   this->last_update_ = micros();
-  this->store_.on_time = 0;
   this->store_.last_interrupt = micros();
 
   this->pin_->attach_interrupt(DutyCycleSensorStore::gpio_intr, &this->store_, CHANGE);

--- a/esphome/components/duty_cycle/duty_cycle_sensor.h
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.h
@@ -29,7 +29,7 @@ class DutyCycleSensor : public sensor::Sensor, public PollingComponent {
  protected:
   GPIOPin *pin_;
 
-  DutyCycleSensorStore store_;
+  DutyCycleSensorStore store_{};
   uint32_t last_update_;
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

Initial value for `duty_cycle` was off (wrong values, sometimes >100%).

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
