### PR TITLE
Fix sm300d2 preamble sensing and checksum calculation

### DIFF
--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -14,7 +14,7 @@ void SM300D2Sensor::update() {
   bool read_success;
 
   // Read bytes off until we see what appears to be a preamble
-  while (1) {
+  while (true) {
     read_success = peek_byte(peeked);
     if (peeked[0] == 0x3C) {
       read_success = read_array(response, SM300D2_RESPONSE_LENGTH);
@@ -98,7 +98,7 @@ void SM300D2Sensor::update() {
     this->humidity_sensor_->publish_state(humidity);
 }
 
-uint8_t SM300D2Sensor::sm300d2_checksum_(uint8_t *ptr) {
+uint8_t SM300D2Sensor::sm300d2_checksum(uint8_t *ptr) {
   uint8_t sum = 0;
   for (int i = 0; i < (SM300D2_RESPONSE_LENGTH - 1); i++) {
     sum += *ptr++;

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -46,10 +46,10 @@ void SM300D2Sensor::update() {
 
   uint8_t calculated_checksum = this->sm300d2_checksum_(response);
   if (calculated_checksum == response[SM300D2_RESPONSE_LENGTH - 1]) {
-  } else if (calculated_checksum-0x80 == response[SM300D2_RESPONSE_LENGTH - 1]) {
+  } else if (calculated_checksum - 0x80 == response[SM300D2_RESPONSE_LENGTH - 1]) {
     // Reason for the frequent 0x80 offset is unknown, it's possible that it represents reading "freshness"
-    ESP_LOGW(TAG, "SM300D2 Checksum matches, with 0x80 offset: 0x%02X+0x80 = 0x%02X", response[SM300D2_RESPONSE_LENGTH - 1],
-             calculated_checksum);
+    ESP_LOGW(TAG, "SM300D2 Checksum matches, with 0x80 offset: 0x%02X+0x80 = 0x%02X",
+             response[SM300D2_RESPONSE_LENGTH - 1], calculated_checksum);
   } else {
     ESP_LOGW(TAG, "SM300D2 Checksum doesn't match: 0x%02X!=0x%02X", response[SM300D2_RESPONSE_LENGTH - 1],
              calculated_checksum);

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -44,7 +44,7 @@ void SM300D2Sensor::update() {
     return;
   }
 
-  uint8_t calculated_checksum = this->sm300d2_checksum_(response);
+  uint8_t calculated_checksum = this->sm300d2_checksum(response);
   if (calculated_checksum == response[SM300D2_RESPONSE_LENGTH - 1]) {
   } else if (calculated_checksum - 0x80 == response[SM300D2_RESPONSE_LENGTH - 1]) {
     // Reason for the frequent 0x80 offset is unknown, it's possible that it represents reading "freshness"

--- a/esphome/components/sm300d2/sm300d2.h
+++ b/esphome/components/sm300d2/sm300d2.h
@@ -23,7 +23,7 @@ class SM300D2Sensor : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  uint16_t sm300d2_checksum_(uint8_t *ptr);
+  uint8_t sm300d2_checksum_(uint8_t *ptr);
 
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *formaldehyde_sensor_{nullptr};

--- a/esphome/components/sm300d2/sm300d2.h
+++ b/esphome/components/sm300d2/sm300d2.h
@@ -23,7 +23,7 @@ class SM300D2Sensor : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  uint8_t sm300d2_checksum_(uint8_t *ptr);
+  uint8_t sm300d2_checksum(uint8_t *ptr);
 
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *formaldehyde_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix? 

- Preamble errors are due to UART buffers overflowing
- Checksum errors are due to an occasional undocumented 0x80 checksum offset (seems to correlate with TVOC updates)
- Remove unnecessary flushes, this is a read-only device

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
