### PR TITLE
Expose select on Frontend `web_server:`

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -25,7 +25,8 @@ namespace web_server {
 
 static const char *const TAG = "web_server";
 
-void write_row(AsyncResponseStream *stream, Nameable *obj, const std::string &klass, const std::string &action) {
+void write_row(AsyncResponseStream *stream, Nameable *obj, const std::string &klass, const std::string &action,
+               const std::function<void(AsyncResponseStream &stream, Nameable *obj)> &action_func = nullptr) {
   if (obj->is_internal())
     return;
   stream->print("<tr class=\"");
@@ -38,6 +39,9 @@ void write_row(AsyncResponseStream *stream, Nameable *obj, const std::string &kl
   stream->print(obj->get_name().c_str());
   stream->print("</td><td></td><td>");
   stream->print(action.c_str());
+  if (action_func) {
+    action_func(*stream, obj);
+  }
   stream->print("</td>");
   stream->print("</tr>");
 }
@@ -219,7 +223,17 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 
 #ifdef USE_SELECT
   for (auto *obj : App.get_selects())
-    write_row(stream, obj, "select", "");
+    write_row(stream, obj, "select", "", [](AsyncResponseStream &stream, Nameable *obj) {
+      select::Select *select = (select::Select *) obj;
+      stream.print("<select>");
+      stream.print("<option></option>");
+      for (auto const &option : select->traits.get_options()) {
+        stream.print("<option>");
+        stream.print(option.c_str());
+        stream.print("</option>");
+      }
+      stream.print("</select>");
+    });
 #endif
 
   stream->print(F("</tbody></table><p>See <a href=\"https://esphome.io/web-api/index.html\">ESPHome Web API</a> for "
@@ -647,8 +661,27 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
       continue;
     if (obj->get_object_id() != match.id)
       continue;
-    std::string data = this->select_json(obj, obj->state);
-    request->send(200, "text/json", data.c_str());
+
+    if (request->method() == HTTP_GET) {
+      std::string data = this->select_json(obj, obj->state);
+      request->send(200, "text/json", data.c_str());
+      return;
+    }
+
+    if (match.method != "set") {
+      request->send(404);
+      return;
+    }
+
+    auto call = obj->make_call();
+
+    if (request->hasParam("option")) {
+      String option = request->getParam("option")->value();
+      call.set_option(option.c_str());  // NOLINT(clang-diagnostic-deprecated-declarations)
+    }
+
+    this->defer([call]() mutable { call.perform(); });
+    request->send(200);
     return;
   }
   request->send(404);
@@ -720,7 +753,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 #endif
 
 #ifdef USE_SELECT
-  if (request->method() == HTTP_GET && match.domain == "select")
+  if ((request->method() == HTTP_POST || request->method() == HTTP_GET) && match.domain == "select")
     return true;
 #endif
 


### PR DESCRIPTION
# What does this implement/fix? 

This exposes a basic select over a simple frontend
with values taken from traits.

<img width="650" alt="Screen Shot 2021-09-06 at 19 22 31" src="https://user-images.githubusercontent.com/2419009/132248980-863f4293-9a59-4c08-8d45-6bce66d58ade.png">

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/1445

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
select:
  - platform: template
    name: "UART Speed"
    update_interval: 1s
    options:
      - "38400"
      - "115200"
      - "1500000"
    lambda: !lambda return esphome::to_string(Serial.baudRate());
    set_action:
      - lambda: !lambda Serial.updateBaudRate(atoi(x.c_str()));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
