### PR TITLE
Fix: Pin flags code generation returning FLAG_NONE

### DIFF
--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -107,6 +107,12 @@ class ExpressionList(Expression):
         return iter(self.args)
 
 
+class ExpressionListFlags(ExpressionList):
+    def __str__(self):
+        text = " | ".join(str(x) for x in self.args)
+        return indent_all_but_first_and_last(text)
+
+
 class TemplateArguments(Expression):
     __slots__ = ("args",)
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -107,12 +107,6 @@ class ExpressionList(Expression):
         return iter(self.args)
 
 
-class ExpressionListFlags(ExpressionList):
-    def __str__(self):
-        text = " | ".join(str(x) for x in self.args)
-        return indent_all_but_first_and_last(text)
-
-
 class TemplateArguments(Expression):
     __slots__ = ("args",)
 
@@ -314,6 +308,19 @@ class FloatLiteral(Literal):
         if math.isnan(self.f):
             return "NAN"
         return f"{self.f}f"
+
+
+class BinOpExpression(Expression):
+    __slots__ = ("op", "lhs", "rhs")
+
+    def __init__(self, op: str, lhs: SafeExpType, rhs: SafeExpType):
+        # Remove every None on end
+        self.op = op
+        self.lhs = safe_exp(lhs)
+        self.rhs = safe_exp(rhs)
+
+    def __str__(self):
+        return f"{self.lhs} {self.op} {self.rhs}"
 
 
 def safe_exp(obj: SafeExpType) -> Expression:
@@ -761,6 +768,10 @@ class MockObj(Expression):
             item = item[1:]
             next_op = "->"
         return MockObj(f"{self.base}[{item}]", next_op)
+
+    def __or__(self, other: SafeExpType) -> "MockObj":
+        op = BinOpExpression("|", self, other)
+        return MockObj(op)
 
 
 class MockObjEnum(MockObj):

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -90,7 +90,7 @@ def gpio_flags_expr(mode):
         CONF_PULLDOWN: cg.gpio_Flags.FLAG_PULLDOWN,
     }
     active_flags = [v for k, v in FLAGS_MAPPING.items() if mode.get(k)]
-    if active_flags:
+    if not active_flags:
         return cg.gpio_Flags.FLAG_NONE
 
     return reduce(operator.or_, active_flags)

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -1,5 +1,4 @@
-import operator
-from functools import reduce
+from esphome.cpp_generator import ExpressionListFlags
 
 from esphome.const import (
     CONF_INPUT,
@@ -93,7 +92,7 @@ def gpio_flags_expr(mode):
     if not active_flags:
         return cg.gpio_Flags.FLAG_NONE
 
-    return reduce(operator.or_, active_flags)
+    return ExpressionListFlags(*active_flags)
 
 
 gpio_pin_schema = _schema_creator

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -1,4 +1,5 @@
-from esphome.cpp_generator import ExpressionListFlags
+import operator
+from functools import reduce
 
 from esphome.const import (
     CONF_INPUT,
@@ -92,7 +93,7 @@ def gpio_flags_expr(mode):
     if not active_flags:
         return cg.gpio_Flags.FLAG_NONE
 
-    return ExpressionListFlags(*active_flags)
+    return reduce(operator.or_, active_flags)
 
 
 gpio_pin_schema = _schema_creator


### PR DESCRIPTION
# What does this implement/fix? 

When pin flags are set, code generation was returning FLAG_NONE rather than the expected list of flags

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
