### PR TITLE
Revert "Light: include ON_OFF capability to BRIGHTNESS ColorMode"

### DIFF
--- a/esphome/components/light/color_mode.h
+++ b/esphome/components/light/color_mode.h
@@ -52,7 +52,7 @@ enum class ColorMode : uint8_t {
   /// Only on/off control.
   ON_OFF = (uint8_t) ColorCapability::ON_OFF,
   /// Dimmable light.
-  BRIGHTNESS = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS),
+  BRIGHTNESS = (uint8_t) ColorCapability::BRIGHTNESS,
   /// White output only (use only if the light also has another color mode such as RGB).
   WHITE = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::WHITE),
   /// Controllable color temperature output.


### PR DESCRIPTION
Reverts esphome/esphome#2186

Reverting this for a patch release and will put it back again in 2021.9.

Fixes esphome/issues#2355