### PR TITLE
Revert "Dont dump legacy fields"

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -793,6 +793,10 @@ void CoverStateResponse::dump_to(std::string &out) const {
   out.append(buffer);
   out.append("\n");
 
+  out.append("  legacy_state: ");
+  out.append(proto_enum_to_string<enums::LegacyCoverState>(this->legacy_state));
+  out.append("\n");
+
   out.append("  position: ");
   sprintf(buffer, "%g", this->position);
   out.append(buffer);
@@ -874,6 +878,10 @@ void CoverCommandRequest::dump_to(std::string &out) const {
 
   out.append("  has_legacy_command: ");
   out.append(YESNO(this->has_legacy_command));
+  out.append("\n");
+
+  out.append("  legacy_command: ");
+  out.append(proto_enum_to_string<enums::LegacyCoverCommand>(this->legacy_command));
   out.append("\n");
 
   out.append("  has_position: ");
@@ -1321,6 +1329,22 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
     out.append(proto_enum_to_string<enums::ColorMode>(it));
     out.append("\n");
   }
+
+  out.append("  legacy_supports_brightness: ");
+  out.append(YESNO(this->legacy_supports_brightness));
+  out.append("\n");
+
+  out.append("  legacy_supports_rgb: ");
+  out.append(YESNO(this->legacy_supports_rgb));
+  out.append("\n");
+
+  out.append("  legacy_supports_white_value: ");
+  out.append(YESNO(this->legacy_supports_white_value));
+  out.append("\n");
+
+  out.append("  legacy_supports_color_temperature: ");
+  out.append(YESNO(this->legacy_supports_color_temperature));
+  out.append("\n");
 
   out.append("  min_mireds: ");
   sprintf(buffer, "%g", this->min_mireds);
@@ -2736,6 +2760,11 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   out.append(YESNO(this->bool_));
   out.append("\n");
 
+  out.append("  legacy_int: ");
+  sprintf(buffer, "%d", this->legacy_int);
+  out.append(buffer);
+  out.append("\n");
+
   out.append("  float_: ");
   sprintf(buffer, "%g", this->float_);
   out.append(buffer);
@@ -3151,6 +3180,10 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append(buffer);
   out.append("\n");
 
+  out.append("  legacy_supports_away: ");
+  out.append(YESNO(this->legacy_supports_away));
+  out.append("\n");
+
   out.append("  supports_action: ");
   out.append(YESNO(this->supports_action));
   out.append("\n");
@@ -3307,6 +3340,10 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("  target_temperature_high: ");
   sprintf(buffer, "%g", this->target_temperature_high);
   out.append(buffer);
+  out.append("\n");
+
+  out.append("  legacy_away: ");
+  out.append(YESNO(this->legacy_away));
   out.append("\n");
 
   out.append("  action: ");
@@ -3506,6 +3543,10 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
 
   out.append("  has_legacy_away: ");
   out.append(YESNO(this->has_legacy_away));
+  out.append("\n");
+
+  out.append("  legacy_away: ");
+  out.append(YESNO(this->legacy_away));
   out.append("\n");
 
   out.append("  has_fan_mode: ");

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -183,8 +183,6 @@ class TypeInfo:
 
     @property
     def dump_content(self):
-        if self.name.startswith("legacy_"):
-            return None
         o = f'out.append("  {self.name}: ");\n'
         o += self.dump(f"this->{self.field_name}") + "\n"
         o += f'out.append("\\n");\n'


### PR DESCRIPTION
Reverts esphome/esphome#2241

Since the fields still exist, then we should dump them or remove them from the proto so that they have no meaning and cannot be used.