### PR TITLE
Remove footer validation for fujitsu_general

### DIFF
--- a/esphome/components/fujitsu_general/fujitsu_general.cpp
+++ b/esphome/components/fujitsu_general/fujitsu_general.cpp
@@ -297,12 +297,6 @@ bool FujitsuGeneralClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
   }
 
-  // Validate footer
-  if (!data.expect_mark(FUJITSU_GENERAL_BIT_MARK)) {
-    ESP_LOGV(TAG, "Footer fail");
-    return false;
-  }
-
   for (uint8_t byte = 0; byte < recv_message_length; ++byte) {
     ESP_LOGVV(TAG, "%02X", recv_message[byte]);
   }


### PR DESCRIPTION
# What does this implement/fix? 

the footer validation was failing like 99% of the time for me. Removing it doesn't seem to introduce any problems, since the codes can be decoded just fine without it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2347

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
substitutions:
  room: "Test"

esphome:
  name: test_ac
  platform: ESP32
  board: nodemcu-32s

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "${room} Ac Fallback Hotspot"
    password: !secret wifi_password

captive_portal:

# Enable logging
logger:
  level: VERBOSE
  
# Enable Home Assistant API
api:

ota:

# esp32_ble_tracker:

remote_receiver:
  id: receiver
  pin:
    number: GPIO15
    inverted: true
  dump: raw
  tolerance: 40%

remote_transmitter:
  pin: GPIO23
  carrier_duty_percent: 50%

climate:
  name: "${room} AC"
  platform: fujitsu_general
  receiver_id: receiver
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
