### PR TITLE
Initialize color temperature to value within range if possible

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -39,6 +39,13 @@ void LightState::setup() {
     effect->init_internal(this);
   }
 
+  // When supported color temperature range is known, initialize color temperature setting within bounds.
+  float min_mireds = this->get_traits().get_min_mireds();
+  if (min_mireds > 0) {
+    this->remote_values.set_color_temperature(min_mireds);
+    this->current_values.set_color_temperature(min_mireds);
+  }
+
   auto call = this->make_call();
   LightStateRTCState recovered{};
   switch (this->restore_mode_) {


### PR DESCRIPTION
# What does this implement/fix? 

Without this fix, the color temperature for CT/RGBCT lights is initialized to 0 on boot. If the light is then turned on without setting a color temperature, this will result in an out-of-range color temperature value being written to the output. It also confuses HA.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
