### PR TITLE
Add i2c bus recovery during initialization

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -22,6 +22,9 @@ class ArduinoI2CBus : public I2CBus, public Component {
   void set_scl_pin(uint8_t scl_pin) { scl_pin_ = scl_pin; }
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
 
+ private:
+  void recover();
+
  protected:
   TwoWire *wire_;
   bool scan_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -24,6 +24,9 @@ class IDFI2CBus : public I2CBus, public Component {
   void set_scl_pullup_enabled(bool scl_pullup_enabled) { scl_pullup_enabled_ = scl_pullup_enabled; }
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
 
+ private:
+  void recover();
+
  protected:
   i2c_port_t port_;
   bool scan_;


### PR DESCRIPTION
This outputs 9 SCL cycles on setup.
This is similar the the linux kernel behaviour. See code comments for some links.

# What does this implement/fix? 

Esphome did not implement i2c bus recovery, yet. The arduino libraries for esp32 and esp8266 contain recovery code. I discovered the issue when using a qmc5883l sensor. After an otau, the sensor was always unresponsive (connected via a long cable, setup failed). This may happen if the I2C master resets, when the I2C slave is within a transaction. For some (most?) I2C slaves it is necessary to let the finish their transaction before the host is able to communicate with the slave again. This is done here by configuring SCL as GPIO output and sending 9 clocks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

no change in yaml

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

I measured this with a logic analyzer for ESP32 arduino and esp-idf build. The resulting clock on SCL is between 50kHz and 100kHz.