### PR TITLE
mqtt_light: remove legacy API config that is not compatible with HA 2021.8

### DIFF
--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -54,12 +54,6 @@ void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscover
   // legacy API
   if (traits.supports_color_capability(ColorCapability::BRIGHTNESS))
     root["brightness"] = true;
-  if (traits.supports_color_capability(ColorCapability::RGB))
-    root["rgb"] = true;
-  if (traits.supports_color_capability(ColorCapability::COLOR_TEMPERATURE))
-    root["color_temp"] = true;
-  if (traits.supports_color_capability(ColorCapability::WHITE))
-    root["white_value"] = true;
 
   if (this->state_->supports_effects()) {
     root["effect"] = true;


### PR DESCRIPTION
# What does this implement/fix? 

@oxan PR #2012 do not work with HA 2021.8.8 and mqtt component. I will get the following log entry and the lights are unavailable in HA.
```
Exception in async_discover when dispatching 'mqtt_discovery_new_light_mqtt': ({'schema': 'json', 'color_mode': True, 'supported_color_modes': ['rgb'], 'brightness': True, 'rgb': True, 'effect': True, 'effect_list': ['Random', 'Strobe', 'Flicker', 'Rainbow', 'Color Wipe', 'Scan', 'Twinkle', 'Random Twinkle', 'Fireworks', 'Addressable Flicker', 'None'], 'name': 'bed_light_right', 'state_topic': 'bed_light/light/bed_light_right/state', 'command_topic': 'bed_light/light/bed_light_right/command', 'availability_topic': 'bed_light/status', 'unique_id': 'ESPlightbed_light_right', 'device': {'identifiers': 'dc4f221c88a2', 'name': 'bed_light', 'sw_version': 'esphome v2021.8.0 Aug 20 2021, 10:58:02', 'model': 'PLATFORMIO_D1_MINI', 'manufacturer': 'espressif'}, 'platform': 'mqtt'},) Traceback (most recent call last): 
File "/usr/local/lib/python3.9/site-packages/voluptuous/schema_builder.py", line 272, in __call__ return self._compiled([], data) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/schema_builder.py", line 817, in validate_callable return schema(data) 
File "/usr/src/homeassistant/homeassistant/components/mqtt/light/schema_json.py", line 100, in valid_color_configuration raise vol.Invalid(f"color_mode must not be combined with any of {deprecated}") voluptuous.error.Invalid: color_mode must not be combined with any of {'hs', 'rgb', 'xy', 'color_temp', 'white_value'} During handling of the above exception, another exception occurred: Traceback (most recent call last): 
File "/usr/src/homeassistant/homeassistant/components/mqtt/mixins.py", line 180, in async_discover config = schema(discovery_payload)
 File "/usr/local/lib/python3.9/site-packages/voluptuous/validators.py", line 218, in __call__ return self._exec((Schema(val) for val in self.validators), v) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/validators.py", line 341, in _exec raise e if self.msg is None else AllInvalid(self.msg, path=path) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/validators.py", line 337, in _exec v = func(v) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/schema_builder.py", line 272, in __call__ return self._compiled([], data) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/schema_builder.py", line 817, in validate_callable return schema(data) 
File "/usr/src/homeassistant/homeassistant/components/mqtt/light/__init__.py", line 26, in validate_mqtt_light return schemas[value[CONF_SCHEMA]](value)
 File "/usr/local/lib/python3.9/site-packages/voluptuous/validators.py", line 218, in __call__ return self._exec((Schema(val) for val in self.validators), v) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/validators.py", line 341, in _exec raise e if self.msg is None else AllInvalid(self.msg, path=path) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/validators.py", line 337, in _exec v = func(v) 
File "/usr/local/lib/python3.9/site-packages/voluptuous/schema_builder.py", line 276, in __call__ raise er.MultipleInvalid([e]) voluptuous.error.MultipleInvalid: color_mode must not be combined with any of {'hs', 'rgb', 'xy', 'color_temp', 'white_value'} 
```

This PR removes the legacy API  entries that are mentioned in the exception. With this PR, it works fine for me.

I am not sure this will break older HA versions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
