### PR TITLE
Discard SenseAir S8 commands echoes & fix calibration result check

### DIFF
--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -78,9 +78,12 @@ uint16_t SenseAirComponent::senseair_checksum_(uint8_t *ptr, uint8_t length) {
 }
 
 void SenseAirComponent::background_calibration() {
+  // Responses are just echoes but must be read to clear the buffer
   ESP_LOGD(TAG, "SenseAir Starting background calibration");
-  this->senseair_write_command_(SENSEAIR_COMMAND_CLEAR_ACK_REGISTER, nullptr, 0);
-  this->senseair_write_command_(SENSEAIR_COMMAND_BACKGROUND_CAL, nullptr, 0);
+  uint8_t command_length = sizeof(SENSEAIR_COMMAND_CLEAR_ACK_REGISTER) / sizeof(SENSEAIR_COMMAND_CLEAR_ACK_REGISTER[0]);
+  uint8_t response[command_length];
+  this->senseair_write_command_(SENSEAIR_COMMAND_CLEAR_ACK_REGISTER, response, command_length);
+  this->senseair_write_command_(SENSEAIR_COMMAND_BACKGROUND_CAL, response, command_length);
 }
 
 void SenseAirComponent::background_calibration_result() {
@@ -98,18 +101,25 @@ void SenseAirComponent::background_calibration_result() {
     return;
   }
 
-  ESP_LOGD(TAG, "SenseAir Result=%s (%02x%02x%02x)", response[2] == 2 ? "OK" : "NOT_OK", response[2], response[3],
-           response[4]);
+  // Check if 5th bit (register CI6) is set
+  ESP_LOGD(TAG, "SenseAir Result=%s (%02x%02x%02x %02x%02x %02x%02x)", (response[4] & 0b100000) != 0 ? "OK" : "NOT_OK",
+           response[0], response[1], response[2], response[3], response[4], response[5], response[6]);
 }
 
 void SenseAirComponent::abc_enable() {
+  // Response is just an echo but must be read to clear the buffer
   ESP_LOGD(TAG, "SenseAir Enabling automatic baseline calibration");
-  this->senseair_write_command_(SENSEAIR_COMMAND_ABC_ENABLE, nullptr, 0);
+  uint8_t command_length = sizeof(SENSEAIR_COMMAND_ABC_ENABLE) / sizeof(SENSEAIR_COMMAND_ABC_ENABLE[0]);
+  uint8_t response[command_length];
+  this->senseair_write_command_(SENSEAIR_COMMAND_ABC_ENABLE, response, command_length);
 }
 
 void SenseAirComponent::abc_disable() {
+  // Response is just an echo but must be read to clear the buffer
   ESP_LOGD(TAG, "SenseAir Disabling automatic baseline calibration");
-  this->senseair_write_command_(SENSEAIR_COMMAND_ABC_DISABLE, nullptr, 0);
+  uint8_t command_length = sizeof(SENSEAIR_COMMAND_ABC_DISABLE) / sizeof(SENSEAIR_COMMAND_ABC_DISABLE[0]);
+  uint8_t response[command_length];
+  this->senseair_write_command_(SENSEAIR_COMMAND_ABC_DISABLE, response, command_length);
 }
 
 void SenseAirComponent::abc_get_period() {


### PR DESCRIPTION
# What does this implement/fix? 

The SenseAir S8 replies to some commands by just echoing them back. This response is useless and can be discarded, but must be read nonetheless to avoid leaving spurious data in the UART's buffer.

The check for the background calibration result was also fixed, since it wasn't checking specifically for the right bit.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [ ] ~~Other~~

**Related issue or feature (if applicable):** should help with esphome/issues#2444 to some extent.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] ~~Tests have been added to verify that the new code works (under `tests/` folder).~~
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] ~~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~~
