### PR TITLE
Fix MQTT discovery for sensor state_class

### DIFF
--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -6,15 +6,15 @@ namespace sensor {
 
 static const char *const TAG = "sensor";
 
-const LogString *state_class_to_string(StateClass state_class) {
+std::string state_class_to_string(StateClass state_class) {
   switch (state_class) {
     case STATE_CLASS_MEASUREMENT:
-      return LOG_STR("measurement");
+      return "measurement";
     case STATE_CLASS_TOTAL_INCREASING:
-      return LOG_STR("total_increasing");
+      return "total_increasing";
     case STATE_CLASS_NONE:
     default:
-      return LOG_STR("");
+      return "";
   }
 }
 

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -14,7 +14,7 @@ namespace sensor {
     if (!(obj)->get_device_class().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
     } \
-    ESP_LOGCONFIG(TAG, "%s  State Class: '%s'", prefix, LOG_STR_ARG(state_class_to_string((obj)->get_state_class()))); \
+    ESP_LOGCONFIG(TAG, "%s  State Class: '%s'", prefix, state_class_to_string((obj)->get_state_class()).c_str()); \
     ESP_LOGCONFIG(TAG, "%s  Unit of Measurement: '%s'", prefix, (obj)->get_unit_of_measurement().c_str()); \
     ESP_LOGCONFIG(TAG, "%s  Accuracy Decimals: %d", prefix, (obj)->get_accuracy_decimals()); \
     if (!(obj)->get_icon().empty()) { \
@@ -37,7 +37,7 @@ enum StateClass : uint8_t {
   STATE_CLASS_TOTAL_INCREASING = 2,
 };
 
-const LogString *state_class_to_string(StateClass state_class);
+std::string state_class_to_string(StateClass state_class);
 
 /** Base-class for all sensors.
  *


### PR DESCRIPTION
# What does this implement/fix? 
The MQTT discovery message for a sensor included `"state_class": true` instead of the expected `measurement` or `total_increasing`. This PR is a quick fix that changes the `state_class_to_string` function to use std::string so the MQTT discovery message is sent as expected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
Regression was introduced in #2274 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
