### PR TITLE
Fix UARTComponent hardware vs software UART0 conflict

### DIFF
--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -107,7 +107,6 @@ class UARTComponent : public Component, public Stream {
   HardwareSerial *hw_serial_{nullptr};
 #ifdef ARDUINO_ARCH_ESP8266
   ESP8266SoftwareSerial *sw_serial_{nullptr};
-  static bool serial0InUse;
 #endif
   optional<uint8_t> tx_pin_;
   optional<uint8_t> rx_pin_;
@@ -119,6 +118,10 @@ class UARTComponent : public Component, public Stream {
   uint8_t stop_bits_;
   uint8_t data_bits_;
   UARTParityOptions parity_;
+ private:
+#ifdef ARDUINO_ARCH_ESP8266
+  static bool serial0InUse;
+#endif
 };
 
 #ifdef ARDUINO_ARCH_ESP32

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -118,6 +118,7 @@ class UARTComponent : public Component, public Stream {
   uint8_t stop_bits_;
   uint8_t data_bits_;
   UARTParityOptions parity_;
+
  private:
 #ifdef ARDUINO_ARCH_ESP8266
   static bool serial0InUse;

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -107,6 +107,7 @@ class UARTComponent : public Component, public Stream {
   HardwareSerial *hw_serial_{nullptr};
 #ifdef ARDUINO_ARCH_ESP8266
   ESP8266SoftwareSerial *sw_serial_{nullptr};
+  static bool serial0InUse;
 #endif
   optional<uint8_t> tx_pin_;
   optional<uint8_t> rx_pin_;

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -55,11 +55,12 @@ void UARTComponent::setup() {
   // is 1 we still want to use Serial.
   SerialConfig config = static_cast<SerialConfig>(get_config());
 
+
   if (!UARTComponent::serial0InUse && this->tx_pin_.value_or(1) == 1 &&
       this->rx_pin_.value_or(3) == 3
 #ifdef USE_LOGGER
       // we will use UART0 if logger isn't using it in swapped mode
-      && logger::global_logger->get_uart() != logger::UART_SELECTION_UART0_SWAP
+      && (logger::global_logger->get_hw_serial() == nullptr || logger::global_logger->get_uart() != logger::UART_SELECTION_UART0_SWAP )
 #endif
   ) {
     this->hw_serial_ = &Serial;
@@ -70,7 +71,7 @@ void UARTComponent::setup() {
              this->rx_pin_.value_or(13) == 13
 #ifdef USE_LOGGER
              // we will use UART0 swapped if logger isn't using it in regular mode
-             && logger::global_logger->get_uart() != logger::UART_SELECTION_UART0
+             && (logger::global_logger->get_hw_serial() == nullptr || logger::global_logger->get_uart() != logger::UART_SELECTION_UART0 )
 #endif
   ) {
     this->hw_serial_ = &Serial;

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -55,7 +55,7 @@ void UARTComponent::setup() {
   // is 1 we still want to use Serial.
   SerialConfig config = static_cast<SerialConfig>(get_config());
 
-  if (!this->serial0InUse && this->tx_pin_.value_or(1) == 1 &&
+  if (!esphome::uart::UARTComponent::serial0InUse && this->tx_pin_.value_or(1) == 1 &&
       this->rx_pin_.value_or(3) == 3
 #ifdef USE_LOGGER
       // we will use UART0 if Logger is using either UART0 or UART1 or NONE
@@ -65,8 +65,8 @@ void UARTComponent::setup() {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
-    this->serial0InUse = true;
-  } else if (!this->serial0InUse && this->tx_pin_.value_or(15) == 15 &&
+    esphome::uart::UARTComponent::serial0InUse = true;
+  } else if (!esphome::uart::UARTComponent::serial0InUse && this->tx_pin_.value_or(15) == 15 &&
              this->rx_pin_.value_or(13) == 13
 #ifdef USE_LOGGER
              // we will use UART0_swapped if Logger is using either UART0_swapped or UART1 or NONE
@@ -77,7 +77,7 @@ void UARTComponent::setup() {
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
     this->hw_serial_->swap();
-    this->serial0InUse = true;
+    esphome::uart::UARTComponent::serial0InUse = true;
   } else if (this->tx_pin_.value_or(2) == 2 && this->rx_pin_.value_or(8) == 8) {
     this->hw_serial_ = &Serial1;
     this->hw_serial_->begin(this->baud_rate_, config);

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -69,8 +69,8 @@ void UARTComponent::setup() {
   } else if (!UARTComponent::serial0InUse && this->tx_pin_.value_or(15) == 15 &&
              this->rx_pin_.value_or(13) == 13
 #ifdef USE_LOGGER
-             // we will use UART0_swapped if Logger is using either UART0_swapped or UART1 or NONE
-             && !(logger::global_logger->get_hw_serial() == &Serial && !(IOSWAP & (1 << IOSWAPU0)))
+             // we will use UART0 swapped if logger isn't using it in regular mode
+             && logger::global_logger->get_uart() != logger::UART_SELECTION_UART0
 #endif
   ) {
     this->hw_serial_ = &Serial;

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -13,7 +13,7 @@ namespace esphome {
 namespace uart {
 
 static const char *const TAG = "uart_esp8266";
-bool UARTComponent::serial0InUse = false;
+bool UARTComponent::serial0InUse = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 uint32_t UARTComponent::get_config() {
   uint32_t config = 0;
@@ -55,7 +55,7 @@ void UARTComponent::setup() {
   // is 1 we still want to use Serial.
   SerialConfig config = static_cast<SerialConfig>(get_config());
 
-  if (!esphome::uart::UARTComponent::serial0InUse && this->tx_pin_.value_or(1) == 1 &&
+  if (!UARTComponent::serial0InUse && this->tx_pin_.value_or(1) == 1 &&
       this->rx_pin_.value_or(3) == 3
 #ifdef USE_LOGGER
       // we will use UART0 if Logger is using either UART0 or UART1 or NONE
@@ -65,8 +65,8 @@ void UARTComponent::setup() {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
-    esphome::uart::UARTComponent::serial0InUse = true;
-  } else if (!esphome::uart::UARTComponent::serial0InUse && this->tx_pin_.value_or(15) == 15 &&
+    UARTComponent::serial0InUse = true;
+  } else if (!UARTComponent::serial0InUse && this->tx_pin_.value_or(15) == 15 &&
              this->rx_pin_.value_or(13) == 13
 #ifdef USE_LOGGER
              // we will use UART0_swapped if Logger is using either UART0_swapped or UART1 or NONE
@@ -77,7 +77,7 @@ void UARTComponent::setup() {
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
     this->hw_serial_->swap();
-    esphome::uart::UARTComponent::serial0InUse = true;
+    UARTComponent::serial0InUse = true;
   } else if (this->tx_pin_.value_or(2) == 2 && this->rx_pin_.value_or(8) == 8) {
     this->hw_serial_ = &Serial1;
     this->hw_serial_->begin(this->baud_rate_, config);

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -55,12 +55,12 @@ void UARTComponent::setup() {
   // is 1 we still want to use Serial.
   SerialConfig config = static_cast<SerialConfig>(get_config());
 
-
   if (!UARTComponent::serial0InUse && this->tx_pin_.value_or(1) == 1 &&
       this->rx_pin_.value_or(3) == 3
 #ifdef USE_LOGGER
       // we will use UART0 if logger isn't using it in swapped mode
-      && (logger::global_logger->get_hw_serial() == nullptr || logger::global_logger->get_uart() != logger::UART_SELECTION_UART0_SWAP )
+      && (logger::global_logger->get_hw_serial() == nullptr ||
+          logger::global_logger->get_uart() != logger::UART_SELECTION_UART0_SWAP)
 #endif
   ) {
     this->hw_serial_ = &Serial;
@@ -71,7 +71,8 @@ void UARTComponent::setup() {
              this->rx_pin_.value_or(13) == 13
 #ifdef USE_LOGGER
              // we will use UART0 swapped if logger isn't using it in regular mode
-             && (logger::global_logger->get_hw_serial() == nullptr || logger::global_logger->get_uart() != logger::UART_SELECTION_UART0 )
+             && (logger::global_logger->get_hw_serial() == nullptr ||
+			     logger::global_logger->get_uart() != logger::UART_SELECTION_UART0)
 #endif
   ) {
     this->hw_serial_ = &Serial;

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -55,22 +55,24 @@ void UARTComponent::setup() {
   // is 1 we still want to use Serial.
   SerialConfig config = static_cast<SerialConfig>(get_config());
 
-  if (!this->serial0InUse && this->tx_pin_.value_or(1) == 1 && this->rx_pin_.value_or(3) == 3
+  if (!this->serial0InUse && this->tx_pin_.value_or(1) == 1 &&
+      this->rx_pin_.value_or(3) == 3
 #ifdef USE_LOGGER
-// we will use UART0 if Logger is using either UART0 or UART1 or NONE
-    && ! (logger::global_logger->get_hw_serial() == &Serial && ( IOSWAP & (1 << IOSWAPU0)) )
+      // we will use UART0 if Logger is using either UART0 or UART1 or NONE
+      && !(logger::global_logger->get_hw_serial() == &Serial && (IOSWAP & (1 << IOSWAPU0)))
 #endif
   ) {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
     this->serial0InUse = true;
-  } else if (!this->serial0InUse && this->tx_pin_.value_or(15) == 15 && this->rx_pin_.value_or(13) == 13
+  } else if (!this->serial0InUse && this->tx_pin_.value_or(15) == 15 &&
+             this->rx_pin_.value_or(13) == 13
 #ifdef USE_LOGGER
-// we will use UART0_swapped if Logger is using either UART0_swapped or UART1 or NONE
-    && ! (logger::global_logger->get_hw_serial() == &Serial && ! ( IOSWAP & (1 << IOSWAPU0)) )
+             // we will use UART0_swapped if Logger is using either UART0_swapped or UART1 or NONE
+             && !(logger::global_logger->get_hw_serial() == &Serial && !(IOSWAP & (1 << IOSWAPU0)))
 #endif
-    ) {
+  ) {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -72,7 +72,7 @@ void UARTComponent::setup() {
 #ifdef USE_LOGGER
              // we will use UART0 swapped if logger isn't using it in regular mode
              && (logger::global_logger->get_hw_serial() == nullptr ||
-			     logger::global_logger->get_uart() != logger::UART_SELECTION_UART0)
+                 logger::global_logger->get_uart() != logger::UART_SELECTION_UART0)
 #endif
   ) {
     this->hw_serial_ = &Serial;

--- a/esphome/components/uart/uart_esp8266.cpp
+++ b/esphome/components/uart/uart_esp8266.cpp
@@ -58,8 +58,8 @@ void UARTComponent::setup() {
   if (!UARTComponent::serial0InUse && this->tx_pin_.value_or(1) == 1 &&
       this->rx_pin_.value_or(3) == 3
 #ifdef USE_LOGGER
-      // we will use UART0 if Logger is using either UART0 or UART1 or NONE
-      && !(logger::global_logger->get_hw_serial() == &Serial && (IOSWAP & (1 << IOSWAPU0)))
+      // we will use UART0 if logger isn't using it in swapped mode
+      && logger::global_logger->get_uart() != logger::UART_SELECTION_UART0_SWAP
 #endif
   ) {
     this->hw_serial_ = &Serial;


### PR DESCRIPTION
# What does this implement/fix? 

Fix for using UARTComponent with logger and pins 1/3 or 15/13.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [ ] ESP32
- [X] ESP8266 (only ESP8266 is affected)

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:

# Use same RX and TX pins & baud rate as the logger does per default, logger is still working UARTComponent will use UART0, component can use RX as input.
  - rx_pin: RX
    tx_pin: TX
    baud_rate: 115200
    id: uart_logger

# Will always use Software Serial.
  - rx_pin: GPIO14
    tx_pin: GPIO12
    baud_rate: 9600
    id: uart_senseair

# Will use hardware UART0 only if it's free.
  - rx_pin: GPIO13
    tx_pin: GPIO15
    baud_rate: 9600
    id: uart_sds011

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
