### PR TITLE
RFC: Api client

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -16,14 +16,17 @@ from esphome.const import (
     CONF_EVENT,
     CONF_TAG,
 )
-from esphome.core import coroutine_with_priority
+from esphome.core import CORE, coroutine_with_priority
 
-DEPENDENCIES = ["network"]
+DEPENDENCIES = []
 AUTO_LOAD = ["async_tcp"]
 CODEOWNERS = ["@OttoWinter"]
 
 api_ns = cg.esphome_ns.namespace("api")
 APIServer = api_ns.class_("APIServer", cg.Component, cg.Controller)
+AsyncAPIServer = api_ns.class_("AsyncAPIServer", APIServer, cg.Component, cg.Controller)
+if CORE.is_esp32 or CORE.is_esp8266:
+    APIServer = AsyncAPIServer
 HomeAssistantServiceCallAction = api_ns.class_(
     "HomeAssistantServiceCallAction", automation.Action
 )

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1,5 +1,5 @@
 // This file was automatically generated with a tool.
-// See scripts/api_protobuf/api_protobuf.py
+// See script/api_protobuf/api_protobuf.py
 #include "api_pb2.h"
 #include "esphome/core/log.h"
 
@@ -268,10 +268,10 @@ void HelloRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HelloRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("HelloRequest {\n");
+  out.append("HelloRequest {\r\n");
   out.append("  client_info: ");
   out.append("'").append(this->client_info).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -307,20 +307,20 @@ void HelloResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HelloResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("HelloResponse {\n");
+  out.append("HelloResponse {\r\n");
   out.append("  api_version_major: ");
   sprintf(buffer, "%u", this->api_version_major);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  api_version_minor: ");
   sprintf(buffer, "%u", this->api_version_minor);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  server_info: ");
   out.append("'").append(this->server_info).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -338,10 +338,10 @@ void ConnectRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_strin
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ConnectRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ConnectRequest {\n");
+  out.append("ConnectRequest {\r\n");
   out.append("  password: ");
   out.append("'").append(this->password).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -359,10 +359,10 @@ void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ConnectResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ConnectResponse {\n");
+  out.append("ConnectResponse {\r\n");
   out.append("  invalid_password: ");
   out.append(YESNO(this->invalid_password));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -448,42 +448,42 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("DeviceInfoResponse {\n");
+  out.append("DeviceInfoResponse {\r\n");
   out.append("  uses_password: ");
   out.append(YESNO(this->uses_password));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  mac_address: ");
   out.append("'").append(this->mac_address).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  esphome_version: ");
   out.append("'").append(this->esphome_version).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  compilation_time: ");
   out.append("'").append(this->compilation_time).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  model: ");
   out.append("'").append(this->model).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_deep_sleep: ");
   out.append(YESNO(this->has_deep_sleep));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  project_name: ");
   out.append("'").append(this->project_name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  project_version: ");
   out.append("'").append(this->project_version).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -557,35 +557,35 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesBinarySensorResponse {\n");
+  out.append("ListEntitiesBinarySensorResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  device_class: ");
   out.append("'").append(this->device_class).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  is_status_binary_sensor: ");
   out.append(YESNO(this->is_status_binary_sensor));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -621,19 +621,19 @@ void BinarySensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void BinarySensorStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("BinarySensorStateResponse {\n");
+  out.append("BinarySensorStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append(YESNO(this->state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  missing_state: ");
   out.append(YESNO(this->missing_state));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -705,43 +705,43 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesCoverResponse {\n");
+  out.append("ListEntitiesCoverResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  assumed_state: ");
   out.append(YESNO(this->assumed_state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_position: ");
   out.append(YESNO(this->supports_position));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_tilt: ");
   out.append(YESNO(this->supports_tilt));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  device_class: ");
   out.append("'").append(this->device_class).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -787,29 +787,29 @@ void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CoverStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("CoverStateResponse {\n");
+  out.append("CoverStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_state: ");
   out.append(proto_enum_to_string<enums::LegacyCoverState>(this->legacy_state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  position: ");
   sprintf(buffer, "%g", this->position);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  tilt: ");
   sprintf(buffer, "%g", this->tilt);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  current_operation: ");
   out.append(proto_enum_to_string<enums::CoverOperation>(this->current_operation));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -870,41 +870,41 @@ void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CoverCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("CoverCommandRequest {\n");
+  out.append("CoverCommandRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_legacy_command: ");
   out.append(YESNO(this->has_legacy_command));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_command: ");
   out.append(proto_enum_to_string<enums::LegacyCoverCommand>(this->legacy_command));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_position: ");
   out.append(YESNO(this->has_position));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  position: ");
   sprintf(buffer, "%g", this->position);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_tilt: ");
   out.append(YESNO(this->has_tilt));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  tilt: ");
   sprintf(buffer, "%g", this->tilt);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  stop: ");
   out.append(YESNO(this->stop));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -976,44 +976,44 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesFanResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesFanResponse {\n");
+  out.append("ListEntitiesFanResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_oscillation: ");
   out.append(YESNO(this->supports_oscillation));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_speed: ");
   out.append(YESNO(this->supports_speed));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_direction: ");
   out.append(YESNO(this->supports_direction));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supported_speed_count: ");
   sprintf(buffer, "%d", this->supported_speed_count);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -1064,32 +1064,32 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void FanStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("FanStateResponse {\n");
+  out.append("FanStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append(YESNO(this->state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  oscillating: ");
   out.append(YESNO(this->oscillating));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  speed: ");
   out.append(proto_enum_to_string<enums::FanSpeed>(this->speed));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  direction: ");
   out.append(proto_enum_to_string<enums::FanDirection>(this->direction));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  speed_level: ");
   sprintf(buffer, "%d", this->speed_level);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -1165,52 +1165,52 @@ void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void FanCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("FanCommandRequest {\n");
+  out.append("FanCommandRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_state: ");
   out.append(YESNO(this->has_state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append(YESNO(this->state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_speed: ");
   out.append(YESNO(this->has_speed));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  speed: ");
   out.append(proto_enum_to_string<enums::FanSpeed>(this->speed));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_oscillating: ");
   out.append(YESNO(this->has_oscillating));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  oscillating: ");
   out.append(YESNO(this->oscillating));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_direction: ");
   out.append(YESNO(this->has_direction));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  direction: ");
   out.append(proto_enum_to_string<enums::FanDirection>(this->direction));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_speed_level: ");
   out.append(YESNO(this->has_speed_level));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  speed_level: ");
   sprintf(buffer, "%d", this->speed_level);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -1306,65 +1306,65 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesLightResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesLightResponse {\n");
+  out.append("ListEntitiesLightResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->supported_color_modes) {
     out.append("  supported_color_modes: ");
     out.append(proto_enum_to_string<enums::ColorMode>(it));
-    out.append("\n");
+    out.append("\r\n");
   }
 
   out.append("  legacy_supports_brightness: ");
   out.append(YESNO(this->legacy_supports_brightness));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_supports_rgb: ");
   out.append(YESNO(this->legacy_supports_rgb));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_supports_white_value: ");
   out.append(YESNO(this->legacy_supports_white_value));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_supports_color_temperature: ");
   out.append(YESNO(this->legacy_supports_color_temperature));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  min_mireds: ");
   sprintf(buffer, "%g", this->min_mireds);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  max_mireds: ");
   sprintf(buffer, "%g", this->max_mireds);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->effects) {
     out.append("  effects: ");
     out.append("'").append(it).append("'");
-    out.append("\n");
+    out.append("\r\n");
   }
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -1456,68 +1456,68 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void LightStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("LightStateResponse {\n");
+  out.append("LightStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append(YESNO(this->state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  brightness: ");
   sprintf(buffer, "%g", this->brightness);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  color_mode: ");
   out.append(proto_enum_to_string<enums::ColorMode>(this->color_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  color_brightness: ");
   sprintf(buffer, "%g", this->color_brightness);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  red: ");
   sprintf(buffer, "%g", this->red);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  green: ");
   sprintf(buffer, "%g", this->green);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  blue: ");
   sprintf(buffer, "%g", this->blue);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  white: ");
   sprintf(buffer, "%g", this->white);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  color_temperature: ");
   sprintf(buffer, "%g", this->color_temperature);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  cold_white: ");
   sprintf(buffer, "%g", this->cold_white);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  warm_white: ");
   sprintf(buffer, "%g", this->warm_white);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  effect: ");
   out.append("'").append(this->effect).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -1679,126 +1679,126 @@ void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void LightCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("LightCommandRequest {\n");
+  out.append("LightCommandRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_state: ");
   out.append(YESNO(this->has_state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append(YESNO(this->state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_brightness: ");
   out.append(YESNO(this->has_brightness));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  brightness: ");
   sprintf(buffer, "%g", this->brightness);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_color_mode: ");
   out.append(YESNO(this->has_color_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  color_mode: ");
   out.append(proto_enum_to_string<enums::ColorMode>(this->color_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_color_brightness: ");
   out.append(YESNO(this->has_color_brightness));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  color_brightness: ");
   sprintf(buffer, "%g", this->color_brightness);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_rgb: ");
   out.append(YESNO(this->has_rgb));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  red: ");
   sprintf(buffer, "%g", this->red);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  green: ");
   sprintf(buffer, "%g", this->green);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  blue: ");
   sprintf(buffer, "%g", this->blue);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_white: ");
   out.append(YESNO(this->has_white));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  white: ");
   sprintf(buffer, "%g", this->white);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_color_temperature: ");
   out.append(YESNO(this->has_color_temperature));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  color_temperature: ");
   sprintf(buffer, "%g", this->color_temperature);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_cold_white: ");
   out.append(YESNO(this->has_cold_white));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  cold_white: ");
   sprintf(buffer, "%g", this->cold_white);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_warm_white: ");
   out.append(YESNO(this->has_warm_white));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  warm_white: ");
   sprintf(buffer, "%g", this->warm_white);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_transition_length: ");
   out.append(YESNO(this->has_transition_length));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  transition_length: ");
   sprintf(buffer, "%u", this->transition_length);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_flash_length: ");
   out.append(YESNO(this->has_flash_length));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  flash_length: ");
   sprintf(buffer, "%u", this->flash_length);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_effect: ");
   out.append(YESNO(this->has_effect));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  effect: ");
   out.append("'").append(this->effect).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -1885,56 +1885,56 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesSensorResponse {\n");
+  out.append("ListEntitiesSensorResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  icon: ");
   out.append("'").append(this->icon).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unit_of_measurement: ");
   out.append("'").append(this->unit_of_measurement).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  accuracy_decimals: ");
   sprintf(buffer, "%d", this->accuracy_decimals);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  force_update: ");
   out.append(YESNO(this->force_update));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  device_class: ");
   out.append("'").append(this->device_class).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state_class: ");
   out.append(proto_enum_to_string<enums::SensorStateClass>(this->state_class));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  last_reset_type: ");
   out.append(proto_enum_to_string<enums::SensorLastResetType>(this->last_reset_type));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -1970,20 +1970,20 @@ void SensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SensorStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SensorStateResponse {\n");
+  out.append("SensorStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   sprintf(buffer, "%g", this->state);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  missing_state: ");
   out.append(YESNO(this->missing_state));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2045,35 +2045,35 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesSwitchResponse {\n");
+  out.append("ListEntitiesSwitchResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  icon: ");
   out.append("'").append(this->icon).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  assumed_state: ");
   out.append(YESNO(this->assumed_state));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2104,15 +2104,15 @@ void SwitchStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SwitchStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SwitchStateResponse {\n");
+  out.append("SwitchStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append(YESNO(this->state));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2143,15 +2143,15 @@ void SwitchCommandRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SwitchCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SwitchCommandRequest {\n");
+  out.append("SwitchCommandRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append(YESNO(this->state));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2208,31 +2208,31 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesTextSensorResponse {\n");
+  out.append("ListEntitiesTextSensorResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  icon: ");
   out.append("'").append(this->icon).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2274,19 +2274,19 @@ void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void TextSensorStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("TextSensorStateResponse {\n");
+  out.append("TextSensorStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append("'").append(this->state).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  missing_state: ");
   out.append(YESNO(this->missing_state));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2311,14 +2311,14 @@ void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeLogsRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SubscribeLogsRequest {\n");
+  out.append("SubscribeLogsRequest {\r\n");
   out.append("  level: ");
   out.append(proto_enum_to_string<enums::LogLevel>(this->level));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  dump_config: ");
   out.append(YESNO(this->dump_config));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2354,18 +2354,18 @@ void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeLogsResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SubscribeLogsResponse {\n");
+  out.append("SubscribeLogsResponse {\r\n");
   out.append("  level: ");
   out.append(proto_enum_to_string<enums::LogLevel>(this->level));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  message: ");
   out.append("'").append(this->message).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  send_failed: ");
   out.append(YESNO(this->send_failed));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2396,14 +2396,14 @@ void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeassistantServiceMap::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("HomeassistantServiceMap {\n");
+  out.append("HomeassistantServiceMap {\r\n");
   out.append("  key: ");
   out.append("'").append(this->key).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  value: ");
   out.append("'").append(this->value).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2455,32 +2455,32 @@ void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeassistantServiceResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("HomeassistantServiceResponse {\n");
+  out.append("HomeassistantServiceResponse {\r\n");
   out.append("  service: ");
   out.append("'").append(this->service).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->data) {
     out.append("  data: ");
     it.dump_to(out);
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->data_template) {
     out.append("  data_template: ");
     it.dump_to(out);
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->variables) {
     out.append("  variables: ");
     it.dump_to(out);
-    out.append("\n");
+    out.append("\r\n");
   }
 
   out.append("  is_event: ");
   out.append(YESNO(this->is_event));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2511,14 +2511,14 @@ void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const 
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SubscribeHomeAssistantStateResponse {\n");
+  out.append("SubscribeHomeAssistantStateResponse {\r\n");
   out.append("  entity_id: ");
   out.append("'").append(this->entity_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  attribute: ");
   out.append("'").append(this->attribute).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2548,18 +2548,18 @@ void HomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void HomeAssistantStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("HomeAssistantStateResponse {\n");
+  out.append("HomeAssistantStateResponse {\r\n");
   out.append("  entity_id: ");
   out.append("'").append(this->entity_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append("'").append(this->state).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  attribute: ");
   out.append("'").append(this->attribute).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2581,11 +2581,11 @@ void GetTimeResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixe
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void GetTimeResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("GetTimeResponse {\n");
+  out.append("GetTimeResponse {\r\n");
   out.append("  epoch_seconds: ");
   sprintf(buffer, "%u", this->epoch_seconds);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2616,14 +2616,14 @@ void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesServicesArgument::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesServicesArgument {\n");
+  out.append("ListEntitiesServicesArgument {\r\n");
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  type: ");
   out.append(proto_enum_to_string<enums::ServiceArgType>(this->type));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2661,20 +2661,20 @@ void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesServicesResponse {\n");
+  out.append("ListEntitiesServicesResponse {\r\n");
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->args) {
     out.append("  args: ");
     it.dump_to(out);
-    out.append("\n");
+    out.append("\r\n");
   }
   out.append("}");
 }
@@ -2755,54 +2755,54 @@ void ExecuteServiceArgument::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ExecuteServiceArgument::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ExecuteServiceArgument {\n");
+  out.append("ExecuteServiceArgument {\r\n");
   out.append("  bool_: ");
   out.append(YESNO(this->bool_));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_int: ");
   sprintf(buffer, "%d", this->legacy_int);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  float_: ");
   sprintf(buffer, "%g", this->float_);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  string_: ");
   out.append("'").append(this->string_).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  int_: ");
   sprintf(buffer, "%d", this->int_);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto it : this->bool_array) {
     out.append("  bool_array: ");
     out.append(YESNO(it));
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->int_array) {
     out.append("  int_array: ");
     sprintf(buffer, "%d", it);
     out.append(buffer);
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->float_array) {
     out.append("  float_array: ");
     sprintf(buffer, "%g", it);
     out.append(buffer);
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->string_array) {
     out.append("  string_array: ");
     out.append("'").append(it).append("'");
-    out.append("\n");
+    out.append("\r\n");
   }
   out.append("}");
 }
@@ -2836,16 +2836,16 @@ void ExecuteServiceRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ExecuteServiceRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ExecuteServiceRequest {\n");
+  out.append("ExecuteServiceRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->args) {
     out.append("  args: ");
     it.dump_to(out);
-    out.append("\n");
+    out.append("\r\n");
   }
   out.append("}");
 }
@@ -2898,27 +2898,27 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesCameraResponse {\n");
+  out.append("ListEntitiesCameraResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2960,19 +2960,19 @@ void CameraImageResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CameraImageResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("CameraImageResponse {\n");
+  out.append("CameraImageResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  data: ");
   out.append("'").append(this->data).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  done: ");
   out.append(YESNO(this->done));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -2997,14 +2997,14 @@ void CameraImageRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void CameraImageRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("CameraImageRequest {\n");
+  out.append("CameraImageRequest {\r\n");
   out.append("  single: ");
   out.append(YESNO(this->single));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  stream: ");
   out.append(YESNO(this->stream));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3133,94 +3133,94 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesClimateResponse {\n");
+  out.append("ListEntitiesClimateResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_current_temperature: ");
   out.append(YESNO(this->supports_current_temperature));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_two_point_target_temperature: ");
   out.append(YESNO(this->supports_two_point_target_temperature));
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->supported_modes) {
     out.append("  supported_modes: ");
     out.append(proto_enum_to_string<enums::ClimateMode>(it));
-    out.append("\n");
+    out.append("\r\n");
   }
 
   out.append("  visual_min_temperature: ");
   sprintf(buffer, "%g", this->visual_min_temperature);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  visual_max_temperature: ");
   sprintf(buffer, "%g", this->visual_max_temperature);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  visual_temperature_step: ");
   sprintf(buffer, "%g", this->visual_temperature_step);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_supports_away: ");
   out.append(YESNO(this->legacy_supports_away));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  supports_action: ");
   out.append(YESNO(this->supports_action));
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->supported_fan_modes) {
     out.append("  supported_fan_modes: ");
     out.append(proto_enum_to_string<enums::ClimateFanMode>(it));
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->supported_swing_modes) {
     out.append("  supported_swing_modes: ");
     out.append(proto_enum_to_string<enums::ClimateSwingMode>(it));
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->supported_custom_fan_modes) {
     out.append("  supported_custom_fan_modes: ");
     out.append("'").append(it).append("'");
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->supported_presets) {
     out.append("  supported_presets: ");
     out.append(proto_enum_to_string<enums::ClimatePreset>(it));
-    out.append("\n");
+    out.append("\r\n");
   }
 
   for (const auto &it : this->supported_custom_presets) {
     out.append("  supported_custom_presets: ");
     out.append("'").append(it).append("'");
-    out.append("\n");
+    out.append("\r\n");
   }
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3312,63 +3312,63 @@ void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ClimateStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ClimateStateResponse {\n");
+  out.append("ClimateStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  mode: ");
   out.append(proto_enum_to_string<enums::ClimateMode>(this->mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  current_temperature: ");
   sprintf(buffer, "%g", this->current_temperature);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  target_temperature: ");
   sprintf(buffer, "%g", this->target_temperature);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  target_temperature_low: ");
   sprintf(buffer, "%g", this->target_temperature_low);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  target_temperature_high: ");
   sprintf(buffer, "%g", this->target_temperature_high);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_away: ");
   out.append(YESNO(this->legacy_away));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  action: ");
   out.append(proto_enum_to_string<enums::ClimateAction>(this->action));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  fan_mode: ");
   out.append(proto_enum_to_string<enums::ClimateFanMode>(this->fan_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  swing_mode: ");
   out.append(proto_enum_to_string<enums::ClimateSwingMode>(this->swing_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  custom_fan_mode: ");
   out.append("'").append(this->custom_fan_mode).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  preset: ");
   out.append(proto_enum_to_string<enums::ClimatePreset>(this->preset));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  custom_preset: ");
   out.append("'").append(this->custom_preset).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3500,94 +3500,94 @@ void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ClimateCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ClimateCommandRequest {\n");
+  out.append("ClimateCommandRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_mode: ");
   out.append(YESNO(this->has_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  mode: ");
   out.append(proto_enum_to_string<enums::ClimateMode>(this->mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_target_temperature: ");
   out.append(YESNO(this->has_target_temperature));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  target_temperature: ");
   sprintf(buffer, "%g", this->target_temperature);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_target_temperature_low: ");
   out.append(YESNO(this->has_target_temperature_low));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  target_temperature_low: ");
   sprintf(buffer, "%g", this->target_temperature_low);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_target_temperature_high: ");
   out.append(YESNO(this->has_target_temperature_high));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  target_temperature_high: ");
   sprintf(buffer, "%g", this->target_temperature_high);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_legacy_away: ");
   out.append(YESNO(this->has_legacy_away));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  legacy_away: ");
   out.append(YESNO(this->legacy_away));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_fan_mode: ");
   out.append(YESNO(this->has_fan_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  fan_mode: ");
   out.append(proto_enum_to_string<enums::ClimateFanMode>(this->fan_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_swing_mode: ");
   out.append(YESNO(this->has_swing_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  swing_mode: ");
   out.append(proto_enum_to_string<enums::ClimateSwingMode>(this->swing_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_custom_fan_mode: ");
   out.append(YESNO(this->has_custom_fan_mode));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  custom_fan_mode: ");
   out.append("'").append(this->custom_fan_mode).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_preset: ");
   out.append(YESNO(this->has_preset));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  preset: ");
   out.append(proto_enum_to_string<enums::ClimatePreset>(this->preset));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  has_custom_preset: ");
   out.append(YESNO(this->has_custom_preset));
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  custom_preset: ");
   out.append("'").append(this->custom_preset).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3659,46 +3659,46 @@ void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesNumberResponse {\n");
+  out.append("ListEntitiesNumberResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  icon: ");
   out.append("'").append(this->icon).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  min_value: ");
   sprintf(buffer, "%g", this->min_value);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  max_value: ");
   sprintf(buffer, "%g", this->max_value);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  step: ");
   sprintf(buffer, "%g", this->step);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3734,20 +3734,20 @@ void NumberStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void NumberStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("NumberStateResponse {\n");
+  out.append("NumberStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   sprintf(buffer, "%g", this->state);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  missing_state: ");
   out.append(YESNO(this->missing_state));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3772,16 +3772,16 @@ void NumberCommandRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void NumberCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("NumberCommandRequest {\n");
+  out.append("NumberCommandRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   sprintf(buffer, "%g", this->state);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3845,37 +3845,37 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("ListEntitiesSelectResponse {\n");
+  out.append("ListEntitiesSelectResponse {\r\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  unique_id: ");
   out.append("'").append(this->unique_id).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  icon: ");
   out.append("'").append(this->icon).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   for (const auto &it : this->options) {
     out.append("  options: ");
     out.append("'").append(it).append("'");
-    out.append("\n");
+    out.append("\r\n");
   }
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3917,19 +3917,19 @@ void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SelectStateResponse::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SelectStateResponse {\n");
+  out.append("SelectStateResponse {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append("'").append(this->state).append("'");
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  missing_state: ");
   out.append(YESNO(this->missing_state));
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif
@@ -3960,15 +3960,15 @@ void SelectCommandRequest::encode(ProtoWriteBuffer buffer) const {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SelectCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
-  out.append("SelectCommandRequest {\n");
+  out.append("SelectCommandRequest {\r\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
-  out.append("\n");
+  out.append("\r\n");
 
   out.append("  state: ");
   out.append("'").append(this->state).append("'");
-  out.append("\n");
+  out.append("\r\n");
   out.append("}");
 }
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1,5 +1,5 @@
 // This file was automatically generated with a tool.
-// See scripts/api_protobuf/api_protobuf.py
+// See script/api_protobuf/api_protobuf.py
 #pragma once
 
 #include "proto.h"

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -1,5 +1,5 @@
 // This file was automatically generated with a tool.
-// See scripts/api_protobuf/api_protobuf.py
+// See script/api_protobuf/api_protobuf.py
 #include "api_pb2_service.h"
 #include "esphome/core/log.h"
 
@@ -88,8 +88,6 @@ bool APIServerConnectionBase::send_cover_state_response(const CoverStateResponse
   return this->send_message_<CoverStateResponse>(msg, 22);
 }
 #endif
-#ifdef USE_COVER
-#endif
 #ifdef USE_FAN
 bool APIServerConnectionBase::send_list_entities_fan_response(const ListEntitiesFanResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -106,8 +104,6 @@ bool APIServerConnectionBase::send_fan_state_response(const FanStateResponse &ms
   return this->send_message_<FanStateResponse>(msg, 23);
 }
 #endif
-#ifdef USE_FAN
-#endif
 #ifdef USE_LIGHT
 bool APIServerConnectionBase::send_list_entities_light_response(const ListEntitiesLightResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -123,8 +119,6 @@ bool APIServerConnectionBase::send_light_state_response(const LightStateResponse
 #endif
   return this->send_message_<LightStateResponse>(msg, 24);
 }
-#endif
-#ifdef USE_LIGHT
 #endif
 #ifdef USE_SENSOR
 bool APIServerConnectionBase::send_list_entities_sensor_response(const ListEntitiesSensorResponse &msg) {
@@ -158,8 +152,6 @@ bool APIServerConnectionBase::send_switch_state_response(const SwitchStateRespon
   return this->send_message_<SwitchStateResponse>(msg, 26);
 }
 #endif
-#ifdef USE_SWITCH
-#endif
 #ifdef USE_TEXT_SENSOR
 bool APIServerConnectionBase::send_list_entities_text_sensor_response(const ListEntitiesTextSensorResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -185,8 +177,7 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
 #endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
-    const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
 #endif
@@ -226,8 +217,6 @@ bool APIServerConnectionBase::send_camera_image_response(const CameraImageRespon
   return this->send_message_<CameraImageResponse>(msg, 44);
 }
 #endif
-#ifdef USE_ESP32_CAMERA
-#endif
 #ifdef USE_CLIMATE
 bool APIServerConnectionBase::send_list_entities_climate_response(const ListEntitiesClimateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -243,8 +232,6 @@ bool APIServerConnectionBase::send_climate_state_response(const ClimateStateResp
 #endif
   return this->send_message_<ClimateStateResponse>(msg, 47);
 }
-#endif
-#ifdef USE_CLIMATE
 #endif
 #ifdef USE_NUMBER
 bool APIServerConnectionBase::send_list_entities_number_response(const ListEntitiesNumberResponse &msg) {
@@ -262,8 +249,6 @@ bool APIServerConnectionBase::send_number_state_response(const NumberStateRespon
   return this->send_message_<NumberStateResponse>(msg, 50);
 }
 #endif
-#ifdef USE_NUMBER
-#endif
 #ifdef USE_SELECT
 bool APIServerConnectionBase::send_list_entities_select_response(const ListEntitiesSelectResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -279,8 +264,6 @@ bool APIServerConnectionBase::send_select_state_response(const SelectStateRespon
 #endif
   return this->send_message_<SelectStateResponse>(msg, 53);
 }
-#endif
-#ifdef USE_SELECT
 #endif
 bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
   switch (msg_type) {
@@ -589,8 +572,7 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(
-    const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -1,5 +1,5 @@
 // This file was automatically generated with a tool.
-// See scripts/api_protobuf/api_protobuf.py
+// See script/api_protobuf/api_protobuf.py
 #pragma once
 
 #include "api_pb2.h"

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -35,6 +35,7 @@ class APIServer : public Component, public Controller {
   void set_port(uint16_t port);
   void set_password(const std::string &password);
   void set_reboot_timeout(uint32_t reboot_timeout);
+  void handle_connect(APIConnection *conn);
   void handle_disconnect(APIConnection *conn);
 #ifdef USE_BINARY_SENSOR
   void on_binary_sensor_update(binary_sensor::BinarySensor *obj, bool state) override;
@@ -86,7 +87,6 @@ class APIServer : public Component, public Controller {
   const std::vector<UserServiceDescriptor *> &get_user_services() const { return this->user_services_; }
 
  protected:
-  AsyncServer server_{0};
   uint16_t port_{6053};
   uint32_t reboot_timeout_{300000};
   uint32_t last_connected_{0};
@@ -102,6 +102,19 @@ template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {
  public:
   bool check(Ts... x) override { return global_api_server->is_connected(); }
 };
+
+#if defined ARDUINO_ARCH_ESP8266 || defined ARDUINO_ARCH_ESP32
+class AsyncAPIServer : public APIServer {
+ public:
+  AsyncAPIServer();
+  void setup() override;
+  void dump_config() override;
+  void on_shutdown() override;
+
+ protected:
+  AsyncServer server_{0};
+};
+#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api_client/__init__.py
+++ b/esphome/components/api_client/__init__.py
@@ -1,0 +1,71 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_TARGET,
+    CONF_UART_ID,
+)
+from esphome.core import coroutine_with_priority
+from esphome.components import uart
+
+DEPENDENCIES = []
+CODEOWNERS = ["@RoganDawes"]
+
+CONF_API_CLIENT = "api_client"
+CONF_API_CLIENT_ID = "api_client_id"
+CONF_API_STREAM_ID = "stream_id"
+CONF_API_ENTITY_KEY = "key"
+
+api_ns = cg.esphome_ns.namespace("api")
+APIClient = api_ns.class_("APIClientConnection", cg.Component)
+StreamAPIClient = api_ns.class_("StreamAPIClientConnection", APIClient, cg.Component)
+AsyncAPIClient = api_ns.class_("AsyncAPIClientConnection", APIClient, cg.Component)
+
+API_CLIENT_STREAM_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(StreamAPIClient),
+            cv.Optional(CONF_PASSWORD, default=""): cv.string,
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+API_CLIENT_ASYNC_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(AsyncAPIClient),
+        cv.Required(CONF_TARGET): cv.ipv4,
+        cv.Optional(CONF_PORT, default=6053): cv.port,
+        cv.Optional(CONF_PASSWORD, default=""): cv.string,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+API_CLIENT_SCHEMA = cv.Schema(
+    cv.Any(
+        cv.Required(API_CLIENT_ASYNC_SCHEMA),
+        cv.Required(API_CLIENT_STREAM_SCHEMA),
+    )
+)
+
+CONFIG_SCHEMA = cv.Schema([API_CLIENT_SCHEMA])
+
+
+@coroutine_with_priority(40.0)
+async def to_code(config):
+    for conf in config:
+        client = None
+        client = cg.new_Pvariable(conf[CONF_ID])
+        if conf.get(CONF_UART_ID) is not None:
+            stream = await cg.get_variable(conf[CONF_UART_ID])
+            cg.add(client.set_stream(stream))
+        elif conf.get(CONF_TARGET) is not None:
+            cg.add(client.set_target(str(conf[CONF_TARGET]), conf[CONF_PORT]))
+        await cg.register_component(client, config)
+
+        password = conf.get(CONF_PASSWORD)
+        if password is not None:
+            cg.add(client.set_password(password))
+
+    cg.add_define("USE_API")
+    cg.add_global(api_ns.using)

--- a/esphome/components/api_client/__init__.py
+++ b/esphome/components/api_client/__init__.py
@@ -15,8 +15,6 @@ CODEOWNERS = ["@RoganDawes"]
 
 CONF_API_CLIENT = "api_client"
 CONF_API_CLIENT_ID = "api_client_id"
-CONF_API_STREAM_ID = "stream_id"
-CONF_API_ENTITY_KEY = "key"
 
 api_client_ns = cg.esphome_ns.namespace("api_client")
 APIClient = api_client_ns.class_("APIClientConnection", cg.Component)

--- a/esphome/components/api_client/__init__.py
+++ b/esphome/components/api_client/__init__.py
@@ -18,10 +18,14 @@ CONF_API_CLIENT_ID = "api_client_id"
 CONF_API_STREAM_ID = "stream_id"
 CONF_API_ENTITY_KEY = "key"
 
-api_ns = cg.esphome_ns.namespace("api")
-APIClient = api_ns.class_("APIClientConnection", cg.Component)
-StreamAPIClient = api_ns.class_("StreamAPIClientConnection", APIClient, cg.Component)
-AsyncAPIClient = api_ns.class_("AsyncAPIClientConnection", APIClient, cg.Component)
+api_client_ns = cg.esphome_ns.namespace("api_client")
+APIClient = api_client_ns.class_("APIClientConnection", cg.Component)
+StreamAPIClient = api_client_ns.class_(
+    "StreamAPIClientConnection", APIClient, cg.Component
+)
+AsyncAPIClient = api_client_ns.class_(
+    "AsyncAPIClientConnection", APIClient, cg.Component
+)
 
 API_CLIENT_STREAM_SCHEMA = (
     cv.Schema(
@@ -68,4 +72,4 @@ async def to_code(config):
             cg.add(client.set_password(password))
 
     cg.add_define("USE_API")
-    cg.add_global(api_ns.using)
+    cg.add_global(api_client_ns.using)

--- a/esphome/components/api_client/api_client_connection.cpp
+++ b/esphome/components/api_client/api_client_connection.cpp
@@ -1,0 +1,436 @@
+#include "api_client_connection.h"
+#include "esphome/core/log.h"
+#include "esphome/core/util.h"
+#include "esphome/core/version.h"
+#include "esphome/components/logger/logger.h"
+#include <string>
+
+namespace esphome {
+namespace api {
+
+static const char *TAG = "api.client_connection";
+
+APIClientConnection::APIClientConnection() {
+  this->send_buffer_.reserve(64);
+  this->recv_buffer_.reserve(32);
+}
+APIClientConnection::~APIClientConnection() {}
+void APIClientConnection::setup() {
+    last_traffic_ = millis();
+    HelloRequest req;
+    req.client_info = App.get_name();
+    this->send_hello_request(req);
+}
+void APIClientConnection::parse_recv_buffer_() {
+    if (this->recv_buffer_.empty())
+        return;
+
+    ESP_LOGV(TAG, "Receive buffer size: %u", this->recv_buffer_.size());
+    if (this->recv_buffer_[0] != 0x00) {
+        ESP_LOGE(TAG, "Invalid preamble from %s : %02x", this->server_info_.c_str(), this->recv_buffer_[0]);
+        this->on_fatal_error();
+        return;
+    }
+    uint32_t i = 1;
+    const uint32_t size = this->recv_buffer_.size();
+    uint32_t consumed;
+    auto msg_size_varint = ProtoVarInt::parse(&this->recv_buffer_[i], size - i, &consumed);
+    if (!msg_size_varint.has_value()) {
+        ESP_LOGVV(TAG, "Insufficient data to read msg_size");
+        return;
+    }
+    i += consumed;
+    uint32_t msg_size = msg_size_varint->as_uint32();
+    ESP_LOGVV(TAG, "msg_size: %u", msg_size);
+
+    auto msg_type_varint = ProtoVarInt::parse(&this->recv_buffer_[i], size - i, &consumed);
+    if (!msg_type_varint.has_value()) {
+        ESP_LOGVV(TAG, "Insufficient data to read msg_type");
+        return;
+    }
+    i += consumed;
+    uint32_t msg_type = msg_type_varint->as_uint32();
+    ESP_LOGVV(TAG, "msg_type: %u", msg_type);
+
+    static uint32_t loop_counter = 0;
+    if (size - i < msg_size) {
+        loop_counter++;
+        ESP_LOGVV(TAG, "Insufficient data to read entire message, got %u, need %u", size - i, msg_size);
+        if (loop_counter == 25) {
+            ESP_LOGE(TAG, "Not making progress, clearing the buffer");
+            this->recv_buffer_.clear();
+        }
+        return;
+    } else {
+        loop_counter = 0;
+    }
+    uint8_t *msg = &this->recv_buffer_[i];
+    this->read_message(msg_size, msg_type, msg);
+    // pop front
+    uint32_t total = i + msg_size;
+    this->recv_buffer_.erase(this->recv_buffer_.begin(), this->recv_buffer_.begin() + total);
+    this->last_traffic_ = millis();
+    ESP_LOGV(TAG, "Receive buffer size: %u", this->recv_buffer_.size());
+}
+void APIClientConnection::register_mapping_(uint32_t key, Nameable *obj) {
+    Nameable *entity = key_map_[key];
+    if (entity != nullptr) {
+        ESP_LOGW(TAG, "Key %d already mapped to %s, attempt to overwrite with %s", 
+                 key, entity->get_name().c_str(), obj->get_name().c_str());
+        return;
+    }
+    key_map_[key] = obj;
+}
+bool APIClientConnection::send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) {
+  std::vector<uint8_t> header;
+  header.push_back(0x00);
+  ProtoVarInt(buffer.get_buffer()->size()).encode(header);
+  ProtoVarInt(message_type).encode(header);
+
+  size_t needed_space = buffer.get_buffer()->size() + header.size();
+
+  if (needed_space > this->space()) {
+    delay(0);
+    if (needed_space > this->space()) {
+      // SubscribeLogsResponse
+      if (message_type != 29) {
+        ESP_LOGV(TAG, "Cannot send message because of Send buffer space");
+      }
+      delay(0);
+      return false;
+    }
+  }
+
+  return this->send_buffer(header, buffer);
+}
+float APIClientConnection::get_setup_priority() const { return setup_priority::PROCESSOR; }
+void APIClientConnection::loop() {
+  this->parse_recv_buffer_();
+
+  const uint32_t keepalive = 10000;
+  if (this->sent_ping_) {
+    // Disconnect if not responded within 2.5*keepalive
+    if (millis() - this->last_traffic_ > (keepalive * 5) / 2) {
+      ESP_LOGW(TAG, "'%s' didn't respond to ping request in time. Disconnecting...", this->server_info_.c_str());
+      this->disconnect_client();
+      return;
+    }
+  } else if (millis() - this->last_traffic_ > keepalive) {
+    this->sent_ping_ = true;
+    this->send_ping_request(PingRequest());
+  }
+}
+#ifdef USE_BINARY_SENSOR
+void APIClientConnection::on_binary_sensor_state_response(const BinarySensorStateResponse &value){
+    Nameable *entity = key_map_[value.key];
+    if (entity != nullptr) {
+        uint32_t key = entity->get_object_id_hash();
+        auto *obj = App.get_binary_sensor_by_key(key);
+        if (obj != nullptr)
+            obj->publish_state(value.state);
+    }
+}
+void APIClientConnection::on_list_entities_binary_sensor_response(const ListEntitiesBinarySensorResponse &value){
+    ESP_LOGD(TAG, "binary_sensor:");
+    ESP_LOGD(TAG, "  - platform: api_relay");
+    ESP_LOGD(TAG, "    id: %s", value.object_id.c_str());
+    ESP_LOGD(TAG, "    key: %u", value.key);
+    ESP_LOGD(TAG, "    name: %s", value.name.c_str());
+    ESP_LOGD(TAG, "    device_class: %s", value.device_class.c_str());
+    ESP_LOGD(TAG, "    is_status_binary_sensor: %s", value.is_status_binary_sensor ? "true" : "false");
+}
+void APIClientConnection::register_binary_sensor(uint32_t key, binary_sensor::BinarySensor *obj){
+    this->register_mapping_(key, obj);
+}
+#endif
+#ifdef USE_COVER
+void APIClientConnection::on_list_entities_cover_response(const ListEntitiesCoverResponse &value){
+}
+void APIClientConnection::on_cover_state_response(const CoverStateResponse &value){
+}
+#endif
+#ifdef USE_FAN
+void APIClientConnection::on_list_entities_fan_response(const ListEntitiesFanResponse &value){
+}
+void APIClientConnection::on_fan_state_response(const FanStateResponse &value){
+}
+#endif
+#ifdef USE_LIGHT
+void APIClientConnection::on_list_entities_light_response(const ListEntitiesLightResponse &value){
+    ESP_LOGD(TAG, "light:");
+    ESP_LOGD(TAG, "  - platform: api_relay");
+    ESP_LOGD(TAG, "    id: %s", value.object_id.c_str());
+    ESP_LOGD(TAG, "    key: %u", value.key);
+    ESP_LOGD(TAG, "    name: %s", value.name.c_str());
+    ESP_LOGD(TAG, "    supports_brightness: %s", value.supports_brightness ? "true" : "false");
+    ESP_LOGD(TAG, "    supports_rgb: %s", value.supports_rgb ? "true" : "false");
+    ESP_LOGD(TAG, "    supports_white_value: %s", value.supports_white_value ? "true" : "false");
+    ESP_LOGD(TAG, "    supports_color_temperature: %s", value.supports_color_temperature ? "true" : "false");
+    ESP_LOGD(TAG, "    min_mireds: %f", value.min_mireds);
+    ESP_LOGD(TAG, "    max_mireds: %f", value.max_mireds);
+}
+void APIClientConnection::on_light_state_response(const LightStateResponse &value){
+    Nameable *entity = key_map_[value.key];
+    if (entity != nullptr) {
+        uint32_t key = entity->get_object_id_hash();
+        auto *obj = App.get_light_by_key(key);
+        if (obj != nullptr)
+            obj->publish_state(value.state);
+    }
+}
+void APIClientConnection::register_light(uint32_t key, light::Light *obj){
+    this->register_mapping_(key, obj);
+}
+#endif
+#ifdef USE_SENSOR
+void APIClientConnection::on_list_entities_sensor_response(const ListEntitiesSensorResponse &value){
+    ESP_LOGD(TAG, "sensor:");
+    ESP_LOGD(TAG, "  - platform: api_relay");
+    ESP_LOGD(TAG, "    id: %s", value.object_id.c_str());
+    ESP_LOGD(TAG, "    key: %u", value.key);
+    ESP_LOGD(TAG, "    name: %s", value.name.c_str());
+    ESP_LOGD(TAG, "    icon: %s", value.icon.c_str());
+    ESP_LOGD(TAG, "    unit_of_measurement: %s", value.unit_of_measurement.c_str());
+    ESP_LOGD(TAG, "    accuracy_decimals: %d", value.accuracy_decimals);
+    ESP_LOGD(TAG, "    device_class: %s", value.device_class.c_str());
+}
+void APIClientConnection::on_sensor_state_response(const SensorStateResponse &value){
+    Nameable *entity = key_map_[value.key];
+    if (entity != nullptr) {
+        uint32_t key = entity->get_object_id_hash();
+        auto *obj = App.get_sensor_by_key(key);
+        if (obj != nullptr)
+            obj->publish_state(value.state);
+    }
+}
+void APIClientConnection::register_sensor(uint32_t key, sensor::Sensor *obj){
+    this->register_mapping_(key, obj);
+}
+#endif
+#ifdef USE_SWITCH
+void APIClientConnection::on_list_entities_switch_response(const ListEntitiesSwitchResponse &value){
+    ESP_LOGD(TAG, "switch:");
+    ESP_LOGD(TAG, "  - platform: api_relay");
+    ESP_LOGD(TAG, "    id: %s", value.object_id.c_str());
+    ESP_LOGD(TAG, "    key: %u", value.key);
+    ESP_LOGD(TAG, "    name: %s", value.name.c_str());
+    ESP_LOGD(TAG, "    icon: %s", value.icon.c_str());
+}
+void APIClientConnection::on_switch_state_response(const SwitchStateResponse &value){
+    Nameable *entity = key_map_[value.key];
+    if (entity != nullptr) {
+        uint32_t key = entity->get_object_id_hash();
+        auto *obj = App.get_switch_by_key(key);
+        if (obj != nullptr)
+            obj->publish_state(value.state);
+    }
+}
+void APIClientConnection::register_switch(uint32_t key, switch_::Switch *obj){
+    this->register_mapping_(key, obj);
+}
+#endif
+#ifdef USE_TEXT_SENSOR
+void APIClientConnection::on_list_entities_text_sensor_response(const ListEntitiesTextSensorResponse &value){
+    ESP_LOGD(TAG, "text_sensor:");
+    ESP_LOGD(TAG, "  - platform: api_relay");
+    ESP_LOGD(TAG, "    id: %s", value.object_id.c_str());
+    ESP_LOGD(TAG, "    key: %u", value.key);
+    ESP_LOGD(TAG, "    name: %s", value.name.c_str());
+    ESP_LOGD(TAG, "    icon: %s", value.icon.c_str());
+}
+void APIClientConnection::on_text_sensor_state_response(const TextSensorStateResponse &value){
+    Nameable *entity = key_map_[value.key];
+    if (entity != nullptr) {
+        uint32_t key = entity->get_object_id_hash();
+        auto *obj = App.get_text_sensor_by_key(key);
+        if (obj != nullptr) {
+            obj->publish_state(value.state);
+        }
+    }
+}
+void APIClientConnection::register_text_sensor(uint32_t key, text_sensor::TextSensor *obj){
+    this->register_mapping_(key, obj);
+}
+#endif
+void APIClientConnection::on_subscribe_logs_response(const SubscribeLogsResponse &value){
+    if (logger::global_logger != nullptr && value.level <= ESPHOME_LOG_LEVEL) {
+        size_t i1 = value.message.find_first_of('[', 7);
+        size_t i2 = -1, i3 = -1;
+        std::string tag;
+        if (i1 >= 0)
+            i1 = value.message.find_first_of('[', i1+1);
+        if (i1 > 0)
+            i2 = value.message.find_first_of(']', i1+1);
+        if (i2 > i1)
+            tag = value.message.substr(i1+1, i2-i1-1);
+        if (!tag.empty()) {
+            i3 = tag.find_first_of(':');
+            int line = atoi(tag.substr(i3+1).c_str());
+            tag = tag.substr(0, i3);
+            std::string message = value.message.substr(i2+2);
+            logger::global_logger->log_vprintf_(value.level, tag.c_str(), line, message.c_str(), va_list());
+        }
+    }
+}
+void APIClientConnection::on_homeassistant_service_response(const HomeassistantServiceResponse &value){
+}
+void APIClientConnection::on_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &value){
+}
+void APIClientConnection::on_get_time_request(const GetTimeRequest &value){
+}
+void APIClientConnection::on_get_time_response(const GetTimeResponse &value){
+}
+void APIClientConnection::on_list_entities_services_response(const ListEntitiesServicesResponse &value){
+}
+void APIClientConnection::on_hello_response(const HelloResponse &value){
+    this->server_info_ = value.server_info;
+    if (value.api_version_major != 1) {
+        this->on_fatal_error();
+        return;
+    }
+    if (value.api_version_minor != 4) {
+        ESP_LOGW(TAG, "API minor version mismatch, sent %d but got %d", 4, value.api_version_minor);
+    }
+    DeviceInfoRequest req;
+    if (!this->send_device_info_request(req)) {
+        ESP_LOGE(TAG, "Failed to send device_info_request");
+        this->on_fatal_error();
+    }
+}
+void APIClientConnection::on_device_info_response(const DeviceInfoResponse &value){
+    ConnectRequest req;
+    if (value.uses_password)
+        req.password = password_;
+    if (!this->send_connect_request(req)) {
+        ESP_LOGE(TAG, "Failed to send connect_request");
+        this->on_fatal_error();
+    }
+}
+void APIClientConnection::on_connect_response(const ConnectResponse &value){
+    if (value.invalid_password) {
+        ESP_LOGE(TAG, "Incorrect password");
+        this->on_fatal_error();
+        return;
+    }
+    // SubscribeLogsRequest req;
+    // req.level = static_cast<enums::LogLevel>(4 /*ESPHOME_LOG_LEVEL*/);
+    // req.dump_config = true;
+    // if (!this->send_subscribe_logs_request(req)) {
+    //     ESP_LOGE(TAG, "Failed to send subscribe_logs_request");
+    //     this->on_fatal_error();
+    //     return;
+    // }
+    ListEntitiesRequest req;
+    if (!this->send_list_entities_request(req)) {
+        ESP_LOGE(TAG, "Failed to send list_entities_request");
+        this->on_fatal_error();
+        return;
+    }
+}
+void APIClientConnection::on_disconnect_request(const DisconnectRequest &value){
+    DisconnectResponse resp;
+    if (!this->send_disconnect_response(resp)) {
+        ESP_LOGE(TAG, "Error sending disconnect response");
+        this->on_fatal_error();
+        return;
+    }
+    this->disconnect_client();
+}
+void APIClientConnection::on_disconnect_response(const DisconnectResponse &value){
+    this->disconnect_client();
+}
+void APIClientConnection::on_ping_request(const PingRequest &value){
+    PingResponse resp;
+    if (!this->send_ping_response(resp)) {
+        ESP_LOGE(TAG, "Error sending ping response");
+        this->on_fatal_error();
+    }
+}
+void APIClientConnection::on_ping_response(const PingResponse &value){
+    this->sent_ping_ = false;
+    this->last_traffic_ = millis();
+}
+void APIClientConnection::on_list_entities_done_response(const ListEntitiesDoneResponse &value){
+    SubscribeStatesRequest req;
+    if (!this->send_subscribe_states_request(req)) {
+        ESP_LOGE(TAG, "Error sending subscribe states request");
+        this->on_fatal_error();
+    }
+}
+#ifdef USE_ESP32_CAMERA
+void APIClientConnection::on_list_entities_camera_response(const ListEntitiesCameraResponse &value){
+}
+void APIClientConnection::on_camera_image_response(const CameraImageResponse &value){
+}
+#endif
+#ifdef USE_CLIMATE
+void APIClientConnection::on_list_entities_climate_response(const ListEntitiesClimateResponse &value){
+}
+void APIClientConnection::on_climate_state_response(const ClimateStateResponse &value){
+}
+#endif
+
+StreamAPIClientConnection::StreamAPIClientConnection() {}
+StreamAPIClientConnection::~StreamAPIClientConnection() {}
+void StreamAPIClientConnection::loop() {
+  size_t available = this->client_->available();
+  uint8_t buf[32];
+  if (available) {
+    while (available) {
+      if (available > sizeof(buf))
+        available = sizeof(buf);
+      size_t read = this->client_->readBytes(buf, available);
+      if (read > 0)
+        this->recv_buffer_.insert(this->recv_buffer_.end(), buf, buf+read);
+      available = this->client_->available();
+    }
+    this->last_traffic_ = millis();
+  }
+  APIClientConnection::loop();
+}
+bool StreamAPIClientConnection::send_buffer(std::vector<uint8_t> header, ProtoWriteBuffer buffer){
+  size_t wrote, expected;
+
+  expected = header.size();
+  wrote = this->client_->write(reinterpret_cast<uint8_t *>(header.data()), header.size());
+  if (wrote != expected) {
+    ESP_LOGE(TAG, "Wrote %d, expected %d", wrote, expected);
+    return false;
+  }
+  expected = buffer.get_buffer()->size();
+  wrote = this->client_->write(reinterpret_cast<uint8_t *>(buffer.get_buffer()->data()), buffer.get_buffer()->size());
+  if (wrote != expected) {
+    ESP_LOGE(TAG, "Wrote %d, expected %d", wrote, expected);
+    return false;
+  }
+  return true;
+}
+void StreamAPIClientConnection::on_fatal_error(){
+  ESP_LOGE(TAG, "Error: Disconnecting %s", this->server_info_.c_str());
+  this->connection_state_ = ConnectionState::WAITING_FOR_HELLO;
+
+  this->last_traffic_ = millis();
+  this->sent_ping_ = false;
+  this->recv_buffer_.clear();
+  this->set_timeout("retry", 15000, [this]() {
+    HelloRequest req;
+    req.client_info = App.get_name();
+    this->send_hello_request(req);
+  });
+}
+void StreamAPIClientConnection::disconnect_client(){
+    ESP_LOGE(TAG, "Disconnecting client, will retry");
+    this->connection_state_ = ConnectionState::WAITING_FOR_HELLO;
+
+    this->last_traffic_ = millis();
+    this->sent_ping_ = false;
+    this->recv_buffer_.clear();
+    this->set_timeout("retry", 5000, [this]() {
+        HelloRequest req;
+        req.client_info = App.get_name();
+        this->send_hello_request(req);
+    });
+}
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api_client/api_client_connection.cpp
+++ b/esphome/components/api_client/api_client_connection.cpp
@@ -288,8 +288,8 @@ void APIClientConnection::on_hello_response(const HelloResponse &value){
         this->on_fatal_error();
         return;
     }
-    if (value.api_version_minor != 4) {
-        ESP_LOGW(TAG, "API minor version mismatch, sent %d but got %d", 4, value.api_version_minor);
+    if (value.api_version_minor != 6) {
+        ESP_LOGW(TAG, "API minor version mismatch, sent %d but got %d", 6, value.api_version_minor);
     }
     DeviceInfoRequest req;
     if (!this->send_device_info_request(req)) {
@@ -312,16 +312,16 @@ void APIClientConnection::on_connect_response(const ConnectResponse &value){
         this->on_fatal_error();
         return;
     }
-    // SubscribeLogsRequest req;
-    // req.level = static_cast<enums::LogLevel>(4 /*ESPHOME_LOG_LEVEL*/);
-    // req.dump_config = true;
-    // if (!this->send_subscribe_logs_request(req)) {
-    //     ESP_LOGE(TAG, "Failed to send subscribe_logs_request");
-    //     this->on_fatal_error();
-    //     return;
-    // }
-    ListEntitiesRequest req;
-    if (!this->send_list_entities_request(req)) {
+    SubscribeLogsRequest slr;
+    slr.level = static_cast<enums::LogLevel>(4 /*ESPHOME_LOG_LEVEL*/);
+    slr.dump_config = true;
+    if (!this->send_subscribe_logs_request(slr)) {
+        ESP_LOGE(TAG, "Failed to send subscribe_logs_request");
+        this->on_fatal_error();
+        return;
+    }
+    ListEntitiesRequest ler;
+    if (!this->send_list_entities_request(ler)) {
         ESP_LOGE(TAG, "Failed to send list_entities_request");
         this->on_fatal_error();
         return;

--- a/esphome/components/api_client/api_client_connection.cpp
+++ b/esphome/components/api_client/api_client_connection.cpp
@@ -6,9 +6,9 @@
 #include <string>
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
-static const char *TAG = "api.client_connection";
+static const char *TAG = "api_client.client_connection";
 
 APIClientConnection::APIClientConnection() {
   this->send_buffer_.reserve(64);
@@ -432,5 +432,5 @@ void StreamAPIClientConnection::disconnect_client(){
     });
 }
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome

--- a/esphome/components/api_client/api_client_connection.h
+++ b/esphome/components/api_client/api_client_connection.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/application.h"
+#include "esphome/core/automation.h"
+#include "../api/api_pb2.h"
+#include "api_pb2_client.h"
+#include <map>
+
+namespace esphome {
+namespace api {
+
+class APIClientConnection : public APIClientConnectionBase, public Component {
+ public:
+  APIClientConnection();
+  virtual ~APIClientConnection();
+
+  virtual void disconnect_client() = 0;
+  void setup();
+  float get_setup_priority() const override;
+  virtual void loop();
+  virtual size_t space() = 0;
+
+  virtual void on_hello_response(const HelloResponse &value);
+  virtual void on_connect_response(const ConnectResponse &value);
+  virtual void on_disconnect_request(const DisconnectRequest &value);
+  virtual void on_disconnect_response(const DisconnectResponse &value);
+  virtual void on_ping_request(const PingRequest &value);
+  virtual void on_ping_response(const PingResponse &value);
+  virtual void on_device_info_response(const DeviceInfoResponse &value);
+  virtual void on_list_entities_done_response(const ListEntitiesDoneResponse &value);
+  virtual void on_subscribe_logs_response(const SubscribeLogsResponse &value);
+  virtual void on_homeassistant_service_response(const HomeassistantServiceResponse &value);
+  virtual void on_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &value);
+  virtual void on_get_time_request(const GetTimeRequest &value);
+  virtual void on_get_time_response(const GetTimeResponse &value);
+  virtual void on_list_entities_services_response(const ListEntitiesServicesResponse &value);
+
+#ifdef USE_BINARY_SENSOR
+  virtual void on_list_entities_binary_sensor_response(const ListEntitiesBinarySensorResponse &value);
+  virtual void on_binary_sensor_state_response(const BinarySensorStateResponse &value);
+  virtual void register_binary_sensor(uint32_t key, binary_sensor::BinarySensor *obj);
+#endif
+#ifdef USE_COVER
+  virtual void on_list_entities_cover_response(const ListEntitiesCoverResponse &value);
+  virtual void on_cover_state_response(const CoverStateResponse &value);
+#endif
+#ifdef USE_FAN
+  virtual void on_list_entities_fan_response(const ListEntitiesFanResponse &value);
+  virtual void on_fan_state_response(const FanStateResponse &value);
+#endif
+#ifdef USE_LIGHT
+  virtual void on_list_entities_light_response(const ListEntitiesLightResponse &value);
+  virtual void on_light_state_response(const LightStateResponse &value);
+  virtual void register_light(uint32_t key, light::Light *obj);
+#endif
+#ifdef USE_SENSOR
+  virtual void on_list_entities_sensor_response(const ListEntitiesSensorResponse &value);
+  virtual void on_sensor_state_response(const SensorStateResponse &value);
+  virtual void register_sensor(uint32_t key, sensor::Sensor *obj);
+#endif
+#ifdef USE_SWITCH
+  virtual void on_list_entities_switch_response(const ListEntitiesSwitchResponse &value);
+  virtual void on_switch_state_response(const SwitchStateResponse &value);
+  virtual void register_switch(uint32_t key, switch_::Switch *obj);
+#endif
+#ifdef USE_TEXT_SENSOR
+  virtual void on_list_entities_text_sensor_response(const ListEntitiesTextSensorResponse &value);
+  virtual void on_text_sensor_state_response(const TextSensorStateResponse &value);
+  virtual void register_text_sensor(uint32_t key, text_sensor::TextSensor *obj);
+#endif
+#ifdef USE_ESP32_CAMERA
+  virtual void on_list_entities_camera_response(const ListEntitiesCameraResponse &value);
+  virtual void on_camera_image_response(const CameraImageResponse &value);
+#endif
+#ifdef USE_CLIMATE
+  virtual void on_list_entities_climate_response(const ListEntitiesClimateResponse &value);
+  virtual void on_climate_state_response(const ClimateStateResponse &value);
+#endif
+
+  ProtoWriteBuffer create_buffer() override {
+    this->send_buffer_.clear();
+    return {&this->send_buffer_};
+  }
+  bool send_buffer(ProtoWriteBuffer buffer, uint32_t message_type);
+  virtual bool send_buffer(std::vector<uint8_t> header, ProtoWriteBuffer buffer) = 0;
+  bool is_authenticated() { return authenticated_; }
+  bool is_connection_setup() { return connected_; }
+  void set_password(std::string password) { this->password_ = password; }
+
+ protected:
+  void parse_recv_buffer_();
+  void register_mapping_(uint32_t key, Nameable *obj);
+
+  enum class ConnectionState {
+    WAITING_FOR_HELLO,
+    CONNECTED,
+    AUTHENTICATED,
+  } connection_state_{ConnectionState::WAITING_FOR_HELLO};
+
+  bool authenticated_{false};
+  bool connected_{false};
+  
+  std::vector<uint8_t> send_buffer_;
+  std::vector<uint8_t> recv_buffer_;
+
+  std::string server_info_;
+  std::string password_;
+
+  uint32_t last_traffic_;
+  bool sent_ping_{false};
+
+  std::map<uint32_t, Nameable *> key_map_{};
+};
+
+class StreamAPIClientConnection : public APIClientConnection {
+ public:
+  StreamAPIClientConnection();
+  virtual ~StreamAPIClientConnection();
+  void on_disconnect_response(const DisconnectResponse &value) override {
+    // just reset connection_state_
+    this->connection_state_ = ConnectionState::WAITING_FOR_HELLO;
+  }
+  DisconnectResponse disconnect(const DisconnectRequest &msg) {
+    // remote initiated disconnect_client
+    this->connection_state_ = ConnectionState::WAITING_FOR_HELLO;
+    DisconnectResponse resp;
+    return resp;
+  }
+  bool send_buffer(std::vector<uint8_t> header, ProtoWriteBuffer buffer) override;
+  void set_password(std::string password) {
+    this->password_ = password;
+    if (password == "") {
+      this->authenticated_ = true;
+      this->connected_ = true;
+    }
+  }
+  void set_stream(Stream *stream) {
+    this->client_ = stream;
+  }
+  void on_fatal_error() override;
+
+  void disconnect_client() override;
+  void loop() override;
+  size_t space() { return 256; }  
+
+ protected:
+  Stream *client_;
+  bool is_connected_() {
+    const uint32_t timeout = 30000;
+    if (millis() - this->last_traffic_ > timeout) {
+      return false;
+    }
+    return true;
+  }
+};
+
+template<typename... Ts> class APIClientConnectedCondition : public Condition<Ts...> {
+ public:
+  bool check(Ts... x) override { return true; }
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api_client/api_client_connection.h
+++ b/esphome/components/api_client/api_client_connection.h
@@ -8,7 +8,7 @@
 #include <map>
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
 class APIClientConnection : public APIClientConnectionBase, public Component {
  public:
@@ -160,5 +160,5 @@ template<typename... Ts> class APIClientConnectedCondition : public Condition<Ts
   bool check(Ts... x) override { return true; }
 };
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome

--- a/esphome/components/api_client/api_pb2_client.cpp
+++ b/esphome/components/api_client/api_pb2_client.cpp
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace api_client {
 
-static const char *TAG = "api_client.client";
+static const char *const TAG = "api_client.client";
 
 bool APIClientConnectionBase::send_hello_request(const HelloRequest &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api_client/api_pb2_client.cpp
+++ b/esphome/components/api_client/api_pb2_client.cpp
@@ -4,9 +4,9 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
-static const char *TAG = "api.client";
+static const char *TAG = "api_client.client";
 
 bool APIClientConnectionBase::send_hello_request(const HelloRequest &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -541,5 +541,5 @@ bool APIClientConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
   return true;
 }
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome

--- a/esphome/components/api_client/api_pb2_client.cpp
+++ b/esphome/components/api_client/api_pb2_client.cpp
@@ -1,0 +1,545 @@
+// This file was automatically generated with a tool.
+// See script/api_protobuf/api_protobuf.py
+#include "api_pb2_client.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace api {
+
+static const char *TAG = "api.client";
+
+bool APIClientConnectionBase::send_hello_request(const HelloRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_hello_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<HelloRequest>(msg, 1);
+}
+bool APIClientConnectionBase::send_connect_request(const ConnectRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_connect_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ConnectRequest>(msg, 3);
+}
+bool APIClientConnectionBase::send_disconnect_request(const DisconnectRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_disconnect_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DisconnectRequest>(msg, 5);
+}
+bool APIClientConnectionBase::send_disconnect_response(const DisconnectResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_disconnect_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DisconnectResponse>(msg, 6);
+}
+bool APIClientConnectionBase::send_ping_request(const PingRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_ping_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<PingRequest>(msg, 7);
+}
+bool APIClientConnectionBase::send_ping_response(const PingResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_ping_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<PingResponse>(msg, 8);
+}
+bool APIClientConnectionBase::send_device_info_request(const DeviceInfoRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_device_info_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DeviceInfoRequest>(msg, 9);
+}
+bool APIClientConnectionBase::send_list_entities_request(const ListEntitiesRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesRequest>(msg, 11);
+}
+bool APIClientConnectionBase::send_subscribe_states_request(const SubscribeStatesRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_subscribe_states_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SubscribeStatesRequest>(msg, 20);
+}
+#ifdef USE_COVER
+bool APIClientConnectionBase::send_cover_command_request(const CoverCommandRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_cover_command_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<CoverCommandRequest>(msg, 30);
+}
+#endif
+#ifdef USE_FAN
+bool APIClientConnectionBase::send_fan_command_request(const FanCommandRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_fan_command_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<FanCommandRequest>(msg, 31);
+}
+#endif
+#ifdef USE_LIGHT
+bool APIClientConnectionBase::send_light_command_request(const LightCommandRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_light_command_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<LightCommandRequest>(msg, 32);
+}
+#endif
+#ifdef USE_SWITCH
+bool APIClientConnectionBase::send_switch_command_request(const SwitchCommandRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_switch_command_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SwitchCommandRequest>(msg, 33);
+}
+#endif
+bool APIClientConnectionBase::send_subscribe_logs_request(const SubscribeLogsRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_subscribe_logs_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SubscribeLogsRequest>(msg, 28);
+}
+bool APIClientConnectionBase::send_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_subscribe_homeassistant_services_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SubscribeHomeassistantServicesRequest>(msg, 34);
+}
+bool APIClientConnectionBase::send_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_subscribe_home_assistant_states_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SubscribeHomeAssistantStatesRequest>(msg, 38);
+}
+bool APIClientConnectionBase::send_home_assistant_state_response(const HomeAssistantStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_home_assistant_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<HomeAssistantStateResponse>(msg, 40);
+}
+bool APIClientConnectionBase::send_get_time_request(const GetTimeRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_get_time_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<GetTimeRequest>(msg, 36);
+}
+bool APIClientConnectionBase::send_get_time_response(const GetTimeResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_get_time_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<GetTimeResponse>(msg, 37);
+}
+bool APIClientConnectionBase::send_execute_service_request(const ExecuteServiceRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_execute_service_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ExecuteServiceRequest>(msg, 42);
+}
+#ifdef USE_ESP32_CAMERA
+bool APIClientConnectionBase::send_camera_image_request(const CameraImageRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_camera_image_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<CameraImageRequest>(msg, 45);
+}
+#endif
+#ifdef USE_CLIMATE
+bool APIClientConnectionBase::send_climate_command_request(const ClimateCommandRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_climate_command_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ClimateCommandRequest>(msg, 48);
+}
+#endif
+#ifdef USE_NUMBER
+bool APIClientConnectionBase::send_number_command_request(const NumberCommandRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_number_command_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<NumberCommandRequest>(msg, 51);
+}
+#endif
+#ifdef USE_SELECT
+bool APIClientConnectionBase::send_select_command_request(const SelectCommandRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_select_command_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SelectCommandRequest>(msg, 54);
+}
+#endif
+bool APIClientConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
+  switch (msg_type) {
+    case 2: {
+      HelloResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_hello_response: %s", msg.dump().c_str());
+#endif
+      this->on_hello_response(msg);
+      break;
+    }
+    case 4: {
+      ConnectResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_connect_response: %s", msg.dump().c_str());
+#endif
+      this->on_connect_response(msg);
+      break;
+    }
+    case 5: {
+      DisconnectRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump().c_str());
+#endif
+      this->on_disconnect_request(msg);
+      break;
+    }
+    case 6: {
+      DisconnectResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump().c_str());
+#endif
+      this->on_disconnect_response(msg);
+      break;
+    }
+    case 7: {
+      PingRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump().c_str());
+#endif
+      this->on_ping_request(msg);
+      break;
+    }
+    case 8: {
+      PingResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump().c_str());
+#endif
+      this->on_ping_response(msg);
+      break;
+    }
+    case 10: {
+      DeviceInfoResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_device_info_response: %s", msg.dump().c_str());
+#endif
+      this->on_device_info_response(msg);
+      break;
+    }
+    case 12: {
+#ifdef USE_BINARY_SENSOR
+      ListEntitiesBinarySensorResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_binary_sensor_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_binary_sensor_response(msg);
+#endif
+      break;
+    }
+    case 13: {
+#ifdef USE_COVER
+      ListEntitiesCoverResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_cover_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_cover_response(msg);
+#endif
+      break;
+    }
+    case 14: {
+#ifdef USE_FAN
+      ListEntitiesFanResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_fan_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_fan_response(msg);
+#endif
+      break;
+    }
+    case 15: {
+#ifdef USE_LIGHT
+      ListEntitiesLightResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_light_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_light_response(msg);
+#endif
+      break;
+    }
+    case 16: {
+#ifdef USE_SENSOR
+      ListEntitiesSensorResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_sensor_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_sensor_response(msg);
+#endif
+      break;
+    }
+    case 17: {
+#ifdef USE_SWITCH
+      ListEntitiesSwitchResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_switch_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_switch_response(msg);
+#endif
+      break;
+    }
+    case 18: {
+#ifdef USE_TEXT_SENSOR
+      ListEntitiesTextSensorResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_text_sensor_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_text_sensor_response(msg);
+#endif
+      break;
+    }
+    case 19: {
+      ListEntitiesDoneResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_done_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_done_response(msg);
+      break;
+    }
+    case 21: {
+#ifdef USE_BINARY_SENSOR
+      BinarySensorStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_binary_sensor_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_binary_sensor_state_response(msg);
+#endif
+      break;
+    }
+    case 22: {
+#ifdef USE_COVER
+      CoverStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_cover_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_cover_state_response(msg);
+#endif
+      break;
+    }
+    case 23: {
+#ifdef USE_FAN
+      FanStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_fan_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_fan_state_response(msg);
+#endif
+      break;
+    }
+    case 24: {
+#ifdef USE_LIGHT
+      LightStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_light_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_light_state_response(msg);
+#endif
+      break;
+    }
+    case 25: {
+#ifdef USE_SENSOR
+      SensorStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_sensor_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_sensor_state_response(msg);
+#endif
+      break;
+    }
+    case 26: {
+#ifdef USE_SWITCH
+      SwitchStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_switch_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_switch_state_response(msg);
+#endif
+      break;
+    }
+    case 27: {
+#ifdef USE_TEXT_SENSOR
+      TextSensorStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_text_sensor_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_text_sensor_state_response(msg);
+#endif
+      break;
+    }
+    case 29: {
+      SubscribeLogsResponse msg;
+      msg.decode(msg_data, msg_size);
+      this->on_subscribe_logs_response(msg);
+      break;
+    }
+    case 35: {
+      HomeassistantServiceResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_homeassistant_service_response: %s", msg.dump().c_str());
+#endif
+      this->on_homeassistant_service_response(msg);
+      break;
+    }
+    case 36: {
+      GetTimeRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_get_time_request: %s", msg.dump().c_str());
+#endif
+      this->on_get_time_request(msg);
+      break;
+    }
+    case 37: {
+      GetTimeResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump().c_str());
+#endif
+      this->on_get_time_response(msg);
+      break;
+    }
+    case 39: {
+      SubscribeHomeAssistantStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_home_assistant_state_response(msg);
+      break;
+    }
+    case 41: {
+      ListEntitiesServicesResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_services_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_services_response(msg);
+      break;
+    }
+    case 43: {
+#ifdef USE_ESP32_CAMERA
+      ListEntitiesCameraResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_camera_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_camera_response(msg);
+#endif
+      break;
+    }
+    case 44: {
+#ifdef USE_ESP32_CAMERA
+      CameraImageResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_camera_image_response: %s", msg.dump().c_str());
+#endif
+      this->on_camera_image_response(msg);
+#endif
+      break;
+    }
+    case 46: {
+#ifdef USE_CLIMATE
+      ListEntitiesClimateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_climate_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_climate_response(msg);
+#endif
+      break;
+    }
+    case 47: {
+#ifdef USE_CLIMATE
+      ClimateStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_climate_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_climate_state_response(msg);
+#endif
+      break;
+    }
+    case 49: {
+#ifdef USE_NUMBER
+      ListEntitiesNumberResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_number_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_number_response(msg);
+#endif
+      break;
+    }
+    case 50: {
+#ifdef USE_NUMBER
+      NumberStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_number_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_number_state_response(msg);
+#endif
+      break;
+    }
+    case 52: {
+#ifdef USE_SELECT
+      ListEntitiesSelectResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_select_response: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_select_response(msg);
+#endif
+      break;
+    }
+    case 53: {
+#ifdef USE_SELECT
+      SelectStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_select_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_select_state_response(msg);
+#endif
+      break;
+    }
+    default:
+      return false;
+  }
+  return true;
+}
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api_client/api_pb2_client.h
+++ b/esphome/components/api_client/api_pb2_client.h
@@ -7,7 +7,7 @@
 #include "esphome/core/defines.h"
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
 class APIClientConnectionBase : public ProtoClient {
  public:
@@ -135,5 +135,5 @@ class APIClientConnectionBase : public ProtoClient {
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
 };
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome

--- a/esphome/components/api_client/api_pb2_client.h
+++ b/esphome/components/api_client/api_pb2_client.h
@@ -1,0 +1,139 @@
+// This file was automatically generated with a tool.
+// See script/api_protobuf/api_protobuf.py
+#pragma once
+
+#include "proto_client.h"
+#include "../api/api_pb2.h"
+#include "esphome/core/defines.h"
+
+namespace esphome {
+namespace api {
+
+class APIClientConnectionBase : public ProtoClient {
+ public:
+  bool send_hello_request(const HelloRequest &msg);
+  virtual void on_hello_response(const HelloResponse &value){};
+  bool send_connect_request(const ConnectRequest &msg);
+  virtual void on_connect_response(const ConnectResponse &value){};
+  bool send_disconnect_request(const DisconnectRequest &msg);
+  virtual void on_disconnect_request(const DisconnectRequest &value){};
+  bool send_disconnect_response(const DisconnectResponse &msg);
+  virtual void on_disconnect_response(const DisconnectResponse &value){};
+  bool send_ping_request(const PingRequest &msg);
+  virtual void on_ping_request(const PingRequest &value){};
+  bool send_ping_response(const PingResponse &msg);
+  virtual void on_ping_response(const PingResponse &value){};
+  bool send_device_info_request(const DeviceInfoRequest &msg);
+  virtual void on_device_info_response(const DeviceInfoResponse &value){};
+  bool send_list_entities_request(const ListEntitiesRequest &msg);
+  virtual void on_list_entities_done_response(const ListEntitiesDoneResponse &value){};
+  bool send_subscribe_states_request(const SubscribeStatesRequest &msg);
+#ifdef USE_BINARY_SENSOR
+  virtual void on_list_entities_binary_sensor_response(const ListEntitiesBinarySensorResponse &value){};
+#endif
+#ifdef USE_BINARY_SENSOR
+  virtual void on_binary_sensor_state_response(const BinarySensorStateResponse &value){};
+#endif
+#ifdef USE_COVER
+  virtual void on_list_entities_cover_response(const ListEntitiesCoverResponse &value){};
+#endif
+#ifdef USE_COVER
+  virtual void on_cover_state_response(const CoverStateResponse &value){};
+#endif
+#ifdef USE_COVER
+  bool send_cover_command_request(const CoverCommandRequest &msg);
+#endif
+#ifdef USE_FAN
+  virtual void on_list_entities_fan_response(const ListEntitiesFanResponse &value){};
+#endif
+#ifdef USE_FAN
+  virtual void on_fan_state_response(const FanStateResponse &value){};
+#endif
+#ifdef USE_FAN
+  bool send_fan_command_request(const FanCommandRequest &msg);
+#endif
+#ifdef USE_LIGHT
+  virtual void on_list_entities_light_response(const ListEntitiesLightResponse &value){};
+#endif
+#ifdef USE_LIGHT
+  virtual void on_light_state_response(const LightStateResponse &value){};
+#endif
+#ifdef USE_LIGHT
+  bool send_light_command_request(const LightCommandRequest &msg);
+#endif
+#ifdef USE_SENSOR
+  virtual void on_list_entities_sensor_response(const ListEntitiesSensorResponse &value){};
+#endif
+#ifdef USE_SENSOR
+  virtual void on_sensor_state_response(const SensorStateResponse &value){};
+#endif
+#ifdef USE_SWITCH
+  virtual void on_list_entities_switch_response(const ListEntitiesSwitchResponse &value){};
+#endif
+#ifdef USE_SWITCH
+  virtual void on_switch_state_response(const SwitchStateResponse &value){};
+#endif
+#ifdef USE_SWITCH
+  bool send_switch_command_request(const SwitchCommandRequest &msg);
+#endif
+#ifdef USE_TEXT_SENSOR
+  virtual void on_list_entities_text_sensor_response(const ListEntitiesTextSensorResponse &value){};
+#endif
+#ifdef USE_TEXT_SENSOR
+  virtual void on_text_sensor_state_response(const TextSensorStateResponse &value){};
+#endif
+  bool send_subscribe_logs_request(const SubscribeLogsRequest &msg);
+  virtual void on_subscribe_logs_response(const SubscribeLogsResponse &value){};
+  bool send_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg);
+  virtual void on_homeassistant_service_response(const HomeassistantServiceResponse &value){};
+  bool send_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg);
+  virtual void on_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &value){};
+  bool send_home_assistant_state_response(const HomeAssistantStateResponse &msg);
+  bool send_get_time_request(const GetTimeRequest &msg);
+  virtual void on_get_time_request(const GetTimeRequest &value){};
+  bool send_get_time_response(const GetTimeResponse &msg);
+  virtual void on_get_time_response(const GetTimeResponse &value){};
+  virtual void on_list_entities_services_response(const ListEntitiesServicesResponse &value){};
+  bool send_execute_service_request(const ExecuteServiceRequest &msg);
+#ifdef USE_ESP32_CAMERA
+  virtual void on_list_entities_camera_response(const ListEntitiesCameraResponse &value){};
+#endif
+#ifdef USE_ESP32_CAMERA
+  virtual void on_camera_image_response(const CameraImageResponse &value){};
+#endif
+#ifdef USE_ESP32_CAMERA
+  bool send_camera_image_request(const CameraImageRequest &msg);
+#endif
+#ifdef USE_CLIMATE
+  virtual void on_list_entities_climate_response(const ListEntitiesClimateResponse &value){};
+#endif
+#ifdef USE_CLIMATE
+  virtual void on_climate_state_response(const ClimateStateResponse &value){};
+#endif
+#ifdef USE_CLIMATE
+  bool send_climate_command_request(const ClimateCommandRequest &msg);
+#endif
+#ifdef USE_NUMBER
+  virtual void on_list_entities_number_response(const ListEntitiesNumberResponse &value){};
+#endif
+#ifdef USE_NUMBER
+  virtual void on_number_state_response(const NumberStateResponse &value){};
+#endif
+#ifdef USE_NUMBER
+  bool send_number_command_request(const NumberCommandRequest &msg);
+#endif
+#ifdef USE_SELECT
+  virtual void on_list_entities_select_response(const ListEntitiesSelectResponse &value){};
+#endif
+#ifdef USE_SELECT
+  virtual void on_select_state_response(const SelectStateResponse &value){};
+#endif
+#ifdef USE_SELECT
+  bool send_select_command_request(const SelectCommandRequest &msg);
+#endif
+ protected:
+  bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api_client/binary_sensor.py
+++ b/esphome/components/api_client/binary_sensor.py
@@ -1,0 +1,29 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import CONF_ID
+from . import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+
+DEPENDENCIES = ["api_client"]
+
+binary_sensor_ns = cg.esphome_ns.namespace("binary_sensor")
+BinarySensor = binary_sensor_ns.class_(
+    "BinarySensor", binary_sensor.BinarySensor, cg.Nameable
+)
+
+CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(BinarySensor),
+        cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
+        cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    paren = yield cg.get_variable(config[CONF_API_CLIENT_ID])
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    yield binary_sensor.register_binary_sensor(var, config)
+
+    cg.add(paren.register_binary_sensor(config[CONF_API_ENTITY_KEY], var))

--- a/esphome/components/api_client/binary_sensor.py
+++ b/esphome/components/api_client/binary_sensor.py
@@ -1,8 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor
-from esphome.const import CONF_ID
-from . import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+from esphome.const import CONF_ID, CONF_KEY
+from . import CONF_API_CLIENT_ID, APIClient
 
 DEPENDENCIES = ["api_client"]
 
@@ -15,7 +15,7 @@ CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(BinarySensor),
         cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
-        cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+        cv.Required(CONF_KEY): cv.uint32_t,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -26,4 +26,4 @@ def to_code(config):
 
     yield binary_sensor.register_binary_sensor(var, config)
 
-    cg.add(paren.register_binary_sensor(config[CONF_API_ENTITY_KEY], var))
+    cg.add(paren.register_binary_sensor(config[CONF_KEY], var))

--- a/esphome/components/api_client/proto_client.h
+++ b/esphome/components/api_client/proto_client.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/api/proto.h"
+
+namespace esphome {
+namespace api {
+
+class ProtoClient {
+ public:
+ protected:
+  virtual bool is_authenticated() = 0;
+  virtual bool is_connection_setup() = 0;
+  virtual void on_fatal_error() = 0;
+  virtual ProtoWriteBuffer create_buffer() = 0;
+  virtual bool send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) = 0;
+  virtual bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) = 0;
+
+  template<class C> bool send_message_(const C &msg, uint32_t message_type) {
+    auto buffer = this->create_buffer();
+    msg.encode(buffer);
+    return this->send_buffer(buffer, message_type);
+  }
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api_client/proto_client.h
+++ b/esphome/components/api_client/proto_client.h
@@ -5,7 +5,8 @@
 #include "esphome/components/api/proto.h"
 
 namespace esphome {
-namespace api {
+namespace api_client {
+using namespace esphome::api;
 
 class ProtoClient {
  public:
@@ -24,5 +25,5 @@ class ProtoClient {
   }
 };
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome

--- a/esphome/components/api_client/sensor.py
+++ b/esphome/components/api_client/sensor.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import CONF_ID, UNIT_EMPTY, ICON_EMPTY
+from . import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+
+DEPENDENCIES = ["api_client"]
+
+sensor_ns = cg.esphome_ns.namespace("sensor")
+Sensor = sensor_ns.class_("Sensor", sensor.Sensor, cg.Nameable)
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(UNIT_EMPTY, ICON_EMPTY, 1)
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(Sensor),
+            cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
+            cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+def to_code(config):
+    paren = yield cg.get_variable(config[CONF_API_CLIENT_ID])
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    yield sensor.register_sensor(var, config)
+
+    cg.add(paren.register_sensor(config[CONF_API_ENTITY_KEY], var))

--- a/esphome/components/api_client/sensor.py
+++ b/esphome/components/api_client/sensor.py
@@ -1,8 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
-from esphome.const import CONF_ID, UNIT_EMPTY, ICON_EMPTY
-from . import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+from esphome.const import CONF_ID, CONF_KEY, UNIT_EMPTY, ICON_EMPTY
+from . import CONF_API_CLIENT_ID, APIClient
 
 DEPENDENCIES = ["api_client"]
 
@@ -15,7 +15,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(Sensor),
             cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
-            cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+            cv.Required(CONF_KEY): cv.uint32_t,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -28,4 +28,4 @@ def to_code(config):
 
     yield sensor.register_sensor(var, config)
 
-    cg.add(paren.register_sensor(config[CONF_API_ENTITY_KEY], var))
+    cg.add(paren.register_sensor(config[CONF_KEY], var))

--- a/esphome/components/api_client/switch/__init__.py
+++ b/esphome/components/api_client/switch/__init__.py
@@ -1,0 +1,29 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+from esphome.const import CONF_ID
+from .. import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+
+DEPENDENCIES = ["api_client"]
+
+api_ns = cg.esphome_ns.namespace("api")
+ApiSwitch = api_ns.class_("ApiClientSwitch", switch.Switch, cg.Component)
+
+CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(ApiSwitch),
+        cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
+        cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    paren = yield cg.get_variable(config[CONF_API_CLIENT_ID])
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    yield switch.register_switch(var, config)
+
+    cg.add(var.set_api_key(config[CONF_API_ENTITY_KEY]))
+    cg.add(var.set_api_parent(paren))
+    cg.add(paren.register_switch(config[CONF_API_ENTITY_KEY], var))

--- a/esphome/components/api_client/switch/__init__.py
+++ b/esphome/components/api_client/switch/__init__.py
@@ -1,8 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
-from esphome.const import CONF_ID
-from .. import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+from esphome.const import CONF_ID, CONF_KEY
+from .. import CONF_API_CLIENT_ID, APIClient
 
 DEPENDENCIES = ["api_client"]
 
@@ -13,7 +13,7 @@ CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(ApiSwitch),
         cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
-        cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+        cv.Required(CONF_KEY): cv.uint32_t,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -24,6 +24,6 @@ def to_code(config):
 
     yield switch.register_switch(var, config)
 
-    cg.add(var.set_api_key(config[CONF_API_ENTITY_KEY]))
+    cg.add(var.set_api_key(config[CONF_KEY]))
     cg.add(var.set_api_parent(paren))
-    cg.add(paren.register_switch(config[CONF_API_ENTITY_KEY], var))
+    cg.add(paren.register_switch(config[CONF_KEY], var))

--- a/esphome/components/api_client/switch/__init__.py
+++ b/esphome/components/api_client/switch/__init__.py
@@ -6,8 +6,8 @@ from .. import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
 
 DEPENDENCIES = ["api_client"]
 
-api_ns = cg.esphome_ns.namespace("api")
-ApiSwitch = api_ns.class_("ApiClientSwitch", switch.Switch, cg.Component)
+api_client_ns = cg.esphome_ns.namespace("api_client")
+ApiSwitch = api_client_ns.class_("ApiClientSwitch", switch.Switch, cg.Component)
 
 CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
     {

--- a/esphome/components/api_client/switch/api_switch.cpp
+++ b/esphome/components/api_client/switch/api_switch.cpp
@@ -1,0 +1,27 @@
+#include "esphome/core/log.h"
+#include "api_switch.h"
+#include "../../api/api_pb2.h"
+
+namespace esphome {
+namespace api {
+
+static const char *TAG = "apiclient.switch";
+
+void ApiClientSwitch::write_state(bool state) {
+  ESP_LOGV(TAG, "Setting switch %u: %s", this->key_, ONOFF(state));
+  SwitchCommandRequest req;
+  req.key = key_;
+  req.state = state;
+  if (!this->parent_->send_switch_command_request(req))
+    ESP_LOGE(TAG, "Unable to send switch_command_request");
+  else
+    this->publish_state(state);
+}
+
+void ApiClientSwitch::dump_config() {
+  LOG_SWITCH("", "API Client Switch", this);
+  ESP_LOGCONFIG(TAG, "  Switch has key ID %u", this->key_);
+}
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api_client/switch/api_switch.cpp
+++ b/esphome/components/api_client/switch/api_switch.cpp
@@ -3,9 +3,9 @@
 #include "../../api/api_pb2.h"
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
-static const char *TAG = "apiclient.switch";
+static const char *TAG = "api_client.switch";
 
 void ApiClientSwitch::write_state(bool state) {
   ESP_LOGV(TAG, "Setting switch %u: %s", this->key_, ONOFF(state));
@@ -23,5 +23,5 @@ void ApiClientSwitch::dump_config() {
   ESP_LOGCONFIG(TAG, "  Switch has key ID %u", this->key_);
 }
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome

--- a/esphome/components/api_client/switch/api_switch.h
+++ b/esphome/components/api_client/switch/api_switch.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "../api_client_connection.h"
+#include "esphome/components/switch/switch.h"
+
+namespace esphome {
+namespace api {
+
+class ApiClientSwitch : public switch_::Switch, public Component {
+ public:
+  void dump_config() override;
+  void set_api_key(uint32_t key) { this->key_ = key; }
+
+  void set_api_parent(APIClientConnection *parent) { this->parent_ = parent; }
+
+ protected:
+  void write_state(bool state) override;
+
+  APIClientConnection *parent_;
+  uint32_t key_{0};
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api_client/switch/api_switch.h
+++ b/esphome/components/api_client/switch/api_switch.h
@@ -5,7 +5,7 @@
 #include "esphome/components/switch/switch.h"
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
 class ApiClientSwitch : public switch_::Switch, public Component {
  public:
@@ -21,5 +21,5 @@ class ApiClientSwitch : public switch_::Switch, public Component {
   uint32_t key_{0};
 };
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome

--- a/esphome/components/api_client/text_sensor.py
+++ b/esphome/components/api_client/text_sensor.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+from esphome.const import CONF_ID
+from . import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+
+DEPENDENCIES = ["api_client"]
+
+text_sensor_ns = cg.esphome_ns.namespace("text_sensor")
+TextSensor = text_sensor_ns.class_("TextSensor", text_sensor.TextSensor, cg.Nameable)
+
+CONFIG_SCHEMA = text_sensor.TEXT_SENSOR_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(TextSensor),
+        cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
+        cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    paren = yield cg.get_variable(config[CONF_API_CLIENT_ID])
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    yield text_sensor.register_text_sensor(var, config)
+
+    cg.add(paren.register_text_sensor(config[CONF_API_ENTITY_KEY], var))

--- a/esphome/components/api_client/text_sensor.py
+++ b/esphome/components/api_client/text_sensor.py
@@ -1,8 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
-from esphome.const import CONF_ID
-from . import CONF_API_CLIENT_ID, CONF_API_ENTITY_KEY, APIClient
+from esphome.const import CONF_ID, CONF_KEY
+from . import CONF_API_CLIENT_ID, APIClient
 
 DEPENDENCIES = ["api_client"]
 
@@ -13,7 +13,7 @@ CONFIG_SCHEMA = text_sensor.TEXT_SENSOR_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(TextSensor),
         cv.GenerateID(CONF_API_CLIENT_ID): cv.use_id(APIClient),
-        cv.Required(CONF_API_ENTITY_KEY): cv.uint32_t,
+        cv.Required(CONF_KEY): cv.uint32_t,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -24,4 +24,4 @@ def to_code(config):
 
     yield text_sensor.register_text_sensor(var, config)
 
-    cg.add(paren.register_text_sensor(config[CONF_API_ENTITY_KEY], var))
+    cg.add(paren.register_text_sensor(config[CONF_KEY], var))

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -968,7 +968,7 @@ cpp += """\
 namespace esphome {
 namespace api_client {
 
-static const char *TAG = "api_client.client";
+static const char *const TAG = "api_client.client";
 
 """
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -956,7 +956,7 @@ hpp += """\
 #include "esphome/core/defines.h"
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
 """
 
@@ -966,9 +966,9 @@ cpp += """\
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace api {
+namespace api_client {
 
-static const char *TAG = "api.client";
+static const char *TAG = "api_client.client";
 
 """
 
@@ -1010,12 +1010,12 @@ hpp += "};\n"
 
 hpp += """\
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome
 """
 cpp += """\
 
-}  // namespace api
+}  // namespace api_client
 }  // namespace esphome
 """
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -951,6 +951,7 @@ hpp = file_header
 hpp += """\
 #pragma once
 
+#include "proto_client.h"
 #include "../api/api_pb2.h"
 #include "esphome/core/defines.h"
 


### PR DESCRIPTION
# What does this implement/fix? 

This PR provides an `api_client` component, that can communicate with another instance of ESPHome using the protobuf-based API. Current implementation operates over a Stream, such as a UART. To support this, APIServer and APIConnection were refactored to support a Stream or AsyncTCP transport. This also opens up the possibility of other transports being used.

An APIClientConnection abstract class was introduced, with an additional implementation supporting a Stream transport. This connects to a suitable APIServer over a pre-configured Stream (UART), performs the appropriate protocol handshake, registers to receive log events, lists the remote entities, maps the desired remote entities to local entities (according to the local configuration file, using the `key` attribute), and synchronizes local and remote entity state by transmitting updates as needed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

Not done yet.

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

On the ESP running as api_client:
```yaml
uart:
  - id: uart2
    tx_pin: GPIO17
    rx_pin: GPIO16
    baud_rate: 115200
    data_bits: 8
    parity: none
    stop_bits: 1
    rx_buffer_size: 1024

api_client:
  - id: api_uart2
    uart_id: uart2
    password: ''

text_sensor:
  - platform: version
    name: Local ESPHome Version

  - platform: api_client
    key: 3740371848 # update this!
    api_client_id: api_uart2
    name: Remote ESPHome Version
    icon: mdi:new-box
```

The API Server configuration is not entirely functional. Configure an ESP32 with `api:` and a UART connected to the client ESP32, then add a line to the end of `src/main.cpp` similar to:

```
api_apiserver->handle_connect(new StreamAPIConnection(uart3, api_apiserver));
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
