### PR TITLE
Dont force 0 state instead of min_power unless explicit config set

### DIFF
--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -17,6 +17,8 @@ from esphome.core import CORE
 CODEOWNERS = ["@esphome/core"]
 IS_PLATFORM_COMPONENT = True
 
+CONF_ZERO_MEANS_ZERO = "zero_means_zero"
+
 BINARY_OUTPUT_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_POWER_SUPPLY): cv.use_id(power_supply.PowerSupply),
@@ -28,6 +30,7 @@ FLOAT_OUTPUT_SCHEMA = BINARY_OUTPUT_SCHEMA.extend(
     {
         cv.Optional(CONF_MAX_POWER): cv.percentage,
         cv.Optional(CONF_MIN_POWER): cv.percentage,
+        cv.Optional(CONF_ZERO_MEANS_ZERO, default=False): cv.boolean,
     }
 )
 
@@ -53,6 +56,7 @@ async def setup_output_platform_(obj, config):
         cg.add(obj.set_max_power(config[CONF_MAX_POWER]))
     if CONF_MIN_POWER in config:
         cg.add(obj.set_min_power(config[CONF_MIN_POWER]))
+    cg.add(obj.set_zero_means_zero(config[CONF_ZERO_MEANS_ZERO]))
 
 
 async def register_output(var, config):

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -56,7 +56,8 @@ async def setup_output_platform_(obj, config):
         cg.add(obj.set_max_power(config[CONF_MAX_POWER]))
     if CONF_MIN_POWER in config:
         cg.add(obj.set_min_power(config[CONF_MIN_POWER]))
-    cg.add(obj.set_zero_means_zero(config[CONF_ZERO_MEANS_ZERO]))
+    if CONF_ZERO_MEANS_ZERO in config:
+        cg.add(obj.set_zero_means_zero(config[CONF_ZERO_MEANS_ZERO]))
 
 
 async def register_output(var, config):

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -17,6 +17,8 @@ void FloatOutput::set_min_power(float min_power) {
   this->min_power_ = clamp(min_power, 0.0f, this->max_power_);  // Clamp to 0.0>=MIN>=MAX
 }
 
+void FloatOutput::set_zero_means_zero(bool zero_means_zero) { this->zero_means_zero_ = zero; }
+
 float FloatOutput::get_min_power() const { return this->min_power_; }
 
 void FloatOutput::set_level(float state) {
@@ -31,7 +33,7 @@ void FloatOutput::set_level(float state) {
 #endif
   if (this->is_inverted())
     state = 1.0f - state;
-  if (state == 0.0f) {  // regardless of min_power_, 0.0 means off
+  if (state == 0.0f && this->zero_means_zero_) {  // regardless of min_power_, 0.0 means off
     this->write_state(state);
     return;
   }

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -17,7 +17,7 @@ void FloatOutput::set_min_power(float min_power) {
   this->min_power_ = clamp(min_power, 0.0f, this->max_power_);  // Clamp to 0.0>=MIN>=MAX
 }
 
-void FloatOutput::set_zero_means_zero(bool zero_means_zero) { this->zero_means_zero_ = zero; }
+void FloatOutput::set_zero_means_zero(bool zero_means_zero) { this->zero_means_zero_ = zero_means_zero; }
 
 float FloatOutput::get_min_power() const { return this->min_power_; }
 

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -46,6 +46,12 @@ class FloatOutput : public BinaryOutput {
    */
   void set_min_power(float min_power);
 
+  /** Sets this output to ignore min_power for a 0 state
+   *
+   * @param zero True if a 0 state should mean 0 and not min_power.
+   */
+  void set_zero_means_zero(bool zero_means_zero);
+
   /** Set the level of this float output, this is called from the front-end.
    *
    * @param state The new state.
@@ -76,6 +82,7 @@ class FloatOutput : public BinaryOutput {
 
   float max_power_{1.0f};
   float min_power_{0.0f};
+  bool zero_means_zero_;
 };
 
 }  // namespace output


### PR DESCRIPTION
# What does this implement/fix? 

This change makes the changes in #2013 only happen when a new variable is set `zero_means_zero: true`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1357

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
