### PR TITLE
Add a dummy color temp

### DIFF
--- a/esphome/components/hbridge/hbridge_light_output.h
+++ b/esphome/components/hbridge/hbridge_light_output.h
@@ -19,6 +19,8 @@ class HBridgeLightOutput : public PollingComponent, public light::LightOutput {
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::COLD_WARM_WHITE});
+    traits.set_min_mireds(153);
+    traits.set_max_mireds(500);    
     return traits;
   }
 

--- a/esphome/components/hbridge/hbridge_light_output.h
+++ b/esphome/components/hbridge/hbridge_light_output.h
@@ -20,7 +20,7 @@ class HBridgeLightOutput : public PollingComponent, public light::LightOutput {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::COLD_WARM_WHITE});
     traits.set_min_mireds(153);
-    traits.set_max_mireds(500);    
+    traits.set_max_mireds(500);
     return traits;
   }
 


### PR DESCRIPTION
# What does this implement/fix? 

Color temperature must be set or HA will not allow you to change it. Added a dummy value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
output:
  - platform: esp8266_pwm
    id: pina
    pin: GPIO12
  - platform: esp8266_pwm
    id: pinb
    pin: GPIO14

light:
  - platform: hbridge
    id: mainlight
    name: "Icicle Lights"
    pin_a: pina
    pin_b: pinb
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
