### PR TITLE
Apply constant brightness mode only to color temperature setting

### DIFF
--- a/esphome/components/cwww/cwww_light_output.h
+++ b/esphome/components/cwww/cwww_light_output.h
@@ -17,6 +17,7 @@ class CWWWLightOutput : public light::LightOutput {
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::COLD_WARM_WHITE});
+    traits.set_constant_brightness(this->constant_brightness_);
     traits.set_min_mireds(this->cold_white_temperature_);
     traits.set_max_mireds(this->warm_white_temperature_);
     return traits;

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -173,22 +173,9 @@ class LightColorValues {
   /// Convert these light color values to an CWWW representation with the given parameters.
   void as_cwww(float *cold_white, float *warm_white, float gamma = 0, bool constant_brightness = false) const {
     if (this->color_mode_ & ColorCapability::COLD_WARM_WHITE) {
-      const float cw_level = gamma_correct(this->cold_white_, gamma);
-      const float ww_level = gamma_correct(this->warm_white_, gamma);
       const float white_level = gamma_correct(this->state_ * this->brightness_, gamma);
-      if (!constant_brightness) {
-        *cold_white = white_level * cw_level;
-        *warm_white = white_level * ww_level;
-      } else {
-        // Just multiplying by cw_level / (cw_level + ww_level) would divide out the brightness information from the
-        // cold_white and warm_white settings (i.e. cw=0.8, ww=0.4 would be identical to cw=0.4, ww=0.2), which breaks
-        // transitions. Use the highest value as the brightness for the white channels (the alternative, using cw+ww/2,
-        // reduces to cw/2 and ww/2, which would still limit brightness to 100% of a single channel, but isn't very
-        // useful in all other aspects -- that behaviour can also be achieved by limiting the output power).
-        const float sum = cw_level > 0 || ww_level > 0 ? cw_level + ww_level : 1;  // Don't divide by zero.
-        *cold_white = white_level * std::max(cw_level, ww_level) * cw_level / sum;
-        *warm_white = white_level * std::max(cw_level, ww_level) * ww_level / sum;
-      }
+      *cold_white = white_level * gamma_correct(this->cold_white_, gamma);
+      *warm_white = white_level * gamma_correct(this->warm_white_, gamma);
     } else {
       *cold_white = *warm_white = 0;
     }

--- a/esphome/components/light/light_traits.h
+++ b/esphome/components/light/light_traits.h
@@ -46,6 +46,9 @@ class LightTraits {
             this->supports_color_mode(ColorMode::COLOR_TEMPERATURE));
   }
 
+  bool get_constant_brightness() const { return this->constant_brightness_; }
+  void set_constant_brightness(bool constant_brightness) { this->constant_brightness_ = constant_brightness; }
+
   float get_min_mireds() const { return this->min_mireds_; }
   void set_min_mireds(float min_mireds) { this->min_mireds_ = min_mireds; }
   float get_max_mireds() const { return this->max_mireds_; }
@@ -53,6 +56,7 @@ class LightTraits {
 
  protected:
   std::set<ColorMode> supported_color_modes_{};
+  bool constant_brightness_{false};
   float min_mireds_{0};
   float max_mireds_{0};
 };

--- a/esphome/components/rgbww/rgbww_light_output.h
+++ b/esphome/components/rgbww/rgbww_light_output.h
@@ -24,6 +24,7 @@ class RGBWWLightOutput : public light::LightOutput {
       traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLD_WARM_WHITE});
     else
       traits.set_supported_color_modes({light::ColorMode::RGB_COLD_WARM_WHITE});
+    traits.set_constant_brightness(this->constant_brightness_);
     traits.set_min_mireds(this->cold_white_temperature_);
     traits.set_max_mireds(this->warm_white_temperature_);
     return traits;


### PR DESCRIPTION
# What does this implement/fix? 

I'm not sure this is the correct solution, so let's discuss. Since we added colormodes, the user can directly control the cold/warm white channels of lights (that have them). What should constant brightness mode do?

Currently, constant brightness is also applied to these inputs. Pre-#2136, this meant that the combined brightness of the cold and warm white channels was fixed to the master brightness. That meant there was no separate brightness control of the white channels for RGBWW lights. This also broke transitions where the cold/warm white channels were turned on/off. Since #2136 the combined brightness is fixed to the maximum of the cold and warm white values, so that brightness control is possible. This still didn't completely fix transitions, as the transitions are done separately for cold and warm white values, so if you're turning one up and the other down, the brightness will dip in the middle of the transitions (esphome/issues#2311).

However, I'm wondering more and more whether it actually makes sense to apply constant brightness to the separate cold/warm white controls at all. Having the cold/warm white controls in HA not actually control the cold/warm outputs directly is counterintuitive. This PR applies the constant brightness only when setting a color temperature, and allows the user unconstrained, direct control of the cold/warm white channels. However, that does allow the user to break the constraint that combined output power is limited to 100% of a single channel.

Furthermore, this PR also doesn't fix esphome/issues#2311 completely. The constant brightness mode works by keeping the sum of the cold and warm white channels after gamma correction constant, but transitions work on the values before gamma correction (it breaks because while the begin and end values of the transition satisfy cw^gamma + ww^gamma = 1, since gamma correction isn't a linear transform intermediate states do not). We can workaround this, but I'm also not sure whether having constant brightness mode keep brightness after instead of before gamma correction constant makes sense at all. If the goal is to have a constant human-observed brightness, the brightness before gamma correction should be kept constant, but of course then the combined output power can go above 100% of a single channel.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2311

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
  - platform: rgbww
    id: light_rgbww_cb
    name: "RGBWW (CB)"
    gamma_correct: 2
    red: pwm1
    green: pwm2
    blue: pwm3
    cold_white: pwm4
    warm_white: pwm5
    cold_white_color_temperature: 3000 K # 333 mireds
    warm_white_color_temperature: 1500 K # 666 mireds
    constant_brightness: true
    color_interlock: false
    default_transition_length: 2s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
