### PR TITLE
get changed files from direct upstream of current branch

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -62,20 +62,18 @@ def splitlines_no_ends(string):
 
 
 def changed_files():
-
+    command = ["git", "symbolic-ref", "-q", "HEAD"]
+    local_ref = splitlines_no_ends(get_output(*command))[0]
     command = [
         "git",
         "for-each-ref",
-        "--format='refs/remotes/%(upstream:short)' $(git symbolic-ref -q HEAD)",
+        "--format=refs/remotes/%(upstream:short)",
+        local_ref,
     ]
-    ref = splitlines_no_ends(get_output(*command))
-    if ref:
-        command = ["git", "merge-base", f"refs/remotes/{ref}", "HEAD"]
-        try:
-            merge_base = splitlines_no_ends(get_output(*command))[0]
-        # pylint: disable=bare-except
-        except:
-            pass
+    remote_ref = splitlines_no_ends(get_output(*command))
+    if remote_ref:
+        command = ["git", "merge-base", remote_ref[0], "HEAD"]
+        merge_base = splitlines_no_ends(get_output(*command))[0]
     else:
         raise ValueError("Git not configured correctly. No upstream repository found")
 


### PR DESCRIPTION
fixes https://github.com/esphome/issues/issues/2439

# What does this implement/fix? 
Use direct upstream path to find the changed files

Quick description and explanation of changes

the quicklint script [hardcodes ](https://github.com/esphome/esphome/blob/8f3a739da77e06b5ef18115248ee469ed0caa95f/script/helpers.py#L68)comparing against the dev branch in the first remote it finds. 
On my fork the branch is called testing and the correct merge-base  is `refs/remotes/origin/testing` but quicklint uses `refs/remotes/origin/dev`. Because I don't have a dev branch quick-lint fails. 
But even if the branches exists quicklint tries `upstream` first instead of `origin` and compare too many files or against the wrong branch. 
To get the upstream ref this command can be used
````
git for-each-ref --format='refs/remotes/%(upstream:short)' $(git symbolic-ref -q HEAD)
````

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2439

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
