### PR TITLE
Only compile protobuf dumping when very verbose logging is enabled

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -261,6 +261,7 @@ bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) 
   }
 }
 void HelloRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->client_info); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void HelloRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("HelloRequest {\n");
@@ -269,6 +270,7 @@ void HelloRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool HelloResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -298,6 +300,7 @@ void HelloResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->api_version_minor);
   buffer.encode_string(3, this->server_info);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void HelloResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("HelloResponse {\n");
@@ -316,6 +319,7 @@ void HelloResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -327,6 +331,7 @@ bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value
   }
 }
 void ConnectRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->password); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ConnectRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ConnectRequest {\n");
@@ -335,6 +340,7 @@ void ConnectRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ConnectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -346,6 +352,7 @@ bool ConnectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   }
 }
 void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ConnectResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ConnectResponse {\n");
@@ -354,16 +361,27 @@ void ConnectResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 void DisconnectRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void DisconnectRequest::dump_to(std::string &out) const { out.append("DisconnectRequest {}"); }
+#endif
 void DisconnectResponse::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void DisconnectResponse::dump_to(std::string &out) const { out.append("DisconnectResponse {}"); }
+#endif
 void PingRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void PingRequest::dump_to(std::string &out) const { out.append("PingRequest {}"); }
+#endif
 void PingResponse::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void PingResponse::dump_to(std::string &out) const { out.append("PingResponse {}"); }
+#endif
 void DeviceInfoRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfoRequest {}"); }
+#endif
 bool DeviceInfoResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -423,6 +441,7 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(8, this->project_name);
   buffer.encode_string(9, this->project_version);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("DeviceInfoResponse {\n");
@@ -463,12 +482,19 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 void ListEntitiesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesRequest::dump_to(std::string &out) const { out.append("ListEntitiesRequest {}"); }
+#endif
 void ListEntitiesDoneResponse::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesDoneResponse::dump_to(std::string &out) const { out.append("ListEntitiesDoneResponse {}"); }
+#endif
 void SubscribeStatesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeStatesRequest::dump_to(std::string &out) const { out.append("SubscribeStatesRequest {}"); }
+#endif
 bool ListEntitiesBinarySensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -519,6 +545,7 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->device_class);
   buffer.encode_bool(6, this->is_status_binary_sensor);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesBinarySensorResponse {\n");
@@ -548,6 +575,7 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool BinarySensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -577,6 +605,7 @@ void BinarySensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void BinarySensorStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("BinarySensorStateResponse {\n");
@@ -594,6 +623,7 @@ void BinarySensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesCoverResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -654,6 +684,7 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(7, this->supports_tilt);
   buffer.encode_string(8, this->device_class);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesCoverResponse {\n");
@@ -691,6 +722,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool CoverStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -730,6 +762,7 @@ void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(4, this->tilt);
   buffer.encode_enum<enums::CoverOperation>(5, this->current_operation);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void CoverStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("CoverStateResponse {\n");
@@ -757,6 +790,7 @@ void CoverStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -811,6 +845,7 @@ void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(7, this->tilt);
   buffer.encode_bool(8, this->stop);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void CoverCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("CoverCommandRequest {\n");
@@ -850,6 +885,7 @@ void CoverCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesFanResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -910,6 +946,7 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(7, this->supports_direction);
   buffer.encode_int32(8, this->supported_speed_count);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesFanResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesFanResponse {\n");
@@ -948,6 +985,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool FanStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -992,6 +1030,7 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::FanDirection>(5, this->direction);
   buffer.encode_int32(6, this->speed_level);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void FanStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("FanStateResponse {\n");
@@ -1022,6 +1061,7 @@ void FanStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1091,6 +1131,7 @@ void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(10, this->has_speed_level);
   buffer.encode_int32(11, this->speed_level);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void FanCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("FanCommandRequest {\n");
@@ -1141,6 +1182,7 @@ void FanCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesLightResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 12: {
@@ -1225,6 +1267,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(11, it, true);
   }
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesLightResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesLightResponse {\n");
@@ -1284,6 +1327,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   }
   out.append("}");
 }
+#endif
 bool LightStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1369,6 +1413,7 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(13, this->warm_white);
   buffer.encode_string(9, this->effect);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void LightStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("LightStateResponse {\n");
@@ -1435,6 +1480,7 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1590,6 +1636,7 @@ void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(18, this->has_effect);
   buffer.encode_string(19, this->effect);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void LightCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("LightCommandRequest {\n");
@@ -1714,6 +1761,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 7: {
@@ -1789,6 +1837,7 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::SensorStateClass>(10, this->state_class);
   buffer.encode_enum<enums::SensorLastResetType>(11, this->last_reset_type);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesSensorResponse {\n");
@@ -1839,6 +1888,7 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool SensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -1868,6 +1918,7 @@ void SensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SensorStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SensorStateResponse {\n");
@@ -1886,6 +1937,7 @@ void SensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesSwitchResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -1936,6 +1988,7 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->assumed_state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesSwitchResponse {\n");
@@ -1965,6 +2018,7 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool SwitchStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1989,6 +2043,7 @@ void SwitchStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SwitchStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SwitchStateResponse {\n");
@@ -2002,6 +2057,7 @@ void SwitchStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -2026,6 +2082,7 @@ void SwitchCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SwitchCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SwitchCommandRequest {\n");
@@ -2039,6 +2096,7 @@ void SwitchCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesTextSensorResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2078,6 +2136,7 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesTextSensorResponse {\n");
@@ -2103,6 +2162,7 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool TextSensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -2138,6 +2198,7 @@ void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void TextSensorStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("TextSensorStateResponse {\n");
@@ -2155,6 +2216,7 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -2173,6 +2235,7 @@ void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::LogLevel>(1, this->level);
   buffer.encode_bool(2, this->dump_config);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeLogsRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SubscribeLogsRequest {\n");
@@ -2185,6 +2248,7 @@ void SubscribeLogsRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool SubscribeLogsResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -2219,6 +2283,7 @@ void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(3, this->message);
   buffer.encode_bool(4, this->send_failed);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeLogsResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SubscribeLogsResponse {\n");
@@ -2239,10 +2304,13 @@ void SubscribeLogsResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 void SubscribeHomeassistantServicesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeHomeassistantServicesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeassistantServicesRequest {}");
 }
+#endif
 bool HomeassistantServiceMap::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2261,6 +2329,7 @@ void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->key);
   buffer.encode_string(2, this->value);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeassistantServiceMap::dump_to(std::string &out) const {
   char buffer[64];
   out.append("HomeassistantServiceMap {\n");
@@ -2273,6 +2342,7 @@ void HomeassistantServiceMap::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool HomeassistantServiceResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -2318,6 +2388,7 @@ void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(5, this->is_event);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeassistantServiceResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("HomeassistantServiceResponse {\n");
@@ -2348,10 +2419,13 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 void SubscribeHomeAssistantStatesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeHomeAssistantStatesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeAssistantStatesRequest {}");
 }
+#endif
 bool SubscribeHomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2370,6 +2444,7 @@ void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const 
   buffer.encode_string(1, this->entity_id);
   buffer.encode_string(2, this->attribute);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SubscribeHomeAssistantStateResponse {\n");
@@ -2382,6 +2457,7 @@ void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2405,6 +2481,7 @@ void HomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->state);
   buffer.encode_string(3, this->attribute);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeAssistantStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("HomeAssistantStateResponse {\n");
@@ -2421,8 +2498,11 @@ void HomeAssistantStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 void GetTimeRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeRequest {}"); }
+#endif
 bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -2434,6 +2514,7 @@ bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
 }
 void GetTimeResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->epoch_seconds); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void GetTimeResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("GetTimeResponse {\n");
@@ -2443,6 +2524,7 @@ void GetTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesServicesArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -2467,6 +2549,7 @@ void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name);
   buffer.encode_enum<enums::ServiceArgType>(2, this->type);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesServicesArgument::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesServicesArgument {\n");
@@ -2479,6 +2562,7 @@ void ListEntitiesServicesArgument::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesServicesResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2510,6 +2594,7 @@ void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_message<ListEntitiesServicesArgument>(3, it, true);
   }
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesServicesResponse {\n");
@@ -2529,6 +2614,7 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   }
   out.append("}");
 }
+#endif
 bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -2602,6 +2688,7 @@ void ExecuteServiceArgument::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(9, it, true);
   }
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ExecuteServiceArgument::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ExecuteServiceArgument {\n");
@@ -2655,6 +2742,7 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   }
   out.append("}");
 }
+#endif
 bool ExecuteServiceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -2681,6 +2769,7 @@ void ExecuteServiceRequest::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_message<ExecuteServiceArgument>(2, it, true);
   }
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ExecuteServiceRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ExecuteServiceRequest {\n");
@@ -2696,6 +2785,7 @@ void ExecuteServiceRequest::dump_to(std::string &out) const {
   }
   out.append("}");
 }
+#endif
 bool ListEntitiesCameraResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2730,6 +2820,7 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(3, this->name);
   buffer.encode_string(4, this->unique_id);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesCameraResponse {\n");
@@ -2751,6 +2842,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool CameraImageResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -2786,6 +2878,7 @@ void CameraImageResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->data);
   buffer.encode_bool(3, this->done);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void CameraImageResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("CameraImageResponse {\n");
@@ -2803,6 +2896,7 @@ void CameraImageResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -2821,6 +2915,7 @@ void CameraImageRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(1, this->single);
   buffer.encode_bool(2, this->stream);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void CameraImageRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("CameraImageRequest {\n");
@@ -2833,6 +2928,7 @@ void CameraImageRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesClimateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -2950,6 +3046,7 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(17, it, true);
   }
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesClimateResponse {\n");
@@ -3038,6 +3135,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   }
   out.append("}");
 }
+#endif
 bool ClimateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -3123,6 +3221,7 @@ void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::ClimatePreset>(12, this->preset);
   buffer.encode_string(13, this->custom_preset);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ClimateStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ClimateStateResponse {\n");
@@ -3184,6 +3283,7 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -3309,6 +3409,7 @@ void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(20, this->has_custom_preset);
   buffer.encode_string(21, this->custom_preset);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ClimateCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ClimateCommandRequest {\n");
@@ -3401,6 +3502,7 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesNumberResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -3455,6 +3557,7 @@ void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(7, this->max_value);
   buffer.encode_float(8, this->step);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesNumberResponse {\n");
@@ -3495,6 +3598,7 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool NumberStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -3524,6 +3628,7 @@ void NumberStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void NumberStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("NumberStateResponse {\n");
@@ -3542,6 +3647,7 @@ void NumberStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -3560,6 +3666,7 @@ void NumberCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_float(2, this->state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void NumberCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("NumberCommandRequest {\n");
@@ -3574,6 +3681,7 @@ void NumberCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool ListEntitiesSelectResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -3620,6 +3728,7 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(6, it, true);
   }
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("ListEntitiesSelectResponse {\n");
@@ -3651,6 +3760,7 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   }
   out.append("}");
 }
+#endif
 bool SelectStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -3686,6 +3796,7 @@ void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SelectStateResponse::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SelectStateResponse {\n");
@@ -3703,6 +3814,7 @@ void SelectStateResponse::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -3727,6 +3839,7 @@ void SelectCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_string(2, this->state);
 }
+#ifdef HAS_PROTO_MESSAGE_DUMP
 void SelectCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
   out.append("SelectCommandRequest {\n");
@@ -3740,6 +3853,7 @@ void SelectCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -123,7 +123,9 @@ class HelloRequest : public ProtoMessage {
  public:
   std::string client_info{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -134,7 +136,9 @@ class HelloResponse : public ProtoMessage {
   uint32_t api_version_minor{0};
   std::string server_info{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -144,7 +148,9 @@ class ConnectRequest : public ProtoMessage {
  public:
   std::string password{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -153,7 +159,9 @@ class ConnectResponse : public ProtoMessage {
  public:
   bool invalid_password{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
@@ -161,35 +169,45 @@ class ConnectResponse : public ProtoMessage {
 class DisconnectRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
 class DisconnectResponse : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
 class PingRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
 class PingResponse : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
 class DeviceInfoRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
@@ -205,7 +223,9 @@ class DeviceInfoResponse : public ProtoMessage {
   std::string project_name{};
   std::string project_version{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -214,21 +234,27 @@ class DeviceInfoResponse : public ProtoMessage {
 class ListEntitiesRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
 class ListEntitiesDoneResponse : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
 class SubscribeStatesRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
@@ -241,7 +267,9 @@ class ListEntitiesBinarySensorResponse : public ProtoMessage {
   std::string device_class{};
   bool is_status_binary_sensor{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -254,7 +282,9 @@ class BinarySensorStateResponse : public ProtoMessage {
   bool state{false};
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -271,7 +301,9 @@ class ListEntitiesCoverResponse : public ProtoMessage {
   bool supports_tilt{false};
   std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -286,7 +318,9 @@ class CoverStateResponse : public ProtoMessage {
   float tilt{0.0f};
   enums::CoverOperation current_operation{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -303,7 +337,9 @@ class CoverCommandRequest : public ProtoMessage {
   float tilt{0.0f};
   bool stop{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -320,7 +356,9 @@ class ListEntitiesFanResponse : public ProtoMessage {
   bool supports_direction{false};
   int32_t supported_speed_count{0};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -336,7 +374,9 @@ class FanStateResponse : public ProtoMessage {
   enums::FanDirection direction{};
   int32_t speed_level{0};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -356,7 +396,9 @@ class FanCommandRequest : public ProtoMessage {
   bool has_speed_level{false};
   int32_t speed_level{0};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -377,7 +419,9 @@ class ListEntitiesLightResponse : public ProtoMessage {
   float max_mireds{0.0f};
   std::vector<std::string> effects{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -400,7 +444,9 @@ class LightStateResponse : public ProtoMessage {
   float warm_white{0.0f};
   std::string effect{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -437,7 +483,9 @@ class LightCommandRequest : public ProtoMessage {
   bool has_effect{false};
   std::string effect{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -458,7 +506,9 @@ class ListEntitiesSensorResponse : public ProtoMessage {
   enums::SensorStateClass state_class{};
   enums::SensorLastResetType last_reset_type{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -471,7 +521,9 @@ class SensorStateResponse : public ProtoMessage {
   float state{0.0f};
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -486,7 +538,9 @@ class ListEntitiesSwitchResponse : public ProtoMessage {
   std::string icon{};
   bool assumed_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -498,7 +552,9 @@ class SwitchStateResponse : public ProtoMessage {
   uint32_t key{0};
   bool state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -509,7 +565,9 @@ class SwitchCommandRequest : public ProtoMessage {
   uint32_t key{0};
   bool state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -523,7 +581,9 @@ class ListEntitiesTextSensorResponse : public ProtoMessage {
   std::string unique_id{};
   std::string icon{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -535,7 +595,9 @@ class TextSensorStateResponse : public ProtoMessage {
   std::string state{};
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -547,7 +609,9 @@ class SubscribeLogsRequest : public ProtoMessage {
   enums::LogLevel level{};
   bool dump_config{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
@@ -559,7 +623,9 @@ class SubscribeLogsResponse : public ProtoMessage {
   std::string message{};
   bool send_failed{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -568,7 +634,9 @@ class SubscribeLogsResponse : public ProtoMessage {
 class SubscribeHomeassistantServicesRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
@@ -577,7 +645,9 @@ class HomeassistantServiceMap : public ProtoMessage {
   std::string key{};
   std::string value{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -590,7 +660,9 @@ class HomeassistantServiceResponse : public ProtoMessage {
   std::vector<HomeassistantServiceMap> variables{};
   bool is_event{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -599,7 +671,9 @@ class HomeassistantServiceResponse : public ProtoMessage {
 class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
@@ -608,7 +682,9 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
   std::string entity_id{};
   std::string attribute{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -619,7 +695,9 @@ class HomeAssistantStateResponse : public ProtoMessage {
   std::string state{};
   std::string attribute{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -627,7 +705,9 @@ class HomeAssistantStateResponse : public ProtoMessage {
 class GetTimeRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
 };
@@ -635,7 +715,9 @@ class GetTimeResponse : public ProtoMessage {
  public:
   uint32_t epoch_seconds{0};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -645,7 +727,9 @@ class ListEntitiesServicesArgument : public ProtoMessage {
   std::string name{};
   enums::ServiceArgType type{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
@@ -657,7 +741,9 @@ class ListEntitiesServicesResponse : public ProtoMessage {
   uint32_t key{0};
   std::vector<ListEntitiesServicesArgument> args{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -675,7 +761,9 @@ class ExecuteServiceArgument : public ProtoMessage {
   std::vector<float> float_array{};
   std::vector<std::string> string_array{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -687,7 +775,9 @@ class ExecuteServiceRequest : public ProtoMessage {
   uint32_t key{0};
   std::vector<ExecuteServiceArgument> args{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -700,7 +790,9 @@ class ListEntitiesCameraResponse : public ProtoMessage {
   std::string name{};
   std::string unique_id{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -712,7 +804,9 @@ class CameraImageResponse : public ProtoMessage {
   std::string data{};
   bool done{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -724,7 +818,9 @@ class CameraImageRequest : public ProtoMessage {
   bool single{false};
   bool stream{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
@@ -749,7 +845,9 @@ class ListEntitiesClimateResponse : public ProtoMessage {
   std::vector<enums::ClimatePreset> supported_presets{};
   std::vector<std::string> supported_custom_presets{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -772,7 +870,9 @@ class ClimateStateResponse : public ProtoMessage {
   enums::ClimatePreset preset{};
   std::string custom_preset{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -803,7 +903,9 @@ class ClimateCommandRequest : public ProtoMessage {
   bool has_custom_preset{false};
   std::string custom_preset{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -821,7 +923,9 @@ class ListEntitiesNumberResponse : public ProtoMessage {
   float max_value{0.0f};
   float step{0.0f};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -833,7 +937,9 @@ class NumberStateResponse : public ProtoMessage {
   float state{0.0f};
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -844,7 +950,9 @@ class NumberCommandRequest : public ProtoMessage {
   uint32_t key{0};
   float state{0.0f};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -858,7 +966,9 @@ class ListEntitiesSelectResponse : public ProtoMessage {
   std::string icon{};
   std::vector<std::string> options{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -870,7 +980,9 @@ class SelectStateResponse : public ProtoMessage {
   std::string state{};
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
@@ -882,7 +994,9 @@ class SelectCommandRequest : public ProtoMessage {
   uint32_t key{0};
   std::string state{};
   void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
+#endif
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -9,58 +9,82 @@ namespace api {
 static const char *const TAG = "api.service";
 
 bool APIServerConnectionBase::send_hello_response(const HelloResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_hello_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<HelloResponse>(msg, 2);
 }
 bool APIServerConnectionBase::send_connect_response(const ConnectResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_connect_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ConnectResponse>(msg, 4);
 }
 bool APIServerConnectionBase::send_disconnect_request(const DisconnectRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_disconnect_request: %s", msg.dump().c_str());
+#endif
   return this->send_message_<DisconnectRequest>(msg, 5);
 }
 bool APIServerConnectionBase::send_disconnect_response(const DisconnectResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_disconnect_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<DisconnectResponse>(msg, 6);
 }
 bool APIServerConnectionBase::send_ping_request(const PingRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_ping_request: %s", msg.dump().c_str());
+#endif
   return this->send_message_<PingRequest>(msg, 7);
 }
 bool APIServerConnectionBase::send_ping_response(const PingResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_ping_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<PingResponse>(msg, 8);
 }
 bool APIServerConnectionBase::send_device_info_response(const DeviceInfoResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_device_info_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<DeviceInfoResponse>(msg, 10);
 }
 bool APIServerConnectionBase::send_list_entities_done_response(const ListEntitiesDoneResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_done_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesDoneResponse>(msg, 19);
 }
 #ifdef USE_BINARY_SENSOR
 bool APIServerConnectionBase::send_list_entities_binary_sensor_response(const ListEntitiesBinarySensorResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_binary_sensor_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesBinarySensorResponse>(msg, 12);
 }
 #endif
 #ifdef USE_BINARY_SENSOR
 bool APIServerConnectionBase::send_binary_sensor_state_response(const BinarySensorStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_binary_sensor_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<BinarySensorStateResponse>(msg, 21);
 }
 #endif
 #ifdef USE_COVER
 bool APIServerConnectionBase::send_list_entities_cover_response(const ListEntitiesCoverResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_cover_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesCoverResponse>(msg, 13);
 }
 #endif
 #ifdef USE_COVER
 bool APIServerConnectionBase::send_cover_state_response(const CoverStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_cover_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<CoverStateResponse>(msg, 22);
 }
 #endif
@@ -68,13 +92,17 @@ bool APIServerConnectionBase::send_cover_state_response(const CoverStateResponse
 #endif
 #ifdef USE_FAN
 bool APIServerConnectionBase::send_list_entities_fan_response(const ListEntitiesFanResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_fan_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesFanResponse>(msg, 14);
 }
 #endif
 #ifdef USE_FAN
 bool APIServerConnectionBase::send_fan_state_response(const FanStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_fan_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<FanStateResponse>(msg, 23);
 }
 #endif
@@ -82,13 +110,17 @@ bool APIServerConnectionBase::send_fan_state_response(const FanStateResponse &ms
 #endif
 #ifdef USE_LIGHT
 bool APIServerConnectionBase::send_list_entities_light_response(const ListEntitiesLightResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_light_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesLightResponse>(msg, 15);
 }
 #endif
 #ifdef USE_LIGHT
 bool APIServerConnectionBase::send_light_state_response(const LightStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_light_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<LightStateResponse>(msg, 24);
 }
 #endif
@@ -96,25 +128,33 @@ bool APIServerConnectionBase::send_light_state_response(const LightStateResponse
 #endif
 #ifdef USE_SENSOR
 bool APIServerConnectionBase::send_list_entities_sensor_response(const ListEntitiesSensorResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_sensor_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesSensorResponse>(msg, 16);
 }
 #endif
 #ifdef USE_SENSOR
 bool APIServerConnectionBase::send_sensor_state_response(const SensorStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_sensor_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<SensorStateResponse>(msg, 25);
 }
 #endif
 #ifdef USE_SWITCH
 bool APIServerConnectionBase::send_list_entities_switch_response(const ListEntitiesSwitchResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_switch_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesSwitchResponse>(msg, 17);
 }
 #endif
 #ifdef USE_SWITCH
 bool APIServerConnectionBase::send_switch_state_response(const SwitchStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_switch_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<SwitchStateResponse>(msg, 26);
 }
 #endif
@@ -122,13 +162,17 @@ bool APIServerConnectionBase::send_switch_state_response(const SwitchStateRespon
 #endif
 #ifdef USE_TEXT_SENSOR
 bool APIServerConnectionBase::send_list_entities_text_sensor_response(const ListEntitiesTextSensorResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_text_sensor_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesTextSensorResponse>(msg, 18);
 }
 #endif
 #ifdef USE_TEXT_SENSOR
 bool APIServerConnectionBase::send_text_sensor_state_response(const TextSensorStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_text_sensor_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<TextSensorStateResponse>(msg, 27);
 }
 #endif
@@ -136,35 +180,49 @@ bool APIServerConnectionBase::send_subscribe_logs_response(const SubscribeLogsRe
   return this->send_message_<SubscribeLogsResponse>(msg, 29);
 }
 bool APIServerConnectionBase::send_homeassistant_service_response(const HomeassistantServiceResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_homeassistant_service_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
 bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
     const SubscribeHomeAssistantStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<SubscribeHomeAssistantStateResponse>(msg, 39);
 }
 bool APIServerConnectionBase::send_get_time_request(const GetTimeRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_get_time_request: %s", msg.dump().c_str());
+#endif
   return this->send_message_<GetTimeRequest>(msg, 36);
 }
 bool APIServerConnectionBase::send_get_time_response(const GetTimeResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_get_time_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<GetTimeResponse>(msg, 37);
 }
 bool APIServerConnectionBase::send_list_entities_services_response(const ListEntitiesServicesResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_services_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesServicesResponse>(msg, 41);
 }
 #ifdef USE_ESP32_CAMERA
 bool APIServerConnectionBase::send_list_entities_camera_response(const ListEntitiesCameraResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_camera_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesCameraResponse>(msg, 43);
 }
 #endif
 #ifdef USE_ESP32_CAMERA
 bool APIServerConnectionBase::send_camera_image_response(const CameraImageResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_camera_image_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<CameraImageResponse>(msg, 44);
 }
 #endif
@@ -172,13 +230,17 @@ bool APIServerConnectionBase::send_camera_image_response(const CameraImageRespon
 #endif
 #ifdef USE_CLIMATE
 bool APIServerConnectionBase::send_list_entities_climate_response(const ListEntitiesClimateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_climate_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesClimateResponse>(msg, 46);
 }
 #endif
 #ifdef USE_CLIMATE
 bool APIServerConnectionBase::send_climate_state_response(const ClimateStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_climate_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ClimateStateResponse>(msg, 47);
 }
 #endif
@@ -186,13 +248,17 @@ bool APIServerConnectionBase::send_climate_state_response(const ClimateStateResp
 #endif
 #ifdef USE_NUMBER
 bool APIServerConnectionBase::send_list_entities_number_response(const ListEntitiesNumberResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_number_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesNumberResponse>(msg, 49);
 }
 #endif
 #ifdef USE_NUMBER
 bool APIServerConnectionBase::send_number_state_response(const NumberStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_number_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<NumberStateResponse>(msg, 50);
 }
 #endif
@@ -200,13 +266,17 @@ bool APIServerConnectionBase::send_number_state_response(const NumberStateRespon
 #endif
 #ifdef USE_SELECT
 bool APIServerConnectionBase::send_list_entities_select_response(const ListEntitiesSelectResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_select_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<ListEntitiesSelectResponse>(msg, 52);
 }
 #endif
 #ifdef USE_SELECT
 bool APIServerConnectionBase::send_select_state_response(const SelectStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_select_state_response: %s", msg.dump().c_str());
+#endif
   return this->send_message_<SelectStateResponse>(msg, 53);
 }
 #endif
@@ -217,70 +287,90 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
     case 1: {
       HelloRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_hello_request: %s", msg.dump().c_str());
+#endif
       this->on_hello_request(msg);
       break;
     }
     case 3: {
       ConnectRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_connect_request: %s", msg.dump().c_str());
+#endif
       this->on_connect_request(msg);
       break;
     }
     case 5: {
       DisconnectRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump().c_str());
+#endif
       this->on_disconnect_request(msg);
       break;
     }
     case 6: {
       DisconnectResponse msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump().c_str());
+#endif
       this->on_disconnect_response(msg);
       break;
     }
     case 7: {
       PingRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump().c_str());
+#endif
       this->on_ping_request(msg);
       break;
     }
     case 8: {
       PingResponse msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump().c_str());
+#endif
       this->on_ping_response(msg);
       break;
     }
     case 9: {
       DeviceInfoRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_device_info_request: %s", msg.dump().c_str());
+#endif
       this->on_device_info_request(msg);
       break;
     }
     case 11: {
       ListEntitiesRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_list_entities_request: %s", msg.dump().c_str());
+#endif
       this->on_list_entities_request(msg);
       break;
     }
     case 20: {
       SubscribeStatesRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_subscribe_states_request: %s", msg.dump().c_str());
+#endif
       this->on_subscribe_states_request(msg);
       break;
     }
     case 28: {
       SubscribeLogsRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_subscribe_logs_request: %s", msg.dump().c_str());
+#endif
       this->on_subscribe_logs_request(msg);
       break;
     }
@@ -288,7 +378,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_COVER
       CoverCommandRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_cover_command_request: %s", msg.dump().c_str());
+#endif
       this->on_cover_command_request(msg);
 #endif
       break;
@@ -297,7 +389,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_FAN
       FanCommandRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_fan_command_request: %s", msg.dump().c_str());
+#endif
       this->on_fan_command_request(msg);
 #endif
       break;
@@ -306,7 +400,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_LIGHT
       LightCommandRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_light_command_request: %s", msg.dump().c_str());
+#endif
       this->on_light_command_request(msg);
 #endif
       break;
@@ -315,7 +411,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_SWITCH
       SwitchCommandRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_switch_command_request: %s", msg.dump().c_str());
+#endif
       this->on_switch_command_request(msg);
 #endif
       break;
@@ -323,42 +421,54 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
     case 34: {
       SubscribeHomeassistantServicesRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_subscribe_homeassistant_services_request: %s", msg.dump().c_str());
+#endif
       this->on_subscribe_homeassistant_services_request(msg);
       break;
     }
     case 36: {
       GetTimeRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_get_time_request: %s", msg.dump().c_str());
+#endif
       this->on_get_time_request(msg);
       break;
     }
     case 37: {
       GetTimeResponse msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump().c_str());
+#endif
       this->on_get_time_response(msg);
       break;
     }
     case 38: {
       SubscribeHomeAssistantStatesRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_subscribe_home_assistant_states_request: %s", msg.dump().c_str());
+#endif
       this->on_subscribe_home_assistant_states_request(msg);
       break;
     }
     case 40: {
       HomeAssistantStateResponse msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_home_assistant_state_response: %s", msg.dump().c_str());
+#endif
       this->on_home_assistant_state_response(msg);
       break;
     }
     case 42: {
       ExecuteServiceRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump().c_str());
+#endif
       this->on_execute_service_request(msg);
       break;
     }
@@ -366,7 +476,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_ESP32_CAMERA
       CameraImageRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_camera_image_request: %s", msg.dump().c_str());
+#endif
       this->on_camera_image_request(msg);
 #endif
       break;
@@ -375,7 +487,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_CLIMATE
       ClimateCommandRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_climate_command_request: %s", msg.dump().c_str());
+#endif
       this->on_climate_command_request(msg);
 #endif
       break;
@@ -384,7 +498,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_NUMBER
       NumberCommandRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_number_command_request: %s", msg.dump().c_str());
+#endif
       this->on_number_command_request(msg);
 #endif
       break;
@@ -393,7 +509,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_SELECT
       SelectCommandRequest msg;
       msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_select_command_request: %s", msg.dump().c_str());
+#endif
       this->on_select_command_request(msg);
 #endif
       break;

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -80,11 +80,13 @@ void ProtoMessage::decode(const uint8_t *buffer, size_t length) {
   }
 }
 
+#ifdef HAS_PROTO_MESSAGE_DUMP
 std::string ProtoMessage::dump() const {
   std::string out;
   this->dump_to(out);
   return out;
 }
+#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+#define HAS_PROTO_MESSAGE_DUMP
+#endif
 
 namespace esphome {
 namespace api {
@@ -243,8 +248,10 @@ class ProtoMessage {
  public:
   virtual void encode(ProtoWriteBuffer buffer) const = 0;
   void decode(const uint8_t *buffer, size_t length);
+#ifdef HAS_PROTO_MESSAGE_DUMP
   std::string dump() const;
   virtual void dump_to(std::string &out) const = 0;
+#endif
 
  protected:
   virtual bool decode_varint(uint32_t field_id, ProtoVarInt value) { return false; }

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -661,8 +661,12 @@ def build_message_type(desc):
             o += "\n"
             o += f"  {o2}\n"
     o += "}\n"
+    cpp += f"#ifdef HAS_PROTO_MESSAGE_DUMP\n"
     cpp += o
-    prot = "void dump_to(std::string &out) const override;"
+    cpp += f"#endif\n"
+    prot = "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
+    prot += "void dump_to(std::string &out) const override;\n"
+    prot += "#endif\n"
     public_content.append(prot)
 
     out = f"class {desc.name} : public ProtoMessage {{\n"
@@ -774,7 +778,9 @@ def build_service_message_type(mt):
         hout += f"bool {func}(const {mt.name} &msg);\n"
         cout += f"bool {class_name}::{func}(const {mt.name} &msg) {{\n"
         if log:
+            cout += f'#ifdef HAS_PROTO_MESSAGE_DUMP\n'
             cout += f'  ESP_LOGVV(TAG, "{func}: %s", msg.dump().c_str());\n'
+            cout += f'#endif\n'
         # cout += f'  this->set_nodelay({str(nodelay).lower()});\n'
         cout += f"  return this->send_message_<{mt.name}>(msg, {id_});\n"
         cout += f"}}\n"
@@ -788,7 +794,9 @@ def build_service_message_type(mt):
         case += f"{mt.name} msg;\n"
         case += f"msg.decode(msg_data, msg_size);\n"
         if log:
+            case += f'#ifdef HAS_PROTO_MESSAGE_DUMP\n'
             case += f'ESP_LOGVV(TAG, "{func}: %s", msg.dump().c_str());\n'
+            case += f'#endif\n'
         case += f"this->{func}(msg);\n"
         if ifdef is not None:
             case += f"#endif\n"


### PR DESCRIPTION
# What does this implement/fix? 

Only compile the protobuf message dumping into the binary when very verbose logging is enabled. Results in a significant reduction of RAM and flash size:

Before:
```txt
RAM:   [=====     ]  47.0% (used 38484 bytes from 81920 bytes)
Flash: [====      ]  41.9% (used 437384 bytes from 1044464 bytes)
```

After:
```txt
RAM:   [====      ]  39.7% (used 32520 bytes from 81920 bytes)
Flash: [====      ]  40.8% (used 426396 bytes from 1044464 bytes)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
