### PR TITLE
Read unencrypted DSMR telegrams in chunks

### DIFF
--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -20,7 +20,8 @@ void Dsmr::loop() {
 }
 
 void Dsmr::receive_telegram_() {
-  while (available()) {
+  int count = 100;
+  while (available() && count-- > 0) {
     const char c = read();
 
     if (c == '/') {  // header: forward slash

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -20,7 +20,7 @@ void Dsmr::loop() {
 }
 
 void Dsmr::receive_telegram_() {
-  int count = 100;
+  int count = MAX_BYTES_PER_LOOP;
   while (available() && count-- > 0) {
     const char c = read();
 

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -24,16 +24,18 @@ void Dsmr::receive_telegram_() {
   while (available() && count-- > 0) {
     const char c = read();
 
-    if (c == '/') {  // header: forward slash
+    // Find a new telegram header, i.e. forward slash.
+    if (c == '/') {
       ESP_LOGV(TAG, "Header found");
       header_found_ = true;
       footer_found_ = false;
       telegram_len_ = 0;
     }
-
     if (!header_found_)
       continue;
-    if (telegram_len_ >= MAX_TELEGRAM_LENGTH) {  // Buffer overflow
+
+    // Check for buffer overflow.
+    if (telegram_len_ >= MAX_TELEGRAM_LENGTH) {
       header_found_ = false;
       footer_found_ = false;
       ESP_LOGE(TAG, "Error: Message larger than buffer");
@@ -46,18 +48,22 @@ void Dsmr::receive_telegram_() {
     while (c == '(' && (telegram_[telegram_len_ - 1] == '\n' || telegram_[telegram_len_ - 1] == '\r'))
       telegram_len_--;
 
+    // Store the byte in the buffer.
     telegram_[telegram_len_] = c;
     telegram_len_++;
-    if (c == '!') {  // footer: exclamation mark
+
+    // Check for a footer, i.e. exlamation mark, followed by a hex checksum.
+    if (c == '!') {
       ESP_LOGV(TAG, "Footer found");
       footer_found_ = true;
-    } else {
-      if (footer_found_ && c == 10) {  // last \n after footer
-        header_found_ = false;
-        // Parse message
-        if (parse_telegram())
-          return;
-      }
+      continue;
+    }
+    // Check for the end of the footer checksum, i.e. a newline.
+    if (footer_found_ && c == '\n') {
+      header_found_ = false;
+      // Parse the telegram and publish sensor values.
+      if (parse_telegram())
+        return;
     }
   }
 }

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -58,7 +58,7 @@ void Dsmr::receive_telegram_() {
       footer_found_ = true;
       continue;
     }
-    // Check for the end of the footer checksum, i.e. a newline.
+    // Check for the end of the hex checksum, i.e. a newline.
     if (footer_found_ && c == '\n') {
       header_found_ = false;
       // Parse the telegram and publish sensor values.

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -89,8 +89,6 @@ class Dsmr : public Component, public uart::UARTDevice {
   // Telegram buffer
   char telegram_[MAX_TELEGRAM_LENGTH];
   int telegram_len_{0};
-  char encypted_telegram_[MAX_TELEGRAM_LENGTH];
-  int encrypted_telegram_len_{0};
 
   // Serial parser
   bool header_found_{false};

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -17,6 +17,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
+static constexpr uint32_t MAX_BYTES_PER_LOOP = 100;
 static constexpr uint32_t POLL_TIMEOUT = 1000;
 
 using namespace ::dsmr::fields;
@@ -88,6 +89,8 @@ class Dsmr : public Component, public uart::UARTDevice {
   // Telegram buffer
   char telegram_[MAX_TELEGRAM_LENGTH];
   int telegram_len_{0};
+  char encypted_telegram_[MAX_TELEGRAM_LENGTH];
+  int encrypted_telegram_len_{0};
 
   // Serial parser
   bool header_found_{false};

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -17,7 +17,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
-static constexpr uint32_t MAX_BYTES_PER_LOOP = 100;
+static constexpr uint32_t MAX_BYTES_PER_LOOP = 50;
 static constexpr uint32_t POLL_TIMEOUT = 1000;
 
 using namespace ::dsmr::fields;


### PR DESCRIPTION
# What does this implement/fix? 

The DSMR component currently keeps reading serial data from its `loop()` code, until no more serial data are available on the bus. Because of this, the `loop()` might block for too long, causing all sorts of issues.

The simplest way to trigger the issue, is setting log level `VERY_VERBOSE`, which results in all bytes on the UART to be logged on individual log lines. This slows down the serial reads so much that the DSMR `loop()` blocks the device for seconds sometimes.
Even worse is when this happens with a DSMR v5 smart meter, which send a lot of measurements, sometimes resulting in never exiting the `loop()`, because telegram dumps might come in even before a previous dump has been processed.

So in short: the typical issue with loop implementation that block for too long.

This PR implements a simple mechanism that lets the loop process a max number of bytes per iteration. After these bytes, control is handed back. Using this fix, I can run my reader device with `VERY_VERBOSE` logging without running into breakage.

**Note:** This change only handles unencrypted telegrams. The structure of the encrypted telegram reader does not support this kind of change currently. I'm planning on doing some more changes for that too, but because that requires some more structural changes, I'll keep that for a separate PR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** one of the possible fixes as cooked up in https://github.com/esphome/issues/issues/2437#issuecomment-925130923

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
