### PR TITLE
Total daily energy methods

### DIFF
--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -40,7 +40,7 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_MIN_SAVE_INTERVAL, default="0s"
             ): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_METHOD, default="trapezoid"): cv.enum(
+            cv.Optional(CONF_METHOD, default="right"): cv.enum(
                 TOTAL_DAILY_ENERGY_METHODS, lower=True
             ),
         }

--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -13,6 +13,12 @@ DEPENDENCIES = ["time"]
 
 CONF_POWER_ID = "power_id"
 CONF_MIN_SAVE_INTERVAL = "min_save_interval"
+CONF_TOTAL_DAILY_ENERGY_METHOD = "method"
+TOTAL_DAILY_ENERGY_METHODS = {
+    "trapezoid": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_TRAPEZOID,
+    "left": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_LEFT,
+    "right": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_RIGHT,
+}
 total_daily_energy_ns = cg.esphome_ns.namespace("total_daily_energy")
 TotalDailyEnergy = total_daily_energy_ns.class_(
     "TotalDailyEnergy", sensor.Sensor, cg.Component
@@ -33,6 +39,9 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_MIN_SAVE_INTERVAL, default="0s"
             ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_TOTAL_DAILY_ENERGY_METHOD, default="trapezoid"): cv.enum(
+                TOTAL_DAILY_ENERGY_METHODS, lower=True
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -50,3 +59,4 @@ async def to_code(config):
     time_ = await cg.get_variable(config[CONF_TIME_ID])
     cg.add(var.set_time(time_))
     cg.add(var.set_min_save_interval(config[CONF_MIN_SAVE_INTERVAL]))
+    cg.add(var.set_method(config[CONF_TOTAL_DAILY_ENERGY_METHOD]))

--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -14,6 +14,7 @@ DEPENDENCIES = ["time"]
 CONF_POWER_ID = "power_id"
 CONF_MIN_SAVE_INTERVAL = "min_save_interval"
 CONF_TOTAL_DAILY_ENERGY_METHOD = "method"
+TotalDailyEnergyMethod = integration_ns.enum("TotalDailyEnergyMethod")
 TOTAL_DAILY_ENERGY_METHODS = {
     "trapezoid": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_TRAPEZOID,
     "left": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_LEFT,

--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -7,13 +7,13 @@ from esphome.const import (
     DEVICE_CLASS_ENERGY,
     LAST_RESET_TYPE_AUTO,
     STATE_CLASS_MEASUREMENT,
+    CONF_METHOD,
 )
 
 DEPENDENCIES = ["time"]
 
 CONF_POWER_ID = "power_id"
 CONF_MIN_SAVE_INTERVAL = "min_save_interval"
-CONF_TOTAL_DAILY_ENERGY_METHOD = "method"
 total_daily_energy_ns = cg.esphome_ns.namespace("total_daily_energy")
 TotalDailyEnergyMethod = total_daily_energy_ns.enum("TotalDailyEnergyMethod")
 TOTAL_DAILY_ENERGY_METHODS = {
@@ -40,7 +40,7 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_MIN_SAVE_INTERVAL, default="0s"
             ): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_TOTAL_DAILY_ENERGY_METHOD, default="trapezoid"): cv.enum(
+            cv.Optional(CONF_METHOD, default="trapezoid"): cv.enum(
                 TOTAL_DAILY_ENERGY_METHODS, lower=True
             ),
         }
@@ -60,4 +60,4 @@ async def to_code(config):
     time_ = await cg.get_variable(config[CONF_TIME_ID])
     cg.add(var.set_time(time_))
     cg.add(var.set_min_save_interval(config[CONF_MIN_SAVE_INTERVAL]))
-    cg.add(var.set_method(config[CONF_TOTAL_DAILY_ENERGY_METHOD]))
+    cg.add(var.set_method(config[CONF_METHOD]))

--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -14,13 +14,13 @@ DEPENDENCIES = ["time"]
 CONF_POWER_ID = "power_id"
 CONF_MIN_SAVE_INTERVAL = "min_save_interval"
 CONF_TOTAL_DAILY_ENERGY_METHOD = "method"
-TotalDailyEnergyMethod = integration_ns.enum("TotalDailyEnergyMethod")
+total_daily_energy_ns = cg.esphome_ns.namespace("total_daily_energy")
+TotalDailyEnergyMethod = total_daily_energy_ns.enum("TotalDailyEnergyMethod")
 TOTAL_DAILY_ENERGY_METHODS = {
     "trapezoid": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_TRAPEZOID,
     "left": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_LEFT,
     "right": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_RIGHT,
 }
-total_daily_energy_ns = cg.esphome_ns.namespace("total_daily_energy")
 TotalDailyEnergy = total_daily_energy_ns.class_(
     "TotalDailyEnergy", sensor.Sensor, cg.Component
 )

--- a/esphome/components/total_daily_energy/total_daily_energy.cpp
+++ b/esphome/components/total_daily_energy/total_daily_energy.cpp
@@ -55,8 +55,8 @@ void TotalDailyEnergy::process_new_state_(float state) {
   if (isnan(state))
     return;
   const uint32_t now = millis();
-  const double old_state = this->last_power_state_;
-  const double new_state = state;
+  const float old_state = this->last_power_state_;
+  const float new_state = state;
   float delta_hours = (now - this->last_update_) / 1000.0f / 60.0f / 60.0f;
   float delta_energy = 0.0f;
   switch (this->method_) {

--- a/esphome/components/total_daily_energy/total_daily_energy.h
+++ b/esphome/components/total_daily_energy/total_daily_energy.h
@@ -8,11 +8,18 @@
 namespace esphome {
 namespace total_daily_energy {
 
+enum TotalDailyEnergyMethod {
+  TOTAL_DAILY_ENERGY_METHOD_TRAPEZOID = 0,
+  TOTAL_DAILY_ENERGY_METHOD_LEFT,
+  TOTAL_DAILY_ENERGY_METHOD_RIGHT,
+};
+
 class TotalDailyEnergy : public sensor::Sensor, public Component {
  public:
   void set_min_save_interval(uint32_t min_interval) { this->min_save_interval_ = min_interval; }
   void set_time(time::RealTimeClock *time) { time_ = time; }
   void set_parent(Sensor *parent) { parent_ = parent; }
+  void set_method(TotalDailyEnergyMethod method) { method_ = method; }
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
@@ -29,11 +36,13 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   ESPPreferenceObject pref_;
   time::RealTimeClock *time_;
   Sensor *parent_;
+  TotalDailyEnergyMethod method_;
   uint16_t last_day_of_year_{};
   uint32_t last_update_{0};
   uint32_t last_save_{0};
   uint32_t min_save_interval_{0};
   float total_energy_{0.0f};
+  float last_power_state_{0.0f};
 };
 
 }  // namespace total_daily_energy


### PR DESCRIPTION
# What does this implement/fix? 

This PR updates the Total Daily Energy sensor to have the option to change the method used to calculate the total similar to the Integration sensor.  This is technically a breaking change because prior to this change the Total Daily Energy sensor was effectively using the "right" method but this PR changes the default to the "trapezoid" method.  Not sure if it is better to have a breaking change that results in a consistent design between the 2 sensor types or a non-breaking change that results in an inconsistent design between the 2 sensor types.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#1786

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1393

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
```yaml
sensor:
  - platform: total_daily_energy
    name: My Device Energy
    power_id: my_device_power
    method: left
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
