### PR TITLE
Always send all light state values in API

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -310,22 +310,15 @@ bool APIConnection::send_light_state(light::LightState *light) {
   resp.key = light->get_object_id_hash();
   resp.state = values.is_on();
   resp.color_mode = static_cast<enums::ColorMode>(color_mode);
-  if (color_mode & light::ColorCapability::BRIGHTNESS)
-    resp.brightness = values.get_brightness();
-  if (color_mode & light::ColorCapability::RGB) {
-    resp.color_brightness = values.get_color_brightness();
-    resp.red = values.get_red();
-    resp.green = values.get_green();
-    resp.blue = values.get_blue();
-  }
-  if (color_mode & light::ColorCapability::WHITE)
-    resp.white = values.get_white();
-  if (color_mode & light::ColorCapability::COLOR_TEMPERATURE)
-    resp.color_temperature = values.get_color_temperature();
-  if (color_mode & light::ColorCapability::COLD_WARM_WHITE) {
-    resp.cold_white = values.get_cold_white();
-    resp.warm_white = values.get_warm_white();
-  }
+  resp.brightness = values.get_brightness();
+  resp.color_brightness = values.get_color_brightness();
+  resp.red = values.get_red();
+  resp.green = values.get_green();
+  resp.blue = values.get_blue();
+  resp.white = values.get_white();
+  resp.color_temperature = values.get_color_temperature();
+  resp.cold_white = values.get_cold_white();
+  resp.warm_white = values.get_warm_white();
   if (light->supports_effects())
     resp.effect = light->get_effect_name();
   return this->send_light_state_response(resp);


### PR DESCRIPTION
# What does this implement/fix? 

Always send all light state values to API clients. I can't think of a reason why we'd leave out non-applicable values, and the checks were actually wrong -- we need to supply the color_temp to HA also for CWWW modes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2304

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
