### PR TITLE
Fix crash when using addressable_set with out-of-range indices

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -159,8 +159,14 @@ template<typename... Ts> class AddressableSet : public Action<Ts...> {
 
   void play(Ts... x) override {
     auto *out = (AddressableLight *) this->parent_->get_output();
-    int32_t range_from = this->range_from_.value_or(x..., 0);
-    int32_t range_to = this->range_to_.value_or(x..., out->size() - 1) + 1;
+    int32_t range_from = interpret_index(this->range_from_.value_or(x..., 0), out->size());
+    if (range_from < 0 || range_from >= out->size())
+      range_from = 0;
+
+    int32_t range_to = interpret_index(this->range_to_.value_or(x..., out->size() - 1) + 1, out->size());
+    if (range_to < 0 || range_to >= out->size())
+      range_to = out->size();
+
     uint8_t color_brightness =
         to_uint8_scale(this->color_brightness_.value_or(x..., this->parent_->remote_values.get_color_brightness()));
     auto range = out->range(range_from, range_to);

--- a/esphome/components/light/esp_range_view.h
+++ b/esphome/components/light/esp_range_view.h
@@ -11,6 +11,9 @@ int32_t interpret_index(int32_t index, int32_t size);
 class AddressableLight;
 class ESPRangeIterator;
 
+/**
+ * A half-open range of LEDs, inclusive of the begin index and exclusive of the end index, using zero-based numbering.
+ */
 class ESPRangeView : public ESPColorSettable {
  public:
   ESPRangeView(AddressableLight *parent, int32_t begin, int32_t end)


### PR DESCRIPTION
# What does this implement/fix? 

As reported on Discord.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
