### PR TITLE
Allow compilation against IDF from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ tests/.esphome/
 .pio/
 
 sdkconfig.*
+!sdkconfig.defaults

--- a/platformio.ini
+++ b/platformio.ini
@@ -96,6 +96,7 @@ lib_deps =
 build_flags =
     ${common.build_flags}
     ${common:esp32.build_flags}
+    -Wno-nonnull-compare
     -DUSE_ESP_IDF
     -DUSE_ESP32_FRAMEWORK_ESP_IDF
 src_filter = ${common:esp32.src_filter}

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,7 @@ src_filter =
 [common:arduino]
 extends = common
 lib_deps =
+    ${common.lib_deps}
     ottowinter/AsyncMqttClient-esphome@0.8.4              ; mqtt
     ottowinter/ArduinoJson-esphomelib@5.13.3              ; json
     esphome/ESPAsyncWebServer-esphome@1.3.0               ; web_server_base

--- a/platformio.ini
+++ b/platformio.ini
@@ -135,6 +135,7 @@ build_flags =
 
 [env:esp32-idf]
 extends = common:espidf
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf
 build_flags =
     ${common:espidf.build_flags}
     ${runtime.build_flags}
@@ -142,6 +143,7 @@ build_flags =
 
 [env:esp32-idf-tidy]
 extends = common:espidf
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf-tidy
 build_flags =
     ${common:espidf.build_flags}
     ${clangtidy.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -144,7 +144,6 @@ build_flags =
     ${common:esp32-idf.build_flags}
     ${runtime.build_flags}
 
-
 [env:esp32-idf-tidy]
 extends = common:esp32-idf
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf-tidy

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,9 +41,9 @@ lib_deps =
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE
 src_filter =
-    +<esphome>
-    +<tests/dummy_main.cpp>
-    +<.temp/all-include.cpp>
+    +<./>
+    +<../tests/dummy_main.cpp>
+    +<../.temp/all-include.cpp>
 
 [common:esp8266]
 extends = common

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@
 ; It's *not* used during runtime.
 
 [platformio]
-default_envs = esp8266, esp32
+default_envs = esp8266, esp32, esp32-idf
 src_dir = esphome
 include_dir =
 
@@ -26,18 +26,8 @@ build_flags =
 
 [common]
 lib_deps =
-    ottowinter/AsyncMqttClient-esphome@0.8.4              ; mqtt
-    ottowinter/ArduinoJson-esphomelib@5.13.3              ; json
-    esphome/ESPAsyncWebServer-esphome@1.3.0               ; web_server_base
-    fastled/FastLED@3.3.2                                 ; fastled_base
-    makuna/NeoPixelBus@2.6.7                              ; neopixelbus
-    mikalhart/TinyGPSPlus@1.0.2                           ; gps
-    freekode/TM1651@1.0.1                                 ; tm1651
-    seeed-studio/Grove - Laser PM2.5 Sensor HM3301@1.0.3  ; hm3301
-    glmnet/Dsmr@0.5                                       ; dsmr
-    rweather/Crypto@0.2.0                                 ; dsmr
-    esphome/noise-c@0.1.1                                 ; api
-    dudanov/MideaUART@1.1.0                               ; midea
+    esphome/noise-c@0.1.1     ; api
+    makuna/NeoPixelBus@2.6.7  ; neopixelbus
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE
 src_filter =
@@ -45,8 +35,31 @@ src_filter =
     +<../tests/dummy_main.cpp>
     +<../.temp/all-include.cpp>
 
-[common:esp8266]
+[common:arduino]
 extends = common
+lib_deps =
+    ottowinter/AsyncMqttClient-esphome@0.8.4              ; mqtt
+    ottowinter/ArduinoJson-esphomelib@5.13.3              ; json
+    esphome/ESPAsyncWebServer-esphome@1.3.0               ; web_server_base
+    fastled/FastLED@3.3.2                                 ; fastled_base
+    mikalhart/TinyGPSPlus@1.0.2                           ; gps
+    freekode/TM1651@1.0.1                                 ; tm1651
+    seeed-studio/Grove - Laser PM2.5 Sensor HM3301@1.0.3  ; hm3301
+    glmnet/Dsmr@0.5                                       ; dsmr
+    rweather/Crypto@0.2.0                                 ; dsmr
+    dudanov/MideaUART@1.1.0                               ; midea
+build_flags =
+    ${common.build_flags}
+    -DUSE_ARDUINO
+
+[common:idf]
+extends = common
+build_flags =
+    ${common.build_flags}
+    -DUSE_ESP_IDF
+
+[common:esp8266]
+extends = common:arduino
 ; when changing this also copy it to esphome-docker-base images
 platform = platformio/espressif8266 @ 3.2.0
 platform_packages =
@@ -55,16 +68,17 @@ platform_packages =
 framework = arduino
 board = nodemcuv2
 lib_deps =
-    ${common.lib_deps}
+    ${common:arduino.lib_deps}
     ESP8266WiFi                           ; wifi (Arduino built-in)
     Update                                ; ota (Arduino built-in)
     ottowinter/ESPAsyncTCP-esphome@1.2.3  ; async_tcp
 build_flags =
-    ${common.build_flags}
+    ${common:arduino.build_flags}
     -DUSE_ESP8266
+    -DUSE_ESP8266_FRAMEWORK_ARDUINO
 
-[common:esp32]
-extends = common
+[common:esp32-arduino]
+extends = common:arduino
 ; when changing this also copy it to esphome-docker-base images
 platform = platformio/espressif32 @ 3.3.2
 platform_packages =
@@ -73,15 +87,16 @@ platform_packages =
 framework = arduino
 board = nodemcu-32s
 lib_deps =
-    ${common.lib_deps}
+    ${common:arduino.lib_deps}
     Hash                            ; ota (Arduino built-in)
     esphome/AsyncTCP-esphome@1.2.2  ; async_tcp
 build_flags =
-    ${common.build_flags}
+    ${common:arduino.build_flags}
     -DUSE_ESP32
-src_filter = ${common.src_filter}
+    -DUSE_ESP32_FRAMEWORK_ARDUINO
 
-[common:espidf]
+[common:esp32-idf]
+extends = common:idf
 ; when changing this also copy it to esphome-docker-base images
 platform = platformio/espressif32 @ 3.3.2
 platform_packages =
@@ -90,60 +105,49 @@ platform_packages =
 framework = espidf
 board = nodemcu-32s
 lib_deps =
-    esphome/noise-c@0.1.1  ; used by api
-    espressif/esp32-camera@1.0.0  ; used by esp32_camera
-    NeoPixelBus@2.6.7
+    ${common:idf.lib_deps}
+    espressif/esp32-camera@1.0.0  ; esp32_camera
 build_flags =
-    ${common.build_flags}
-    ${common:esp32.build_flags}
+    ${common:idf.build_flags}
     -Wno-nonnull-compare
-    -DUSE_ESP_IDF
+    -DUSE_ESP32
     -DUSE_ESP32_FRAMEWORK_ESP_IDF
-src_filter = ${common:esp32.src_filter}
 
 [env:esp8266]
 extends = common:esp8266
 build_flags =
     ${common:esp8266.build_flags}
     ${runtime.build_flags}
-    -DUSE_ARDUINO
-    -DUSE_ESP8266_FRAMEWORK_ARDUINO
 
 [env:esp8266-tidy]
 extends = common:esp8266
 build_flags =
     ${common:esp8266.build_flags}
     ${clangtidy.build_flags}
-    -DUSE_ARDUINO
-    -DUSE_ESP8266_FRAMEWORK_ARDUINO
 
 [env:esp32]
-extends = common:esp32
+extends = common:esp32-arduino
 build_flags =
-    ${common:esp32.build_flags}
+    ${common:esp32-arduino.build_flags}
     ${runtime.build_flags}
-    -DUSE_ARDUINO
-    -DUSE_ESP32_FRAMEWORK_ARDUINO
 
 [env:esp32-tidy]
-extends = common:esp32
+extends = common:esp32-arduino
 build_flags =
-    ${common:esp32.build_flags}
+    ${common:esp32-arduino.build_flags}
     ${clangtidy.build_flags}
-    -DUSE_ARDUINO
-    -DUSE_ESP32_FRAMEWORK_ARDUINO
 
 [env:esp32-idf]
-extends = common:espidf
+extends = common:esp32-idf
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf
 build_flags =
-    ${common:espidf.build_flags}
+    ${common:esp32-idf.build_flags}
     ${runtime.build_flags}
 
 
 [env:esp32-idf-tidy]
-extends = common:espidf
+extends = common:esp32-idf
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf-tidy
 build_flags =
-    ${common:espidf.build_flags}
+    ${common:esp32-idf.build_flags}
     ${clangtidy.build_flags}

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -54,7 +54,9 @@ def clang_options(idedata):
 
     # copy compiler flags, except those clang doesn't understand.
     cmd.extend(flag for flag in idedata['cxx_flags'].split(' ')
-               if flag not in ('-free', '-fipa-pta', '-fstrict-volatile-bitfields', '-mlongcalls', '-mtext-section-literals'))
+               if flag not in ('-free', '-fipa-pta', '-fstrict-volatile-bitfields',
+                               '-mlongcalls', '-mtext-section-literals',
+                               '-mfix-esp32-psram-cache-issue', '-mfix-esp32-psram-cache-strategy=memw'))
 
     # defines
     cmd.extend(f'-D{define}' for define in idedata['defines'])

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,0 +1,17 @@
+# ESP-IDF sdkconfig defaults used for development purposes only, not used during runtime. Used when PlatformIO is ran
+# directly from the source directory, e.g. by IDEs or for static analysis (clang-tidy). This should enable all flags
+# that are set by any component.
+
+# esp32
+CONFIG_COMPILER_OPTIMIZATION_DEFAULT=n
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+CONFIG_PARTITION_TABLE_CUSTOM=y
+#CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_SINGLE_APP=n
+
+# esp32_ble
+CONFIG_BT_ENABLED=y
+
+# esp32_camera
+CONFIG_RTCIO_SUPPORT_RTC_GPIO_DESC=y
+CONFIG_ESP32_SPIRAM_SUPPORT=y


### PR DESCRIPTION
# What does this implement/fix? 

Together these changes make it possible to run `pio run -e esp32-idf` from within the repository (it doesn't generate flashable), which I often use to check if my changes didn't break anything (it's faster than clang-tidy as it uses incremental builds). Regardless of the goal, I think they are worthwhile cleanups. 

Based upon #2353.

* The ESP32 component set `-Wno-nonnull-compare` for builds using the IDF, set it in platformio.ini as well.
* Create a sdkconfig.defaults file with all sdkconfig options we set, instead of hardcoding one in `scripts/helpers.py`. This file is automatically used by the ESP-IDF when generating the full sdkconfig file, which we move to the `.temp` directory. Use of a full sdkconfig for static analysis is because warnings may have different behaviour based on optimization level (notably `-Wmaybe-uninitialized`). 
* Setting the optimization level also added some compiler arguments clang-tidy didn't understand, add them to the ignore list.
* Strip out some new compiler arguments that clang-tidy. 
* Clean-up platformio.ini a bit to reduce duplication.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
