### PR TITLE
Misc fixes for esp-idf

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -176,13 +176,12 @@ void Logger::pre_setup() {
         uart_num_ = UART_NUM_2;
         break;
     }
-    uart_config_t uart_config = {
-        .baud_rate = (int) baud_rate_,
-        .data_bits = UART_DATA_8_BITS,
-        .parity = UART_PARITY_DISABLE,
-        .stop_bits = UART_STOP_BITS_1,
-        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
-    };
+    uart_config_t uart_config{};
+    uart_config.baud_rate = (int) baud_rate_;
+    uart_config.data_bits = UART_DATA_8_BITS;
+    uart_config.parity = UART_PARITY_DISABLE;
+    uart_config.stop_bits = UART_STOP_BITS_1;
+    uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     uart_param_config(uart_num_, &uart_config);
     const int uart_buffer_size = tx_buffer_size_;
     // Install UART driver using an event queue here

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -247,7 +247,11 @@ async def _add_automations(config):
 @coroutine_with_priority(100.0)
 async def to_code(config):
     cg.add_global(cg.global_ns.namespace("esphome").using)
+    # These can be used by user lambdas, put them to default scope
     cg.add_global(cg.RawExpression("using std::isnan"))
+    cg.add_global(cg.RawExpression("using std::min"))
+    cg.add_global(cg.RawExpression("using std::max"))
+
     cg.add(
         cg.App.pre_setup(
             config[CONF_NAME],

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -247,6 +247,7 @@ async def _add_automations(config):
 @coroutine_with_priority(100.0)
 async def to_code(config):
     cg.add_global(cg.global_ns.namespace("esphome").using)
+    cg.add_global(cg.RawExpression("using std::isnan"))
     cg.add(
         cg.App.pre_setup(
             config[CONF_NAME],


### PR DESCRIPTION
# What does this implement/fix? 

Ref https://github.com/esphome/esphome/pull/2303

`std::isnan` may be used by user lambdas, so add a global `using` statement for it

Newer esp-idfs have more uart_config_t fields (that can be 0). Set each field individually to prevent compiler warnings (and ensure rest is 0-initialized)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
