### PR TITLE
Added tuya_number

### DIFF
--- a/esphome/components/tuya/number/__init__.py
+++ b/esphome/components/tuya/number/__init__.py
@@ -1,0 +1,44 @@
+from esphome.components import number
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import (
+    CONF_ID,
+    CONF_MIN_VALUE,
+    CONF_MAX_VALUE,
+    CONF_NUMBER_DATAPOINT,
+    CONF_STEP,
+)
+from .. import tuya_ns, CONF_TUYA_ID, Tuya
+
+DEPENDENCIES = ["tuya"]
+CODEOWNERS = ["@jkolo"]
+
+TuyaNumber = tuya_ns.class_("TuyaNumber", number.Number, cg.Component)
+
+CONFIG_SCHEMA = number.NUMBER_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(TuyaNumber),
+        cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
+        cv.Required(CONF_NUMBER_DATAPOINT): cv.uint8_t,
+        cv.Required(CONF_MAX_VALUE): cv.float_,
+        cv.Required(CONF_MIN_VALUE): cv.float_,
+        cv.Required(CONF_STEP): cv.positive_float,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await number.register_number(
+        var,
+        config,
+        min_value=config[CONF_MIN_VALUE],
+        max_value=config[CONF_MAX_VALUE],
+        step=config[CONF_STEP],
+    )
+
+    paren = await cg.get_variable(config[CONF_TUYA_ID])
+    cg.add(var.set_tuya_parent(paren))
+
+    cg.add(var.set_number_id(config[CONF_NUMBER_DATAPOINT]))

--- a/esphome/components/tuya/number/tuya_number.cpp
+++ b/esphome/components/tuya/number/tuya_number.cpp
@@ -1,0 +1,28 @@
+#include "esphome/core/log.h"
+#include "tuya_number.h"
+
+namespace esphome {
+namespace tuya {
+
+static const char *const TAG = "tuya.number";
+
+void TuyaNumber::setup() {
+  this->parent_->register_listener(this->number_id_, [this](const TuyaDatapoint &datapoint) {
+    ESP_LOGV(TAG, "MCU reported number %u is: %d", this->number_id_, datapoint.value_int);
+    this->publish_state(datapoint.value_int);
+  });
+}
+
+void TuyaNumber::control(float value) {
+  ESP_LOGV(TAG, "Setting number %u: %s", this->number_id_, value);
+  this->parent_->set_integer_datapoint_value(this->number_id_, value);
+  this->publish_state(value);
+}
+
+void TuyaNumber::dump_config() {
+  LOG_NUMBER("", "Tuya Number", this);
+  ESP_LOGCONFIG(TAG, "  Number has datapoint ID %u", this->number_id_);
+}
+
+}  // namespace tuya
+}  // namespace esphome

--- a/esphome/components/tuya/number/tuya_number.h
+++ b/esphome/components/tuya/number/tuya_number.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/tuya/tuya.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace tuya {
+
+class TuyaNumber : public number::Number, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void set_number_id(uint8_t number_id) { this->number_id_ = number_id; }
+
+  void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
+
+ protected:
+  void control(float value) override;
+
+  Tuya *parent_;
+  uint8_t number_id_{0};
+};
+
+}  // namespace tuya
+}  // namespace esphome


### PR DESCRIPTION
Signed-off-by: Jerzy Kołosowski <jerzy@kolosowscy.pl>

# What does this implement/fix? 

Added number component for tuya

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#??? (WIP)

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
number:
  - platform: tuya
    name: Water Temperature
    number_datapoint: 102
    min_value: 35
    max_value: 100
    step: 1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
