### PR TITLE
template: select: fix initial_value cannot be used with lambda

### DIFF
--- a/esphome/components/template/select/__init__.py
+++ b/esphome/components/template/select/__init__.py
@@ -19,17 +19,6 @@ TemplateSelect = template_ns.class_(
 CONF_SET_ACTION = "set_action"
 
 
-def validate_initial_value_in_options(config):
-    if CONF_INITIAL_OPTION in config:
-        if config[CONF_INITIAL_OPTION] not in config[CONF_OPTIONS]:
-            raise cv.Invalid(
-                f"initial_option '{config[CONF_INITIAL_OPTION]}' is not a valid option [{', '.join(config[CONF_OPTIONS])}]"
-            )
-    else:
-        config[CONF_INITIAL_OPTION] = config[CONF_OPTIONS][0]
-    return config
-
-
 def validate(config):
     if CONF_LAMBDA in config:
         if config[CONF_OPTIMISTIC]:
@@ -38,6 +27,14 @@ def validate(config):
             raise cv.Invalid("initial_value cannot be used with lambda")
         if CONF_RESTORE_VALUE in config:
             raise cv.Invalid("restore_value cannot be used with lambda")
+    elif CONF_INITIAL_OPTION in config:
+        if config[CONF_INITIAL_OPTION] not in config[CONF_OPTIONS]:
+            raise cv.Invalid(
+                f"initial_option '{config[CONF_INITIAL_OPTION]}' is not a valid option [{', '.join(config[CONF_OPTIONS])}]"
+            )
+    else:
+        config[CONF_INITIAL_OPTION] = config[CONF_OPTIONS][0]
+
     if not config[CONF_OPTIMISTIC] and CONF_SET_ACTION not in config:
         raise cv.Invalid(
             "Either optimistic mode must be enabled, or set_action must be set, to handle the option being set."
@@ -59,7 +56,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
         }
     ).extend(cv.polling_component_schema("60s")),
-    validate_initial_value_in_options,
     validate,
 )
 


### PR DESCRIPTION
# What does this implement/fix? 

The usage of `select: template` with lambda generates a failure
after the https://github.com/esphome/esphome/pull/2230 generating failure:

```
select.template: [source configs-iot/esp8266-uart-link.yaml:29]
  
  initial_value cannot be used with lambda.
  platform: template
```

This happens due to validation not taking into account the usage of `lambda`
and the fact that `initial_option:` cannot be set.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
select:
  - platform: template
    name: "Test"
    options:
      - "1"
      - "2"
      - "3"
    lambda: !lambda return "1";
    set_action:
      - lambda: !lambda true;
```

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
