### PR TITLE
ADE7953 Power Factor

### DIFF
--- a/esphome/components/ade7953/ade7953.cpp
+++ b/esphome/components/ade7953/ade7953.cpp
@@ -18,6 +18,12 @@ void ADE7953::dump_config() {
   LOG_SENSOR("  ", "Current B Sensor", this->current_b_sensor_);
   LOG_SENSOR("  ", "Active Power A Sensor", this->active_power_a_sensor_);
   LOG_SENSOR("  ", "Active Power B Sensor", this->active_power_b_sensor_);
+  LOG_SENSOR("  ", "Apparent Power A Sensor", this->apparent_power_a_sensor_);
+  LOG_SENSOR("  ", "Apparent Power B Sensor", this->apparent_power_b_sensor_);
+  LOG_SENSOR("  ", "Reactive Power A Sensor", this->reactive_power_a_sensor_);
+  LOG_SENSOR("  ", "Reactive Power B Sensor", this->reactive_power_b_sensor_);
+  LOG_SENSOR("  ", "Power Factor A Sensor", this->power_factor_a_sensor_);
+  LOG_SENSOR("  ", "Power Factor B Sensor", this->power_factor_b_sensor_);
 }
 
 #define ADE_PUBLISH_(name, factor) \
@@ -41,13 +47,18 @@ void ADE7953::update() {
   ADE_PUBLISH(current_b, 100000.0f);
   auto voltage = this->ade_read_<uint32_t>(0x031C);
   ADE_PUBLISH(voltage, 26000.0f);
-
-  //    auto apparent_power_a = this->ade_read_<int32_t>(0x0310);
-  //    auto apparent_power_b = this->ade_read_<int32_t>(0x0311);
-  //    auto reactive_power_a = this->ade_read_<int32_t>(0x0314);
-  //    auto reactive_power_b = this->ade_read_<int32_t>(0x0315);
-  //    auto power_factor_a = this->ade_read_<int16_t>(0x010A);
-  //    auto power_factor_b = this->ade_read_<int16_t>(0x010B);
+  auto apparent_power_a = this->ade_read_<int32_t>(0x0310);
+  ADE_PUBLISH(apparent_power_a, 154.0f);
+  auto apparent_power_b = this->ade_read_<int32_t>(0x0311);
+  ADE_PUBLISH(apparent_power_b, 154.0f);
+  auto reactive_power_a = this->ade_read_<int32_t>(0x0314);
+  ADE_PUBLISH(reactive_power_a, 154.0f);
+  auto reactive_power_b = this->ade_read_<int32_t>(0x0315);
+  ADE_PUBLISH(reactive_power_b, 154.0f);
+  auto power_factor_a = this->ade_read_<int16_t>(0x010A);
+  ADE_PUBLISH(power_factor_a, 1.0f);
+  auto power_factor_b = this->ade_read_<int16_t>(0x010B);
+  ADE_PUBLISH(power_factor_b, 1.0f);
 }
 
 }  // namespace ade7953

--- a/esphome/components/ade7953/ade7953.cpp
+++ b/esphome/components/ade7953/ade7953.cpp
@@ -56,9 +56,9 @@ void ADE7953::update() {
   auto reactive_power_b = this->ade_read_<int32_t>(0x0315);
   ADE_PUBLISH(reactive_power_b, 154.0f);
   auto power_factor_a = this->ade_read_<int16_t>(0x010A);
-  ADE_PUBLISH(power_factor_a, 1.0f);
+  ADE_PUBLISH(power_factor_a, 32767.0f);
   auto power_factor_b = this->ade_read_<int16_t>(0x010B);
-  ADE_PUBLISH(power_factor_b, 1.0f);
+  ADE_PUBLISH(power_factor_b, 32767.0f);
 }
 
 }  // namespace ade7953

--- a/esphome/components/ade7953/ade7953.h
+++ b/esphome/components/ade7953/ade7953.h
@@ -23,6 +23,30 @@ class ADE7953 : public i2c::I2CDevice, public PollingComponent {
     active_power_b_sensor_ = active_power_b_sensor;
   }
 
+  void set_apparent_power_a_sensor(sensor::Sensor *apparent_power_a_sensor) {
+    apparent_power_a_sensor_ = apparent_power_a_sensor;
+  }
+
+  void set_apparent_power_b_sensor(sensor::Sensor *apparent_power_b_sensor) {
+    apparent_power_b_sensor_ = apparent_power_b_sensor;
+  }
+
+  void set_reactive_power_a_sensor(sensor::Sensor *reactive_power_a_sensor) {
+    reactive_power_a_sensor_ = reactive_power_a_sensor;
+  }
+
+  void set_reactive_power_b_sensor(sensor::Sensor *reactive_power_b_sensor) {
+    reactive_power_b_sensor_ = reactive_power_b_sensor;
+  }
+
+    void set_power_factor_a_sensor(sensor::Sensor *power_factor_a_sensor) {
+    power_factor_a_sensor_ = power_factor_a_sensor;
+  }
+
+  void set_power_factor_b_sensor(sensor::Sensor *power_factor_b_sensor) {
+    power_factor_b_sensor_ = power_factor_b_sensor;
+  }
+
   void setup() override {
     if (this->has_irq_) {
       auto pin = GPIOPin(this->irq_pin_number_, INPUT);
@@ -73,6 +97,12 @@ class ADE7953 : public i2c::I2CDevice, public PollingComponent {
   sensor::Sensor *current_b_sensor_{nullptr};
   sensor::Sensor *active_power_a_sensor_{nullptr};
   sensor::Sensor *active_power_b_sensor_{nullptr};
+  sensor::Sensor *apparent_power_a_sensor_{nullptr};
+  sensor::Sensor *apparent_power_b_sensor_{nullptr};
+  sensor::Sensor *reactive_power_a_sensor_{nullptr};
+  sensor::Sensor *reactive_power_b_sensor_{nullptr};
+  sensor::Sensor *power_factor_a_sensor_{nullptr};
+  sensor::Sensor *power_factor_b_sensor_{nullptr};
 };
 
 }  // namespace ade7953

--- a/esphome/components/ade7953/sensor.py
+++ b/esphome/components/ade7953/sensor.py
@@ -8,6 +8,7 @@ from esphome.const import (
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
+    DEVICE_CLASS_POWER_FACTOR,
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
     UNIT_AMPERE,
@@ -24,6 +25,12 @@ CONF_CURRENT_A = "current_a"
 CONF_CURRENT_B = "current_b"
 CONF_ACTIVE_POWER_A = "active_power_a"
 CONF_ACTIVE_POWER_B = "active_power_b"
+CONF_APPARENT_POWER_A = "apparent_power_a"
+CONF_APPARENT_POWER_B = "apparent_power_b"
+CONF_REACTIVE_POWER_A = "reactive_power_a"
+CONF_REACTIVE_POWER_B = "reactive_power_b"
+CONF_POWER_FACTOR_A = "power_factor_a"
+CONF_POWER_FACTOR_B = "power_factor_b"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -60,6 +67,40 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_APPARENT_POWER_A): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VA,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_APPARENT_POWER_B): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VA,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_REACTIVE_POWER_A): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VAR,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_REACTIVE_POWER_B): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VAR,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER_FACTOR_A): sensor.sensor_schema(
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER_FACTOR_B): sensor.sensor_schema(
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -81,6 +122,12 @@ async def to_code(config):
         CONF_CURRENT_B,
         CONF_ACTIVE_POWER_A,
         CONF_ACTIVE_POWER_B,
+        CONF_APPARENT_POWER_A,
+        CONF_APPARENT_POWER_B,
+        CONF_REACTIVE_POWER_A,
+        CONF_REACTIVE_POWER_B,
+        CONF_POWER_FACTOR_A,
+        CONF_POWER_FACTOR_B
     ]:
         if key not in config:
             continue

--- a/esphome/components/ade7953/sensor.py
+++ b/esphome/components/ade7953/sensor.py
@@ -13,6 +13,8 @@ from esphome.const import (
     UNIT_VOLT,
     UNIT_AMPERE,
     UNIT_WATT,
+    UNIT_VOLT_AMPS,
+    UNIT_VOLT_AMPS_REACTIVE
 )
 
 DEPENDENCIES = ["i2c"]
@@ -68,25 +70,25 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_APPARENT_POWER_A): sensor.sensor_schema(
-                unit_of_measurement=UNIT_VA,
+                unit_of_measurement=UNIT_VOLT_AMPS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_APPARENT_POWER_B): sensor.sensor_schema(
-                unit_of_measurement=UNIT_VA,
+                unit_of_measurement=UNIT_VOLT_AMPS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_REACTIVE_POWER_A): sensor.sensor_schema(
-                unit_of_measurement=UNIT_VAR,
+                unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_REACTIVE_POWER_B): sensor.sensor_schema(
-                unit_of_measurement=UNIT_VAR,
+                unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
# What does this implement/fix? 

Adds the commented out measurements this chip can do (Power Factor, Reactive power, Apparent power)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: ade7953
    irq_pin: GPIO4
    voltage:
      name: ADE7953 Voltage
    current_a:
      name: ADE7953 Current A
      filters:
        multiply: 3.819847328244275
    active_power_a:
      name: ADE7953 Active Power A
      filters:
        multiply: -3.819847328244275
    apparent_power_a:
      name: Apparent Power A Sensor
      filters:
        multiply: 3.819847328244275
    reactive_power_a:
      name: Reactive Power A Sensor
      filters:
        multiply: 3.819847328244275
    power_factor_a:
      name: Power Factor A Sensor
      filters:
        multiply: -1
      
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
