### PR TITLE
Don't mark COLOR_* constants as static in header

### DIFF
--- a/esphome/core/color.cpp
+++ b/esphome/core/color.cpp
@@ -5,4 +5,7 @@ namespace esphome {
 const Color Color::BLACK(0, 0, 0, 0);
 const Color Color::WHITE(255, 255, 255, 255);
 
+const Color COLOR_BLACK(0, 0, 0, 0);
+const Color COLOR_WHITE(255, 255, 255, 255);
+
 }  // namespace esphome

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -149,8 +149,8 @@ struct Color {
 };
 
 ESPDEPRECATED("Use Color::BLACK instead of COLOR_BLACK", "v1.21")
-static const Color COLOR_BLACK(0, 0, 0, 0);
+extern const Color COLOR_BLACK;
 ESPDEPRECATED("Use Color::WHITE instead of COLOR_WHITE", "v1.21")
-static const Color COLOR_WHITE(255, 255, 255, 255);
+extern const Color COLOR_WHITE;
 
 }  // namespace esphome


### PR DESCRIPTION
`COLOR_BLACK` and `COLOR_WHITE` were marked as static in `color.h`, which of course caused the value of the constants to be embedded once for every file including that header, wasting 80 bytes of precious memory. Don't do that.

(For the record, even though I was the last one to touch these constants, they were already static long before I had even heard of ESPHome :P)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
