### PR TITLE
Suppress excessive warnings about deprecated Fan interfaces

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -214,6 +214,9 @@ void APIConnection::cover_command(const CoverCommandRequest &msg) {
 #endif
 
 #ifdef USE_FAN
+// Shut-up about usage of deprecated speed_level_to_enum/speed_enum_to_level functions for a bit.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 bool APIConnection::send_fan_state(fan::FanState *fan) {
   if (!this->state_subscription_)
     return false;
@@ -262,13 +265,13 @@ void APIConnection::fan_command(const FanCommandRequest &msg) {
     // Prefer level
     call.set_speed(msg.speed_level);
   } else if (msg.has_speed) {
-    // NOLINTNEXTLINE(clang-diagnostic-deprecated-declarations)
     call.set_speed(fan::speed_enum_to_level(static_cast<fan::FanSpeed>(msg.speed), traits.supported_speed_count()));
   }
   if (msg.has_direction)
     call.set_direction(static_cast<fan::FanDirection>(msg.direction));
   call.perform();
 }
+#pragma GCC diagnostic pop
 #endif
 
 #ifdef USE_LIGHT

--- a/esphome/components/fan/fan_helpers.cpp
+++ b/esphome/components/fan/fan_helpers.cpp
@@ -4,14 +4,15 @@
 namespace esphome {
 namespace fan {
 
-// NOLINTNEXTLINE(clang-diagnostic-deprecated-declarations)
+// This whole file is deprecated, don't warn about usage of deprecated types in here.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 FanSpeed speed_level_to_enum(int speed_level, int supported_speed_levels) {
   const auto speed_ratio = static_cast<float>(speed_level) / (supported_speed_levels + 1);
   const auto legacy_level = clamp<int>(static_cast<int>(ceilf(speed_ratio * 3)), 1, 3);
-  return static_cast<FanSpeed>(legacy_level - 1);  // NOLINT(clang-diagnostic-deprecated-declarations)
+  return static_cast<FanSpeed>(legacy_level - 1);
 }
 
-// NOLINTNEXTLINE(clang-diagnostic-deprecated-declarations)
 int speed_enum_to_level(FanSpeed speed, int supported_speed_levels) {
   const auto enum_level = static_cast<int>(speed) + 1;
   const auto speed_level = roundf(enum_level / 3.0f * supported_speed_levels);

--- a/esphome/components/fan/fan_helpers.h
+++ b/esphome/components/fan/fan_helpers.h
@@ -4,8 +4,16 @@
 namespace esphome {
 namespace fan {
 
+// Shut-up about usage of deprecated FanSpeed for a bit.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+ESPDEPRECATED("FanSpeed and speed_level_to_enum() are deprecated.", "2021.9")
 FanSpeed speed_level_to_enum(int speed_level, int supported_speed_levels);
+ESPDEPRECATED("FanSpeed and speed_enum_to_level() are deprecated.", "2021.9")
 int speed_enum_to_level(FanSpeed speed, int supported_speed_levels);
+
+#pragma GCC diagnostic pop
 
 }  // namespace fan
 }  // namespace esphome

--- a/esphome/components/fan/fan_state.cpp
+++ b/esphome/components/fan/fan_state.cpp
@@ -67,6 +67,8 @@ void FanStateCall::perform() const {
   this->state_->state_callback_.call();
 }
 
+// This whole method is deprecated, don't warn about usage of deprecated methods inside of it.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 FanStateCall &FanStateCall::set_speed(const char *legacy_speed) {
   const auto supported_speed_count = this->state_->get_traits().supported_speed_count();
   if (strcasecmp(legacy_speed, "low") == 0) {

--- a/esphome/components/mqtt/mqtt_fan.cpp
+++ b/esphome/components/mqtt/mqtt_fan.cpp
@@ -100,6 +100,7 @@ bool MQTTFanComponent::publish_state() {
   auto traits = this->state_->get_traits();
   if (traits.supports_speed()) {
     const char *payload;
+    // NOLINTNEXTLINE(clang-diagnostic-deprecated-declarations)
     switch (fan::speed_level_to_enum(this->state_->speed, traits.supported_speed_count())) {
       case FAN_SPEED_LOW: {  // NOLINT(clang-diagnostic-deprecated-declarations)
         payload = "low";

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -397,6 +397,7 @@ std::string WebServer::fan_json(fan::FanState *obj) {
     const auto traits = obj->get_traits();
     if (traits.supports_speed()) {
       root["speed_level"] = obj->speed;
+      // NOLINTNEXTLINE(clang-diagnostic-deprecated-declarations)
       switch (fan::speed_level_to_enum(obj->speed, traits.supported_speed_count())) {
         case fan::FAN_SPEED_LOW:  // NOLINT(clang-diagnostic-deprecated-declarations)
           root["speed"] = "low";


### PR DESCRIPTION
# What does this implement/fix? 

The deprecation warnings added in #2185 resulted in excessive warnings during a default build about usage of `FanSpeed` in legacy code. Suppress those warnings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2391

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
