### PR TITLE
Improves ct_clamp component accuracy

### DIFF
--- a/esphome/components/ct_clamp/ct_clamp_sensor.h
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.h
@@ -43,6 +43,7 @@ class CTClampSensor : public sensor::Sensor, public PollingComponent {
    * https://en.wikipedia.org/wiki/Root_mean_square
    */
 
+  float last_value_ = 0.0f;
   float sample_sum_ = 0.0f;
   float sample_squared_sum_ = 0.0f;
   uint32_t num_samples_ = 0;


### PR DESCRIPTION
# What does this implement/fix? 

Improves accuracy avoiding duplicated samples (esphome can request up to 1000 SPS while ADCs rarely provides more than 860 SPS [ads1115]).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example configuration entry
ads1115:
  - address: 0x48

sensor:
  - platform: ct_clamp
    sensor: adc_sensor
    name: "Measured Current"
    update_interval: 60s

  - platform: ads1115
    multiplexer: 'A0_GND'
    gain: 6.144
    name: "ADS1115 Channel A0-GND"
    id: adc_sensor
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
