### PR TITLE
Optionally set direction on fan.turn_on action

### DIFF
--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -18,6 +18,7 @@ from esphome.const import (
     CONF_ON_TURN_OFF,
     CONF_ON_TURN_ON,
     CONF_TRIGGER_ID,
+    CONF_DIRECTION
 )
 from esphome.core import CORE, coroutine_with_priority
 
@@ -26,6 +27,12 @@ IS_PLATFORM_COMPONENT = True
 fan_ns = cg.esphome_ns.namespace("fan")
 FanState = fan_ns.class_("FanState", cg.Nameable, cg.Component)
 MakeFan = cg.Application.struct("MakeFan")
+
+FanDirection = fan_ns.enum("FanDirection")
+FAN_DIRECTION_ENUM = {
+    "FORWARD": FanDirection.FAN_DIRECTION_FORWARD,
+    "REVERSE": FanDirection.FAN_DIRECTION_REVERSE,
+}
 
 # Actions
 TurnOnAction = fan_ns.class_("TurnOnAction", automation.Action)
@@ -143,6 +150,9 @@ async def fan_turn_off_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_ID): cv.use_id(FanState),
             cv.Optional(CONF_OSCILLATING): cv.templatable(cv.boolean),
             cv.Optional(CONF_SPEED): cv.templatable(cv.int_range(1)),
+            cv.Optional(CONF_DIRECTION, default="FORWARD"): cv.enum(
+                FAN_DIRECTION_ENUM, upper=True
+            ),
         }
     ),
 )
@@ -155,6 +165,9 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
     if CONF_SPEED in config:
         template_ = await cg.templatable(config[CONF_SPEED], args, int)
         cg.add(var.set_speed(template_))
+    if CONF_DIRECTION in config:
+        template_ = await cg.templatable(FAN_DIRECTION_ENUM[config[CONF_DIRECTION]], args, FanDirection)
+        cg.add(var.set_direction(template_))
     return var
 
 

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -150,8 +150,8 @@ async def fan_turn_off_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_ID): cv.use_id(FanState),
             cv.Optional(CONF_OSCILLATING): cv.templatable(cv.boolean),
             cv.Optional(CONF_SPEED): cv.templatable(cv.int_range(1)),
-            cv.Optional(CONF_DIRECTION, default="FORWARD"): cv.enum(
-                FAN_DIRECTION_ENUM, upper=True
+            cv.Optional(CONF_DIRECTION, default="FORWARD"): cv.templatable(
+                cv.enum(FAN_DIRECTION_ENUM, upper=True)
             ),
         }
     ),
@@ -166,9 +166,7 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(config[CONF_SPEED], args, int)
         cg.add(var.set_speed(template_))
     if CONF_DIRECTION in config:
-        template_ = await cg.templatable(
-            FAN_DIRECTION_ENUM[config[CONF_DIRECTION]], args, FanDirection
-        )
+        template_ = await cg.templatable(config[CONF_DIRECTION], args, FanDirection)
         cg.add(var.set_direction(template_))
     return var
 

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -18,7 +18,7 @@ from esphome.const import (
     CONF_ON_TURN_OFF,
     CONF_ON_TURN_ON,
     CONF_TRIGGER_ID,
-    CONF_DIRECTION
+    CONF_DIRECTION,
 )
 from esphome.core import CORE, coroutine_with_priority
 
@@ -166,7 +166,9 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(config[CONF_SPEED], args, int)
         cg.add(var.set_speed(template_))
     if CONF_DIRECTION in config:
-        template_ = await cg.templatable(FAN_DIRECTION_ENUM[config[CONF_DIRECTION]], args, FanDirection)
+        template_ = await cg.templatable(
+            FAN_DIRECTION_ENUM[config[CONF_DIRECTION]], args, FanDirection
+        )
         cg.add(var.set_direction(template_))
     return var
 

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -150,7 +150,7 @@ async def fan_turn_off_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_ID): cv.use_id(FanState),
             cv.Optional(CONF_OSCILLATING): cv.templatable(cv.boolean),
             cv.Optional(CONF_SPEED): cv.templatable(cv.int_range(1)),
-            cv.Optional(CONF_DIRECTION, default="FORWARD"): cv.templatable(
+            cv.Optional(CONF_DIRECTION): cv.templatable(
                 cv.enum(FAN_DIRECTION_ENUM, upper=True)
             ),
         }

--- a/esphome/components/fan/automation.h
+++ b/esphome/components/fan/automation.h
@@ -13,6 +13,7 @@ template<typename... Ts> class TurnOnAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(bool, oscillating)
   TEMPLATABLE_VALUE(int, speed)
+  TEMPLATABLE_VALUE(FanDirection, direction)
 
   void play(Ts... x) override {
     auto call = this->state_->turn_on();
@@ -21,6 +22,9 @@ template<typename... Ts> class TurnOnAction : public Action<Ts...> {
     }
     if (this->speed_.has_value()) {
       call.set_speed(this->speed_.value(x...));
+    }
+    if (this->direction_.has_value()) {
+      call.set_direction(this->direction_.value(x...));
     }
     call.perform();
   }


### PR DESCRIPTION
# What does this implement/fix? 

Makes sense to be able to set the direction of a fan component from the fan.turn_on action using esphome, since you can already set the speed, etc.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1411

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
      - fan.turn_on:
          id: exhaust_fan
          speed: 50
          direction: reverse
      - fan.turn_on:
          id: intake_fan
          speed: 50
          direction: forward
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
