### PR TITLE
Fix error reporting for DHT bit read loop

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -122,6 +122,8 @@ bool HOT ICACHE_RAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, 
           break;
         }
       }
+      if (error_code != 0)
+        break;
 
       start_time = micros();
       uint32_t end_time = start_time;
@@ -136,6 +138,8 @@ bool HOT ICACHE_RAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, 
           break;
         }
       }
+      if (error_code != 0)
+        break;
 
       if (i < 0)
         continue;


### PR DESCRIPTION
# What does this implement/fix? 

The main for loop of DHT for reading bits was overwriting error codes for previous bits. Due to lack of tests on error code, loop continued even if an error occurred.
This caused wrong warning messages (like falling edge failed for bit 40 even if the error occurred on bit 1).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
