### PR TITLE
Logger prevent recursive logging

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -43,21 +43,24 @@ void Logger::write_header_(int level, const char *tag, int line) {
 }
 
 void HOT Logger::log_vprintf_(int level, const char *tag, int line, const char *format, va_list args) {  // NOLINT
-  if (level > this->level_for(tag))
+  if (level > this->level_for(tag) || recursion_guard_)
     return;
 
+  recursion_guard_ = true;
   this->reset_buffer_();
   this->write_header_(level, tag, line);
   this->vprintf_to_buffer_(format, args);
   this->write_footer_();
   this->log_message_(level, tag);
+  recursion_guard_ = false;
 }
 #ifdef USE_STORE_LOG_STR_IN_FLASH
 void Logger::log_vprintf_(int level, const char *tag, int line, const __FlashStringHelper *format,
                           va_list args) {  // NOLINT
-  if (level > this->level_for(tag))
+  if (level > this->level_for(tag) || recursion_guard_)
     return;
 
+  recursion_guard_ = true;
   this->reset_buffer_();
   // copy format string
   const char *format_pgm_p = (PGM_P) format;
@@ -78,6 +81,7 @@ void Logger::log_vprintf_(int level, const char *tag, int line, const __FlashStr
   this->vprintf_to_buffer_(this->tx_buffer_, args);
   this->write_footer_();
   this->log_message_(level, tag, offset);
+  recursion_guard_ = false;
 }
 #endif
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -113,6 +113,8 @@ class Logger : public Component {
   };
   std::vector<LogLevelOverride> log_levels_;
   CallbackManager<void(int, const char *, const char *)> log_callback_{};
+  /// Prevents recursive log calls, if true a log message is already being processed.
+  bool recursion_guard_ = false;
 };
 
 extern Logger *global_logger;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix? 

Some logging sinks in some cases also log themselves, which messes up the logger's log buffers.

Fix by adding a recursion guard that detect recursive prints and just refuses to log then (not ideal, but much better than what happens at the moment)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
