### PR TITLE
Fix aioesphomeapi API logger with explicit API port config

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_run_logs(config, address):
     conf = config["api"]
-    port: int = conf[CONF_PORT]
+    port: int = int(conf[CONF_PORT])
     password: str = conf[CONF_PASSWORD]
     noise_psk: Optional[str] = None
     if CONF_ENCRYPTION in conf:


### PR DESCRIPTION
# What does this implement/fix? 

When using an explicit port number in the device YAML file, `esphome logs device.yaml` no longer works. An exception `OSError: Int or String expected` is raised from Pyton's `socket.py` lib. This issue was introduced after moving to aioesphomeapi for the logs.

The reason for the error, is that the config value `api.port` is of type `esphome.helpers.EInt`. This type is not expected, nor accepted by the called Python library.

This PR fixes the issue by casting the port to an integer in the API client code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml (this triggers the issue)
api:
  port: 6053
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
