### PR TITLE
1.20.4

### DIFF
--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -312,8 +312,12 @@ void Climate::add_on_state_callback(std::function<void()> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 
+// Random 32bit value; If this changes existing restore preferences are invalidated
+static const uint32_t RESTORE_STATE_VERSION = 0x848EA6ADUL;
+
 optional<ClimateDeviceRestoreState> Climate::restore_state_() {
-  this->rtc_ = global_preferences.make_preference<ClimateDeviceRestoreState>(this->get_object_id_hash());
+  this->rtc_ =
+      global_preferences.make_preference<ClimateDeviceRestoreState>(this->get_object_id_hash() ^ RESTORE_STATE_VERSION);
   ClimateDeviceRestoreState recovered{};
   if (!this->rtc_.load(&recovered))
     return {};

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -120,6 +120,7 @@ class ClimateCall {
 };
 
 /// Struct used to save the state of the climate device in restore memory.
+/// Make sure to update RESTORE_STATE_VERSION when changing the struct entries.
 struct ClimateDeviceRestoreState {
   ClimateMode mode;
   bool uses_custom_fan_mode{false};

--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -31,7 +31,9 @@ DisplayPageShowPrevAction = display_ns.class_(
 DisplayIsDisplayingPageCondition = display_ns.class_(
     "DisplayIsDisplayingPageCondition", automation.Condition
 )
-DisplayOnPageChangeTrigger = display_ns.class_("DisplayOnPageChangeTrigger")
+DisplayOnPageChangeTrigger = display_ns.class_(
+    "DisplayOnPageChangeTrigger", automation.Trigger
+)
 
 CONF_ON_PAGE_CHANGE = "on_page_change"
 

--- a/esphome/components/duty_cycle/duty_cycle_sensor.cpp
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.cpp
@@ -13,6 +13,7 @@ void DutyCycleSensor::setup() {
   this->store_.pin = this->pin_->to_isr();
   this->store_.last_level = this->pin_->digital_read();
   this->last_update_ = micros();
+  this->store_.last_interrupt = micros();
 
   this->pin_->attach_interrupt(DutyCycleSensorStore::gpio_intr, &this->store_, CHANGE);
 }

--- a/esphome/components/duty_cycle/duty_cycle_sensor.h
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.h
@@ -29,7 +29,7 @@ class DutyCycleSensor : public sensor::Sensor, public PollingComponent {
  protected:
   GPIOPin *pin_;
 
-  DutyCycleSensorStore store_;
+  DutyCycleSensorStore store_{};
   uint32_t last_update_;
 };
 

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -147,7 +147,7 @@ def _process_git_config(config: dict, refresh) -> str:
         age = datetime.datetime.now() - datetime.datetime.fromtimestamp(
             file_timestamp.stat().st_mtime
         )
-        if age.seconds > refresh.total_seconds:
+        if age.total_seconds() > refresh.total_seconds:
             _LOGGER.info("Updating %s", key)
             _LOGGER.debug("Location: %s", repo_dir)
             # Stash local changes (if any)

--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -39,8 +39,8 @@ void MQTTNumberComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryCo
   // https://www.home-assistant.io/integrations/number.mqtt/
   if (!traits.get_icon().empty())
     root["icon"] = traits.get_icon();
-  root["min_value"] = traits.get_min_value();
-  root["max_value"] = traits.get_max_value();
+  root["min"] = traits.get_min_value();
+  root["max"] = traits.get_max_value();
   root["step"] = traits.get_step();
 
   config.command_topic = true;

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -37,7 +37,7 @@ void PIDClimate::control(const climate::ClimateCall &call) {
 
   // If switching to off mode, set output immediately
   if (this->mode == climate::CLIMATE_MODE_OFF)
-    this->handle_non_auto_mode_();
+    this->write_output_(0.0f);
 
   this->publish_state();
 }
@@ -98,15 +98,6 @@ void PIDClimate::write_output_(float value) {
   }
   this->pid_computed_callback_.call();
 }
-void PIDClimate::handle_non_auto_mode_() {
-  // in non-auto mode, switch directly to appropriate action
-  //  - OFF mode -> Output at 0%
-  if (this->mode == climate::CLIMATE_MODE_OFF) {
-    this->write_output_(0.0);
-  } else {
-    assert(false);
-  }
-}
 void PIDClimate::update_pid_() {
   float value;
   if (isnan(this->current_temperature) || isnan(this->target_temperature)) {
@@ -135,7 +126,7 @@ void PIDClimate::update_pid_() {
   }
 
   if (this->mode == climate::CLIMATE_MODE_OFF) {
-    this->handle_non_auto_mode_();
+    this->write_output_(0.0);
   } else {
     this->write_output_(value);
   }

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -56,7 +56,6 @@ class PIDClimate : public climate::Climate, public Component {
   bool supports_heat_() const { return this->heat_output_ != nullptr; }
 
   void write_output_(float value);
-  void handle_non_auto_mode_();
 
   /// The sensor used for getting the current temperature
   sensor::Sensor *sensor_;

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -41,6 +41,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   bool initialized_{false};
   std::vector<rmt_item32_t> rmt_temp_;
   esp_err_t error_code_{ESP_OK};
+  bool inverted_{false};
 #endif
   uint8_t carrier_duty_percent_{50};
 };

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -50,6 +50,7 @@ void RemoteTransmitterComponent::configure_rmt() {
   } else {
     c.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
     c.tx_config.idle_level = RMT_IDLE_LEVEL_HIGH;
+    this->inverted_ = true;
   }
 
   esp_err_t error = rmt_config(&c);
@@ -95,10 +96,10 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
       val -= item;
 
       if (rmt_i % 2 == 0) {
-        rmt_item.level0 = static_cast<uint32_t>(level);
+        rmt_item.level0 = static_cast<uint32_t>(level ^ this->inverted_);
         rmt_item.duration0 = static_cast<uint32_t>(item);
       } else {
-        rmt_item.level1 = static_cast<uint32_t>(level);
+        rmt_item.level1 = static_cast<uint32_t>(level ^ this->inverted_);
         rmt_item.duration1 = static_cast<uint32_t>(item);
         this->rmt_temp_.push_back(rmt_item);
       }

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -9,7 +9,7 @@ namespace remote_transmitter {
 
 static const char *const TAG = "remote_transmitter";
 
-void RemoteTransmitterComponent::setup() {}
+void RemoteTransmitterComponent::setup() { this->configure_rmt(); }
 
 void RemoteTransmitterComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Transmitter...");

--- a/esphome/components/time/automation.cpp
+++ b/esphome/components/time/automation.cpp
@@ -22,7 +22,10 @@ void CronTrigger::loop() {
     return;
 
   if (this->last_check_.has_value()) {
-    if (*this->last_check_ >= time) {
+    if (*this->last_check_ > time && this->last_check_->timestamp - time.timestamp > 900) {
+      // We went back in time (a lot), probably caused by time synchronization
+      ESP_LOGW(TAG, "Time has jumped back!");
+    } else if (*this->last_check_ >= time) {
       // already handled this one
       return;
     }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "1.20.3"
+__version__ = "1.20.4"
 
 ESP_PLATFORM_ESP32 = "ESP32"
 ESP_PLATFORM_ESP8266 = "ESP8266"

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -1104,7 +1104,7 @@ def shorthand_input_pullup_pin(value):
 
 def shorthand_analog_pin(value):
     value = analog_pin(value)
-    return GPIO_FULL_INPUT_PIN_SCHEMA({CONF_NUMBER: value})
+    return GPIO_FULL_ANALOG_PIN_SCHEMA({CONF_NUMBER: value})
 
 
 def validate_has_interrupt(value):


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Beware of bugs in the above code; I have only proved it correct, not tried it. "_

~ Donald Knuth
- Correctly invert esp32 RMT TX [esphome#2022](https://github.com/esphome/esphome/pull/2022)
- Move configure_rmt() into setup() [esphome#2028](https://github.com/esphome/esphome/pull/2028)
- Fix climate restore schema changed resulting in invalid restore [esphome#2068](https://github.com/esphome/esphome/pull/2068)
- Fix PID climate breaks when restoring old modes [esphome#2086](https://github.com/esphome/esphome/pull/2086)
- fix diplay trigger missing base class [esphome#2099](https://github.com/esphome/esphome/pull/2099)
- Fix min/max keys in MQTT Number to match Home Assistant [esphome#2102](https://github.com/esphome/esphome/pull/2102)
- Use proper schema for the analog pin shorthand [esphome#2103](https://github.com/esphome/esphome/pull/2103)
- [duty_cycle] initialize two missing variables [esphome#2088](https://github.com/esphome/esphome/pull/2088)
- Fix time.on_time triggering if time jumped back [esphome#1806](https://github.com/esphome/esphome/pull/1806)
- Fix external components not refreshing with default or high refresh time [esphome#2122](https://github.com/esphome/esphome/pull/2122)
