### PR TITLE
Fix two i2c error code return errors

### DIFF
--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -12,7 +12,9 @@ namespace pn532_i2c {
 
 static const char *const TAG = "pn532_i2c";
 
-bool PN532I2C::write_data(const std::vector<uint8_t> &data) { return this->write(data.data(), data.size()); }
+bool PN532I2C::write_data(const std::vector<uint8_t> &data) {
+  return this->write(data.data(), data.size()) == i2c::ERROR_OK;
+}
 
 bool PN532I2C::read_data(std::vector<uint8_t> &data, uint8_t len) {
   delay(1);

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -198,7 +198,7 @@ bool SCD30Component::write_command_(uint16_t command, uint16_t data) {
   raw[2] = data >> 8;
   raw[3] = data & 0xFF;
   raw[4] = sht_crc_(raw[2], raw[3]);
-  return this->write(raw, 5);
+  return this->write(raw, 5) == i2c::ERROR_OK;
 }
 
 uint8_t SCD30Component::sht_crc_(uint8_t data1, uint8_t data2) {


### PR DESCRIPTION
# What does this implement/fix? 

Noticed this while reviewing https://github.com/esphome/esphome/pull/2217/files

The new method write returns `i2c::ErrorCode`, when returning as bool the conversion must be done by checking against i2c::ERROR_OK (otherwise it will be exactly inverted)

ref https://github.com/esphome/esphome/pull/2303

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
