### PR TITLE
Fix min/max keys in MQTT Number to match Home Assistant

### DIFF
--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -39,8 +39,8 @@ void MQTTNumberComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryCo
   // https://www.home-assistant.io/integrations/number.mqtt/
   if (!traits.get_icon().empty())
     root["icon"] = traits.get_icon();
-  root["min_value"] = traits.get_min_value();
-  root["max_value"] = traits.get_max_value();
+  root["min"] = traits.get_min_value();
+  root["max"] = traits.get_max_value();
   root["step"] = traits.get_step();
 
   config.command_topic = true;


### PR DESCRIPTION
# What does this implement/fix? 

MQTT discovery for the Number integration was sending 'min_value' and 'max_value' as keys, while Home Assistant was expecting 'min' and 'max' respectively. See [MQTT Number](https://www.home-assistant.io/integrations/number.mqtt/).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
N/A

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
number:
  - platform: template
    name: "Template number"
    update_interval: never
    min_value: 0
    max_value: 100
    step: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
