### PR TITLE
Don't discard cold/warm white brightness in constant brightness mode

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -171,12 +171,18 @@ class LightColorValues {
       const float cw_level = gamma_correct(this->cold_white_, gamma);
       const float ww_level = gamma_correct(this->warm_white_, gamma);
       const float white_level = gamma_correct(this->state_ * this->brightness_, gamma);
-      *cold_white = white_level * cw_level;
-      *warm_white = white_level * ww_level;
-      if (constant_brightness && (cw_level > 0 || ww_level > 0)) {
-        const float sum = cw_level + ww_level;
-        *cold_white /= sum;
-        *warm_white /= sum;
+      if (!constant_brightness) {
+        *cold_white = white_level * cw_level;
+        *warm_white = white_level * ww_level;
+      } else {
+        // Just multiplying by cw_level / (cw_level + ww_level) would divide out the brightness information from the
+        // cold_white and warm_white settings (i.e. cw=0.8, ww=0.4 would be identical to cw=0.4, ww=0.2), which breaks
+        // transitions. Use the highest value as the brightness for the white channels (the alternative, using cw+ww/2,
+        // reduces to cw/2 and ww/2, which would still limit brightness to 100% of a single channel, but isn't very
+        // useful in all other aspects -- that behaviour can also be achieved by limiting the output power).
+        const float sum = cw_level > 0 || ww_level > 0 ? cw_level + ww_level : 1; // Don't divide by zero.
+        *cold_white = white_level * std::max(cw_level, ww_level) * cw_level / sum;
+        *warm_white = white_level * std::max(cw_level, ww_level) * ww_level / sum;
       }
     } else {
       *cold_white = *warm_white = 0;

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -180,7 +180,7 @@ class LightColorValues {
         // transitions. Use the highest value as the brightness for the white channels (the alternative, using cw+ww/2,
         // reduces to cw/2 and ww/2, which would still limit brightness to 100% of a single channel, but isn't very
         // useful in all other aspects -- that behaviour can also be achieved by limiting the output power).
-        const float sum = cw_level > 0 || ww_level > 0 ? cw_level + ww_level : 1; // Don't divide by zero.
+        const float sum = cw_level > 0 || ww_level > 0 ? cw_level + ww_level : 1;  // Don't divide by zero.
         *cold_white = white_level * std::max(cw_level, ww_level) * cw_level / sum;
         *warm_white = white_level * std::max(cw_level, ww_level) * ww_level / sum;
       }


### PR DESCRIPTION
Constnat brightness mode for RGBWW/CWWW lights discarded the brightness information encoded in the `cold_white` and `warm_white` values, and only looked at their relative values. This broke transitions, since they lowered the brightness in these values.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2292

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
