### PR TITLE
Correctly invert the float output state

### DIFF
--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -31,14 +31,13 @@ void FloatOutput::set_level(float state) {
     this->power_.unrequest();
   }
 #endif
+
+  if (!(state == 0.0f && this->zero_means_zero_))  // regardless of min_power_, 0.0 means off
+    state = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
+
   if (this->is_inverted())
     state = 1.0f - state;
-  if (state == 0.0f && this->zero_means_zero_) {  // regardless of min_power_, 0.0 means off
-    this->write_state(state);
-    return;
-  }
-  float adjusted_value = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
-  this->write_state(adjusted_value);
+  this->write_state(state);
 }
 
 void FloatOutput::write_state(bool state) { this->set_level(state != this->inverted_ ? 1.0f : 0.0f); }


### PR DESCRIPTION
# What does this implement/fix? 

Adjusts to min/max before inverting as per findings of `NZrocks#4179` on discord

![float](https://user-images.githubusercontent.com/3060199/134286573-9877ec93-8cb9-4969-a981-e380ea96be61.png)




## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
