### PR TITLE
Fix SPIDevice::write_byte16 to actually take a 16 bit argument

### DIFF
--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -246,7 +246,7 @@ class SPIDevice {
     return this->parent_->template write_byte<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data);
   }
 
-  void write_byte16(uint8_t data) {
+  void write_byte16(uint16_t data) {
     return this->parent_->template write_byte16<BIT_ORDER, CLOCK_POLARITY, CLOCK_PHASE>(data);
   }
 


### PR DESCRIPTION
# What does this implement/fix? 

SPIDevice::write_byte16 currently takes only a uint8_t argument. If one passes a 16 bit value (as one would expect to be able to given the name) this causes the high 8 bits to be sent as 0 on the SPI bus regardless of their value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
