### PR TITLE
Fix addressable light control without transitions & effects with transitions

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -50,6 +50,10 @@ void AddressableLight::write_state(LightState *state) {
 }
 
 void AddressableLightTransformer::start() {
+  // don't try to transition over running effects.
+  if (this->light_.is_effect_active())
+    return;
+
   auto end_values = this->target_values_;
   this->target_color_ = esp_color_from_light_color_values(end_values);
 

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -46,6 +46,7 @@ void AddressableLight::write_state(LightState *state) {
 
   // don't use LightState helper, gamma correction+brightness is handled by ESPColorView
   this->all() = esp_color_from_light_color_values(val);
+  this->schedule_show();
 }
 
 void AddressableLightTransformer::start() {


### PR DESCRIPTION
# What does this implement/fix? 

* A `schedule_show()` call was accidentally dropped from `AddressableLight.write_state()` in #2124. This causes updates of the addressable light state without transitions to (sometimes) not work. 
* When an addressable effect is running, don't temporarily raise the brightness to 100% when starting a transition. This would be harmless, but because the double scheduling addressable lights use (see #1963) this causes a small brightness flash.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2339

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
