### PR TITLE
Fix docker multiarch problems on some systems

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,9 @@ ARG BASEIMGTYPE=docker
 FROM ghcr.io/hassio-addons/debian-base/amd64:5.0.0 AS base-hassio-amd64
 FROM ghcr.io/hassio-addons/debian-base/aarch64:5.0.0 AS base-hassio-arm64
 FROM ghcr.io/hassio-addons/debian-base/armv7:5.0.0 AS base-hassio-armv7
-FROM debian:bullseye-20210816-slim AS base-docker-amd64
-FROM debian:bullseye-20210816-slim AS base-docker-arm64
-FROM debian:bullseye-20210816-slim AS base-docker-armv7
+FROM amd64/debian:bullseye-20210816-slim AS base-docker-amd64
+FROM arm64v8/debian:bullseye-20210816-slim AS base-docker-arm64
+FROM arm32v7/debian:bullseye-20210816-slim AS base-docker-armv7
 
 # Use TARGETARCH/TARGETVARIANT defined by docker
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope

--- a/docker/build.py
+++ b/docker/build.py
@@ -58,7 +58,7 @@ class DockerParams:
         }[build_type]
         platform = {
             ARCH_AMD64: "linux/amd64",
-            ARCH_ARMV7: "linux/arm/v7",
+            ARCH_ARMV7: "linux/arm",
             ARCH_AARCH64: "linux/arm64",
         }[arch]
         target = {


### PR DESCRIPTION
# What does this implement/fix? 

Apparently the docker.io `debian` image with `--platform=linux/arm/v7` is not the same as `arm32v7/debian` and causes some issues for rpi users (bug in a docker dep, as detailed here https://docs.linuxserver.io/faq)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
