### PR TITLE
Enable a bunch of clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,8 +5,6 @@ Checks: >-
   -altera-*,
   -android-*,
   -boost-*,
-  -bugprone-branch-clone,
-  -bugprone-easily-swappable-parameters,
   -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
   -bugprone-too-small-loop-variable,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,7 +36,6 @@ Checks: >-
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-special-member-functions,
-  -fuchsia-default-arguments,
   -fuchsia-multiple-inheritance,
   -fuchsia-overloaded-operator,
   -fuchsia-statically-constructed-objects,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: >-
   -clang-diagnostic-sign-compare,
   -clang-diagnostic-unused-variable,
   -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-parameter,
   -concurrency-*,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-goto,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,6 @@ Checks: >-
   -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
   -clang-diagnostic-shadow-field,
   -clang-diagnostic-sign-compare,
-  -clang-diagnostic-unused-variable,
   -clang-diagnostic-unused-const-variable,
   -clang-diagnostic-unused-parameter,
   -concurrency-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,6 @@ Checks: >-
   -clang-diagnostic-unused-parameter,
   -concurrency-*,
   -cppcoreguidelines-avoid-c-arrays,
-  -cppcoreguidelines-avoid-goto,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-macro-usage,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,6 @@ Checks: >-
   -clang-diagnostic-delete-abstract-non-virtual-dtor,
   -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
   -clang-diagnostic-shadow-field,
-  -clang-diagnostic-sign-compare,
   -clang-diagnostic-unused-const-variable,
   -clang-diagnostic-unused-parameter,
   -concurrency-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@ Checks: >-
   -boost-*,
   -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
-  -bugprone-too-small-loop-variable,
   -cert-dcl50-cpp,
   -cert-err58-cpp,
   -cert-oop57-cpp,

--- a/esphome/components/adalight/adalight_light_effect.cpp
+++ b/esphome/components/adalight/adalight_light_effect.cpp
@@ -25,7 +25,7 @@ void AdalightLightEffect::stop() {
   AddressableLightEffect::stop();
 }
 
-int AdalightLightEffect::get_frame_size_(int led_count) const {
+unsigned int AdalightLightEffect::get_frame_size_(int led_count) const {
   // 3 bytes: Ada
   // 2 bytes: LED count
   // 1 byte: checksum

--- a/esphome/components/adalight/adalight_light_effect.h
+++ b/esphome/components/adalight/adalight_light_effect.h
@@ -25,7 +25,7 @@ class AdalightLightEffect : public light::AddressableLightEffect, public uart::U
     CONSUMED,
   };
 
-  int get_frame_size_(int led_count) const;
+  unsigned int get_frame_size_(int led_count) const;
   void reset_frame_(light::AddressableLight &it);
   void blank_all_leds_(light::AddressableLight &it);
   Frame parse_frame_(light::AddressableLight &it);

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -110,12 +110,12 @@ void AHT10Component::update() {
   uint32_t raw_temperature = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5];
   uint32_t raw_humidity = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4;
 
-  float temperature = ((200.0 * (float) raw_temperature) / 1048576.0) - 50.0;
+  float temperature = ((200.0f * (float) raw_temperature) / 1048576.0f) - 50.0f;
   float humidity;
   if (raw_humidity == 0) {  // unrealistic value
     humidity = NAN;
   } else {
-    humidity = (float) raw_humidity * 100.0 / 1048576.0;
+    humidity = (float) raw_humidity * 100.0f / 1048576.0f;
   }
 
   if (this->temperature_sensor_ != nullptr) {

--- a/esphome/components/am2320/am2320.cpp
+++ b/esphome/components/am2320/am2320.cpp
@@ -38,9 +38,9 @@ void AM2320Component::update() {
     return;
   }
 
-  float temperature = (((data[4] & 0x7F) << 8) + data[5]) / 10.0;
+  float temperature = (((data[4] & 0x7F) << 8) + data[5]) / 10.0f;
   temperature = (data[4] & 0x80) ? -temperature : temperature;
-  float humidity = ((data[2] << 8) + data[3]) / 10.0;
+  float humidity = ((data[2] << 8) + data[3]) / 10.0f;
 
   ESP_LOGD(TAG, "Got temperature=%.1f°C humidity=%.1f%%", temperature, humidity);
   if (this->temperature_sensor_ != nullptr)

--- a/esphome/components/anova/anova_base.cpp
+++ b/esphome/components/anova/anova_base.cpp
@@ -103,13 +103,7 @@ void AnovaCodec::decode(const uint8_t *data, uint16_t length) {
       }
       break;
     }
-    case READ_TARGET_TEMPERATURE: {
-      this->target_temp_ = parse_number<float>(str_until(buf, '\r')).value_or(0.0f);
-      if (this->fahrenheit_)
-        this->target_temp_ = ftoc(this->target_temp_);
-      this->has_target_temp_ = true;
-      break;
-    }
+    case READ_TARGET_TEMPERATURE:
     case SET_TARGET_TEMPERATURE: {
       this->target_temp_ = parse_number<float>(str_until(buf, '\r')).value_or(0.0f);
       if (this->fahrenheit_)

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -132,7 +132,7 @@ void APIConnection::loop() {
 
   if (state_subs_at_ != -1) {
     const auto &subs = this->parent_->get_state_subs();
-    if (state_subs_at_ >= subs.size()) {
+    if (state_subs_at_ >= (int) subs.size()) {
       state_subs_at_ = -1;
     } else {
       auto &it = subs[state_subs_at_];

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -174,9 +174,6 @@ APIError APINoiseFrameHelper::loop() {
  * errno API_ERROR_HANDSHAKE_PACKET_LEN: Packet too big for this phase.
  */
 APIError APINoiseFrameHelper::try_read_frame_(ParsedFrame *frame) {
-  int err;
-  APIError aerr;
-
   if (frame == nullptr) {
     HELPER_LOG("Bad argument for try_read_frame_");
     return APIError::BAD_ARG;
@@ -544,7 +541,6 @@ APIError APINoiseFrameHelper::try_send_tx_buf_() {
 APIError APINoiseFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
   if (iovcnt == 0)
     return APIError::OK;
-  int err;
   APIError aerr;
 
   size_t total_write_len = 0;
@@ -778,9 +774,6 @@ APIError APIPlaintextFrameHelper::loop() {
  * error API_ERROR_BAD_INDICATOR: Bad indicator byte at start of frame.
  */
 APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
-  int err;
-  APIError aerr;
-
   if (frame == nullptr) {
     HELPER_LOG("Bad argument for try_read_frame_");
     return APIError::BAD_ARG;
@@ -874,7 +867,6 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
 }
 
 APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
-  int err;
   APIError aerr;
 
   if (state_ != State::DATA) {
@@ -894,9 +886,6 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
 }
 bool APIPlaintextFrameHelper::can_write_without_blocking() { return state_ == State::DATA && tx_buf_.empty(); }
 APIError APIPlaintextFrameHelper::write_packet(uint16_t type, const uint8_t *payload, size_t payload_len) {
-  int err;
-  APIError aerr;
-
   if (state_ != State::DATA) {
     return APIError::BAD_STATE;
   }
@@ -940,7 +929,6 @@ APIError APIPlaintextFrameHelper::try_send_tx_buf_() {
 APIError APIPlaintextFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
   if (iovcnt == 0)
     return APIError::OK;
-  int err;
   APIError aerr;
 
   size_t total_write_len = 0;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -197,7 +197,7 @@ APIError APINoiseFrameHelper::try_read_frame_(ParsedFrame *frame) {
       return APIError::CONNECTION_CLOSED;
     }
     rx_header_buf_len_ += received;
-    if (received != to_read) {
+    if ((size_t) received != to_read) {
       // not a full read
       return APIError::WOULD_BLOCK;
     }
@@ -244,7 +244,7 @@ APIError APINoiseFrameHelper::try_read_frame_(ParsedFrame *frame) {
       return APIError::CONNECTION_CLOSED;
     }
     rx_buf_len_ += received;
-    if (received != to_read) {
+    if ((size_t) received != to_read) {
       // not all read
       return APIError::WOULD_BLOCK;
     }
@@ -580,7 +580,7 @@ APIError APINoiseFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
     state_ = State::FAILED;
     HELPER_LOG("Socket write failed with errno %d", errno);
     return APIError::SOCKET_WRITE_FAILED;
-  } else if (sent != total_write_len) {
+  } else if ((size_t) sent != total_write_len) {
     // partially sent, add end to tx_buf
     size_t to_consume = sent;
     for (int i = 0; i < iovcnt; i++) {
@@ -847,7 +847,7 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
       return APIError::CONNECTION_CLOSED;
     }
     rx_buf_len_ += received;
-    if (received != to_read) {
+    if ((size_t) received != to_read) {
       // not all read
       return APIError::WOULD_BLOCK;
     }
@@ -968,7 +968,7 @@ APIError APIPlaintextFrameHelper::write_raw_(const struct iovec *iov, int iovcnt
     state_ = State::FAILED;
     HELPER_LOG("Socket write failed with errno %d", errno);
     return APIError::SOCKET_WRITE_FAILED;
-  } else if (sent != total_write_len) {
+  } else if ((size_t) sent != total_write_len) {
     // partially sent, add end to tx_buf
     size_t to_consume = sent;
     for (int i = 0; i < iovcnt; i++) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -291,7 +291,7 @@ bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) 
 void HelloRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->client_info); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HelloRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("HelloRequest {\n");
   out.append("  client_info: ");
   out.append("'").append(this->client_info).append("'");
@@ -330,7 +330,7 @@ void HelloResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HelloResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("HelloResponse {\n");
   out.append("  api_version_major: ");
   sprintf(buffer, "%u", this->api_version_major);
@@ -361,7 +361,7 @@ bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value
 void ConnectRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->password); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ConnectRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ConnectRequest {\n");
   out.append("  password: ");
   out.append("'").append(this->password).append("'");
@@ -382,7 +382,7 @@ bool ConnectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
 void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ConnectResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ConnectResponse {\n");
   out.append("  invalid_password: ");
   out.append(YESNO(this->invalid_password));
@@ -476,7 +476,7 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("DeviceInfoResponse {\n");
   out.append("  uses_password: ");
   out.append(YESNO(this->uses_password));
@@ -600,7 +600,7 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesBinarySensorResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -672,7 +672,7 @@ void BinarySensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void BinarySensorStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("BinarySensorStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -766,7 +766,7 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCoverResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCoverResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -856,7 +856,7 @@ void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CoverStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("CoverStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -939,7 +939,7 @@ void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CoverCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("CoverCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -1055,7 +1055,7 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesFanResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesFanResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -1151,7 +1151,7 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void FanStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("FanStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -1252,7 +1252,7 @@ void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void FanCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("FanCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -1403,7 +1403,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesLightResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLightResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -1561,7 +1561,7 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void LightStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("LightStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -1784,7 +1784,7 @@ void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void LightCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("LightCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -1995,7 +1995,7 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSensorResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSensorResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -2084,7 +2084,7 @@ void SensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SensorStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SensorStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -2164,7 +2164,7 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSwitchResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -2227,7 +2227,7 @@ void SwitchStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SwitchStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SwitchStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -2266,7 +2266,7 @@ void SwitchCommandRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SwitchCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SwitchCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -2336,7 +2336,7 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextSensorResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -2406,7 +2406,7 @@ void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void TextSensorStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("TextSensorStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -2443,7 +2443,7 @@ void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeLogsRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SubscribeLogsRequest {\n");
   out.append("  level: ");
   out.append(proto_enum_to_string<enums::LogLevel>(this->level));
@@ -2486,7 +2486,7 @@ void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeLogsResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SubscribeLogsResponse {\n");
   out.append("  level: ");
   out.append(proto_enum_to_string<enums::LogLevel>(this->level));
@@ -2528,7 +2528,7 @@ void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeassistantServiceMap::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceMap {\n");
   out.append("  key: ");
   out.append("'").append(this->key).append("'");
@@ -2587,7 +2587,7 @@ void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeassistantServiceResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceResponse {\n");
   out.append("  service: ");
   out.append("'").append(this->service).append("'");
@@ -2643,7 +2643,7 @@ void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const 
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SubscribeHomeAssistantStateResponse {\n");
   out.append("  entity_id: ");
   out.append("'").append(this->entity_id).append("'");
@@ -2680,7 +2680,7 @@ void HomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeAssistantStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("HomeAssistantStateResponse {\n");
   out.append("  entity_id: ");
   out.append("'").append(this->entity_id).append("'");
@@ -2713,7 +2713,7 @@ bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void GetTimeResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->epoch_seconds); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void GetTimeResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("GetTimeResponse {\n");
   out.append("  epoch_seconds: ");
   sprintf(buffer, "%u", this->epoch_seconds);
@@ -2748,7 +2748,7 @@ void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesServicesArgument::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesArgument {\n");
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
@@ -2793,7 +2793,7 @@ void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesServicesResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesResponse {\n");
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
@@ -2887,7 +2887,7 @@ void ExecuteServiceArgument::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ExecuteServiceArgument::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ExecuteServiceArgument {\n");
   out.append("  bool_: ");
   out.append(YESNO(this->bool_));
@@ -2968,7 +2968,7 @@ void ExecuteServiceRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ExecuteServiceRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ExecuteServiceRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -3040,7 +3040,7 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCameraResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCameraResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -3110,7 +3110,7 @@ void CameraImageResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CameraImageResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("CameraImageResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -3147,7 +3147,7 @@ void CameraImageRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CameraImageRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("CameraImageRequest {\n");
   out.append("  single: ");
   out.append(YESNO(this->single));
@@ -3293,7 +3293,7 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesClimateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesClimateResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -3480,7 +3480,7 @@ void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ClimateStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ClimateStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -3668,7 +3668,7 @@ void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ClimateCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ClimateCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -3842,7 +3842,7 @@ void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesNumberResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesNumberResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -3929,7 +3929,7 @@ void NumberStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void NumberStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("NumberStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -3967,7 +3967,7 @@ void NumberCommandRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void NumberCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("NumberCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -4045,7 +4045,7 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSelectResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSelectResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -4121,7 +4121,7 @@ void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SelectStateResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SelectStateResponse {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
@@ -4164,7 +4164,7 @@ void SelectCommandRequest::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SelectCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("SelectCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -85,14 +85,7 @@ void CaptivePortal::start() {
   this->dns_server_->start(53, "*", (uint32_t) ip);
 
   this->base_->get_server()->onNotFound([this](AsyncWebServerRequest *req) {
-    bool not_found = false;
-    if (!this->active_) {
-      not_found = true;
-    } else if (req->host().c_str() == wifi::global_wifi_component->wifi_soft_ap_ip().str()) {
-      not_found = true;
-    }
-
-    if (not_found) {
+    if (!this->active_ || req->host().c_str() == wifi::global_wifi_component->wifi_soft_ap_ip().str()) {
       req->send(404, "text/html", "File not found");
       return;
     }

--- a/esphome/components/cs5460a/cs5460a.cpp
+++ b/esphome/components/cs5460a/cs5460a.cpp
@@ -102,8 +102,6 @@ void CS5460AComponent::hw_init_() {
 
 /* Doesn't reset the register values etc., just restarts the "computation cycle" */
 void CS5460AComponent::restart_() {
-  int cnt;
-
   this->enable();
   /* Stop running conversion, wake up if needed */
   this->write_byte(CMD_POWER_UP);

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -149,9 +149,9 @@ void CSE7766Component::parse_data_() {
   }
 }
 void CSE7766Component::update() {
-  float voltage = this->voltage_counts_ > 0 ? this->voltage_acc_ / this->voltage_counts_ : 0.0;
-  float current = this->current_counts_ > 0 ? this->current_acc_ / this->current_counts_ : 0.0;
-  float power = this->power_counts_ > 0 ? this->power_acc_ / this->power_counts_ : 0.0;
+  float voltage = this->voltage_counts_ > 0 ? this->voltage_acc_ / this->voltage_counts_ : 0.0f;
+  float current = this->current_counts_ > 0 ? this->current_acc_ / this->current_counts_ : 0.0f;
+  float power = this->power_counts_ > 0 ? this->power_acc_ / this->power_counts_ : 0.0f;
 
   ESP_LOGV(TAG, "Got voltage_acc=%.2f current_acc=%.2f power_acc=%.2f", this->voltage_acc_, this->current_acc_,
            this->power_acc_);

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -231,7 +231,7 @@ bool DaikinClimate::on_receive(remote_base::RemoteReceiveData data) {
       // frame header
       if (byte != 0x27)
         return false;
-    } else if (pos == 3) {
+    } else if (pos == 3) {  // NOLINT(bugprone-branch-clone)
       // frame header
       if (byte != 0x00)
         return false;

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -496,7 +496,7 @@ bool Animation::get_pixel(int x, int y) const {
     return false;
   const uint32_t width_8 = ((this->width_ + 7u) / 8u) * 8u;
   const uint32_t frame_index = this->height_ * width_8 * this->current_frame_;
-  if (frame_index >= this->width_ * this->height_ * this->animation_frame_count_)
+  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
     return false;
   const uint32_t pos = x + y * width_8 + frame_index;
   return progmem_read_byte(this->data_start_ + (pos / 8u)) & (0x80 >> (pos % 8u));
@@ -505,7 +505,7 @@ Color Animation::get_color_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= this->width_ * this->height_ * this->animation_frame_count_)
+  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index) * 3;
   const uint32_t color32 = (progmem_read_byte(this->data_start_ + pos + 2) << 0) |
@@ -517,7 +517,7 @@ Color Animation::get_grayscale_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= this->width_ * this->height_ * this->animation_frame_count_)
+  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index);
   const uint8_t gray = progmem_read_byte(this->data_start_ + pos);

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -114,10 +114,10 @@ class Dsmr : public Component, public uart::UARTDevice {
   bool receive_timeout_reached_();
   size_t max_telegram_len_;
   char *telegram_{nullptr};
-  int bytes_read_{0};
+  size_t bytes_read_{0};
   uint8_t *crypt_telegram_{nullptr};
   size_t crypt_telegram_len_{0};
-  int crypt_bytes_read_{0};
+  size_t crypt_bytes_read_{0};
   uint32_t last_read_time_{0};
   bool header_found_{false};
   bool footer_found_{false};

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -9,7 +9,7 @@ namespace esp8266 {
 static const char *const TAG = "esp8266";
 
 static int IRAM_ATTR flags_to_mode(gpio::Flags flags, uint8_t pin) {
-  if (flags == gpio::FLAG_INPUT) {
+  if (flags == gpio::FLAG_INPUT) {  // NOLINT(bugprone-branch-clone)
     return INPUT;
   } else if (flags == gpio::FLAG_OUTPUT) {
     return OUTPUT;

--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -55,7 +55,7 @@ static inline bool esp_rtc_user_mem_write(uint32_t index, uint32_t value) {
 
 extern "C" uint32_t _SPIFFS_end;  // NOLINT
 
-static const uint32_t get_esp8266_flash_sector() {
+static uint32_t get_esp8266_flash_sector() {
   union {
     uint32_t *ptr;
     uint32_t uint;
@@ -63,7 +63,7 @@ static const uint32_t get_esp8266_flash_sector() {
   data.ptr = &_SPIFFS_end;
   return (data.uint - 0x40200000) / SPI_FLASH_SEC_SIZE;
 }
-static const uint32_t get_esp8266_flash_address() { return get_esp8266_flash_sector() * SPI_FLASH_SEC_SIZE; }
+static uint32_t get_esp8266_flash_address() { return get_esp8266_flash_sector() * SPI_FLASH_SEC_SIZE; }
 
 template<class It> uint32_t calculate_crc(It first, It last, uint32_t type) {
   uint32_t crc = type;

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -75,7 +75,7 @@ void EZOSensor::loop() {
     return;
 
   // some sensors return multiple comma-separated values, terminate string after first one
-  for (int i = 1; i < sizeof(buf) - 1; i++)
+  for (size_t i = 1; i < sizeof(buf) - 1; i++)
     if (buf[i] == ',')
       buf[i] = '\0';
 

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -132,7 +132,7 @@ void Graph::draw(DisplayBuffer *buff, uint16_t x_offset, uint16_t y_offset, Colo
   if (!std::isnan(this->gridspacing_y_)) {
     for (int y = yn; y <= ym; y++) {
       int16_t py = (int16_t) roundf((this->height_ - 1) * (1.0 - (float) (y - yn) / (ym - yn)));
-      for (int x = 0; x < this->width_; x += 2) {
+      for (uint32_t x = 0; x < this->width_; x += 2) {
         buff->draw_pixel_at(x_offset + x, y_offset + py, color);
       }
     }
@@ -147,7 +147,7 @@ void Graph::draw(DisplayBuffer *buff, uint16_t x_offset, uint16_t y_offset, Colo
       ESP_LOGW(TAG, "Graphing reducing x-scale to prevent too many gridlines");
     }
     for (int i = 0; i <= n; i++) {
-      for (int y = 0; y < this->height_; y += 2) {
+      for (uint32_t y = 0; y < this->height_; y += 2) {
         buff->draw_pixel_at(x_offset + i * (this->width_ - 1) / n, y_offset + y, color);
       }
     }

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -179,8 +179,8 @@ void GraphLegend::init(Graph *g) {
   parent_ = g;
 
   // Determine maximum expected text and value width / height
-  int txtw = 0, txtos = 0, txtbl = 0, txth = 0;
-  int valw = 0, valos = 0, valbl = 0, valh = 0;
+  int txtw = 0, txth = 0;
+  int valw = 0, valh = 0;
   int lt = 0;
   for (auto *trace : g->traces_) {
     std::string txtstr = trace->get_name();

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -86,7 +86,7 @@ void Graph::draw(DisplayBuffer *buff, uint16_t x_offset, uint16_t y_offset, Colo
     // Look back in trace data to best-fit into local range
     float mx = NAN;
     float mn = NAN;
-    for (int16_t i = 0; i < this->width_; i++) {
+    for (uint32_t i = 0; i < this->width_; i++) {
       for (auto *trace : traces_) {
         float v = trace->get_tracedata()->get_value(i);
         if (!std::isnan(v)) {
@@ -158,14 +158,14 @@ void Graph::draw(DisplayBuffer *buff, uint16_t x_offset, uint16_t y_offset, Colo
   for (auto *trace : traces_) {
     Color c = trace->get_line_color();
     uint16_t thick = trace->get_line_thickness();
-    for (int16_t i = 0; i < this->width_; i++) {
+    for (uint32_t i = 0; i < this->width_; i++) {
       float v = (trace->get_tracedata()->get_value(i) - ymin) / yrange;
       if (!std::isnan(v) && (thick > 0)) {
         int16_t x = this->width_ - 1 - i;
         uint8_t b = (i % (thick * LineType::PATTERN_LENGTH)) / thick;
         if (((uint8_t) trace->get_line_type() & (1 << b)) == (1 << b)) {
           int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2;
-          for (int16_t t = 0; t < thick; t++) {
+          for (uint16_t t = 0; t < thick; t++) {
             buff->draw_pixel_at(x_offset + x, y_offset + y + t, c);
           }
         }
@@ -320,7 +320,7 @@ void Graph::draw_legend(display::DisplayBuffer *buff, uint16_t x_offset, uint16_
 
     if (legend_->lines_) {
       uint16_t thick = trace->get_line_thickness();
-      for (int16_t i = 0; i < legend_->x0_ * 4 / 3; i++) {
+      for (int i = 0; i < legend_->x0_ * 4 / 3; i++) {
         uint8_t b = (i % (thick * LineType::PATTERN_LENGTH)) / thick;
         if (((uint8_t) trace->get_line_type() & (1 << b)) == (1 << b)) {
           buff->vertical_line(x - legend_->x0_ * 2 / 3 + i, y + legend_->yl_ - thick / 2, thick,

--- a/esphome/components/hitachi_ac344/hitachi_ac344.cpp
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.cpp
@@ -299,9 +299,7 @@ bool HitachiClimate::parse_swing_(const uint8_t remote_state[]) {
       GETBITS8(remote_state[HITACHI_AC344_SWINGH_BYTE], HITACHI_AC344_SWINGH_OFFSET, HITACHI_AC344_SWINGH_SIZE);
   ESP_LOGV(TAG, "SwingH: %02X %02X", remote_state[HITACHI_AC344_SWINGH_BYTE], swing_modeh);
 
-  if ((swing_modeh & 0x7) == 0x0) {
-    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-  } else if ((swing_modeh & 0x3) == 0x3) {
+  if ((swing_modeh & 0x3) == 0x3) {
     this->swing_mode = climate::CLIMATE_SWING_OFF;
   } else {
     this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;

--- a/esphome/components/hitachi_ac424/hitachi_ac424.cpp
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.cpp
@@ -300,9 +300,7 @@ bool HitachiClimate::parse_swing_(const uint8_t remote_state[]) {
                                                HITACHI_AC424_SWINGH_SIZE);
   ESP_LOGV(TAG, "SwingH: %02X %02X", remote_state[HITACHI_AC424_SWINGH_BYTE], swing_modeh);
 
-  if ((swing_modeh & 0x7) == 0x0) {
-    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-  } else if ((swing_modeh & 0x3) == 0x3) {
+  if ((swing_modeh & 0x3) == 0x3) {
     this->swing_mode = climate::CLIMATE_SWING_OFF;
   } else {
     this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -86,8 +86,8 @@ void ILI9341Display::update() {
 
 void ILI9341Display::display_() {
   // we will only update the changed window to the display
-  int w = this->x_high_ - this->x_low_ + 1;
-  int h = this->y_high_ - this->y_low_ + 1;
+  uint16_t w = this->x_high_ - this->x_low_ + 1;
+  uint16_t h = this->y_high_ - this->y_low_ + 1;
 
   set_addr_window_(this->x_low_, this->y_low_, w, h);
   this->start_data_();

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -145,7 +145,7 @@ bool ImprovSerialComponent::parse_improv_serial_byte_(uint8_t byte) {
 
   if (at == 8 + data_len + 1) {
     uint8_t checksum = 0x00;
-    for (uint8_t i = 0; i < at; i++)
+    for (size_t i = 0; i < at; i++)
       checksum += raw[i];
 
     if (checksum != byte) {

--- a/esphome/components/lcd_gpio/gpio_lcd_display.cpp
+++ b/esphome/components/lcd_gpio/gpio_lcd_display.cpp
@@ -17,7 +17,7 @@ void GPIOLCDDisplay::setup() {
   this->enable_pin_->setup();  // OUTPUT
   this->enable_pin_->digital_write(false);
 
-  for (uint8_t i = 0; i < (this->is_four_bit_mode() ? 4 : 8); i++) {
+  for (uint8_t i = 0; i < (uint8_t)(this->is_four_bit_mode() ? 4u : 8u); i++) {
     this->data_pins_[i]->setup();  // OUTPUT
     this->data_pins_[i]->digital_write(false);
   }

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -167,7 +167,7 @@ class AddressableScanEffect : public AddressableLightEffect {
     this->last_move_ = now;
 
     it.all() = Color::BLACK;
-    for (auto i = 0; i < this->scan_width_; i++) {
+    for (uint32_t i = 0; i < this->scan_width_; i++) {
       it[this->at_led_ + i] = current_color;
     }
 
@@ -178,7 +178,7 @@ class AddressableScanEffect : public AddressableLightEffect {
   uint32_t move_interval_{};
   uint32_t scan_width_{1};
   uint32_t last_move_{0};
-  int at_led_{0};
+  uint32_t at_led_{0};
   bool direction_{true};
 };
 

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -98,7 +98,7 @@ void LightCall::perform() {
     // EFFECT
     auto effect = this->effect_;
     const char *effect_s;
-    if (effect == 0)
+    if (effect == 0u)
       effect_s = "None";
     else
       effect_s = this->parent_->effects_[*this->effect_ - 1]->get_name().c_str();

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -97,7 +97,7 @@ void LTR390Component::read_mode_(int mode_index) {
 
     // If there are more modes to read then begin the next
     // otherwise stop
-    if (mode_index + 1 < this->mode_funcs_.size()) {
+    if (mode_index + 1 < (int) this->mode_funcs_.size()) {
       this->read_mode_(mode_index + 1);
     } else {
       this->reading_ = false;

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -203,16 +203,16 @@ float MAX31865Sensor::calc_temperature_(float rtd_ratio) {
     rtd_resistance *= 100;
   }
   float rpoly = rtd_resistance;
-  float neg_temp = -242.02;
-  neg_temp += 2.2228 * rpoly;
+  float neg_temp = -242.02f;
+  neg_temp += 2.2228f * rpoly;
   rpoly *= rtd_resistance;  // square
-  neg_temp += 2.5859e-3 * rpoly;
+  neg_temp += 2.5859e-3f * rpoly;
   rpoly *= rtd_resistance;  // ^3
-  neg_temp -= 4.8260e-6 * rpoly;
+  neg_temp -= 4.8260e-6f * rpoly;
   rpoly *= rtd_resistance;  // ^4
-  neg_temp -= 2.8183e-8 * rpoly;
+  neg_temp -= 2.8183e-8f * rpoly;
   rpoly *= rtd_resistance;  // ^5
-  neg_temp += 1.5243e-10 * rpoly;
+  neg_temp += 1.5243e-10f * rpoly;
   return neg_temp;
 }
 

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -76,7 +76,7 @@ void MAX7219Component::loop() {
     this->stepsleft_ = 0;
 
   // Return if there is no need to scroll or scroll is off
-  if (!this->scroll_ || (this->max_displaybuffer_[0].size() <= get_width_internal())) {
+  if (!this->scroll_ || (this->max_displaybuffer_[0].size() <= (size_t) get_width_internal())) {
     this->display();
     return;
   }
@@ -88,7 +88,7 @@ void MAX7219Component::loop() {
 
   // Dwell time at end of string in case of stop at end
   if (this->scroll_mode_ == ScrollMode::STOP) {
-    if (this->stepsleft_ >= this->max_displaybuffer_[0].size() - get_width_internal() + 1) {
+    if (this->stepsleft_ >= this->max_displaybuffer_[0].size() - (size_t) get_width_internal() + 1) {
       if (now - this->last_scroll_ >= this->scroll_dwell_) {
         this->stepsleft_ = 0;
         this->last_scroll_ = now;
@@ -155,7 +155,7 @@ int MAX7219Component::get_height_internal() {
 int MAX7219Component::get_width_internal() { return this->num_chips_ / this->num_chip_lines_ * 8; }
 
 void HOT MAX7219Component::draw_absolute_pixel_internal(int x, int y, Color color) {
-  if (x + 1 > this->max_displaybuffer_[0].size()) {  // Extend the display buffer in case required
+  if (x + 1 > (int) this->max_displaybuffer_[0].size()) {  // Extend the display buffer in case required
     for (int chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
       this->max_displaybuffer_[chip_line].resize(x + 1, this->bckgrnd_);
     }

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -35,7 +35,6 @@ void MCP23S08::dump_config() {
 }
 
 bool MCP23S08::read_reg(uint8_t reg, uint8_t *value) {
-  uint8_t data;
   this->enable();
   this->transfer_byte(this->device_opcode_ | 1);
   this->transfer_byte(reg);

--- a/esphome/components/mcp2515/mcp2515.cpp
+++ b/esphome/components/mcp2515/mcp2515.cpp
@@ -127,9 +127,6 @@ canbus::Error MCP2515::set_mode_(const CanctrlReqopMode mode) {
 }
 
 canbus::Error MCP2515::set_clk_out_(const CanClkOut divisor) {
-  canbus::Error res;
-  uint8_t cfg3;
-
   if (divisor == CLKOUT_DISABLE) {
     /* Turn off CLKEN */
     modify_register_(MCP_CANCTRL, CANCTRL_CLKEN, 0x00);

--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.cpp
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.cpp
@@ -13,8 +13,6 @@ void ModbusBinarySensor::parse_and_publish(const std::vector<uint8_t> &data) {
 
   switch (this->register_type) {
     case ModbusRegisterType::DISCRETE_INPUT:
-      value = coil_from_vector(this->offset, data);
-      break;
     case ModbusRegisterType::COIL:
       // offset for coil is the actual number of the coil not the byte offset
       value = coil_from_vector(this->offset, data);

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -219,7 +219,7 @@ template<typename N> N mask_and_shift_by_rightbit(N data, uint32_t mask) {
   if (result == 0) {
     return result;
   }
-  for (int pos = 0; pos < sizeof(N) << 3; pos++) {
+  for (size_t pos = 0; pos < sizeof(N) << 3; pos++) {
     if ((mask & (1 << pos)) != 0)
       return result >> pos;
   }

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -102,8 +102,6 @@ inline ModbusFunctionCode modbus_register_write_function(ModbusRegisterType reg_
       return ModbusFunctionCode::READ_WRITE_MULTIPLE_REGISTERS;
       break;
     case ModbusRegisterType::READ:
-      return ModbusFunctionCode::CUSTOM;
-      break;
     default:
       return ModbusFunctionCode::CUSTOM;
       break;

--- a/esphome/components/modbus_controller/number/modbus_number.cpp
+++ b/esphome/components/modbus_controller/number/modbus_number.cpp
@@ -8,11 +8,6 @@ namespace modbus_controller {
 static const char *const TAG = "modbus.number";
 
 void ModbusNumber::parse_and_publish(const std::vector<uint8_t> &data) {
-  union {
-    float float_value;
-    uint32_t raw;
-  } raw_to_float;
-
   float result = payload_to_float(data, *this);
 
   // Is there a lambda registered
@@ -31,13 +26,7 @@ void ModbusNumber::parse_and_publish(const std::vector<uint8_t> &data) {
 }
 
 void ModbusNumber::control(float value) {
-  union {
-    float float_value;
-    uint32_t raw;
-  } raw_to_float;
-
   std::vector<uint16_t> data;
-  auto original_value = value;
   // Is there are lambda configured?
   if (this->write_transform_func_.has_value()) {
     // data is passed by reference

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -13,11 +13,6 @@ void ModbusOutput::setup() {}
  *
  */
 void ModbusOutput::write_state(float value) {
-  union {
-    float float_value;
-    uint32_t raw;
-  } raw_to_float;
-
   std::vector<uint16_t> data;
   auto original_value = value;
   // Is there are lambda configured?

--- a/esphome/components/modbus_controller/sensor/modbus_sensor.cpp
+++ b/esphome/components/modbus_controller/sensor/modbus_sensor.cpp
@@ -10,11 +10,6 @@ static const char *const TAG = "modbus_controller.sensor";
 void ModbusSensor::dump_config() { LOG_SENSOR(TAG, "Modbus Controller Sensor", this); }
 
 void ModbusSensor::parse_and_publish(const std::vector<uint8_t> &data) {
-  union {
-    float float_value;
-    uint32_t raw;
-  } raw_to_float;
-
   float result = payload_to_float(data, *this);
 
   // Is there a lambda registered

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -64,7 +64,7 @@ bool Nextion::check_connect_() {
   if (response.empty() || response.find("comok") == std::string::npos) {
 #ifdef NEXTION_PROTOCOL_LOG
     ESP_LOGN(TAG, "Bad connect request %s", response.c_str());
-    for (int i = 0; i < response.length(); i++) {
+    for (size_t i = 0; i < response.length(); i++) {
       ESP_LOGN(TAG, "response %s %d %d %c", response.c_str(), i, response[i], response[i]);
     }
 #endif
@@ -563,11 +563,10 @@ void Nextion::process_nextion_commands_() {
       // FF FF FF - End
       case 0x90: {  // Switched component
         std::string variable_name;
-        uint8_t index = 0;
 
         // Get variable name
-        index = to_process.find('\0');
-        if (static_cast<char>(index) == std::string::npos || (to_process_length - index - 1) < 1) {
+        auto index = to_process.find('\0');
+        if (index == std::string::npos || (to_process_length - index - 1) < 1) {
           ESP_LOGE(TAG, "Bad switch component data received for 0x90 event!");
           ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
@@ -591,10 +590,9 @@ void Nextion::process_nextion_commands_() {
       // FF FF FF - End
       case 0x91: {  // Sensor component
         std::string variable_name;
-        uint8_t index = 0;
 
-        index = to_process.find('\0');
-        if (static_cast<char>(index) == std::string::npos || (to_process_length - index - 1) != 4) {
+        auto index = to_process.find('\0');
+        if (index == std::string::npos || (to_process_length - index - 1) != 4) {
           ESP_LOGE(TAG, "Bad sensor component data received for 0x91 event!");
           ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
@@ -626,11 +624,10 @@ void Nextion::process_nextion_commands_() {
       case 0x92: {  // Text Sensor Component
         std::string variable_name;
         std::string text_value;
-        uint8_t index = 0;
 
         // Get variable name
-        index = to_process.find('\0');
-        if (static_cast<char>(index) == std::string::npos || (to_process_length - index - 1) < 1) {
+        auto index = to_process.find('\0');
+        if (index == std::string::npos || (to_process_length - index - 1) < 1) {
           ESP_LOGE(TAG, "Bad text sensor component data received for 0x92 event!");
           ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
@@ -660,11 +657,10 @@ void Nextion::process_nextion_commands_() {
       // FF FF FF - End
       case 0x93: {  // Binary Sensor component
         std::string variable_name;
-        uint8_t index = 0;
 
         // Get variable name
-        index = to_process.find('\0');
-        if (static_cast<char>(index) == std::string::npos || (to_process_length - index - 1) < 1) {
+        auto index = to_process.find('\0');
+        if (index == std::string::npos || (to_process_length - index - 1) < 1) {
           ESP_LOGE(TAG, "Bad binary sensor component data received for 0x92 event!");
           ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
@@ -736,7 +732,7 @@ void Nextion::process_nextion_commands_() {
   uint32_t ms = millis();
 
   if (!this->nextion_queue_.empty() && this->nextion_queue_.front()->queue_time + this->max_q_age_ms_ < ms) {
-    for (int i = 0; i < this->nextion_queue_.size(); i++) {
+    for (size_t i = 0; i < this->nextion_queue_.size(); i++) {
       NextionComponentBase *component = this->nextion_queue_[i]->component;
       if (this->nextion_queue_[i]->queue_time + this->max_q_age_ms_ < ms) {
         if (this->nextion_queue_[i]->queue_time == 0)

--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -95,7 +95,7 @@ int Nextion::upload_by_chunks_(HTTPClient *http, int range_start) {
   }
   http->end();
   ESP_LOGN(TAG, "this->content_length_ %d sent %d", this->content_length_, sent);
-  for (uint32_t i = 0; i < range; i += 4096) {
+  for (int i = 0; i < range; i += 4096) {
     this->write_array(&this->transfer_buffer_[i], 4096);
     this->content_length_ -= 4096;
     ESP_LOGN(TAG, "this->content_length_ %d range %d range_end %d range_start %d", this->content_length_, range,
@@ -238,7 +238,7 @@ void Nextion::upload_tft() {
   // The Nextion display will, if it's ready to accept data, send a 0x05 byte.
   ESP_LOGD(TAG, "Upgrade response is %s %zu", response.c_str(), response.length());
 
-  for (int i = 0; i < response.length(); i++) {
+  for (size_t i = 0; i < response.length(); i++) {
     ESP_LOGD(TAG, "Available %d : 0x%02X", i, response[i]);
   }
 

--- a/esphome/components/nextion/sensor/nextion_sensor.cpp
+++ b/esphome/components/nextion/sensor/nextion_sensor.cpp
@@ -24,7 +24,7 @@ void NextionSensor::add_to_wave_buffer(float state) {
 
   wave_buffer_.push_back(wave_state);
 
-  if (this->wave_buffer_.size() > this->wave_max_length_) {
+  if (this->wave_buffer_.size() > (size_t) this->wave_max_length_) {
     this->wave_buffer_.erase(this->wave_buffer_.begin());
   }
 }

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -93,7 +93,7 @@ bool NdefMessage::add_uri_record(const std::string &uri) { return this->add_reco
 std::vector<uint8_t> NdefMessage::encode() {
   std::vector<uint8_t> data;
 
-  for (uint8_t i = 0; i < this->records_.size(); i++) {
+  for (size_t i = 0; i < this->records_.size(); i++) {
     auto encoded_record = this->records_[i]->encode(i == 0, (i + 1) == this->records_.size());
     data.insert(data.end(), encoded_record.begin(), encoded_record.end());
   }

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "nfc";
 std::string format_uid(std::vector<uint8_t> &uid) {
   char buf[(uid.size() * 2) + uid.size() - 1];
   int offset = 0;
-  for (uint8_t i = 0; i < uid.size(); i++) {
+  for (size_t i = 0; i < uid.size(); i++) {
     const char *format = "%02X";
     if (i + 1 < uid.size())
       format = "%02X-";
@@ -22,7 +22,7 @@ std::string format_uid(std::vector<uint8_t> &uid) {
 std::string format_bytes(std::vector<uint8_t> &bytes) {
   char buf[(bytes.size() * 2) + bytes.size() - 1];
   int offset = 0;
-  for (uint8_t i = 0; i < bytes.size(); i++) {
+  for (size_t i = 0; i < bytes.size(); i++) {
     const char *format = "%02X";
     if (i + 1 < bytes.size())
       format = "%02X ";

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -141,14 +141,14 @@ void OTAComponent::handle_() {
 
   if (!this->readall_(buf, 5)) {
     ESP_LOGW(TAG, "Reading magic bytes failed!");
-    goto error;
+    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
   }
   // 0x6C, 0x26, 0xF7, 0x5C, 0x45
   if (buf[0] != 0x6C || buf[1] != 0x26 || buf[2] != 0xF7 || buf[3] != 0x5C || buf[4] != 0x45) {
     ESP_LOGW(TAG, "Magic bytes do not match! 0x%02X-0x%02X-0x%02X-0x%02X-0x%02X", buf[0], buf[1], buf[2], buf[3],
              buf[4]);
     error_code = OTA_RESPONSE_ERROR_MAGIC;
-    goto error;
+    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
   }
 
   // Send OK and version - 2 bytes
@@ -161,7 +161,7 @@ void OTAComponent::handle_() {
   // Read features - 1 byte
   if (!this->readall_(buf, 1)) {
     ESP_LOGW(TAG, "Reading features failed!");
-    goto error;
+    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
   }
   ota_features = buf[0];  // NOLINT
   ESP_LOGV(TAG, "OTA features is 0x%02X", ota_features);
@@ -189,7 +189,7 @@ void OTAComponent::handle_() {
     // Send nonce, 32 bytes hex MD5
     if (!this->writeall_(reinterpret_cast<uint8_t *>(sbuf), 32)) {
       ESP_LOGW(TAG, "Auth: Writing nonce failed!");
-      goto error;
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
 
     // prepare challenge
@@ -201,7 +201,7 @@ void OTAComponent::handle_() {
     // Receive cnonce, 32 bytes hex MD5
     if (!this->readall_(buf, 32)) {
       ESP_LOGW(TAG, "Auth: Reading cnonce failed!");
-      goto error;
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
     sbuf[32] = '\0';
     ESP_LOGV(TAG, "Auth: CNonce is %s", sbuf);
@@ -216,7 +216,7 @@ void OTAComponent::handle_() {
     // Receive result, 32 bytes hex MD5
     if (!this->readall_(buf + 64, 32)) {
       ESP_LOGW(TAG, "Auth: Reading response failed!");
-      goto error;
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
     sbuf[64 + 32] = '\0';
     ESP_LOGV(TAG, "Auth: Response is %s", sbuf + 64);
@@ -228,7 +228,7 @@ void OTAComponent::handle_() {
     if (!matches) {
       ESP_LOGW(TAG, "Auth failed! Passwords do not match!");
       error_code = OTA_RESPONSE_ERROR_AUTH_INVALID;
-      goto error;
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
   }
 #endif  // USE_OTA_PASSWORD
@@ -240,7 +240,7 @@ void OTAComponent::handle_() {
   // Read size, 4 bytes MSB first
   if (!this->readall_(buf, 4)) {
     ESP_LOGW(TAG, "Reading size failed!");
-    goto error;
+    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
   }
   ota_size = 0;
   for (uint8_t i = 0; i < 4; i++) {
@@ -251,7 +251,7 @@ void OTAComponent::handle_() {
 
   error_code = backend->begin(ota_size);
   if (error_code != OTA_RESPONSE_OK)
-    goto error;
+    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
   update_started = true;
 
   // Acknowledge prepare OK - 1 byte
@@ -261,7 +261,7 @@ void OTAComponent::handle_() {
   // Read binary MD5, 32 bytes
   if (!this->readall_(buf, 32)) {
     ESP_LOGW(TAG, "Reading binary MD5 checksum failed!");
-    goto error;
+    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
   }
   sbuf[32] = '\0';
   ESP_LOGV(TAG, "Update: Binary MD5 is %s", sbuf);
@@ -281,19 +281,19 @@ void OTAComponent::handle_() {
         continue;
       }
       ESP_LOGW(TAG, "Error receiving data for update, errno: %d", errno);
-      goto error;
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     } else if (read == 0) {
       // $ man recv
       // "When  a  stream socket peer has performed an orderly shutdown, the return value will
       // be 0 (the traditional "end-of-file" return)."
       ESP_LOGW(TAG, "Remote end closed connection");
-      goto error;
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
 
     error_code = backend->write(buf, read);
     if (error_code != OTA_RESPONSE_OK) {
       ESP_LOGW(TAG, "Error writing binary data to flash!");
-      goto error;
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
     total += read;
 
@@ -317,7 +317,7 @@ void OTAComponent::handle_() {
   error_code = backend->end();
   if (error_code != OTA_RESPONSE_OK) {
     ESP_LOGW(TAG, "Error ending OTA!");
-    goto error;
+    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
   }
 
   // Acknowledge Update end OK - 1 byte

--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -330,7 +330,7 @@ bool PIDAutotuner::OscillationAmplitudeDetector::has_enough_data() const {
 float PIDAutotuner::OscillationAmplitudeDetector::get_mean_oscillation_amplitude() const {
   float total_amplitudes = 0;
   size_t total_amplitudes_n = 0;
-  for (int i = 1; i < std::min(phase_mins.size(), phase_maxs.size()) - 1; i++) {
+  for (size_t i = 1; i < std::min(phase_mins.size(), phase_maxs.size()) - 1; i++) {
     total_amplitudes += std::abs(phase_maxs[i] - phase_mins[i + 1]);
     total_amplitudes_n++;
   }

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -479,7 +479,7 @@ void Pipsolar::loop() {
         ESP_LOGD(TAG, "Decode QFLAG");
         // result like:"(EbkuvxzDajy"
         // get through all char: ignore first "(" Enable flag on 'E', Disable on 'D') else set the corresponding value
-        for (int i = 1; i < strlen(tmp); i++) {
+        for (size_t i = 1; i < strlen(tmp); i++) {
           switch (tmp[i]) {
             case 'E':
               enabled = true;
@@ -528,7 +528,7 @@ void Pipsolar::loop() {
         this->value_warnings_present_ = false;
         this->value_faults_present_ = true;
 
-        for (int i = 1; i < strlen(tmp); i++) {
+        for (size_t i = 1; i < strlen(tmp); i++) {
           enabled = tmp[i] == '1';
           switch (i) {
             case 1:

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -413,8 +413,6 @@ void Pipsolar::loop() {
         this->state_ = STATE_IDLE;
         break;
       case POLLING_QT:
-        this->state_ = STATE_IDLE;
-        break;
       case POLLING_QMN:
         this->state_ = STATE_IDLE;
         break;

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -145,7 +145,7 @@ void PN532::loop() {
 
   if (nfcid.size() == this->current_uid_.size()) {
     bool same_uid = false;
-    for (uint8_t i = 0; i < nfcid.size(); i++)
+    for (size_t i = 0; i < nfcid.size(); i++)
       same_uid |= nfcid[i] == this->current_uid_[i];
     if (same_uid)
       return;
@@ -367,7 +367,7 @@ bool PN532BinarySensor::process(std::vector<uint8_t> &data) {
   if (data.size() != this->uid_.size())
     return false;
 
-  for (uint8_t i = 0; i < data.size(); i++) {
+  for (size_t i = 0; i < data.size(); i++) {
     if (data[i] != this->uid_[i])
       return false;
   }

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -35,7 +35,7 @@ void PulseMeterSensor::loop() {
       this->publish_state(0);
     } else {
       // Calculate pulses/min from the pulse width in ms
-      this->publish_state((60.0 * 1000.0) / pulse_width_ms);
+      this->publish_state((60.0f * 1000.0f) / pulse_width_ms);
     }
   }
 

--- a/esphome/components/rc522/rc522.cpp
+++ b/esphome/components/rc522/rc522.cpp
@@ -28,7 +28,7 @@ std::string format_buffer(uint8_t *b, uint8_t len) {
 std::string format_uid(std::vector<uint8_t> &uid) {
   char buf[32];
   int offset = 0;
-  for (uint8_t i = 0; i < uid.size(); i++) {
+  for (size_t i = 0; i < uid.size(); i++) {
     const char *format = "%02X";
     if (i + 1 < uid.size())
       format = "%02X-";

--- a/esphome/components/rc522/rc522.cpp
+++ b/esphome/components/rc522/rc522.cpp
@@ -479,7 +479,7 @@ bool RC522BinarySensor::process(std::vector<uint8_t> &data) {
   if (data.size() != this->uid_.size())
     result = false;
   else {
-    for (uint8_t i = 0; i < data.size(); i++) {
+    for (size_t i = 0; i < data.size(); i++) {
       if (data[i] != this->uid_[i]) {
         result = false;
         break;

--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -113,7 +113,7 @@ void ProntoProtocol::send_pronto_(RemoteTransmitData *dst, const std::string &st
   const char *p = str.c_str();
   char *endptr[1];
 
-  for (uint16_t i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     uint16_t x = strtol(p, endptr, 16);
     if (x == 0 && i >= NUMBERS_IN_PREAMBLE) {
       // Alignment error?, bail immediately (often right result).

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -33,7 +33,7 @@ void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {
   uint32_t buffer_offset = 0;
   buffer_offset += sprintf(buffer, "Sending times=%u wait=%ums: ", send_times, send_wait);
 
-  for (int32_t i = 0; i < vec.size(); i++) {
+  for (size_t i = 0; i < vec.size(); i++) {
     const int32_t value = vec[i];
     const uint32_t remaining_length = sizeof(buffer) - buffer_offset;
     int written;

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -113,7 +113,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     this->rmt_temp_.push_back(rmt_item);
   }
 
-  for (uint16_t i = 0; i < send_times; i++) {
+  for (uint32_t i = 0; i < send_times; i++) {
     esp_err_t error = rmt_write_items(this->channel_, this->rmt_temp_.data(), this->rmt_temp_.size(), true);
     if (error != ESP_OK) {
       ESP_LOGW(TAG, "rmt_write_items failed: %s", esp_err_to_name(error));

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -159,7 +159,7 @@ void Rtttl::loop() {
   // Now play the note
   if (note) {
     auto note_index = (scale - 4) * 12 + note;
-    if (note_index < 0 || note_index >= sizeof(NOTES)) {
+    if (note_index < 0 || note_index >= (int) sizeof(NOTES)) {
       ESP_LOGE(TAG, "Note out of valid range");
       return;
     }

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -147,8 +147,8 @@ void SGP30Component::read_iaq_baseline_() {
         // much
         if (this->store_baseline_ &&
             (this->seconds_since_last_store_ > SHORTEST_BASELINE_STORE_INTERVAL ||
-             abs(this->baselines_storage_.eco2 - this->eco2_baseline_) > MAXIMUM_STORAGE_DIFF ||
-             abs(this->baselines_storage_.tvoc - this->tvoc_baseline_) > MAXIMUM_STORAGE_DIFF)) {
+             (uint32_t) abs(this->baselines_storage_.eco2 - this->eco2_baseline_) > MAXIMUM_STORAGE_DIFF ||
+             (uint32_t) abs(this->baselines_storage_.tvoc - this->tvoc_baseline_) > MAXIMUM_STORAGE_DIFF)) {
           this->seconds_since_last_store_ = 0;
           this->baselines_storage_.eco2 = this->eco2_baseline_;
           this->baselines_storage_.tvoc = this->tvoc_baseline_;

--- a/esphome/components/sgp40/sensirion_voc_algorithm.cpp
+++ b/esphome/components/sgp40/sensirion_voc_algorithm.cpp
@@ -149,7 +149,7 @@ static fix16_t fix16_div(fix16_t a, fix16_t b) {
   /* Figure out the sign of result */
   if ((a ^ b) & 0x80000000) {
 #ifndef FIXMATH_NO_OVERFLOW
-    if (result == FIX16_MINIMUM)
+    if (result == FIX16_MINIMUM)  // NOLINT(clang-diagnostic-sign-compare)
       return FIX16_OVERFLOW;
 #endif
 

--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -144,8 +144,8 @@ int32_t SGP40Component::measure_voc_index_() {
   // much
   if (this->store_baseline_ && this->seconds_since_last_store_ > SHORTEST_BASELINE_STORE_INTERVAL) {
     voc_algorithm_get_states(&voc_algorithm_params_, &this->state0_, &this->state1_);
-    if (abs(this->baselines_storage_.state0 - this->state0_) > MAXIMUM_STORAGE_DIFF ||
-        abs(this->baselines_storage_.state1 - this->state1_) > MAXIMUM_STORAGE_DIFF) {
+    if ((uint32_t) abs(this->baselines_storage_.state0 - this->state0_) > MAXIMUM_STORAGE_DIFF ||
+        (uint32_t) abs(this->baselines_storage_.state1 - this->state1_) > MAXIMUM_STORAGE_DIFF) {
       this->seconds_since_last_store_ = 0;
       this->baselines_storage_.state0 = this->state0_;
       this->baselines_storage_.state1 = this->state1_;

--- a/esphome/components/sgp40/sgp40.h
+++ b/esphome/components/sgp40/sgp40.h
@@ -66,7 +66,7 @@ class SGP40Component : public PollingComponent, public sensor::Sensor, public i2
   uint8_t generate_crc_(const uint8_t *data, uint8_t datalen);
   uint16_t measure_raw_();
   ESPPreferenceObject pref_;
-  int32_t seconds_since_last_store_;
+  uint32_t seconds_since_last_store_;
   SGP40Baselines baselines_storage_;
   VocAlgorithmParams voc_algorithm_params_;
   bool self_test_complete_;

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -50,10 +50,10 @@ void SM300D2Sensor::update() {
   const uint16_t pm_2_5 = (response[8] * 256) + response[9];
   const uint16_t pm_10_0 = (response[10] * 256) + response[11];
   // A negative value is indicated by adding 0x80 (128) to the temperature value
-  const float temperature = ((response[12] + (response[13] * 0.1)) > 128)
-                                ? (((response[12] + (response[13] * 0.1)) - 128) * -1)
-                                : response[12] + (response[13] * 0.1);
-  const float humidity = response[14] + (response[15] * 0.1);
+  const float temperature = ((response[12] + (response[13] * 0.1f)) > 128)
+                                ? (((response[12] + (response[13] * 0.1f)) - 128) * -1)
+                                : response[12] + (response[13] * 0.1f);
+  const float humidity = response[14] + (response[15] * 0.1f);
 
   ESP_LOGD(TAG, "Received CO₂: %u ppm", co2);
   if (this->co2_sensor_ != nullptr)

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -383,7 +383,7 @@ class LWIPRawImpl : public Socket {
         return err;
       }
       ret += err;
-      if (err != iov[i].iov_len)
+      if ((size_t) err != iov[i].iov_len)
         break;
     }
     return ret;
@@ -462,7 +462,7 @@ class LWIPRawImpl : public Socket {
         return err;
       }
       written += err;
-      if (err != iov[i].iov_len)
+      if ((size_t) err != iov[i].iov_len)
         break;
     }
     if (written == 0)

--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -55,13 +55,9 @@ void SPIComponent::setup() {
     }
   }
 #ifdef USE_ESP8266
-  if (clk_pin == 6 && miso_pin == 7 && mosi_pin == 8) {
-    // pass
-  } else if (clk_pin == 14 && (!has_miso || miso_pin == 12) && (!has_mosi || mosi_pin == 13)) {
-    // pass
-  } else {
+  if (!(clk_pin == 6 && miso_pin == 7 && mosi_pin == 8) &&
+      !(clk_pin == 14 && (!has_miso || miso_pin == 12) && (!has_mosi || mosi_pin == 13)))
     use_hw_spi = false;
-  }
 
   if (use_hw_spi) {
     this->hw_spi_ = &SPI;

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -292,7 +292,7 @@ const char *SSD1306::model_str_() {
     case SSD1305_MODEL_128_32:
       return "SSD1305 128x32";
     case SSD1305_MODEL_128_64:
-      return "SSD1305 128x32";
+      return "SSD1305 128x64";
     default:
       return "Unknown";
   }

--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
@@ -40,12 +40,12 @@ void I2CSSD1306::command(uint8_t value) { this->write_byte(0x00, value); }
 void HOT I2CSSD1306::write_display_data() {
   if (this->is_sh1106_()) {
     uint32_t i = 0;
-    for (uint8_t page = 0; page < this->get_height_internal() / 8; page++) {
+    for (uint8_t page = 0; page < (uint8_t) this->get_height_internal() / 8; page++) {
       this->command(0xB0 + page);  // row
       this->command(0x02);         // lower column
       this->command(0x10);         // higher column
 
-      for (uint8_t x = 0; x < this->get_width_internal() / 16; x++) {
+      for (uint8_t x = 0; x < (uint8_t) this->get_width_internal() / 16; x++) {
         uint8_t data[16];
         for (uint8_t &j : data)
           j = this->buffer_[i++];

--- a/esphome/components/ssd1306_spi/ssd1306_spi.cpp
+++ b/esphome/components/ssd1306_spi/ssd1306_spi.cpp
@@ -37,12 +37,12 @@ void SPISSD1306::command(uint8_t value) {
 }
 void HOT SPISSD1306::write_display_data() {
   if (this->is_sh1106_()) {
-    for (uint8_t y = 0; y < this->get_height_internal() / 8; y++) {
+    for (uint8_t y = 0; y < (uint8_t) this->get_height_internal() / 8; y++) {
       this->command(0xB0 + y);
       this->command(0x02);
       this->command(0x10);
       this->dc_pin_->digital_write(true);
-      for (uint8_t x = 0; x < this->get_width_internal(); x++) {
+      for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x++) {
         this->enable();
         this->write_byte(this->buffer_[x + y * this->get_width_internal()]);
         this->disable();

--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -446,7 +446,7 @@ void HOT ST7735::write_display_data_() {
   this->dc_pin_->digital_write(true);
 
   if (this->eightbitcolor_) {
-    for (int line = 0; line < this->get_buffer_length(); line = line + this->get_width_internal()) {
+    for (size_t line = 0; line < this->get_buffer_length(); line = line + this->get_width_internal()) {
       for (int index = 0; index < this->get_width_internal(); ++index) {
         auto color332 = display::ColorUtil::to_color(this->buffer_[index + line], display::ColorOrder::COLOR_ORDER_RGB,
                                                      display::ColorBitness::COLOR_BITNESS_332, true);

--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -275,7 +275,7 @@ void ST7735::setup() {
 
   uint8_t data = 0;
   if (this->model_ != INITR_HALLOWING) {
-    uint8_t data = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY;
+    data = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY;
   }
   if (this->usebgr_) {
     data = data | ST7735_MADCTL_BGR;

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -74,7 +74,7 @@ void ST7920::goto_xy_(uint16_t x, uint16_t y) {
 
 void HOT ST7920::write_display_data() {
   uint8_t i, j, b;
-  for (j = 0; j < this->get_height_internal() / 2; j++) {
+  for (j = 0; j < (uint8_t)(this->get_height_internal() / 2); j++) {
     this->goto_xy_(0, j);
     this->enable();
     for (i = 0; i < 16; i++) {  // 16 bytes from line #0+

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -118,7 +118,7 @@ void TeleInfo::loop() {
        *
        */
       while ((buf_finger = static_cast<char *>(memchr(buf_finger, (int) 0xa, buf_index_ - 1))) &&
-             ((buf_finger - buf_) < buf_index_)) {
+             ((buf_finger - buf_) < buf_index_)) {  // NOLINT(clang-diagnostic-sign-compare)
         /*
          * Make sure timesamp is nullified between each tag as some tags don't
          * have a timestamp

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -64,7 +64,7 @@ optional<std::string> PrependFilter::new_value(std::string value) { return this-
 // Substitute
 optional<std::string> SubstituteFilter::new_value(std::string value) {
   std::size_t pos;
-  for (int i = 0; i < this->from_strings_.size(); i++)
+  for (size_t i = 0; i < this->from_strings_.size(); i++)
     while ((pos = value.find(this->from_strings_[i])) != std::string::npos)
       value.replace(pos, this->from_strings_[i].size(), this->to_strings_[i]);
   return value;

--- a/esphome/components/tof10120/tof10120_sensor.cpp
+++ b/esphome/components/tof10120/tof10120_sensor.cpp
@@ -50,7 +50,7 @@ void TOF10120Sensor::update() {
     ESP_LOGW(TAG, "Distance measurement out of range");
     this->publish_state(NAN);
   } else {
-    this->publish_state(distance_mm / 1000.0);
+    this->publish_state(distance_mm / 1000.0f);
   }
   this->status_clear_warning();
 }

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -580,13 +580,13 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
         temperature_code =
             (message[4] >> 4) | (message[14] & RAC_PT1411HWRU_FLAG_FRAC) | (message[15] & RAC_PT1411HWRU_FLAG_NEG);
         if (message[15] & RAC_PT1411HWRU_FLAG_FAH) {
-          for (uint8_t i = 0; i < RAC_PT1411HWRU_TEMPERATURE_F.size(); i++) {
+          for (size_t i = 0; i < RAC_PT1411HWRU_TEMPERATURE_F.size(); i++) {
             if (RAC_PT1411HWRU_TEMPERATURE_F[i] == temperature_code) {
               this->target_temperature = static_cast<float>((i + TOSHIBA_RAC_PT1411HWRU_TEMP_F_MIN - 32) * 5) / 9;
             }
           }
         } else {
-          for (uint8_t i = 0; i < RAC_PT1411HWRU_TEMPERATURE_C.size(); i++) {
+          for (size_t i = 0; i < RAC_PT1411HWRU_TEMPERATURE_C.size(); i++) {
             if (RAC_PT1411HWRU_TEMPERATURE_C[i] == temperature_code) {
               this->target_temperature = i + TOSHIBA_RAC_PT1411HWRU_TEMP_C_MIN;
             }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -339,8 +339,6 @@ void Tuya::send_raw_command_(TuyaCommand command) {
       this->expected_response_ = TuyaCommandType::CONF_QUERY;
       break;
     case TuyaCommandType::DATAPOINT_DELIVER:
-      this->expected_response_ = TuyaCommandType::DATAPOINT_REPORT;
-      break;
     case TuyaCommandType::DATAPOINT_QUERY:
       this->expected_response_ = TuyaCommandType::DATAPOINT_REPORT;
       break;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -143,7 +143,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
     case TuyaCommandType::PRODUCT_QUERY: {
       // check it is a valid string made up of printable characters
       bool valid = true;
-      for (int i = 0; i < len; i++) {
+      for (size_t i = 0; i < len; i++) {
         if (!std::isprint(buffer[i])) {
           valid = false;
           break;

--- a/esphome/components/tx20/tx20.cpp
+++ b/esphome/components/tx20/tx20.cpp
@@ -113,7 +113,7 @@ void Tx20Component::decode_and_publish_() {
   if (tx20_sa == 4) {
     if (chk == tx20_sd) {
       if (tx20_sf == tx20_sc) {
-        tx20_wind_speed_kmh = float(tx20_sc) * 0.36;
+        tx20_wind_speed_kmh = float(tx20_sc) * 0.36f;
         ESP_LOGV(TAG, "WindSpeed %f", tx20_wind_speed_kmh);
         if (this->wind_speed_sensor_ != nullptr)
           this->wind_speed_sensor_->publish_state(tx20_wind_speed_kmh);

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -209,9 +209,7 @@ void IRAM_ATTR ESP8266SoftwareSerial::gpio_intr(ESP8266SoftwareSerial *arg) {
 
   /* If parity is enabled, just read it and ignore it. */
   /* TODO: Should we check parity? Or is it too slow for nothing added..*/
-  if (arg->parity_ == UART_CONFIG_PARITY_EVEN)
-    arg->read_bit_(&wait, start);
-  else if (arg->parity_ == UART_CONFIG_PARITY_ODD)
+  if (arg->parity_ == UART_CONFIG_PARITY_EVEN || arg->parity_ == UART_CONFIG_PARITY_ODD)
     arg->read_bit_(&wait, start);
 
   // Stop bit

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -425,11 +425,10 @@ void WaveshareEPaperTypeA::set_full_update_every(uint32_t full_update_every) {
   this->full_update_every_ = full_update_every;
 }
 
-int WaveshareEPaperTypeA::idle_timeout_() {
+uint32_t WaveshareEPaperTypeA::idle_timeout_() {
   switch (this->model_) {
     case TTGO_EPAPER_2_13_IN_B1:
       return 2500;
-      break;
     default:
       return WaveshareEPaper::idle_timeout_();
   }
@@ -638,7 +637,7 @@ void HOT WaveshareEPaper2P9InB::display() {
   this->command(0x13);
   delay(2);
   this->start_data_();
-  for (int i = 0; i < this->get_buffer_length_(); i++)
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
     this->write_byte(0x00);
   this->end_data_();
   delay(2);
@@ -817,7 +816,7 @@ void HOT WaveshareEPaper4P2InBV2::display() {
   // COMMAND DATA START TRANSMISSION 2 (RED data)
   this->command(0x13);
   this->start_data_();
-  for (int i = 0; i < this->get_buffer_length_(); i++)
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
     this->write_byte(0xFF);
   this->end_data_();
   delay(2);
@@ -1285,7 +1284,7 @@ void HOT WaveshareEPaper2P13InDKE::display() {
 
 int WaveshareEPaper2P13InDKE::get_width_internal() { return 128; }
 int WaveshareEPaper2P13InDKE::get_height_internal() { return 250; }
-int WaveshareEPaper2P13InDKE::idle_timeout_() { return 5000; }
+uint32_t WaveshareEPaper2P13InDKE::idle_timeout_() { return 5000; }
 void WaveshareEPaper2P13InDKE::dump_config() {
   LOG_DISPLAY("", "Waveshare E-Paper", this);
   ESP_LOGCONFIG(TAG, "  Model: 2.13inDKE");

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -360,15 +360,18 @@ void HOT WaveshareEPaperTypeA::display() {
 
   // COMMAND DISPLAY UPDATE CONTROL 2
   this->command(0x22);
-  if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ == WAVESHARE_EPAPER_1_54_IN_V2) {
-    this->data(full_update ? 0xF7 : 0xFF);
-  } else if (this->model_ == TTGO_EPAPER_2_13_IN_B73) {
-    this->data(0xC7);
-  } else if (this->model_ == TTGO_EPAPER_2_13_IN_B74) {
-    // this->data(0xC7);
-    this->data(full_update ? 0xF7 : 0xFF);
-  } else {
-    this->data(0xC4);
+  switch (this->model_) {
+    case WAVESHARE_EPAPER_2_9_IN_V2:
+    case WAVESHARE_EPAPER_1_54_IN_V2:
+    case TTGO_EPAPER_2_13_IN_B74:
+      this->data(full_update ? 0xF7 : 0xFF);
+      break;
+    case TTGO_EPAPER_2_13_IN_B73:
+      this->data(0xC7);
+      break;
+    default:
+      this->data(0xC4);
+      break;
   }
 
   // COMMAND MASTER ACTIVATION
@@ -381,20 +384,14 @@ void HOT WaveshareEPaperTypeA::display() {
 int WaveshareEPaperTypeA::get_width_internal() {
   switch (this->model_) {
     case WAVESHARE_EPAPER_1_54_IN:
-      return 200;
     case WAVESHARE_EPAPER_1_54_IN_V2:
       return 200;
     case WAVESHARE_EPAPER_2_13_IN:
-      return 128;
     case TTGO_EPAPER_2_13_IN:
-      return 128;
     case TTGO_EPAPER_2_13_IN_B73:
     case TTGO_EPAPER_2_13_IN_B74:
-      return 128;
     case TTGO_EPAPER_2_13_IN_B1:
-      return 128;
     case WAVESHARE_EPAPER_2_9_IN:
-      return 128;
     case WAVESHARE_EPAPER_2_9_IN_V2:
       return 128;
   }
@@ -403,20 +400,15 @@ int WaveshareEPaperTypeA::get_width_internal() {
 int WaveshareEPaperTypeA::get_height_internal() {
   switch (this->model_) {
     case WAVESHARE_EPAPER_1_54_IN:
-      return 200;
     case WAVESHARE_EPAPER_1_54_IN_V2:
       return 200;
     case WAVESHARE_EPAPER_2_13_IN:
-      return 250;
     case TTGO_EPAPER_2_13_IN:
-      return 250;
     case TTGO_EPAPER_2_13_IN_B73:
     case TTGO_EPAPER_2_13_IN_B74:
-      return 250;
     case TTGO_EPAPER_2_13_IN_B1:
       return 250;
     case WAVESHARE_EPAPER_2_9_IN:
-      return 296;
     case WAVESHARE_EPAPER_2_9_IN_V2:
       return 296;
   }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -61,7 +61,7 @@ class WaveshareEPaper : public PollingComponent,
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *dc_pin_;
   GPIOPin *busy_pin_{nullptr};
-  virtual int idle_timeout_() { return 1000; }  // NOLINT(readability-identifier-naming)
+  virtual uint32_t idle_timeout_() { return 1000u; }  // NOLINT(readability-identifier-naming)
 };
 
 enum WaveshareEPaperTypeAModel {
@@ -110,7 +110,7 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   uint32_t full_update_every_{30};
   uint32_t at_update_{0};
   WaveshareEPaperTypeAModel model_;
-  int idle_timeout_() override;
+  uint32_t idle_timeout_() override;
 };
 
 enum WaveshareEPaperTypeBModel {
@@ -346,7 +346,7 @@ class WaveshareEPaper2P13InDKE : public WaveshareEPaper {
 
   int get_height_internal() override;
 
-  int idle_timeout_() override;
+  uint32_t idle_timeout_() override;
 
   uint32_t full_update_every_{30};
   uint32_t at_update_{0};

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -67,9 +67,9 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
   memset(&event, 0, sizeof(IDFWiFiEvent));
   event.event_base = event_base;
   event.event_id = event_id;
-  if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+  if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {  // NOLINT(bugprone-branch-clone)
     // no data
-  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_STOP) {
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_STOP) {  // NOLINT(bugprone-branch-clone)
     // no data
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_AUTHMODE_CHANGE) {
     memcpy(&event.data.sta_authmode_change, event_data, sizeof(wifi_event_sta_authmode_change_t));
@@ -79,13 +79,13 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
     memcpy(&event.data.sta_disconnected, event_data, sizeof(wifi_event_sta_disconnected_t));
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
     memcpy(&event.data.ip_got_ip, event_data, sizeof(ip_event_got_ip_t));
-  } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_LOST_IP) {
+  } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_LOST_IP) {  // NOLINT(bugprone-branch-clone)
     // no data
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_SCAN_DONE) {
     memcpy(&event.data.sta_scan_done, event_data, sizeof(wifi_event_sta_scan_done_t));
-  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_AP_START) {
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_AP_START) {  // NOLINT(bugprone-branch-clone)
     // no data
-  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_AP_STOP) {
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_AP_STOP) {  // NOLINT(bugprone-branch-clone)
     // no data
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_AP_PROBEREQRECVED) {
     memcpy(&event.data.ap_probe_req_rx, event_data, sizeof(wifi_event_ap_probe_req_rx_t));

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -171,10 +171,8 @@ optional<XiaomiParseResult> parse_xiaomi_header(const esp32_ble_tracker::Service
     result.type = XiaomiParseResult::TYPE_MUE4094RT;
     result.name = "MUE4094RT";
     result.raw_offset -= 6;
-  } else if ((raw[2] == 0x47) && (raw[3] == 0x03)) {  // ClearGrass-branded, round body, e-ink display
-    result.type = XiaomiParseResult::TYPE_CGG1;
-    result.name = "CGG1";
-  } else if ((raw[2] == 0x48) && (raw[3] == 0x0B)) {  // Qingping-branded, round body, e-ink display — with bindkeys
+  } else if ((raw[2] == 0x47 && raw[3] == 0x03) ||  // ClearGrass-branded, round body, e-ink display
+             (raw[2] == 0x48 && raw[3] == 0x0B)) {  // Qingping-branded, round body, e-ink display — with bindkeys
     result.type = XiaomiParseResult::TYPE_CGG1;
     result.name = "CGG1";
   } else if ((raw[2] == 0xbc) && (raw[3] == 0x03)) {  // VegTrug Grow Care Garden

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -94,7 +94,7 @@ void Application::loop() {
   }
   this->last_loop_ = now;
 
-  if (this->dump_config_at_ >= 0 && this->dump_config_at_ < this->components_.size()) {
+  if (this->dump_config_at_ < this->components_.size()) {
     if (this->dump_config_at_ == 0) {
       ESP_LOGI(TAG, "ESPHome version " ESPHOME_VERSION " compiled on %s", this->compilation_time_.c_str());
 #ifdef ESPHOME_PROJECT_NAME

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -309,7 +309,7 @@ class Application {
   bool name_add_mac_suffix_;
   uint32_t last_loop_{0};
   uint32_t loop_interval_{16};
-  int dump_config_at_{-1};
+  size_t dump_config_at_{SIZE_MAX};
   uint32_t app_state_{0};
 };
 

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -96,7 +96,7 @@ void Component::call() {
       // State loop: Call loop
       this->call_loop();
       break;
-    case COMPONENT_STATE_FAILED:
+    case COMPONENT_STATE_FAILED:  // NOLINT(bugprone-branch-clone)
       // State failed: Do nothing
       break;
     default:

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,7 @@ build_flags =
 ; This are the flags for clang-tidy.
 build_flags =
     -Wall
+    -Wextra
     -Wunreachable-code
     -Wfor-loop-analysis
     -Wshadow-field

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,6 @@ include_dir =
 [runtime]
 ; This are the flags as set by the runtime.
 build_flags =
-    -Wno-unused-variable
     -Wno-unused-but-set-variable
     -Wno-sign-compare
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ build_flags =
     -Wfor-loop-analysis
     -Wshadow-field
     -Wshadow-field-in-constructor
+    -Wshadow-uncaptured-local
 
 [common]
 lib_deps =

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -649,7 +649,7 @@ def build_message_type(desc):
             o += f" {dump[0]} "
         else:
             o += "\n"
-            o += f"  char buffer[64];\n"
+            o += f"  __attribute__((unused)) char buffer[64];\n"
             o += f'  out.append("{desc.name} {{\\n");\n'
             o += indent("\n".join(dump)) + "\n"
             o += f'  out.append("}}");\n'


### PR DESCRIPTION
# What does this implement/fix? 

Enable a bunch more clang-tidy checks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
