### PR TITLE
Add version argument to ESPDEPRECATED macro

### DIFF
--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -63,9 +63,9 @@ class ClimateCall {
    * For climate devices with two point target temperature control
    */
   ClimateCall &set_target_temperature_high(optional<float> target_temperature_high);
-  ESPDEPRECATED("set_away() is deprecated, please use .set_preset(CLIMATE_PRESET_AWAY) instead")
+  ESPDEPRECATED("set_away() is deprecated, please use .set_preset(CLIMATE_PRESET_AWAY) instead", "v1.20")
   ClimateCall &set_away(bool away);
-  ESPDEPRECATED("set_away() is deprecated, please use .set_preset(CLIMATE_PRESET_AWAY) instead")
+  ESPDEPRECATED("set_away() is deprecated, please use .set_preset(CLIMATE_PRESET_AWAY) instead", "v1.20")
   ClimateCall &set_away(optional<bool> away);
   /// Set the fan mode of the climate device.
   ClimateCall &set_fan_mode(ClimateFanMode fan_mode);
@@ -96,7 +96,7 @@ class ClimateCall {
   const optional<float> &get_target_temperature() const;
   const optional<float> &get_target_temperature_low() const;
   const optional<float> &get_target_temperature_high() const;
-  ESPDEPRECATED("get_away() is deprecated, please use .get_preset() instead")
+  ESPDEPRECATED("get_away() is deprecated, please use .get_preset() instead", "v1.20")
   optional<bool> get_away() const;
   const optional<ClimateFanMode> &get_fan_mode() const;
   const optional<ClimateSwingMode> &get_swing_mode() const;
@@ -193,7 +193,7 @@ class Climate : public Nameable {
    * Away allows climate devices to have two different target temperature configs:
    * one for normal mode and one for away mode.
    */
-  ESPDEPRECATED("away is deprecated, use preset instead")
+  ESPDEPRECATED("away is deprecated, use preset instead", "v1.20")
   bool away{false};
 
   /// The active fan mode of the climate device.

--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -50,19 +50,19 @@ class ClimateTraits {
   }
   void set_supported_modes(std::set<ClimateMode> modes) { supported_modes_ = std::move(modes); }
   void add_supported_mode(ClimateMode mode) { supported_modes_.insert(mode); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead", "v1.20")
   void set_supports_auto_mode(bool supports_auto_mode) { set_mode_support_(CLIMATE_MODE_AUTO, supports_auto_mode); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead", "v1.20")
   void set_supports_cool_mode(bool supports_cool_mode) { set_mode_support_(CLIMATE_MODE_COOL, supports_cool_mode); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead", "v1.20")
   void set_supports_heat_mode(bool supports_heat_mode) { set_mode_support_(CLIMATE_MODE_HEAT, supports_heat_mode); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead", "v1.20")
   void set_supports_heat_cool_mode(bool supported) { set_mode_support_(CLIMATE_MODE_HEAT_COOL, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead", "v1.20")
   void set_supports_fan_only_mode(bool supports_fan_only_mode) {
     set_mode_support_(CLIMATE_MODE_FAN_ONLY, supports_fan_only_mode);
   }
-  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead", "v1.20")
   void set_supports_dry_mode(bool supports_dry_mode) { set_mode_support_(CLIMATE_MODE_DRY, supports_dry_mode); }
   bool supports_mode(ClimateMode mode) const { return supported_modes_.count(mode); }
   const std::set<ClimateMode> get_supported_modes() const { return supported_modes_; }
@@ -72,23 +72,23 @@ class ClimateTraits {
 
   void set_supported_fan_modes(std::set<ClimateFanMode> modes) { supported_fan_modes_ = std::move(modes); }
   void add_supported_fan_mode(ClimateFanMode mode) { supported_fan_modes_.insert(mode); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_on(bool supported) { set_fan_mode_support_(CLIMATE_FAN_ON, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_off(bool supported) { set_fan_mode_support_(CLIMATE_FAN_OFF, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_auto(bool supported) { set_fan_mode_support_(CLIMATE_FAN_AUTO, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_low(bool supported) { set_fan_mode_support_(CLIMATE_FAN_LOW, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_medium(bool supported) { set_fan_mode_support_(CLIMATE_FAN_MEDIUM, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_high(bool supported) { set_fan_mode_support_(CLIMATE_FAN_HIGH, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_middle(bool supported) { set_fan_mode_support_(CLIMATE_FAN_MIDDLE, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_focus(bool supported) { set_fan_mode_support_(CLIMATE_FAN_FOCUS, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_fan_modes() instead", "v1.20")
   void set_supports_fan_mode_diffuse(bool supported) { set_fan_mode_support_(CLIMATE_FAN_DIFFUSE, supported); }
   bool supports_fan_mode(ClimateFanMode fan_mode) const { return supported_fan_modes_.count(fan_mode); }
   bool get_supports_fan_modes() const { return !supported_fan_modes_.empty() || !supported_custom_fan_modes_.empty(); }
@@ -115,25 +115,25 @@ class ClimateTraits {
   bool supports_custom_preset(const std::string &custom_preset) const {
     return supported_custom_presets_.count(custom_preset);
   }
-  ESPDEPRECATED("This method is deprecated, use set_supported_presets() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_presets() instead", "v1.20")
   void set_supports_away(bool supports) {
     if (supports) {
       supported_presets_.insert(CLIMATE_PRESET_AWAY);
       supported_presets_.insert(CLIMATE_PRESET_HOME);
     }
   }
-  ESPDEPRECATED("This method is deprecated, use supports_preset() instead")
+  ESPDEPRECATED("This method is deprecated, use supports_preset() instead", "v1.20")
   bool get_supports_away() const { return supports_preset(CLIMATE_PRESET_AWAY); }
 
   void set_supported_swing_modes(std::set<ClimateSwingMode> modes) { supported_swing_modes_ = std::move(modes); }
   void add_supported_swing_mode(ClimateSwingMode mode) { supported_swing_modes_.insert(mode); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead", "v1.20")
   void set_supports_swing_mode_off(bool supported) { set_swing_mode_support_(CLIMATE_SWING_OFF, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead", "v1.20")
   void set_supports_swing_mode_both(bool supported) { set_swing_mode_support_(CLIMATE_SWING_BOTH, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead", "v1.20")
   void set_supports_swing_mode_vertical(bool supported) { set_swing_mode_support_(CLIMATE_SWING_VERTICAL, supported); }
-  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead")
+  ESPDEPRECATED("This method is deprecated, use set_supported_swing_modes() instead", "v1.20")
   void set_supports_swing_mode_horizontal(bool supported) {
     set_swing_mode_support_(CLIMATE_SWING_HORIZONTAL, supported);
   }

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -16,7 +16,7 @@
 namespace esphome {
 namespace light {
 
-using ESPColor ESPDEPRECATED("esphome::light::ESPColor is deprecated, use esphome::Color instead.") = Color;
+using ESPColor ESPDEPRECATED("esphome::light::ESPColor is deprecated, use esphome::Color instead.", "v1.21") = Color;
 
 class AddressableLight : public LightOutput, public Component {
  public:

--- a/esphome/components/light/light_traits.h
+++ b/esphome/components/light/light_traits.h
@@ -26,20 +26,20 @@ class LightTraits {
     return false;
   }
 
-  ESPDEPRECATED("get_supports_brightness() is deprecated, use color modes instead.")
+  ESPDEPRECATED("get_supports_brightness() is deprecated, use color modes instead.", "v1.21")
   bool get_supports_brightness() const { return this->supports_color_capability(ColorCapability::BRIGHTNESS); }
-  ESPDEPRECATED("get_supports_rgb() is deprecated, use color modes instead.")
+  ESPDEPRECATED("get_supports_rgb() is deprecated, use color modes instead.", "v1.21")
   bool get_supports_rgb() const { return this->supports_color_capability(ColorCapability::RGB); }
-  ESPDEPRECATED("get_supports_rgb_white_value() is deprecated, use color modes instead.")
+  ESPDEPRECATED("get_supports_rgb_white_value() is deprecated, use color modes instead.", "v1.21")
   bool get_supports_rgb_white_value() const {
     return this->supports_color_mode(ColorMode::RGB_WHITE) ||
            this->supports_color_mode(ColorMode::RGB_COLOR_TEMPERATURE);
   }
-  ESPDEPRECATED("get_supports_color_temperature() is deprecated, use color modes instead.")
+  ESPDEPRECATED("get_supports_color_temperature() is deprecated, use color modes instead.", "v1.21")
   bool get_supports_color_temperature() const {
     return this->supports_color_capability(ColorCapability::COLOR_TEMPERATURE);
   }
-  ESPDEPRECATED("get_supports_color_interlock() is deprecated, use color modes instead.")
+  ESPDEPRECATED("get_supports_color_interlock() is deprecated, use color modes instead.", "v1.21")
   bool get_supports_color_interlock() const {
     return this->supports_color_mode(ColorMode::RGB) &&
            (this->supports_color_mode(ColorMode::WHITE) || this->supports_color_mode(ColorMode::COLD_WARM_WHITE) ||

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -1086,8 +1086,8 @@ void Nextion::add_addt_command_to_queue(NextionComponentBase *component) {
 
 void Nextion::set_writer(const nextion_writer_t &writer) { this->writer_ = writer; }
 
-ESPDEPRECATED("set_wait_for_ack(bool) is deprecated and has no effect")
-void Nextion::set_wait_for_ack(bool wait_for_ack) { ESP_LOGE(TAG, "This command is depreciated"); }
+ESPDEPRECATED("set_wait_for_ack(bool) is deprecated and has no effect", "v1.20")
+void Nextion::set_wait_for_ack(bool wait_for_ack) { ESP_LOGE(TAG, "This command is deprecated"); }
 
 }  // namespace nextion
 }  // namespace esphome

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -148,9 +148,9 @@ struct Color {
   static const Color WHITE;
 };
 
-ESPDEPRECATED("Use Color::BLACK instead of COLOR_BLACK")
+ESPDEPRECATED("Use Color::BLACK instead of COLOR_BLACK", "v1.21")
 static const Color COLOR_BLACK(0, 0, 0, 0);
-ESPDEPRECATED("Use Color::WHITE instead of COLOR_WHITE")
+ESPDEPRECATED("Use Color::WHITE instead of COLOR_WHITE", "v1.21")
 static const Color COLOR_WHITE(255, 255, 255, 255);
 
 }  // namespace esphome

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -17,7 +17,7 @@
 #endif
 
 #define HOT __attribute__((hot))
-#define ESPDEPRECATED(msg) __attribute__((deprecated(msg)))
+#define ESPDEPRECATED(msg, when) __attribute__((deprecated(msg)))
 #define ALWAYS_INLINE __attribute__((always_inline))
 #define PACKED __attribute__((packed))
 


### PR DESCRIPTION
# What does this implement/fix? 

This allows us to track how old deprecations are, and delete them when they're old enough.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
