### PR TITLE
Tuya fan component uses enum datapoint type for speed instead of integer

### DIFF
--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -80,7 +80,7 @@ void TuyaFan::write_state() {
   }
   if (this->speed_id_.has_value()) {
     ESP_LOGV(TAG, "Setting speed: %d", this->fan_->speed);
-    this->parent_->set_integer_datapoint_value(*this->speed_id_, this->fan_->speed - 1);
+    this->parent_->set_enum_datapoint_value(*this->speed_id_, this->fan_->speed - 1);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix? 

PR #2059 incorrectly changed the Tuya fan speed datapoint type to integer, this PR changes it to the correct type of enum.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2319

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
