### PR TITLE
Various follow-up fixes to color mode changes

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -205,15 +205,15 @@ LightColorValues LightCall::validate_() {
     }
   }
 
-#define VALIDATE_RANGE_(name_, upper_name) \
+#define VALIDATE_RANGE_(name_, upper_name, min, max) \
   if (name_##_.has_value()) { \
     auto val = *name_##_; \
-    if (val < 0.0f || val > 1.0f) { \
-      ESP_LOGW(TAG, "'%s' - %s value %.2f is out of range [0.0 - 1.0]!", name, upper_name, val); \
-      name_##_ = clamp(val, 0.0f, 1.0f); \
+    if (val < (min) || val > (max)) { \
+      ESP_LOGW(TAG, "'%s' - %s value %.2f is out of range [%.1f - %.1f]!", name, upper_name, val, (min), (max)); \
+      name_##_ = clamp(val, (min), (max)); \
     } \
   }
-#define VALIDATE_RANGE(name, upper_name) VALIDATE_RANGE_(name, upper_name)
+#define VALIDATE_RANGE(name, upper_name) VALIDATE_RANGE_(name, upper_name, 0.0f, 1.0f)
 
   // Range checks
   VALIDATE_RANGE(brightness, "Brightness")
@@ -224,6 +224,7 @@ LightColorValues LightCall::validate_() {
   VALIDATE_RANGE(white, "White")
   VALIDATE_RANGE(cold_white, "Cold white")
   VALIDATE_RANGE(warm_white, "Warm white")
+  VALIDATE_RANGE_(color_temperature, "Color temperature", traits.get_min_mireds(), traits.get_max_mireds())
 
   // Turn off when brightness is set to zero, and reset brightness (so that it has nonzero brightness when turned on).
   if (this->brightness_.has_value() && *this->brightness_ == 0.0f) {

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -53,6 +53,9 @@ void LightCall::perform() {
       ESP_LOGD(TAG, "  Brightness: %.0f%%", v.get_brightness() * 100.0f);
     }
 
+    if (this->color_brightness_.has_value()) {
+      ESP_LOGD(TAG, "  Color brightness: %.0f%%", v.get_color_brightness() * 100.0f);
+    }
     if (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value()) {
       ESP_LOGD(TAG, "  Red: %.0f%%, Green: %.0f%%, Blue: %.0f%%", v.get_red() * 100.0f, v.get_green() * 100.0f,
                v.get_blue() * 100.0f);

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -220,6 +220,12 @@ LightColorValues LightCall::validate_() {
   VALIDATE_RANGE(cold_white, "Cold white")
   VALIDATE_RANGE(warm_white, "Warm white")
 
+  // Turn off when brightness is set to zero, and reset brightness (so that it has nonzero brightness when turned on).
+  if (this->brightness_.has_value() && *this->brightness_ == 0.0f) {
+    this->state_ = optional<float>(false);
+    this->brightness_ = optional<float>(1.0f);
+  }
+
   // Set color brightness to 100% if currently zero and a color is set.
   if (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value()) {
     if (!this->color_brightness_.has_value() && this->parent_->remote_values.get_color_brightness() == 0.0f)

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -262,7 +262,7 @@ LightColorValues LightCall::validate_() {
   if (this->warm_white_.has_value())
     v.set_warm_white(*this->warm_white_);
 
-  v.normalize_color(traits);
+  v.normalize_color();
 
   // Flash length check
   if (this->has_flash_() && *this->flash_length_ == 0) {

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -152,7 +152,7 @@ LightColorValues LightCall::validate_() {
   this->transform_parameters_();
 
   // Brightness exists check
-  if (this->brightness_.has_value() && !(color_mode & ColorCapability::BRIGHTNESS)) {
+  if (this->brightness_.has_value() && *this->brightness_ > 0.0f && !(color_mode & ColorCapability::BRIGHTNESS)) {
     ESP_LOGW(TAG, "'%s' - This light does not support setting brightness!", name);
     this->brightness_.reset();
   }
@@ -165,13 +165,14 @@ LightColorValues LightCall::validate_() {
   }
 
   // Color brightness exists check
-  if (this->color_brightness_.has_value() && !(color_mode & ColorCapability::RGB)) {
+  if (this->color_brightness_.has_value() && *this->color_brightness_ > 0.0f && !(color_mode & ColorCapability::RGB)) {
     ESP_LOGW(TAG, "'%s' - This color mode does not support setting RGB brightness!", name);
     this->color_brightness_.reset();
   }
 
   // RGB exists check
-  if (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value()) {
+  if ((this->red_.has_value() && *this->red_ > 0.0f) || (this->green_.has_value() && *this->green_ > 0.0f) ||
+      (this->blue_.has_value() && *this->blue_ > 0.0f)) {
     if (!(color_mode & ColorCapability::RGB)) {
       ESP_LOGW(TAG, "'%s' - This color mode does not support setting RGB color!", name);
       this->red_.reset();
@@ -181,7 +182,7 @@ LightColorValues LightCall::validate_() {
   }
 
   // White value exists check
-  if (this->white_.has_value() &&
+  if (this->white_.has_value() && *this->white_ > 0.0f &&
       !(color_mode & ColorCapability::WHITE || color_mode & ColorCapability::COLD_WARM_WHITE)) {
     ESP_LOGW(TAG, "'%s' - This color mode does not support setting white value!", name);
     this->white_.reset();
@@ -195,7 +196,8 @@ LightColorValues LightCall::validate_() {
   }
 
   // Cold/warm white value exists check
-  if (this->cold_white_.has_value() || this->warm_white_.has_value()) {
+  if ((this->cold_white_.has_value() && *this->cold_white_ > 0.0f) ||
+      (this->warm_white_.has_value() && *this->warm_white_ > 0.0f)) {
     if (!(color_mode & ColorCapability::COLD_WARM_WHITE)) {
       ESP_LOGW(TAG, "'%s' - This color mode does not support setting cold/warm white value!", name);
       this->cold_white_.reset();

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/optional.h"
 #include "light_color_values.h"
+#include <set>
 
 namespace esphome {
 namespace light {

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -2,7 +2,7 @@
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
-#include "light_traits.h"
+#include "color_mode.h"
 
 #ifdef USE_JSON
 #include "esphome/components/json/json_util.h"
@@ -112,7 +112,7 @@ class LightColorValues {
    *
    * @param traits Used for determining which attributes to consider.
    */
-  void normalize_color(const LightTraits &traits) {
+  void normalize_color() {
     if (this->color_mode_ & ColorCapability::RGB) {
       float max_value = fmaxf(this->get_red(), fmaxf(this->get_green(), this->get_blue()));
       if (max_value == 0.0f) {

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -125,13 +125,6 @@ class LightColorValues {
         this->set_blue(this->get_blue() / max_value);
       }
     }
-
-    if (this->color_mode_ & ColorCapability::BRIGHTNESS && this->get_brightness() == 0.0f) {
-      // 0% brightness means off
-      this->set_state(false);
-      // reset brightness to 100%
-      this->set_brightness(1.0f);
-    }
   }
 
   // Note that method signature of as_* methods is kept as-is for compatibility reasons, so not all parameters

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -1,12 +1,7 @@
 #pragma once
 
 #include "esphome/core/helpers.h"
-#include "esphome/core/defines.h"
 #include "color_mode.h"
-
-#ifdef USE_JSON
-#include "esphome/components/json/json_util.h"
-#endif
 
 namespace esphome {
 namespace light {

--- a/esphome/components/light/light_effect.h
+++ b/esphome/components/light/light_effect.h
@@ -3,8 +3,6 @@
 #include <utility>
 
 #include "esphome/core/component.h"
-#include "light_color_values.h"
-#include "light_state.h"
 
 namespace esphome {
 namespace light {

--- a/esphome/components/light/light_json_schema.h
+++ b/esphome/components/light/light_json_schema.h
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "light_call.h"
-#include "light_state.h"
+#include "esphome/core/defines.h"
 
 #ifdef USE_JSON
+
+#include "esphome/components/json/json_util.h"
+#include "light_call.h"
+#include "light_state.h"
 
 namespace esphome {
 namespace light {

--- a/esphome/components/light/light_output.h
+++ b/esphome/components/light/light_output.h
@@ -7,8 +7,6 @@
 namespace esphome {
 namespace light {
 
-class LightState;
-
 /// Interface to write LightStates to hardware.
 class LightOutput {
  public:

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -54,6 +54,8 @@ class LightState : public Nameable, public Component {
    * property will be changed continuously (in contrast to .remote_values, where they
    * are constant during transitions).
    *
+   * This value does not have gamma correction applied.
+   *
    * This property is read-only for users. Any changes to it will be ignored.
    */
   LightColorValues current_values;
@@ -63,6 +65,8 @@ class LightState : public Nameable, public Component {
    * These are different from the "current" values: For example transitions will
    * continuously change the "current" values. But the remote values will immediately
    * switch to the target value for a transition, reducing the number of packets sent.
+   *
+   * This value does not have gamma correction applied.
    *
    * This property is read-only for users. Any changes to it will be ignored.
    */
@@ -112,6 +116,7 @@ class LightState : public Nameable, public Component {
   /// Add effects for this light state.
   void add_effects(const std::vector<LightEffect *> &effects);
 
+  /// The result of all the current_values_as_* methods have gamma correction applied.
   void current_values_as_binary(bool *binary);
 
   void current_values_as_brightness(float *brightness);

--- a/esphome/components/light/light_transformer.h
+++ b/esphome/components/light/light_transformer.h
@@ -85,6 +85,8 @@ class LightTransitionTransformer : public LightTransformer {
   bool publish_at_end() override { return false; }
   bool is_transition() override { return true; }
 
+  // This looks crazy, but it reduces to 6x^5 - 15x^4 + 10x^3 which is just a smooth sigmoid-like
+  // transition from 0 to 1 on x = [0, 1]
   static float smoothed_progress(float x) { return x * x * x * (x * (x * 6.0f - 15.0f) + 10.0f); }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix? 

Various simple follow-up fixes to the color mode changes. I decided to group them together to spare you guys from having to review 6 trivial PRs :)

* Validate that the color temperature argument is within the range supported by this light.
* Always allow light parameters to be set to zero, even if they're not applicable to the current color mode. This fixes the issue @OttoWinter noticed where a warning was always logged with interlocked lights and old HA versions. It 
* Also log the color brightness when it's changed
* Some code clean-up:
  * Move the conversion of (state: on, brightness: 0) to (state: off, brightness: 1) to LightCall.validate()
  * Drop now-unused traits parameter to `normalize_color()`
  * Add some comments about things that confused me
  * Clean-up some header includes that are no longer necessary

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
