### PR TITLE
Allow transforms and flashes to not update remote_values

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -77,7 +77,7 @@ void LightCall::perform() {
       ESP_LOGD(TAG, "  Flash length: %.1fs", *this->flash_length_ / 1e3f);
     }
 
-    this->parent_->start_flash_(v, *this->flash_length_);
+    this->parent_->start_flash_(v, *this->flash_length_, this->publish_);
   } else if (this->has_transition_()) {
     // TRANSITION
     if (this->publish_) {
@@ -92,7 +92,7 @@ void LightCall::perform() {
       this->parent_->stop_effect_();
     }
 
-    this->parent_->start_transition_(v, *this->transition_length_);
+    this->parent_->start_transition_(v, *this->transition_length_, this->publish_);
 
   } else if (this->has_effect_()) {
     // EFFECT

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -228,13 +228,16 @@ void LightState::stop_effect_() {
   this->active_effect_index_ = 0;
 }
 
-void LightState::start_transition_(const LightColorValues &target, uint32_t length) {
+void LightState::start_transition_(const LightColorValues &target, uint32_t length, bool set_remote_values) {
   this->transformer_ = this->output_->create_default_transition();
   this->transformer_->setup(this->current_values, target, length);
-  this->remote_values = target;
+
+  if (set_remote_values) {
+    this->remote_values = target;
+  }
 }
 
-void LightState::start_flash_(const LightColorValues &target, uint32_t length) {
+void LightState::start_flash_(const LightColorValues &target, uint32_t length, bool set_remote_values) {
   LightColorValues end_colors = this->remote_values;
   // If starting a flash if one is already happening, set end values to end values of current flash
   // Hacky but works
@@ -243,7 +246,10 @@ void LightState::start_flash_(const LightColorValues &target, uint32_t length) {
 
   this->transformer_ = make_unique<LightFlashTransformer>(*this);
   this->transformer_->setup(end_colors, target, length);
-  this->remote_values = target;
+
+  if (set_remote_values) {
+    this->remote_values = target;
+  };
 }
 
 void LightState::set_immediately_(const LightColorValues &target, bool set_remote_values) {

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -154,10 +154,10 @@ class LightState : public Nameable, public Component {
   /// Internal method to stop the current effect (if one is active).
   void stop_effect_();
   /// Internal method to start a transition to the target color with the given length.
-  void start_transition_(const LightColorValues &target, uint32_t length);
+  void start_transition_(const LightColorValues &target, uint32_t length, bool set_remote_values);
 
   /// Internal method to start a flash for the specified amount of time.
-  void start_flash_(const LightColorValues &target, uint32_t length);
+  void start_flash_(const LightColorValues &target, uint32_t length, bool set_remote_values);
 
   /// Internal method to set the color values to target immediately (with no transition).
   void set_immediately_(const LightColorValues &target, bool set_remote_values);


### PR DESCRIPTION
This fixes https://github.com/esphome/issues/issues/2417, where adding a
transition to a LightCall with `set_publish(false)` would always update
the remote_values LightColorValues, and would do so out-of-sync with the
state published to the frontend.

This was done in a similar manner to the implementation of
`set_immediately_()`, where an additional set_remote_values flag was
added to skip the remote_values update if not needed.

# What does this implement/fix? 

Fixes issue described here: https://github.com/esphome/issues/issues/2417.
In short, start_flash_ and start_transition_ always updated remote_values, 
evenif not published. This allows transitions without an update to the local 
remote_values.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2417

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation: Not Applicable
## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: example
  platform: ESP8266
  board: d1_mini

logger:
api:
ota:

wifi: !include includes/wifi.yaml

output:
  - platform: esp8266_pwm
    pin: D2
    frequency: 120HZ
    id: J3_pwm

light:
  - platform: monochromatic
    output: J3_pwm
    name: J3
    id: J3
    effects:
      - lambda:
          name: No Publish
          update_interval: 1000ms
          lambda: |-
            auto call = id(J3)->turn_on();
            float remote = id(J3)->remote_values.get_brightness();
            esph_log_d(__FILE__, "brightness: %f", remote);
            call.set_brightness(remote * 0.5);
            call.set_transition_length(100);
            call.set_publish(false);
            call.set_save(false);
            call.set_state(true);
            call.perform();
      - lambda:
          name: Publish
          update_interval: 1000ms
          lambda: |-
            auto call = id(J3)->turn_on();
            float remote = id(J3)->remote_values.get_brightness();
            esph_log_d(__FILE__, "brightness: %f", remote);
            call.set_brightness(remote * 0.5);
            call.set_transition_length(100);
            call.set_publish(true);
            call.set_save(false);
            call.set_state(true);
            call.perform();
```

Expected behavior of `No Publish` is to remain at 50% of the set value. Publish will decrease in brightness 50% each time, publishing each value as it is set.

Example logs for `No Publish`:
```
[18:34:55][D][example.yaml:030]: brightness: 1.000000
[18:34:56][D][example.yaml:030]: brightness: 1.000000
[18:34:57][D][example.yaml:030]: brightness: 1.000000
[18:34:58][D][example.yaml:030]: brightness: 1.000000
[18:34:59][D][light:035]: 'J3' Setting:
[18:34:59][D][light:050]:   Brightness: 62%
[18:34:59][D][light:084]:   Transition length: 1.0s
[18:34:59][D][example.yaml:030]: brightness: 0.619608
[18:35:00][D][example.yaml:030]: brightness: 0.619608
[18:35:01][D][example.yaml:030]: brightness: 0.619608
[18:35:02][D][example.yaml:030]: brightness: 0.619608
```

Example logs for `Publish`:
```
[18:35:55][D][example.yaml:043]: brightness: 1.000000
[18:35:55][D][light:035]: 'J3' Setting:
[18:35:55][D][light:050]:   Brightness: 50%
[18:35:55][D][light:084]:   Transition length: 0.1s
[18:35:56][D][example.yaml:043]: brightness: 0.500000
[18:35:56][D][light:035]: 'J3' Setting:
[18:35:56][D][light:050]:   Brightness: 25%
[18:35:56][D][light:084]:   Transition length: 0.1s
[18:35:57][D][example.yaml:043]: brightness: 0.250000
[18:35:57][D][light:035]: 'J3' Setting:
[18:35:57][D][light:050]:   Brightness: 12%
[18:35:57][D][light:084]:   Transition length: 0.1s
[18:35:58][D][example.yaml:043]: brightness: 0.125000
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
