### PR TITLE
Fix: Light flash not restoring previous LightState

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -79,7 +79,7 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
   // dynamically-calculated alpha values to match the look.
 
   float denom = (1.0f - smoothed_progress);
-  float alpha = denom == 0.0f ? 0.0f : (smoothed_progress - this->last_transition_progress_) / denom;
+  float alpha = denom == 0.0f ? 1.0f : (smoothed_progress - this->last_transition_progress_) / denom;
 
   // We need to use a low-resolution alpha here which makes the transition set in only after ~half of the length
   // We solve this by accumulating the fractional part of the alpha over time.

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -127,6 +127,7 @@ void LightState::loop() {
       this->transformer_->stop();
       this->transformer_ = nullptr;
       this->target_state_reached_callback_.call();
+      this->output_->update_state(this);
     }
   }
 

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -127,7 +127,6 @@ void LightState::loop() {
       this->transformer_->stop();
       this->transformer_ = nullptr;
       this->target_state_reached_callback_.call();
-      this->output_->update_state(this);
     }
   }
 

--- a/esphome/components/light/light_transformer.h
+++ b/esphome/components/light/light_transformer.h
@@ -40,9 +40,13 @@ class LightTransformer {
  protected:
   /// The progress of this transition, on a scale of 0 to 1.
   float get_progress_() {
-    if (this->length_ == 0.0f)
+    uint32_t now = esphome::millis();
+    if (now < this->start_time_)
+      return 0.0f;
+    if (now >= this->start_time_ + this->length_)
       return 1.0f;
-    return clamp((millis() - this->start_time_) / float(this->length_), 0.0f, 1.0f);
+
+    return clamp((now - this->start_time_) / float(this->length_), 0.0f, 1.0f);
   }
 
   uint32_t start_time_;

--- a/esphome/components/light/light_transformer.h
+++ b/esphome/components/light/light_transformer.h
@@ -39,7 +39,11 @@ class LightTransformer {
 
  protected:
   /// The progress of this transition, on a scale of 0 to 1.
-  float get_progress_() { return clamp((millis() - this->start_time_) / float(this->length_), 0.0f, 1.0f); }
+  float get_progress_() {
+    if (this->length_ == 0.0f)
+      return 1.0f;
+    return clamp((millis() - this->start_time_) / float(this->length_), 0.0f, 1.0f);
+  }
 
   uint32_t start_time_;
   uint32_t length_;

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -109,9 +109,7 @@ class LightFlashTransformer : public LightTransformer {
     this->state_.publish_state();
   }
 
-  bool is_finished() override {
-    return this->begun_lightstate_restore_ && LightTransformer::is_finished();
-  }
+  bool is_finished() override { return this->begun_lightstate_restore_ && LightTransformer::is_finished(); }
 
  protected:
   LightState &state_;

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -69,6 +69,8 @@ class LightFlashTransformer : public LightTransformer {
     if (this->transition_length_ * 2 > this->length_)
       this->transition_length_ = this->length_ / 2;
 
+    this->begun_lightstate_restore_ = false;
+
     // first transition to original target
     this->transformer_ = this->state_.get_output()->create_default_transition();
     this->transformer_->setup(this->state_.current_values, this->target_values_, this->transition_length_);
@@ -81,6 +83,7 @@ class LightFlashTransformer : public LightTransformer {
       // second transition back to start value
       this->transformer_ = this->state_.get_output()->create_default_transition();
       this->transformer_->setup(this->state_.current_values, this->get_start_values(), this->transition_length_);
+      this->begun_lightstate_restore_ = true;
     }
 
     if (this->transformer_ != nullptr) {
@@ -106,10 +109,15 @@ class LightFlashTransformer : public LightTransformer {
     this->state_.publish_state();
   }
 
+  bool is_finished() override {
+    return this->begun_lightstate_restore_ && LightTransformer::is_finished();
+  }
+
  protected:
   LightState &state_;
   uint32_t transition_length_;
   std::unique_ptr<LightTransformer> transformer_{nullptr};
+  bool begun_lightstate_restore_;
 };
 
 }  // namespace light

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "esphome/core/log.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "light_color_values.h"


### PR DESCRIPTION
# What does this implement/fix? 

When a `LightFlashTransformer` is finished, the previous state is restored in the Home Assistant UI but not written to the actual light.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2470.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
