### PR TITLE
Fix external components not refreshing with default or high refresh time

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -147,7 +147,7 @@ def _process_git_config(config: dict, refresh) -> str:
         age = datetime.datetime.now() - datetime.datetime.fromtimestamp(
             file_timestamp.stat().st_mtime
         )
-        if age.seconds > refresh.total_seconds:
+        if age.total_seconds() > refresh.total_seconds:
             _LOGGER.info("Updating %s", key)
             _LOGGER.debug("Location: %s", repo_dir)
             # Stash local changes (if any)


### PR DESCRIPTION
# What does this implement/fix? 

`datetime.timedelta.seconds` returns the seconds in a minute of a timedelta, not the total seconds.

https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
