### PR TITLE
Support inverting color temperature on tuya lights

### DIFF
--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -18,6 +18,7 @@ DEPENDENCIES = ["tuya"]
 CONF_DIMMER_DATAPOINT = "dimmer_datapoint"
 CONF_MIN_VALUE_DATAPOINT = "min_value_datapoint"
 CONF_COLOR_TEMPERATURE_DATAPOINT = "color_temperature_datapoint"
+CONF_COLOR_TEMPERATURE_INVERT = "color_temperature_invert"
 CONF_COLOR_TEMPERATURE_MAX_VALUE = "color_temperature_max_value"
 
 TuyaLight = tuya_ns.class_("TuyaLight", light.LightOutput, cg.Component)
@@ -33,6 +34,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Inclusive(
                 CONF_COLOR_TEMPERATURE_DATAPOINT, "color_temperature"
             ): cv.uint8_t,
+            cv.Optional(CONF_COLOR_TEMPERATURE_INVERT, default=False): cv.boolean,
             cv.Optional(CONF_MIN_VALUE): cv.int_,
             cv.Optional(CONF_MAX_VALUE): cv.int_,
             cv.Optional(CONF_COLOR_TEMPERATURE_MAX_VALUE): cv.int_,
@@ -67,6 +69,8 @@ async def to_code(config):
         cg.add(var.set_switch_id(config[CONF_SWITCH_DATAPOINT]))
     if CONF_COLOR_TEMPERATURE_DATAPOINT in config:
         cg.add(var.set_color_temperature_id(config[CONF_COLOR_TEMPERATURE_DATAPOINT]))
+        cg.add(var.set_color_temperature_invert(config[CONF_COLOR_TEMPERATURE_INVERT]))
+
         cg.add(
             var.set_cold_white_temperature(config[CONF_COLD_WHITE_COLOR_TEMPERATURE])
         )

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -9,10 +9,14 @@ static const char *const TAG = "tuya.light";
 void TuyaLight::setup() {
   if (this->color_temperature_id_.has_value()) {
     this->parent_->register_listener(*this->color_temperature_id_, [this](const TuyaDatapoint &datapoint) {
+      auto datapoint_value = datapoint.value_uint;
+      if (this->color_temperature_invert_) {
+        datapoint_value = this->color_temperature_max_value_-datapoint_value;
+      }
       auto call = this->state_->make_call();
       call.set_color_temperature(this->cold_white_temperature_ +
                                  (this->warm_white_temperature_ - this->cold_white_temperature_) *
-                                     (float(datapoint.value_uint) / float(this->color_temperature_max_value_)));
+                                     (float(datapoint_value) / this->color_temperature_max_value_));
       call.perform();
     });
   }
@@ -78,6 +82,9 @@ void TuyaLight::write_state(light::LightState *state) {
         static_cast<uint32_t>(this->color_temperature_max_value_ *
                               (state->current_values.get_color_temperature() - this->cold_white_temperature_) /
                               (this->warm_white_temperature_ - this->cold_white_temperature_));
+    if (this->color_temperature_invert_) {
+      color_temp_int = this->color_temperature_max_value_-color_temp_int;
+    }
     parent_->set_integer_datapoint_value(*this->color_temperature_id_, color_temp_int);
   }
 

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -11,7 +11,7 @@ void TuyaLight::setup() {
     this->parent_->register_listener(*this->color_temperature_id_, [this](const TuyaDatapoint &datapoint) {
       auto datapoint_value = datapoint.value_uint;
       if (this->color_temperature_invert_) {
-        datapoint_value = this->color_temperature_max_value_-datapoint_value;
+        datapoint_value = this->color_temperature_max_value_ - datapoint_value;
       }
       auto call = this->state_->make_call();
       call.set_color_temperature(this->cold_white_temperature_ +
@@ -83,7 +83,7 @@ void TuyaLight::write_state(light::LightState *state) {
                               (state->current_values.get_color_temperature() - this->cold_white_temperature_) /
                               (this->warm_white_temperature_ - this->cold_white_temperature_));
     if (this->color_temperature_invert_) {
-      color_temp_int = this->color_temperature_max_value_-color_temp_int;
+      color_temp_int = this->color_temperature_max_value_ - color_temp_int;
     }
     parent_->set_integer_datapoint_value(*this->color_temperature_id_, color_temp_int);
   }

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -17,7 +17,9 @@ class TuyaLight : public Component, public light::LightOutput {
   }
   void set_switch_id(uint8_t switch_id) { this->switch_id_ = switch_id; }
   void set_color_temperature_id(uint8_t color_temperature_id) { this->color_temperature_id_ = color_temperature_id; }
-  void set_color_temperature_invert(bool color_temperature_invert) { this->color_temperature_invert_ = color_temperature_invert; }
+  void set_color_temperature_invert(bool color_temperature_invert) {
+    this->color_temperature_invert_ = color_temperature_invert;
+  }
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
   void set_min_value(uint32_t min_value) { min_value_ = min_value; }
   void set_max_value(uint32_t max_value) { max_value_ = max_value; }

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -17,6 +17,7 @@ class TuyaLight : public Component, public light::LightOutput {
   }
   void set_switch_id(uint8_t switch_id) { this->switch_id_ = switch_id; }
   void set_color_temperature_id(uint8_t color_temperature_id) { this->color_temperature_id_ = color_temperature_id; }
+  void set_color_temperature_invert(bool color_temperature_invert) { this->color_temperature_invert_ = color_temperature_invert; }
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
   void set_min_value(uint32_t min_value) { min_value_ = min_value; }
   void set_max_value(uint32_t max_value) { max_value_ = max_value; }
@@ -47,6 +48,7 @@ class TuyaLight : public Component, public light::LightOutput {
   uint32_t color_temperature_max_value_ = 255;
   float cold_white_temperature_;
   float warm_white_temperature_;
+  bool color_temperature_invert_{false};
   light::LightState *state_{nullptr};
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

The current tuya_light component treats cool white color temp as 0 and warm white as 255 (or whatever the max is set to.)

Some tuya lights have that inverted so 0 is warm white and max is cool white; this PR adds support to invert the color temperature.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** n/a
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1465

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
light:
  - platform: tuya
    name: "${friendly_name}"
    switch_datapoint: 1
    dimmer_datapoint: 2
    color_temperature_datapoint: 3
    color_temperature_invert: true
    cold_white_color_temperature: 5000 K
    warm_white_color_temperature: 2500 K
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
