### PR TITLE
Increase task wdt timeout for ESP32/ESP32-C3

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -59,6 +59,7 @@ void Application::setup() {
   ESP_LOGI(TAG, "setup() finished successfully!");
   this->schedule_dump_config();
   this->calculate_looping_components_();
+  this->post_setup_arch_();
 
   // Dummy function to link some symbols into the binary.
   force_link_symbols();

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -59,7 +59,6 @@ void Application::setup() {
   ESP_LOGI(TAG, "setup() finished successfully!");
   this->schedule_dump_config();
   this->calculate_looping_components_();
-  this->post_setup_arch_();
 
   // Dummy function to link some symbols into the binary.
   force_link_symbols();

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -117,12 +117,7 @@ void ICACHE_RAM_ATTR HOT Application::feed_wdt() {
   static uint32_t LAST_FEED = 0;
   uint32_t now = millis();
   if (now - LAST_FEED > 3) {
-#ifdef ARDUINO_ARCH_ESP8266
-    ESP.wdtFeed();
-#endif
-#ifdef ARDUINO_ARCH_ESP32
-    yield();
-#endif
+    this->feed_wdt_arch_();
     LAST_FEED = now;
 #ifdef USE_STATUS_LED
     if (status_led::global_status_led != nullptr) {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -53,6 +53,7 @@ void Application::setup() {
       }
       this->app_state_ = new_app_state;
       yield();
+      this->feed_wdt();
     } while (!component->can_proceed());
   }
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -41,7 +41,6 @@ namespace esphome {
 class Application {
  public:
   void pre_setup(const std::string &name, const char *compilation_time, bool name_add_mac_suffix) {
-    pre_setup_arch_();
     this->name_add_mac_suffix_ = name_add_mac_suffix;
     if (name_add_mac_suffix) {
       this->name_ = name + "-" + get_mac_address().substr(6);
@@ -236,8 +235,6 @@ class Application {
   void calculate_looping_components_();
 
   void feed_wdt_arch_();
-  void pre_setup_arch_();
-  void post_setup_arch_();
 
   std::vector<Component *> components_{};
   std::vector<Component *> looping_components_{};

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -41,6 +41,7 @@ namespace esphome {
 class Application {
  public:
   void pre_setup(const std::string &name, const char *compilation_time, bool name_add_mac_suffix) {
+    pre_setup_arch_();
     this->name_add_mac_suffix_ = name_add_mac_suffix;
     if (name_add_mac_suffix) {
       this->name_ = name + "-" + get_mac_address().substr(6);
@@ -235,6 +236,8 @@ class Application {
   void calculate_looping_components_();
 
   void feed_wdt_arch_();
+  void pre_setup_arch_();
+  void post_setup_arch_();
 
   std::vector<Component *> components_{};
   std::vector<Component *> looping_components_{};

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -234,6 +234,8 @@ class Application {
 
   void calculate_looping_components_();
 
+  void feed_wdt_arch_();
+
   std::vector<Component *> components_{};
   std::vector<Component *> looping_components_{};
 

--- a/esphome/core/application_esp32.cpp
+++ b/esphome/core/application_esp32.cpp
@@ -2,20 +2,11 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 
-#include <esp_task_wdt.h>
-
 namespace esphome {
 
 static const char *const TAG = "app_esp32";
 
 void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() { yield(); }
-
-void Application::pre_setup_arch_() {
-  // Increase timeout during setup() time to avoid task watchdog resets.
-  esp_task_wdt_init(30, true);
-}
-
-void Application::post_setup_arch_() { esp_task_wdt_init(5, true); }
 
 }  // namespace esphome
 #endif

--- a/esphome/core/application_esp32.cpp
+++ b/esphome/core/application_esp32.cpp
@@ -1,0 +1,12 @@
+#include "esphome/core/application.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+namespace esphome {
+
+static const char *const TAG = "app_esp32";
+
+void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() { yield(); }
+
+}  // namespace esphome
+#endif

--- a/esphome/core/application_esp32.cpp
+++ b/esphome/core/application_esp32.cpp
@@ -6,7 +6,16 @@ namespace esphome {
 
 static const char *const TAG = "app_esp32";
 
-void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() { yield(); }
+void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() {
+#if CONFIG_ARDUINO_RUNNING_CORE == 0
+#ifdef CONFIG_TASK_WDT_CHECK_IDLE_TASK_CPU0
+  // ESP32 uses "Task Watchdog" which is hooked to the FreeRTOS idle task.
+  // To cause the Watchdog to be triggered we need to put the current task
+  // to sleep to get the idle task scheduled.
+  delay(1);
+#endif
+#endif
+}
 
 }  // namespace esphome
 #endif

--- a/esphome/core/application_esp32.cpp
+++ b/esphome/core/application_esp32.cpp
@@ -2,11 +2,20 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 
+#include <esp_task_wdt.h>
+
 namespace esphome {
 
 static const char *const TAG = "app_esp32";
 
 void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() { yield(); }
+
+void Application::pre_setup_arch_() {
+  // Increase timeout during setup() time to avoid task watchdog resets.
+  esp_task_wdt_init(30, true);
+}
+
+void Application::post_setup_arch_() { esp_task_wdt_init(5, true); }
 
 }  // namespace esphome
 #endif

--- a/esphome/core/application_esp8266.cpp
+++ b/esphome/core/application_esp8266.cpp
@@ -1,0 +1,12 @@
+#include "esphome/core/application.h"
+
+#ifdef ARDUINO_ARCH_ESP8266
+
+namespace esphome {
+
+static const char *const TAG = "app_esp8266";
+
+void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() { ESP.wdtFeed(); }
+
+}  // namespace esphome
+#endif

--- a/esphome/core/application_esp8266.cpp
+++ b/esphome/core/application_esp8266.cpp
@@ -8,8 +8,5 @@ static const char *const TAG = "app_esp8266";
 
 void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() { ESP.wdtFeed(); }
 
-void Application::pre_setup_arch_() {}
-void Application::post_setup_arch_() {}
-
 }  // namespace esphome
 #endif

--- a/esphome/core/application_esp8266.cpp
+++ b/esphome/core/application_esp8266.cpp
@@ -8,5 +8,8 @@ static const char *const TAG = "app_esp8266";
 
 void ICACHE_RAM_ATTR HOT Application::feed_wdt_arch_() { ESP.wdtFeed(); }
 
+void Application::pre_setup_arch_() {}
+void Application::post_setup_arch_() {}
+
 }  // namespace esphome
 #endif


### PR DESCRIPTION
# What does this implement/fix? 

Introduce application_esp32.cpp/application_esp8266.cpp and 
pre_/post_setup_arch_(). Use the function to increase the Task 
Watchdog timeout from 5s to 10s before entering `setup()` phase.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2277

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32/ESP32-C3
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
