### PR TITLE
Add ble_client binary_output

### DIFF
--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -388,6 +388,15 @@ BLEDescriptor *BLECharacteristic::get_descriptor(uint16_t uuid) {
   return this->get_descriptor(espbt::ESPBTUUID::from_uint16(uuid));
 }
 
+void BLECharacteristic::write_value(uint8_t newVal) {
+  auto client = this->service->client;
+  auto status = esp_ble_gattc_write_char(client->gattc_if, client->conn_id, this->handle, sizeof(newVal), &newVal,
+                                         ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+  if (status) {
+    ESP_LOGW(TAG, "Error sending write value to BLE gattc server, status=%d", status);
+  }
+}
+
 }  // namespace ble_client
 }  // namespace esphome
 

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -388,9 +388,9 @@ BLEDescriptor *BLECharacteristic::get_descriptor(uint16_t uuid) {
   return this->get_descriptor(espbt::ESPBTUUID::from_uint16(uuid));
 }
 
-void BLECharacteristic::write_value(uint8_t *newVal, int16_t newValSize) {
+void BLECharacteristic::write_value(uint8_t *new_val, int16_t new_val_size) {
   auto client = this->service->client;
-  auto status = esp_ble_gattc_write_char(client->gattc_if, client->conn_id, this->handle, newValSize, newVal,
+  auto status = esp_ble_gattc_write_char(client->gattc_if, client->conn_id, this->handle, new_val_size, new_val,
                                          ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (status) {
     ESP_LOGW(TAG, "Error sending write value to BLE gattc server, status=%d", status);

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -388,9 +388,9 @@ BLEDescriptor *BLECharacteristic::get_descriptor(uint16_t uuid) {
   return this->get_descriptor(espbt::ESPBTUUID::from_uint16(uuid));
 }
 
-void BLECharacteristic::write_value(uint8_t newVal) {
+void BLECharacteristic::write_value(uint8_t *newVal, int16_t newValSize) {
   auto client = this->service->client;
-  auto status = esp_ble_gattc_write_char(client->gattc_if, client->conn_id, this->handle, sizeof(newVal), &newVal,
+  auto status = esp_ble_gattc_write_char(client->gattc_if, client->conn_id, this->handle, newValSize, newVal,
                                          ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (status) {
     ESP_LOGW(TAG, "Error sending write value to BLE gattc server, status=%d", status);

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -59,7 +59,7 @@ class BLECharacteristic {
   void parse_descriptors();
   BLEDescriptor *get_descriptor(espbt::ESPBTUUID uuid);
   BLEDescriptor *get_descriptor(uint16_t uuid);
-  void write_value(uint8_t newVal);
+  void write_value(uint8_t *newVal, int16_t newValSize);
   BLEService *service;
 };
 

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -59,7 +59,7 @@ class BLECharacteristic {
   void parse_descriptors();
   BLEDescriptor *get_descriptor(espbt::ESPBTUUID uuid);
   BLEDescriptor *get_descriptor(uint16_t uuid);
-  void write_value(uint8_t *newVal, int16_t newValSize);
+  void write_value(uint8_t *new_val, int16_t new_val_size);
   BLEService *service;
 };
 

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -59,7 +59,7 @@ class BLECharacteristic {
   void parse_descriptors();
   BLEDescriptor *get_descriptor(espbt::ESPBTUUID uuid);
   BLEDescriptor *get_descriptor(uint16_t uuid);
-
+  void write_value(uint8_t newVal);
   BLEService *service;
 };
 

--- a/esphome/components/ble_client/output/__init__.py
+++ b/esphome/components/ble_client/output/__init__.py
@@ -1,0 +1,65 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import output, ble_client, esp32_ble_tracker
+from esphome.const import CONF_ID, CONF_SERVICE_UUID
+from .. import ble_client_ns
+
+
+DEPENDENCIES = ["ble_client"]
+
+CONF_CHARACTERISTIC_UUID = "characteristic_uuid"
+
+BLEBinaryOutput = ble_client_ns.class_(
+    "BLEBinaryOutput", output.BinaryOutput, ble_client.BLEClientNode, cg.Component
+)
+
+CONFIG_SCHEMA = cv.All(
+    output.BINARY_OUTPUT_SCHEMA.extend(
+        {
+            cv.Required(CONF_ID): cv.declare_id(BLEBinaryOutput),
+            cv.Required(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
+            cv.Required(CONF_CHARACTERISTIC_UUID): esp32_ble_tracker.bt_uuid,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_client.BLE_CLIENT_SCHEMA)
+)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    if len(config[CONF_SERVICE_UUID]) == len(esp32_ble_tracker.bt_uuid16_format):
+        cg.add(
+            var.set_service_uuid16(esp32_ble_tracker.as_hex(config[CONF_SERVICE_UUID]))
+        )
+    elif len(config[CONF_SERVICE_UUID]) == len(esp32_ble_tracker.bt_uuid32_format):
+        cg.add(
+            var.set_service_uuid32(esp32_ble_tracker.as_hex(config[CONF_SERVICE_UUID]))
+        )
+    elif len(config[CONF_SERVICE_UUID]) == len(esp32_ble_tracker.bt_uuid128_format):
+        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_SERVICE_UUID])
+        cg.add(var.set_service_uuid128(uuid128))
+
+    if len(config[CONF_CHARACTERISTIC_UUID]) == len(esp32_ble_tracker.bt_uuid16_format):
+        cg.add(
+            var.set_char_uuid16(
+                esp32_ble_tracker.as_hex(config[CONF_CHARACTERISTIC_UUID])
+            )
+        )
+    elif len(config[CONF_CHARACTERISTIC_UUID]) == len(
+        esp32_ble_tracker.bt_uuid32_format
+    ):
+        cg.add(
+            var.set_char_uuid32(
+                esp32_ble_tracker.as_hex(config[CONF_CHARACTERISTIC_UUID])
+            )
+        )
+    elif len(config[CONF_CHARACTERISTIC_UUID]) == len(
+        esp32_ble_tracker.bt_uuid128_format
+    ):
+        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_CHARACTERISTIC_UUID])
+        cg.add(var.set_char_uuid128(uuid128))
+
+    yield output.register_output(var, config)
+    yield ble_client.register_ble_node(var, config)
+    yield cg.register_component(var, config)

--- a/esphome/components/ble_client/output/__init__.py
+++ b/esphome/components/ble_client/output/__init__.py
@@ -37,7 +37,7 @@ def to_code(config):
             var.set_service_uuid32(esp32_ble_tracker.as_hex(config[CONF_SERVICE_UUID]))
         )
     elif len(config[CONF_SERVICE_UUID]) == len(esp32_ble_tracker.bt_uuid128_format):
-        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_SERVICE_UUID])
+        uuid128 = esp32_ble_tracker.as_reversed_hex_array(config[CONF_SERVICE_UUID])
         cg.add(var.set_service_uuid128(uuid128))
 
     if len(config[CONF_CHARACTERISTIC_UUID]) == len(esp32_ble_tracker.bt_uuid16_format):
@@ -57,7 +57,9 @@ def to_code(config):
     elif len(config[CONF_CHARACTERISTIC_UUID]) == len(
         esp32_ble_tracker.bt_uuid128_format
     ):
-        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_CHARACTERISTIC_UUID])
+        uuid128 = esp32_ble_tracker.as_reversed_hex_array(
+            config[CONF_CHARACTERISTIC_UUID]
+        )
         cg.add(var.set_char_uuid128(uuid128))
 
     yield output.register_output(var, config)

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
-#ifdef ARDUINO_ARCH_ESP32
+#ifdef USE_ESP32
 namespace esphome {
 namespace ble_client {
 

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -28,13 +28,17 @@ void BLEBinaryOutput::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
       this->client_state_ = espbt::ClientState::Idle;
       break;
     case ESP_GATTC_WRITE_CHAR_EVT: {
+      if (param->write.status == 0) {
+        break;
+      }
+
       auto chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
       if (chr == nullptr) {
         ESP_LOGW(TAG, "[%s] Characteristic not found.", this->char_uuid_.to_string().c_str());
         break;
       }
       if (param->write.handle == chr->handle) {
-        ESP_LOGD(TAG, "[%s] Write complete, status=%d", this->char_uuid_.to_string().c_str(), param->write.status);
+        ESP_LOGW(TAG, "[%s] Write error, status=%d", this->char_uuid_.to_string().c_str(), param->write.status);
       }
       break;
     }

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -61,9 +61,9 @@ void BLEBinaryOutput::write_state(bool state) {
     return;
   }
 
-  uint8_t stateAsUint = (uint8_t) state;
-  ESP_LOGV(TAG, "[%s] Write State: %d", this->char_uuid_.to_string().c_str(), stateAsUint);
-  chr->write_value(&stateAsUint, sizeof(stateAsUint));
+  uint8_t state_as_uint = (uint8_t) state;
+  ESP_LOGV(TAG, "[%s] Write State: %d", this->char_uuid_.to_string().c_str(), state_as_uint);
+  chr->write_value(&state_as_uint, sizeof(state_as_uint));
 }
 
 }  // namespace ble_client

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -1,0 +1,55 @@
+#include "ble_binary_output.h"
+#include "esphome/core/log.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+namespace esphome {
+namespace ble_client {
+
+static const char *const TAG = "ble_binary_output";
+
+void BLEBinaryOutput::dump_config() {
+  ESP_LOGCONFIG(TAG, "BLE Binary Output:");
+  ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str().c_str());
+  ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_string().c_str());
+  ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_string().c_str());
+  LOG_BINARY_OUTPUT(this);
+}
+
+void BLEBinaryOutput::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                                          esp_ble_gattc_cb_param_t *param) {
+  switch (event) {
+    case ESP_GATTC_OPEN_EVT:
+      this->client_state_ = espbt::ClientState::Established;
+      ESP_LOGW(TAG, "[%s] Connected successfully!", this->char_uuid_.to_string().c_str());
+      break;
+    case ESP_GATTC_DISCONNECT_EVT:
+      ESP_LOGW(TAG, "[%s] Disconnected", this->char_uuid_.to_string().c_str());
+      this->client_state_ = espbt::ClientState::Idle;
+      break;
+    default:
+      break;
+  }
+}
+
+void BLEBinaryOutput::write_state(bool state) {
+  if (this->client_state_ == espbt::ClientState::Established) {
+    auto chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
+    if (chr == nullptr) {
+      ESP_LOGW(TAG, "[%s] Characteristic not found.  State update can not be written.",
+               this->char_uuid_.to_string().c_str());
+    }
+    auto stateAsUint = (uint8_t) state;
+    ESP_LOGV(TAG, "[%s] Write State: %d", this->char_uuid_.to_string().c_str(), stateAsUint);
+    chr->write_value(stateAsUint);
+    ESP_LOGVV(TAG, "[%s] SUCCESS! State:% d ", this->char_uuid_.to_string().c_str(), stateAsUint);
+  } else {
+    ESP_LOGW(TAG, "[%s] Not connected to BLE client.  State update can not be written.",
+             this->char_uuid_.to_string().c_str());
+    return;
+  }
+}
+
+}  // namespace ble_client
+}  // namespace esphome
+#endif

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -20,12 +20,12 @@ void BLEBinaryOutput::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
                                           esp_ble_gattc_cb_param_t *param) {
   switch (event) {
     case ESP_GATTC_OPEN_EVT:
-      this->client_state_ = espbt::ClientState::Established;
+      this->client_state_ = espbt::ClientState::ESTABLISHED;
       ESP_LOGW(TAG, "[%s] Connected successfully!", this->char_uuid_.to_string().c_str());
       break;
     case ESP_GATTC_DISCONNECT_EVT:
       ESP_LOGW(TAG, "[%s] Disconnected", this->char_uuid_.to_string().c_str());
-      this->client_state_ = espbt::ClientState::Idle;
+      this->client_state_ = espbt::ClientState::IDLE;
       break;
     case ESP_GATTC_WRITE_CHAR_EVT: {
       if (param->write.status == 0) {
@@ -48,7 +48,7 @@ void BLEBinaryOutput::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
 }
 
 void BLEBinaryOutput::write_state(bool state) {
-  if (this->client_state_ != espbt::ClientState::Established) {
+  if (this->client_state_ != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Not connected to BLE client.  State update can not be written.",
              this->char_uuid_.to_string().c_str());
     return;

--- a/esphome/components/ble_client/output/ble_binary_output.h
+++ b/esphome/components/ble_client/output/ble_binary_output.h
@@ -5,7 +5,7 @@
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/output/binary_output.h"
 
-#ifdef ARDUINO_ARCH_ESP32
+#ifdef USE_ESP32
 #include <esp_gattc_api.h>
 namespace esphome {
 namespace ble_client {

--- a/esphome/components/ble_client/output/ble_binary_output.h
+++ b/esphome/components/ble_client/output/ble_binary_output.h
@@ -23,10 +23,10 @@ class BLEBinaryOutput : public output::BinaryOutput, public BLEClientNode, publi
   void set_char_uuid16(uint16_t uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_char_uuid32(uint32_t uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
   void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override;
 
  protected:
-  void write_state(bool state);
+  void write_state(bool state) override;
   espbt::ESPBTUUID service_uuid_;
   espbt::ESPBTUUID char_uuid_;
   espbt::ClientState client_state_;

--- a/esphome/components/ble_client/output/ble_binary_output.h
+++ b/esphome/components/ble_client/output/ble_binary_output.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/ble_client/ble_client.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/output/binary_output.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+#include <esp_gattc_api.h>
+namespace esphome {
+namespace ble_client {
+
+namespace espbt = esphome::esp32_ble_tracker;
+
+class BLEBinaryOutput : public output::BinaryOutput, public BLEClientNode, public Component {
+ public:
+  void dump_config() override;
+  void loop() override {}
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  void set_service_uuid16(uint16_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
+  void set_service_uuid32(uint32_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
+  void set_service_uuid128(uint8_t *uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
+  void set_char_uuid16(uint16_t uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
+  void set_char_uuid32(uint32_t uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
+  void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
+
+ protected:
+  void write_state(bool state);
+  espbt::ESPBTUUID service_uuid_;
+  espbt::ESPBTUUID char_uuid_;
+  espbt::ClientState client_state_;
+};
+
+}  // namespace ble_client
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ble_client/output/ble_binary_output.h
+++ b/esphome/components/ble_client/output/ble_binary_output.h
@@ -23,7 +23,8 @@ class BLEBinaryOutput : public output::BinaryOutput, public BLEClientNode, publi
   void set_char_uuid16(uint16_t uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_char_uuid32(uint32_t uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
   void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override;
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override;
 
  protected:
   void write_state(bool state) override;


### PR DESCRIPTION
# What does this implement/fix? 
Adds ble_client binary_output.  

Quick description and explanation of changes
Allows you to write binary values to BLE Characteristics.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1417

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
    esp32_ble_tracker:
    ble_client:
      - mac_address: FF:FF:20:00:0F:15
        id: itag_black
    output:
      - platform: ble_client
        ble_client_id: itag_black
        service_uuid: "10110000-5354-4F52-5A26-4249434B454C"
        characteristic_uuid: "10110013-5354-4f52-5a26-4249434b454c"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
