### PR TITLE
Fix ESP8266 preferences not set up

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -10,11 +10,11 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
 )
-from esphome.core import CORE
+from esphome.core import CORE, coroutine_with_priority
 import esphome.config_validation as cv
 import esphome.codegen as cg
 
-from .const import CONF_RESTORE_FROM_FLASH, KEY_BOARD, KEY_ESP8266
+from .const import CONF_RESTORE_FROM_FLASH, KEY_BOARD, KEY_ESP8266, esp8266_ns
 from .boards import ESP8266_FLASH_SIZES, ESP8266_LD_SCRIPTS
 
 # force import gpio to register pin schema
@@ -152,7 +152,10 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
+@coroutine_with_priority(1000)
 async def to_code(config):
+    cg.add(esp8266_ns.setup_preferences())
+
     cg.add_platformio_option("board", config[CONF_BOARD])
     cg.add_build_flag("-DUSE_ESP8266")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])

--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -32,6 +32,13 @@ uint32_t arch_get_cpu_cycle_count() {
 }
 uint32_t arch_get_cpu_freq_hz() { return F_CPU; }
 
+extern "C" void resetPins() {  // NOLINT
+  // Added in framework 2.7.0
+  // usually this sets up all pins to be in INPUT mode
+  // however, not strictly needed as we set up the pins properly
+  // ourselves and this causes pins to toggle during reboot.
+}
+
 }  // namespace esphome
 
 #endif  // USE_ESP8266

--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -32,11 +32,26 @@ uint32_t arch_get_cpu_cycle_count() {
 }
 uint32_t arch_get_cpu_freq_hz() { return F_CPU; }
 
+void force_link_symbols() {
+  // Tasmota uses magic bytes in the binary to check if an OTA firmware is compatible
+  // with their settings - ESPHome uses a different settings system (that can also survive
+  // erases). So set magic bytes indicating all tasmota versions are supported.
+  // This only adds 12 bytes of binary size, which is an acceptable price to pay for easier support
+  // for Tasmota.
+  // https://github.com/arendst/Tasmota/blob/b05301b1497942167a015a6113b7f424e42942cd/tasmota/settings.ino#L346-L380
+  // https://github.com/arendst/Tasmota/blob/b05301b1497942167a015a6113b7f424e42942cd/tasmota/i18n.h#L652-L654
+  const static uint32_t TASMOTA_MAGIC_BYTES[] PROGMEM = {0x5AA55AA5, 0xFFFFFFFF, 0xA55AA55A};
+  // Force link symbol by using a volatile integer (GCC attribute used does not work because of LTO)
+  volatile int x = 0;
+  x = TASMOTA_MAGIC_BYTES[x];
+}
+
 extern "C" void resetPins() {  // NOLINT
   // Added in framework 2.7.0
   // usually this sets up all pins to be in INPUT mode
   // however, not strictly needed as we set up the pins properly
   // ourselves and this causes pins to toggle during reboot.
+  force_link_symbols();
 }
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 

After https://github.com/esphome/esphome/pull/2303 wifi has been broken, wifi tries to set up a preference by calling `global_preferences`, but the pointer is null.

Call `setup_preferences early on boot (and copy the other methods from esphal.cpp that were not migrated initially)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
