### PR TITLE
Add device class support to MQTT cover

### DIFF
--- a/esphome/components/mqtt/mqtt_cover.cpp
+++ b/esphome/components/mqtt/mqtt_cover.cpp
@@ -61,6 +61,9 @@ void MQTTCoverComponent::dump_config() {
   }
 }
 void MQTTCoverComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) {
+  if (!this->cover_->get_device_class().empty())
+    root["device_class"] = this->cover_->get_device_class();
+
   auto traits = this->cover_->get_traits();
   if (traits.get_is_assumed_state()) {
     root["optimistic"] = true;


### PR DESCRIPTION
# What does this implement/fix? 

Adds `device_class` support in discovery for MQTT covers. Similar to https://github.com/esphome/esphome/pull/1832, which did the same thing for MQTT sensors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2023 and fixes https://github.com/esphome/feature-requests/issues/1158

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
mqtt:
  id: mqtt_client
  broker: !secret broker
  username: !secret mqtt_username
  password: !secret mqtt_password

switch:
  - platform: gpio
    pin: D3
    name: "Garage Door Open Switch"
    id: open_switch
  - platform: gpio
    pin: D4
    name: "Garage Door Close Switch"
    id: close_switch

cover:
  - platform: template
    device_class: garage
    name: "Garage Door"
    open_action:
      - switch.turn_off: close_switch
      - switch.turn_on: open_switch
      - delay: 0.1s
      - switch.turn_off: open_switch
    close_action:
      - switch.turn_off: open_switch
      - switch.turn_on: close_switch
      - delay: 0.1s
      - switch.turn_off: close_switch
    stop_action:
      - switch.turn_off: close_switch
      - switch.turn_off: open_switch
    optimistic: true
    assumed_state: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
