### PR TITLE
Implement smart pointer buffer using PSRAM

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -14,7 +14,7 @@ const Color COLOR_OFF(0, 0, 0, 0);
 const Color COLOR_ON(255, 255, 255, 255);
 
 void DisplayBuffer::init_internal_(uint32_t buffer_length) {
-  this->buffer_ = new (std::nothrow) uint8_t[buffer_length];  // NOLINT
+  this->buffer_ = ExternalBuffer<uint8_t>(buffer_length, true);
   if (this->buffer_ == nullptr) {
     ESP_LOGE(TAG, "Could not allocate buffer for display!");
     return;

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -317,7 +317,7 @@ class DisplayBuffer {
 
   void do_update_();
 
-  uint8_t *buffer_{nullptr};
+  ExternalBuffer<uint8_t> buffer_{nullptr};
   DisplayRotation rotation_{DISPLAY_ROTATION_0_DEGREES};
   optional<display_writer_t> writer_{};
   DisplayPage *page_{nullptr};

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -42,40 +42,30 @@ void Inkplate6::setup() {
 void Inkplate6::initialize_() {
   uint32_t buffer_size = this->get_buffer_length_();
 
-  if (this->partial_buffer_ != nullptr) {
-    free(this->partial_buffer_);  // NOLINT
-  }
-  if (this->partial_buffer_2_ != nullptr) {
-    free(this->partial_buffer_2_);  // NOLINT
-  }
-  if (this->buffer_ != nullptr) {
-    free(this->buffer_);  // NOLINT
-  }
-
-  this->buffer_ = (uint8_t *) ps_malloc(buffer_size);
+  this->buffer_ = ExternalBuffer<uint8_t>(buffer_size);
   if (this->buffer_ == nullptr) {
     ESP_LOGE(TAG, "Could not allocate buffer for display!");
     this->mark_failed();
     return;
   }
   if (!this->greyscale_) {
-    this->partial_buffer_ = (uint8_t *) ps_malloc(buffer_size);
+    this->partial_buffer_ = ExternalBuffer<uint8_t>(buffer_size);
     if (this->partial_buffer_ == nullptr) {
       ESP_LOGE(TAG, "Could not allocate partial buffer for display!");
       this->mark_failed();
       return;
     }
-    this->partial_buffer_2_ = (uint8_t *) ps_malloc(buffer_size * 2);
+    this->partial_buffer_2_ = ExternalBuffer<uint8_t>(buffer_size * 2);
     if (this->partial_buffer_2_ == nullptr) {
       ESP_LOGE(TAG, "Could not allocate partial buffer 2 for display!");
       this->mark_failed();
       return;
     }
-    memset(this->partial_buffer_, 0, buffer_size);
-    memset(this->partial_buffer_2_, 0, buffer_size * 2);
+    memset(this->partial_buffer_.get(), 0, buffer_size);
+    memset(this->partial_buffer_2_.get(), 0, buffer_size * 2);
   }
 
-  memset(this->buffer_, 0, buffer_size);
+  memset(this->buffer_.get(), 0, buffer_size);
 }
 float Inkplate6::get_setup_priority() const { return setup_priority::PROCESSOR; }
 size_t Inkplate6::get_buffer_length_() {

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -120,8 +120,8 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
   uint8_t panel_on_ = 0;
   uint8_t temperature_;
 
-  uint8_t *partial_buffer_{nullptr};
-  uint8_t *partial_buffer_2_{nullptr};
+  ExternalBuffer<uint8_t>  partial_buffer_;
+  ExternalBuffer<uint8_t> partial_buffer_2_;
 
   uint32_t full_update_every_;
   uint32_t partial_updates_{0};

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -830,7 +830,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
 
 #ifdef USE_TFT_UPLOAD
   std::string tft_url_;
-  uint8_t *transfer_buffer_{nullptr};
+  ExternalBuffer<uint8_t> transfer_buffer_;
   size_t transfer_buffer_size_;
   bool upload_first_chunk_sent_ = false;
 #endif


### PR DESCRIPTION
# What does this implement/fix? 

Currently, usage of PSRAM requires manual memory management, either through `ps_malloc` or by the unused `new_buffer` helper function. Introduce a smart pointer class `ExternalBuffer` that uses PSRAM if available.

This also moves the display buffer to PSRAM if available.

Totally untested, but design feedback is welcome.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
