### PR TITLE
Fix runtime exception due to dict typing

### DIFF
--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -1,7 +1,7 @@
 import socket
 import threading
 import time
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from zeroconf import (
     _CLASS_IN,

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -1,7 +1,7 @@
 import socket
 import threading
 import time
-from typing import Optional
+from typing import Optional, Dict
 
 from zeroconf import (
     _CLASS_IN,
@@ -64,7 +64,7 @@ class DashboardStatus(RecordUpdateListener, threading.Thread):
         threading.Thread.__init__(self)
         self.zc = zc
         self.query_hosts: set[str] = set()
-        self.key_to_host: dict[str, str] = {}
+        self.key_to_host: Dict[str, str] = {}
         self.stop_event = threading.Event()
         self.query_event = threading.Event()
         self.on_update = on_update
@@ -72,7 +72,7 @@ class DashboardStatus(RecordUpdateListener, threading.Thread):
     def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
         pass
 
-    def request_query(self, hosts: dict[str, str]) -> None:
+    def request_query(self, hosts: Dict[str, str]) -> None:
         self.query_hosts = set(hosts.values())
         self.key_to_host = hosts
         self.query_event.set()


### PR DESCRIPTION
# What does this implement/fix? 

Can't use dict for generic types as it results in runtime exception. Must use typing.Dict instead for generic types. Fixes runtime exception due to #2192

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
