### PR TITLE
fix i2c scanning eror for Arduino

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -33,10 +33,8 @@ void ArduinoI2CBus::dump_config() {
   if (this->scan_) {
     ESP_LOGI(TAG, "Scanning i2c bus for active devices...");
     uint8_t found = 0;
-    for (uint8_t address = 1; address < 120; address++) {
-      wire_->beginTransmission(address);
-      auto err = wire_->endTransmission(true);
-
+    for (uint8_t address = 1; address < 127; address++) {
+      auto err = writev(address, nullptr, 0);
       if (err == ERROR_OK) {
         ESP_LOGI(TAG, "Found i2c device at address 0x%02X", address);
         found++;

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -34,7 +34,8 @@ void ArduinoI2CBus::dump_config() {
     ESP_LOGI(TAG, "Scanning i2c bus for active devices...");
     uint8_t found = 0;
     for (uint8_t address = 1; address < 120; address++) {
-      auto err = readv(address, nullptr, 0);
+      wire_->beginTransmission(address);
+      auto err = wire_->endTransmission(true);
 
       if (err == ERROR_OK) {
         ESP_LOGI(TAG, "Found i2c device at address 0x%02X", address);

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -33,7 +33,7 @@ void ArduinoI2CBus::dump_config() {
   if (this->scan_) {
     ESP_LOGI(TAG, "Scanning i2c bus for active devices...");
     uint8_t found = 0;
-    for (uint8_t address = 1; address < 127; address++) {
+    for (uint8_t address = 8; address < 120; address++) {
       auto err = writev(address, nullptr, 0);
       if (err == ERROR_OK) {
         ESP_LOGI(TAG, "Found i2c device at address 0x%02X", address);

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -43,8 +43,8 @@ void IDFI2CBus::dump_config() {
   if (this->scan_) {
     ESP_LOGI(TAG, "Scanning i2c bus for active devices...");
     uint8_t found = 0;
-    for (uint8_t address = 1; address < 120; address++) {
-      auto err = readv(address, nullptr, 0);
+    for (uint8_t address = 8; address < 120; address++) {
+      auto err = writev(address, nullptr, 0);
 
       if (err == ERROR_OK) {
         ESP_LOGI(TAG, "Found i2c device at address 0x%02X", address);


### PR DESCRIPTION
revert to the old scan implementation.

# What does this implement/fix? 
getting correct i2c scan results

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2453

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
substitutions:
  updates: 60s
  unique_id: bme280

esphome:
  name: ${unique_id}

esp32:
  board: TinyPICO
  framework:
    type: arduino

logger:
  level: VERBOSE
i2c:
  sda: 21
  scl: 22
  scan: True
  id: bus_a

sensor:
  - platform: bme280
    temperature:
      name: "Temperatur (Huette)"
      id: hut_temperature
    humidity:
      name: "Luftfeuchtigkeit (Huette)"
      id: hut_humidity
    update_interval: ${updates}
    address: 0x76
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).


