### PR TITLE
Template sensors always publish on update interval

### DIFF
--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -7,12 +7,13 @@ namespace template_ {
 static const char *const TAG = "template.binary_sensor";
 
 void TemplateBinarySensor::loop() {
-  if (!this->f_.has_value())
-    return;
-
-  auto s = (*this->f_)();
-  if (s.has_value()) {
-    this->publish_state(*s);
+  if (this->f_.has_value()) {
+    auto s = (*this->f_)();
+    if (s.has_value()) {
+      this->publish_state(*s);
+    }
+  } else if (this->has_state()) {
+    this->publish_state(this->state);
   }
 }
 void TemplateBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Template Binary Sensor", this); }

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -7,13 +7,12 @@ namespace template_ {
 static const char *const TAG = "template.binary_sensor";
 
 void TemplateBinarySensor::loop() {
-  if (this->f_.has_value()) {
-    auto s = (*this->f_)();
-    if (s.has_value()) {
-      this->publish_state(*s);
-    }
-  } else if (this->has_state()) {
-    this->publish_state(this->state);
+  if (!this->f_.has_value())
+    return;
+
+  auto s = (*this->f_)();
+  if (s.has_value()) {
+    this->publish_state(*s);
   }
 }
 void TemplateBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Template Binary Sensor", this); }

--- a/esphome/components/template/sensor/template_sensor.cpp
+++ b/esphome/components/template/sensor/template_sensor.cpp
@@ -7,12 +7,13 @@ namespace template_ {
 static const char *const TAG = "template.sensor";
 
 void TemplateSensor::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (val.has_value()) {
-    this->publish_state(*val);
+  if (this->f_.has_value()) {
+    auto val = (*this->f_)();
+    if (val.has_value()) {
+      this->publish_state(*val);
+    }
+  } else if (!isnan(this->get_raw_state())) {
+    this->publish_state(this->get_raw_state());
   }
 }
 float TemplateSensor::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/template/text_sensor/template_text_sensor.cpp
+++ b/esphome/components/template/text_sensor/template_text_sensor.cpp
@@ -7,12 +7,13 @@ namespace template_ {
 static const char *const TAG = "template.text_sensor";
 
 void TemplateTextSensor::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (val.has_value()) {
-    this->publish_state(*val);
+  if (this->f_.has_value()) {
+    auto val = (*this->f_)();
+    if (val.has_value()) {
+      this->publish_state(*val);
+    }
+  } else if (this->has_state()) {
+    this->publish_state(this->state);
   }
 }
 float TemplateTextSensor::get_setup_priority() const { return setup_priority::HARDWARE; }


### PR DESCRIPTION
# What does this implement/fix? 

This PR updates the template sensors (binary_sensor, sensor, text_sensor) to always publish their value on the update interval regardless if the value came from a lambda function or was published from an automation.  The primary purpose of this is so that if the source sensor of the Integration or Total Daily Value sensor is a template sensor the aggregate value will get updated periodically rather than only when the source sensor changes value.  While this is less of a concern for the text sensor I thought it made sense to have them all behave the same.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1444

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
