### PR TITLE
Revert "Bump tzlocal from 2.1 to 3.0 (#2154)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ paho-mqtt==1.5.1
 colorama==0.4.4
 tornado==6.1
 protobuf==3.17.3
-tzlocal==3.0
+tzlocal==2.1
 pytz==2021.1
 pyserial==3.5
 ifaddr==0.1.7


### PR DESCRIPTION
This reverts commit e0cff214b215ab2cd4dfb221b37d0f56dbce141b.

# What does this implement/fix? 

Looks like it's pulling in `backports.zoneinfo` now which doesn't exist on aarch64 yet, thus breaking the docker build :(

https://github.com/esphome/esphome/runs/3588577010?check_suite_focus=true

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
