### PR TITLE
Fix css/js file loading for webserver when esphome not executed form config directory

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -13,7 +13,7 @@ from esphome.const import (
     CONF_USERNAME,
     CONF_PASSWORD,
 )
-from esphome.core import coroutine_with_priority
+from esphome.core import CORE, coroutine_with_priority
 
 AUTO_LOAD = ["json", "web_server_base"]
 
@@ -61,9 +61,11 @@ async def to_code(config):
         cg.add(var.set_password(config[CONF_AUTH][CONF_PASSWORD]))
     if CONF_CSS_INCLUDE in config:
         cg.add_define("WEBSERVER_CSS_INCLUDE")
-        with open(config[CONF_CSS_INCLUDE], "r") as myfile:
+        path = CORE.relative_config_path(config[CONF_CSS_INCLUDE])
+        with open(path, "r") as myfile:
             cg.add(var.set_css_include(myfile.read()))
     if CONF_JS_INCLUDE in config:
         cg.add_define("WEBSERVER_JS_INCLUDE")
-        with open(config[CONF_JS_INCLUDE], "r") as myfile:
+        path = CORE.relative_config_path(config[CONF_JS_INCLUDE])
+        with open(path, "r") as myfile:
             cg.add(var.set_js_include(myfile.read()))

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1354,7 +1354,7 @@ def file_(value):
             "Path '{}' is not a file (full path: {})."
             "".format(path, os.path.abspath(path))
         )
-    return path
+    return value
 
 
 ENTITY_ID_CHARACTERS = "abcdefghijklmnopqrstuvwxyz0123456789_"

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1354,7 +1354,7 @@ def file_(value):
             "Path '{}' is not a file (full path: {})."
             "".format(path, os.path.abspath(path))
         )
-    return value
+    return path
 
 
 ENTITY_ID_CHARACTERS = "abcdefghijklmnopqrstuvwxyz0123456789_"


### PR DESCRIPTION
# What does this implement/fix? 

Fix css/js file loading for webserver when esphome not executed form config directory

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
