### PR TITLE
Fix broken compilation due to conflict between #1237 and IDF changes

### DIFF
--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -35,11 +35,11 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void set_contrast(float contrast);
   void init_brightness(float brightness) { this->brightness_ = brightness; }
   void set_brightness(float brightness);
-  void init_flip_x(boolean flip_x) { this->flip_x_ = flip_x; }
-  void init_flip_y(boolean flip_y) { this->flip_y_ = flip_y; }
+  void init_flip_x(bool flip_x) { this->flip_x_ = flip_x; }
+  void init_flip_y(bool flip_y) { this->flip_y_ = flip_y; }
   void init_offset_x(uint8_t offset_x) { this->offset_x_ = offset_x; }
   void init_offset_y(uint8_t offset_y) { this->offset_y_ = offset_y; }
-  void init_invert(boolean invert) { this->invert_ = invert; }
+  void init_invert(bool invert) { this->invert_ = invert; }
   bool is_on();
   void turn_on();
   void turn_off();


### PR DESCRIPTION
# What does this implement/fix? 

Fix parts of #1237 that depended upon Arduino.h being included. We're probably gonna see this happen for a while with old PRs...

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
