### PR TITLE
Add Tuya text_sensor component

### DIFF
--- a/esphome/components/tuya/text_sensor/__init__.py
+++ b/esphome/components/tuya/text_sensor/__init__.py
@@ -5,7 +5,6 @@ from esphome.const import CONF_ID
 from .. import tuya_ns, CONF_TUYA_ID, Tuya
 
 DEPENDENCIES = ["tuya"]
-CODEOWNERS = ["@tony-fav"]
 
 CONF_SENSOR_DATAPOINT = "sensor_datapoint"
 

--- a/esphome/components/tuya/text_sensor/__init__.py
+++ b/esphome/components/tuya/text_sensor/__init__.py
@@ -1,0 +1,31 @@
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import CONF_ID
+from .. import tuya_ns, CONF_TUYA_ID, Tuya
+
+DEPENDENCIES = ["tuya"]
+CODEOWNERS = ["@tony-fav"]
+
+CONF_SENSOR_DATAPOINT = "sensor_datapoint"
+
+TuyaTextSensor = tuya_ns.class_("TuyaTextSensor", text_sensor.TextSensor, cg.Component)
+
+CONFIG_SCHEMA = text_sensor.TEXT_SENSOR_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(TuyaTextSensor),
+        cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
+        cv.Required(CONF_SENSOR_DATAPOINT): cv.uint8_t,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await text_sensor.register_text_sensor(var, config)
+
+    paren = await cg.get_variable(config[CONF_TUYA_ID])
+    cg.add(var.set_tuya_parent(paren))
+
+    cg.add(var.set_sensor_id(config[CONF_SENSOR_DATAPOINT]))

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -34,7 +34,7 @@ uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_i
 std::vector<uint8_t> raw_decode(const std::string &dp_data_string) {
   std::string res;
   for (int i = 0; i < dp_data_string.size(); i = i + 2) {
-    res += hexpair_to_int(dp_data_string,i);
+    res += hexpair_to_int(dp_data_string, i);
   }
   std::vector<uint8_t> res_vec;
   res_vec.assign(res.begin(), res.end());

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -6,43 +6,43 @@ namespace tuya {
 
 static const char *const TAG = "tuya.text_sensor";
 
-uint8_t hexchar_to_int(const std::string& dp_data_string, const uint8_t index_in_string)
+uint8_t hexchar_to_int(const std::string &dp_data_string, const uint8_t index_in_string)
 {
-    uint8_t out = dp_data_string[index_in_string];
-    if (out >= '0' && out <= '9')
-      out = (out - '0');
-    else if (out >= 'A' && out <= 'F') 
-      out = (10 + (out - 'A'));
-    else if (out >= 'a' && out <= 'f') 
-      out = (10 + (out - 'a'));
-    return out;
+  uint8_t out = dp_data_string[index_in_string];
+  if (out >= '0' && out <= '9')
+    out = (out - '0');
+  else if (out >= 'A' && out <= 'F') 
+    out = (10 + (out - 'A'));
+  else if (out >= 'a' && out <= 'f') 
+    out = (10 + (out - 'a'));
+  return out;
 }
 
-uint16_t hexpair_to_int(const std::string& dp_data_string, const uint8_t index_in_string)
+uint16_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string)
 {
-    uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
-    uint8_t b = hexchar_to_int(dp_data_string, index_in_string+1);
-    return (a << 4) | b;
+  uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
+  uint8_t b = hexchar_to_int(dp_data_string, index_in_string+1);
+  return (a << 4) | b;
 }
 
-uint32_t hexquad_to_int(const std::string& dp_data_string, const uint8_t index_in_string)
+uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string)
 {
-    uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
-    uint8_t b = hexchar_to_int(dp_data_string, index_in_string+1);
-    uint8_t c = hexchar_to_int(dp_data_string, index_in_string+2);
-    uint8_t d = hexchar_to_int(dp_data_string, index_in_string+3);
-    return (a << 12) | (b << 8) | (c << 4) | d;
+  uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
+  uint8_t b = hexchar_to_int(dp_data_string, index_in_string+1);
+  uint8_t c = hexchar_to_int(dp_data_string, index_in_string+2);
+  uint8_t d = hexchar_to_int(dp_data_string, index_in_string+3);
+  return (a << 12) | (b << 8) | (c << 4) | d;
 }
 
-std::vector<uint8_t> raw_decode(const std::string& dp_data_string) 
+std::vector<uint8_t> raw_decode(const std::string &dp_data_string) 
 {
-    std::string res;
-    for (int i = 0; i < dp_data_string.size(); i=i+2) {
-        res += hexpair_to_int(dp_data_string,i);
-    }
-    std::vector<uint8_t> res_vec;
-    res_vec.assign(res.begin(), res.end());
-    return res_vec;
+  std::string res;
+  for (int i = 0; i < dp_data_string.size(); i=i+2) {
+    res += hexpair_to_int(dp_data_string,i);
+  }
+  std::vector<uint8_t> res_vec;
+  res_vec.assign(res.begin(), res.end());
+  return res_vec;
 }
 
 std::string raw_encode(const uint8_t *data, uint32_t len) {
@@ -65,7 +65,8 @@ void TuyaTextSensor::setup() {
       ESP_LOGV(TAG, "MCU reported text sensor %u is (string): %s", datapoint.id, datapoint.value_string.c_str());
       this->publish_state(datapoint.value_string);
     } else if (datapoint.type == TuyaDatapointType::RAW) {
-      ESP_LOGV(TAG, "MCU reported text sensor %u is (raw as string): %s", datapoint.id, raw_encode(datapoint.value_raw).c_str());
+      ESP_LOGV(TAG, "MCU reported text sensor %u is (raw as string): %s", datapoint.id, 
+               raw_encode(datapoint.value_raw).c_str());
       this->publish_state(raw_encode(datapoint.value_raw));
     }
   });

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -17,13 +17,13 @@ uint8_t hexchar_to_int(const std::string &dp_data_string, const uint8_t index_in
   return out;
 }
 
-uint16_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string) {
+uint8_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string) {
   uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
   uint8_t b = hexchar_to_int(dp_data_string, index_in_string + 1);
   return (a << 4) | b;
 }
 
-uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string) {
+uint16_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string) {
   uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
   uint8_t b = hexchar_to_int(dp_data_string, index_in_string + 1);
   uint8_t c = hexchar_to_int(dp_data_string, index_in_string + 2);
@@ -32,13 +32,11 @@ uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_i
 }
 
 std::vector<uint8_t> raw_decode(const std::string &dp_data_string) {
-  std::string res;
-  for (int i = 0; i < dp_data_string.size(); i = i + 2) {
-    res += hexpair_to_int(dp_data_string, i);
-  }
-  std::vector<uint8_t> res_vec;
-  res_vec.assign(res.begin(), res.end());
-  return res_vec;
+  std::vector<uint8_t> res;
+  res.resize(dp_data_string.size() / 2); // reserve enough memory for all bytes
+  for(size_t i = 0; i < dp_data_string.size(); i += 2)
+    res.push_back(hexpair_to_int(dp_data_string, i));
+  return res;
 }
 
 std::string raw_encode(const uint8_t *data, uint32_t len) {

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -1,0 +1,86 @@
+#include "esphome/core/log.h"
+#include "tuya_text_sensor.h"
+
+namespace esphome {
+namespace tuya {
+
+static const char *const TAG = "tuya.text_sensor";
+
+int hexpair_to_int(std::string x, uint8 i)
+{
+    char a = x[i];
+    char b = x[i+1];
+    int value = 0;
+    if      (a >= '0' && a <= '9') a =       (a - '0');
+    else if (a >= 'A' && a <= 'F') a = (10 + (a - 'A'));
+    else if (a >= 'a' && a <= 'f') a = (10 + (a - 'a'));
+    if      (b >= '0' && b <= '9') b =       (b - '0');
+    else if (b >= 'A' && b <= 'F') b = (10 + (b - 'A'));
+    else if (b >= 'a' && b <= 'f') b = (10 + (b - 'a'));
+    value = (a << 4) | b;
+    return value;
+}
+
+int hexquad_to_int(std::string x, uint8 i)
+{
+    char a = x[i];
+    char b = x[i+1];
+    char c = x[i+2];
+    char d = x[i+3];
+    int value = 0;
+    if      (a >= '0' && a <= '9') a =       (a - '0');
+    else if (a >= 'A' && a <= 'F') a = (10 + (a - 'A'));
+    else if (a >= 'a' && a <= 'f') a = (10 + (a - 'a'));
+    if      (b >= '0' && b <= '9') b =       (b - '0');
+    else if (b >= 'A' && b <= 'F') b = (10 + (b - 'A'));
+    else if (b >= 'a' && b <= 'f') b = (10 + (b - 'a'));
+    if      (c >= '0' && c <= '9') c =       (c - '0');
+    else if (c >= 'A' && c <= 'F') c = (10 + (c - 'A'));
+    else if (c >= 'a' && c <= 'f') c = (10 + (c - 'a'));
+    if      (d >= '0' && d <= '9') d =       (d - '0');
+    else if (d >= 'A' && d <= 'F') d = (10 + (d - 'A'));
+    else if (d >= 'a' && d <= 'f') d = (10 + (d - 'a'));
+    value = (a << 12) | (b << 8) | (c << 4) | d;
+    return value;
+}
+
+std::string raw_decode(std::string x) 
+{
+    std::string res;
+    for (int i = 0; i < x.size(); i=i+2) {
+        res += hexpair_to_int(x,i);
+    }
+    return res;
+}
+
+std::string raw_encode(const uint8_t *data, uint32_t len) {
+  char buf[20];
+  std::string res;
+  for (size_t i = 0; i < len; i++) {
+    if (i + 1 != len) {
+      sprintf(buf, "%02X", data[i]);
+    } else {
+      sprintf(buf, "%02X", data[i]);
+    }
+    res += buf;
+  }
+  return res;
+}
+
+void TuyaTextSensor::setup() {
+  this->parent_->register_listener(this->sensor_id_, [this](const TuyaDatapoint &datapoint) {
+    if (datapoint.type == TuyaDatapointType::STRING) {
+      this->publish_state(datapoint.value_string.c_str());
+    } else if (datapoint.type == TuyaDatapointType::RAW) {
+      this->publish_state(raw_encode(datapoint.value_raw).c_str());
+    }
+  });
+}
+
+void TuyaTextSensor::dump_config() {
+  LOG_TEXT_SENSOR("", "Tuya Text Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Text Sensor has datapoint ID %u", this->sensor_id_);
+}
+
+}  // namespace tuya
+}  // namespace esphome

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -6,38 +6,34 @@ namespace tuya {
 
 static const char *const TAG = "tuya.text_sensor";
 
-uint8_t hexchar_to_int(const std::string &dp_data_string, const uint8_t index_in_string)
-{
+uint8_t hexchar_to_int(const std::string &dp_data_string, const uint8_t index_in_string) {
   uint8_t out = dp_data_string[index_in_string];
   if (out >= '0' && out <= '9')
     out = (out - '0');
-  else if (out >= 'A' && out <= 'F') 
+  else if (out >= 'A' && out <= 'F')
     out = (10 + (out - 'A'));
-  else if (out >= 'a' && out <= 'f') 
+  else if (out >= 'a' && out <= 'f')
     out = (10 + (out - 'a'));
   return out;
 }
 
-uint16_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string)
-{
+uint16_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string) {
   uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
-  uint8_t b = hexchar_to_int(dp_data_string, index_in_string+1);
+  uint8_t b = hexchar_to_int(dp_data_string, index_in_string + 1);
   return (a << 4) | b;
 }
 
-uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string)
-{
+uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string) {
   uint8_t a = hexchar_to_int(dp_data_string, index_in_string);
-  uint8_t b = hexchar_to_int(dp_data_string, index_in_string+1);
-  uint8_t c = hexchar_to_int(dp_data_string, index_in_string+2);
-  uint8_t d = hexchar_to_int(dp_data_string, index_in_string+3);
+  uint8_t b = hexchar_to_int(dp_data_string, index_in_string + 1);
+  uint8_t c = hexchar_to_int(dp_data_string, index_in_string + 2);
+  uint8_t d = hexchar_to_int(dp_data_string, index_in_string + 3);
   return (a << 12) | (b << 8) | (c << 4) | d;
 }
 
-std::vector<uint8_t> raw_decode(const std::string &dp_data_string) 
-{
+std::vector<uint8_t> raw_decode(const std::string &dp_data_string) {
   std::string res;
-  for (int i = 0; i < dp_data_string.size(); i=i+2) {
+  for (int i = 0; i < dp_data_string.size(); i = i + 2) {
     res += hexpair_to_int(dp_data_string,i);
   }
   std::vector<uint8_t> res_vec;
@@ -65,7 +61,7 @@ void TuyaTextSensor::setup() {
       ESP_LOGV(TAG, "MCU reported text sensor %u is (string): %s", datapoint.id, datapoint.value_string.c_str());
       this->publish_state(datapoint.value_string);
     } else if (datapoint.type == TuyaDatapointType::RAW) {
-      ESP_LOGV(TAG, "MCU reported text sensor %u is (raw as string): %s", datapoint.id, 
+      ESP_LOGV(TAG, "MCU reported text sensor %u is (raw as string): %s", datapoint.id,
                raw_encode(datapoint.value_raw).c_str());
       this->publish_state(raw_encode(datapoint.value_raw));
     }

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -33,7 +33,6 @@ uint16_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_i
 
 std::vector<uint8_t> raw_decode(const std::string &dp_data_string) {
   std::vector<uint8_t> res;
-  res.resize(dp_data_string.size() / 2); // reserve enough memory for all bytes
   for(size_t i = 0; i < dp_data_string.size(); i += 2)
     res.push_back(hexpair_to_int(dp_data_string, i));
   return res;

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -44,13 +44,15 @@ int hexquad_to_int(std::string x, uint8 i)
     return value;
 }
 
-std::string raw_decode(std::string x) 
+std::vector<uint8_t> raw_decode(std::string x) 
 {
     std::string res;
     for (int i = 0; i < x.size(); i=i+2) {
         res += hexpair_to_int(x,i);
     }
-    return res;
+    std::vector<uint8_t> res_vec;
+    res_vec.assign(res.begin(), res.end());
+    return res_vec;
 }
 
 std::string raw_encode(const uint8_t *data, uint32_t len) {

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -33,7 +33,7 @@ uint16_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_i
 
 std::vector<uint8_t> raw_decode(const std::string &dp_data_string) {
   std::vector<uint8_t> res;
-  for(size_t i = 0; i < dp_data_string.size(); i += 2)
+  for (size_t i = 0; i < dp_data_string.size(); i += 2)
     res.push_back(hexpair_to_int(dp_data_string, i));
   return res;
 }

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.h
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/tuya/tuya.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome {
+namespace tuya {
+
+class TuyaTextSensor : public text_sensor::TextSensor, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void set_sensor_id(uint8_t sensor_id) { this->sensor_id_ = sensor_id; }
+
+  void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
+
+ protected:
+  Tuya *parent_;
+  uint8_t sensor_id_{0};
+};
+
+// helper functions
+int hexpair_to_int(std::string x, uint8 i);
+int hexquad_to_int(std::string x, uint8 i);
+std::string raw_decode(std::string x);
+std::string raw_encode(const uint8_t *data, uint32_t len);
+template<typename T> std::string raw_encode(const T &data) { return raw_encode(data.data(), data.size()); }
+
+}  // namespace tuya
+}  // namespace esphome

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.h
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.h
@@ -23,7 +23,7 @@ class TuyaTextSensor : public text_sensor::TextSensor, public Component {
 // helper functions
 int hexpair_to_int(std::string x, uint8 i);
 int hexquad_to_int(std::string x, uint8 i);
-std::string raw_decode(std::string x);
+std::vector<uint8_t> raw_decode(std::string x);
 std::string raw_encode(const uint8_t *data, uint32_t len);
 template<typename T> std::string raw_encode(const T &data) { return raw_encode(data.data(), data.size()); }
 

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.h
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.h
@@ -21,10 +21,10 @@ class TuyaTextSensor : public text_sensor::TextSensor, public Component {
 };
 
 // helper functions
-uint8_t hexchar_to_int(const std::string& dp_data_string, const uint8_t index_in_string);
-uint16_t hexpair_to_int(const std::string& dp_data_string, const uint8_t index_in_string);
-uint32_t hexquad_to_int(const std::string& dp_data_string, const uint8_t index_in_string);
-std::vector<uint8_t> raw_decode(const std::string& dp_data_string);
+uint8_t hexchar_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
+uint16_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
+uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
+std::vector<uint8_t> raw_decode(const std::string &dp_data_string);
 std::string raw_encode(const uint8_t *data, uint32_t len);
 template<typename T> std::string raw_encode(const T &data) { return raw_encode(data.data(), data.size()); }
 

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.h
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.h
@@ -22,8 +22,8 @@ class TuyaTextSensor : public text_sensor::TextSensor, public Component {
 
 // helper functions
 uint8_t hexchar_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
-uint16_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
-uint32_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
+uint8_t hexpair_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
+uint16_t hexquad_to_int(const std::string &dp_data_string, const uint8_t index_in_string);
 std::vector<uint8_t> raw_decode(const std::string &dp_data_string);
 std::string raw_encode(const uint8_t *data, uint32_t len);
 template<typename T> std::string raw_encode(const T &data) { return raw_encode(data.data(), data.size()); }

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.h
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.h
@@ -21,9 +21,10 @@ class TuyaTextSensor : public text_sensor::TextSensor, public Component {
 };
 
 // helper functions
-int hexpair_to_int(std::string x, uint8 i);
-int hexquad_to_int(std::string x, uint8 i);
-std::vector<uint8_t> raw_decode(std::string x);
+uint8_t hexchar_to_int(const std::string& dp_data_string, const uint8_t index_in_string);
+uint16_t hexpair_to_int(const std::string& dp_data_string, const uint8_t index_in_string);
+uint32_t hexquad_to_int(const std::string& dp_data_string, const uint8_t index_in_string);
+std::vector<uint8_t> raw_decode(const std::string& dp_data_string);
 std::string raw_encode(const uint8_t *data, uint32_t len);
 template<typename T> std::string raw_encode(const T &data) { return raw_encode(data.data(), data.size()); }
 


### PR DESCRIPTION
# What does this implement/fix? 

This adds a text_sensor to the Tuya implementation equivalent to the sensor but for string and raw datapoints. Raw datapoints are encoded to strings. Combined with the set_xxx_datapoint_value functions. This enables very powerful Tuya implementations. I have several tuya based lights with effect modes, colors, alarms, etc... that are implemented through raw datapoints. A few helper functions are included for later manipulation of the raw data points in lambda functions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/feature-requests/issues/1342>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
text_sensor:
  - platform: tuya
    id: dpid_103
    sensor_datapoint: 103

light:
  - platform: tuya
    name: "${friendly_title} Effect Light"
    id: effect_light
    switch_datapoint: 102
    dimmer_datapoint: 123
    min_value: 10
    max_value: 1000
    effects:
      - lambda:
          name: "Aurora Left"
          update_interval: 1s
          lambda: |-
            std::string value = id(dpid_103).state;
            if ((value[1] != '0') or (value[89] != '0')) 
            {
              value[1] = '0';
              value[89] = '0'; 
              id(tuya_mcu).set_raw_datapoint_value(103, esphome::tuya::raw_decode(value));
            }
      - lambda:
          name: "Sunlight Sunset Orange"
          update_interval: 1s
          lambda: |-
            std::string value = id(dpid_103).state;
            if ((value[1] != '1') or (value[89] != '0')) 
            {
              value[1] = '1';
              value[89] = '0'; 
              id(tuya_mcu).set_raw_datapoint_value(103, esphome::tuya::raw_decode(value));
            }
      - lambda:
          name: "Night Red"
          update_interval: 1s
          lambda: |-
            std::string value = id(dpid_103).state;
            if ((value[1] != '2') or (value[89] != '0')) 
            {
              value[1] = '2';
              value[89] = '0'; 
              id(tuya_mcu).set_raw_datapoint_value(103, esphome::tuya::raw_decode(value));
            }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
