### PR TITLE
Add ESPHOME_VERSION_CODE define

### DIFF
--- a/esphome/core/version.h
+++ b/esphome/core/version.h
@@ -6,4 +6,7 @@
 //
 // This file is only used by static analyzers and IDEs.
 
+#include "esphome/core/macros.h"
+
 #define ESPHOME_VERSION "dev"
+#define ESPHOME_VERSION_CODE VERSION_CODE(2099, 12, 0)

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -428,12 +428,12 @@ def generate_defines_h():
 
 
 def generate_version_h():
-    match = re.match(r'^(\d+)\.(\d+).(\d+)-?\w*$', __version__)
+    match = re.match(r"^(\d+)\.(\d+).(\d+)-?\w*$", __version__)
     if not match:
-        raise EsphomeError(
-            f"Could not parse version {__version__}."
-        )
-    return VERSION_H_FORMAT.format(__version__, match.group(1), match.group(2), match.group(3))
+        raise EsphomeError(f"Could not parse version {__version__}.")
+    return VERSION_H_FORMAT.format(
+        __version__, match.group(1), match.group(2), match.group(3)
+    )
 
 
 def write_cpp(code_s):

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -342,7 +342,9 @@ DEFINES_H_FORMAT = ESPHOME_H_FORMAT = """\
 """
 VERSION_H_FORMAT = """\
 #pragma once
+#include "esphome/core/macros.h"
 #define ESPHOME_VERSION "{}"
+#define ESPHOME_VERSION_CODE VERSION_CODE({}, {}, {})
 """
 DEFINES_H_TARGET = "esphome/core/defines.h"
 VERSION_H_TARGET = "esphome/core/version.h"
@@ -415,8 +417,7 @@ def copy_src_tree():
         CORE.relative_src_path("esphome.h"), ESPHOME_H_FORMAT.format(include_s)
     )
     write_file_if_changed(
-        CORE.relative_src_path("esphome", "core", "version.h"),
-        VERSION_H_FORMAT.format(__version__),
+        CORE.relative_src_path("esphome", "core", "version.h"), generate_version_h()
     )
 
 
@@ -424,6 +425,15 @@ def generate_defines_h():
     define_content_l = [x.as_macro for x in CORE.defines]
     define_content_l.sort()
     return DEFINES_H_FORMAT.format("\n".join(define_content_l))
+
+
+def generate_version_h():
+    match = re.match(r'^(\d+)\.(\d+).(\d+)-?\w*$', __version__)
+    if not match:
+        raise EsphomeError(
+            f"Could not parse version {__version__}."
+        )
+    return VERSION_H_FORMAT.format(__version__, match.group(1), match.group(2), match.group(3))
 
 
 def write_cpp(code_s):


### PR DESCRIPTION
# What does this implement/fix? 

This define can be used by external components to detect the current ESPHome version in an easily-comparable way. Useful to make external components compatible with multiple ESPHome versions that have different APIs, e.g.

```cpp
#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
   obj->some_api_introduced_next_month();
#else
   obj->some_legacy_api();
#endif
```

Of course keeping old APIs available and deprecating them before removal is still preferable, but that's not always possible. 

CC @mmakaay 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
