### PR TITLE
Bug fix of NFC message & records becoming inaccessible in on_tag lambdas

### DIFF
--- a/esphome/components/nfc/ndef_message.h
+++ b/esphome/components/nfc/ndef_message.h
@@ -22,7 +22,7 @@ class NdefMessage {
     }
   }
 
-  const std::vector<std::unique_ptr<NdefRecord>> &get_records() { return this->records_; };
+  const std::vector<std::shared_ptr<NdefRecord>> &get_records() { return this->records_; };
 
   bool add_record(std::unique_ptr<NdefRecord> record);
   bool add_text_record(const std::string &text);
@@ -32,7 +32,7 @@ class NdefMessage {
   std::vector<uint8_t> encode();
 
  protected:
-  std::vector<std::unique_ptr<NdefRecord>> records_;
+  std::vector<std::shared_ptr<NdefRecord>> records_;
 };
 
 }  // namespace nfc

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -43,13 +43,13 @@ class NfcTag {
   std::vector<uint8_t> &get_uid() { return this->uid_; };
   const std::string &get_tag_type() { return this->tag_type_; };
   bool has_ndef_message() { return this->ndef_message_ != nullptr; };
-  const std::unique_ptr<NdefMessage> &get_ndef_message() { return this->ndef_message_; };
+  const std::shared_ptr<NdefMessage> &get_ndef_message() { return this->ndef_message_; };
   void set_ndef_message(std::unique_ptr<NdefMessage> ndef_message) { this->ndef_message_ = std::move(ndef_message); };
 
  protected:
   std::vector<uint8_t> uid_;
   std::string tag_type_;
-  std::unique_ptr<NdefMessage> ndef_message_;
+  std::shared_ptr<NdefMessage> ndef_message_;
 };
 
 }  // namespace nfc


### PR DESCRIPTION
# What does this implement/fix? 
Fixes something that broke in #1891 

This PR changes the NFC message of a tag and the records contained in that message to be referenced by `shared_ptr` instead of `unique_ptr`.
This allows for outside access without forcing the NFC tag/message to let go of the ownership of their data.

Enables the on_tag lambda to work same way as it was before the implementation of smart pointers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example of simplified code found in Esphome docs for NFC:
```yaml
pn532_spi:
  id: pn532_board
  cs_pin: GPIO4
  update_interval: 1s
  on_tag:
    - then:
      - lambda: |-
          if (!tag.has_ndef_message()) {
            return;
          }
          auto message = tag.get_ndef_message();
          auto records = message->get_records();

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
