### PR TITLE
Use proper schema for the analog pin shorthand

### DIFF
--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -271,7 +271,7 @@ def shorthand_input_pullup_pin(value):
 
 def shorthand_analog_pin(value):
     value = analog_pin(value)
-    return GPIO_FULL_INPUT_PIN_SCHEMA({CONF_NUMBER: value})
+    return GPIO_FULL_ANALOG_PIN_SCHEMA({CONF_NUMBER: value})
 
 
 def validate_has_interrupt(value):


### PR DESCRIPTION
# What does this implement/fix? 

Analog pin validation

The wrong error message is displayed like:
> GPIO17 (TOUT) is an analog-only pin on the ESP8266.
in case of the analog pin validation because the method `shorthand_analog_pin` uses wrong `GPIO_FULL_INPUT_PIN_SCHEMA` instead of `GPIO_FULL_ANALOG_PIN_SCHEMA`.

It fixes the improper schema usage for the analog pin validation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: test_sensor
    pin: A0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
