### PR TITLE
Add 'icon' field to lights

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -388,6 +388,7 @@ message ListEntitiesLightResponse {
   float max_mireds = 10;
   repeated string effects = 11;
   bool disabled_by_default = 13;
+  string icon = 14;
 }
 message LightStateResponse {
   option (id) = 24;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -335,6 +335,7 @@ bool APIConnection::send_light_info(light::LightState *light) {
   msg.key = light->get_object_id_hash();
   msg.object_id = light->get_object_id();
   msg.name = light->get_name();
+  msg.icon = light->get_icon();
   msg.unique_id = get_default_unique_id("light", light);
 
   msg.disabled_by_default = light->is_disabled_by_default();

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1262,6 +1262,10 @@ bool ListEntitiesLightResponse::decode_length(uint32_t field_id, ProtoLengthDeli
       this->effects.push_back(value.as_string());
       return true;
     }
+    case 14: {
+      this->icon = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -1302,6 +1306,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(11, it, true);
   }
   buffer.encode_bool(13, this->disabled_by_default);
+  buffer.encode_string(14, this->icon);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesLightResponse::dump_to(std::string &out) const {
@@ -1364,6 +1369,10 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -424,6 +424,7 @@ class ListEntitiesLightResponse : public ProtoMessage {
   float max_mireds{0.0f};
   std::vector<std::string> effects{};
   bool disabled_by_default{false};
+  std::string icon{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_EFFECTS,
     CONF_FLASH_TRANSITION_LENGTH,
     CONF_GAMMA_CORRECT,
+    CONF_ICON,
     CONF_ID,
     CONF_INTERNAL,
     CONF_NAME,
@@ -20,6 +21,7 @@ from esphome.const import (
     CONF_TRIGGER_ID,
     CONF_COLD_WHITE_COLOR_TEMPERATURE,
     CONF_WARM_WHITE_COLOR_TEMPERATURE,
+    ICON_EMPTY,
 )
 from esphome.core import coroutine_with_priority
 from .automation import light_control_to_code  # noqa
@@ -57,6 +59,7 @@ RESTORE_MODES = {
 LIGHT_SCHEMA = cv.NAMEABLE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).extend(
     {
         cv.GenerateID(): cv.declare_id(LightState),
+        cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
         cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTJSONLightComponent),
         cv.Optional(CONF_RESTORE_MODE, default="restore_default_off"): cv.enum(
             RESTORE_MODES, upper=True, space="_"
@@ -126,6 +129,7 @@ def validate_color_temperature_channels(value):
 
 
 async def setup_light_core_(light_var, output_var, config):
+    cg.add(light_var.set_icon(config[CONF_ICON]))
     cg.add(light_var.set_disabled_by_default(config[CONF_DISABLED_BY_DEFAULT]))
     cg.add(light_var.set_restore_mode(config[CONF_RESTORE_MODE]))
     if CONF_INTERNAL in config:

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -96,7 +96,7 @@ void LightState::setup() {
 void LightState::dump_config() {
   ESP_LOGCONFIG(TAG, "Light '%s'", this->get_name().c_str());
   if (!this->get_icon().empty())
-   ESP_LOGCONFIG(TAG, "  Icon: '%s'", this->get_icon().c_str());
+    ESP_LOGCONFIG(TAG, "  Icon: '%s'", this->get_icon().c_str());
   if (this->get_traits().supports_color_capability(ColorCapability::BRIGHTNESS)) {
     ESP_LOGCONFIG(TAG, "  Default Transition Length: %.1fs", this->default_transition_length_ / 1e3f);
     ESP_LOGCONFIG(TAG, "  Gamma Correct: %.2f", this->gamma_correct_);

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -95,6 +95,8 @@ void LightState::setup() {
 }
 void LightState::dump_config() {
   ESP_LOGCONFIG(TAG, "Light '%s'", this->get_name().c_str());
+  if (!this->get_icon().empty())
+   ESP_LOGCONFIG(TAG, "  Icon: '%s'", this->get_icon().c_str());
   if (this->get_traits().supports_color_capability(ColorCapability::BRIGHTNESS)) {
     ESP_LOGCONFIG(TAG, "  Default Transition Length: %.1fs", this->default_transition_length_ / 1e3f);
     ESP_LOGCONFIG(TAG, "  Gamma Correct: %.2f", this->gamma_correct_);

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -109,6 +109,10 @@ class LightState : public Nameable, public Component {
   void set_gamma_correct(float gamma_correct);
   float get_gamma_correct() const { return this->gamma_correct_; }
 
+  /// Set the icon
+  void set_icon(std::string icon) { this->icon_ = std::move(icon); }
+  const std::string &get_icon() const { return this->icon_; }
+
   /// Set the restore mode of this light
   void set_restore_mode(LightRestoreMode restore_mode);
 
@@ -197,6 +201,8 @@ class LightState : public Nameable, public Component {
   uint32_t flash_transition_length_{};
   /// Gamma correction factor for the light.
   float gamma_correct_{};
+  /// Icon for the light
+  std::string icon_;
   /// Restore mode of the light.
   LightRestoreMode restore_mode_;
   /// List of effects for this light.

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -36,6 +36,9 @@ void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscover
   root["schema"] = "json";
   auto traits = this->state_->get_traits();
 
+  if (!this->state_->get_icon().empty())
+   root["icon"] = this->state_->get_icon();
+
   root["color_mode"] = true;
   JsonArray &color_modes = root.createNestedArray("supported_color_modes");
   if (traits.supports_color_mode(ColorMode::ON_OFF))

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -37,7 +37,7 @@ void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscover
   auto traits = this->state_->get_traits();
 
   if (!this->state_->get_icon().empty())
-   root["icon"] = this->state_->get_icon();
+    root["icon"] = this->state_->get_icon();
 
   root["color_mode"] = true;
   JsonArray &color_modes = root.createNestedArray("supported_color_modes");

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1390,6 +1390,7 @@ light:
   - platform: monochromatic
     name: 'Kitchen Lights'
     id: kitchen
+    icon: mdi:ceiling-light
     output: gpio_19
     gamma_correct: 2.8
     default_transition_length: 2s


### PR DESCRIPTION
# What does this implement/fix? 
Adds the option for a user to specify an `icon` for lights.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
light:
  - platform: rgbww
    icon: mdi:ceiling-light
    # other config

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
