### PR TITLE
Update clang-tidy and clang-format to version 13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,6 +51,6 @@
     "files.associations": {
       "**/.vscode/*.json": "jsonc"
     },
-    "C_Cpp.clang_format_path": "/usr/bin/clang-format-11",
+    "C_Cpp.clang_format_path": "/usr/bin/clang-format-13",
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Install clang tools
         run: |
           sudo apt-get install \
-              clang-format-11 \
-              clang-tidy-11
+              clang-format-13 \
+              clang-tidy-13
         if: matrix.id == 'clang-tidy' || matrix.id == 'clang-format'
 
       - name: Register problem matchers

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -133,10 +133,20 @@ ENV \
 
 RUN \
     apt-get update \
+    && apt-get install -y --no-install-recommends gnupg \
+    && rm -rf \
+        /tmp/* \
+        /var/{cache,log}/* \
+        /var/lib/apt/lists/*
+
+RUN \
+    curl https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add - \
+    && echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main" >> /etc/apt/sources.list \
+    && apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        clang-format-11=1:11.0.1-2 \
-        clang-tidy-11=1:11.0.1-2 \
+        clang-format-13 \
+        clang-tidy-13 \
         patch=2.7.6-7 \
         software-properties-common=0.96.20.2-2.1 \
         nano=5.4-2 \

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -63,7 +63,7 @@ void Am43Component::control(const CoverCall &call) {
 
     if (this->invert_position_)
       pos = 1 - pos;
-    auto packet = this->encoder_->get_set_position_request(100 - (uint8_t)(pos * 100));
+    auto packet = this->encoder_->get_set_position_request(100 - (uint8_t) (pos * 100));
     auto status =
         esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_, packet->length,
                                  packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -276,7 +276,7 @@ APIError APINoiseFrameHelper::state_action_() {
     if (aerr != APIError::OK)
       return aerr;
     // ignore contents, may be used in future for flags
-    prologue_.push_back((uint8_t)(frame.msg.size() >> 8));
+    prologue_.push_back((uint8_t) (frame.msg.size() >> 8));
     prologue_.push_back((uint8_t) frame.msg.size());
     prologue_.insert(prologue_.end(), frame.msg.begin(), frame.msg.end());
 
@@ -466,9 +466,9 @@ APIError APINoiseFrameHelper::write_packet(uint16_t type, const uint8_t *payload
   // tmpbuf[1], tmpbuf[2] to be set later
   const uint8_t msg_offset = 3;
   const uint8_t payload_offset = msg_offset + 4;
-  tmpbuf[msg_offset + 0] = (uint8_t)(type >> 8);  // type
+  tmpbuf[msg_offset + 0] = (uint8_t) (type >> 8);  // type
   tmpbuf[msg_offset + 1] = (uint8_t) type;
-  tmpbuf[msg_offset + 2] = (uint8_t)(payload_len >> 8);  // data_len
+  tmpbuf[msg_offset + 2] = (uint8_t) (payload_len >> 8);  // data_len
   tmpbuf[msg_offset + 3] = (uint8_t) payload_len;
   // copy data
   std::copy(payload, payload + payload_len, &tmpbuf[payload_offset]);
@@ -486,7 +486,7 @@ APIError APINoiseFrameHelper::write_packet(uint16_t type, const uint8_t *payload
   }
 
   size_t total_len = 3 + mbuf.size;
-  tmpbuf[1] = (uint8_t)(mbuf.size >> 8);
+  tmpbuf[1] = (uint8_t) (mbuf.size >> 8);
   tmpbuf[2] = (uint8_t) mbuf.size;
 
   struct iovec iov;
@@ -584,7 +584,7 @@ APIError APINoiseFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
 APIError APINoiseFrameHelper::write_frame_(const uint8_t *data, size_t len) {
   uint8_t header[3];
   header[0] = 0x01;  // indicator
-  header[1] = (uint8_t)(len >> 8);
+  header[1] = (uint8_t) (len >> 8);
   header[2] = (uint8_t) len;
 
   struct iovec iov[2];

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -57,10 +57,10 @@ bool BLEClient::parse_device(const espbt::ESPBTDevice &device) {
 
 std::string BLEClient::address_str() const {
   char buf[20];
-  sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x", (uint8_t)(this->address >> 40) & 0xff,
-          (uint8_t)(this->address >> 32) & 0xff, (uint8_t)(this->address >> 24) & 0xff,
-          (uint8_t)(this->address >> 16) & 0xff, (uint8_t)(this->address >> 8) & 0xff,
-          (uint8_t)(this->address >> 0) & 0xff);
+  sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x", (uint8_t) (this->address >> 40) & 0xff,
+          (uint8_t) (this->address >> 32) & 0xff, (uint8_t) (this->address >> 24) & 0xff,
+          (uint8_t) (this->address >> 16) & 0xff, (uint8_t) (this->address >> 8) & 0xff,
+          (uint8_t) (this->address >> 0) & 0xff);
   std::string ret;
   ret = buf;
   return ret;
@@ -217,32 +217,32 @@ float BLEClient::parse_char_value(uint8_t *value, uint16_t length) {
     case 0x5:  // uint12.
     case 0x6:  // uint16.
       if (length > 2) {
-        return (float) ((uint16_t)(value[1] << 8) + (uint16_t) value[2]);
+        return (float) ((uint16_t) (value[1] << 8) + (uint16_t) value[2]);
       }
     case 0x7:  // uint24.
       if (length > 3) {
-        return (float) ((uint32_t)(value[1] << 16) + (uint32_t)(value[2] << 8) + (uint32_t)(value[3]));
+        return (float) ((uint32_t) (value[1] << 16) + (uint32_t) (value[2] << 8) + (uint32_t) (value[3]));
       }
     case 0x8:  // uint32.
       if (length > 4) {
-        return (float) ((uint32_t)(value[1] << 24) + (uint32_t)(value[2] << 16) + (uint32_t)(value[3] << 8) +
-                        (uint32_t)(value[4]));
+        return (float) ((uint32_t) (value[1] << 24) + (uint32_t) (value[2] << 16) + (uint32_t) (value[3] << 8) +
+                        (uint32_t) (value[4]));
       }
     case 0xC:  // int8.
       return (float) ((int8_t) value[1]);
     case 0xD:  // int12.
     case 0xE:  // int16.
       if (length > 2) {
-        return (float) ((int16_t)(value[1] << 8) + (int16_t) value[2]);
+        return (float) ((int16_t) (value[1] << 8) + (int16_t) value[2]);
       }
     case 0xF:  // int24.
       if (length > 3) {
-        return (float) ((int32_t)(value[1] << 16) + (int32_t)(value[2] << 8) + (int32_t)(value[3]));
+        return (float) ((int32_t) (value[1] << 16) + (int32_t) (value[2] << 8) + (int32_t) (value[3]));
       }
     case 0x10:  // int32.
       if (length > 4) {
-        return (float) ((int32_t)(value[1] << 24) + (int32_t)(value[2] << 16) + (int32_t)(value[3] << 8) +
-                        (int32_t)(value[4]));
+        return (float) ((int32_t) (value[1] << 24) + (int32_t) (value[2] << 16) + (int32_t) (value[3] << 8) +
+                        (int32_t) (value[4]));
       }
   }
   ESP_LOGW(TAG, "Cannot parse characteristic value of type 0x%x length %d", value[0], length);

--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -269,8 +269,8 @@ uint8_t BME680Component::calc_heater_resistance_(uint16_t temperature) {
   var3 = var1 + (var2 / 2);
   var4 = (var3 / (res_heat_range + 4));
   var5 = (131 * res_heat_val) + 65536;
-  heatr_res_x100 = (int32_t)(((var4 / var5) - 250) * 34);
-  heatr_res = (uint8_t)((heatr_res_x100 + 50) / 100);
+  heatr_res_x100 = (int32_t) (((var4 / var5) - 250) * 34);
+  heatr_res = (uint8_t) ((heatr_res_x100 + 50) / 100);
 
   return heatr_res;
 }

--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -141,8 +141,8 @@ void CCS811Component::send_env_data_() {
   // https://github.com/adafruit/Adafruit_CCS811/blob/0990f5c620354d8bc087c4706bec091d8e6e5dfd/Adafruit_CCS811.cpp#L135-L142
   uint16_t hum_conv = static_cast<uint16_t>(lroundf(humidity * 512.0f + 0.5f));
   uint16_t temp_conv = static_cast<uint16_t>(lroundf(temperature * 512.0f + 0.5f));
-  this->write_bytes(0x05, {(uint8_t)((hum_conv >> 8) & 0xff), (uint8_t)((hum_conv & 0xff)),
-                           (uint8_t)((temp_conv >> 8) & 0xff), (uint8_t)((temp_conv & 0xff))});
+  this->write_bytes(0x05, {(uint8_t) ((hum_conv >> 8) & 0xff), (uint8_t) ((hum_conv & 0xff)),
+                           (uint8_t) ((temp_conv >> 8) & 0xff), (uint8_t) ((temp_conv & 0xff))});
 }
 void CCS811Component::dump_config() {
   ESP_LOGCONFIG(TAG, "CCS811");

--- a/esphome/components/cs5460a/cs5460a.cpp
+++ b/esphome/components/cs5460a/cs5460a.cpp
@@ -307,7 +307,7 @@ bool CS5460AComponent::check_status_() {
       voltage_sensor_->publish_state(raw_voltage * voltage_multiplier_);
 
     if (power_sensor_ != nullptr && raw_energy != prev_raw_energy_) {
-      int32_t raw = (int32_t)(raw_energy << 8) >> 8; /* Sign-extend */
+      int32_t raw = (int32_t) (raw_energy << 8) >> 8; /* Sign-extend */
       power_sensor_->publish_state(raw * power_multiplier_);
       prev_raw_energy_ = raw_energy;
     }

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -59,8 +59,8 @@ void DalyBmsComponent::request_data(uint8_t data_id) {
   request_message[9] = 0x00;     //     |
   request_message[10] = 0x00;    //     |
   request_message[11] = 0x00;    // Empty Data
-  request_message[12] = (uint8_t)(request_message[0] + request_message[1] + request_message[2] +
-                                  request_message[3]);  // Checksum (Lower byte of the other bytes sum)
+  request_message[12] = (uint8_t) (request_message[0] + request_message[1] + request_message[2] +
+                                   request_message[3]);  // Checksum (Lower byte of the other bytes sum)
 
   this->write_array(request_message, sizeof(request_message));
   this->flush();

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -19,7 +19,7 @@ void DFPlayer::play_folder(uint16_t folder, uint16_t file) {
 }
 
 void DFPlayer::send_cmd_(uint8_t cmd, uint16_t argument) {
-  uint8_t buffer[10]{0x7e, 0xff, 0x06, cmd, 0x01, (uint8_t)(argument >> 8), (uint8_t) argument, 0x00, 0x00, 0xef};
+  uint8_t buffer[10]{0x7e, 0xff, 0x06, cmd, 0x01, (uint8_t) (argument >> 8), (uint8_t) argument, 0x00, 0x00, 0xef};
   uint16_t checksum = 0;
   for (uint8_t i = 1; i < 7; i++)
     checksum += buffer[i];

--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -18,7 +18,7 @@ void loop();
 namespace esphome {
 
 void IRAM_ATTR HOT yield() { vPortYield(); }
-uint32_t IRAM_ATTR HOT millis() { return (uint32_t)(esp_timer_get_time() / 1000ULL); }
+uint32_t IRAM_ATTR HOT millis() { return (uint32_t) (esp_timer_get_time() / 1000ULL); }
 void IRAM_ATTR HOT delay(uint32_t ms) { vTaskDelay(ms / portTICK_PERIOD_MS); }
 uint32_t IRAM_ATTR HOT micros() { return (uint32_t) esp_timer_get_time(); }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) {

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -148,39 +148,39 @@ bool BLECharacteristic::is_failed() {
 
 void BLECharacteristic::set_broadcast_property(bool value) {
   if (value)
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ | ESP_GATT_CHAR_PROP_BIT_BROADCAST);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_BROADCAST);
   else
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_BROADCAST);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_BROADCAST);
 }
 void BLECharacteristic::set_indicate_property(bool value) {
   if (value)
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ | ESP_GATT_CHAR_PROP_BIT_INDICATE);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_INDICATE);
   else
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_INDICATE);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_INDICATE);
 }
 void BLECharacteristic::set_notify_property(bool value) {
   if (value)
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ | ESP_GATT_CHAR_PROP_BIT_NOTIFY);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_NOTIFY);
   else
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_NOTIFY);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_NOTIFY);
 }
 void BLECharacteristic::set_read_property(bool value) {
   if (value)
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ | ESP_GATT_CHAR_PROP_BIT_READ);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_READ);
   else
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_READ);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_READ);
 }
 void BLECharacteristic::set_write_property(bool value) {
   if (value)
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ | ESP_GATT_CHAR_PROP_BIT_WRITE);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_WRITE);
   else
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_WRITE);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_WRITE);
 }
 void BLECharacteristic::set_write_no_response_property(bool value) {
   if (value)
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ | ESP_GATT_CHAR_PROP_BIT_WRITE_NR);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_WRITE_NR);
   else
-    this->properties_ = (esp_gatt_char_prop_t)(this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_WRITE_NR);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_WRITE_NR);
 }
 
 void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -88,7 +88,7 @@ void IRAM_ATTR ISRInternalGPIOPin::digital_write(bool value) {
 }
 void IRAM_ATTR ISRInternalGPIOPin::clear_interrupt() {
   auto *arg = reinterpret_cast<ISRPinArg *>(arg_);
-  GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1UL << arg->pin);
+  GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1UL << arg->pin);  // NOLINT(performance-no-int-to-ptr)
 }
 
 }  // namespace esphome

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -95,7 +95,7 @@ void FingerprintGrowComponent::scan_and_match_() {
   }
   if (this->scan_image_(1) == OK) {
     this->waiting_removal_ = true;
-    this->data_ = {SEARCH, 0x01, 0x00, 0x00, (uint8_t)(this->capacity_ >> 8), (uint8_t)(this->capacity_ & 0xFF)};
+    this->data_ = {SEARCH, 0x01, 0x00, 0x00, (uint8_t) (this->capacity_ >> 8), (uint8_t) (this->capacity_ & 0xFF)};
     switch (this->send_command_()) {
       case OK: {
         ESP_LOGD(TAG, "Fingerprint matched");
@@ -171,7 +171,7 @@ uint8_t FingerprintGrowComponent::save_fingerprint_() {
   }
 
   ESP_LOGI(TAG, "Storing model");
-  this->data_ = {STORE, 0x01, (uint8_t)(this->enrollment_slot_ >> 8), (uint8_t)(this->enrollment_slot_ & 0xFF)};
+  this->data_ = {STORE, 0x01, (uint8_t) (this->enrollment_slot_ >> 8), (uint8_t) (this->enrollment_slot_ & 0xFF)};
   switch (this->send_command_()) {
     case OK:
       ESP_LOGI(TAG, "Stored model");
@@ -188,8 +188,8 @@ uint8_t FingerprintGrowComponent::save_fingerprint_() {
 
 bool FingerprintGrowComponent::check_password_() {
   ESP_LOGD(TAG, "Checking password");
-  this->data_ = {VERIFY_PASSWORD, (uint8_t)(this->password_ >> 24), (uint8_t)(this->password_ >> 16),
-                 (uint8_t)(this->password_ >> 8), (uint8_t)(this->password_ & 0xFF)};
+  this->data_ = {VERIFY_PASSWORD, (uint8_t) (this->password_ >> 24), (uint8_t) (this->password_ >> 16),
+                 (uint8_t) (this->password_ >> 8), (uint8_t) (this->password_ & 0xFF)};
   switch (this->send_command_()) {
     case OK:
       ESP_LOGD(TAG, "Password verified");
@@ -203,8 +203,8 @@ bool FingerprintGrowComponent::check_password_() {
 
 bool FingerprintGrowComponent::set_password_() {
   ESP_LOGI(TAG, "Setting new password: %d", *this->new_password_);
-  this->data_ = {SET_PASSWORD, (uint8_t)(*this->new_password_ >> 24), (uint8_t)(*this->new_password_ >> 16),
-                 (uint8_t)(*this->new_password_ >> 8), (uint8_t)(*this->new_password_ & 0xFF)};
+  this->data_ = {SET_PASSWORD, (uint8_t) (*this->new_password_ >> 24), (uint8_t) (*this->new_password_ >> 16),
+                 (uint8_t) (*this->new_password_ >> 8), (uint8_t) (*this->new_password_ & 0xFF)};
   if (this->send_command_() == OK) {
     ESP_LOGI(TAG, "New password successfully set");
     ESP_LOGI(TAG, "Define the new password in your configuration and reflash now");
@@ -250,7 +250,7 @@ void FingerprintGrowComponent::get_fingerprint_count_() {
 
 void FingerprintGrowComponent::delete_fingerprint(uint16_t finger_id) {
   ESP_LOGI(TAG, "Deleting fingerprint in slot %d", finger_id);
-  this->data_ = {DELETE, (uint8_t)(finger_id >> 8), (uint8_t)(finger_id & 0xFF), 0x00, 0x01};
+  this->data_ = {DELETE, (uint8_t) (finger_id >> 8), (uint8_t) (finger_id & 0xFF), 0x00, 0x01};
   switch (this->send_command_()) {
     case OK:
       ESP_LOGI(TAG, "Deleted fingerprint");
@@ -319,8 +319,8 @@ void FingerprintGrowComponent::aura_led_control(uint8_t state, uint8_t speed, ui
 }
 
 uint8_t FingerprintGrowComponent::send_command_() {
-  this->write((uint8_t)(START_CODE >> 8));
-  this->write((uint8_t)(START_CODE & 0xFF));
+  this->write((uint8_t) (START_CODE >> 8));
+  this->write((uint8_t) (START_CODE & 0xFF));
   this->write(this->address_[0]);
   this->write(this->address_[1]);
   this->write(this->address_[2]);
@@ -328,8 +328,8 @@ uint8_t FingerprintGrowComponent::send_command_() {
   this->write(COMMAND);
 
   uint16_t wire_length = this->data_.size() + 2;
-  this->write((uint8_t)(wire_length >> 8));
-  this->write((uint8_t)(wire_length & 0xFF));
+  this->write((uint8_t) (wire_length >> 8));
+  this->write((uint8_t) (wire_length & 0xFF));
 
   uint16_t sum = ((wire_length) >> 8) + ((wire_length) &0xFF) + COMMAND;
   for (auto data : this->data_) {
@@ -337,8 +337,8 @@ uint8_t FingerprintGrowComponent::send_command_() {
     sum += data;
   }
 
-  this->write((uint8_t)(sum >> 8));
-  this->write((uint8_t)(sum & 0xFF));
+  this->write((uint8_t) (sum >> 8));
+  this->write((uint8_t) (sum & 0xFF));
 
   this->data_.clear();
 
@@ -353,11 +353,11 @@ uint8_t FingerprintGrowComponent::send_command_() {
     byte = this->read();
     switch (idx) {
       case 0:
-        if (byte != (uint8_t)(START_CODE >> 8))
+        if (byte != (uint8_t) (START_CODE >> 8))
           continue;
         break;
       case 1:
-        if (byte != (uint8_t)(START_CODE & 0xFF)) {
+        if (byte != (uint8_t) (START_CODE & 0xFF)) {
           idx = 0;
           continue;
         }

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -85,10 +85,10 @@ class FingerprintGrowComponent : public PollingComponent, public uart::UARTDevic
   void dump_config() override;
 
   void set_address(uint32_t address) {
-    this->address_[0] = (uint8_t)(address >> 24);
-    this->address_[1] = (uint8_t)(address >> 16);
-    this->address_[2] = (uint8_t)(address >> 8);
-    this->address_[3] = (uint8_t)(address & 0xFF);
+    this->address_[0] = (uint8_t) (address >> 24);
+    this->address_[1] = (uint8_t) (address >> 16);
+    this->address_[2] = (uint8_t) (address >> 8);
+    this->address_[3] = (uint8_t) (address & 0xFF);
   }
   void set_sensing_pin(GPIOPin *sensing_pin) { this->sensing_pin_ = sensing_pin; }
   void set_password(uint32_t password) { this->password_ = password; }

--- a/esphome/components/hitachi_ac344/hitachi_ac344.cpp
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.cpp
@@ -12,7 +12,7 @@ void set_bits(uint8_t *const dst, const uint8_t offset, const uint8_t nbits, con
   uint8_t mask = UINT8_MAX >> (8 - ((nbits > 8) ? 8 : nbits));
   // Calculate the mask & clear the space for the data.
   // Clear the destination bits.
-  *dst &= ~(uint8_t)(mask << offset);
+  *dst &= ~(uint8_t) (mask << offset);
   // Merge in the data.
   *dst |= ((data & mask) << offset);
 }

--- a/esphome/components/hitachi_ac424/hitachi_ac424.cpp
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.cpp
@@ -12,7 +12,7 @@ void set_bits(uint8_t *const dst, const uint8_t offset, const uint8_t nbits, con
   uint8_t mask = UINT8_MAX >> (8 - ((nbits > 8) ? 8 : nbits));
   // Calculate the mask & clear the space for the data.
   // Clear the destination bits.
-  *dst &= ~(uint8_t)(mask << offset);
+  *dst &= ~(uint8_t) (mask << offset);
   // Merge in the data.
   *dst |= ((data & mask) << offset);
 }

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -149,7 +149,7 @@ void ILI9341Display::fill_internal_(Color color) {
     auto color565 = display::ColorUtil::color_to_565(color);
 
     while (dst < transfer_buffer_ + sizeof(transfer_buffer_)) {
-      *dst++ = (uint8_t)(color565 >> 8);
+      *dst++ = (uint8_t) (color565 >> 8);
       *dst++ = (uint8_t) color565;
     }
   }
@@ -248,7 +248,7 @@ uint32_t ILI9341Display::buffer_to_transfer_(uint32_t pos, uint32_t sz) {
 
   for (uint32_t i = 0; i < sz; ++i) {
     uint16_t color = convert_to_16bit_color_(*src++);
-    *dst++ = (uint8_t)(color >> 8);
+    *dst++ = (uint8_t) (color >> 8);
     *dst++ = (uint8_t) color;
   }
 

--- a/esphome/components/light/color_mode.h
+++ b/esphome/components/light/color_mode.h
@@ -52,25 +52,26 @@ enum class ColorMode : uint8_t {
   /// Only on/off control.
   ON_OFF = (uint8_t) ColorCapability::ON_OFF,
   /// Dimmable light.
-  BRIGHTNESS = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS),
+  BRIGHTNESS = (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS),
   /// White output only (use only if the light also has another color mode such as RGB).
-  WHITE = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::WHITE),
+  WHITE = (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::WHITE),
   /// Controllable color temperature output.
   COLOR_TEMPERATURE =
-      (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::COLOR_TEMPERATURE),
+      (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::COLOR_TEMPERATURE),
   /// Cold and warm white output with individually controllable brightness.
-  COLD_WARM_WHITE = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::COLD_WARM_WHITE),
+  COLD_WARM_WHITE =
+      (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::COLD_WARM_WHITE),
   /// RGB color output.
-  RGB = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB),
+  RGB = (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB),
   /// RGB color output and a separate white output.
   RGB_WHITE =
-      (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB | ColorCapability::WHITE),
+      (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB | ColorCapability::WHITE),
   /// RGB color output and a separate white output with controllable color temperature.
-  RGB_COLOR_TEMPERATURE = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB |
-                                    ColorCapability::WHITE | ColorCapability::COLOR_TEMPERATURE),
+  RGB_COLOR_TEMPERATURE = (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB |
+                                     ColorCapability::WHITE | ColorCapability::COLOR_TEMPERATURE),
   /// RGB color output, and separate cold and warm white outputs.
-  RGB_COLD_WARM_WHITE = (uint8_t)(ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB |
-                                  ColorCapability::COLD_WARM_WHITE),
+  RGB_COLD_WARM_WHITE = (uint8_t) (ColorCapability::ON_OFF | ColorCapability::BRIGHTNESS | ColorCapability::RGB |
+                                   ColorCapability::COLD_WARM_WHITE),
 };
 
 /// Helper class to allow bitwise operations on ColorMode with ColorCapability

--- a/esphome/components/mcp2515/mcp2515.cpp
+++ b/esphome/components/mcp2515/mcp2515.cpp
@@ -151,19 +151,19 @@ canbus::Error MCP2515::set_clk_out_(const CanClkOut divisor) {
 }
 
 void MCP2515::prepare_id_(uint8_t *buffer, const bool extended, const uint32_t id) {
-  uint16_t canid = (uint16_t)(id & 0x0FFFF);
+  uint16_t canid = (uint16_t) (id & 0x0FFFF);
 
   if (extended) {
-    buffer[MCP_EID0] = (uint8_t)(canid & 0xFF);
-    buffer[MCP_EID8] = (uint8_t)(canid >> 8);
-    canid = (uint16_t)(id >> 16);
-    buffer[MCP_SIDL] = (uint8_t)(canid & 0x03);
-    buffer[MCP_SIDL] += (uint8_t)((canid & 0x1C) << 3);
+    buffer[MCP_EID0] = (uint8_t) (canid & 0xFF);
+    buffer[MCP_EID8] = (uint8_t) (canid >> 8);
+    canid = (uint16_t) (id >> 16);
+    buffer[MCP_SIDL] = (uint8_t) (canid & 0x03);
+    buffer[MCP_SIDL] += (uint8_t) ((canid & 0x1C) << 3);
     buffer[MCP_SIDL] |= TXB_EXIDE_MASK;
-    buffer[MCP_SIDH] = (uint8_t)(canid >> 5);
+    buffer[MCP_SIDH] = (uint8_t) (canid >> 5);
   } else {
-    buffer[MCP_SIDH] = (uint8_t)(canid >> 3);
-    buffer[MCP_SIDL] = (uint8_t)((canid & 0x07) << 5);
+    buffer[MCP_SIDH] = (uint8_t) (canid >> 3);
+    buffer[MCP_SIDL] = (uint8_t) ((canid & 0x07) << 5);
     buffer[MCP_EID0] = 0;
     buffer[MCP_EID8] = 0;
   }

--- a/esphome/components/mcp9808/mcp9808.cpp
+++ b/esphome/components/mcp9808/mcp9808.cpp
@@ -54,16 +54,16 @@ void MCP9808Sensor::update() {
   }
 
   float temp = NAN;
-  uint8_t msb = (uint8_t)((raw_temp & 0xff00) >> 8);
+  uint8_t msb = (uint8_t) ((raw_temp & 0xff00) >> 8);
   uint8_t lsb = raw_temp & 0x00ff;
 
   msb = msb & MCP9808_AMBIENT_CLEAR_FLAGS;
 
   if ((msb & MCP9808_AMBIENT_TEMP_NEGATIVE) == MCP9808_AMBIENT_TEMP_NEGATIVE) {
     msb = msb & MCP9808_AMBIENT_CLEAR_SIGN;
-    temp = (256 - ((uint16_t)(msb) *16 + lsb / 16.0f)) * -1;
+    temp = (256 - ((uint16_t) (msb) *16 + lsb / 16.0f)) * -1;
   } else {
-    temp = (uint16_t)(msb) *16 + lsb / 16.0f;
+    temp = (uint16_t) (msb) *16 + lsb / 16.0f;
   }
 
   if (std::isnan(temp)) {

--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -12,10 +12,10 @@ struct IPAddress {
   IPAddress() : addr_({0, 0, 0, 0}) {}
   IPAddress(uint8_t first, uint8_t second, uint8_t third, uint8_t fourth) : addr_({first, second, third, fourth}) {}
   IPAddress(uint32_t raw) {
-    addr_[0] = (uint8_t)(raw >> 0);
-    addr_[1] = (uint8_t)(raw >> 8);
-    addr_[2] = (uint8_t)(raw >> 16);
-    addr_[3] = (uint8_t)(raw >> 24);
+    addr_[0] = (uint8_t) (raw >> 0);
+    addr_[1] = (uint8_t) (raw >> 8);
+    addr_[2] = (uint8_t) (raw >> 16);
+    addr_[3] = (uint8_t) (raw >> 24);
   }
   operator uint32_t() const {
     uint32_t res = 0;

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -772,15 +772,15 @@ uint8_t Pipsolar::check_incoming_crc_() {
   uint16_t crc16;
   crc16 = calc_crc_(read_buffer_, read_pos_ - 3);
   ESP_LOGD(TAG, "checking crc on incoming message");
-  if (((uint8_t)((crc16) >> 8)) == read_buffer_[read_pos_ - 3] &&
-      ((uint8_t)((crc16) &0xff)) == read_buffer_[read_pos_ - 2]) {
+  if (((uint8_t) ((crc16) >> 8)) == read_buffer_[read_pos_ - 3] &&
+      ((uint8_t) ((crc16) &0xff)) == read_buffer_[read_pos_ - 2]) {
     ESP_LOGD(TAG, "CRC OK");
     read_buffer_[read_pos_ - 1] = 0;
     read_buffer_[read_pos_ - 2] = 0;
     read_buffer_[read_pos_ - 3] = 0;
     return 1;
   }
-  ESP_LOGD(TAG, "CRC NOK expected: %X %X but got: %X %X", ((uint8_t)((crc16) >> 8)), ((uint8_t)((crc16) &0xff)),
+  ESP_LOGD(TAG, "CRC NOK expected: %X %X but got: %X %X", ((uint8_t) ((crc16) >> 8)), ((uint8_t) ((crc16) &0xff)),
            read_buffer_[read_pos_ - 3], read_buffer_[read_pos_ - 2]);
   return 0;
 }
@@ -802,8 +802,8 @@ uint8_t Pipsolar::send_next_command_() {
     crc16 = calc_crc_(byte_command, length);
     this->write_str(command);
     // checksum
-    this->write(((uint8_t)((crc16) >> 8)));   // highbyte
-    this->write(((uint8_t)((crc16) &0xff)));  // lowbyte
+    this->write(((uint8_t) ((crc16) >> 8)));   // highbyte
+    this->write(((uint8_t) ((crc16) &0xff)));  // lowbyte
     // end Byte
     this->write(0x0D);
     ESP_LOGD(TAG, "Sending command from queue: %s with length %d", command, length);
@@ -831,8 +831,8 @@ void Pipsolar::send_next_poll_() {
   this->write_array(this->used_polling_commands_[this->last_polling_command_].command,
                     this->used_polling_commands_[this->last_polling_command_].length);
   // checksum
-  this->write(((uint8_t)((crc16) >> 8)));   // highbyte
-  this->write(((uint8_t)((crc16) &0xff)));  // lowbyte
+  this->write(((uint8_t) ((crc16) >> 8)));   // highbyte
+  this->write(((uint8_t) ((crc16) &0xff)));  // lowbyte
   // end Byte
   this->write(0x0D);
   ESP_LOGD(TAG, "Sending polling command : %s with length %d",
@@ -884,7 +884,7 @@ void Pipsolar::add_polling_command_(const char *command, ENUMPollingCommand poll
       used_polling_command.command = new uint8_t[length];  // NOLINT(cppcoreguidelines-owning-memory)
       size_t i = 0;
       for (; beg != end; ++beg, ++i) {
-        used_polling_command.command[i] = (uint8_t)(*beg);
+        used_polling_command.command[i] = (uint8_t) (*beg);
       }
       used_polling_command.errors = 0;
       used_polling_command.identifier = polling_command;

--- a/esphome/components/remote_base/rc5_protocol.cpp
+++ b/esphome/components/remote_base/rc5_protocol.cpp
@@ -78,7 +78,7 @@ optional<RC5Data> RC5Protocol::decode(RemoteReceiveData src) {
     out_data |= 1;
   }
 
-  out.command = (uint8_t)(out_data & 0x3F) + (1 - field_bit) * 64u;
+  out.command = (uint8_t) (out_data & 0x3F) + (1 - field_bit) * 64u;
   out.address = (out_data >> 6) & 0x1F;
   return out;
 }

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -49,7 +49,7 @@ void SCD30Component::setup() {
            uint16_t(raw_firmware_version[0] & 0xFF));
 
   if (this->temperature_offset_ != 0) {
-    if (!this->write_command_(SCD30_CMD_TEMPERATURE_OFFSET, (uint16_t)(temperature_offset_ * 100.0))) {
+    if (!this->write_command_(SCD30_CMD_TEMPERATURE_OFFSET, (uint16_t) (temperature_offset_ * 100.0))) {
       ESP_LOGE(TAG, "Sensor SCD30 error setting temperature offset.");
       this->error_code_ = MEASUREMENT_INIT_FAILED;
       this->mark_failed();

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -16,7 +16,7 @@ class SCD30Component : public PollingComponent, public i2c::I2CDevice {
   void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
   void set_altitude_compensation(uint16_t altitude) { altitude_compensation_ = altitude; }
   void set_ambient_pressure_compensation(float pressure) {
-    ambient_pressure_compensation_ = (uint16_t)(pressure * 1000);
+    ambient_pressure_compensation_ = (uint16_t) (pressure * 1000);
   }
   void set_temperature_offset(float offset) { temperature_offset_ = offset; }
 

--- a/esphome/components/sgp40/sensirion_voc_algorithm.h
+++ b/esphome/components/sgp40/sensirion_voc_algorithm.h
@@ -11,7 +11,7 @@ namespace sgp40 {
 
 using fix16_t = int32_t;
 
-#define F16(x) ((fix16_t)(((x) >= 0) ? ((x) *65536.0 + 0.5) : ((x) *65536.0 - 0.5)))
+#define F16(x) ((fix16_t) (((x) >= 0) ? ((x) *65536.0 + 0.5) : ((x) *65536.0 - 0.5)))
 
 static const float VOC_ALGORITHM_SAMPLING_INTERVAL(1.);
 static const float VOC_ALGORITHM_INITIAL_BLACKOUT(45.);

--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -183,11 +183,11 @@ uint16_t SGP40Component::measure_raw_() {
   command[0] = 0x26;
   command[1] = 0x0F;
 
-  uint16_t rhticks = llround((uint16_t)((humidity * 65535) / 100));
+  uint16_t rhticks = llround((uint16_t) ((humidity * 65535) / 100));
   command[2] = rhticks >> 8;
   command[3] = rhticks & 0xFF;
   command[4] = generate_crc_(command + 2, 2);
-  uint16_t tempticks = (uint16_t)(((temperature + 45) * 65535) / 175);
+  uint16_t tempticks = (uint16_t) (((temperature + 45) * 65535) / 175);
   command[5] = tempticks >> 8;
   command[6] = tempticks & 0xFF;
   command[7] = generate_crc_(command + 5, 2);

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -19,7 +19,7 @@ void SHT4XComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up sht4x...");
 
   if (this->duty_cycle_ > 0.0) {
-    uint32_t heater_interval = (uint32_t)(this->heater_time_ / this->duty_cycle_);
+    uint32_t heater_interval = (uint32_t) (this->heater_time_ / this->duty_cycle_);
     ESP_LOGD(TAG, "Heater interval: %i", heater_interval);
 
     if (this->heater_power_ == SHT4X_HEATERPOWER_HIGH) {

--- a/esphome/components/sn74hc595/sn74hc595.cpp
+++ b/esphome/components/sn74hc595/sn74hc595.cpp
@@ -40,7 +40,7 @@ void SN74HC595Component::digital_write_(uint8_t pin, bool value) {
 
 bool SN74HC595Component::write_gpio_() {
   for (int i = this->sr_count_ - 1; i >= 0; i--) {
-    uint8_t data = (uint8_t)(this->output_bits_ >> (8 * i) & 0xff);
+    uint8_t data = (uint8_t) (this->output_bits_ >> (8 * i) & 0xff);
     for (int j = 0; j < 8; j++) {
       this->data_pin_->digital_write(data & (1 << (7 - j)));
       this->clock_pin_->digital_write(true);

--- a/esphome/components/sun/sun.cpp
+++ b/esphome/components/sun/sun.cpp
@@ -271,7 +271,7 @@ struct SunAtLocation {
     num_t jd = julian_day(date) + added_d;
 
     num_t eot = SunAtTime(jd).equation_of_time() * 240;
-    time_t new_timestamp = (time_t)(date.timestamp + added_d * 86400 - eot);
+    time_t new_timestamp = (time_t) (date.timestamp + added_d * 86400 - eot);
     return time::ESPTime::from_epoch_utc(new_timestamp);
   }
 };

--- a/esphome/components/sun/sun.cpp
+++ b/esphome/components/sun/sun.cpp
@@ -1,5 +1,7 @@
 #include "sun.h"
+
 #include "esphome/core/log.h"
+#include <cstddef>
 
 /*
 The formulas/algorithms in this module are based on the book
@@ -301,7 +303,7 @@ optional<time::ESPTime> Sun::calc_event_(bool rising, double zenith) {
   if (it.has_value() && it->timestamp < now.timestamp) {
     // We're calculating *next* sunrise/sunset, but calculated event
     // is today, so try again tomorrow
-    time_t new_timestamp = today.timestamp + 24 * 60 * 60;
+    time_t new_timestamp = today.timestamp + 24ULL * 60 * 60;
     today = time::ESPTime::from_epoch_utc(new_timestamp);
     it = sun.event(rising, today, zenith);
   }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -323,8 +323,8 @@ void Tuya::handle_datapoint_(const uint8_t *buffer, size_t len) {
 }
 
 void Tuya::send_raw_command_(TuyaCommand command) {
-  uint8_t len_hi = (uint8_t)(command.payload.size() >> 8);
-  uint8_t len_lo = (uint8_t)(command.payload.size() & 0xFF);
+  uint8_t len_hi = (uint8_t) (command.payload.size() >> 8);
+  uint8_t len_lo = (uint8_t) (command.payload.size() & 0xFF);
   uint8_t version = 0;
 
   this->last_command_timestamp_ = millis();

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -88,7 +88,7 @@ void VL53L0XSensor::setup() {
 
   this->timeout_start_us_ = micros();
   while (reg(0x83).get() == 0x00) {
-    if (this->timeout_us_ > 0 && ((uint16_t)(micros() - this->timeout_start_us_) > this->timeout_us_)) {
+    if (this->timeout_us_ > 0 && ((uint16_t) (micros() - this->timeout_start_us_) > this->timeout_us_)) {
       ESP_LOGE(TAG, "'%s' - setup timeout", this->name_.c_str());
       this->mark_failed();
       return;

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -78,7 +78,7 @@ void WhirlpoolClimate::transmit_state() {
 
   // Temperature
   auto temp = (uint8_t) roundf(clamp(this->target_temperature, this->temperature_min_(), this->temperature_max_()));
-  remote_state[3] |= (uint8_t)(temp - this->temperature_min_()) << 4;
+  remote_state[3] |= (uint8_t) (temp - this->temperature_min_()) << 4;
 
   // Fan speed
   switch (this->fan_mode.value()) {

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -224,12 +224,12 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   }
 
   uint8_t mac_reverse[6] = {0};
-  mac_reverse[5] = (uint8_t)(address >> 40);
-  mac_reverse[4] = (uint8_t)(address >> 32);
-  mac_reverse[3] = (uint8_t)(address >> 24);
-  mac_reverse[2] = (uint8_t)(address >> 16);
-  mac_reverse[1] = (uint8_t)(address >> 8);
-  mac_reverse[0] = (uint8_t)(address >> 0);
+  mac_reverse[5] = (uint8_t) (address >> 40);
+  mac_reverse[4] = (uint8_t) (address >> 32);
+  mac_reverse[3] = (uint8_t) (address >> 24);
+  mac_reverse[2] = (uint8_t) (address >> 16);
+  mac_reverse[1] = (uint8_t) (address >> 8);
+  mac_reverse[0] = (uint8_t) (address >> 0);
 
   XiaomiAESVector vector{.key = {0},
                          .plaintext = {0},

--- a/esphome/components/xpt2046/xpt2046.cpp
+++ b/esphome/components/xpt2046/xpt2046.cpp
@@ -92,8 +92,8 @@ void XPT2046Component::update() {
       y_val = 0x7fff - y_val;
     }
 
-    x_val = (int16_t)((int) x_val * this->x_dim_ / 0x7fff);
-    y_val = (int16_t)((int) y_val * this->y_dim_ / 0x7fff);
+    x_val = (int16_t) ((int) x_val * this->x_dim_ / 0x7fff);
+    y_val = (int16_t) ((int) y_val * this->y_dim_ / 0x7fff);
 
     if (!this->touched || (now - this->last_pos_ms_) >= this->report_millis_) {
       ESP_LOGD(TAG, "Raw [x, y] = [%d, %d], transformed = [%d, %d]", this->x_raw, this->y_raw, x_val, y_val);
@@ -177,7 +177,7 @@ int16_t XPT2046Component::normalize(int16_t val, int16_t min_val, int16_t max_va
   } else if (val >= max_val) {
     ret = 0x7fff;
   } else {
-    ret = (int16_t)((int) 0x7fff * (val - min_val) / (max_val - min_val));
+    ret = (int16_t) ((int) 0x7fff * (val - min_val) / (max_val - min_val));
   }
 
   return ret;

--- a/esphome/core/log.h
+++ b/esphome/core/log.h
@@ -177,7 +177,7 @@ struct LogString;
 #include <pgmspace.h>
 
 #if ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 0)
-#define LOG_STR_ARG(s) ((PGM_P)(s))
+#define LOG_STR_ARG(s) ((PGM_P) (s))
 #else
 // Pre-Arduino 2.5, we can't pass a PSTR() to printf(). Emulate support by copying the message to a
 // local buffer first. String length is limited to 63 characters.
@@ -186,7 +186,7 @@ struct LogString;
   ({ \
     char __buf[64]; \
     __buf[63] = '\0'; \
-    strncpy_P(__buf, (PGM_P)(s), 63); \
+    strncpy_P(__buf, (PGM_P) (s), 63); \
     __buf; \
   })
 #endif

--- a/script/clang-format
+++ b/script/clang-format
@@ -19,7 +19,7 @@ def run_format(args, queue, lock, failed_files):
     """Takes filenames out of queue and runs clang-format on them."""
     while True:
         path = queue.get()
-        invocation = ['clang-format-11']
+        invocation = ['clang-format-13']
         if args.inplace:
             invocation.append('-i')
         else:
@@ -56,13 +56,13 @@ def main():
     args = parser.parse_args()
 
     try:
-        get_output('clang-format-11', '-version')
+        get_output('clang-format-13', '-version')
     except:
         print("""
         Oops. It looks like clang-format is not installed. 
         
-        Please check you can run "clang-format-11 -version" in your terminal and install
-        clang-format (v11) if necessary.
+        Please check you can run "clang-format-13 -version" in your terminal and install
+        clang-format (v13) if necessary.
         
         Note you can also upload your code as a pull request on GitHub and see the CI check
         output to apply clang-format.

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -75,7 +75,7 @@ def clang_options(idedata):
 def run_tidy(args, options, tmpdir, queue, lock, failed_files):
     while True:
         path = queue.get()
-        invocation = ['clang-tidy-11']
+        invocation = ['clang-tidy-13']
 
         if tmpdir is not None:
             invocation.append('--export-fixes')
@@ -140,13 +140,13 @@ def main():
     args = parser.parse_args()
 
     try:
-        get_output('clang-tidy-11', '-version')
+        get_output('clang-tidy-13', '-version')
     except:
         print("""
-        Oops. It looks like clang-tidy-11 is not installed.
+        Oops. It looks like clang-tidy-13 is not installed.
 
-        Please check you can run "clang-tidy-11 -version" in your terminal and install
-        clang-tidy (v11) if necessary.
+        Please check you can run "clang-tidy-13 -version" in your terminal and install
+        clang-tidy (v13) if necessary.
 
         Note you can also upload your code as a pull request on GitHub and see the CI check
         output to apply clang-tidy.
@@ -213,7 +213,7 @@ def main():
     if args.fix and failed_files:
         print('Applying fixes ...')
         try:
-            subprocess.call(['clang-apply-replacements-11', tmpdir])
+            subprocess.call(['clang-apply-replacements-13', tmpdir])
         except:
             print('Error applying fixes.\n', file=sys.stderr)
             raise


### PR DESCRIPTION
# What does this implement/fix? 

This updates clang to the latest released version. The packages are used from the official llvm apt repository. Unfortunately it is not possible to pin the package versions. Only the newest package versions per released clang version are available.

The code changes do not change any logic. They are required because of the different behaviour of clang-tidy and clang-format between version 11 and 13. Only style fixes are applied here from clang-format-13 and clang-tidy-13.
Most of the changes are due to clang-format, since the current code in dev did not follow `SpaceAfterCStyleCast: true`. See separate commits that fix the individual issues.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
