### PR TITLE
Reject template select/number/switches that don't handle user input

### DIFF
--- a/esphome/components/template/number/__init__.py
+++ b/esphome/components/template/number/__init__.py
@@ -29,7 +29,7 @@ def validate_min_max(config):
 
 def validate(config):
     if CONF_LAMBDA in config:
-        if CONF_OPTIMISTIC in config:
+        if config[CONF_OPTIMISTIC]:
             raise cv.Invalid("optimistic cannot be used with lambda")
         if CONF_INITIAL_VALUE in config:
             raise cv.Invalid("initial_value cannot be used with lambda")
@@ -46,7 +46,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MIN_VALUE): cv.float_,
             cv.Required(CONF_STEP): cv.positive_float,
             cv.Optional(CONF_LAMBDA): cv.returning_lambda,
-            cv.Optional(CONF_OPTIMISTIC): cv.boolean,
+            cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
             cv.Optional(CONF_SET_ACTION): automation.validate_automation(single=True),
             cv.Optional(CONF_INITIAL_VALUE): cv.float_,
             cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
@@ -75,8 +75,7 @@ async def to_code(config):
         cg.add(var.set_template(template_))
 
     else:
-        if CONF_OPTIMISTIC in config:
-            cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
+        cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
         if CONF_INITIAL_VALUE in config:
             cg.add(var.set_initial_value(config[CONF_INITIAL_VALUE]))
         if CONF_RESTORE_VALUE in config:

--- a/esphome/components/template/number/__init__.py
+++ b/esphome/components/template/number/__init__.py
@@ -35,6 +35,10 @@ def validate(config):
             raise cv.Invalid("initial_value cannot be used with lambda")
         if CONF_RESTORE_VALUE in config:
             raise cv.Invalid("restore_value cannot be used with lambda")
+    if not config[CONF_OPTIMISTIC] and CONF_SET_ACTION not in config:
+        raise cv.Invalid(
+            "Either optimistic mode must be enabled, or set_action must be set, to handle the number being set."
+        )
     return config
 
 

--- a/esphome/components/template/select/__init__.py
+++ b/esphome/components/template/select/__init__.py
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.ensure_list(cv.string_strict), cv.Length(min=1)
             ),
             cv.Optional(CONF_LAMBDA): cv.returning_lambda,
-            cv.Optional(CONF_OPTIMISTIC): cv.boolean,
+            cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
             cv.Optional(CONF_SET_ACTION): automation.validate_automation(single=True),
             cv.Optional(CONF_INITIAL_OPTION): cv.string_strict,
             cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
@@ -60,9 +60,7 @@ async def to_code(config):
         cg.add(var.set_template(template_))
 
     else:
-        if CONF_OPTIMISTIC in config:
-            cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
-
+        cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
         cg.add(var.set_initial_option(config[CONF_INITIAL_OPTION]))
 
         if CONF_RESTORE_VALUE in config:

--- a/esphome/components/template/select/__init__.py
+++ b/esphome/components/template/select/__init__.py
@@ -30,6 +30,17 @@ def validate_initial_value_in_options(config):
     return config
 
 
+def validate(config):
+    if CONF_LAMBDA in config:
+        if config[CONF_OPTIMISTIC]:
+            raise cv.Invalid("optimistic cannot be used with lambda")
+        if CONF_INITIAL_OPTION in config:
+            raise cv.Invalid("initial_value cannot be used with lambda")
+        if CONF_RESTORE_VALUE in config:
+            raise cv.Invalid("restore_value cannot be used with lambda")
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     select.SELECT_SCHEMA.extend(
         {
@@ -45,6 +56,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.polling_component_schema("60s")),
     validate_initial_value_in_options,
+    validate,
 )
 
 

--- a/esphome/components/template/select/__init__.py
+++ b/esphome/components/template/select/__init__.py
@@ -38,6 +38,10 @@ def validate(config):
             raise cv.Invalid("initial_value cannot be used with lambda")
         if CONF_RESTORE_VALUE in config:
             raise cv.Invalid("restore_value cannot be used with lambda")
+    if not config[CONF_OPTIMISTIC] and CONF_SET_ACTION not in config:
+        raise cv.Invalid(
+            "Either optimistic mode must be enabled, or set_action must be set, to handle the option being set."
+        )
     return config
 
 

--- a/esphome/components/template/switch/__init__.py
+++ b/esphome/components/template/switch/__init__.py
@@ -16,17 +16,38 @@ from .. import template_ns
 
 TemplateSwitch = template_ns.class_("TemplateSwitch", switch.Switch, cg.Component)
 
-CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(TemplateSwitch),
-        cv.Optional(CONF_LAMBDA): cv.returning_lambda,
-        cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
-        cv.Optional(CONF_ASSUMED_STATE, default=False): cv.boolean,
-        cv.Optional(CONF_TURN_OFF_ACTION): automation.validate_automation(single=True),
-        cv.Optional(CONF_TURN_ON_ACTION): automation.validate_automation(single=True),
-        cv.Optional(CONF_RESTORE_STATE, default=False): cv.boolean,
-    }
-).extend(cv.COMPONENT_SCHEMA)
+
+def validate(config):
+    if (
+        not config[CONF_OPTIMISTIC]
+        and CONF_TURN_ON_ACTION not in config
+        and CONF_TURN_OFF_ACTION not in config
+    ):
+        raise cv.Invalid(
+            "Either optimistic mode must be enabled, or turn_on_action or turn_off_action must be set, "
+            "to handle the switch being set."
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    switch.SWITCH_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(TemplateSwitch),
+            cv.Optional(CONF_LAMBDA): cv.returning_lambda,
+            cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
+            cv.Optional(CONF_ASSUMED_STATE, default=False): cv.boolean,
+            cv.Optional(CONF_TURN_OFF_ACTION): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_TURN_ON_ACTION): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_RESTORE_STATE, default=False): cv.boolean,
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    validate,
+)
 
 
 async def to_code(config):

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1862,6 +1862,7 @@ switch:
       inverted: False
   - platform: template
     id: ble1_status
+    optimistic: true
 
 fan:
   - platform: binary


### PR DESCRIPTION
# What does this implement/fix? 

Reject the creation of template selects/numbers/switches with `optimistic` mode disabled that don't have `set_action`. These selects/numbers/switches are useless, since they cannot possibly do anything with user input; and a sensor should be used instead. This frequently confused users that used such a template in combination with an `on_value` that never triggered. See e.g. esphome/issues#1911, esphome/issues#2328, esphome/issues#2370, but there's plenty more reports on the Discord.

Also some cleanups:
* Set default value for `optimistic` in the schema, as is convention.
* Reject the usage of `optimistic`, `initial_option` and `restore_value` with `lambda` for select, like number already does. These options are ignored when a lambda is set anyway.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2328

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
select:
  - platform: template
    name: "Template"
    options:
      - A
      - B
      - C
    update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
