### PR TITLE
sm300d2: Accept (undocumented) 0x80 checksum offset.

### DIFF
--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -27,7 +27,8 @@ void SM300D2Sensor::update() {
   }
 
   uint16_t calculated_checksum = this->sm300d2_checksum_(response);
-  if (calculated_checksum != response[SM300D2_RESPONSE_LENGTH - 1]) {
+  if ((calculated_checksum != response[SM300D2_RESPONSE_LENGTH - 1]) &&
+      (calculated_checksum - 0x80 != response[SM300D2_RESPONSE_LENGTH - 1])) {
     ESP_LOGW(TAG, "SM300D2 Checksum doesn't match: 0x%02X!=0x%02X", response[SM300D2_RESPONSE_LENGTH - 1],
              calculated_checksum);
     this->status_set_warning();


### PR DESCRIPTION
# What does this implement/fix? 

Accept valid readings with 0x80 checksum offset

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
