### PR TITLE
2021.8.1

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -46,9 +46,14 @@ void AddressableLight::write_state(LightState *state) {
 
   // don't use LightState helper, gamma correction+brightness is handled by ESPColorView
   this->all() = esp_color_from_light_color_values(val);
+  this->schedule_show();
 }
 
 void AddressableLightTransformer::start() {
+  // don't try to transition over running effects.
+  if (this->light_.is_effect_active())
+    return;
+
   auto end_values = this->target_values_;
   this->target_color_ = esp_color_from_light_color_values(end_values);
 

--- a/esphome/components/light/color_mode.h
+++ b/esphome/components/light/color_mode.h
@@ -52,7 +52,7 @@ enum class ColorMode : uint8_t {
   /// Only on/off control.
   ON_OFF = (uint8_t) ColorCapability::ON_OFF,
   /// Dimmable light.
-  BRIGHTNESS = (uint8_t) ColorCapability::BRIGHTNESS,
+  BRIGHTNESS = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS),
   /// White output only (use only if the light also has another color mode such as RGB).
   WHITE = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::WHITE),
   /// Controllable color temperature output.

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -60,6 +60,8 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
   root["max_temp"] = traits.get_visual_max_temperature();
   // temp_step
   root["temp_step"] = traits.get_visual_temperature_step();
+  // temperature units are always coerced to Celsius internally
+  root["temp_unit"] = "C";
 
   if (traits.supports_preset(CLIMATE_PRESET_AWAY)) {
     // away_mode_command_topic

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -54,12 +54,6 @@ void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscover
   // legacy API
   if (traits.supports_color_capability(ColorCapability::BRIGHTNESS))
     root["brightness"] = true;
-  if (traits.supports_color_capability(ColorCapability::RGB))
-    root["rgb"] = true;
-  if (traits.supports_color_capability(ColorCapability::COLOR_TEMPERATURE))
-    root["color_temp"] = true;
-  if (traits.supports_color_capability(ColorCapability::WHITE))
-    root["white_value"] = true;
 
   if (this->state_->supports_effects()) {
     root["effect"] = true;

--- a/esphome/components/template/select/__init__.py
+++ b/esphome/components/template/select/__init__.py
@@ -55,7 +55,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         template_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [], return_type=cg.optional.template(str)
+            config[CONF_LAMBDA], [], return_type=cg.optional.template(cg.std_string)
         )
         cg.add(var.set_template(template_))
 

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -80,7 +80,7 @@ void TuyaFan::write_state() {
   }
   if (this->speed_id_.has_value()) {
     ESP_LOGV(TAG, "Setting speed: %d", this->fan_->speed);
-    this->parent_->set_integer_datapoint_value(*this->speed_id_, this->fan_->speed - 1);
+    this->parent_->set_enum_datapoint_value(*this->speed_id_, this->fan_->speed - 1);
   }
 }
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2021.8.0"
+__version__ = "2021.8.1"
 
 ESP_PLATFORM_ESP32 = "ESP32"
 ESP_PLATFORM_ESP8266 = "ESP8266"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ PYPI_URL = "https://pypi.python.org/pypi/{}".format(PROJECT_PACKAGE_NAME)
 GITHUB_PATH = "{}/{}".format(PROJECT_GITHUB_USERNAME, PROJECT_GITHUB_REPOSITORY)
 GITHUB_URL = "https://github.com/{}".format(GITHUB_PATH)
 
-DOWNLOAD_URL = "{}/archive/v{}.zip".format(GITHUB_URL, const.__version__)
+DOWNLOAD_URL = "{}/archive/{}.zip".format(GITHUB_URL, const.__version__)
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Two things are infinite: the universe and human stupidity; and I’m not sure about the universe."_

~ Albert Einstein
- Fix pypi download url [esphome#2177](https://github.com/esphome/esphome/pull/2177)
- Light: include ON_OFF capability to BRIGHTNESS ColorMode [esphome#2186](https://github.com/esphome/esphome/pull/2186)
- Fix addressable light control without transitions & effects with transitions [esphome#2187](https://github.com/esphome/esphome/pull/2187)
- mqtt_light: remove legacy API config that is not compatible with HA 2021.8 [esphome#2183](https://github.com/esphome/esphome/pull/2183)
- Tuya fan component uses enum datapoint type for speed instead of integer [esphome#2182](https://github.com/esphome/esphome/pull/2182)
- Fix template select lambda [esphome#2198](https://github.com/esphome/esphome/pull/2198)
- Send Celsius temperature unit in MQTT discovery message [esphome#1840](https://github.com/esphome/esphome/pull/1840)
