### PR TITLE
Send HA correct color mode for CWWW/RGBCT over MQTT

### DIFF
--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -30,8 +30,8 @@ void LightJSONSchema::dump_json(LightState &state, JsonObject &root) {
     case ColorMode::COLOR_TEMPERATURE:
       root["color_mode"] = "color_temp";
       break;
-    case ColorMode::COLD_WARM_WHITE:  // not supported by HA
-      root["color_mode"] = "cwww";
+    case ColorMode::COLD_WARM_WHITE:
+      root["color_mode"] = "color_temp";
       break;
     case ColorMode::RGB:
       root["color_mode"] = "rgb";
@@ -39,8 +39,9 @@ void LightJSONSchema::dump_json(LightState &state, JsonObject &root) {
     case ColorMode::RGB_WHITE:
       root["color_mode"] = "rgbw";
       break;
-    case ColorMode::RGB_COLOR_TEMPERATURE:  // not supported by HA
-      root["color_mode"] = "rgbct";
+    case ColorMode::RGB_COLOR_TEMPERATURE:
+      // HA doesn't support RGBCT, and there's no CWWW->CT emulation in ESPHome yet, so ignore CT control for now
+      root["color_mode"] = "rgbw";
       break;
     case ColorMode::RGB_COLD_WARM_WHITE:
       root["color_mode"] = "rgbww";

--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -7,6 +7,8 @@ namespace esphome {
 namespace light {
 
 // See https://www.home-assistant.io/integrations/light.mqtt/#json-schema for documentation on the schema
+// and https://github.com/home-assistant/core/blob/dev/homeassistant/components/mqtt/light/schema_json.py#L295 for the
+// actual implementation that diverts from the documentation.
 
 void LightJSONSchema::dump_json(LightState &state, JsonObject &root) {
   if (state.supports_effects())
@@ -63,8 +65,10 @@ void LightJSONSchema::dump_json(LightState &state, JsonObject &root) {
     color["w"] = uint8_t(values.get_white() * 255);
     root["white_value"] = uint8_t(values.get_white() * 255);  // legacy API
   }
-  if (values.get_color_mode() & ColorCapability::COLOR_TEMPERATURE) {
+  if ((values.get_color_mode() & ColorCapability::COLOR_TEMPERATURE) ||
+      (values.get_color_mode() & ColorCapability::COLD_WARM_WHITE)) {
     // this one isn't under the color subkey for some reason
+    // in CWWW mode current value might not be correct if light is manually set with CW/WW values
     root["color_temp"] = uint32_t(values.get_color_temperature());
   }
   if (values.get_color_mode() & ColorCapability::COLD_WARM_WHITE) {


### PR DESCRIPTION
# What does this implement/fix? 

Untested fix for esphome/issues#2388. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2388

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
