### PR TITLE
Add invert_colors option for st7735

### DIFF
--- a/esphome/components/st7735/display.py
+++ b/esphome/components/st7735/display.py
@@ -23,6 +23,7 @@ CONF_ROW_START = "row_start"
 CONF_COL_START = "col_start"
 CONF_EIGHT_BIT_COLOR = "eight_bit_color"
 CONF_USE_BGR = "use_bgr"
+CONF_INVERT_COLORS = "invert_colors"
 
 SPIST7735 = st7735_ns.class_(
     "ST7735", cg.PollingComponent, display.DisplayBuffer, spi.SPIDevice
@@ -58,6 +59,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_ROW_START): cv.int_,
             cv.Optional(CONF_EIGHT_BIT_COLOR, default=False): cv.boolean,
             cv.Optional(CONF_USE_BGR, default=False): cv.boolean,
+            cv.Optional(CONF_INVERT_COLORS, default=False): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -90,6 +92,7 @@ async def to_code(config):
         config[CONF_ROW_START],
         config[CONF_EIGHT_BIT_COLOR],
         config[CONF_USE_BGR],
+        config[CONF_INVERT_COLORS],
     )
     await setup_st7735(var, config)
     await spi.register_spi_device(var, config)

--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -220,12 +220,14 @@ static const uint8_t PROGMEM
 // clang-format on
 static const char *const TAG = "st7735";
 
-ST7735::ST7735(ST7735Model model, int width, int height, int colstart, int rowstart, bool eightbitcolor, bool usebgr)
+ST7735::ST7735(ST7735Model model, int width, int height, int colstart, int rowstart, bool eightbitcolor, bool usebgr,
+               bool invert_colors)
     : model_(model),
       colstart_(colstart),
       rowstart_(rowstart),
       eightbitcolor_(eightbitcolor),
       usebgr_(usebgr),
+      invert_colors_(invert_colors),
       width_(width),
       height_(height) {}
 
@@ -280,6 +282,9 @@ void ST7735::setup() {
     data = data | ST77XX_MADCTL_RGB;
   }
   sendcommand_(ST77XX_MADCTL, &data, 1);
+
+  if (this->invert_colors_)
+    sendcommand_(ST77XX_INVON, nullptr, 0);
 
   this->init_internal_(this->get_buffer_length());
   memset(this->buffer_, 0x00, this->get_buffer_length());

--- a/esphome/components/st7735/st7735.h
+++ b/esphome/components/st7735/st7735.h
@@ -37,7 +37,8 @@ class ST7735 : public PollingComponent,
                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                      spi::DATA_RATE_8MHZ> {
  public:
-  ST7735(ST7735Model model, int width, int height, int colstart, int rowstart, bool eightbitcolor, bool usebgr);
+  ST7735(ST7735Model model, int width, int height, int colstart, int rowstart, bool eightbitcolor, bool usebgr,
+         bool invert_colors);
   void dump_config() override;
   void setup() override;
 
@@ -77,6 +78,7 @@ class ST7735 : public PollingComponent,
   uint8_t colstart_ = 0, rowstart_ = 0;
   bool eightbitcolor_ = false;
   bool usebgr_ = false;
+  bool invert_colors_ = false;
   int16_t width_ = 80, height_ = 80;  // Watch heap size
 
   GPIOPin *reset_pin_{nullptr};


### PR DESCRIPTION
# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1479

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  - platform: st7735
    model: INITR_MINI160X80
    cs_pin: GPIO5
    dc_pin: GPIO23
    reset_pin: GPIO18
    device_width: 82
    device_height: 162
    row_start: 0
    col_start: 26
    use_bgr: true
    invert_colors: true
    rotation: 270
    id: main_display
    pages:
      - id: main_page
        lambda: |-
          it.fill(id(disp_background));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
