### PR TITLE
SGP40 sensor start-up fix

### DIFF
--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -94,6 +94,7 @@ void SGP40Component::self_test_() {
     }
 
     if (reply[0] == 0xD400) {
+      this->self_test_complete_ = true;
       ESP_LOGD(TAG, "selfTest completed");
       return;
     }
@@ -113,6 +114,9 @@ void SGP40Component::self_test_() {
  */
 int32_t SGP40Component::measure_voc_index_() {
   int32_t voc_index;
+
+  if (this->self_test_complete_ == false)
+    return UINT16_MAX;
 
   uint16_t sraw = measure_raw_();
 
@@ -174,11 +178,11 @@ uint16_t SGP40Component::measure_raw_() {
   command[0] = 0x26;
   command[1] = 0x0F;
 
-  uint16_t rhticks = llround((uint16_t)((humidity * 65535) / 100));
+  uint16_t rhticks = llround((uint16_t) ((humidity * 65535) / 100));
   command[2] = rhticks >> 8;
   command[3] = rhticks & 0xFF;
   command[4] = generate_crc_(command + 2, 2);
-  uint16_t tempticks = (uint16_t)(((temperature + 45) * 65535) / 175);
+  uint16_t tempticks = (uint16_t) (((temperature + 45) * 65535) / 175);
   command[5] = tempticks >> 8;
   command[6] = tempticks & 0xFF;
   command[7] = generate_crc_(command + 5, 2);

--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -115,7 +115,7 @@ void SGP40Component::self_test_() {
 int32_t SGP40Component::measure_voc_index_() {
   int32_t voc_index;
 
-  if (this->self_test_complete_ == false)
+  if (!this->self_test_complete_)
     return UINT16_MAX;
 
   uint16_t sraw = measure_raw_();
@@ -178,11 +178,11 @@ uint16_t SGP40Component::measure_raw_() {
   command[0] = 0x26;
   command[1] = 0x0F;
 
-  uint16_t rhticks = llround((uint16_t) ((humidity * 65535) / 100));
+  uint16_t rhticks = llround((uint16_t)((humidity * 65535) / 100));
   command[2] = rhticks >> 8;
   command[3] = rhticks & 0xFF;
   command[4] = generate_crc_(command + 2, 2);
-  uint16_t tempticks = (uint16_t) (((temperature + 45) * 65535) / 175);
+  uint16_t tempticks = (uint16_t)(((temperature + 45) * 65535) / 175);
   command[5] = tempticks >> 8;
   command[6] = tempticks & 0xFF;
   command[7] = generate_crc_(command + 5, 2);

--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -78,28 +78,28 @@ void SGP40Component::setup() {
 }
 
 void SGP40Component::self_test_() {
-  ESP_LOGD(TAG, "selfTest started");
+  ESP_LOGD(TAG, "Self-test started");
   if (!this->write_command_(SGP40_CMD_SELF_TEST)) {
     this->error_code_ = COMMUNICATION_FAILED;
-    ESP_LOGD(TAG, "selfTest communicatin failed");
+    ESP_LOGD(TAG, "Self-test communication failed");
     this->mark_failed();
   }
 
   this->set_timeout(250, [this]() {
     uint16_t reply[1];
     if (!this->read_data_(reply, 1)) {
-      ESP_LOGD(TAG, "selfTest read_data_ failed");
+      ESP_LOGD(TAG, "Self-test read_data_ failed");
       this->mark_failed();
       return;
     }
 
     if (reply[0] == 0xD400) {
       this->self_test_complete_ = true;
-      ESP_LOGD(TAG, "selfTest completed");
+      ESP_LOGD(TAG, "Self-test completed");
       return;
     }
 
-    ESP_LOGD(TAG, "selfTest failed");
+    ESP_LOGD(TAG, "Self-test failed");
     this->mark_failed();
   });
 }
@@ -114,9 +114,6 @@ void SGP40Component::self_test_() {
  */
 int32_t SGP40Component::measure_voc_index_() {
   int32_t voc_index;
-
-  if (!this->self_test_complete_)
-    return UINT16_MAX;
 
   uint16_t sraw = measure_raw_();
 
@@ -158,6 +155,12 @@ int32_t SGP40Component::measure_voc_index_() {
  */
 uint16_t SGP40Component::measure_raw_() {
   float humidity = NAN;
+
+  if (!this->self_test_complete_) {
+    ESP_LOGD(TAG, "Self-test not yet complete");
+    return UINT16_MAX;
+  }
+
   if (this->humidity_sensor_ != nullptr) {
     humidity = this->humidity_sensor_->state;
   }

--- a/esphome/components/sgp40/sgp40.h
+++ b/esphome/components/sgp40/sgp40.h
@@ -68,6 +68,7 @@ class SGP40Component : public PollingComponent, public sensor::Sensor, public i2
   int32_t seconds_since_last_store_;
   SGP40Baselines baselines_storage_;
   VocAlgorithmParams voc_algorithm_params_;
+  bool self_test_complete_;
   bool store_baseline_;
   int32_t state0_;
   int32_t state1_;


### PR DESCRIPTION
# What does this implement/fix? 

Quick fix to block `update()` before the sensor's self-test (performed at every boot) is complete.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2276

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): N/A**

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). **N/A**