### PR TITLE
fix diplay trigger missing base class

### DIFF
--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -31,7 +31,9 @@ DisplayPageShowPrevAction = display_ns.class_(
 DisplayIsDisplayingPageCondition = display_ns.class_(
     "DisplayIsDisplayingPageCondition", automation.Condition
 )
-DisplayOnPageChangeTrigger = display_ns.class_("DisplayOnPageChangeTrigger")
+DisplayOnPageChangeTrigger = display_ns.class_(
+    "DisplayOnPageChangeTrigger", automation.Trigger
+)
 
 CONF_ON_PAGE_CHANGE = "on_page_change"
 


### PR DESCRIPTION
# What does this implement/fix? 

Quick fix missing base type

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
