### PR TITLE
convert SCD30 into Component, polls dataready register

### DIFF
--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -195,14 +195,14 @@ void SCD30Component::update() {
 void SCD30Component::schedule_next_check_() {
   // check each 500ms if data is ready before reading the value
   this->set_timeout("status-check", 500, [this]() {
-    if (isDataReady()) {
+    if (is_data_ready_()) {
       this->update();
     }
     this->schedule_next_check_();
   });
 }
 
-bool SCD30Component::isDataReady() {
+bool SCD30Component::is_data_ready_() {
   if (!this->write_command_(SCD30_CMD_GET_DATA_READY_STATUS)) {
     return false;
   }

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -32,7 +32,7 @@ class SCD30Component : public Component, public i2c::I2CDevice {
   bool write_command_(uint16_t command, uint16_t data);
   bool read_data_(uint16_t *data, uint8_t len);
   uint8_t sht_crc_(uint8_t data1, uint8_t data2);
-  bool isDataReady();
+  bool is_data_ready_();
 
   enum ErrorCode {
     COMMUNICATION_FAILED,

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -27,7 +27,6 @@ class SCD30Component : public Component, public i2c::I2CDevice {
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
-  void schedule_next_check_();
   bool write_command_(uint16_t command);
   bool write_command_(uint16_t command, uint16_t data);
   bool read_data_(uint16_t *data, uint8_t len);

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -8,7 +8,7 @@ namespace esphome {
 namespace scd30 {
 
 /// This class implements support for the Sensirion scd30 i2c GAS (VOC and CO2eq) sensors.
-class SCD30Component : public PollingComponent, public i2c::I2CDevice {
+class SCD30Component : public Component, public i2c::I2CDevice {
  public:
   void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
   void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
@@ -19,17 +19,20 @@ class SCD30Component : public PollingComponent, public i2c::I2CDevice {
     ambient_pressure_compensation_ = (uint16_t)(pressure * 1000);
   }
   void set_temperature_offset(float offset) { temperature_offset_ = offset; }
+  void set_update_interval(uint16_t interval) { update_interval_ = interval; }
 
   void setup() override;
-  void update() override;
+  void update();
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
+  void schedule_next_check_();
   bool write_command_(uint16_t command);
   bool write_command_(uint16_t command, uint16_t data);
   bool read_data_(uint16_t *data, uint8_t len);
   uint8_t sht_crc_(uint8_t data1, uint8_t data2);
+  bool isDataReady();
 
   enum ErrorCode {
     COMMUNICATION_FAILED,
@@ -41,6 +44,7 @@ class SCD30Component : public PollingComponent, public i2c::I2CDevice {
   uint16_t altitude_compensation_{0xFFFF};
   uint16_t ambient_pressure_compensation_{0x0000};
   float temperature_offset_{0.0};
+  uint16_t update_interval_{0xFFFF};
 
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -1,3 +1,4 @@
+from esphome import core
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c, sensor
@@ -56,9 +57,12 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
             cv.Optional(CONF_TEMPERATURE_OFFSET): cv.temperature,
-            cv.Optional(
-                CONF_UPDATE_INTERVAL, default="60s"
-            ): cv.positive_time_period_seconds,
+            cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.All(
+                cv.positive_time_period_seconds,
+                cv.Range(
+                    min=core.TimePeriod(seconds=1), max=core.TimePeriod(seconds=1800)
+                ),
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_HUMIDITY,
     CONF_TEMPERATURE,
     CONF_CO2,
+    CONF_UPDATE_INTERVAL,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
@@ -18,7 +19,7 @@ from esphome.const import (
 DEPENDENCIES = ["i2c"]
 
 scd30_ns = cg.esphome_ns.namespace("scd30")
-SCD30Component = scd30_ns.class_("SCD30Component", cg.PollingComponent, i2c.I2CDevice)
+SCD30Component = scd30_ns.class_("SCD30Component", cg.Component, i2c.I2CDevice)
 
 CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
 CONF_ALTITUDE_COMPENSATION = "altitude_compensation"
@@ -55,9 +56,12 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
             cv.Optional(CONF_TEMPERATURE_OFFSET): cv.temperature,
+            cv.Optional(
+                CONF_UPDATE_INTERVAL, default="60s"
+            ): cv.positive_time_period_seconds,
         }
     )
-    .extend(cv.polling_component_schema("60s"))
+    .extend(cv.COMPONENT_SCHEMA)
     .extend(i2c.i2c_device_schema(0x61))
 )
 
@@ -80,6 +84,9 @@ async def to_code(config):
 
     if CONF_TEMPERATURE_OFFSET in config:
         cg.add(var.set_temperature_offset(config[CONF_TEMPERATURE_OFFSET]))
+
+    if CONF_UPDATE_INTERVAL in config:
+        cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
 
     if CONF_CO2 in config:
         sens = await sensor.new_sensor(config[CONF_CO2])

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -89,8 +89,7 @@ async def to_code(config):
     if CONF_TEMPERATURE_OFFSET in config:
         cg.add(var.set_temperature_offset(config[CONF_TEMPERATURE_OFFSET]))
 
-    if CONF_UPDATE_INTERVAL in config:
-        cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
+    cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
 
     if CONF_CO2 in config:
         sens = await sensor.new_sensor(config[CONF_CO2])


### PR DESCRIPTION
# What does this implement/fix? 

Converts the SCD30 component from PollingComponent into an ordinary Component. Instead of using the PollingComponent's software timer we now rely on the SCD30's internal timer and dataready register. Therefore setting the components `update_internval` will from now on directly set the SCD30's measurement interval where it was left untouched earlier.
As a feature this will directly affect the average power usage of the sensor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2410

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
i2c:
  sda: 21
  scl: 22
  scan: True
  id: bus_a

sensor:
  - platform: scd30
    co2:
      name: "Slaapkamer CO2"
      accuracy_decimals: 1
    temperature:
      name: "Slaapkamer Temperature"
      accuracy_decimals: 2
    humidity:
      name: "Slaapkamer Humidity"
      accuracy_decimals: 1
    address: 0x61
    i2c_id: bus_a
    update_interval: 120s
    temperature_offset: 1.5 °C
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). -> no changes required
