### PR TITLE
Add initial support for m5stack_4relay

### DIFF
--- a/esphome/components/m5stack_4relay/__init__.py
+++ b/esphome/components/m5stack_4relay/__init__.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c
+from esphome.const import (
+    CONF_ID
+)
+
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+AUTO_LOAD = ["switch"]
+
+m5stack_4relay_ns = cg.esphome_ns.namespace("m5stack_4relay")
+M5STACK4RELAYOutput = m5stack_4relay_ns.class_("M5STACK4RELAYSwitchComponent", cg.Component, i2c.I2CDevice)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(M5STACK4RELAYOutput),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x26))
+)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield i2c.register_i2c_device(var, config)
+
+    # cg.add_library("adafruit/Adafruit M5STACK4RELAY", "1.0.7")

--- a/esphome/components/m5stack_4relay/__init__.py
+++ b/esphome/components/m5stack_4relay/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ID
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = True
 AUTO_LOAD = ["switch"]
+CODEOWNERS = ["@brotherdust"]
 
 m5stack_4relay_ns = cg.esphome_ns.namespace("m5stack_4relay")
 M5STACK4RELAYOutput = m5stack_4relay_ns.class_(

--- a/esphome/components/m5stack_4relay/__init__.py
+++ b/esphome/components/m5stack_4relay/__init__.py
@@ -1,16 +1,16 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c
-from esphome.const import (
-    CONF_ID
-)
+from esphome.const import CONF_ID
 
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = True
 AUTO_LOAD = ["switch"]
 
 m5stack_4relay_ns = cg.esphome_ns.namespace("m5stack_4relay")
-M5STACK4RELAYOutput = m5stack_4relay_ns.class_("M5STACK4RELAYSwitchComponent", cg.Component, i2c.I2CDevice)
+M5STACK4RELAYOutput = m5stack_4relay_ns.class_(
+    "M5STACK4RELAYSwitchComponent", cg.Component, i2c.I2CDevice
+)
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -27,5 +27,3 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     yield i2c.register_i2c_device(var, config)
-
-    # cg.add_library("adafruit/Adafruit M5STACK4RELAY", "1.0.7")

--- a/esphome/components/m5stack_4relay/m5stack_4relay.cpp
+++ b/esphome/components/m5stack_4relay/m5stack_4relay.cpp
@@ -3,7 +3,6 @@
 #include "esphome/core/log.h"
 namespace esphome {
 namespace m5stack_4relay {
-uint8_t component_status;
 static const char *const TAG = "m5stack_4relay.switch";
 
 void M5STACK4RELAYSwitchComponent::setup() {
@@ -22,7 +21,7 @@ void M5STACK4RELAYSwitchComponent::get_status(uint8_t *state) { this->read_byte(
 bool M5STACK4RELAYSwitchComponent::set_channel_value_(uint8_t channel, bool state) {
   get_status(&component_status);
 
-  ESP_LOGD(TAG, "Current Status 0x%02X", component_status);
+  ESP_LOGD(TAG, "Current status 0x%02X", component_status);
   ESP_LOGD(TAG, "Desired channel: %1u", channel);
   ESP_LOGD(TAG, "Desired state: %1u", state);
 

--- a/esphome/components/m5stack_4relay/m5stack_4relay.cpp
+++ b/esphome/components/m5stack_4relay/m5stack_4relay.cpp
@@ -1,92 +1,50 @@
 #include "m5stack_4relay.h"
-#include "esphome/core/log.h"
 #include <bitset>
-namespace esphome
-{
-  namespace m5stack_4relay
-  {
-    const uint8_t MODE_CONTROL_REG = 0x10;
-    const uint8_t RELAY_CONTROL_REG = 0x11;
-    uint8_t component_status;
-    static const char *const TAG = "m5stack_4relay.switch";
+#include "esphome/core/log.h"
+namespace esphome {
+namespace m5stack_4relay {
+uint8_t component_status;
+static const char *const TAG = "m5stack_4relay.switch";
 
-    void M5STACK4RELAYSwitchComponent::setup()
-    {
-      ESP_LOGCONFIG(TAG, "Setting up M5STACK4RELAY (0x%02X)...", this->address_);
-      component_status = 0;
-      get_status(&component_status);
-      ESP_LOGD(TAG, "Setup Status 0x%02X", component_status);
-      // this->address_;
-    }
+void M5STACK4RELAYSwitchComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up M5STACK4RELAY (0x%02X)...", this->address_);
+  component_status = 0;
+  get_status(&component_status);
+  ESP_LOGD(TAG, "Setup Status 0x%02X", component_status);
+}
 
-    M5STACK4RELAYChannel *M5STACK4RELAYSwitchComponent::create_channel(uint8_t channel)
-    {
-      auto *c = new M5STACK4RELAYChannel(this, channel);
-      return c;
-    }
+M5STACK4RELAYChannel *M5STACK4RELAYSwitchComponent::create_channel(uint8_t channel) {
+  return new M5STACK4RELAYChannel(this, channel);
+}
 
-    void M5STACK4RELAYSwitchComponent::get_status(uint8_t *state)
-    {
-      this->read_byte(RELAY_CONTROL_REG);
-    }
+void M5STACK4RELAYSwitchComponent::get_status(uint8_t *state) { this->read_byte(RELAY_CONTROL_REG); }
 
-    bool M5STACK4RELAYSwitchComponent::set_channel_value_(uint8_t channel, bool state)
-    {
-      get_status(&component_status);
+bool M5STACK4RELAYSwitchComponent::set_channel_value_(uint8_t channel, bool state) {
+  get_status(&component_status);
 
-      ESP_LOGD(TAG, "Current Status 0x%02X", component_status);
-      ESP_LOGD(TAG, "Desired channel: %1u", channel);
-      ESP_LOGD(TAG, "Desired state: %1u", state);
+  ESP_LOGD(TAG, "Current Status 0x%02X", component_status);
+  ESP_LOGD(TAG, "Desired channel: %1u", channel);
+  ESP_LOGD(TAG, "Desired state: %1u", state);
 
-      // M5Stack thought it would be best if the relay mappings are backwards. So, bit 0 is relay 4.
-      // We'll just remap it here. The best way to do this would probably be a lshift(channel) mod(4).
-      // Alas...
-      switch (channel)
-      {
-      case 0:
-        channel = 3;
-        break;
-      case 1:
-        channel = 2;
-        break;
-      case 2:
-        channel = 1;
-        break;
-      case 3:
-        channel = 0;
-        break;
-      }
-      if (state)
-      {
-        component_status |= (1u << channel);
-      }
-      else
-      {
-        component_status &= ~(1u << channel);
-      }
+  channel = 3 - channel;
+  if (state) {
+    component_status |= (1u << channel);
+  } else {
+    component_status &= ~(1u << channel);
+  }
 
-      ESP_LOGD(TAG, "New status 0x%02X", component_status);
+  ESP_LOGD(TAG, "New status 0x%02X", component_status);
 
-      if (!this->parent_->write_byte(this->address_, RELAY_CONTROL_REG, component_status))
-      {
-        return false;
-      }
+  return this->parent_->write_byte(this->address_, RELAY_CONTROL_REG, component_status);
+}
 
-      return true;
-    }
+void M5STACK4RELAYChannel::write_state(bool state) {
+  if (!this->parent_->set_channel_value_(this->channel_, state)) {
+    publish_state(false);
+  } else {
+    publish_state(state);
+  }
+}
 
-    void M5STACK4RELAYChannel::write_state(bool state)
-    {
-
-      if (!this->parent_->set_channel_value_(this->channel_, state))
-      {
-        publish_state(false);
-      }
-      else
-      {
-        publish_state(state);
-      }
-    }
-
-  } // namespace m5stack_4relay
-} // namespace esphome
+}  // namespace m5stack_4relay
+}  // namespace esphome

--- a/esphome/components/m5stack_4relay/m5stack_4relay.cpp
+++ b/esphome/components/m5stack_4relay/m5stack_4relay.cpp
@@ -1,0 +1,92 @@
+#include "m5stack_4relay.h"
+#include "esphome/core/log.h"
+#include <bitset>
+namespace esphome
+{
+  namespace m5stack_4relay
+  {
+    const uint8_t MODE_CONTROL_REG = 0x10;
+    const uint8_t RELAY_CONTROL_REG = 0x11;
+    uint8_t component_status;
+    static const char *const TAG = "m5stack_4relay.switch";
+
+    void M5STACK4RELAYSwitchComponent::setup()
+    {
+      ESP_LOGCONFIG(TAG, "Setting up M5STACK4RELAY (0x%02X)...", this->address_);
+      component_status = 0;
+      get_status(&component_status);
+      ESP_LOGD(TAG, "Setup Status 0x%02X", component_status);
+      // this->address_;
+    }
+
+    M5STACK4RELAYChannel *M5STACK4RELAYSwitchComponent::create_channel(uint8_t channel)
+    {
+      auto *c = new M5STACK4RELAYChannel(this, channel);
+      return c;
+    }
+
+    void M5STACK4RELAYSwitchComponent::get_status(uint8_t *state)
+    {
+      this->read_byte(RELAY_CONTROL_REG);
+    }
+
+    bool M5STACK4RELAYSwitchComponent::set_channel_value_(uint8_t channel, bool state)
+    {
+      get_status(&component_status);
+
+      ESP_LOGD(TAG, "Current Status 0x%02X", component_status);
+      ESP_LOGD(TAG, "Desired channel: %1u", channel);
+      ESP_LOGD(TAG, "Desired state: %1u", state);
+
+      // M5Stack thought it would be best if the relay mappings are backwards. So, bit 0 is relay 4.
+      // We'll just remap it here. The best way to do this would probably be a lshift(channel) mod(4).
+      // Alas...
+      switch (channel)
+      {
+      case 0:
+        channel = 3;
+        break;
+      case 1:
+        channel = 2;
+        break;
+      case 2:
+        channel = 1;
+        break;
+      case 3:
+        channel = 0;
+        break;
+      }
+      if (state)
+      {
+        component_status |= (1u << channel);
+      }
+      else
+      {
+        component_status &= ~(1u << channel);
+      }
+
+      ESP_LOGD(TAG, "New status 0x%02X", component_status);
+
+      if (!this->parent_->write_byte(this->address_, RELAY_CONTROL_REG, component_status))
+      {
+        return false;
+      }
+
+      return true;
+    }
+
+    void M5STACK4RELAYChannel::write_state(bool state)
+    {
+
+      if (!this->parent_->set_channel_value_(this->channel_, state))
+      {
+        publish_state(false);
+      }
+      else
+      {
+        publish_state(state);
+      }
+    }
+
+  } // namespace m5stack_4relay
+} // namespace esphome

--- a/esphome/components/m5stack_4relay/m5stack_4relay.h
+++ b/esphome/components/m5stack_4relay/m5stack_4relay.h
@@ -5,65 +5,45 @@
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 
-namespace esphome
-{
-  namespace m5stack_4relay
-  {
-    extern const uint8_t MODE_CONTROL_REG;
-    extern const uint8_t RELAY_CONTROL_REG;
-    extern uint8_t component_status;
+namespace esphome {
+namespace m5stack_4relay {
 
-    class M5STACK4RELAYSwitchComponent;
-    class M5STACK4RELAYChannel : public switch_::Switch
-    {
-    public:
-      M5STACK4RELAYChannel(M5STACK4RELAYSwitchComponent *parent, uint8_t channel) : parent_(parent), channel_(channel) {}
+class M5STACK4RELAYSwitchComponent;
+class M5STACK4RELAYChannel : public switch_::Switch {
+ public:
+  M5STACK4RELAYChannel(M5STACK4RELAYSwitchComponent *parent, uint8_t channel) : parent_(parent), channel_(channel) {}
 
-    protected:
-      void write_state(bool state) override;
+ protected:
+  void write_state(bool state) override;
 
-      M5STACK4RELAYSwitchComponent *parent_;
-      uint8_t channel_;
-    };
+  M5STACK4RELAYSwitchComponent *parent_;
+  uint8_t channel_;
+};
 
-    class M5STACK4RELAYSwitchComponent : public Component, public i2c::I2CDevice
-    {
-    public:
-      M5STACK4RELAYSwitchComponent() {}
-      M5STACK4RELAYChannel *create_channel(uint8_t channel);
+class M5STACK4RELAYSwitchComponent : public Component, public i2c::I2CDevice {
+ public:
+  const uint8_t MODE_CONTROL_REG = 0x10;
+  const uint8_t RELAY_CONTROL_REG = 0x11;
+  uint8_t component_status;
+  M5STACK4RELAYSwitchComponent() {}
+  M5STACK4RELAYChannel *create_channel(uint8_t channel);
 
-      void setup() override;
-      float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void setup() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-    protected:
-      friend M5STACK4RELAYChannel;
+ protected:
+  friend M5STACK4RELAYChannel;
 
-      void get_status(uint8_t *state);
+  void get_status(uint8_t *state);
 
-      bool set_channel_value_(uint8_t channel, bool state);
-      // bool read_bytes_(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
+  bool set_channel_value_(uint8_t channel, bool state);
 
-      bool read_bytes_(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion)
-      {
+  bool read_bytes_(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {
+    return this->parent_->raw_receive(this->address_, data, len);
+  }
 
-        // if (!this->write_bytes(a_register, data, 2))
-        // {
-        //   ESP_LOGW(TAG, "Writing bytes for AM2320 failed!");
-        //   return false;
-        // }
+  float value_;
+};
 
-        // if (conversion > 0)
-        //   delay(conversion);
-        return this->parent_->raw_receive(this->address_, data, len);
-      }
-      enum ErrorCode
-      {
-        NONE = 0,
-        COMMUNICATION_FAILED
-      } error_code_{NONE};
-
-      float value_;
-    };
-
-  } // namespace m5stack_4relay
-} // namespace esphome
+}  // namespace m5stack_4relay
+}  // namespace esphome

--- a/esphome/components/m5stack_4relay/m5stack_4relay.h
+++ b/esphome/components/m5stack_4relay/m5stack_4relay.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+
+namespace esphome
+{
+  namespace m5stack_4relay
+  {
+    extern const uint8_t MODE_CONTROL_REG;
+    extern const uint8_t RELAY_CONTROL_REG;
+    extern uint8_t component_status;
+
+    class M5STACK4RELAYSwitchComponent;
+    class M5STACK4RELAYChannel : public switch_::Switch
+    {
+    public:
+      M5STACK4RELAYChannel(M5STACK4RELAYSwitchComponent *parent, uint8_t channel) : parent_(parent), channel_(channel) {}
+
+    protected:
+      void write_state(bool state) override;
+
+      M5STACK4RELAYSwitchComponent *parent_;
+      uint8_t channel_;
+    };
+
+    class M5STACK4RELAYSwitchComponent : public Component, public i2c::I2CDevice
+    {
+    public:
+      M5STACK4RELAYSwitchComponent() {}
+      M5STACK4RELAYChannel *create_channel(uint8_t channel);
+
+      void setup() override;
+      float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+    protected:
+      friend M5STACK4RELAYChannel;
+
+      void get_status(uint8_t *state);
+
+      bool set_channel_value_(uint8_t channel, bool state);
+      // bool read_bytes_(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
+
+      bool read_bytes_(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion)
+      {
+
+        // if (!this->write_bytes(a_register, data, 2))
+        // {
+        //   ESP_LOGW(TAG, "Writing bytes for AM2320 failed!");
+        //   return false;
+        // }
+
+        // if (conversion > 0)
+        //   delay(conversion);
+        return this->parent_->raw_receive(this->address_, data, len);
+      }
+      enum ErrorCode
+      {
+        NONE = 0,
+        COMMUNICATION_FAILED
+      } error_code_{NONE};
+
+      float value_;
+    };
+
+  } // namespace m5stack_4relay
+} // namespace esphome

--- a/esphome/components/m5stack_4relay/switch.py
+++ b/esphome/components/m5stack_4relay/switch.py
@@ -7,19 +7,19 @@ from . import M5STACK4RELAYOutput, m5stack_4relay_ns
 DEPENDENCIES = ["m5stack_4relay"]
 
 M5STACK4RELAYChannel = m5stack_4relay_ns.class_("M5STACK4RELAYChannel", switch.Switch)
-CONF_M5STACK4RELAY_ID = "m5stack_4relay_id"
+CONF_M5STACK_4RELAY_ID = "m5stack_4relay_id"
 
 CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
     {
         cv.Required(CONF_ID): cv.declare_id(M5STACK4RELAYChannel),
-        cv.GenerateID(CONF_M5STACK4RELAY_ID): cv.use_id(M5STACK4RELAYOutput),
+        cv.GenerateID(CONF_M5STACK_4RELAY_ID): cv.use_id(M5STACK4RELAYOutput),
         cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=3),
     }
 )
 
 
 async def to_code(config):
-    paren = await cg.get_variable(config[CONF_M5STACK4RELAY_ID])
+    paren = await cg.get_variable(config[CONF_M5STACK_4RELAY_ID])
     rhs = paren.create_channel(config[CONF_CHANNEL])
     var = cg.Pvariable(config[CONF_ID], rhs)
     await switch.register_switch(var, config)

--- a/esphome/components/m5stack_4relay/switch.py
+++ b/esphome/components/m5stack_4relay/switch.py
@@ -1,0 +1,25 @@
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.components import output, switch
+from esphome.const import CONF_ID, CONF_CHANNEL
+from . import M5STACK4RELAYOutput, m5stack_4relay_ns
+
+DEPENDENCIES = ["m5stack_4relay"]
+
+M5STACK4RELAYChannel = m5stack_4relay_ns.class_("M5STACK4RELAYChannel", switch.Switch)
+CONF_M5STACK4RELAY_ID = "m5stack_4relay_id"
+
+CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(M5STACK4RELAYChannel),
+        cv.GenerateID(CONF_M5STACK4RELAY_ID): cv.use_id(M5STACK4RELAYOutput),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=3)
+    }
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_M5STACK4RELAY_ID])
+    rhs = paren.create_channel(config[CONF_CHANNEL])
+    var = cg.Pvariable(config[CONF_ID], rhs)
+    await switch.register_switch(var, config)

--- a/esphome/components/m5stack_4relay/switch.py
+++ b/esphome/components/m5stack_4relay/switch.py
@@ -1,6 +1,6 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.components import output, switch
+from esphome.components import switch
 from esphome.const import CONF_ID, CONF_CHANNEL
 from . import M5STACK4RELAYOutput, m5stack_4relay_ns
 
@@ -13,7 +13,7 @@ CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
     {
         cv.Required(CONF_ID): cv.declare_id(M5STACK4RELAYChannel),
         cv.GenerateID(CONF_M5STACK4RELAY_ID): cv.use_id(M5STACK4RELAYOutput),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=3)
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=3),
     }
 )
 


### PR DESCRIPTION
Signed-off-by: Jarad Olson <brotherdust@gmail.com>

# What does this implement/fix? 

Adds support for the [M5Stack 4Relay](https://docs.m5stack.com/en/unit/4relay?id=description)

Pull request in esphome-docs with documentation (if applicable): esphome/esphome-docs#1408

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other




## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
i2c:
  - id: i2c_0
    sda: GPIO32
    scl: GPIO26
    scan: True
  - id: i2c_1
    sda: GPIO25
    scl: GPIO21
    scan: True
m5stack_4relay:
  i2c_id: i2c_0
  address: 0x26
switch:
  - platform: m5stack_4relay
    id: relay_1
    channel: 0
    name: ${disp_name} Relay 1
  - platform: m5stack_4relay
    id: relay_2
    channel: 1
    name: ${disp_name} Relay 2
  - platform: m5stack_4relay
    id: relay_3
    channel: 2
    name: ${disp_name} Relay 3
  - platform: m5stack_4relay
    id: relay_4
    channel: 3
    name: ${disp_name} Relay 4
  - platform: restart
    name: ${disp_name} Restart

```


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
