### PR TITLE
Allow usage of unknown (to ESPHome) boards and add MCU configuration option

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -74,6 +74,7 @@ Length = vol.Length
 Exclusive = vol.Exclusive
 Inclusive = vol.Inclusive
 ALLOW_EXTRA = vol.ALLOW_EXTRA
+PREVENT_EXTRA = vol.PREVENT_EXTRA
 UNDEFINED = vol.UNDEFINED
 RequiredFieldInvalid = vol.RequiredFieldInvalid
 # this sentinel object can be placed in an 'Invalid' path to say

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -6,6 +6,21 @@ ESP_PLATFORM_ESP32 = "ESP32"
 ESP_PLATFORM_ESP8266 = "ESP8266"
 ESP_PLATFORMS = [ESP_PLATFORM_ESP32, ESP_PLATFORM_ESP8266]
 
+ESP_MCU_ESP8266 = "ESP8266"
+ESP_MCU_ESP32 = "ESP32"
+ESP_MCU_ESP32C3 = "ESP32-C3"
+ESP_MCU_ESP32S2 = "ESP32-S2"
+ESP_MCU_ESP32S3 = "ESP32-S3"
+ESP_MCUS = {
+    ESP_PLATFORM_ESP8266: [ESP_MCU_ESP8266],
+    ESP_PLATFORM_ESP32: [
+        ESP_MCU_ESP32,
+        ESP_MCU_ESP32C3,
+        ESP_MCU_ESP32S2,
+        ESP_MCU_ESP32S3,
+    ],
+}
+
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 
 # Lookup table from ESP32 arduino framework version to latest platformio
@@ -42,6 +57,14 @@ ARDUINO_VERSION_ESP8266 = {
     "2.4.0": "platformio/espressif8266@1.6.0",
     "2.3.0": "platformio/espressif8266@1.5.0",
 }
+
+PLATFORMIO_MCU_LUT = {
+    ESP_MCU_ESP8266: "esp8266",
+    ESP_MCU_ESP32: "esp32",
+    ESP_MCU_ESP32C3: "esp32c3",
+    ESP_MCU_ESP32S2: "esp32s2",
+}
+
 SOURCE_FILE_EXTENSIONS = {".cpp", ".hpp", ".h", ".c", ".tcc", ".ino"}
 HEADER_FILE_EXTENSIONS = {".h", ".hpp", ".tcc"}
 
@@ -352,6 +375,7 @@ CONF_MAX_SPEED = "max_speed"
 CONF_MAX_TEMPERATURE = "max_temperature"
 CONF_MAX_VALUE = "max_value"
 CONF_MAX_VOLTAGE = "max_voltage"
+CONF_MCU = "mcu"
 CONF_MEASUREMENT_DURATION = "measurement_duration"
 CONF_MEASUREMENT_SEQUENCE_NUMBER = "measurement_sequence_number"
 CONF_MEDIUM = "medium"

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -58,6 +58,27 @@ ARDUINO_VERSION_ESP8266 = {
     "2.3.0": "platformio/espressif8266@1.5.0",
 }
 
+PLATFORMIO_ESP8266_LUT = {
+    **ARDUINO_VERSION_ESP8266,
+    # Keep this in mind when updating the recommended version:
+    #  * New framework historically have had some regressions, especially for WiFi, BLE and the
+    #    bootloader system. The new version needs to be thoroughly validated before changing the
+    #    recommended version as otherwise a bunch of devices could be bricked
+    #  * The docker images need to be updated to ship the new recommended version, in order not
+    #    to DDoS platformio servers.
+    #    Update this file: https://github.com/esphome/esphome-docker-base/blob/main/platformio.ini
+    "RECOMMENDED": ARDUINO_VERSION_ESP8266["2.7.4"],
+    "LATEST": "platformio/espressif8266",
+    "DEV": ARDUINO_VERSION_ESP8266["dev"],
+}
+PLATFORMIO_ESP32_LUT = {
+    **ARDUINO_VERSION_ESP32,
+    # See PLATFORMIO_ESP8266_LUT for considerations when changing the recommended version
+    "RECOMMENDED": ARDUINO_VERSION_ESP32["1.0.6"],
+    "LATEST": "platformio/espressif32",
+    "DEV": ARDUINO_VERSION_ESP32["dev"],
+}
+
 PLATFORMIO_MCU_LUT = {
     ESP_MCU_ESP8266: "esp8266",
     ESP_MCU_ESP32: "esp32",

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -20,7 +20,6 @@ from esphome.coroutine import FakeEventLoop as _FakeEventLoop
 from esphome.coroutine import coroutine, coroutine_with_priority  # noqa
 from esphome.helpers import ensure_unique_string, is_hassio
 from esphome.util import OrderedDict
-from esphome import boards
 
 if TYPE_CHECKING:
     from ..cpp_generator import MockObj, MockObjClass, Statement
@@ -470,6 +469,8 @@ class EsphomeCore:
         self.build_path: Optional[str] = None
         # The platform (ESP8266, ESP32) of this device
         self.esp_platform: Optional[str] = None
+        # The MCU (ESP32, ESP32S2, ESP32C3) of this device
+        self.mcu: Optional[str] = None
         # The board that's used (for example nodemcuv2)
         self.board: Optional[str] = None
         # The full raw configuration
@@ -507,6 +508,7 @@ class EsphomeCore:
         self.config_path = None
         self.build_path = None
         self.esp_platform = None
+        self.mcu = None
         self.board = None
         self.raw_config = None
         self.config = None
@@ -597,16 +599,11 @@ class EsphomeCore:
         """Check if the ESP32 platform is used.
 
         This checks if the ESP32 platform is in use, which
-        support ESP32 as well as other chips such as ESP32-C3
+        supports ESP32 as well as other chips such as ESP32-C3
         """
         if self.esp_platform is None:
             raise ValueError("No platform specified")
         return self.esp_platform == "ESP32"
-
-    @property
-    def is_esp32_c3(self):
-        """Check if the ESP32-C3 SoC is being used."""
-        return self.is_esp32 and self.board in boards.ESP32_C3_BOARD_PINS
 
     def add_job(self, func, *args, **kwargs):
         self.event_loop.add_job(func, *args, **kwargs)

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -385,7 +385,10 @@ async def to_code(config):
     if config[CONF_INCLUDES]:
         CORE.add_job(add_includes, config[CONF_INCLUDES])
 
+    cg.add_define("ESPHOME_PLATFORM_" + CORE.esp_platform, 1)
+    cg.add_define("ESPHOME_MCU_" + CORE.mcu.replace("-", "_"), 1)
     cg.add_define("ESPHOME_BOARD", CORE.board)
+
     if CONF_PROJECT in config:
         cg.add_define("ESPHOME_PROJECT_NAME", config[CONF_PROJECT][CONF_NAME])
         cg.add_define("ESPHOME_PROJECT_VERSION", config[CONF_PROJECT][CONF_VERSION])

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -25,8 +25,6 @@ from esphome.const import (
     CONF_PROJECT,
     CONF_TRIGGER_ID,
     CONF_ESP8266_RESTORE_FROM_FLASH,
-    ARDUINO_VERSION_ESP8266,
-    ARDUINO_VERSION_ESP32,
     CONF_VERSION,
     ESP_PLATFORMS,
     ESP_MCUS,
@@ -35,6 +33,8 @@ from esphome.const import (
     ESP_MCU_ESP32C3,
     ESP_MCU_ESP32S2,
     ESP_MCU_ESP32S3,
+    PLATFORMIO_ESP8266_LUT,
+    PLATFORMIO_ESP32_LUT,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, walk_files
@@ -97,29 +97,6 @@ def validate_mcu_board(schema):
         )
 
     return schema
-
-
-PLATFORMIO_ESP8266_LUT = {
-    **ARDUINO_VERSION_ESP8266,
-    # Keep this in mind when updating the recommended version:
-    #  * New framework historically have had some regressions, especially for WiFi, BLE and the
-    #    bootloader system. The new version needs to be thoroughly validated before changing the
-    #    recommended version as otherwise a bunch of devices could be bricked
-    #  * The docker images need to be updated to ship the new recommended version, in order not
-    #    to DDoS platformio servers.
-    #    Update this file: https://github.com/esphome/esphome-docker-base/blob/main/platformio.ini
-    "RECOMMENDED": ARDUINO_VERSION_ESP8266["2.7.4"],
-    "LATEST": "espressif8266",
-    "DEV": ARDUINO_VERSION_ESP8266["dev"],
-}
-
-PLATFORMIO_ESP32_LUT = {
-    **ARDUINO_VERSION_ESP32,
-    # See PLATFORMIO_ESP8266_LUT for considerations when changing the recommended version
-    "RECOMMENDED": ARDUINO_VERSION_ESP32["1.0.6"],
-    "LATEST": "espressif32",
-    "DEV": ARDUINO_VERSION_ESP32["dev"],
-}
 
 
 def validate_arduino_version(value):

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -1,7 +1,7 @@
 import logging
 
 import esphome.config_validation as cv
-from esphome.const import CONF_INVERTED, CONF_MODE, CONF_NUMBER
+from esphome.const import ESP_MCU_ESP32C3, CONF_INVERTED, CONF_MODE, CONF_NUMBER
 from esphome.core import CORE
 from esphome.util import SimpleRegistry
 from esphome import boards
@@ -14,7 +14,7 @@ def _lookup_pin(value):
         board_pins_dict = boards.ESP8266_BOARD_PINS
         base_pins = boards.ESP8266_BASE_PINS
     elif CORE.is_esp32:
-        if CORE.board in boards.ESP32_C3_BOARD_PINS:
+        if CORE.mcu == ESP_MCU_ESP32C3:
             board_pins_dict = boards.ESP32_C3_BOARD_PINS
             base_pins = boards.ESP32_C3_BASE_PINS
         else:
@@ -72,7 +72,7 @@ _ESP32C3_SDIO_PINS = {
 
 def validate_gpio_pin(value):
     value = _translate_pin(value)
-    if CORE.is_esp32_c3:
+    if CORE.is_esp32 and CORE.mcu == ESP_MCU_ESP32C3:
         if value < 0 or value > 22:
             raise cv.Invalid(f"ESP32-C3: Invalid pin number: {value}")
         if value in _ESP32C3_SDIO_PINS:
@@ -158,7 +158,7 @@ def output_pin(value):
 def analog_pin(value):
     value = validate_gpio_pin(value)
     if CORE.is_esp32:
-        if CORE.is_esp32_c3:
+        if CORE.mcu == ESP_MCU_ESP32C3:
             if 0 <= value <= 4:  # ADC1
                 return value
             raise cv.Invalid("ESP32-C3: Only pins 0 though 4 support ADC.")

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -12,6 +12,7 @@ from esphome.const import (
     HEADER_FILE_EXTENSIONS,
     SOURCE_FILE_EXTENSIONS,
     __version__,
+    PLATFORMIO_MCU_LUT,
     ARDUINO_VERSION_ESP8266,
     ENV_NOGITIGNORE,
 )
@@ -235,6 +236,7 @@ def get_ini_content():
     data = {
         "platform": CORE.arduino_version,
         "board": CORE.board,
+        "board_build.mcu": PLATFORMIO_MCU_LUT[CORE.mcu],
         "framework": "arduino",
         "lib_deps": lib_deps + ["${common.lib_deps}"],
         "build_flags": build_flags + ["${common.build_flags}"],


### PR DESCRIPTION
# What does this implement/fix? 

* Don't require that boards are known by ESPHome. It is only used for pin aliases, and this allows boards that aren't in our list (yet) to be used. Log a warning if an unknown board is used.
* Add an (optional) `mcu` option under the `esphome` config key, which can be used to set the MCU (e.g. ESP32-S2/ESP32-C3/etc) for unknown boards. If the mcu set is different than what the board is known to have, log a warning (this could be an error if prefered). 
* Add `ESPHOME_PLATFORM_ESP32` and `ESPHOME_MCU_ESP32_C3`-style defines. These can be used instead of `ARDUINO_ARCH_ESP32` to make code framework-agnostic.
* Move the PlatformIO Arduino version lookup table to `const.py` (where the Arduino versions already were), I'm always searching for it. 

(The context for this was https://github.com/esphome/issues/issues/2343, where I wanted to give them a board option to try it out, but then I discovered that we don't actually allow to use boards that haven't been whitelisted in ESPHome. That seems like a pretty pointless restriction. The MCU option follows from this, as we need to know the MCU for unknown boards, and this also allows to use a generic board with ESP32-S2/-C3 mcu option to test those out.)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Example of usage with an unknown board (I haven't actually tested whether the S2 works yet, this is just an example of how this can be useful):
```yaml
esphome:
  name: mcutest
  platform: ESP32
  mcu: ESP32-S2
  board: esp32-s2-saola-1
  arduino_version: https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
