### PR TITLE
Fix ESP8266 ADC

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -4,7 +4,11 @@
 #ifdef USE_ADC_SENSOR_VCC
 #include <Esp.h>
 ADC_MODE(ADC_VCC)
+#else
+#include <Arduino.h>
 #endif
+
+
 
 namespace esphome {
 namespace adc {

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -8,8 +8,6 @@ ADC_MODE(ADC_VCC)
 #include <Arduino.h>
 #endif
 
-
-
 namespace esphome {
 namespace adc {
 

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -1,11 +1,13 @@
 #include "adc_sensor.h"
 #include "esphome/core/log.h"
 
+#ifdef USE_ESP8266
 #ifdef USE_ADC_SENSOR_VCC
 #include <Esp.h>
 ADC_MODE(ADC_VCC)
 #else
 #include <Arduino.h>
+#endif
 #endif
 
 namespace esphome {


### PR DESCRIPTION
# What does this implement/fix? 

`analogRead` was being used without including `<Arduino.h>`, resulting in build errors. This slipped through CI testing because test3.yaml is the only ESP8266 config, and the `adc` test measures `VCC`, which uses a different function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
Introduced in #2303 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
