### PR TITLE
Fix clang-tidy header filter

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -135,10 +135,14 @@ CheckOptions:
     value:           'UPPER_CASE'
   - key:             readability-identifier-naming.ParameterCase
     value:           'lower_case'
-  - key:             readability-identifier-naming.PrivateMemberPrefix
-    value:           'NO_PRIVATE_MEMBERS_ALWAYS_USE_PROTECTED'
-  - key:             readability-identifier-naming.PrivateMethodPrefix
-    value:           'NO_PRIVATE_METHODS_ALWAYS_USE_PROTECTED'
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMethodSuffix
+    value:           '_'
   - key:             readability-identifier-naming.ClassMemberCase
     value:           'lower_case'
   - key:             readability-identifier-naming.ClassMemberCase

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -31,7 +31,7 @@ void AirthingsWavePlus::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
         break;
       }
       this->handle_ = chr->handle;
-      this->node_state = esp32_ble_tracker::ClientState::Established;
+      this->node_state = esp32_ble_tracker::ClientState::ESTABLISHED;
 
       request_read_values_();
       break;
@@ -99,7 +99,7 @@ bool AirthingsWavePlus::is_valid_co2_value_(uint16_t co2) { return 0 <= co2 && c
 void AirthingsWavePlus::loop() {}
 
 void AirthingsWavePlus::update() {
-  if (this->node_state != esp32_ble_tracker::ClientState::Established) {
+  if (this->node_state != esp32_ble_tracker::ClientState::ESTABLISHED) {
     if (!parent()->enabled) {
       ESP_LOGW(TAG, "Reconnecting to device");
       parent()->set_enabled(true);

--- a/esphome/components/am43/am43.cpp
+++ b/esphome/components/am43/am43.cpp
@@ -31,7 +31,7 @@ void Am43::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_i
     }
     case ESP_GATTC_DISCONNECT_EVT: {
       this->logged_in_ = false;
-      this->node_state = espbt::ClientState::Idle;
+      this->node_state = espbt::ClientState::IDLE;
       if (this->battery_ != nullptr)
         this->battery_->publish_state(NAN);
       if (this->illuminance_ != nullptr)
@@ -54,7 +54,7 @@ void Am43::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_i
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->node_state = espbt::ClientState::Established;
+      this->node_state = espbt::ClientState::ESTABLISHED;
       this->update();
       break;
     }
@@ -93,7 +93,7 @@ void Am43::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_i
 }
 
 void Am43::update() {
-  if (this->node_state != espbt::ClientState::Established) {
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Cannot poll, not connected", this->parent_->address_str().c_str());
     return;
   }

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -24,7 +24,7 @@ void Am43Component::setup() {
 }
 
 void Am43Component::loop() {
-  if (this->node_state == espbt::ClientState::Established && !this->logged_in_) {
+  if (this->node_state == espbt::ClientState::ESTABLISHED && !this->logged_in_) {
     auto packet = this->encoder_->get_send_pin_request(this->pin_);
     auto status =
         esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_, packet->length,
@@ -46,7 +46,7 @@ CoverTraits Am43Component::get_traits() {
 }
 
 void Am43Component::control(const CoverCall &call) {
-  if (this->node_state != espbt::ClientState::Established) {
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Cannot send cover control, not connected", this->get_name().c_str());
     return;
   }
@@ -98,7 +98,7 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->node_state = espbt::ClientState::Established;
+      this->node_state = espbt::ClientState::ESTABLISHED;
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {

--- a/esphome/components/anova/anova.cpp
+++ b/esphome/components/anova/anova.cpp
@@ -72,7 +72,7 @@ void Anova::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->node_state = espbt::ClientState::Established;
+      this->node_state = espbt::ClientState::ESTABLISHED;
       this->current_request_ = 0;
       this->update();
       break;
@@ -129,7 +129,7 @@ void Anova::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_
 void Anova::set_unit_of_measurement(const char *unit) { this->fahrenheit_ = !strncmp(unit, "f", 1); }
 
 void Anova::update() {
-  if (this->node_state != espbt::ClientState::Established)
+  if (this->node_state != espbt::ClientState::ESTABLISHED)
     return;
 
   if (this->current_request_ < 2) {

--- a/esphome/components/anova/anova.h
+++ b/esphome/components/anova/anova.h
@@ -27,7 +27,7 @@ class Anova : public climate::Climate, public esphome::ble_client::BLEClientNode
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
-  climate::ClimateTraits traits() {
+  climate::ClimateTraits traits() override {
     auto traits = climate::ClimateTraits();
     traits.set_supports_current_temperature(true);
     traits.set_supports_heat_mode(true);

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -1,7 +1,8 @@
 #pragma once
 #include <cstdint>
-#include <vector>
 #include <deque>
+#include <utility>
+#include <vector>
 
 #include "esphome/core/defines.h"
 
@@ -75,8 +76,8 @@ class APIFrameHelper {
 class APINoiseFrameHelper : public APIFrameHelper {
  public:
   APINoiseFrameHelper(std::unique_ptr<socket::Socket> socket, std::shared_ptr<APINoiseContext> ctx)
-      : socket_(std::move(socket)), ctx_(ctx) {}
-  ~APINoiseFrameHelper();
+      : socket_(std::move(socket)), ctx_(std::move(std::move(ctx))) {}
+  ~APINoiseFrameHelper() override;
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
@@ -136,7 +137,7 @@ class APINoiseFrameHelper : public APIFrameHelper {
 class APIPlaintextFrameHelper : public APIFrameHelper {
  public:
   APIPlaintextFrameHelper(std::unique_ptr<socket::Socket> socket) : socket_(std::move(socket)) {}
-  ~APIPlaintextFrameHelper() = default;
+  ~APIPlaintextFrameHelper() override = default;
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;

--- a/esphome/components/api/api_noise_context.h
+++ b/esphome/components/api/api_noise_context.h
@@ -11,7 +11,7 @@ using psk_t = std::array<uint8_t, 32>;
 
 class APINoiseContext {
  public:
-  void set_psk(psk_t psk) { psk_ = std::move(psk); }
+  void set_psk(psk_t psk) { psk_ = psk; }
   const psk_t &get_psk() const { return psk_; }
 
  protected:

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -32,7 +32,7 @@ class APIServer : public Component, public Controller {
   void set_reboot_timeout(uint32_t reboot_timeout);
 
 #ifdef USE_API_NOISE
-  void set_noise_psk(psk_t psk) { noise_ctx_->set_psk(std::move(psk)); }
+  void set_noise_psk(psk_t psk) { noise_ctx_->set_psk(psk); }
   std::shared_ptr<APINoiseContext> get_noise_ctx() { return noise_ctx_; }
 #endif  // USE_API_NOISE
 

--- a/esphome/components/atc_mithermometer/atc_mithermometer.cpp
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.cpp
@@ -25,14 +25,14 @@ bool ATCMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &device
 
   bool success = false;
   for (auto &service_data : device.get_service_datas()) {
-    auto res = parse_header(service_data);
+    auto res = parse_header_(service_data);
     if (!res.has_value()) {
       continue;
     }
-    if (!(parse_message(service_data.data, *res))) {
+    if (!(parse_message_(service_data.data, *res))) {
       continue;
     }
-    if (!(report_results(res, device.address_str()))) {
+    if (!(report_results_(res, device.address_str()))) {
       continue;
     }
     if (res->temperature.has_value() && this->temperature_ != nullptr)
@@ -49,7 +49,7 @@ bool ATCMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &device
   return success;
 }
 
-optional<ParseResult> ATCMiThermometer::parse_header(const esp32_ble_tracker::ServiceData &service_data) {
+optional<ParseResult> ATCMiThermometer::parse_header_(const esp32_ble_tracker::ServiceData &service_data) {
   ParseResult result;
   if (!service_data.uuid.contains(0x1A, 0x18)) {
     ESP_LOGVV(TAG, "parse_header(): no service data UUID magic bytes.");
@@ -68,7 +68,7 @@ optional<ParseResult> ATCMiThermometer::parse_header(const esp32_ble_tracker::Se
   return result;
 }
 
-bool ATCMiThermometer::parse_message(const std::vector<uint8_t> &message, ParseResult &result) {
+bool ATCMiThermometer::parse_message_(const std::vector<uint8_t> &message, ParseResult &result) {
   // Byte 0-5 mac in correct order
   // Byte 6-7 Temperature in uint16
   // Byte 8 Humidity in percent
@@ -101,7 +101,7 @@ bool ATCMiThermometer::parse_message(const std::vector<uint8_t> &message, ParseR
   return true;
 }
 
-bool ATCMiThermometer::report_results(const optional<ParseResult> &result, const std::string &address) {
+bool ATCMiThermometer::report_results_(const optional<ParseResult> &result, const std::string &address) {
   if (!result.has_value()) {
     ESP_LOGVV(TAG, "report_results(): no results available.");
     return false;

--- a/esphome/components/atc_mithermometer/atc_mithermometer.h
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.h
@@ -36,9 +36,9 @@ class ATCMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevice
   sensor::Sensor *battery_level_{nullptr};
   sensor::Sensor *battery_voltage_{nullptr};
 
-  optional<ParseResult> parse_header(const esp32_ble_tracker::ServiceData &service_data);
-  bool parse_message(const std::vector<uint8_t> &message, ParseResult &result);
-  bool report_results(const optional<ParseResult> &result, const std::string &address);
+  optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
+  bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
+  bool report_results_(const optional<ParseResult> &result, const std::string &address);
 };
 
 }  // namespace atc_mithermometer

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -11,7 +11,8 @@ class BLEClientConnectTrigger : public Trigger<>, public BLEClientNode {
  public:
   explicit BLEClientConnectTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override {
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override {
     if (event == ESP_GATTC_OPEN_EVT && param->open.status == ESP_GATT_OK)
       this->trigger();
     if (event == ESP_GATTC_SEARCH_CMPL_EVT)
@@ -23,7 +24,8 @@ class BLEClientDisconnectTrigger : public Trigger<>, public BLEClientNode {
  public:
   explicit BLEClientDisconnectTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override {
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override {
     if (event == ESP_GATTC_DISCONNECT_EVT && memcmp(param->disconnect.remote_bda, this->parent_->remote_bda, 6) == 0)
       this->trigger();
     if (event == ESP_GATTC_SEARCH_CMPL_EVT)

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -11,11 +11,11 @@ class BLEClientConnectTrigger : public Trigger<>, public BLEClientNode {
  public:
   explicit BLEClientConnectTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override {
     if (event == ESP_GATTC_OPEN_EVT && param->open.status == ESP_GATT_OK)
       this->trigger();
     if (event == ESP_GATTC_SEARCH_CMPL_EVT)
-      this->node_state = espbt::ClientState::Established;
+      this->node_state = espbt::ClientState::ESTABLISHED;
   }
 };
 
@@ -23,11 +23,11 @@ class BLEClientDisconnectTrigger : public Trigger<>, public BLEClientNode {
  public:
   explicit BLEClientDisconnectTrigger(BLEClient *parent) { parent->register_ble_node(this); }
   void loop() override {}
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override {
     if (event == ESP_GATTC_DISCONNECT_EVT && memcmp(param->disconnect.remote_bda, this->parent_->remote_bda, 6) == 0)
       this->trigger();
     if (event == ESP_GATTC_SEARCH_CMPL_EVT)
-      this->node_state = espbt::ClientState::Established;
+      this->node_state = espbt::ClientState::ESTABLISHED;
   }
 };
 

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -17,12 +17,12 @@ void BLEClient::setup() {
     ESP_LOGE(TAG, "gattc app register failed. app_id=%d code=%d", this->app_id, ret);
     this->mark_failed();
   }
-  this->set_states(espbt::ClientState::Idle);
+  this->set_states_(espbt::ClientState::IDLE);
   this->enabled = true;
 }
 
 void BLEClient::loop() {
-  if (this->state() == espbt::ClientState::Discovered) {
+  if (this->state() == espbt::ClientState::DISCOVERED) {
     this->connect();
   }
   for (auto *node : this->nodes_)
@@ -39,11 +39,11 @@ bool BLEClient::parse_device(const espbt::ESPBTDevice &device) {
     return false;
   if (device.address_uint64() != this->address)
     return false;
-  if (this->state() != espbt::ClientState::Idle)
+  if (this->state() != espbt::ClientState::IDLE)
     return false;
 
   ESP_LOGD(TAG, "Found device at MAC address [%s]", device.address_str().c_str());
-  this->set_states(espbt::ClientState::Discovered);
+  this->set_states_(espbt::ClientState::DISCOVERED);
 
   auto addr = device.address_uint64();
   this->remote_bda[0] = (addr >> 40) & 0xFF;
@@ -69,7 +69,7 @@ std::string BLEClient::address_str() const {
 void BLEClient::set_enabled(bool enabled) {
   if (enabled == this->enabled)
     return;
-  if (!enabled && this->state() != espbt::ClientState::Idle) {
+  if (!enabled && this->state() != espbt::ClientState::IDLE) {
     ESP_LOGI(TAG, "[%s] Disabling BLE client.", this->address_str().c_str());
     auto ret = esp_ble_gattc_close(this->gattc_if, this->conn_id);
     if (ret) {
@@ -84,9 +84,9 @@ void BLEClient::connect() {
   auto ret = esp_ble_gattc_open(this->gattc_if, this->remote_bda, BLE_ADDR_TYPE_PUBLIC, true);
   if (ret) {
     ESP_LOGW(TAG, "esp_ble_gattc_open error, address=%s status=%d", this->address_str().c_str(), ret);
-    this->set_states(espbt::ClientState::Idle);
+    this->set_states_(espbt::ClientState::IDLE);
   } else {
-    this->set_states(espbt::ClientState::Connecting);
+    this->set_states_(espbt::ClientState::CONNECTING);
   }
 }
 
@@ -97,7 +97,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
   if (event != ESP_GATTC_REG_EVT && esp_gattc_if != ESP_GATT_IF_NONE && esp_gattc_if != this->gattc_if)
     return;
 
-  bool all_established = this->all_nodes_established();
+  bool all_established = this->all_nodes_established_();
 
   switch (event) {
     case ESP_GATTC_REG_EVT: {
@@ -113,7 +113,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
       ESP_LOGV(TAG, "[%s] ESP_GATTC_OPEN_EVT", this->address_str().c_str());
       if (param->open.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "connect to %s failed, status=%d", this->address_str().c_str(), param->open.status);
-        this->set_states(espbt::ClientState::Idle);
+        this->set_states_(espbt::ClientState::IDLE);
         break;
       }
       this->conn_id = param->open.conn_id;
@@ -126,7 +126,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
     case ESP_GATTC_CFG_MTU_EVT: {
       if (param->cfg_mtu.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "cfg_mtu to %s failed, status %d", this->address_str().c_str(), param->cfg_mtu.status);
-        this->set_states(espbt::ClientState::Idle);
+        this->set_states_(espbt::ClientState::IDLE);
         break;
       }
       ESP_LOGV(TAG, "cfg_mtu status %d, mtu %d", param->cfg_mtu.status, param->cfg_mtu.mtu);
@@ -141,7 +141,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
       for (auto &svc : this->services_)
         delete svc;  // NOLINT(cppcoreguidelines-owning-memory)
       this->services_.clear();
-      this->set_states(espbt::ClientState::Idle);
+      this->set_states_(espbt::ClientState::IDLE);
       break;
     }
     case ESP_GATTC_SEARCH_RES_EVT: {
@@ -160,8 +160,8 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
         ESP_LOGI(TAG, "  start_handle: 0x%x  end_handle: 0x%x", svc->start_handle, svc->end_handle);
         svc->parse_characteristics();
       }
-      this->set_states(espbt::ClientState::Connected);
-      this->set_state(espbt::ClientState::Established);
+      this->set_states_(espbt::ClientState::CONNECTED);
+      this->set_state(espbt::ClientState::ESTABLISHED);
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
@@ -192,7 +192,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
     node->gattc_event_handler(event, esp_gattc_if, param);
 
   // Delete characteristics after clients have used them to save RAM.
-  if (!all_established && this->all_nodes_established()) {
+  if (!all_established && this->all_nodes_established_()) {
     for (auto &svc : this->services_)
       delete svc;  // NOLINT(cppcoreguidelines-owning-memory)
     this->services_.clear();

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -82,7 +82,8 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   void dump_config() override;
   void loop() override;
 
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override;
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override;
   bool parse_device(const espbt::ESPBTDevice &device) override;
   void on_scan_end() override {}
   void connect() override;

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -82,10 +82,10 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   void dump_config() override;
   void loop() override;
 
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override;
   bool parse_device(const espbt::ESPBTDevice &device) override;
   void on_scan_end() override {}
-  void connect();
+  void connect() override;
 
   void set_address(uint64_t address) { this->address = address; }
 
@@ -116,16 +116,16 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   std::string address_str() const;
 
  protected:
-  void set_states(espbt::ClientState st) {
+  void set_states_(espbt::ClientState st) {
     this->set_state(st);
     for (auto &node : nodes_)
       node->node_state = st;
   }
-  bool all_nodes_established() {
-    if (this->state() != espbt::ClientState::Established)
+  bool all_nodes_established_() {
+    if (this->state() != espbt::ClientState::ESTABLISHED)
       return false;
     for (auto &node : nodes_)
-      if (node->node_state != espbt::ClientState::Established)
+      if (node->node_state != espbt::ClientState::ESTABLISHED)
         return false;
     return true;
   }

--- a/esphome/components/ble_client/sensor/automation.h
+++ b/esphome/components/ble_client/sensor/automation.h
@@ -11,10 +11,10 @@ namespace ble_client {
 class BLESensorNotifyTrigger : public Trigger<float>, public BLESensor {
  public:
   explicit BLESensorNotifyTrigger(BLESensor *sensor) { sensor_ = sensor; }
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override {
     switch (event) {
       case ESP_GATTC_SEARCH_CMPL_EVT: {
-        this->sensor_->node_state = espbt::ClientState::Established;
+        this->sensor_->node_state = espbt::ClientState::ESTABLISHED;
         break;
       }
       case ESP_GATTC_NOTIFY_EVT: {

--- a/esphome/components/ble_client/sensor/automation.h
+++ b/esphome/components/ble_client/sensor/automation.h
@@ -11,7 +11,8 @@ namespace ble_client {
 class BLESensorNotifyTrigger : public Trigger<float>, public BLESensor {
  public:
   explicit BLESensorNotifyTrigger(BLESensor *sensor) { sensor_ = sensor; }
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override {
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override {
     switch (event) {
       case ESP_GATTC_SEARCH_CMPL_EVT: {
         this->sensor_->node_state = espbt::ClientState::ESTABLISHED;

--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -71,7 +71,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
           ESP_LOGW(TAG, "esp_ble_gattc_register_for_notify failed, status=%d", status);
         }
       } else {
-        this->node_state = espbt::ClientState::Established;
+        this->node_state = espbt::ClientState::ESTABLISHED;
       }
       break;
     }
@@ -84,7 +84,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
       }
       if (param->read.handle == this->handle) {
         this->status_clear_warning();
-        this->publish_state(this->parse_data(param->read.value, param->read.value_len));
+        this->publish_state(this->parse_data_(param->read.value, param->read.value_len));
       }
       break;
     }
@@ -93,11 +93,11 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
         break;
       ESP_LOGV(TAG, "[%s] ESP_GATTC_NOTIFY_EVT: handle=0x%x, value=0x%x", this->get_name().c_str(),
                param->notify.handle, param->notify.value[0]);
-      this->publish_state(this->parse_data(param->notify.value, param->notify.value_len));
+      this->publish_state(this->parse_data_(param->notify.value, param->notify.value_len));
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->node_state = espbt::ClientState::Established;
+      this->node_state = espbt::ClientState::ESTABLISHED;
       break;
     }
     default:
@@ -105,7 +105,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
   }
 }
 
-float BLESensor::parse_data(uint8_t *value, uint16_t value_len) {
+float BLESensor::parse_data_(uint8_t *value, uint16_t value_len) {
   if (this->data_to_value_func_.has_value()) {
     std::vector<uint8_t> data(value, value + value_len);
     return (*this->data_to_value_func_)(data);
@@ -115,7 +115,7 @@ float BLESensor::parse_data(uint8_t *value, uint16_t value_len) {
 }
 
 void BLESensor::update() {
-  if (this->node_state != espbt::ClientState::Established) {
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Cannot poll, not connected", this->get_name().c_str());
     return;
   }

--- a/esphome/components/ble_client/sensor/ble_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_sensor.h
@@ -32,13 +32,13 @@ class BLESensor : public sensor::Sensor, public PollingComponent, public BLEClie
   void set_descr_uuid16(uint16_t uuid) { this->descr_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_descr_uuid32(uint32_t uuid) { this->descr_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
   void set_descr_uuid128(uint8_t *uuid) { this->descr_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
-  void set_data_to_value(data_to_value_t &&lambda_) { this->data_to_value_func_ = lambda_; }
+  void set_data_to_value(data_to_value_t &&lambda) { this->data_to_value_func_ = lambda; }
   void set_enable_notify(bool notify) { this->notify_ = notify; }
   uint16_t handle;
 
  protected:
   uint32_t hash_base() override;
-  float parse_data(uint8_t *value, uint16_t value_len);
+  float parse_data_(uint8_t *value, uint16_t value_len);
   optional<data_to_value_t> data_to_value_func_{};
   bool notify_;
   espbt::ESPBTUUID service_uuid_;

--- a/esphome/components/ble_client/switch/ble_switch.cpp
+++ b/esphome/components/ble_client/switch/ble_switch.cpp
@@ -21,10 +21,10 @@ void BLEClientSwitch::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
       this->publish_state(this->parent_->enabled);
       break;
     case ESP_GATTC_OPEN_EVT:
-      this->node_state = espbt::ClientState::Established;
+      this->node_state = espbt::ClientState::ESTABLISHED;
       break;
     case ESP_GATTC_DISCONNECT_EVT:
-      this->node_state = espbt::ClientState::Idle;
+      this->node_state = espbt::ClientState::IDLE;
       this->publish_state(this->parent_->enabled);
       break;
     default:

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -93,8 +93,8 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
-  enum MATCH_TYPE { MATCH_BY_MAC_ADDRESS, MATCH_BY_SERVICE_UUID, MATCH_BY_IBEACON_UUID };
-  MATCH_TYPE match_by_;
+  enum MatchType { MATCH_BY_MAC_ADDRESS, MATCH_BY_SERVICE_UUID, MATCH_BY_IBEACON_UUID };
+  MatchType match_by_;
 
   bool found_{false};
 

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -15,7 +15,7 @@ namespace ble_scanner {
 class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
-    this->publish_state("{\"timestamp\":" + to_string(::time(NULL)) +
+    this->publish_state("{\"timestamp\":" + to_string(::time(nullptr)) +
                         ","
                         "\"address\":\"" +
                         device.address_str() +

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -26,25 +26,25 @@ void DalyBmsComponent::dump_config() {
 }
 
 void DalyBmsComponent::update() {
-  this->request_data(DALY_REQUEST_BATTERY_LEVEL);
-  this->request_data(DALY_REQUEST_MIN_MAX_VOLTAGE);
-  this->request_data(DALY_REQUEST_MIN_MAX_TEMPERATURE);
-  this->request_data(DALY_REQUEST_MOS);
-  this->request_data(DALY_REQUEST_STATUS);
-  this->request_data(DALY_REQUEST_TEMPERATURE);
+  this->request_data_(DALY_REQUEST_BATTERY_LEVEL);
+  this->request_data_(DALY_REQUEST_MIN_MAX_VOLTAGE);
+  this->request_data_(DALY_REQUEST_MIN_MAX_TEMPERATURE);
+  this->request_data_(DALY_REQUEST_MOS);
+  this->request_data_(DALY_REQUEST_STATUS);
+  this->request_data_(DALY_REQUEST_TEMPERATURE);
 
   std::vector<uint8_t> get_battery_level_data;
   int available_data = this->available();
   if (available_data >= DALY_FRAME_SIZE) {
     get_battery_level_data.resize(available_data);
     this->read_array(get_battery_level_data.data(), available_data);
-    this->decode_data(get_battery_level_data);
+    this->decode_data_(get_battery_level_data);
   }
 }
 
 float DalyBmsComponent::get_setup_priority() const { return setup_priority::DATA; }
 
-void DalyBmsComponent::request_data(uint8_t data_id) {
+void DalyBmsComponent::request_data_(uint8_t data_id) {
   uint8_t request_message[DALY_FRAME_SIZE];
 
   request_message[0] = 0xA5;     // Start Flag
@@ -66,7 +66,7 @@ void DalyBmsComponent::request_data(uint8_t data_id) {
   this->flush();
 }
 
-void DalyBmsComponent::decode_data(std::vector<uint8_t> data) {
+void DalyBmsComponent::decode_data_(std::vector<uint8_t> data) {
   auto it = data.begin();
 
   while ((it = std::find(it, data.end(), 0xA5)) != data.end()) {

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -54,8 +54,8 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   float get_setup_priority() const override;
 
  protected:
-  void request_data(uint8_t data_id);
-  void decode_data(std::vector<uint8_t> data);
+  void request_data_(uint8_t data_id);
+  void decode_data_(std::vector<uint8_t> data);
 
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};

--- a/esphome/components/esp32/gpio_arduino.cpp
+++ b/esphome/components/esp32/gpio_arduino.cpp
@@ -21,7 +21,7 @@ ISRInternalGPIOPin ArduinoInternalGPIOPin::to_isr() const {
   return ISRInternalGPIOPin((void *) arg);
 }
 
-void ArduinoInternalGPIOPin::attach_interrupt_(void (*func)(void *), void *arg, gpio::InterruptType type) const {
+void ArduinoInternalGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const {
   uint8_t arduino_mode = DISABLED;
   switch (type) {
     case gpio::INTERRUPT_RISING_EDGE:

--- a/esphome/components/esp32/gpio_arduino.h
+++ b/esphome/components/esp32/gpio_arduino.h
@@ -23,7 +23,7 @@ class ArduinoInternalGPIOPin : public InternalGPIOPin {
   bool is_inverted() const override { return inverted_; }
 
  protected:
-  void attach_interrupt_(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
+  void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
   uint8_t pin_;
   bool inverted_;

--- a/esphome/components/esp32/gpio_idf.cpp
+++ b/esphome/components/esp32/gpio_idf.cpp
@@ -8,7 +8,7 @@ namespace esp32 {
 
 static const char *const TAG = "esp32";
 
-bool IDFInternalGPIOPin::isr_service_installed_ = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+bool IDFInternalGPIOPin::isr_service_installed = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct ISRPinArg {
   gpio_num_t pin;

--- a/esphome/components/esp32/gpio_idf.h
+++ b/esphome/components/esp32/gpio_idf.h
@@ -87,6 +87,7 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
   bool inverted_;
   gpio_drive_cap_t drive_strength_;
   gpio::Flags flags_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool isr_service_installed;
 };
 

--- a/esphome/components/esp32/gpio_idf.h
+++ b/esphome/components/esp32/gpio_idf.h
@@ -21,7 +21,7 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
   void pin_mode(gpio::Flags flags) override {
     gpio_config_t conf{};
     conf.pin_bit_mask = 1ULL << static_cast<uint32_t>(pin_);
-    conf.mode = flags_to_mode_(flags);
+    conf.mode = flags_to_mode(flags);
     conf.pull_up_en = flags & gpio::FLAG_PULLUP ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
     conf.pull_down_en = flags & gpio::FLAG_PULLDOWN ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE;
     conf.intr_type = GPIO_INTR_DISABLE;
@@ -36,7 +36,7 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
   bool is_inverted() const override { return inverted_; }
 
  protected:
-  static gpio_mode_t flags_to_mode_(gpio::Flags flags) {
+  static gpio_mode_t flags_to_mode(gpio::Flags flags) {
     flags = (gpio::Flags)(flags & ~(gpio::FLAG_PULLUP | gpio::FLAG_PULLDOWN));
     if (flags == gpio::FLAG_NONE) {
       return GPIO_MODE_DISABLE;
@@ -55,7 +55,7 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
       return GPIO_MODE_DISABLE;
     }
   }
-  void attach_interrupt_(void (*func)(void *), void *arg, gpio::InterruptType type) const override {
+  void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override {
     gpio_int_type_t idf_type = GPIO_INTR_ANYEDGE;
     switch (type) {
       case gpio::INTERRUPT_RISING_EDGE:
@@ -76,9 +76,9 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
     }
     gpio_set_intr_type(pin_, idf_type);
     gpio_intr_enable(pin_);
-    if (!isr_service_installed_) {
+    if (!isr_service_installed) {
       gpio_install_isr_service(ESP_INTR_FLAG_LEVEL5);
-      isr_service_installed_ = true;
+      isr_service_installed = true;
     }
     gpio_isr_handler_add(pin_, func, arg);
   }
@@ -87,7 +87,7 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
   bool inverted_;
   gpio_drive_cap_t drive_strength_;
   gpio::Flags flags_;
-  static bool isr_service_installed_;
+  static bool isr_service_installed;
 };
 
 }  // namespace esp32

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -19,6 +19,7 @@
 namespace esphome {
 namespace esp32_ble {
 
+// NOLINTNEXTLINE(modernize-use-using)
 typedef struct {
   void *peer_device;
   bool connected;
@@ -65,6 +66,7 @@ class ESP32BLE : public Component {
   BLEAdvertising *advertising_;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern ESP32BLE *global_ble;
 
 }  // namespace esp32_ble

--- a/esphome/components/esp32_ble/queue.h
+++ b/esphome/components/esp32_ble/queue.h
@@ -28,33 +28,33 @@ namespace esp32_ble {
 
 template<class T> class Queue {
  public:
-  Queue() { m = xSemaphoreCreateMutex(); }
+  Queue() { m_ = xSemaphoreCreateMutex(); }
 
   void push(T *element) {
     if (element == nullptr)
       return;
-    if (xSemaphoreTake(m, 5L / portTICK_PERIOD_MS)) {
-      q.push(element);
-      xSemaphoreGive(m);
+    if (xSemaphoreTake(m_, 5L / portTICK_PERIOD_MS)) {
+      q_.push(element);
+      xSemaphoreGive(m_);
     }
   }
 
   T *pop() {
     T *element = nullptr;
 
-    if (xSemaphoreTake(m, 5L / portTICK_PERIOD_MS)) {
-      if (!q.empty()) {
-        element = q.front();
-        q.pop();
+    if (xSemaphoreTake(m_, 5L / portTICK_PERIOD_MS)) {
+      if (!q_.empty()) {
+        element = q_.front();
+        q_.pop();
       }
-      xSemaphoreGive(m);
+      xSemaphoreGive(m_);
     }
     return element;
   }
 
  protected:
-  std::queue<T *> q;
-  SemaphoreHandle_t m;
+  std::queue<T *> q_;
+  SemaphoreHandle_t m_;
 };
 
 // Received GAP, GATTC and GATTS events are only queued, and get processed in the main loop().
@@ -105,11 +105,13 @@ class BLEEvent {
   };
 
   union {
+    // NOLINTNEXTLINE(readability-identifier-naming)
     struct gap_event {
       esp_gap_ble_cb_event_t gap_event;
       esp_ble_gap_cb_param_t gap_param;
     } gap;
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     struct gattc_event {
       esp_gattc_cb_event_t gattc_event;
       esp_gatt_if_t gattc_if;
@@ -117,6 +119,7 @@ class BLEEvent {
       uint8_t data[64];
     } gattc;
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     struct gatts_event {
       esp_gatts_cb_event_t gatts_event;
       esp_gatt_if_t gatts_if;
@@ -124,6 +127,7 @@ class BLEEvent {
       uint8_t data[64];
     } gatts;
   } event_;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   enum ble_event_t : uint8_t {
     GAP,
     GATTC,

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -9,6 +9,7 @@
 namespace esphome {
 namespace esp32_ble_beacon {
 
+// NOLINTNEXTLINE(modernize-use-using)
 typedef struct {
   uint8_t flags[3];
   uint8_t length;
@@ -17,6 +18,7 @@ typedef struct {
   uint16_t beacon_type;
 } __attribute__((packed)) esp_ble_ibeacon_head_t;
 
+// NOLINTNEXTLINE(modernize-use-using)
 typedef struct {
   uint8_t proximity_uuid[16];
   uint16_t major;
@@ -24,6 +26,7 @@ typedef struct {
   uint8_t measured_power;
 } __attribute__((packed)) esp_ble_ibeacon_vendor_t;
 
+// NOLINTNEXTLINE(modernize-use-using)
 typedef struct {
   esp_ble_ibeacon_head_t ibeacon_head;
   esp_ble_ibeacon_vendor_t ibeacon_vendor;
@@ -50,6 +53,7 @@ class ESP32BLEBeacon : public Component {
   uint16_t minor_{};
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern ESP32BLEBeacon *global_esp32_ble_beacon;
 
 }  // namespace esp32_ble_beacon

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -24,7 +24,7 @@ class BLEService;
 
 class BLECharacteristic {
  public:
-  BLECharacteristic(const ESPBTUUID uuid, uint32_t properties);
+  BLECharacteristic(ESPBTUUID uuid, uint32_t properties);
 
   void set_value(const uint8_t *data, size_t length);
   void set_value(std::vector<uint8_t> value);
@@ -49,7 +49,7 @@ class BLECharacteristic {
   void do_create(BLEService *service);
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
 
-  void on_write(const std::function<void(const std::vector<uint8_t> &)> &&func) { this->on_write_ = std::move(func); }
+  void on_write(const std::function<void(const std::vector<uint8_t> &)> &&func) { this->on_write_ = func; }
 
   void add_descriptor(BLEDescriptor *descriptor);
 

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -87,6 +87,7 @@ class BLEServer : public Component {
   } state_{INIT};
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern BLEServer *global_ble_server;
 
 }  // namespace esp32_ble_server

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -58,7 +58,7 @@ void ESP32BLETracker::loop() {
   while (ble_event != nullptr) {
     if (ble_event->type_)
       this->real_gattc_event_handler_(ble_event->event_.gattc.gattc_event, ble_event->event_.gattc.gattc_if,
-                                     &ble_event->event_.gattc.gattc_param);
+                                      &ble_event->event_.gattc.gattc_param);
     else
       this->real_gap_event_handler_(ble_event->event_.gap.gap_event, &ble_event->event_.gap.gap_param);
     delete ble_event;  // NOLINT(cppcoreguidelines-owning-memory)
@@ -284,7 +284,7 @@ void ESP32BLETracker::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
 }  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 void ESP32BLETracker::real_gattc_event_handler_(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
-                                               esp_ble_gattc_cb_param_t *param) {
+                                                esp_ble_gattc_cb_param_t *param) {
   for (auto *client : global_esp32_ble_tracker->clients_) {
     client->gattc_event_handler(event, gattc_if, param);
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -135,15 +135,15 @@ class ESPBTDeviceListener {
 
 enum class ClientState {
   // Connection is idle, no device detected.
-  Idle,
+  IDLE,
   // Device advertisement found.
-  Discovered,
+  DISCOVERED,
   // Connection in progress.
-  Connecting,
+  CONNECTING,
   // Initial connection established.
-  Connected,
+  CONNECTED,
   // The client and sub-clients have completed setup.
-  Established,
+  ESTABLISHED,
 };
 
 class ESPBTClient : public ESPBTDeviceListener {
@@ -185,23 +185,23 @@ class ESP32BLETracker : public Component {
   /// The FreeRTOS task managing the bluetooth interface.
   static bool ble_setup();
   /// Start a single scan by setting up the parameters and doing some esp-idf calls.
-  void start_scan(bool first);
+  void start_scan_(bool first);
   /// Callback that will handle all GAP events and redistribute them to other callbacks.
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
-  void real_gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
+  void real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
   /// Called when a `ESP_GAP_BLE_SCAN_RESULT_EVT` event is received.
-  void gap_scan_result(const esp_ble_gap_cb_param_t::ble_scan_result_evt_param &param);
+  void gap_scan_result_(const esp_ble_gap_cb_param_t::ble_scan_result_evt_param &param);
   /// Called when a `ESP_GAP_BLE_SCAN_PARAM_SET_COMPLETE_EVT` event is received.
-  void gap_scan_set_param_complete(const esp_ble_gap_cb_param_t::ble_scan_param_cmpl_evt_param &param);
+  void gap_scan_set_param_complete_(const esp_ble_gap_cb_param_t::ble_scan_param_cmpl_evt_param &param);
   /// Called when a `ESP_GAP_BLE_SCAN_START_COMPLETE_EVT` event is received.
-  void gap_scan_start_complete(const esp_ble_gap_cb_param_t::ble_scan_start_cmpl_evt_param &param);
+  void gap_scan_start_complete_(const esp_ble_gap_cb_param_t::ble_scan_start_cmpl_evt_param &param);
   /// Called when a `ESP_GAP_BLE_SCAN_STOP_COMPLETE_EVT` event is received.
-  void gap_scan_stop_complete(const esp_ble_gap_cb_param_t::ble_scan_stop_cmpl_evt_param &param);
+  void gap_scan_stop_complete_(const esp_ble_gap_cb_param_t::ble_scan_stop_cmpl_evt_param &param);
 
   int app_id_;
   /// Callback that will handle all GATTC events and redistribute them to other callbacks.
   static void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
-  void real_gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
+  void real_gattc_event_handler_(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
 
   /// Vector of addresses that have already been printed in print_bt_device_info
   std::vector<uint64_t> already_discovered_;
@@ -225,6 +225,7 @@ class ESP32BLETracker : public Component {
   Queue<BLEEvent> ble_events_;
 };
 
+// NOLINTNEXTLINE
 extern ESP32BLETracker *global_esp32_ble_tracker;
 
 }  // namespace esp32_ble_tracker

--- a/esphome/components/esp32_ble_tracker/queue.h
+++ b/esphome/components/esp32_ble_tracker/queue.h
@@ -26,33 +26,33 @@ namespace esp32_ble_tracker {
 
 template<class T> class Queue {
  public:
-  Queue() { m = xSemaphoreCreateMutex(); }
+  Queue() { m_ = xSemaphoreCreateMutex(); }
 
   void push(T *element) {
     if (element == nullptr)
       return;
-    if (xSemaphoreTake(m, 5L / portTICK_PERIOD_MS)) {
-      q.push(element);
-      xSemaphoreGive(m);
+    if (xSemaphoreTake(m_, 5L / portTICK_PERIOD_MS)) {
+      q_.push(element);
+      xSemaphoreGive(m_);
     }
   }
 
   T *pop() {
     T *element = nullptr;
 
-    if (xSemaphoreTake(m, 5L / portTICK_PERIOD_MS)) {
-      if (!q.empty()) {
-        element = q.front();
-        q.pop();
+    if (xSemaphoreTake(m_, 5L / portTICK_PERIOD_MS)) {
+      if (!q_.empty()) {
+        element = q_.front();
+        q_.pop();
       }
-      xSemaphoreGive(m);
+      xSemaphoreGive(m_);
     }
     return element;
   }
 
  protected:
-  std::queue<T *> q;
-  SemaphoreHandle_t m;
+  std::queue<T *> q_;
+  SemaphoreHandle_t m_;
 };
 
 // Received GAP and GATTC events are only queued, and get processed in the main loop().
@@ -87,12 +87,12 @@ class BLEEvent {
   };
 
   union {
-    struct gap_event {
+    struct gap_event {  // NOLINT(readability-identifier-naming)
       esp_gap_ble_cb_event_t gap_event;
       esp_ble_gap_cb_param_t gap_param;
     } gap;
 
-    struct gattc_event {
+    struct gattc_event {  // NOLINT(readability-identifier-naming)
       esp_gattc_cb_event_t gattc_event;
       esp_gatt_if_t gattc_if;
       esp_ble_gattc_cb_param_t gattc_param;

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -106,6 +106,7 @@ class ESP32Camera : public Component, public Nameable {
   uint32_t last_update_{0};
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern ESP32Camera *global_esp32_camera;
 
 }  // namespace esp32_camera

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -126,7 +126,7 @@ void ESP32ImprovComponent::loop() {
 
         std::string url = "https://my.home-assistant.io/redirect/config_flow_start?domain=esphome";
         std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, {url});
-        this->send_response(data);
+        this->send_response_(data);
         this->set_timeout("end-service", 1000, [this] {
           this->service_->stop();
           this->set_state_(improv::STATE_STOPPED);
@@ -181,7 +181,7 @@ void ESP32ImprovComponent::set_error_(improv::Error error) {
   }
 }
 
-void ESP32ImprovComponent::send_response(std::vector<uint8_t> &response) {
+void ESP32ImprovComponent::send_response_(std::vector<uint8_t> &response) {
   this->rpc_response_->set_value(response);
   if (this->state_ != improv::STATE_STOPPED)
     this->rpc_response_->notify();

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -63,12 +63,13 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
 
   void set_state_(improv::State state);
   void set_error_(improv::Error error);
-  void send_response(std::vector<uint8_t> &response);
+  void send_response_(std::vector<uint8_t> &response);
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
   bool check_identify_();
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern ESP32ImprovComponent *global_improv_component;
 
 }  // namespace esp32_improv

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -20,7 +20,7 @@ ISRInternalGPIOPin ESP8266GPIOPin::to_isr() const {
   return ISRInternalGPIOPin((void *) arg);
 }
 
-void ESP8266GPIOPin::attach_interrupt_(void (*func)(void *), void *arg, gpio::InterruptType type) const {
+void ESP8266GPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const {
   uint8_t arduino_mode = 0;
   switch (type) {
     case gpio::INTERRUPT_RISING_EDGE:

--- a/esphome/components/esp8266/gpio.h
+++ b/esphome/components/esp8266/gpio.h
@@ -25,7 +25,7 @@ class ESP8266GPIOPin : public InternalGPIOPin {
   bool is_inverted() const override { return inverted_; }
 
  protected:
-  void attach_interrupt_(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
+  void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
   uint8_t pin_;
   bool inverted_;

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -45,11 +45,11 @@ void EthernetComponent::setup() {
 
   switch (this->type_) {
     case ETHERNET_TYPE_LAN8720: {
-      memcpy(&this->eth_config, &phy_lan8720_default_ethernet_config, sizeof(eth_config_t));
+      memcpy(&this->eth_config_, &phy_lan8720_default_ethernet_config, sizeof(eth_config_t));
       break;
     }
     case ETHERNET_TYPE_TLK110: {
-      memcpy(&this->eth_config, &phy_tlk110_default_ethernet_config, sizeof(eth_config_t));
+      memcpy(&this->eth_config_, &phy_tlk110_default_ethernet_config, sizeof(eth_config_t));
       break;
     }
     default: {
@@ -58,20 +58,20 @@ void EthernetComponent::setup() {
     }
   }
 
-  this->eth_config.phy_addr = static_cast<eth_phy_base_t>(this->phy_addr_);
-  this->eth_config.clock_mode = this->clk_mode_;
-  this->eth_config.gpio_config = EthernetComponent::eth_phy_config_gpio_;
-  this->eth_config.tcpip_input = tcpip_adapter_eth_input;
+  this->eth_config_.phy_addr = static_cast<eth_phy_base_t>(this->phy_addr_);
+  this->eth_config_.clock_mode = this->clk_mode_;
+  this->eth_config_.gpio_config = EthernetComponent::eth_phy_config_gpio;
+  this->eth_config_.tcpip_input = tcpip_adapter_eth_input;
 
   if (this->power_pin_ != nullptr) {
-    this->orig_power_enable_fun_ = this->eth_config.phy_power_enable;
-    this->eth_config.phy_power_enable = EthernetComponent::eth_phy_power_enable_;
+    this->orig_power_enable_fun_ = this->eth_config_.phy_power_enable;
+    this->eth_config_.phy_power_enable = EthernetComponent::eth_phy_power_enable;
   }
 
   tcpipInit();
 
   esp_err_t err;
-  err = esp_eth_init(&this->eth_config);
+  err = esp_eth_init(&this->eth_config_);
   ESPHL_ERROR_CHECK(err, "ETH init error");
   err = esp_eth_enable();
   ESPHL_ERROR_CHECK(err, "ETH enable error");
@@ -209,11 +209,11 @@ void EthernetComponent::start_connect_() {
   this->connect_begin_ = millis();
   this->status_set_warning();
 }
-void EthernetComponent::eth_phy_config_gpio_() {
+void EthernetComponent::eth_phy_config_gpio() {
   phy_rmii_configure_data_interface_pins();
   phy_rmii_smi_configure_pins(global_eth_component->mdc_pin_, global_eth_component->mdio_pin_);
 }
-void EthernetComponent::eth_phy_power_enable_(bool enable) {
+void EthernetComponent::eth_phy_power_enable(bool enable) {
   global_eth_component->power_pin_->digital_write(enable);
   // power up takes some time, datasheet says max 300µs
   delay(1);
@@ -242,9 +242,9 @@ void EthernetComponent::dump_connect_params_() {
   uint8_t mac[6];
   esp_eth_get_mac(mac);
   ESP_LOGCONFIG(TAG, "  MAC Address: %02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-  ESP_LOGCONFIG(TAG, "  Is Full Duplex: %s", YESNO(this->eth_config.phy_get_duplex_mode()));
-  ESP_LOGCONFIG(TAG, "  Link Up: %s", YESNO(this->eth_config.phy_check_link()));
-  ESP_LOGCONFIG(TAG, "  Link Speed: %u", this->eth_config.phy_get_speed_mode() ? 100 : 10);
+  ESP_LOGCONFIG(TAG, "  Is Full Duplex: %s", YESNO(this->eth_config_.phy_get_duplex_mode()));
+  ESP_LOGCONFIG(TAG, "  Link Up: %s", YESNO(this->eth_config_.phy_check_link()));
+  ESP_LOGCONFIG(TAG, "  Link Speed: %u", this->eth_config_.phy_get_speed_mode() ? 100 : 10);
 }
 void EthernetComponent::set_phy_addr(uint8_t phy_addr) { this->phy_addr_ = phy_addr; }
 void EthernetComponent::set_power_pin(GPIOPin *power_pin) { this->power_pin_ = power_pin; }

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -60,8 +60,8 @@ class EthernetComponent : public Component {
   void start_connect_();
   void dump_connect_params_();
 
-  static void eth_phy_config_gpio_();
-  static void eth_phy_power_enable_(bool enable);
+  static void eth_phy_config_gpio();
+  static void eth_phy_power_enable(bool enable);
 
   std::string use_address_;
   uint8_t phy_addr_{0};
@@ -76,10 +76,11 @@ class EthernetComponent : public Component {
   bool connected_{false};
   EthernetComponentState state_{EthernetComponentState::STOPPED};
   uint32_t connect_begin_;
-  eth_config_t eth_config;
+  eth_config_t eth_config_;
   eth_phy_power_enable_func orig_power_enable_fun_;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern EthernetComponent *global_eth_component;
 
 }  // namespace ethernet

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -44,33 +44,33 @@ class FastLEDLightOutput : public light::AddressableLight {
   CLEDController &add_leds(int num_leds) {
     switch (CHIPSET) {
       case LPD8806: {
-        static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+        return add_leds(&controller, num_leds);
       }
       case WS2801: {
-        static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+        return add_leds(&controller, num_leds);
       }
       case WS2803: {
-        static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+        return add_leds(&controller, num_leds);
       }
       case SM16716: {
-        static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+        return add_leds(&controller, num_leds);
       }
       case P9813: {
-        static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+        return add_leds(&controller, num_leds);
       }
       case DOTSTAR:
       case APA102: {
-        static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+        return add_leds(&controller, num_leds);
       }
       case SK9822: {
-        static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+        return add_leds(&controller, num_leds);
       }
     }
   }
@@ -78,33 +78,33 @@ class FastLEDLightOutput : public light::AddressableLight {
   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> CLEDController &add_leds(int num_leds) {
     switch (CHIPSET) {
       case LPD8806: {
-        static LPD8806Controller<DATA_PIN, CLOCK_PIN> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static LPD8806Controller<DATA_PIN, CLOCK_PIN> controller;
+        return add_leds(&controller, num_leds);
       }
       case WS2801: {
-        static WS2801Controller<DATA_PIN, CLOCK_PIN> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static WS2801Controller<DATA_PIN, CLOCK_PIN> controller;
+        return add_leds(&controller, num_leds);
       }
       case WS2803: {
-        static WS2803Controller<DATA_PIN, CLOCK_PIN> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static WS2803Controller<DATA_PIN, CLOCK_PIN> controller;
+        return add_leds(&controller, num_leds);
       }
       case SM16716: {
-        static SM16716Controller<DATA_PIN, CLOCK_PIN> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static SM16716Controller<DATA_PIN, CLOCK_PIN> controller;
+        return add_leds(&controller, num_leds);
       }
       case P9813: {
-        static P9813Controller<DATA_PIN, CLOCK_PIN> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static P9813Controller<DATA_PIN, CLOCK_PIN> controller;
+        return add_leds(&controller, num_leds);
       }
       case DOTSTAR:
       case APA102: {
-        static APA102Controller<DATA_PIN, CLOCK_PIN> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static APA102Controller<DATA_PIN, CLOCK_PIN> controller;
+        return add_leds(&controller, num_leds);
       }
       case SK9822: {
-        static SK9822Controller<DATA_PIN, CLOCK_PIN> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static SK9822Controller<DATA_PIN, CLOCK_PIN> controller;
+        return add_leds(&controller, num_leds);
       }
     }
   }
@@ -113,33 +113,33 @@ class FastLEDLightOutput : public light::AddressableLight {
   CLEDController &add_leds(int num_leds) {
     switch (CHIPSET) {
       case LPD8806: {
-        static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+        return add_leds(&controller, num_leds);
       }
       case WS2801: {
-        static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+        return add_leds(&controller, num_leds);
       }
       case WS2803: {
-        static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+        return add_leds(&controller, num_leds);
       }
       case SM16716: {
-        static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+        return add_leds(&controller, num_leds);
       }
       case P9813: {
-        static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+        return add_leds(&controller, num_leds);
       }
       case DOTSTAR:
       case APA102: {
-        static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+        return add_leds(&controller, num_leds);
       }
       case SK9822: {
-        static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> CONTROLLER;
-        return add_leds(&CONTROLLER, num_leds);
+        static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+        return add_leds(&controller, num_leds);
       }
     }
   }
@@ -147,30 +147,30 @@ class FastLEDLightOutput : public light::AddressableLight {
 #ifdef FASTLED_HAS_CLOCKLESS
   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN, EOrder RGB_ORDER>
   CLEDController &add_leds(int num_leds) {
-    static CHIPSET<DATA_PIN, RGB_ORDER> CONTROLLER;
-    return add_leds(&CONTROLLER, num_leds);
+    static CHIPSET<DATA_PIN, RGB_ORDER> controller;
+    return add_leds(&controller, num_leds);
   }
 
   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN>
   CLEDController &add_leds(int num_leds) {
-    static CHIPSET<DATA_PIN, RGB> CONTROLLER;
-    return add_leds(&CONTROLLER, num_leds);
+    static CHIPSET<DATA_PIN, RGB> controller;
+    return add_leds(&controller, num_leds);
   }
 
   template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> CLEDController &add_leds(int num_leds) {
-    static CHIPSET<DATA_PIN> CONTROLLER;
-    return add_leds(&CONTROLLER, num_leds);
+    static CHIPSET<DATA_PIN> controller;
+    return add_leds(&controller, num_leds);
   }
 #endif
 
   template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
-    static CHIPSET<RGB_ORDER> CONTROLLER;
-    return add_leds(&CONTROLLER, num_leds);
+    static CHIPSET<RGB_ORDER> controller;
+    return add_leds(&controller, num_leds);
   }
 
   template<template<EOrder RGB_ORDER> class CHIPSET> CLEDController &add_leds(int num_leds) {
-    static CHIPSET<RGB> CONTROLLER;
-    return add_leds(&CONTROLLER, num_leds);
+    static CHIPSET<RGB> controller;
+    return add_leds(&controller, num_leds);
   }
 
 #ifdef FASTLED_HAS_BLOCKLESS

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -185,7 +185,7 @@ void GraphLegend::init(Graph *g) {
   for (auto *trace : g->traces_) {
     std::string txtstr = trace->get_name();
     int fw, fos, fbl, fh;
-    this->font_label->measure(txtstr.c_str(), &fw, &fos, &fbl, &fh);
+    this->font_label_->measure(txtstr.c_str(), &fw, &fos, &fbl, &fh);
     if (fw > txtw)
       txtw = fw;
     if (fh > txth)
@@ -201,7 +201,7 @@ void GraphLegend::init(Graph *g) {
       if (this->units_) {
         valstr += trace->sensor_->get_unit_of_measurement();
       }
-      this->font_value->measure(valstr.c_str(), &fw, &fos, &fbl, &fh);
+      this->font_value_->measure(valstr.c_str(), &fw, &fos, &fbl, &fh);
       if (fw > valw)
         valw = fw;
       if (fh > valh)
@@ -218,11 +218,11 @@ void GraphLegend::init(Graph *g) {
   uint16_t h = this->height_;
   DirectionType dir = this->direction_;
   ValuePositionType valpos = this->values_;
-  if (!this->font_value) {
+  if (!this->font_value_) {
     valpos = VALUE_POSITION_TYPE_NONE;
   }
   // Line sample always goes below text for compactness
-  this->yl = txth + (txth / 4) + lt / 2;
+  this->yl_ = txth + (txth / 4) + lt / 2;
 
   if (dir == DIRECTION_TYPE_AUTO) {
     dir = DIRECTION_TYPE_HORIZONTAL;  // as default
@@ -237,62 +237,62 @@ void GraphLegend::init(Graph *g) {
   }
 
   if (valpos == VALUE_POSITION_TYPE_BELOW) {
-    this->yv = txth + (txth / 4);
+    this->yv_ = txth + (txth / 4);
     if (this->lines_)
-      this->yv += txth / 4 + lt;
+      this->yv_ += txth / 4 + lt;
   } else if (valpos == VALUE_POSITION_TYPE_BESIDE) {
-    this->xv = (txtw + valw) / 2;
+    this->xv_ = (txtw + valw) / 2;
   }
 
   // If width or height is specified we divide evenly within, else we do tight-fit
   if (w == 0) {
-    this->x0 = txtw / 2;
-    this->xs = txtw;
+    this->x0_ = txtw / 2;
+    this->xs_ = txtw;
     if (valpos == VALUE_POSITION_TYPE_BELOW) {
-      this->xs = std::max(txtw, valw);
+      this->xs_ = std::max(txtw, valw);
       ;
-      this->x0 = this->xs / 2;
+      this->x0_ = this->xs_ / 2;
     } else if (valpos == VALUE_POSITION_TYPE_BESIDE) {
-      this->xs = txtw + valw;
+      this->xs_ = txtw + valw;
     }
     if (dir == DIRECTION_TYPE_VERTICAL) {
-      this->width_ = this->xs;
+      this->width_ = this->xs_;
     } else {
-      this->width_ = this->xs * n;
+      this->width_ = this->xs_ * n;
     }
   } else {
-    this->xs = w / n;
-    this->x0 = this->xs / 2;
+    this->xs_ = w / n;
+    this->x0_ = this->xs_ / 2;
   }
 
   if (h == 0) {
-    this->ys = txth;
+    this->ys_ = txth;
     if (valpos == VALUE_POSITION_TYPE_BELOW) {
-      this->ys = txth + txth / 2 + valh;
+      this->ys_ = txth + txth / 2 + valh;
       if (this->lines_) {
-        this->ys += lt;
+        this->ys_ += lt;
       }
     } else if (valpos == VALUE_POSITION_TYPE_BESIDE) {
       if (this->lines_) {
-        this->ys = std::max(txth + txth / 4 + lt + txth / 4, valh + valh / 4);
+        this->ys_ = std::max(txth + txth / 4 + lt + txth / 4, valh + valh / 4);
       } else {
-        this->ys = std::max(txth + txth / 4, valh + valh / 4);
+        this->ys_ = std::max(txth + txth / 4, valh + valh / 4);
       }
-      this->height_ = this->ys * n;
+      this->height_ = this->ys_ * n;
     }
     if (dir == DIRECTION_TYPE_HORIZONTAL) {
-      this->height_ = this->ys;
+      this->height_ = this->ys_;
     } else {
-      this->height_ = this->ys * n;
+      this->height_ = this->ys_ * n;
     }
   } else {
-    this->ys = h / n;
+    this->ys_ = h / n;
   }
 
   if (dir == DIRECTION_TYPE_HORIZONTAL) {
-    this->ys = 0;
+    this->ys_ = 0;
   } else {
-    this->xs = 0;
+    this->xs_ = 0;
   }
 }
 
@@ -310,38 +310,38 @@ void Graph::draw_legend(display::DisplayBuffer *buff, uint16_t x_offset, uint16_
     buff->vertical_line(x_offset + w - 1, y_offset, h, color);
   }
 
-  int x = x_offset + legend_->x0;
+  int x = x_offset + legend_->x0_;
   int y = y_offset;
   for (auto *trace : traces_) {
     std::string txtstr = trace->get_name();
     ESP_LOGV(TAG, "  %s", txtstr.c_str());
 
-    buff->printf(x, y, legend_->font_label, trace->get_line_color(), TextAlign::TOP_CENTER, "%s", txtstr.c_str());
+    buff->printf(x, y, legend_->font_label_, trace->get_line_color(), TextAlign::TOP_CENTER, "%s", txtstr.c_str());
 
     if (legend_->lines_) {
       uint16_t thick = trace->get_line_thickness();
-      for (int16_t i = 0; i < legend_->x0 * 4 / 3; i++) {
+      for (int16_t i = 0; i < legend_->x0_ * 4 / 3; i++) {
         uint8_t b = (i % (thick * LineType::PATTERN_LENGTH)) / thick;
         if (((uint8_t) trace->get_line_type() & (1 << b)) == (1 << b)) {
-          buff->vertical_line(x - legend_->x0 * 2 / 3 + i, y + legend_->yl - thick / 2, thick, trace->get_line_color());
+          buff->vertical_line(x - legend_->x0_ * 2 / 3 + i, y + legend_->yl_ - thick / 2, thick, trace->get_line_color());
         }
       }
     }
 
     if (legend_->values_ != VALUE_POSITION_TYPE_NONE) {
-      int xv = x + legend_->xv;
-      int yv = y + legend_->yv;
+      int xv = x + legend_->xv_;
+      int yv = y + legend_->yv_;
       std::stringstream ss;
       ss << std::fixed << std::setprecision(trace->sensor_->get_accuracy_decimals()) << trace->sensor_->get_state();
       std::string valstr = ss.str();
       if (legend_->units_) {
         valstr += trace->sensor_->get_unit_of_measurement();
       }
-      buff->printf(xv, yv, legend_->font_value, trace->get_line_color(), TextAlign::TOP_CENTER, "%s", valstr.c_str());
+      buff->printf(xv, yv, legend_->font_value_, trace->get_line_color(), TextAlign::TOP_CENTER, "%s", valstr.c_str());
       ESP_LOGV(TAG, "    value: %s", valstr.c_str());
     }
-    x += legend_->xs;
-    y += legend_->ys;
+    x += legend_->xs_;
+    y += legend_->ys_;
   }
 }
 

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -323,7 +323,8 @@ void Graph::draw_legend(display::DisplayBuffer *buff, uint16_t x_offset, uint16_
       for (int16_t i = 0; i < legend_->x0_ * 4 / 3; i++) {
         uint8_t b = (i % (thick * LineType::PATTERN_LENGTH)) / thick;
         if (((uint8_t) trace->get_line_type() & (1 << b)) == (1 << b)) {
-          buff->vertical_line(x - legend_->x0_ * 2 / 3 + i, y + legend_->yl_ - thick / 2, thick, trace->get_line_color());
+          buff->vertical_line(x - legend_->x0_ * 2 / 3 + i, y + legend_->yl_ - thick / 2, thick,
+                              trace->get_line_color());
         }
       }
     }

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -1,8 +1,9 @@
 #pragma once
-#include <cstdint>
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/core/color.h"
 #include "esphome/core/component.h"
-#include "esphome/components/sensor/sensor.h"
+#include <cstdint>
+#include <utility>
 
 namespace esphome {
 
@@ -43,8 +44,8 @@ enum ValuePositionType {
 class GraphLegend {
  public:
   void init(Graph *g);
-  void set_name_font(display::Font *font) { this->font_label = font; }
-  void set_value_font(display::Font *font) { this->font_value = font; }
+  void set_name_font(display::Font *font) { this->font_label_ = font; }
+  void set_value_font(display::Font *font) { this->font_value_ = font; }
   void set_width(uint32_t width) { this->width_ = width; }
   void set_height(uint32_t height) { this->height_ = height; }
   void set_border(bool val) { this->border_ = val; }
@@ -61,8 +62,8 @@ class GraphLegend {
   ValuePositionType values_{VALUE_POSITION_TYPE_AUTO};
   bool units_{true};
   DirectionType direction_{DIRECTION_TYPE_AUTO};
-  display::Font *font_label{nullptr};
-  display::Font *font_value{nullptr};
+  display::Font *font_label_{nullptr};
+  display::Font *font_value_{nullptr};
   // Calculated values
   Graph *parent_{nullptr};
   //                      (x0)          (xs,ys)         (xs,ys)
@@ -72,12 +73,12 @@ class GraphLegend {
   //                          (0,yl)|   \-> VALUE1+units
   //                                v     (top_center)
   //                            LINE_SAMPLE
-  int x0{0};  // X-offset to centre of label text
-  int xs{0};  // X spacing between labels
-  int ys{0};  // Y spacing between labels
-  int yl{0};  // Y spacing from label to line sample
-  int xv{0};  // X distance between label to value text
-  int yv{0};  // Y distance between label to value text
+  int x0_{0};  // X-offset to centre of label text
+  int xs_{0};  // X spacing between labels
+  int ys_{0};  // Y spacing between labels
+  int yl_{0};  // Y spacing from label to line sample
+  int xv_{0};  // X distance between label to value text
+  int yv_{0};  // Y distance between label to value text
   friend Graph;
 };
 
@@ -106,7 +107,7 @@ class HistoryData {
 class GraphTrace {
  public:
   void init(Graph *g);
-  void set_name(std::string name) { name_ = name; }
+  void set_name(std::string name) { name_ = std::move(name); }
   void set_sensor(sensor::Sensor *sensor) { sensor_ = sensor; }
   uint8_t get_line_thickness() { return this->line_thickness_; }
   void set_line_thickness(uint8_t val) { this->line_thickness_ = val; }
@@ -114,7 +115,7 @@ class GraphTrace {
   void set_line_type(enum LineType val) { this->line_type_ = val; }
   Color get_line_color() { return this->line_color_; }
   void set_line_color(Color val) { this->line_color_ = val; }
-  const std::string get_name(void) { return name_; }
+  const std::string get_name() { return name_; }
   const HistoryData *get_tracedata() { return &data_; }
 
  protected:

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -11,7 +11,7 @@ namespace i2c {
 static const char *const TAG = "i2c.arduino";
 
 void ArduinoI2CBus::setup() {
-  recover();
+  recover_();
 #ifdef USE_ESP32
   static uint8_t next_bus_num = 0;
   if (next_bus_num == 0)
@@ -92,7 +92,7 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
   return ERROR_UNKNOWN;
 }
 
-void ArduinoI2CBus::recover() {
+void ArduinoI2CBus::recover_() {
   // Perform I2C bus recovery, see
   // https://www.analog.com/media/en/technical-documentation/application-notes/54305147357414AN686_0.pdf
   // or see the linux kernel implementation, e.g.

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -23,7 +23,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
 
  private:
-  void recover();
+  void recover_();
 
  protected:
   TwoWire *wire_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -14,7 +14,7 @@ void IDFI2CBus::setup() {
   static i2c_port_t next_port = 0;
   port_ = next_port++;
 
-  recover();
+  recover_();
 
   i2c_config_t conf{};
   memset(&conf, 0, sizeof(conf));
@@ -144,7 +144,7 @@ ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt) {
   return ERROR_OK;
 }
 
-void IDFI2CBus::recover() {
+void IDFI2CBus::recover_() {
   // Perform I2C bus recovery, see
   // https://www.analog.com/media/en/technical-documentation/application-notes/54305147357414AN686_0.pdf
   // or see the linux kernel implementation, e.g.

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -25,7 +25,7 @@ class IDFI2CBus : public I2CBus, public Component {
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
 
  private:
-  void recover();
+  void recover_();
 
  protected:
   i2c_port_t port_;

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -8,7 +8,7 @@ namespace inkbird_ibsth1_mini {
 
 static const char *const TAG = "inkbird_ibsth1_mini";
 
-void InkbirdIBSTH1_MINI::dump_config() {
+void InkbirdIbstH1Mini::dump_config() {
   ESP_LOGCONFIG(TAG, "Inkbird IBS TH1 MINI");
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "External Temperature", this->external_temperature_);
@@ -16,7 +16,7 @@ void InkbirdIBSTH1_MINI::dump_config() {
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
 
-bool InkbirdIBSTH1_MINI::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   // The below is based on my research and reverse engineering of a single device
   // It is entirely possible that some of that may be inaccurate or incomplete
 

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace inkbird_ibsth1_mini {
 
-class InkbirdIBSTH1_MINI : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class InkbirdIbstH1Mini : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
 

--- a/esphome/components/inkbird_ibsth1_mini/sensor.py
+++ b/esphome/components/inkbird_ibsth1_mini/sensor.py
@@ -21,14 +21,14 @@ DEPENDENCIES = ["esp32_ble_tracker"]
 CONF_EXTERNAL_TEMPERATURE = "external_temperature"
 
 inkbird_ibsth1_mini_ns = cg.esphome_ns.namespace("inkbird_ibsth1_mini")
-InkbirdUBSTH1_MINI = inkbird_ibsth1_mini_ns.class_(
-    "InkbirdIBSTH1_MINI", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
+InkbirdIbstH1Mini = inkbird_ibsth1_mini_ns.class_(
+    "InkbirdIbstH1Mini", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
 )
 
 CONFIG_SCHEMA = (
     cv.Schema(
         {
-            cv.GenerateID(): cv.declare_id(InkbirdUBSTH1_MINI),
+            cv.GenerateID(): cv.declare_id(InkbirdIbstH1Mini),
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,

--- a/esphome/components/ledc/ledc_output.h
+++ b/esphome/components/ledc/ledc_output.h
@@ -10,6 +10,7 @@
 namespace esphome {
 namespace ledc {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern uint8_t next_ledc_channel;
 
 class LEDCOutput : public output::FloatOutput, public Component {

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -80,7 +80,7 @@ class AddressableLight : public LightOutput, public Component {
 
   void mark_shown_() {
 #ifdef USE_POWER_SUPPLY
-    for (auto c : *this) {
+    for (const auto& c : *this) {
       if (c.get().is_on()) {
         this->power_.request();
         return;

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -80,7 +80,7 @@ class AddressableLight : public LightOutput, public Component {
 
   void mark_shown_() {
 #ifdef USE_POWER_SUPPLY
-    for (const auto& c : *this) {
+    for (const auto &c : *this) {
       if (c.get().is_on()) {
         this->power_.request();
         return;

--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -9,7 +9,7 @@ namespace light {
 class AddressableLightWrapper : public light::AddressableLight {
  public:
   explicit AddressableLightWrapper(light::LightState *light_state) : light_state_(light_state) {
-    this->wrapper_state_ = new uint8_t[5];
+    this->wrapper_state_ = new uint8_t[5];  // NOLINT(cppcoreguidelines-owning-memory)
   }
 
   int32_t size() const override { return 1; }

--- a/esphome/components/light/esp_range_view.h
+++ b/esphome/components/light/esp_range_view.h
@@ -18,6 +18,7 @@ class ESPRangeView : public ESPColorSettable {
  public:
   ESPRangeView(AddressableLight *parent, int32_t begin, int32_t end)
       : parent_(parent), begin_(begin), end_(end < begin ? begin : end) {}
+  ESPRangeView(const ESPRangeView &) = default;
 
   int32_t size() const { return this->end_ - this->begin_; }
   ESPColorView operator[](int32_t index) const;
@@ -62,6 +63,7 @@ class ESPRangeView : public ESPColorSettable {
 class ESPRangeIterator {
  public:
   ESPRangeIterator(const ESPRangeView &range, int32_t i) : range_(range), i_(i) {}
+  ESPRangeIterator(const ESPRangeIterator &) = default;
   ESPRangeIterator operator++() {
     this->i_++;
     return *this;

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -31,7 +31,7 @@ class ApplianceBase : public Component, public uart::UARTDevice, public climate:
   ApplianceBase() {
     this->base_.setStream(this);
     this->base_.addOnStateCallback(std::bind(&ApplianceBase::on_status_change, this));
-    dudanov::midea::ApplianceBase::setLogger([](int level, const char *tag, int line, String format, va_list args) {
+    dudanov::midea::ApplianceBase::setLogger([](int level, const char *tag, int line, const String& format, va_list args) {
       esp_log_vprintf_(level, tag, line, format.c_str(), args);
     });
   }
@@ -46,11 +46,11 @@ class ApplianceBase : public Component, public uart::UARTDevice, public climate:
   void set_request_attempts(uint32_t attempts) { this->base_.setNumAttempts(attempts); }
   void set_beeper_feedback(bool state) { this->base_.setBeeper(state); }
   void set_autoconf(bool value) { this->base_.setAutoconf(value); }
-  void set_supported_modes(std::set<ClimateMode> modes) { this->supported_modes_ = std::move(modes); }
-  void set_supported_swing_modes(std::set<ClimateSwingMode> modes) { this->supported_swing_modes_ = std::move(modes); }
-  void set_supported_presets(std::set<ClimatePreset> presets) { this->supported_presets_ = std::move(presets); }
-  void set_custom_presets(std::set<std::string> presets) { this->supported_custom_presets_ = std::move(presets); }
-  void set_custom_fan_modes(std::set<std::string> modes) { this->supported_custom_fan_modes_ = std::move(modes); }
+  void set_supported_modes(const std::set<ClimateMode>& modes) { this->supported_modes_ = modes; }
+  void set_supported_swing_modes(const std::set<ClimateSwingMode>& modes) { this->supported_swing_modes_ = modes; }
+  void set_supported_presets(const std::set<ClimatePreset>& presets) { this->supported_presets_ = presets; }
+  void set_custom_presets(const std::set<std::string>& presets) { this->supported_custom_presets_ = presets; }
+  void set_custom_fan_modes(const std::set<std::string>& modes) { this->supported_custom_fan_modes_ = modes; }
   virtual void on_status_change() = 0;
 #ifdef USE_REMOTE_TRANSMITTER
   void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) {

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -31,9 +31,10 @@ class ApplianceBase : public Component, public uart::UARTDevice, public climate:
   ApplianceBase() {
     this->base_.setStream(this);
     this->base_.addOnStateCallback(std::bind(&ApplianceBase::on_status_change, this));
-    dudanov::midea::ApplianceBase::setLogger([](int level, const char *tag, int line, const String& format, va_list args) {
-      esp_log_vprintf_(level, tag, line, format.c_str(), args);
-    });
+    dudanov::midea::ApplianceBase::setLogger(
+        [](int level, const char *tag, int line, const String &format, va_list args) {
+          esp_log_vprintf_(level, tag, line, format.c_str(), args);
+        });
   }
   bool can_proceed() override {
     return this->base_.getAutoconfStatus() != dudanov::midea::AutoconfStatus::AUTOCONF_PROGRESS;
@@ -46,11 +47,11 @@ class ApplianceBase : public Component, public uart::UARTDevice, public climate:
   void set_request_attempts(uint32_t attempts) { this->base_.setNumAttempts(attempts); }
   void set_beeper_feedback(bool state) { this->base_.setBeeper(state); }
   void set_autoconf(bool value) { this->base_.setAutoconf(value); }
-  void set_supported_modes(const std::set<ClimateMode>& modes) { this->supported_modes_ = modes; }
-  void set_supported_swing_modes(const std::set<ClimateSwingMode>& modes) { this->supported_swing_modes_ = modes; }
-  void set_supported_presets(const std::set<ClimatePreset>& presets) { this->supported_presets_ = presets; }
-  void set_custom_presets(const std::set<std::string>& presets) { this->supported_custom_presets_ = presets; }
-  void set_custom_fan_modes(const std::set<std::string>& modes) { this->supported_custom_fan_modes_ = modes; }
+  void set_supported_modes(const std::set<ClimateMode> &modes) { this->supported_modes_ = modes; }
+  void set_supported_swing_modes(const std::set<ClimateSwingMode> &modes) { this->supported_swing_modes_ = modes; }
+  void set_supported_presets(const std::set<ClimatePreset> &presets) { this->supported_presets_ = presets; }
+  void set_custom_presets(const std::set<std::string> &presets) { this->supported_custom_presets_ = presets; }
+  void set_custom_fan_modes(const std::set<std::string> &modes) { this->supported_custom_fan_modes_ = modes; }
   virtual void on_status_change() = 0;
 #ifdef USE_REMOTE_TRANSMITTER
   void set_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) {

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
@@ -25,14 +25,14 @@ bool PVVXMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
 
   bool success = false;
   for (auto &service_data : device.get_service_datas()) {
-    auto res = parse_header(service_data);
+    auto res = parse_header_(service_data);
     if (!res.has_value()) {
       continue;
     }
-    if (!(parse_message(service_data.data, *res))) {
+    if (!(parse_message_(service_data.data, *res))) {
       continue;
     }
-    if (!(report_results(res, device.address_str()))) {
+    if (!(report_results_(res, device.address_str()))) {
       continue;
     }
     if (res->temperature.has_value() && this->temperature_ != nullptr)
@@ -49,7 +49,7 @@ bool PVVXMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
   return success;
 }
 
-optional<ParseResult> PVVXMiThermometer::parse_header(const esp32_ble_tracker::ServiceData &service_data) {
+optional<ParseResult> PVVXMiThermometer::parse_header_(const esp32_ble_tracker::ServiceData &service_data) {
   ParseResult result;
   if (!service_data.uuid.contains(0x1A, 0x18)) {
     ESP_LOGVV(TAG, "parse_header(): no service data UUID magic bytes.");
@@ -68,7 +68,7 @@ optional<ParseResult> PVVXMiThermometer::parse_header(const esp32_ble_tracker::S
   return result;
 }
 
-bool PVVXMiThermometer::parse_message(const std::vector<uint8_t> &message, ParseResult &result) {
+bool PVVXMiThermometer::parse_message_(const std::vector<uint8_t> &message, ParseResult &result) {
   /*
   All data little endian
   uint8_t     size;   // = 19
@@ -109,7 +109,7 @@ bool PVVXMiThermometer::parse_message(const std::vector<uint8_t> &message, Parse
   return true;
 }
 
-bool PVVXMiThermometer::report_results(const optional<ParseResult> &result, const std::string &address) {
+bool PVVXMiThermometer::report_results_(const optional<ParseResult> &result, const std::string &address) {
   if (!result.has_value()) {
     ESP_LOGVV(TAG, "report_results(): no results available.");
     return false;

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -36,9 +36,9 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
   sensor::Sensor *battery_level_{nullptr};
   sensor::Sensor *battery_voltage_{nullptr};
 
-  optional<ParseResult> parse_header(const esp32_ble_tracker::ServiceData &service_data);
-  bool parse_message(const std::vector<uint8_t> &message, ParseResult &result);
-  bool report_results(const optional<ParseResult> &result, const std::string &address);
+  optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
+  bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
+  bool report_results_(const optional<ParseResult> &result, const std::string &address);
 };
 
 }  // namespace pvvx_mithermometer

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -92,7 +92,7 @@ using MideaDumper = RemoteReceiverDumper<MideaProtocol, MideaData>;
 
 template<typename... Ts> class MideaAction : public RemoteTransmitterActionBase<Ts...> {
   TEMPLATABLE_VALUE(std::vector<uint8_t>, code)
-  void set_code(const std::vector<uint8_t>& code) { code_ = code; }
+  void set_code(const std::vector<uint8_t> &code) { code_ = code; }
   void encode(RemoteTransmitData *dst, Ts... x) override {
     MideaData data = this->code_.value(x...);
     data.finalize();

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -92,7 +92,7 @@ using MideaDumper = RemoteReceiverDumper<MideaProtocol, MideaData>;
 
 template<typename... Ts> class MideaAction : public RemoteTransmitterActionBase<Ts...> {
   TEMPLATABLE_VALUE(std::vector<uint8_t>, code)
-  void set_code(std::vector<uint8_t> code) { code_ = code; }
+  void set_code(const std::vector<uint8_t>& code) { code_ = code; }
   void encode(RemoteTransmitData *dst, Ts... x) override {
     MideaData data = this->code_.value(x...);
     data.finalize();

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -161,11 +161,11 @@ class RemoteRMTChannel {
   void set_clock_divider(uint8_t clock_divider) { this->clock_divider_ = clock_divider; }
 
  protected:
-  uint32_t from_microseconds(uint32_t us) {
+  uint32_t from_microseconds_(uint32_t us) {
     const uint32_t ticks_per_ten_us = 80000000u / this->clock_divider_ / 100000u;
     return us * ticks_per_ten_us / 10;
   }
-  uint32_t to_microseconds(uint32_t ticks) {
+  uint32_t to_microseconds_(uint32_t ticks) {
     const uint32_t ticks_per_ten_us = 80000000u / this->clock_divider_ / 100000u;
     return (ticks * 10) / ticks_per_ten_us;
   }

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -20,9 +20,9 @@ void RemoteReceiverComponent::setup() {
     rmt.rx_config.filter_en = false;
   } else {
     rmt.rx_config.filter_en = true;
-    rmt.rx_config.filter_ticks_thresh = this->from_microseconds(this->filter_us_);
+    rmt.rx_config.filter_ticks_thresh = this->from_microseconds_(this->filter_us_);
   }
-  rmt.rx_config.idle_threshold = this->from_microseconds(this->idle_us_);
+  rmt.rx_config.idle_threshold = this->from_microseconds_(this->idle_us_);
 
   esp_err_t error = rmt_config(&rmt);
   if (error != ESP_OK) {
@@ -90,14 +90,14 @@ void RemoteReceiverComponent::decode_rmt_(rmt_item32_t *item, size_t len) {
   ESP_LOGVV(TAG, "START:");
   for (size_t i = 0; i < len; i++) {
     if (item[i].level0) {
-      ESP_LOGVV(TAG, "%u A: ON %uus (%u ticks)", i, this->to_microseconds(item[i].duration0), item[i].duration0);
+      ESP_LOGVV(TAG, "%u A: ON %uus (%u ticks)", i, this->to_microseconds_(item[i].duration0), item[i].duration0);
     } else {
-      ESP_LOGVV(TAG, "%u A: OFF %uus (%u ticks)", i, this->to_microseconds(item[i].duration0), item[i].duration0);
+      ESP_LOGVV(TAG, "%u A: OFF %uus (%u ticks)", i, this->to_microseconds_(item[i].duration0), item[i].duration0);
     }
     if (item[i].level1) {
-      ESP_LOGVV(TAG, "%u B: ON %uus (%u ticks)", i, this->to_microseconds(item[i].duration1), item[i].duration1);
+      ESP_LOGVV(TAG, "%u B: ON %uus (%u ticks)", i, this->to_microseconds_(item[i].duration1), item[i].duration1);
     } else {
-      ESP_LOGVV(TAG, "%u B: OFF %uus (%u ticks)", i, this->to_microseconds(item[i].duration1), item[i].duration1);
+      ESP_LOGVV(TAG, "%u B: OFF %uus (%u ticks)", i, this->to_microseconds_(item[i].duration1), item[i].duration1);
     }
   }
   ESP_LOGVV(TAG, "\n");
@@ -111,16 +111,16 @@ void RemoteReceiverComponent::decode_rmt_(rmt_item32_t *item, size_t len) {
     } else {
       if (prev_length > 0) {
         if (prev_level) {
-          this->temp_.push_back(this->to_microseconds(prev_length) * multiplier);
+          this->temp_.push_back(this->to_microseconds_(prev_length) * multiplier);
         } else {
-          this->temp_.push_back(-int32_t(this->to_microseconds(prev_length)) * multiplier);
+          this->temp_.push_back(-int32_t(this->to_microseconds_(prev_length)) * multiplier);
         }
       }
       prev_level = bool(item[i].level0);
       prev_length = item[i].duration0;
     }
 
-    if (this->to_microseconds(prev_length) > this->idle_us_) {
+    if (this->to_microseconds_(prev_length) > this->idle_us_) {
       break;
     }
 
@@ -131,24 +131,24 @@ void RemoteReceiverComponent::decode_rmt_(rmt_item32_t *item, size_t len) {
     } else {
       if (prev_length > 0) {
         if (prev_level) {
-          this->temp_.push_back(this->to_microseconds(prev_length) * multiplier);
+          this->temp_.push_back(this->to_microseconds_(prev_length) * multiplier);
         } else {
-          this->temp_.push_back(-int32_t(this->to_microseconds(prev_length)) * multiplier);
+          this->temp_.push_back(-int32_t(this->to_microseconds_(prev_length)) * multiplier);
         }
       }
       prev_level = bool(item[i].level1);
       prev_length = item[i].duration1;
     }
 
-    if (this->to_microseconds(prev_length) > this->idle_us_) {
+    if (this->to_microseconds_(prev_length) > this->idle_us_) {
       break;
     }
   }
   if (prev_length > 0) {
     if (prev_level) {
-      this->temp_.push_back(this->to_microseconds(prev_length) * multiplier);
+      this->temp_.push_back(this->to_microseconds_(prev_length) * multiplier);
     } else {
-      this->temp_.push_back(-int32_t(this->to_microseconds(prev_length)) * multiplier);
+      this->temp_.push_back(-int32_t(this->to_microseconds_(prev_length)) * multiplier);
     }
   }
 }

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -35,7 +35,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 #endif
 
 #ifdef USE_ESP32
-  void configure_rmt();
+  void configure_rmt_();
 
   uint32_t current_carrier_frequency_{UINT32_MAX};
   bool initialized_{false};

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -9,7 +9,7 @@ namespace remote_transmitter {
 
 static const char *const TAG = "remote_transmitter";
 
-void RemoteTransmitterComponent::setup() { this->configure_rmt(); }
+void RemoteTransmitterComponent::setup() { this->configure_rmt_(); }
 
 void RemoteTransmitterComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Transmitter...");
@@ -27,7 +27,7 @@ void RemoteTransmitterComponent::dump_config() {
   }
 }
 
-void RemoteTransmitterComponent::configure_rmt() {
+void RemoteTransmitterComponent::configure_rmt_() {
   rmt_config_t c{};
 
   this->config_rmt(c);
@@ -77,7 +77,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
 
   if (this->current_carrier_frequency_ != this->temp_.get_carrier_frequency()) {
     this->current_carrier_frequency_ = this->temp_.get_carrier_frequency();
-    this->configure_rmt();
+    this->configure_rmt_();
   }
 
   this->rmt_temp_.clear();

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -89,7 +89,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     bool level = val >= 0;
     if (!level)
       val = -val;
-    val = this->from_microseconds(static_cast<uint32_t>(val));
+    val = this->from_microseconds_(static_cast<uint32_t>(val));
 
     do {
       int32_t item = std::min(val, int32_t(32767));

--- a/esphome/components/socket/headers.h
+++ b/esphome/components/socket/headers.h
@@ -7,10 +7,10 @@
 #ifdef USE_SOCKET_IMPL_LWIP_TCP
 
 #define LWIP_INTERNAL
-#include <sys/types.h>
 #include "lwip/inet.h"
-#include <stdint.h>
-#include <errno.h>
+#include <cerrno>
+#include <cstdint>
+#include <sys/types.h>
 
 /* Address families.  */
 #define AF_UNSPEC 0
@@ -45,9 +45,10 @@
 
 #define SOL_SOCKET 0xfff /* options for socket level */
 
-typedef uint8_t sa_family_t;
-typedef uint16_t in_port_t;
+using sa_family_t = uint8_t;
+using in_port_t = uint16_t;
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct sockaddr_in {
   uint8_t sin_len;
   sa_family_t sin_family;
@@ -57,6 +58,7 @@ struct sockaddr_in {
   char sin_zero[SIN_ZERO_LEN];
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct sockaddr_in6 {
   uint8_t sin6_len;          /* length of this structure    */
   sa_family_t sin6_family;   /* AF_INET6                    */
@@ -66,12 +68,14 @@ struct sockaddr_in6 {
   uint32_t sin6_scope_id;    /* Set of interfaces for scope */
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct sockaddr {
   uint8_t sa_len;
   sa_family_t sa_family;
   char sa_data[14];
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct sockaddr_storage {
   uint8_t s2_len;
   sa_family_t ss_family;
@@ -79,8 +83,9 @@ struct sockaddr_storage {
   uint32_t s2_data2[3];
   uint32_t s2_data3[3];
 };
-typedef uint32_t socklen_t;
+using socklen_t = uint32_t;
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct iovec {
   void *iov_base;
   size_t iov_len;
@@ -106,13 +111,13 @@ struct iovec {
 
 #ifdef USE_SOCKET_IMPL_BSD_SOCKETS
 
-#include <sys/types.h>
-#include <sys/socket.h>
+#include <cstdint>
+#include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdint.h>
 
 #ifdef USE_ARDUINO
 // arduino-esp32 declares a global var called INADDR_NONE which is replaced
@@ -121,7 +126,7 @@ struct iovec {
 #undef INADDR_NONE
 #endif
 // not defined for ESP32
-typedef uint32_t socklen_t;
+using socklen_t = uint32_t;
 
 #define ESPHOME_INADDR_ANY ((uint32_t) 0x00000000UL)
 #define ESPHOME_INADDR_NONE ((uint32_t) 0xFFFFFFFFUL)

--- a/esphome/components/t6615/t6615.h
+++ b/esphome/components/t6615/t6615.h
@@ -35,7 +35,7 @@ class T6615Component : public PollingComponent, public uart::UARTDevice {
   void send_ppm_command_();
 
   T6615Command command_ = T6615Command::NONE;
-  unsigned long command_time_ = 0;
+  uint32_t command_time_ = 0;
 
   sensor::Sensor *co2_sensor_{nullptr};
 };

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -13,7 +13,7 @@ namespace esphome {
 namespace uart {
 
 static const char *const TAG = "uart.arduino_esp8266";
-bool ESP8266UartComponent::serial0InUse = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+bool ESP8266UartComponent::serial0_in_use = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 uint32_t ESP8266UartComponent::get_config() {
   uint32_t config = 0;
@@ -55,7 +55,7 @@ void ESP8266UartComponent::setup() {
   // is 1 we still want to use Serial.
   SerialConfig config = static_cast<SerialConfig>(get_config());
 
-  if (!ESP8266UartComponent::serial0InUse && (tx_pin_ == nullptr || tx_pin_->get_pin() == 1) &&
+  if (!ESP8266UartComponent::serial0_in_use && (tx_pin_ == nullptr || tx_pin_->get_pin() == 1) &&
       (rx_pin_ == nullptr || rx_pin_->get_pin() == 3)
 #ifdef USE_LOGGER
       // we will use UART0 if logger isn't using it in swapped mode
@@ -66,8 +66,8 @@ void ESP8266UartComponent::setup() {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
-    ESP8266UartComponent::serial0InUse = true;
-  } else if (!ESP8266UartComponent::serial0InUse && (tx_pin_ == nullptr || tx_pin_->get_pin() == 15) &&
+    ESP8266UartComponent::serial0_in_use = true;
+  } else if (!ESP8266UartComponent::serial0_in_use && (tx_pin_ == nullptr || tx_pin_->get_pin() == 15) &&
              (rx_pin_ == nullptr || rx_pin_->get_pin() == 13)
 #ifdef USE_LOGGER
              // we will use UART0 swapped if logger isn't using it in regular mode
@@ -79,7 +79,7 @@ void ESP8266UartComponent::setup() {
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
     this->hw_serial_->swap();
-    ESP8266UartComponent::serial0InUse = true;
+    ESP8266UartComponent::serial0_in_use = true;
   } else if ((tx_pin_ == nullptr || tx_pin_->get_pin() == 2) && (rx_pin_ == nullptr || rx_pin_->get_pin() == 8)) {
     this->hw_serial_ = &Serial1;
     this->hw_serial_->begin(this->baud_rate_, config);

--- a/esphome/components/uart/uart_component_esp8266.h
+++ b/esphome/components/uart/uart_component_esp8266.h
@@ -70,7 +70,7 @@ class ESP8266UartComponent : public UARTComponent, public Component {
   ESP8266SoftwareSerial *sw_serial_{nullptr};
 
  private:
-  static bool serial0InUse;
+  static bool serial0_in_use;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 };
 
 }  // namespace uart

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -14,7 +14,7 @@ namespace esphome {
 namespace uart {
 static const char *const TAG = "uart.idf";
 
-uart_config_t IDFUARTComponent::get_config() {
+uart_config_t IDFUARTComponent::get_config_() {
   uart_parity_t parity = UART_PARITY_DISABLE;
   if (this->parity_ == UART_CONFIG_PARITY_EVEN)
     parity = UART_PARITY_EVEN;
@@ -70,7 +70,7 @@ void IDFUARTComponent::setup() {
 
   xSemaphoreTake(this->lock_, portMAX_DELAY);
 
-  uart_config_t uart_config = this->get_config();
+  uart_config_t uart_config = this->get_config_();
   esp_err_t err = uart_param_config(this->uart_num_, &uart_config);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_param_config failed: %s", esp_err_to_name(err));

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -26,7 +26,7 @@ class IDFUARTComponent : public UARTComponent, public Component {
  protected:
   void check_logger_conflict() override;
   uart_port_t uart_num_;
-  uart_config_t get_config();
+  uart_config_t get_config_();
   SemaphoreHandle_t lock_;
 
   bool has_peek_{false};

--- a/esphome/components/wifi_info/wifi_info_text_sensor.h
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.h
@@ -13,7 +13,7 @@ class IPAddressWiFiInfo : public Component, public text_sensor::TextSensor {
     auto ip = wifi::global_wifi_component->wifi_sta_ip();
     if (ip != this->last_ip_) {
       this->last_ip_ = ip;
-      this->publish_state(ip.str().c_str());
+      this->publish_state(ip.str());
     }
   }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
@@ -23,16 +23,16 @@ bool XiaomiMiscale::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 
   bool success = false;
   for (auto &service_data : device.get_service_datas()) {
-    auto res = parse_header(service_data);
+    auto res = parse_header_(service_data);
     if (!res.has_value()) {
       continue;
     }
 
-    if (!(parse_message(service_data.data, *res))) {
+    if (!(parse_message_(service_data.data, *res))) {
       continue;
     }
 
-    if (!(report_results(res, device.address_str()))) {
+    if (!(report_results_(res, device.address_str()))) {
       continue;
     }
 
@@ -49,7 +49,7 @@ bool XiaomiMiscale::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-optional<ParseResult> XiaomiMiscale::parse_header(const esp32_ble_tracker::ServiceData &service_data) {
+optional<ParseResult> XiaomiMiscale::parse_header_(const esp32_ble_tracker::ServiceData &service_data) {
   ParseResult result;
   if (service_data.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x181D) && service_data.data.size() == 10) {
     result.version = 1;
@@ -65,15 +65,15 @@ optional<ParseResult> XiaomiMiscale::parse_header(const esp32_ble_tracker::Servi
   return result;
 }
 
-bool XiaomiMiscale::parse_message(const std::vector<uint8_t> &message, ParseResult &result) {
+bool XiaomiMiscale::parse_message_(const std::vector<uint8_t> &message, ParseResult &result) {
   if (result.version == 1) {
-    return parse_message_V1(message, result);
+    return parse_message_v1_(message, result);
   } else {
-    return parse_message_V2(message, result);
+    return parse_message_v2_(message, result);
   }
 }
 
-bool XiaomiMiscale::parse_message_V1(const std::vector<uint8_t> &message, ParseResult &result) {
+bool XiaomiMiscale::parse_message_v1_(const std::vector<uint8_t> &message, ParseResult &result) {
   // message size is checked in parse_header
   // 1-2 Weight (MISCALE 181D)
   // 3-4 Years (MISCALE 181D)
@@ -97,7 +97,7 @@ bool XiaomiMiscale::parse_message_V1(const std::vector<uint8_t> &message, ParseR
   return true;
 }
 
-bool XiaomiMiscale::parse_message_V2(const std::vector<uint8_t> &message, ParseResult &result) {
+bool XiaomiMiscale::parse_message_v2_(const std::vector<uint8_t> &message, ParseResult &result) {
   // message size is checked in parse_header
   // 2-3 Years (MISCALE 2 181B)
   // 4 month (MISCALE 2 181B)
@@ -138,7 +138,7 @@ bool XiaomiMiscale::parse_message_V2(const std::vector<uint8_t> &message, ParseR
   return true;
 }
 
-bool XiaomiMiscale::report_results(const optional<ParseResult> &result, const std::string &address) {
+bool XiaomiMiscale::report_results_(const optional<ParseResult> &result, const std::string &address) {
   if (!result.has_value()) {
     ESP_LOGVV(TAG, "report_results(): no results available.");
     return false;

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.h
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.h
@@ -30,11 +30,11 @@ class XiaomiMiscale : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   sensor::Sensor *weight_{nullptr};
   sensor::Sensor *impedance_{nullptr};
 
-  optional<ParseResult> parse_header(const esp32_ble_tracker::ServiceData &service_data);
-  bool parse_message(const std::vector<uint8_t> &message, ParseResult &result);
-  bool parse_message_V1(const std::vector<uint8_t> &message, ParseResult &result);
-  bool parse_message_V2(const std::vector<uint8_t> &message, ParseResult &result);
-  bool report_results(const optional<ParseResult> &result, const std::string &address);
+  optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
+  bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
+  bool parse_message_v1_(const std::vector<uint8_t> &message, ParseResult &result);
+  bool parse_message_v2_(const std::vector<uint8_t> &message, ParseResult &result);
+  bool report_results_(const optional<ParseResult> &result, const std::string &address);
 };
 
 }  // namespace xiaomi_miscale

--- a/esphome/core/gpio.h
+++ b/esphome/core/gpio.h
@@ -6,7 +6,7 @@ namespace esphome {
 
 #define LOG_PIN(prefix, pin) \
   if ((pin) != nullptr) { \
-    ESP_LOGCONFIG(TAG, prefix "%s", pin->dump_summary().c_str()); \
+    ESP_LOGCONFIG(TAG, prefix "%s", (pin)->dump_summary().c_str()); \
   }
 
 // put GPIO flags in a namepsace to not pollute esphome namespace
@@ -78,7 +78,7 @@ class ISRInternalGPIOPin {
 class InternalGPIOPin : public GPIOPin {
  public:
   template<typename T> void attach_interrupt(void (*func)(T *), T *arg, gpio::InterruptType type) const {
-    this->attach_interrupt_(reinterpret_cast<void (*)(void *)>(func), arg, type);
+    this->attach_interrupt(reinterpret_cast<void (*)(void *)>(func), arg, type);
   }
 
   virtual void detach_interrupt() const = 0;
@@ -92,7 +92,7 @@ class InternalGPIOPin : public GPIOPin {
   virtual bool is_inverted() const = 0;
 
  protected:
-  virtual void attach_interrupt_(void (*func)(void *), void *arg, gpio::InterruptType type) const = 0;
+  virtual void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const = 0;
 };
 
 }  // namespace esphome

--- a/esphome/core/hal.h
+++ b/esphome/core/hal.h
@@ -37,7 +37,7 @@ void yield();
 uint32_t millis();
 uint32_t micros();
 void delay(uint32_t ms);
-void delayMicroseconds(uint32_t us);
+void delayMicroseconds(uint32_t us);  // NOLINT(readability-identifier-naming)
 void __attribute__((noreturn)) arch_restart();
 void arch_feed_wdt();
 uint32_t arch_get_cpu_cycle_count();

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -333,10 +333,10 @@ template<typename T> T *new_buffer(size_t length) {
   if (psramFound()) {
     buffer = (T *) ps_malloc(length);
   } else {
-    buffer = new T[length];
+    buffer = new T[length];  // NOLINT(cppcoreguidelines-owning-memory)
   }
 #else
-  buffer = new T[length];  // NOLINT
+  buffer = new T[length];  // NOLINT(cppcoreguidelines-owning-memory)
 #endif
 
   return buffer;

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -17,7 +17,7 @@ import pexpect
 
 sys.path.append(os.path.dirname(__file__))
 from helpers import shlex_quote, get_output, filter_grep, \
-    build_all_include, temp_header_file, git_ls_files, filter_changed, load_idedata
+    build_all_include, temp_header_file, git_ls_files, filter_changed, load_idedata, basepath
 
 
 def clang_options(idedata):
@@ -89,6 +89,7 @@ def run_tidy(args, options, tmpdir, queue, lock, failed_files):
             invocation.append('-quiet')
 
         invocation.append(os.path.abspath(path))
+        invocation.append(f"--header-filter={os.path.abspath(basepath)}/.*")
         invocation.append('--')
         invocation.extend(options)
         invocation_s = ' '.join(shlex_quote(x) for x in invocation)


### PR DESCRIPTION
# What does this implement/fix? 

See also https://github.com/esphome/esphome/pull/2379#discussion_r715593889

clang-tidy wasn't checking any of our header files before because of a broken header filter.

This should work better (works here at least)

Also allows private class members/methods as discussed in the linked PR

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
