### PR TITLE
Migrate COLOR constants to Color class & disallow implicit conversions to Color

### DIFF
--- a/esphome/components/adalight/adalight_light_effect.cpp
+++ b/esphome/components/adalight/adalight_light_effect.cpp
@@ -42,7 +42,7 @@ void AdalightLightEffect::reset_frame_(light::AddressableLight &it) {
 
 void AdalightLightEffect::blank_all_leds_(light::AddressableLight &it) {
   for (int led = it.size(); led-- > 0;) {
-    it[led].set(COLOR_BLACK);
+    it[led].set(Color::BLACK);
   }
 }
 

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -461,7 +461,7 @@ bool Image::get_pixel(int x, int y) const {
 }
 Color Image::get_color_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
-    return 0;
+    return Color::BLACK;
   const uint32_t pos = (x + y * this->width_) * 3;
   const uint32_t color32 = (pgm_read_byte(this->data_start_ + pos + 2) << 0) |
                            (pgm_read_byte(this->data_start_ + pos + 1) << 8) |
@@ -470,7 +470,7 @@ Color Image::get_color_pixel(int x, int y) const {
 }
 Color Image::get_grayscale_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
-    return 0;
+    return Color::BLACK;
   const uint32_t pos = (x + y * this->width_);
   const uint8_t gray = pgm_read_byte(this->data_start_ + pos);
   return Color(gray | gray << 8 | gray << 16 | gray << 24);
@@ -493,10 +493,10 @@ bool Animation::get_pixel(int x, int y) const {
 }
 Color Animation::get_color_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
-    return 0;
+    return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
   if (frame_index >= this->width_ * this->height_ * this->animation_frame_count_)
-    return 0;
+    return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index) * 3;
   const uint32_t color32 = (pgm_read_byte(this->data_start_ + pos + 2) << 0) |
                            (pgm_read_byte(this->data_start_ + pos + 1) << 8) |
@@ -505,10 +505,10 @@ Color Animation::get_color_pixel(int x, int y) const {
 }
 Color Animation::get_grayscale_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
-    return 0;
+    return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
   if (frame_index >= this->width_ * this->height_ * this->animation_frame_count_)
-    return 0;
+    return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index);
   const uint8_t gray = pgm_read_byte(this->data_start_ + pos);
   return Color(gray | gray << 8 | gray << 16 | gray << 24);

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -225,7 +225,7 @@ void ILI9341M5Stack::initialize() {
   this->width_ = 320;
   this->height_ = 240;
   this->invert_display_(true);
-  this->fill_internal_(COLOR_BLACK);
+  this->fill_internal_(Color::BLACK);
 }
 
 //   24_TFT display
@@ -233,7 +233,7 @@ void ILI9341TFT24::initialize() {
   this->init_lcd_(INITCMD_TFT);
   this->width_ = 240;
   this->height_ = 320;
-  this->fill_internal_(COLOR_BLACK);
+  this->fill_internal_(Color::BLACK);
 }
 
 }  // namespace ili9341

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -16,7 +16,7 @@
 namespace esphome {
 namespace light {
 
-using ESPColor = Color;
+using ESPColor ESPDEPRECATED("esphome::light::ESPColor is deprecated, use esphome::Color instead.") = Color;
 
 class AddressableLight : public LightOutput, public Component {
  public:

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -151,7 +151,7 @@ class AddressableScanEffect : public AddressableLightEffect {
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
   void set_scan_width(uint32_t scan_width) { this->scan_width_ = scan_width; }
   void apply(AddressableLight &it, const Color &current_color) override {
-    it.all() = COLOR_BLACK;
+    it.all() = Color::BLACK;
 
     for (auto i = 0; i < this->scan_width_; i++) {
       it[this->at_led_ + i] = current_color;
@@ -201,7 +201,7 @@ class AddressableTwinkleEffect : public AddressableLightEffect {
         else
           view.set_effect_data(new_pos);
       } else {
-        view = COLOR_BLACK;
+        view = Color::BLACK;
       }
     }
     while (random_float() < this->twinkle_probability_) {
@@ -272,7 +272,7 @@ class AddressableFireworksEffect : public AddressableLightEffect {
   explicit AddressableFireworksEffect(const std::string &name) : AddressableLightEffect(name) {}
   void start() override {
     auto &it = *this->get_addressable_();
-    it.all() = COLOR_BLACK;
+    it.all() = Color::BLACK;
   }
   void apply(AddressableLight &it, const Color &current_color) override {
     const uint32_t now = millis();

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -7,8 +7,6 @@ namespace ssd1306_base {
 
 static const char *const TAG = "ssd1306";
 
-static const uint8_t BLACK = 0;
-static const uint8_t WHITE = 1;
 static const uint8_t SSD1306_MAX_CONTRAST = 255;
 
 static const uint8_t SSD1306_COMMAND_DISPLAY_OFF = 0xAE;
@@ -89,8 +87,8 @@ void SSD1306::setup() {
 
   set_brightness(this->brightness_);
 
-  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();    // ...write buffer, which actually clears the display's memory
+  this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
+  this->display();           // ...write buffer, which actually clears the display's memory
 
   this->turn_on();
 }

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -107,8 +107,8 @@ void SSD1322::setup() {
   this->command(SSD1322_ENABLEGRAYSCALETABLE);
   set_brightness(this->brightness_);
   this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();          // ...write buffer, which actually clears the display's memory
-  this->turn_on();          // display ON
+  this->display();           // ...write buffer, which actually clears the display's memory
+  this->turn_on();           // display ON
 }
 void SSD1322::display() {
   this->command(SSD1322_SETCOLUMNADDRESS);  // set column address

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -106,7 +106,7 @@ void SSD1322::setup() {
   this->data(180);
   this->command(SSD1322_ENABLEGRAYSCALETABLE);
   set_brightness(this->brightness_);
-  this->fill(COLOR_BLACK);  // clear display - ensures we do not see garbage at power-on
+  this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
   this->display();          // ...write buffer, which actually clears the display's memory
   this->turn_on();          // display ON
 }

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -7,8 +7,6 @@ namespace ssd1325_base {
 
 static const char *const TAG = "ssd1325";
 
-static const uint8_t BLACK = 0;
-static const uint8_t WHITE = 15;
 static const uint8_t SSD1325_MAX_CONTRAST = 127;
 static const uint8_t SSD1325_COLORMASK = 0x0f;
 static const uint8_t SSD1325_COLORSHIFT = 4;
@@ -114,9 +112,9 @@ void SSD1325::setup() {
   this->command(0x0D | 0x02);
   this->command(SSD1325_NORMALDISPLAY);  // set display mode
   set_brightness(this->brightness_);
-  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();    // ...write buffer, which actually clears the display's memory
-  this->turn_on();    // display ON
+  this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
+  this->display();           // ...write buffer, which actually clears the display's memory
+  this->turn_on();           // display ON
 }
 void SSD1325::display() {
   this->command(SSD1325_SETCOLADDR);  // set column address

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -78,7 +78,7 @@ void SSD1327::setup() {
   this->command(0x1C);
   this->command(SSD1327_NORMALDISPLAY);  // set display mode
   set_brightness(this->brightness_);
-  this->fill(COLOR_BLACK);  // clear display - ensures we do not see garbage at power-on
+  this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
   this->display();          // ...write buffer, which actually clears the display's memory
   this->turn_on();          // display ON
 }

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -79,8 +79,8 @@ void SSD1327::setup() {
   this->command(SSD1327_NORMALDISPLAY);  // set display mode
   set_brightness(this->brightness_);
   this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();          // ...write buffer, which actually clears the display's memory
-  this->turn_on();          // display ON
+  this->display();           // ...write buffer, which actually clears the display's memory
+  this->turn_on();           // display ON
 }
 void SSD1327::display() {
   this->command(SSD1327_SETCOLUMNADDRESS);  // set column address

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -78,7 +78,7 @@ void SSD1331::setup() {
   set_brightness(this->brightness_);
   this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
   this->display();           // ...write buffer, which actually clears the display's memory
-  this->turn_on();          // display ON
+  this->turn_on();           // display ON
 }
 void SSD1331::display() {
   this->command(SSD1331_SETCOLUMN);  // set column address

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -7,8 +7,6 @@ namespace ssd1331_base {
 
 static const char *const TAG = "ssd1331";
 
-static const uint16_t BLACK = 0;
-static const uint16_t WHITE = 0xffff;
 static const uint16_t SSD1331_COLORMASK = 0xffff;
 static const uint8_t SSD1331_MAX_CONTRASTA = 0x91;
 static const uint8_t SSD1331_MAX_CONTRASTB = 0x50;
@@ -78,9 +76,9 @@ void SSD1331::setup() {
   this->command(SSD1331_MASTERCURRENT);  // 0x87
   this->command(0x06);
   set_brightness(this->brightness_);
-  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();    // ...write buffer, which actually clears the display's memory
-  this->turn_on();    // display ON
+  this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
+  this->display();           // ...write buffer, which actually clears the display's memory
+  this->turn_on();          // display ON
 }
 void SSD1331::display() {
   this->command(SSD1331_SETCOLUMN);  // set column address

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -7,8 +7,6 @@ namespace ssd1351_base {
 
 static const char *const TAG = "ssd1351";
 
-static const uint16_t BLACK = 0;
-static const uint16_t WHITE = 0xffff;
 static const uint16_t SSD1351_COLORMASK = 0xffff;
 static const uint8_t SSD1351_MAX_CONTRAST = 15;
 static const uint8_t SSD1351_BYTESPERPIXEL = 2;
@@ -87,9 +85,9 @@ void SSD1351::setup() {
   this->data(0x80);
   this->data(0xC8);
   set_brightness(this->brightness_);
-  this->fill(BLACK);  // clear display - ensures we do not see garbage at power-on
-  this->display();    // ...write buffer, which actually clears the display's memory
-  this->turn_on();    // display ON
+  this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on
+  this->display();           // ...write buffer, which actually clears the display's memory
+  this->turn_on();           // display ON
 }
 void SSD1351::display() {
   this->command(SSD1351_SETCOLUMN);  // set column address

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -40,7 +40,7 @@ void WLEDLightEffect::stop() {
 
 void WLEDLightEffect::blank_all_leds_(light::AddressableLight &it) {
   for (int led = it.size(); led-- > 0;) {
-    it[led].set(COLOR_BLACK);
+    it[led].set(Color::BLACK);
   }
 }
 

--- a/esphome/core/color.cpp
+++ b/esphome/core/color.cpp
@@ -1,0 +1,8 @@
+#include "esphome/core/color.h"
+
+namespace esphome {
+
+const Color Color::BLACK(0, 0, 0, 0);
+const Color Color::WHITE(255, 255, 255, 255);
+
+}  // namespace esphome

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -38,10 +38,10 @@ struct Color {
                                                                                         g(green),
                                                                                         b(blue),
                                                                                         w(white) {}
-  inline Color(uint32_t colorcode) ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
-                                                   g((colorcode >> 8) & 0xFF),
-                                                   b((colorcode >> 0) & 0xFF),
-                                                   w((colorcode >> 24) & 0xFF) {}
+  inline explicit Color(uint32_t colorcode) ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
+                                                            g((colorcode >> 8) & 0xFF),
+                                                            b((colorcode >> 0) & 0xFF),
+                                                            w((colorcode >> 24) & 0xFF) {}
 
   inline bool is_on() ALWAYS_INLINE { return this->raw_32 != 0; }
   inline Color &operator=(const Color &rhs) ALWAYS_INLINE {  // NOLINT

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -143,8 +143,14 @@ struct Color {
   Color fade_to_black(uint8_t amnt) { return *this * amnt; }
   Color lighten(uint8_t delta) { return *this + delta; }
   Color darken(uint8_t delta) { return *this - delta; }
+
+  static const Color BLACK;
+  static const Color WHITE;
 };
 
-static const Color COLOR_BLACK(0, 0, 0);
+ESPDEPRECATED("Use Color::BLACK instead of COLOR_BLACK")
+static const Color COLOR_BLACK(0, 0, 0, 0);
+ESPDEPRECATED("Use Color::WHITE instead of COLOR_WHITE")
 static const Color COLOR_WHITE(255, 255, 255, 255);
-};  // namespace esphome
+
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 

* Migrate COLOR_BLACK and COLOR_WHITE constants to be static members of the Color class. Fixes esphome/issues#2068.
* Disallow implicit conversions from an integer to the Color class. This conversion is rarely wanted, and has caused bugs in the past. This is (mostly) taken from PR #1300. 
* Mark the ESPColor alias in the light namespace as deprecated, as the docs already point out that it is.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
