### PR TITLE
on component registration, store name so we can log it when needed

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -11,7 +11,7 @@ namespace esphome {
 
 static const char *const TAG = "app";
 
-void Application::register_component_(Component *comp) {
+void Application::register_component_(Component *comp, std::string id) {
   if (comp == nullptr) {
     ESP_LOGW(TAG, "Tried to register null component!");
     return;
@@ -23,6 +23,7 @@ void Application::register_component_(Component *comp) {
       return;
     }
   }
+  comp->esphome_component_name = id;
   this->components_.push_back(comp);
 }
 void Application::setup() {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -90,9 +90,9 @@ class Application {
 #endif
 
   /// Register the component in this Application instance.
-  template<class C> C *register_component(C *c) {
+  template<class C> C *register_component(C *c, std::string id) {
     static_assert(std::is_base_of<Component, C>::value, "Only Component subclasses can be registered");
-    this->register_component_((Component *) c);
+    this->register_component_((Component *) c, id);
     return c;
   }
 
@@ -230,7 +230,7 @@ class Application {
  protected:
   friend Component;
 
-  void register_component_(Component *comp);
+  void register_component_(Component *comp, std::string id);
 
   void calculate_looping_components_();
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -92,7 +92,7 @@ class Application {
   /// Register the component in this Application instance.
   template<class C> C *register_component(C *c, std::string id) {
     static_assert(std::is_base_of<Component, C>::value, "Only Component subclasses can be registered");
-    this->register_component_((Component *) c, id);
+    this->register_component_((Component *) c, std::move(id));
     return c;
   }
 

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -93,7 +93,8 @@ void Component::call() {
   }
 }
 void Component::mark_failed() {
-  ESP_LOGE(TAG, "Component was marked as failed.");
+  ESP_LOGE(TAG, "Component (%s) was marked as failed. Config dump of failing component follows:", this->esphome_component_name.c_str());
+  this->dump_config();
   this->component_state_ &= ~COMPONENT_STATE_MASK;
   this->component_state_ |= COMPONENT_STATE_FAILED;
   this->status_set_error();

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -93,7 +93,8 @@ void Component::call() {
   }
 }
 void Component::mark_failed() {
-  ESP_LOGE(TAG, "Component (%s) was marked as failed. Config dump of failing component follows:", this->esphome_component_name.c_str());
+  ESP_LOGE(TAG, "Component (%s) was marked as failed. Config dump of failing component follows:",
+           this->esphome_component_name.c_str());
   this->dump_config();
   this->component_state_ &= ~COMPONENT_STATE_MASK;
   this->component_state_ |= COMPONENT_STATE_FAILED;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -130,6 +130,8 @@ class Component {
 
   bool has_overridden_loop() const;
 
+  std::string esphome_component_name;
+
  protected:
   virtual void call_loop();
   virtual void call_setup();

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -54,7 +54,7 @@ async def register_component(var, config):
         add(var.set_setup_priority(config[CONF_SETUP_PRIORITY]))
     if CONF_UPDATE_INTERVAL in config:
         add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
-    add(App.register_component(var))
+    add(App.register_component(var, id_))
     return var
 
 


### PR DESCRIPTION
# What does this implement/fix? 

I'll let a small part of the diff speak for itself:
```
 void Component::mark_failed() {
-  ESP_LOGE(TAG, "Component was marked as failed.");
+  ESP_LOGE(TAG, "Component (%s) was marked as failed. Config dump of failing component follows:", this->esphome_component_name.c_str());
+  this->dump_config();
```

Comments welcome on the approach, on the variable name, and of course on anything else. If this looks good, I can try extending the name-printing to the code that says a component took too much time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none yet - unsure one is needed

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# no config for this PR
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
