### PR TITLE
Install python requirements after apt ones for better caching

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,16 +51,16 @@ RUN \
     && platformio settings set check_platforms_interval 1000000 \
     && mkdir -p /piolibs
 
+
+
+# ======================= docker-type image =======================
+FROM base AS docker
+
 # First install requirements to leverage caching when requirements don't change
 COPY requirements.txt requirements_optional.txt docker/platformio_install_deps.py platformio.ini /
 RUN \
     pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
     && /platformio_install_deps.py /platformio.ini
-
-
-
-# ======================= docker-type image =======================
-FROM base AS docker
 
 # Copy esphome and install
 COPY . /esphome
@@ -104,6 +104,12 @@ ARG BUILD_VERSION=dev
 # Copy root filesystem
 COPY docker/hassio-rootfs/ /
 
+# First install requirements to leverage caching when requirements don't change
+COPY requirements.txt requirements_optional.txt docker/platformio_install_deps.py platformio.ini /
+RUN \
+    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
+    && /platformio_install_deps.py /platformio.ini
+
 # Copy esphome and install
 COPY . /esphome
 RUN pip3 install --no-cache-dir -e /esphome
@@ -140,6 +146,11 @@ RUN \
         /tmp/* \
         /var/{cache,log}/* \
         /var/lib/apt/lists/*
+
+COPY requirements.txt requirements_optional.txt docker/platformio_install_deps.py platformio.ini /
+RUN \
+    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
+    && /platformio_install_deps.py /platformio.ini
 
 VOLUME ["/esphome"]
 WORKDIR /esphome

--- a/docker/build.py
+++ b/docker/build.py
@@ -109,9 +109,9 @@ def main():
         # 1. pull cache image
         params = DockerParams.for_type_arch(args.build_type, args.arch)
         cache_tag = {
-            CHANNEL_DEV: "dev",
-            CHANNEL_BETA: "beta",
-            CHANNEL_RELEASE: "latest",
+            CHANNEL_DEV: "cache-dev",
+            CHANNEL_BETA: "cache-beta",
+            CHANNEL_RELEASE: "cache-latest",
         }[channel]
         cache_img = f"ghcr.io/{params.build_to}:{cache_tag}"
 
@@ -123,7 +123,7 @@ def main():
             "docker", "buildx", "build",
             "--build-arg", f"BASEIMGTYPE={params.baseimgtype}",
             "--build-arg", f"BUILD_VERSION={args.tag}",
-            "--cache-from", cache_img,
+            "--cache-from", f"type=registry,ref={cache_img}",
             "--file", "docker/Dockerfile",
             "--platform", params.platform,
             "--target", params.target,
@@ -131,7 +131,7 @@ def main():
         for img in imgs:
             cmd += ["--tag", img]
         if args.push:
-            cmd.append("--push")
+            cmd += ["--push", "--cache-to", f"type=registry,ref={cache_img},mode=max"]
 
         run_command(*cmd, ".")
     elif args.command == "manifest":


### PR DESCRIPTION
# What does this implement/fix? 

Previously the requirements and pio lib deps would be installed after the apt dependencies. Switch that around to get better caching (python/pio reqs change more often than deb ones)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
