### PR TITLE
Removed unused arguments from rgbww code

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -157,16 +157,14 @@ class LightColorValues {
   }
 
   /// Convert these light color values to an RGBWW representation with the given parameters.
-  void as_rgbww(float color_temperature_cw, float color_temperature_ww, float *red, float *green, float *blue,
-                float *cold_white, float *warm_white, float gamma = 0, bool constant_brightness = false,
-                bool color_interlock = false) const {
+  void as_rgbww(float *red, float *green, float *blue, float *cold_white, float *warm_white, float gamma = 0,
+                bool constant_brightness = false) const {
     this->as_rgb(red, green, blue, gamma);
-    this->as_cwww(0, 0, cold_white, warm_white, gamma, constant_brightness);
+    this->as_cwww(cold_white, warm_white, gamma, constant_brightness);
   }
 
   /// Convert these light color values to an CWWW representation with the given parameters.
-  void as_cwww(float color_temperature_cw, float color_temperature_ww, float *cold_white, float *warm_white,
-               float gamma = 0, bool constant_brightness = false) const {
+  void as_cwww(float *cold_white, float *warm_white, float gamma = 0, bool constant_brightness = false) const {
     if (this->color_mode_ & ColorCapability::COLD_WARM_WHITE) {
       const float cw_level = gamma_correct(this->cold_white_, gamma);
       const float ww_level = gamma_correct(this->warm_white_, gamma);

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -1,6 +1,6 @@
 #include "light_state.h"
-#include "light_output.h"
 #include "esphome/core/log.h"
+#include "light_output.h"
 
 namespace esphome {
 namespace light {
@@ -174,15 +174,13 @@ void LightState::current_values_as_rgbw(float *red, float *green, float *blue, f
   this->current_values.as_rgbw(red, green, blue, white, this->gamma_correct_, false);
 }
 void LightState::current_values_as_rgbww(float *red, float *green, float *blue, float *cold_white, float *warm_white,
-                                         bool constant_brightness, bool color_interlock) {
+                                         bool constant_brightness) {
   auto traits = this->get_traits();
-  this->current_values.as_rgbww(traits.get_min_mireds(), traits.get_max_mireds(), red, green, blue, cold_white,
-                                warm_white, this->gamma_correct_, constant_brightness, false);
+  this->current_values.as_rgbww(red, green, blue, cold_white, warm_white, this->gamma_correct_, constant_brightness);
 }
 void LightState::current_values_as_cwww(float *cold_white, float *warm_white, bool constant_brightness) {
   auto traits = this->get_traits();
-  this->current_values.as_cwww(traits.get_min_mireds(), traits.get_max_mireds(), cold_white, warm_white,
-                               this->gamma_correct_, constant_brightness);
+  this->current_values.as_cwww(cold_white, warm_white, this->gamma_correct_, constant_brightness);
 }
 
 void LightState::start_effect_(uint32_t effect_index) {

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -3,9 +3,9 @@
 #include "esphome/core/component.h"
 #include "esphome/core/optional.h"
 #include "esphome/core/preferences.h"
-#include "light_effect.h"
-#include "light_color_values.h"
 #include "light_call.h"
+#include "light_color_values.h"
+#include "light_effect.h"
 #include "light_traits.h"
 #include "light_transformer.h"
 
@@ -126,7 +126,7 @@ class LightState : public Nameable, public Component {
   void current_values_as_rgbw(float *red, float *green, float *blue, float *white, bool color_interlock = false);
 
   void current_values_as_rgbww(float *red, float *green, float *blue, float *cold_white, float *warm_white,
-                               bool constant_brightness = false, bool color_interlock = false);
+                               bool constant_brightness = false);
 
   void current_values_as_cwww(float *cold_white, float *warm_white, bool constant_brightness = false);
 

--- a/esphome/components/rgbww/rgbww_light_output.h
+++ b/esphome/components/rgbww/rgbww_light_output.h
@@ -30,8 +30,7 @@ class RGBWWLightOutput : public light::LightOutput {
   }
   void write_state(light::LightState *state) override {
     float red, green, blue, cwhite, wwhite;
-    state->current_values_as_rgbww(&red, &green, &blue, &cwhite, &wwhite, this->constant_brightness_,
-                                   this->color_interlock_);
+    state->current_values_as_rgbww(&red, &green, &blue, &cwhite, &wwhite, this->constant_brightness_);
     this->red_->set_level(red);
     this->green_->set_level(green);
     this->blue_->set_level(blue);


### PR DESCRIPTION
# What does this implement/fix? 

Removed unused arguments from rgbww code

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
