### PR TITLE
Add new total_increasing state-class for Home Assistant 2021.9+

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -448,8 +448,7 @@ message LightCommandRequest {
 enum SensorStateClass {
   STATE_CLASS_NONE = 0;
   STATE_CLASS_MEASUREMENT = 1;
-  STATE_CLASS_TOTAL = 2;
-  STATE_CLASS_TOTAL_INCREASING = 3;
+  STATE_CLASS_TOTAL_INCREASING = 2;
 }
 
 enum SensorLastResetType {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -448,6 +448,8 @@ message LightCommandRequest {
 enum SensorStateClass {
   STATE_CLASS_NONE = 0;
   STATE_CLASS_MEASUREMENT = 1;
+  STATE_CLASS_TOTAL = 2;
+  STATE_CLASS_TOTAL_INCREASING = 3;
 }
 
 enum SensorLastResetType {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -94,8 +94,6 @@ template<> const char *proto_enum_to_string<enums::SensorStateClass>(enums::Sens
       return "STATE_CLASS_NONE";
     case enums::STATE_CLASS_MEASUREMENT:
       return "STATE_CLASS_MEASUREMENT";
-    case enums::STATE_CLASS_TOTAL:
-      return "STATE_CLASS_TOTAL";
     case enums::STATE_CLASS_TOTAL_INCREASING:
       return "STATE_CLASS_TOTAL_INCREASING";
     default:

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -94,6 +94,10 @@ template<> const char *proto_enum_to_string<enums::SensorStateClass>(enums::Sens
       return "STATE_CLASS_NONE";
     case enums::STATE_CLASS_MEASUREMENT:
       return "STATE_CLASS_MEASUREMENT";
+    case enums::STATE_CLASS_TOTAL:
+      return "STATE_CLASS_TOTAL";
+    case enums::STATE_CLASS_TOTAL_INCREASING:
+      return "STATE_CLASS_TOTAL_INCREASING";
     default:
       return "UNKNOWN";
   }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -47,6 +47,8 @@ enum ColorMode : uint32_t {
 enum SensorStateClass : uint32_t {
   STATE_CLASS_NONE = 0,
   STATE_CLASS_MEASUREMENT = 1,
+  STATE_CLASS_TOTAL = 2,
+  STATE_CLASS_TOTAL_INCREASING = 3,
 };
 enum SensorLastResetType : uint32_t {
   LAST_RESET_NONE = 0,

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -47,8 +47,7 @@ enum ColorMode : uint32_t {
 enum SensorStateClass : uint32_t {
   STATE_CLASS_NONE = 0,
   STATE_CLASS_MEASUREMENT = 1,
-  STATE_CLASS_TOTAL = 2,
-  STATE_CLASS_TOTAL_INCREASING = 3,
+  STATE_CLASS_TOTAL_INCREASING = 2,
 };
 enum SensorLastResetType : uint32_t {
   LAST_RESET_NONE = 0,

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -79,6 +79,8 @@ StateClasses = sensor_ns.enum("StateClass")
 STATE_CLASSES = {
     "": StateClasses.STATE_CLASS_NONE,
     "measurement": StateClasses.STATE_CLASS_MEASUREMENT,
+    "total": StateClasses.STATE_CLASS_TOTAL,
+    "total_increasing": StateClasses.STATE_CLASS_TOTAL_INCREASING,
 }
 validate_state_class = cv.enum(STATE_CLASSES, lower=True, space="_")
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -79,7 +79,6 @@ StateClasses = sensor_ns.enum("StateClass")
 STATE_CLASSES = {
     "": StateClasses.STATE_CLASS_NONE,
     "measurement": StateClasses.STATE_CLASS_MEASUREMENT,
-    "total": StateClasses.STATE_CLASS_TOTAL,
     "total_increasing": StateClasses.STATE_CLASS_TOTAL_INCREASING,
 }
 validate_state_class = cv.enum(STATE_CLASSES, lower=True, space="_")

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -10,6 +10,10 @@ const char *state_class_to_string(StateClass state_class) {
   switch (state_class) {
     case STATE_CLASS_MEASUREMENT:
       return "measurement";
+    case STATE_CLASS_TOTAL:
+      return "total";
+    case STATE_CLASS_TOTAL_INCREASING:
+      return "total_increasing";
     case STATE_CLASS_NONE:
     default:
       return "";
@@ -72,6 +76,10 @@ void Sensor::set_state_class(StateClass state_class) { this->state_class = state
 void Sensor::set_state_class(const std::string &state_class) {
   if (str_equals_case_insensitive(state_class, "measurement")) {
     this->state_class = STATE_CLASS_MEASUREMENT;
+  } else if (str_equals_case_insensitive(state_class, "total")) {
+    this->state_class = STATE_CLASS_TOTAL;
+  } else if (str_equals_case_insensitive(state_class, "total_increasing")) {
+    this->state_class = STATE_CLASS_TOTAL_INCREASING;
   } else {
     ESP_LOGW(TAG, "'%s' - Unrecognized state class %s", this->get_name().c_str(), state_class.c_str());
   }

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -10,8 +10,6 @@ const char *state_class_to_string(StateClass state_class) {
   switch (state_class) {
     case STATE_CLASS_MEASUREMENT:
       return "measurement";
-    case STATE_CLASS_TOTAL:
-      return "total";
     case STATE_CLASS_TOTAL_INCREASING:
       return "total_increasing";
     case STATE_CLASS_NONE:
@@ -76,8 +74,6 @@ void Sensor::set_state_class(StateClass state_class) { this->state_class = state
 void Sensor::set_state_class(const std::string &state_class) {
   if (str_equals_case_insensitive(state_class, "measurement")) {
     this->state_class = STATE_CLASS_MEASUREMENT;
-  } else if (str_equals_case_insensitive(state_class, "total")) {
-    this->state_class = STATE_CLASS_TOTAL;
   } else if (str_equals_case_insensitive(state_class, "total_increasing")) {
     this->state_class = STATE_CLASS_TOTAL_INCREASING;
   } else {

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -37,8 +37,7 @@ namespace sensor {
 enum StateClass : uint8_t {
   STATE_CLASS_NONE = 0,
   STATE_CLASS_MEASUREMENT = 1,
-  STATE_CLASS_TOTAL = 2,
-  STATE_CLASS_TOTAL_INCREASING = 3,
+  STATE_CLASS_TOTAL_INCREASING = 2,
 };
 
 const char *state_class_to_string(StateClass state_class);

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -37,6 +37,8 @@ namespace sensor {
 enum StateClass : uint8_t {
   STATE_CLASS_NONE = 0,
   STATE_CLASS_MEASUREMENT = 1,
+  STATE_CLASS_TOTAL = 2,
+  STATE_CLASS_TOTAL_INCREASING = 3,
 };
 
 const char *state_class_to_string(StateClass state_class);

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -840,6 +840,12 @@ STATE_CLASS_NONE = ""
 # The state represents a measurement in present time
 STATE_CLASS_MEASUREMENT = "measurement"
 
+# The state represents a total that can increase or decrease
+STATE_CLASS_TOTAL = "total"
+
+# The state represents a total that only increases, a decrease is considered a reset.
+STATE_CLASS_TOTAL_INCREASING = "total_increasing"
+
 # This sensor does not support resetting. ie, it is not accumulative
 LAST_RESET_TYPE_NONE = ""
 # This sensor is expected to never reset its value

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -840,9 +840,6 @@ STATE_CLASS_NONE = ""
 # The state represents a measurement in present time
 STATE_CLASS_MEASUREMENT = "measurement"
 
-# The state represents a total that can increase or decrease
-STATE_CLASS_TOTAL = "total"
-
 # The state represents a total that only increases, a decrease is considered a reset.
 STATE_CLASS_TOTAL_INCREASING = "total_increasing"
 


### PR DESCRIPTION
# What does this implement/fix? 

Add new total_increasing state-classe for Home Assistant 2021.9+

- esphome/aioesphomeapi#90

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
