### PR TITLE
Expose WHITE/CWWW/RGBCT color modes over MQTT

### DIFF
--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -38,18 +38,23 @@ void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscover
 
   root["color_mode"] = true;
   JsonArray &color_modes = root.createNestedArray("supported_color_modes");
-  if (traits.supports_color_mode(ColorMode::COLOR_TEMPERATURE))
+  if (traits.supports_color_mode(ColorMode::ON_OFF))
+    color_modes.add("onoff");
+  if (traits.supports_color_mode(ColorMode::BRIGHTNESS))
+    color_modes.add("brightness");
+  if (traits.supports_color_mode(ColorMode::WHITE))
+    color_modes.add("white");
+  if (traits.supports_color_mode(ColorMode::COLOR_TEMPERATURE) ||
+      traits.supports_color_mode(ColorMode::COLD_WARM_WHITE))
     color_modes.add("color_temp");
   if (traits.supports_color_mode(ColorMode::RGB))
     color_modes.add("rgb");
-  if (traits.supports_color_mode(ColorMode::RGB_WHITE))
+  if (traits.supports_color_mode(ColorMode::RGB_WHITE) ||
+      // HA doesn't support RGBCT, and there's not CWWW->CT emulation in ESPHome yet, so ignore CT control for now
+      traits.supports_color_mode(ColorMode::RGB_COLOR_TEMPERATURE))
     color_modes.add("rgbw");
   if (traits.supports_color_mode(ColorMode::RGB_COLD_WARM_WHITE))
     color_modes.add("rgbww");
-  if (traits.supports_color_mode(ColorMode::BRIGHTNESS))
-    color_modes.add("brightness");
-  if (traits.supports_color_mode(ColorMode::ON_OFF))
-    color_modes.add("onoff");
 
   // legacy API
   if (traits.supports_color_capability(ColorCapability::BRIGHTNESS))

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -50,7 +50,7 @@ void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscover
   if (traits.supports_color_mode(ColorMode::RGB))
     color_modes.add("rgb");
   if (traits.supports_color_mode(ColorMode::RGB_WHITE) ||
-      // HA doesn't support RGBCT, and there's not CWWW->CT emulation in ESPHome yet, so ignore CT control for now
+      // HA doesn't support RGBCT, and there's no CWWW->CT emulation in ESPHome yet, so ignore CT control for now
       traits.supports_color_mode(ColorMode::RGB_COLOR_TEMPERATURE))
     color_modes.add("rgbw");
   if (traits.supports_color_mode(ColorMode::RGB_COLD_WARM_WHITE))


### PR DESCRIPTION
# What does this implement/fix? 

The White, CWWW and RGBCT color modes weren't exposed over MQTT. RGBCT is somewhat problematic as HA only offers a RGBWW mode, and we don't have CWWW -> CT emulation in ESPHome at the moment (and I don't have time/interest to add that in the short term). Just expose RGBCT as RGBW for now, it's better than nothing. 

I haven't tested this beyond compilation as I don't have an MQTT setup.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2358

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
