### PR TITLE
Thermostat delayed fan mode fix

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -57,20 +57,20 @@ void ThermostatClimate::refresh() {
 }
 
 bool ThermostatClimate::climate_action_change_delayed() {
-  bool stateMismatch = this->action != this->compute_action_(true);
+  bool state_mismatch = this->action != this->compute_action_(true);
 
   switch (this->compute_action_(true)) {
     case climate::CLIMATE_ACTION_OFF:
     case climate::CLIMATE_ACTION_IDLE:
-      return stateMismatch && (!this->idle_action_ready_());
+      return state_mismatch && (!this->idle_action_ready_());
     case climate::CLIMATE_ACTION_COOLING:
-      return stateMismatch && (!this->cooling_action_ready_());
+      return state_mismatch && (!this->cooling_action_ready_());
     case climate::CLIMATE_ACTION_HEATING:
-      return stateMismatch && (!this->heating_action_ready_());
+      return state_mismatch && (!this->heating_action_ready_());
     case climate::CLIMATE_ACTION_FAN:
-      return stateMismatch && (!this->fanning_action_ready_());
+      return state_mismatch && (!this->fanning_action_ready_());
     case climate::CLIMATE_ACTION_DRYING:
-      return stateMismatch && (!this->drying_action_ready_());
+      return state_mismatch && (!this->drying_action_ready_());
     default:
       break;
   }
@@ -78,8 +78,8 @@ bool ThermostatClimate::climate_action_change_delayed() {
 }
 
 bool ThermostatClimate::fan_mode_change_delayed() {
-  bool stateMismatch = this->fan_mode.value_or(climate::CLIMATE_FAN_ON) != this->prev_fan_mode_;
-  return stateMismatch && (!this->fan_mode_ready_());
+  bool state_mismatch = this->fan_mode.value_or(climate::CLIMATE_FAN_ON) != this->prev_fan_mode_;
+  return state_mismatch && (!this->fan_mode_ready_());
 }
 
 climate::ClimateAction ThermostatClimate::delayed_climate_action() { return this->compute_action_(true); }

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -57,29 +57,34 @@ void ThermostatClimate::refresh() {
 }
 
 bool ThermostatClimate::climate_action_change_delayed() {
+  bool stateMismatch = this->action != this->compute_action_(true);
+
   switch (this->compute_action_(true)) {
     case climate::CLIMATE_ACTION_OFF:
     case climate::CLIMATE_ACTION_IDLE:
-      return !this->idle_action_ready_();
+      return stateMismatch && (!this->idle_action_ready_());
     case climate::CLIMATE_ACTION_COOLING:
-      return !this->cooling_action_ready_();
+      return stateMismatch && (!this->cooling_action_ready_());
     case climate::CLIMATE_ACTION_HEATING:
-      return !this->heating_action_ready_();
+      return stateMismatch && (!this->heating_action_ready_());
     case climate::CLIMATE_ACTION_FAN:
-      return !this->fanning_action_ready_();
+      return stateMismatch && (!this->fanning_action_ready_());
     case climate::CLIMATE_ACTION_DRYING:
-      return !this->drying_action_ready_();
+      return stateMismatch && (!this->drying_action_ready_());
     default:
       break;
   }
   return false;
 }
 
-bool ThermostatClimate::fan_mode_change_delayed() { return !this->fan_mode_ready_(); }
+bool ThermostatClimate::fan_mode_change_delayed() {
+  bool stateMismatch = this->fan_mode.value_or(climate::CLIMATE_FAN_ON) != this->prev_fan_mode_;
+  return stateMismatch && (!this->fan_mode_ready_());
+}
 
 climate::ClimateAction ThermostatClimate::delayed_climate_action() { return this->compute_action_(true); }
 
-climate::ClimateFanMode ThermostatClimate::delayed_fan_mode() { return this->desired_fan_mode_; }
+climate::ClimateFanMode ThermostatClimate::locked_fan_mode() { return this->prev_fan_mode_; }
 
 bool ThermostatClimate::hysteresis_valid() {
   if ((this->supports_cool_ || (this->supports_fan_only_ && this->supports_fan_only_cooling_)) &&
@@ -510,7 +515,7 @@ void ThermostatClimate::switch_to_fan_mode_(climate::ClimateFanMode fan_mode) {
     // already in target mode
     return;
 
-  this->desired_fan_mode_ = fan_mode;  // needed for timer callback
+  this->fan_mode = fan_mode;
 
   if (this->fan_mode_ready_()) {
     Trigger<> *trig = this->fan_mode_auto_trigger_;
@@ -564,7 +569,6 @@ void ThermostatClimate::switch_to_fan_mode_(climate::ClimateFanMode fan_mode) {
     this->start_timer_(thermostat::TIMER_FAN_MODE);
     assert(trig != nullptr);
     trig->trigger();
-    this->fan_mode = fan_mode;
     this->prev_fan_mode_ = fan_mode;
     this->prev_fan_mode_trigger_ = trig;
   }
@@ -733,7 +737,7 @@ void ThermostatClimate::cooling_on_timer_callback_() {
 void ThermostatClimate::fan_mode_timer_callback_() {
   ESP_LOGVV(TAG, "fan_mode timer expired");
   this->timer_[thermostat::TIMER_FAN_MODE].active = false;
-  this->switch_to_fan_mode_(this->desired_fan_mode_);
+  this->switch_to_fan_mode_(this->fan_mode.value_or(climate::CLIMATE_FAN_ON));
   if (this->supports_fan_only_action_uses_fan_mode_timer_)
     this->switch_to_action_(this->compute_action_());
 }

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -136,8 +136,8 @@ class ThermostatClimate : public climate::Climate, public Component {
   bool fan_mode_change_delayed();
   /// Returns the climate action that is being delayed (check climate_action_change_delayed(), first!)
   climate::ClimateAction delayed_climate_action();
-  /// Returns the fan mode that is being delayed (check fan_mode_change_delayed(), first!)
-  climate::ClimateFanMode delayed_fan_mode();
+  /// Returns the fan mode that is locked in (check fan_mode_change_delayed(), first!)
+  climate::ClimateFanMode locked_fan_mode();
   /// Set point and hysteresis validation
   bool hysteresis_valid();  // returns true if valid
   void validate_target_temperature();
@@ -376,9 +376,6 @@ class ThermostatClimate : public climate::Climate, public Component {
   Trigger<> *prev_fan_mode_trigger_{nullptr};
   Trigger<> *prev_mode_trigger_{nullptr};
   Trigger<> *prev_swing_mode_trigger_{nullptr};
-
-  /// Desired fan_mode -- used to store desired mode for callback when switching is delayed
-  climate::ClimateFanMode desired_fan_mode_{climate::CLIMATE_FAN_ON};
 
   /// Store previously-known states
   ///


### PR DESCRIPTION
# What does this implement/fix?

Just a quick fix for a small bug ~~I'd created~~ I just discovered with delayed fan mode switching -- specifically as it relates to reporting the delay(s) & locked-in mode.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not required

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). **N/A**