### PR TITLE
mqtt_sensor: properly send state_class via MQTT

### DIFF
--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -61,8 +61,8 @@ void MQTTSensorComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryCo
   if (this->sensor_->get_force_update())
     root["force_update"] = true;
 
-  if (this->sensor_->state_class == sensor::STATE_CLASS_MEASUREMENT)
-    root["state_class"] = "measurement";
+  if (this->sensor_->state_class != STATE_CLASS_NONE)
+    root["state_class"] = state_class_to_string(this->sensor_->state_class);
 
   config.command_topic = false;
 }


### PR DESCRIPTION
# What does this implement/fix? 

This sends `state_class` as configured via `mqtt` discovery: https://www.home-assistant.io/integrations/sensor.mqtt/.
Prior to this change only `measurement` would be send, this also sends other possible configurations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32
- [-] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [-] ~Tests have been added to verify that the new code works (under `tests/` folder)~: unlikely it is needed
  