### PR TITLE
Let sensors announce their state_class via mqtt

### DIFF
--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -61,6 +61,9 @@ void MQTTSensorComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryCo
   if (this->sensor_->get_force_update())
     root["force_update"] = true;
 
+  if (this->sensor_->state_class == sensor::STATE_CLASS_MEASUREMENT)
+    root["state_class"] = "measurement";
+
   config.command_topic = false;
 }
 bool MQTTSensorComponent::send_initial_state() {


### PR DESCRIPTION
# What does this implement/fix? 

Sensors do not announce their `state_class` when MQTT is used. This small pull request will fix it.

Please continue to support MQTT in esphome! 

**Related issue or feature (if applicable):** fixes esphome/issues#2312

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
