### PR TITLE
Fix esp-idf pinmask bit-shift overflow

### DIFF
--- a/esphome/components/esp32/gpio_idf.h
+++ b/esphome/components/esp32/gpio_idf.h
@@ -20,7 +20,7 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
   }
   void pin_mode(gpio::Flags flags) override {
     gpio_config_t conf{};
-    conf.pin_bit_mask = 1 << static_cast<uint32_t>(pin_);
+    conf.pin_bit_mask = 1ULL << static_cast<uint32_t>(pin_);
     conf.mode = flags_to_mode_(flags);
     conf.pull_up_en = flags & gpio::FLAG_PULLUP ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
     conf.pull_down_en = flags & gpio::FLAG_PULLDOWN ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE;


### PR DESCRIPTION
# What does this implement/fix? 

For esp32 pins starting from 32, conf.pin_bit_mask was 0, so the wrong
pin (pin 0) was configured. This commit fixed this issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

To see the problem, e.g. configure pin 33 as an input.

```yaml
binary_sensor:
  - platform: gpio
    pin: 33
    name: "Living Room Window"
    device_class: window
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
