### PR TITLE
Apply color brightness to addressable light effects

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<LightTransformer> AddressableLight::create_default_transition() 
   return make_unique<AddressableLightTransformer>(*this);
 }
 
-Color esp_color_from_light_color_values(LightColorValues val) {
+Color color_from_light_color_values(LightColorValues val) {
   auto r = to_uint8_scale(val.get_color_brightness() * val.get_red());
   auto g = to_uint8_scale(val.get_color_brightness() * val.get_green());
   auto b = to_uint8_scale(val.get_color_brightness() * val.get_blue());
@@ -44,7 +44,7 @@ void AddressableLight::update_state(LightState *state) {
     return;
 
   // don't use LightState helper, gamma correction+brightness is handled by ESPColorView
-  this->all() = esp_color_from_light_color_values(val);
+  this->all() = color_from_light_color_values(val);
   this->schedule_show();
 }
 
@@ -54,7 +54,7 @@ void AddressableLightTransformer::start() {
     return;
 
   auto end_values = this->target_values_;
-  this->target_color_ = esp_color_from_light_color_values(end_values);
+  this->target_color_ = color_from_light_color_values(end_values);
 
   // our transition will handle brightness, disable brightness in correction.
   this->light_.correction_.set_local_brightness(255);

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -19,6 +19,9 @@ namespace light {
 
 using ESPColor ESPDEPRECATED("esphome::light::ESPColor is deprecated, use esphome::Color instead.", "v1.21") = Color;
 
+/// Convert the color information from a `LightColorValues` object to a `Color` object (does not apply brightness).
+Color color_from_light_color_values(LightColorValues val);
+
 class AddressableLight : public LightOutput, public Component {
  public:
   virtual int32_t size() const = 0;

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -38,11 +38,8 @@ class AddressableLightEffect : public LightEffect {
   void stop() override { this->get_addressable_()->set_effect_active(false); }
   virtual void apply(AddressableLight &it, const Color &current_color) = 0;
   void apply() override {
-    LightColorValues color = this->state_->remote_values;
-    // not using any color correction etc. that will be handled by the addressable layer
-    Color current_color =
-        Color(static_cast<uint8_t>(color.get_red() * 255), static_cast<uint8_t>(color.get_green() * 255),
-              static_cast<uint8_t>(color.get_blue() * 255), static_cast<uint8_t>(color.get_white() * 255));
+    // not using any color correction etc. that will be handled by the addressable layer through ESPColorCorrection
+    Color current_color = color_from_light_color_values(this->state_->remote_values);
     this->apply(*this->get_addressable_(), current_color);
   }
 


### PR DESCRIPTION
When addressable effects use the current color, also apply the color
brightness there. Color brightness isn't applied to config-specified and
generated colors.

Fixes esphome/issues#2413.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
