### PR TITLE
ESP32 NVS component

### DIFF
--- a/esphome/components/esp32_nvs/__init__.py
+++ b/esphome/components/esp32_nvs/__init__.py
@@ -1,0 +1,77 @@
+import hashlib
+
+from esphome import config_validation as cv, automation
+from esphome import codegen as cg
+from esphome.const import CONF_ID, CONF_INITIAL_VALUE, CONF_TYPE, CONF_VALUE, ESP_PLATFORM_ESP32
+from esphome.core import coroutine_with_priority
+
+ESP_PLATFORMS = [ESP_PLATFORM_ESP32]
+
+CONF_NVS_NAMESPACE = 'nvs_namespace'
+CONF_KEY = 'key'
+
+esp32nvs_ns = cg.esphome_ns.namespace('esp32_nvs')
+Esp32NvsComponent = esp32nvs_ns.class_('Esp32NvsComponent', cg.Component)
+Esp32NvsVarSetAction = esp32nvs_ns.class_('Esp32NvsVarSetAction', automation.Action)
+Esp32NvsEraseAction = esp32nvs_ns.class_('Esp32NvsEraseAction', automation.Action)
+Esp32NvsSetIdAction = esp32nvs_ns.class_('Esp32NvsSetIdAction', automation.Action)
+
+MULTI_CONF = True
+CONFIG_SCHEMA = cv.Schema({
+    #could not figure out how to set a max length of 15 for the ID
+    cv.Required(CONF_ID): cv.declare_id(Esp32NvsComponent),
+    cv.Required(CONF_TYPE): cv.Any(cv.string_strict, cv.int_, cv.float_),
+    cv.Required(CONF_NVS_NAMESPACE): cv.All(cv.string, cv.Length(max=15), cv.Length(min=1)),
+    cv.Required(CONF_INITIAL_VALUE): cv.Any(cv.string_strict, cv.int_, cv.float_),
+}).extend(cv.COMPONENT_SCHEMA)
+
+
+# Run with low priority so that namespaces are registered first
+@coroutine_with_priority(-100.0)
+def to_code(config):
+    type_ = cg.RawExpression(config[CONF_TYPE])
+    template_args = cg.TemplateArguments(type_)
+    res_type = Esp32NvsComponent.template(template_args)
+
+    initial_value = config[CONF_INITIAL_VALUE]
+
+    rhs = Esp32NvsComponent.new(template_args, initial_value)
+    glob = cg.Pvariable(config[CONF_ID], rhs, res_type)
+    yield cg.register_component(glob, config)
+
+    cg.add(glob.set_nvs_ns_key(config[CONF_NVS_NAMESPACE], config[CONF_ID].id))
+
+@automation.register_action('esp32_nvs.set', Esp32NvsVarSetAction, cv.Schema({
+    cv.Required(CONF_ID): cv.use_id(Esp32NvsComponent),
+    cv.Required(CONF_VALUE): cv.templatable(cv.string_strict),
+}))
+def esp32nvs_set_to_code(config, action_id, template_arg, args):
+    full_id, paren = yield cg.get_variable_with_full_id(config[CONF_ID])
+    template_arg = cg.TemplateArguments(full_id.type, *template_arg)
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    templ = yield cg.templatable(config[CONF_VALUE], args, None, to_exp=cg.RawExpression)
+    cg.add(var.set_value(templ))
+    yield var
+
+@automation.register_action('esp32_nvs.erase', Esp32NvsEraseAction, cv.Schema({
+    cv.Required(CONF_ID): cv.use_id(Esp32NvsComponent)
+}))
+def esp32nvs_erase_to_code(config, action_id, template_arg, args):
+    full_id, paren = yield cg.get_variable_with_full_id(config[CONF_ID])
+    template_arg = cg.TemplateArguments(full_id.type, *template_arg)
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    yield var
+
+@automation.register_action('esp32_nvs.set_id', Esp32NvsSetIdAction, cv.Schema({
+    cv.Required(CONF_ID): cv.use_id(Esp32NvsComponent),
+    cv.Required(CONF_NVS_NAMESPACE): cv.templatable(cv.string),
+    cv.Required(CONF_KEY): cv.templatable(cv.string),
+    cv.Required(CONF_VALUE): cv.templatable(cv.string_strict),
+}))
+def esp32nvs_set_id_to_code(config, action_id, template_arg, args):
+    full_id, paren = yield cg.get_variable_with_full_id(config[CONF_ID])
+    template_arg = cg.TemplateArguments(full_id.type, *template_arg)
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    templ = yield cg.templatable(config[CONF_VALUE], args, None, to_exp=cg.RawExpression)
+    cg.add(var.set_value(templ))
+    yield var

--- a/esphome/components/esp32_nvs/esp32_nvs.h
+++ b/esphome/components/esp32_nvs/esp32_nvs.h
@@ -1,0 +1,180 @@
+
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+#include "nvsflasher.h"
+
+// override the log level for debugging
+// #undef LOG_LOCAL_LEVEL
+// #define LOG_LOCAL_LEVEL ESP_LOG_INFO
+
+using std::string;
+
+//debug to dump nvs to serial port
+extern "C" void nvs_dump(const char *partName);
+
+namespace esphome {
+namespace esp32_nvs {
+
+static const char *TAG = "esp32_nvs";
+
+template<typename T> class Esp32NvsComponent : public Component {
+public:
+  using value_type = T;
+
+  explicit Esp32NvsComponent(T initial_value) : initial_value_(initial_value) {  }
+
+  T &value() { return this->value_; }
+  string &get_id() { return this->id_; }
+  string &get_namespace() { return this->nvs_namespace_; }
+
+  void setup() override {  }
+
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  void loop() override {  }
+
+  void dump_config() {
+    string myval = to_string(this->value_);
+    ESP_LOGCONFIG(TAG, "%s/%s = %s", this->nvs_namespace_.c_str(), this->id_.c_str(), myval.c_str());
+  }
+
+  // needed to convert T into a character buffer suitable for nvs functions
+  // (<string> is handled in a specialized template, below)
+  void prepare_buffers(bool update, string ns, string key, T new_value) {
+    uint32_t len = sizeof(T);
+    // ESP_LOGI(TAG, "prepare int: len=%d", len);
+    unsigned char* rd_bfr = new unsigned char[len];
+    unsigned char* wr_bfr = new unsigned char[len];
+    memcpy(wr_bfr, &new_value, len);
+    NvsResultBfrType success = NONE;
+    success = NvsFlasher::reconcile_flash(ns.c_str(), key.c_str(), rd_bfr, len, wr_bfr, len, update);
+    if(success == READ_BFR)
+      memcpy(&this->value_, rd_bfr, len);
+    else if(success == WRITE_BFR)
+      memcpy(&this->value_, wr_bfr, len);
+    delete[] rd_bfr;
+    delete[] wr_bfr;
+  }
+
+  // save the namespace and key name at initialization for this id
+  void set_nvs_ns_key(string nvs_namespace, string key) {
+    this->nvs_namespace_ = nvs_namespace;
+    this->id_ = key;
+    esp_err_t err = nvs_flash_init();
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND)
+    {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        err = nvs_flash_init();
+    }
+    //ESP_LOGI(TAG, "set_nvs_ns_key = %s/%s", nvs_namespace_.c_str(), id_.c_str());
+
+    // initial_value_ was saved in the constructor
+    this->prepare_buffers(false, nvs_namespace, key, initial_value_);
+
+    //uncomment nvs_dump to dump the entire nvs partition to the debug port
+    //nvs_dump("nvs");
+  }
+
+protected:
+  T value_{};
+  T initial_value_;
+  string nvs_namespace_;
+  string id_;
+};
+
+// specialized template for handling 'string' since converting it between
+// char[] is very different from the other types
+template <>
+inline void Esp32NvsComponent<string>::prepare_buffers(bool update, string ns, string key, string new_value) {
+  uint32_t wr_len = new_value.length() + 1; //+1 for 0x0 terminator
+  uint32_t rd_len = NvsFlasher::get_required_size(ns.c_str(), key.c_str());
+  if(rd_len == 0)
+    rd_len = wr_len;
+  unsigned char* rd_bfr = new unsigned char[rd_len];
+  unsigned char* wr_bfr = new unsigned char[wr_len];
+  memcpy(wr_bfr, new_value.c_str(), wr_len);
+  // ESP_LOGI(TAG, "prepare string: rd_len=%d, wr_len=%d", rd_len, wr_len);
+  NvsResultBfrType success = NONE;
+  success = NvsFlasher::reconcile_flash(ns.c_str(), key.c_str(), rd_bfr, rd_len, wr_bfr, wr_len, update);
+  if(success == READ_BFR)
+      this->value_ = (char *)rd_bfr; // this does a copy. rd_bfr can now be deleted
+  else if(success == WRITE_BFR)
+      this->value_ = (char *)wr_bfr; // this does a copy. wr_bfr can now be deleted
+  delete[] rd_bfr;
+  delete[] wr_bfr;
+  // ESP_LOGI(TAG, "%s/%s value = %s", ns.c_str(), key.c_str(), this->value_.c_str());
+}
+
+// esp32nvs.set
+// set the id named in the yaml
+template<class C, typename... Ts> class Esp32NvsVarSetAction : public Action<Ts...> {
+public:
+  explicit Esp32NvsVarSetAction(C *parent) : parent_(parent) {}
+
+  using T = typename C::value_type;
+
+  TEMPLATABLE_VALUE(T, value);
+
+  void play(Ts... x) override 
+  { 
+    this->parent_->prepare_buffers(true, 
+                                  this->parent_->get_namespace(), 
+                                  this->parent_->get_id(), 
+                                  this->value_.value(x...));
+    this->parent_->dump_config();
+  }
+
+protected:
+  C *parent_;
+};
+
+// esp32nvs.erase
+template<class C, typename... Ts> class Esp32NvsEraseAction : public Action<Ts...> {
+public:
+  explicit Esp32NvsEraseAction(C *parent) : parent_(parent) {}
+
+  using T = typename C::value_type;
+
+  TEMPLATABLE_STRING_VALUE(value);
+
+  void play(Ts... x) override 
+  { 
+    NvsFlasher::erase_namespace(this->parent_->get_namespace().c_str());
+  }
+
+protected:
+  C *parent_;
+};
+
+// esp32nvs.set_id
+// set the id passed as a parameter of the Action
+template<class C, typename... Ts> class Esp32NvsSetIdAction : public Action<Ts...> {
+public:
+  explicit Esp32NvsSetIdAction(C *parent) : parent_(parent) {}
+
+  using T = typename C::value_type;
+
+  TEMPLATABLE_VALUE(T, value);
+
+  void play(Ts... x) override 
+  { 
+    this->parent_->prepare_buffers(true, x...);
+    this->parent_->dump_config();
+  }
+
+protected:
+  C *parent_;
+};
+
+template<typename T>
+T &id(Esp32NvsComponent<T> *value) { return value->value(); }
+
+}  // namespace esp32_nvs
+}  // namespace esphome
+
+#endif //ARDUINO_ARCH_ESP32

--- a/esphome/components/esp32_nvs/nvsflasher.h
+++ b/esphome/components/esp32_nvs/nvsflasher.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "esphome/core/component.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+#include "nvs.h"
+#include "nvs_flash.h"
+
+//debug to dump nvs to serial port
+extern "C" void nvs_dump(const char *partName);
+
+namespace esphome {
+namespace esp32_nvs {
+
+  static const char *TAG1 = "nvsflasher";
+
+  enum NvsResultBfrType { NONE=0, READ_BFR=1, WRITE_BFR=2 };
+
+// ref: docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_flash.html
+
+// all of the esp32_nvs templates can share the actual nvs interface functions
+// rather than duplicate them in the Esp32NvsComponent class
+class NvsFlasher {
+public:
+
+  // if overwrite==true, create or update the flash key/value with the wr_bfr
+  // if overwrite==false:
+  //   if the key is already in nvs, read the value into rd_bfr
+  //   if the key is not in nvs, write the key/value to flash from wr_bfr
+  static NvsResultBfrType reconcile_flash(const char* nvs_namespace, const char* id,
+      unsigned char *rd_bfr, uint32_t rd_len, unsigned char *wr_bfr, uint32_t wr_len, bool overwrite) {
+    NvsResultBfrType result = NONE; //default to 'failed'
+    nvs_handle handle;
+    //ESP_LOGI(TAG1, "reconcile_flash: starting");
+    esp_err_t err = nvs_open(nvs_namespace, NVS_READWRITE, &handle);
+    if(err) {
+      ESP_LOGE(TAG1, "reconcile_flash: nvs_open(%s) failed: %s", nvs_namespace, esp_err_to_name(err));
+    }
+    else {
+      // opened OK
+      bool do_overwrite = false;
+      err = nvs_get_blob(handle, id, rd_bfr, &rd_len);
+      if(err != ESP_OK)
+        do_overwrite = true;  //it's not already flashed
+      else {
+        // there is already a value in flash
+        //ESP_LOGI(TAG1, "reconcile_flash: nvs_get_blob(%s/%s) len %d already exists", nvs_namespace, id, rd_len);
+        //ESP_LOG_BUFFER_HEXDUMP(TAG1, rd_bfr, rd_len, ESP_LOG_ERROR); //must be level ERROR or it won't print
+        if(!overwrite)
+          result = READ_BFR; //we are done, rd_bfr to be copied to this->value_
+        else {
+          // overwrite is true
+          // copy wr_bfr to flash unless it is already there
+          if (rd_len != wr_len)
+            do_overwrite = true;
+          else if(memcmp(rd_bfr, wr_bfr, wr_len) != 0)
+            do_overwrite = true;
+        }
+      }
+      if(do_overwrite) {
+        // new or overwrite namespace/key
+        err = nvs_set_blob(handle, id, wr_bfr, wr_len);
+        if(err) {
+          ESP_LOGE(TAG1, "reconcile_flash: nvs_set_blob(%s/%s): %s", nvs_namespace, id, esp_err_to_name(err));
+        }
+        else {
+          // wrote OK
+          //ESP_LOGI(TAG1, "reconcile_flash: nvs_set_blob(%s/%s) success", nvs_namespace_.c_str(), id_.c_str());
+          err = nvs_commit(handle);
+          if(err) {
+            ESP_LOGE(TAG1, "reconcile_flash: nvs_commit(%s/%s): %s", nvs_namespace, id, esp_err_to_name(err));
+          }
+          else {
+            //ESP_LOGI(TAG1, "reconcile_flash: nvs_commit(%s/%s) success", nvs_namespace, id);
+            //nvs_dump("nvs");
+            //ESP_LOG_BUFFER_HEXDUMP(TAG1, wr_bfr, wr_len, ESP_LOG_ERROR);
+            result = WRITE_BFR; //wr_bfr gets written to this->value_
+          }
+        }
+      }
+      nvs_close(handle);
+    }
+    return result;
+  }
+
+  // returns the size of nvs_namespace/id if it already resides in flash
+  static uint32_t get_required_size(const char* nvs_namespace, const char* id) {
+    size_t required_size = 0;  // value will default to 0, if not set yet in NVS
+    nvs_handle handle;
+    esp_err_t err = nvs_open(nvs_namespace, NVS_READWRITE, &handle);
+    if(err) {
+      ESP_LOGE(TAG1, "get_required_size: nvs_open(%s) failed: %s", nvs_namespace, esp_err_to_name(err));
+    }
+    else {
+      // Read the size of memory space required for blob
+      err = nvs_get_blob(handle, id, NULL, &required_size);
+      if(err)
+        required_size = 0;
+      nvs_close(handle);
+    }
+    //ESP_LOGI(TAG1, "get_required_size: returning %d", required_size);
+    return required_size;
+  }
+
+  // erases the entire namespace
+  static void erase_namespace(const char* nvs_namespace) {
+    nvs_handle handle;
+    esp_err_t err = nvs_open(nvs_namespace, NVS_READWRITE, &handle);
+    if(err) {
+      ESP_LOGE(TAG1, "erase_namespace: nvs_open(%s) failed: %s", nvs_namespace, esp_err_to_name(err));
+    }
+    else {
+      err = nvs_erase_all(handle);
+      if(err) {
+        ESP_LOGE(TAG1, "erase_namespace: nvs_erase_all(%s) failed: %s", nvs_namespace, esp_err_to_name(err));
+      }
+      else {
+        nvs_commit(handle);
+        nvs_close(handle);
+        // nvs_dump("nvs");
+      }
+    }
+  }
+
+};
+
+}   //esp32_nvs
+}   //esphome
+
+#endif //ARDUINO_ARCH_ESP32


### PR DESCRIPTION
# What does this implement/fix? 

New feature to add access to non-volatile storage on the ESP32 through the esp-idf non-volatile storage library.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X ] ESP32
- [ ] ESP8266

```yaml
# Example config.yaml
esp32_nvs:
  - id: var_name
    type: string
    nvs_namespace: 'var_namespace'
    initial_value: 'initial string'
```

## Checklist:
  - [X ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
