### PR TITLE
Simple time.sleep in place of threading wait due to upgraded zeroconf

### DIFF
--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -49,7 +49,7 @@ class HostResolver(RecordUpdateListener):
                     next_ = now + delay
                     delay *= 2
 
-                zc.wait(min(next_, last) - now)
+                time.sleep(min(next_, last) - now)
                 now = time.time()
         finally:
             zc.remove_listener(self)


### PR DESCRIPTION
# What does this implement/fix? 

The upgraded zeroconf that platformio 5.2.0 uses has removed `wait(timeout)` and replaced with `async_wait(timeout)` but the main code does not utilize async code yet so this was the simple approach to fixing this for now.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
