### PR TITLE
Allow multiple unnamed libraries

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -653,7 +653,7 @@ class EsphomeCore:
                 "".format(library, type(library))
             )
         for other in self.libraries[:]:
-            if other.name != library.name:
+            if other.name != library.name or other.name is None or library.name is None:
                 continue
             if other.repository is not None:
                 if library.repository is None or other.repository == library.repository:


### PR DESCRIPTION
# What does this implement/fix? 

The introduction of named libraries support makes sure that libraries
with the same name have not conflicting repositories.

However, unnamed libraries likely are different libraries actually and
need to be excluded from that check.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2295

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  platform: ESP32
  board: esp32dev

  libraries:
    - "https://github.com/adafruit/Adafruit_VEML6070"
    - "https://github.com/egzumer/Arduino-LaCrosse-TX23-Library"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
