### PR TITLE
Fix ESP8266 preference loading

### DIFF
--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -149,6 +149,7 @@ class ESP8266PreferenceBackend : public ESPPreferenceBackend {
       return false;
 
     uint32_t crc = calculate_crc(buffer.begin(), buffer.end() - 1, type);
+    memcpy(data, buffer.data(), len);
     return buffer[buffer.size() - 1] == crc;
   }
 };

--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -149,7 +149,7 @@ class ESP8266PreferenceBackend : public ESPPreferenceBackend {
       return false;
 
     uint32_t crc = calculate_crc(buffer.begin(), buffer.end() - 1, type);
-    if(buffer[buffer.size() - 1] != crc) {
+    if (buffer[buffer.size() - 1] != crc) {
       return false;
     }
 

--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -149,8 +149,12 @@ class ESP8266PreferenceBackend : public ESPPreferenceBackend {
       return false;
 
     uint32_t crc = calculate_crc(buffer.begin(), buffer.end() - 1, type);
+    if(buffer[buffer.size() - 1] != crc) {
+      return false;
+    }
+
     memcpy(data, buffer.data(), len);
-    return buffer[buffer.size() - 1] == crc;
+    return true;
   }
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

Preferences loaded from RTC or flash were not being copied back to the data pointer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
