### PR TITLE
Use standard version of make_unique when available

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -70,7 +70,6 @@ Checks: >-
   -modernize-use-default-member-init,
   -modernize-use-equals-default,
   -modernize-use-trailing-return-type,
-  -modernize-make-unique,
   -modernize-use-nodiscard,
   -mpi-*,
   -objc-*,
@@ -114,6 +113,8 @@ CheckOptions:
     value:           llvm
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'make_unique'
   - key:             readability-identifier-naming.LocalVariableCase
     value:           'lower_case'
   - key:             readability-identifier-naming.ClassCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -115,6 +115,8 @@ CheckOptions:
     value:           'NULL'
   - key:             modernize-make-unique.MakeSmartPtrFunction
     value:           'make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           'esphome/core/helpers.h'
   - key:             readability-identifier-naming.LocalVariableCase
     value:           'lower_case'
   - key:             readability-identifier-naming.ClassCase

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -83,11 +83,11 @@ bool NdefMessage::add_text_record(const std::string &text) { return this->add_te
 
 bool NdefMessage::add_text_record(const std::string &text, const std::string &encoding) {
   std::string payload = to_string(text.length()) + encoding + text;
-  return this->add_record(std::unique_ptr<NdefRecord>{new NdefRecord(TNF_WELL_KNOWN, "T", payload)});
+  return this->add_record(make_unique<NdefRecord>(TNF_WELL_KNOWN, "T", payload));
 }
 
 bool NdefMessage::add_uri_record(const std::string &uri) {
-  return this->add_record(std::unique_ptr<NdefRecord>{new NdefRecord(TNF_WELL_KNOWN, "U", uri)});
+  return this->add_record(make_unique<NdefRecord>(TNF_WELL_KNOWN, "U", uri));
 }
 
 std::vector<uint8_t> NdefMessage::encode() {

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -31,13 +31,13 @@ class NfcTag {
   NfcTag(std::vector<uint8_t> &uid, const std::string &tag_type, std::vector<uint8_t> &ndef_data) {
     this->uid_ = uid;
     this->tag_type_ = tag_type;
-    this->ndef_message_ = std::unique_ptr<NdefMessage>(new NdefMessage(ndef_data));
+    this->ndef_message_ = make_unique<NdefMessage>(ndef_data);
   };
   NfcTag(const NfcTag &rhs) {
     uid_ = rhs.uid_;
     tag_type_ = rhs.tag_type_;
     if (rhs.ndef_message_ != nullptr)
-      ndef_message_ = std::unique_ptr<NdefMessage>(new NdefMessage(*rhs.ndef_message_));
+      ndef_message_ = make_unique<NdefMessage>(*rhs.ndef_message_);
   }
 
   std::vector<uint8_t> &get_uid() { return this->uid_; };

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -1,4 +1,6 @@
 #include "pn532.h"
+
+#include <memory>
 #include "esphome/core/log.h"
 
 // Based on:
@@ -104,7 +106,7 @@ void PN532::loop() {
   if (!success) {
     // Something failed
     if (!this->current_uid_.empty()) {
-      auto tag = std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(this->current_uid_)};
+      auto tag = make_unique<nfc::NfcTag>(this->current_uid_);
       for (auto *trigger : this->triggers_ontagremoved_)
         trigger->process(tag);
     }
@@ -117,7 +119,7 @@ void PN532::loop() {
   if (num_targets != 1) {
     // no tags found or too many
     if (!this->current_uid_.empty()) {
-      auto tag = std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(this->current_uid_)};
+      auto tag = make_unique<nfc::NfcTag>(this->current_uid_);
       for (auto *trigger : this->triggers_ontagremoved_)
         trigger->process(tag);
     }
@@ -281,9 +283,9 @@ std::unique_ptr<nfc::NfcTag> PN532::read_tag_(std::vector<uint8_t> &uid) {
     return this->read_mifare_ultralight_tag_(uid);
   } else if (type == nfc::TAG_TYPE_UNKNOWN) {
     ESP_LOGV(TAG, "Cannot determine tag type");
-    return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid)};
+    return make_unique<nfc::NfcTag>(uid);
   } else {
-    return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid)};
+    return make_unique<nfc::NfcTag>(uid);
   }
 }
 

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "pn532.h"
 #include "esphome/core/log.h"
 
@@ -15,15 +17,15 @@ std::unique_ptr<nfc::NfcTag> PN532::read_mifare_classic_tag_(std::vector<uint8_t
     std::vector<uint8_t> data;
     if (this->read_mifare_classic_block_(current_block, data)) {
       if (!nfc::decode_mifare_classic_tlv(data, message_length, message_start_index)) {
-        return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::ERROR)};
+        return make_unique<nfc::NfcTag>(uid, nfc::ERROR);
       }
     } else {
       ESP_LOGE(TAG, "Failed to read block %d", current_block);
-      return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::MIFARE_CLASSIC)};
+      return make_unique<nfc::NfcTag>(uid, nfc::MIFARE_CLASSIC);
     }
   } else {
     ESP_LOGV(TAG, "Tag is not NDEF formatted");
-    return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::MIFARE_CLASSIC)};
+    return make_unique<nfc::NfcTag>(uid, nfc::MIFARE_CLASSIC);
   }
 
   uint32_t index = 0;
@@ -51,7 +53,7 @@ std::unique_ptr<nfc::NfcTag> PN532::read_mifare_classic_tag_(std::vector<uint8_t
     }
   }
   buffer.erase(buffer.begin(), buffer.begin() + message_start_index);
-  return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::MIFARE_CLASSIC, buffer)};
+  return make_unique<nfc::NfcTag>(uid, nfc::MIFARE_CLASSIC, buffer);
 }
 
 bool PN532::read_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data) {

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "pn532.h"
 #include "esphome/core/log.h"
 
@@ -9,25 +11,25 @@ static const char *const TAG = "pn532.mifare_ultralight";
 std::unique_ptr<nfc::NfcTag> PN532::read_mifare_ultralight_tag_(std::vector<uint8_t> &uid) {
   if (!this->is_mifare_ultralight_formatted_()) {
     ESP_LOGD(TAG, "Not NDEF formatted");
-    return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2)};
+    return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
   }
 
   uint8_t message_length;
   uint8_t message_start_index;
   if (!this->find_mifare_ultralight_ndef_(message_length, message_start_index)) {
-    return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2)};
+    return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
   }
   ESP_LOGVV(TAG, "message length: %d, start: %d", message_length, message_start_index);
 
   if (message_length == 0) {
-    return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2)};
+    return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
   }
   std::vector<uint8_t> data;
   for (uint8_t page = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; page < nfc::MIFARE_ULTRALIGHT_MAX_PAGE; page++) {
     std::vector<uint8_t> page_data;
     if (!this->read_mifare_ultralight_page_(page, page_data)) {
       ESP_LOGE(TAG, "Error reading page %d", page);
-      return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2)};
+      return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2);
     }
     data.insert(data.end(), page_data.begin(), page_data.end());
 
@@ -38,7 +40,7 @@ std::unique_ptr<nfc::NfcTag> PN532::read_mifare_ultralight_tag_(std::vector<uint
   data.erase(data.begin(), data.begin() + message_start_index);
   data.erase(data.begin() + message_length, data.end());
 
-  return std::unique_ptr<nfc::NfcTag>{new nfc::NfcTag(uid, nfc::NFC_FORUM_TYPE_2, data)};
+  return make_unique<nfc::NfcTag>(uid, nfc::NFC_FORUM_TYPE_2, data);
 }
 
 bool PN532::read_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &data) {

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -1,5 +1,6 @@
 #include "socket.h"
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
 
 #ifdef USE_SOCKET_IMPL_BSD_SOCKETS
 
@@ -39,7 +40,7 @@ class BSDSocketImpl : public Socket {
     int fd = ::accept(fd_, addr, addrlen);
     if (fd == -1)
       return {};
-    return std::unique_ptr<BSDSocketImpl>{new BSDSocketImpl(fd)};
+    return make_unique<BSDSocketImpl>(fd);
   }
   int bind(const struct sockaddr *addr, socklen_t addrlen) override { return ::bind(fd_, addr, addrlen); }
   int close() override {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -88,10 +88,15 @@ template<typename T> T clamp(T val, T min, T max);
  */
 float lerp(float completion, float start, float end);
 
-/// std::make_unique
+// Not all platforms we support target C++14 yet, so we can't unconditionally use std::make_unique. Provide our own
+// implementation if needed, and otherwise pull std::make_unique into scope so that we have a uniform API.
+#if __cplusplus >= 201402L
+using std::make_unique;
+#else
 template<typename T, typename... Args> std::unique_ptr<T> make_unique(Args &&...args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+#endif
 
 /// Return a random 32 bit unsigned integer.
 uint32_t random_uint32();


### PR DESCRIPTION
# What does this implement/fix? 

This avoids ambiguous method resolution errors when using C++14 or higher and calling make_unique() with an argument in the std namespace: due to argument dependent lookup, std::make_unique is also a candidate function for those calls.

The result of me-talking-to-myself in #2146 :laughing: 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
