### PR TITLE
Light transition fixes

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -121,6 +121,9 @@ void LightState::loop() {
     }
 
     if (this->transformer_->is_finished()) {
+      // if the transition has written directly to the output, current_values is outdated, so update it
+      this->current_values = this->transformer_->get_target_values();
+
       this->transformer_->stop();
       this->transformer_ = nullptr;
       this->target_state_reached_callback_.call();

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -12,10 +12,16 @@ namespace light {
 class LightTransitionTransformer : public LightTransformer {
  public:
   void start() override {
-    // When turning light on from off state, use colors from target state.
+    // When turning light on from off state, use target state and only increase brightness from zero.
     if (!this->start_values_.is_on() && this->target_values_.is_on()) {
       this->start_values_ = LightColorValues(this->target_values_);
       this->start_values_.set_brightness(0.0f);
+    }
+
+    // When turning light off from on state, use source state and only decrease brightness to zero.
+    if (this->start_values_.is_on() && !this->target_values_.is_on()) {
+      this->target_values_ = LightColorValues(this->start_values_);
+      this->target_values_.set_brightness(0.0f);
     }
 
     // When changing color mode, go through off state, as color modes are orthogonal and there can't be two active.


### PR DESCRIPTION
# What does this implement/fix? 

* Fix brightness increasing during transition when turning light off by setting brightness to zero (pre-existing issue).
* Apply transition to addressable lights while an effect is active (regression from #2124).
* Update `current_values` in the LightState after a transition has finished, so that it's uptodate for addressable transitions (regression from #2124). 

~Draft for now as I want to test it some more to avoid breaking things again. People do crazy stuff with transitions.~ Seems to work fine.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#1565, fixes esphome/issues#2262, fixes esphome/issues#2362, fixes esphome/issues#2367.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
