### PR TITLE
Fix docker pio settings not applied

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -4,15 +4,21 @@
 # otherwise use path in /config (so that PIO packages aren't downloaded on each compile)
 
 if [[ -d /cache ]]; then
-    export PLATFORMIO_CORE_DIR=/cache/platformio
+    pio_cache_base=/cache/platformio
 else
-    export PLATFORMIO_CORE_DIR=/config/.esphome/platformio
+    pio_cache_base=/config/.esphome/platformio
 fi
 
-if [[ ! -d "${PLATFORMIO_CORE_DIR}" ]]; then
-    echo "Creating cache directory ${PLATFORMIO_CORE_DIR}"
+if [[ ! -d "${pio_cache_base}" ]]; then
+    echo "Creating cache directory ${pio_cache_base}"
     echo "You can change this behavior by mounting a directory to the container's /cache directory."
-    mkdir -p "${PLATFORMIO_CORE_DIR}"
+    mkdir -p "${pio_cache_base}"
 fi
+
+# we can't set core_dir, because the settings file is stored in `core_dir/appstate.json`
+# setting `core_dir` would therefore prevent pio from accessing
+export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
+export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
+export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
 
 exec esphome "$@"

--- a/docker/hassio-rootfs/etc/cont-init.d/30-dirs.sh
+++ b/docker/hassio-rootfs/etc/cont-init.d/30-dirs.sh
@@ -4,6 +4,6 @@
 # This files creates all directories used by esphome
 # ==============================================================================
 
-PLATFORMIO_CORE_DIR=/data/cache/platformio
+pio_cache_base=/data/cache/platformio
 
-mkdir -p "${PLATFORMIO_CORE_DIR}"
+mkdir -p "${pio_cache_base}"

--- a/docker/hassio-rootfs/etc/services.d/esphome/run
+++ b/docker/hassio-rootfs/etc/services.d/esphome/run
@@ -22,7 +22,13 @@ if bashio::config.has_value 'relative_url'; then
     export ESPHOME_DASHBOARD_RELATIVE_URL=$(bashio::config 'relative_url')
 fi
 
-export PLATFORMIO_CORE_DIR=/data/cache/platformio
+pio_cache_base=/data/cache/platformio
+# we can't set core_dir, because the settings file is stored in `core_dir/appstate.json`
+# setting `core_dir` would therefore prevent pio from accessing
+export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
+export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
+export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
+
 export PLATFORMIO_GLOBALLIB_DIR=/piolibs
 
 bashio::log.info "Starting ESPHome dashboard..."


### PR DESCRIPTION
# What does this implement/fix? 

As reported in discord #devs; After https://github.com/esphome/esphome/pull/2338 the pio `enable_telemetry` setting no longer took effect.

This is because the setting is stored in `<core_dir>/appstate.json`, but during the build `core_dir` is different from the runtime `core_dir`.

Fix by not setting `core_dir` in the container, but each of the dirs where packages are stored in individually

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
