### PR TITLE
Fix SM300D2 sensor component routines so they correctly read the sensor output 

### DIFF
--- a/esphome/components/sm300d2/sensor.py
+++ b/esphome/components/sm300d2/sensor.py
@@ -64,13 +64,13 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
-                accuracy_decimals=0,
+                accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
-                accuracy_decimals=0,
+                accuracy_decimals=1,
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -9,10 +9,12 @@ static const uint8_t SM300D2_RESPONSE_LENGTH = 17;
 
 void SM300D2Sensor::update() {
   uint8_t response[SM300D2_RESPONSE_LENGTH];
+  uint8_t peeked;
 
-  flush();
+  while (this->available() > 0 && this->peek_byte(&peeked) && peeked != 0x3C)
+    this->read();
+
   bool read_success = read_array(response, SM300D2_RESPONSE_LENGTH);
-  flush();
 
   if (!read_success) {
     ESP_LOGW(TAG, "Reading data from SM300D2 failed!");

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -62,7 +62,7 @@ void SM300D2Sensor::update() {
   if (this->pm_2_5_sensor_ != nullptr)
     this->pm_2_5_sensor_->publish_state(pm_2_5);
 
-  ESP_LOGD(TAG, "Received pm_10_0: %u µg/m³", pm_10_0);
+  ESP_LOGD(TAG, "Received PM10: %u µg/m³", pm_10_0);
   if (this->pm_10_0_sensor_ != nullptr)
     this->pm_10_0_sensor_->publish_state(pm_10_0);
 


### PR DESCRIPTION
# What does this implement/fix? 

Fixes the SM300D2 sensor to work more reliably, the previous code seems to fail because it reads 17 bytes from the serial port expecting them to be aligned to the buffer where the sensor appears to just be streaming data

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/2273>


## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:


```yaml
esphome:
  name: ${device_name}
  platform: ESP32
  board: nodemcu-32s

# logger:
#   baud_rate: 0

uart:
  rx_pin: GPIO17
  baud_rate: 9600

sensor:
  - platform: uptime
    name: Uptime

  - platform: wifi_signal
    name: Wifi Signal
    update_interval: 60s

  - platform: sm300d2
    co2:
      name: "CO2"
    formaldehyde:
      name: "Formaldehyde"
    tvoc:
      name: "TVOC"
    pm_2_5:
      name: "PM2.5"
    pm_10_0:
      name: "PM10"
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    update_interval: 10s


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
