### PR TITLE
Minor code cleanup in light components

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -19,7 +19,7 @@ void AddressableLight::call_setup() {
       ESP_LOGVV(TAG, "  [%2d] Color: R=%3u G=%3u B=%3u W=%3u", i, color.get_red_raw(), color.get_green_raw(),
                 color.get_blue_raw(), color.get_white_raw());
     }
-    ESP_LOGVV(TAG, "");
+    ESP_LOGVV(TAG, " ");
   });
 #endif
 }

--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -196,7 +196,6 @@ class FlickerLightEffect : public LightEffect {
     out.set_warm_white(remote.get_warm_white() * beta + current.get_warm_white() * alpha +
                        (random_cubic_float() * this->intensity_));
 
-    auto traits = this->state_->get_traits();
     auto call = this->state_->make_call();
     call.set_publish(false);
     call.set_save(false);


### PR DESCRIPTION
# What does this implement/fix? 

* There was an unneeded call to `get_traits()` in the flicker effect.
* Compiling with `VERY_VERBOSE` yielded the `zero-length gnu_printf format string` compiler warning.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
logger:
  level: VERY_VERBOSE

light:
  - platform: ...
    effects:
      - flicker:
           name: "Flicker"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
