### PR TITLE
Fix missing include in light_traits.h

### DIFF
--- a/esphome/components/light/light_traits.h
+++ b/esphome/components/light/light_traits.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/helpers.h"
 #include "color_mode.h"
 #include <set>
 


### PR DESCRIPTION
With color mode changes a bunch of ESPDEPRECATED were placed in
light_traits.h however the macro was never explicitly included. This
broke the build on at least tuya light.

# What does this implement/fix? 

Prevents a broken build when using tuya light component.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable): No issue filed

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml - This will break without the change
wifi:
  ssid: "ssid"
  password: "password"

# Make sure logging is not using the serial port
logger:
  baud_rate: 0

# My dimmer used the hardware serial port on the alternate pins
uart:
  rx_pin: GPIO13
  tx_pin: GPIO15
  baud_rate: 9600

# Register the Tuya MCU connection
tuya:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
