### PR TITLE
Introduce call_dump_config() indirection

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -186,6 +186,12 @@ void MQTTComponent::call_loop() {
     this->schedule_resend_state();
   }
 }
+void MQTTComponent::call_dump_config() {
+  if (this->is_internal())
+    return;
+
+  this->dump_config();
+}
 void MQTTComponent::schedule_resend_state() { this->resend_state_ = true; }
 std::string MQTTComponent::unique_id() { return ""; }
 bool MQTTComponent::is_connected_() const { return global_mqtt_client->is_connected(); }

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -62,6 +62,8 @@ class MQTTComponent : public Component {
 
   void call_loop() override;
 
+  void call_dump_config() override;
+
   /// Send discovery info the Home Assistant, override this.
   virtual void send_discovery(JsonObject &root, SendDiscoveryConfig &config) = 0;
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -105,7 +105,7 @@ void Application::loop() {
 #endif
     }
 
-    this->components_[this->dump_config_at_]->dump_config();
+    this->components_[this->dump_config_at_]->call_dump_config();
     this->dump_config_at_++;
   }
 }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -64,8 +64,9 @@ bool Component::cancel_timeout(const std::string &name) {  // NOLINT
 }
 
 void Component::call_loop() { this->loop(); }
-
 void Component::call_setup() { this->setup(); }
+void Component::call_dump_config() { this->dump_config(); }
+
 uint32_t Component::get_component_state() const { return this->component_state_; }
 void Component::call() {
   uint32_t state = this->component_state_ & COMPONENT_STATE_MASK;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -148,8 +148,12 @@ class Component {
   const char *get_component_source() const;
 
  protected:
+  friend class Application;
+
   virtual void call_loop();
   virtual void call_setup();
+  virtual void call_dump_config();
+
   /** Set an interval function with a unique name. Empty name means no cancelling possible.
    *
    * This will call f every interval ms. Can be cancelled via CancelInterval().


### PR DESCRIPTION
# What does this implement/fix? 

Introduce the `call_dump_config()` indirection, analogous to the `call_setup()` and `call_loop()` indirections that already exist. This allows the MQTT component to suppress the `dump_config()` call for components that are internal (and thus aren't published over MQTT). 

See #1859 for motivation behind this change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
