### PR TITLE
Added state property to ota component

### DIFF
--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -244,6 +244,7 @@ void OTAComponent::handle_() {
     if (now - last_progress > 1000) {
       last_progress = now;
       float percentage = (total * 100.0f) / ota_size;
+      state = percentage;
       ESP_LOGD(TAG, "OTA in progress: %0.1f%%", percentage);
 #ifdef USE_OTA_STATE_CALLBACK
       this->state_callback_.call(OTA_IN_PROGRESS, percentage, 0);

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -243,11 +243,10 @@ void OTAComponent::handle_() {
     uint32_t now = millis();
     if (now - last_progress > 1000) {
       last_progress = now;
-      float percentage = (total * 100.0f) / ota_size;
-      state = percentage;
-      ESP_LOGD(TAG, "OTA in progress: %0.1f%%", percentage);
+      state = (total * 100.0f) / ota_size;
+      ESP_LOGD(TAG, "OTA in progress: %0.1f%%", state);
 #ifdef USE_OTA_STATE_CALLBACK
-      this->state_callback_.call(OTA_IN_PROGRESS, percentage, 0);
+      this->state_callback_.call(OTA_IN_PROGRESS, state, 0);
 #endif
       // slow down OTA update to avoid getting killed by task watchdog (task_wdt)
       delay(10);

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -69,6 +69,8 @@ class OTAComponent : public Component {
 
   void on_safe_shutdown() override;
 
+  float state = 0.0;
+
  protected:
   void write_rtc_(uint32_t val);
   uint32_t read_rtc_();


### PR DESCRIPTION
# What does this implement/fix? 

Added `float state` variable to ota component.
Exposed for components that fetch update progress outside ota triggers (see code below).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
ota:
  id: ota_comp
  on_begin:
    then:
      - display.page.show: update_page
      - component.update: my_lcd
  on_progress:
    then:
      - component.update: my_lcd
  on_end:
    then:
      - display.page.show: update_end_page
      - component.update: my_lcd

display:
  - platform: ...
    id: my_lcd
    # ...
    pages:
      - id: main_page
        lambda: |-
          //...
      - id: update_page
        lambda: |-
          it.fill(Color::BLACK);
          it.printf(0, 15, id(my_font), "Updating: %0.1f%%", id(ota_comp).state);
      - id: update_end_page
        lambda: |-
          it.fill(Color::BLACK);
          it.print(0, 15, id(my_font), "Update finished. Rebooting...");

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
