### PR TITLE
Add get_safe_mode_boot_count method

### DIFF
--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -372,7 +372,7 @@ bool OTAComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_
   this->safe_mode_start_time_ = millis();
   this->safe_mode_enable_time_ = enable_time;
   this->safe_mode_num_attempts_ = num_attempts;
-  this->rtc_ = global_preferences.make_preference<uint32_t>(233825507UL, false);
+  this->rtc_ = global_preferences.make_preference<uint32_t>(233825507UL);
   this->safe_mode_rtc_value_ = this->read_rtc_();
 
   ESP_LOGCONFIG(TAG, "There have been %u suspected unsuccessful boot attempts.", this->safe_mode_rtc_value_);

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -399,7 +399,7 @@ bool OTAComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_
     return false;
   }
 }
-uint32_t OTAComponent::get_safe_mode_boot_count() { return this->safe_mode_rtc_value_; }
+uint32_t OTAComponent::get_safe_mode_boot_count() const { return this->safe_mode_rtc_value_; }
 void OTAComponent::write_rtc_(uint32_t val) { this->rtc_.save(&val); }
 uint32_t OTAComponent::read_rtc_() {
   uint32_t val;

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -399,6 +399,7 @@ bool OTAComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_
     return false;
   }
 }
+uint32_t OTAComponent::get_safe_mode_boot_count() { return this->safe_mode_rtc_value_; }
 void OTAComponent::write_rtc_(uint32_t val) { this->rtc_.save(&val); }
 uint32_t OTAComponent::read_rtc_() {
   uint32_t val;

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -52,6 +52,8 @@ class OTAComponent : public Component {
 
   bool should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_time);
 
+  uint32_t get_safe_mode_boot_count();
+
 #ifdef USE_OTA_STATE_CALLBACK
   void add_on_state_callback(std::function<void(OTAState, float, uint8_t)> &&callback);
 #endif

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -52,7 +52,7 @@ class OTAComponent : public Component {
 
   bool should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_time);
 
-  uint32_t get_safe_mode_boot_count();
+  uint32_t get_safe_mode_boot_count() const;
 
 #ifdef USE_OTA_STATE_CALLBACK
   void add_on_state_callback(std::function<void(OTAState, float, uint8_t)> &&callback);


### PR DESCRIPTION
# What does this implement/fix? 
Allows public access to boot count to allow for automations based on the current boot count. 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
