### PR TITLE
Add is_on and is_off conditions for the fan component

### DIFF
--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -42,6 +42,9 @@ ToggleAction = fan_ns.class_("ToggleAction", automation.Action)
 FanTurnOnTrigger = fan_ns.class_("FanTurnOnTrigger", automation.Trigger.template())
 FanTurnOffTrigger = fan_ns.class_("FanTurnOffTrigger", automation.Trigger.template())
 
+FanIsOnCondition = fan_ns.class_("FanIsOnCondition", automation.Condition.template())
+FanIsOffCondition = fan_ns.class_("FanIsOffCondition", automation.Condition.template())
+
 FAN_SCHEMA = cv.NAMEABLE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).extend(
     {
         cv.GenerateID(): cv.declare_id(FanState),
@@ -169,6 +172,29 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(config[CONF_DIRECTION], args, FanDirection)
         cg.add(var.set_direction(template_))
     return var
+
+
+@automation.register_condition(
+    "fan.is_on",
+    FanIsOnCondition,
+    automation.maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(FanState),
+        }
+    ),
+)
+@automation.register_condition(
+    "fan.is_off",
+    FanIsOffCondition,
+    automation.maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(FanState),
+        }
+    ),
+)
+async def fan_is_on_off_to_code(config, condition_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(condition_id, template_arg, paren)
 
 
 @coroutine_with_priority(100.0)

--- a/esphome/components/fan/automation.h
+++ b/esphome/components/fan/automation.h
@@ -50,6 +50,23 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
   FanState *state_;
 };
 
+template<typename... Ts> class FanIsOnCondition : public Condition<Ts...> {
+ public:
+  explicit FanIsOnCondition(FanState *state) : state_(state) {}
+  bool check(Ts... x) override { return this->state_->state; }
+
+ protected:
+  FanState *state_;
+};
+template<typename... Ts> class FanIsOffCondition : public Condition<Ts...> {
+ public:
+  explicit FanIsOffCondition(FanState *state) : state_(state) {}
+  bool check(Ts... x) override { return !this->state_->state; }
+
+ protected:
+  FanState *state_;
+};
+
 class FanTurnOnTrigger : public Trigger<> {
  public:
   FanTurnOnTrigger(FanState *state) {

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -129,6 +129,8 @@ mqtt:
             - mqtt.connected:
             - light.is_on: kitchen
             - light.is_off: kitchen
+            - fan.is_on: fan_speed
+            - fan.is_off: fan_speed
           then:
             - lambda: |-
                 int data = x["my_data"];
@@ -1868,6 +1870,7 @@ fan:
     oscillation_output: gpio_19
     direction_output: gpio_26
   - platform: speed
+    id: fan_speed
     output: pca_6
     speed_count: 10
     name: 'Living Room Fan 2'


### PR DESCRIPTION
# What does this implement/fix? 

This PR adds fan.is_on and fan.is_off conditions

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/feature-requests#1382

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1436

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
```yaml
output:
  - platform: gpio
    id: my_fan_output
    pin: GPIO10

fan:
  - platform: binary
    name: My Fan
    id: my_fan
    output: my_fan_output

interval:
  - interval: 1min
    then:
      - if:
          condition:
            fan.is_on: my_fan
          then:
            fan.turn_off: my_fan
  - interval: 1min
    then:
      - if:
          condition:
            fan.is_off: my_fan
          then:
            fan.turn_on: my_fan
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
