### PR TITLE
Added telegram debug option to dsmr

### DIFF
--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -13,6 +13,7 @@ AUTO_LOAD = ["sensor", "text_sensor"]
 
 CONF_DSMR_ID = "dsmr_id"
 CONF_DECRYPTION_KEY = "decryption_key"
+CONF_DEBUG_TELEGRAMS = "debug_telegrams"
 
 # Hack to prevent compile error due to ambiguity with lib namespace
 dsmr_ns = cg.esphome_ns.namespace("esphome::dsmr")
@@ -41,6 +42,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Dsmr),
         cv.Optional(CONF_DECRYPTION_KEY): _validate_key,
+        cv.Optional(CONF_DEBUG_TELEGRAMS, default=False): cv.boolean,
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
 
@@ -50,6 +52,9 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID], uart_component)
     if CONF_DECRYPTION_KEY in config:
         cg.add(var.set_decryption_key(config[CONF_DECRYPTION_KEY]))
+    if config[CONF_DEBUG_TELEGRAMS]:
+        cg.add_define("USE_TELEGRAM_DEBUGGER")
+
     await cg.register_component(var, config)
 
     # DSMR Parser

--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -53,7 +53,7 @@ async def to_code(config):
     if CONF_DECRYPTION_KEY in config:
         cg.add(var.set_decryption_key(config[CONF_DECRYPTION_KEY]))
     if config[CONF_DEBUG_TELEGRAMS]:
-        cg.add_define("USE_TELEGRAM_DEBUGGER")
+        cg.add_define("USE_DSMR_TELEGRAM_DEBUGGER")
 
     await cg.register_component(var, config)
 

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -25,18 +25,16 @@ void Dsmr::receive_telegram_() {
     if (c == '\r') {
       debug_[debug_len_++] = '\\';
       debug_[debug_len_++] = 'r';
-    }
-    else if (c == '\n') {
+    } else if (c == '\n') {
       debug_[debug_len_++] = '\\';
       debug_[debug_len_++] = 'n';
       debug_[debug_len_] = 0;
       ESP_LOGD(TAG, "Telegram line: %s", debug_);
       debug_len_ = 0;
-    }
-    else if (c >= 32 && c <= 126) {
+    } else if (c >= 32 && c <= 126) {
       debug_[debug_len_++] = c;
     } else {
-      sprintf(debug_+debug_len_, "0x%02x", c);
+      sprintf(debug_ + debug_len_, "0x%02x", c);
       debug_len_ += 4;
     }
     if (debug_len_ >= (MAX_DEBUG_LENGTH - 5)) {

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -15,6 +15,9 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
+#ifdef USE_TELEGRAM_DEBUGGER
+static constexpr uint32_t MAX_DEBUG_LENGTH = 500;
+#endif
 static constexpr uint32_t POLL_TIMEOUT = 1000;
 
 using namespace ::dsmr::fields;
@@ -86,6 +89,12 @@ class Dsmr : public Component, public uart::UARTDevice {
   // Telegram buffer
   char telegram_[MAX_TELEGRAM_LENGTH];
   int telegram_len_{0};
+
+#ifdef USE_TELEGRAM_DEBUGGER
+  // Telegram debug buffer
+  char debug_[MAX_DEBUG_LENGTH];
+  int debug_len_{0};
+#endif
 
   // Serial parser
   bool header_found_{false};

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -15,7 +15,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
-#ifdef USE_TELEGRAM_DEBUGGER
+#ifdef USE_DSMR_TELEGRAM_DEBUGGER
 static constexpr uint32_t MAX_DEBUG_LENGTH = 500;
 #endif
 static constexpr uint32_t POLL_TIMEOUT = 1000;
@@ -90,7 +90,7 @@ class Dsmr : public Component, public uart::UARTDevice {
   char telegram_[MAX_TELEGRAM_LENGTH];
   int telegram_len_{0};
 
-#ifdef USE_TELEGRAM_DEBUGGER
+#ifdef USE_DSMR_TELEGRAM_DEBUGGER
   // Telegram debug buffer
   char debug_[MAX_DEBUG_LENGTH];
   int debug_len_{0};

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1219,3 +1219,4 @@ fingerprint_grow:
 dsmr:
   decryption_key: 00112233445566778899aabbccddeeff
   uart_id: uart6
+  debug_telegrams: true


### PR DESCRIPTION
# What does this implement/fix? 

This PR adds a debugging option for (unencrypted) telegrams to the dsmr component.

The option was created to be able to help out somebody on discord with a DSMR issue. The messages that did appear in the logs were not useful for investigation the reason why the reader didn't publish any values. Knowing exactly what the ESP device sees on the serial input can help a lot with debugging issues.

When this is a feature that will be added to the core, I will write the documentation for it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
dsmr:
    debug_telegrams: true
```

## Example debug output:

```
[00:25:54][D][dsmr:033]: Telegram line: /XMX5LGBBFFB231091148\r\n
[00:25:54][D][dsmr:033]: Telegram line: \r\n
[00:25:54][D][dsmr:033]: Telegram line: 1-3:0.2.8(42)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 0-0:1.0.0(210911002507S)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 0-0:96.1.1(4530303034303031353533323936343134)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 1-0:1.8.1(014929.404*kWh)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 1-0:2.8.1(000000.000*kWh)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 1-0:1.8.2(013924.519*kWh)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 1-0:2.8.2(000000.000*kWh)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 0-0:96.14.0(0001)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 1-0:1.7.0(00.437*kW)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 1-0:2.7.0(00.000*kW)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 0-0:96.7.21(00018)\r\n
[00:25:54][D][dsmr:033]: Telegram line: 0-0:96.7.9(00012)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 1-0:99.97.0(10)(0-0:96.7.19)(210720094504S)(0000003186*s)(200121103821W)(0000004130*s)(200121095247W)(0000001396*s)(190913115333S)(0000004756*s)(190602053738S)(0000004875*s)(190311143349W)(0000014248*s)(190212141013W)(0000010991*s)(190201235215W)(0000003233*s)(161117115617W)(0000005845*s)(161012112034S)(0000007089*s)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 1-0:32.32.0(00000)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 1-0:32.36.0(00000)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 0-0:96.13.1()\r\n
[00:25:55][D][dsmr:033]: Telegram line: 0-0:96.13.0()\r\n
[00:25:55][D][dsmr:033]: Telegram line: 1-0:31.7.0(002*A)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 1-0:21.7.0(00.437*kW)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 1-0:22.7.0(00.000*kW)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 0-1:24.1.0(003)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 0-1:96.1.0(4730303032333430313532393631373134)\r\n
[00:25:55][D][dsmr:033]: Telegram line: 0-1:24.2.1(210911000000S)(09458.088*m3)\r\n
[00:25:55][D][dsmr:033]: Telegram line: !3BAB\r\n
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
