### PR TITLE
LOG_UPDATE_INTERVAL: correctly report "never"

### DIFF
--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -38,8 +38,12 @@ extern const float LATE;
 
 }  // namespace setup_priority
 
+static const uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
+
 #define LOG_UPDATE_INTERVAL(this) \
-  if (this->get_update_interval() < 100) { \
+  if (this->get_update_interval() == SCHEDULER_DONT_RUN) { \
+    ESP_LOGCONFIG(TAG, "  Update Interval: never"); \
+  } else if (this->get_update_interval() < 100) { \
     ESP_LOGCONFIG(TAG, "  Update Interval: %.3fs", this->get_update_interval() / 1000.0f); \
   } else { \
     ESP_LOGCONFIG(TAG, "  Update Interval: %.1fs", this->get_update_interval() / 1000.0f); \

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -7,7 +7,6 @@ namespace esphome {
 
 static const char *const TAG = "scheduler";
 
-static const uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
 static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 10;
 
 // Uncomment to debug scheduler


### PR DESCRIPTION
# What does this implement/fix? 

Before:
`Update Interval: 4294967.5s`

After:
`Update Interval: never`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: pm1006
    pm_2_5:
      name: "Particulate Matter <2.5µm (1)"
#    update_interval: 10s
#    update_interval: never
```

(I tested implicit `never` (the default), explicit `never`, and `10s`. All three behave correctly.)

(Note that pm1006 only has `update_interval` in #2214)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
