### PR TITLE
Properly calculate negative temperatures in sm300d2

### DIFF
--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -49,12 +49,8 @@ void SM300D2Sensor::update() {
   const uint16_t tvoc = (response[6] * 256) + response[7];
   const uint16_t pm_2_5 = (response[8] * 256) + response[9];
   const uint16_t pm_10_0 = (response[10] * 256) + response[11];
-  float temperature = response[12] + (response[13] * 0.1);
-
   // A negative value is indicated by adding 0x80 (128) to the temperature value
-  if (temperature >= 128) {
-    temperature = (temperature - 128) * -1;
-  }
+  const float temperature = ((response[12] + (response[13] * 0.1)) > 128) ? (((response[12] + (response[13] * 0.1)) - 128) * -1) : response[12] + (response[13] * 0.1) ;
   const float humidity = response[14] + (response[15] * 0.1);
 
   ESP_LOGD(TAG, "Received CO₂: %u ppm", co2);

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -29,8 +29,11 @@ void SM300D2Sensor::update() {
   }
 
   uint16_t calculated_checksum = this->sm300d2_checksum_(response);
+  // Occasionally the checksum has a +/- 0x80 offset. Negative temperatures are
+  // responsible for some of these. The rest are unknown/undocumented.
   if ((calculated_checksum != response[SM300D2_RESPONSE_LENGTH - 1]) &&
-      (calculated_checksum - 0x80 != response[SM300D2_RESPONSE_LENGTH - 1])) {
+      (calculated_checksum - 0x80 != response[SM300D2_RESPONSE_LENGTH - 1]) &&
+      (calculated_checksum + 0x80 != response[SM300D2_RESPONSE_LENGTH - 1])) {
     ESP_LOGW(TAG, "SM300D2 Checksum doesn't match: 0x%02X!=0x%02X", response[SM300D2_RESPONSE_LENGTH - 1],
              calculated_checksum);
     this->status_set_warning();
@@ -46,7 +49,12 @@ void SM300D2Sensor::update() {
   const uint16_t tvoc = (response[6] * 256) + response[7];
   const uint16_t pm_2_5 = (response[8] * 256) + response[9];
   const uint16_t pm_10_0 = (response[10] * 256) + response[11];
-  const float temperature = response[12] + (response[13] * 0.1);
+  float temperature = response[12] + (response[13] * 0.1);
+
+  // A negative value is indicated by adding 0x80 (128) to the temperature value
+  if (temperature >= 128) {
+    temperature = (temperature - 128) * -1;
+  }
   const float humidity = response[14] + (response[15] * 0.1);
 
   ESP_LOGD(TAG, "Received CO₂: %u ppm", co2);

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -50,7 +50,9 @@ void SM300D2Sensor::update() {
   const uint16_t pm_2_5 = (response[8] * 256) + response[9];
   const uint16_t pm_10_0 = (response[10] * 256) + response[11];
   // A negative value is indicated by adding 0x80 (128) to the temperature value
-  const float temperature = ((response[12] + (response[13] * 0.1)) > 128) ? (((response[12] + (response[13] * 0.1)) - 128) * -1) : response[12] + (response[13] * 0.1) ;
+  const float temperature = ((response[12] + (response[13] * 0.1)) > 128)
+                                ? (((response[12] + (response[13] * 0.1)) - 128) * -1)
+                                : response[12] + (response[13] * 0.1);
   const float humidity = response[14] + (response[15] * 0.1);
 
   ESP_LOGD(TAG, "Received CO₂: %u ppm", co2);


### PR DESCRIPTION
# What does this implement/fix? 

Negative temperature values are now properly handled

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
