### PR TITLE
Untangle core headers (part 1)

### DIFF
--- a/esphome/components/ade7953/ade7953.h
+++ b/esphome/components/ade7953/ade7953.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/sensor/sensor.h"
 

--- a/esphome/components/am43/am43_base.cpp
+++ b/esphome/components/am43/am43_base.cpp
@@ -1,4 +1,6 @@
 #include "am43_base.h"
+#include <cstring>
+#include <cstdio>
 
 namespace esphome {
 namespace am43 {

--- a/esphome/components/anova/anova_base.cpp
+++ b/esphome/components/anova/anova_base.cpp
@@ -1,4 +1,6 @@
 #include "anova_base.h"
+#include <cstdio>
+#include <cstring>
 
 namespace esphome {
 namespace anova {

--- a/esphome/components/as3935/as3935.h
+++ b/esphome/components/as3935/as3935.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 

--- a/esphome/components/climate/climate_traits.cpp
+++ b/esphome/components/climate/climate_traits.cpp
@@ -1,5 +1,5 @@
 #include "climate_traits.h"
-#include "esphome/core/log.h"
+#include <cstdio>
 
 namespace esphome {
 namespace climate {

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/esphal.h"
 
 namespace esphome {
 namespace deep_sleep {

--- a/esphome/components/dht/dht.h
+++ b/esphome/components/dht/dht.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/sensor/sensor.h"
 
 namespace esphome {

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/helpers.h"
+#include "esphome/core/esphal.h"
 
 #ifdef ARDUINO_ARCH_ESP32
 

--- a/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
+++ b/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
 namespace esphome {

--- a/esphome/components/gpio/switch/gpio_switch.h
+++ b/esphome/components/gpio/switch/gpio_switch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/switch/switch.h"
 
 namespace esphome {

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -1,4 +1,5 @@
 #include "nfc.h"
+#include <cstdio>
 #include "esphome/core/log.h"
 
 namespace esphome {

--- a/esphome/components/rc522/rc522.h
+++ b/esphome/components/rc522/rc522.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 

--- a/esphome/components/remote_receiver/remote_receiver_esp8266.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp8266.cpp
@@ -1,4 +1,5 @@
 #include "remote_receiver.h"
+#include "esphome/core/esphal.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -2,6 +2,7 @@
 
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "sx1509_gpio_pin.h"
 #include "sx1509_registers.h"
 

--- a/esphome/components/ttp229_bsf/ttp229_bsf.h
+++ b/esphome/components/ttp229_bsf/ttp229_bsf.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
 namespace esphome {

--- a/esphome/components/tx20/tx20.h
+++ b/esphome/components/tx20/tx20.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/sensor/sensor.h"
 
 namespace esphome {

--- a/esphome/components/vl53l0x/vl53l0x_sensor.h
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.h
@@ -3,6 +3,7 @@
 #include <list>
 
 #include "esphome/core/component.h"
+#include "esphome/core/esphal.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 

--- a/esphome/core/esphal.h
+++ b/esphome/core/esphal.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "Arduino.h"
-#ifdef ARDUINO_ARCH_ESP32
-#include <esp32-hal.h>
-#endif
+
 // Fix some arduino defs
 #ifdef round
 #undef round

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -6,8 +6,11 @@
 #include <memory>
 #include <type_traits>
 
+#ifdef ARDUINO_ARCH_ESP32
+#include "esp32-hal-psram.h"
+#endif
+
 #include "esphome/core/optional.h"
-#include "esphome/core/esphal.h"
 
 #ifdef CLANG_TIDY
 #undef ICACHE_RAM_ATTR

--- a/esphome/core/log.h
+++ b/esphome/core/log.h
@@ -11,10 +11,6 @@
 // avoid esp-idf redefining our macros
 #include "esphome/core/esphal.h"
 
-#ifdef ARDUINO_ARCH_ESP32
-#include "esp_err.h"
-#endif
-
 namespace esphome {
 
 #define ESPHOME_LOG_LEVEL_NONE 0

--- a/esphome/core/log.h
+++ b/esphome/core/log.h
@@ -3,13 +3,19 @@
 #include <cassert>
 #include <cstdarg>
 #include <string>
+
 #ifdef USE_STORE_LOG_STR_IN_FLASH
 #include "WString.h"
 #endif
 
+// Both the ESP-IDF and Arduino also define ESP_LOG* macros. Include them here, so that they won't
+// be reincluded later on and redefine our macros.
+#ifdef ARDUINO_ARCH_ESP32
+#include <esp_log.h>
+#include <esp32-hal-log.h>
+#endif
+
 #include "esphome/core/macros.h"
-// avoid esp-idf redefining our macros
-#include "esphome/core/esphal.h"
 
 namespace esphome {
 

--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <string>
+#include <cstring>
 
-#include "esphome/core/esphal.h"
 #include "esphome/core/defines.h"
 
 namespace esphome {


### PR DESCRIPTION
# What does this implement/fix? 

Remove unnecessary includes of `esphal.h` from core headers such as `helpers.h`, `log.h` and `preferences.h`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
