### PR TITLE
Fix src_filter in platformio.ini after src_dir change

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,9 +41,9 @@ lib_deps =
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE
 src_filter =
-    +<esphome>
-    +<tests/dummy_main.cpp>
-    +<.temp/all-include.cpp>
+    +<./>
+    +<../tests/dummy_main.cpp>
+    +<../.temp/all-include.cpp>
 
 [common:esp8266]
 extends = common


### PR DESCRIPTION
# What does this implement/fix? 

I changed `src_dir` in https://github.com/esphome/esphome/pull/2303 (for some reason the idf toolchain didn't like having a git directory there); now also `src_filter` needs to be updated

Before this, `pio run -t compiledb -e esp32` would only generate compile commands entries for libdeps, as no src filter matched.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
