### PR TITLE
Fix a few ESP32-C3 compiler issues

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -707,7 +707,7 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
     }
 
     size_t i = 1;
-    size_t consumed = 0;
+    uint32_t consumed = 0;
     auto msg_size_varint = ProtoVarInt::parse(&rx_header_buf_[i], rx_header_buf_.size() - i, &consumed);
     if (!msg_size_varint.has_value()) {
       // not enough data there yet

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -49,7 +49,7 @@ void PN532::setup() {
   }
 
   // Set up SAM (secure access module)
-  uint8_t sam_timeout = std::min(255u, this->update_interval_ / 50);
+  uint8_t sam_timeout = std::min<uint8_t>(255u, this->update_interval_ / 50);
   if (!this->write_command_({
           PN532_COMMAND_SAMCONFIGURATION,
           0x01,         // normal mode

--- a/esphome/components/uart/uart_esp32.cpp
+++ b/esphome/components/uart/uart_esp32.cpp
@@ -73,7 +73,11 @@ void UARTComponent::setup() {
   // Use Arduino HardwareSerial UARTs if all used pins match the ones
   // preconfigured by the platform. For example if RX disabled but TX pin
   // is 1 we still want to use Serial.
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+  if (this->tx_pin_.value_or(21) == 21 && this->rx_pin_.value_or(20) == 20) {
+#else
   if (this->tx_pin_.value_or(1) == 1 && this->rx_pin_.value_or(3) == 3) {
+#endif
     this->hw_serial_ = &Serial;
   } else {
     this->hw_serial_ = new HardwareSerial(next_uart_num++);


### PR DESCRIPTION
# What does this implement/fix? 

- Fix using Serial when using ESP32-C3 standard pins
- size_t is a different size so dont try use it for a uint32_t
- std::min wants the arguments to be the same type, or use the template


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
