### PR TITLE
Dont dump legacy fields

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -793,10 +793,6 @@ void CoverStateResponse::dump_to(std::string &out) const {
   out.append(buffer);
   out.append("\n");
 
-  out.append("  legacy_state: ");
-  out.append(proto_enum_to_string<enums::LegacyCoverState>(this->legacy_state));
-  out.append("\n");
-
   out.append("  position: ");
   sprintf(buffer, "%g", this->position);
   out.append(buffer);
@@ -878,10 +874,6 @@ void CoverCommandRequest::dump_to(std::string &out) const {
 
   out.append("  has_legacy_command: ");
   out.append(YESNO(this->has_legacy_command));
-  out.append("\n");
-
-  out.append("  legacy_command: ");
-  out.append(proto_enum_to_string<enums::LegacyCoverCommand>(this->legacy_command));
   out.append("\n");
 
   out.append("  has_position: ");
@@ -1329,22 +1321,6 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
     out.append(proto_enum_to_string<enums::ColorMode>(it));
     out.append("\n");
   }
-
-  out.append("  legacy_supports_brightness: ");
-  out.append(YESNO(this->legacy_supports_brightness));
-  out.append("\n");
-
-  out.append("  legacy_supports_rgb: ");
-  out.append(YESNO(this->legacy_supports_rgb));
-  out.append("\n");
-
-  out.append("  legacy_supports_white_value: ");
-  out.append(YESNO(this->legacy_supports_white_value));
-  out.append("\n");
-
-  out.append("  legacy_supports_color_temperature: ");
-  out.append(YESNO(this->legacy_supports_color_temperature));
-  out.append("\n");
 
   out.append("  min_mireds: ");
   sprintf(buffer, "%g", this->min_mireds);
@@ -2760,11 +2736,6 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   out.append(YESNO(this->bool_));
   out.append("\n");
 
-  out.append("  legacy_int: ");
-  sprintf(buffer, "%d", this->legacy_int);
-  out.append(buffer);
-  out.append("\n");
-
   out.append("  float_: ");
   sprintf(buffer, "%g", this->float_);
   out.append(buffer);
@@ -3180,10 +3151,6 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append(buffer);
   out.append("\n");
 
-  out.append("  legacy_supports_away: ");
-  out.append(YESNO(this->legacy_supports_away));
-  out.append("\n");
-
   out.append("  supports_action: ");
   out.append(YESNO(this->supports_action));
   out.append("\n");
@@ -3340,10 +3307,6 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("  target_temperature_high: ");
   sprintf(buffer, "%g", this->target_temperature_high);
   out.append(buffer);
-  out.append("\n");
-
-  out.append("  legacy_away: ");
-  out.append(YESNO(this->legacy_away));
   out.append("\n");
 
   out.append("  action: ");
@@ -3543,10 +3506,6 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
 
   out.append("  has_legacy_away: ");
   out.append(YESNO(this->has_legacy_away));
-  out.append("\n");
-
-  out.append("  legacy_away: ");
-  out.append(YESNO(this->legacy_away));
   out.append("\n");
 
   out.append("  has_fan_mode: ");

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -183,6 +183,8 @@ class TypeInfo:
 
     @property
     def dump_content(self):
+        if self.name.startswith("legacy_"):
+            return None
         o = f'out.append("  {self.name}: ");\n'
         o += self.dump(f"this->{self.field_name}") + "\n"
         o += f'out.append("\\n");\n'
@@ -778,9 +780,9 @@ def build_service_message_type(mt):
         hout += f"bool {func}(const {mt.name} &msg);\n"
         cout += f"bool {class_name}::{func}(const {mt.name} &msg) {{\n"
         if log:
-            cout += f'#ifdef HAS_PROTO_MESSAGE_DUMP\n'
+            cout += f"#ifdef HAS_PROTO_MESSAGE_DUMP\n"
             cout += f'  ESP_LOGVV(TAG, "{func}: %s", msg.dump().c_str());\n'
-            cout += f'#endif\n'
+            cout += f"#endif\n"
         # cout += f'  this->set_nodelay({str(nodelay).lower()});\n'
         cout += f"  return this->send_message_<{mt.name}>(msg, {id_});\n"
         cout += f"}}\n"
@@ -794,9 +796,9 @@ def build_service_message_type(mt):
         case += f"{mt.name} msg;\n"
         case += f"msg.decode(msg_data, msg_size);\n"
         if log:
-            case += f'#ifdef HAS_PROTO_MESSAGE_DUMP\n'
+            case += f"#ifdef HAS_PROTO_MESSAGE_DUMP\n"
             case += f'ESP_LOGVV(TAG, "{func}: %s", msg.dump().c_str());\n'
-            case += f'#endif\n'
+            case += f"#endif\n"
         case += f"this->{func}(msg);\n"
         if ifdef is not None:
             case += f"#endif\n"


### PR DESCRIPTION
# What does this implement/fix? 

Just had a thought to remove some dumping of legacy fields that are mostly not used in code, but only exist to keep the proto file the same.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
