### PR TITLE
Fix InterruptLock on ESP-IDF

### DIFF
--- a/esphome/components/dallas/__init__.py
+++ b/esphome/components/dallas/__init__.py
@@ -11,13 +11,17 @@ dallas_ns = cg.esphome_ns.namespace("dallas")
 DallasComponent = dallas_ns.class_("DallasComponent", cg.PollingComponent)
 ESPOneWire = dallas_ns.class_("ESPOneWire")
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(DallasComponent),
-        cv.GenerateID(CONF_ONE_WIRE_ID): cv.declare_id(ESPOneWire),
-        cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
-    }
-).extend(cv.polling_component_schema("60s"))
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DallasComponent),
+            cv.GenerateID(CONF_ONE_WIRE_ID): cv.declare_id(ESPOneWire),
+            cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
+        }
+    ).extend(cv.polling_component_schema("60s")),
+    # pin_mode call logs in esp-idf, but InterruptLock is active -> crash
+    cv.only_with_arduino,
+)
 
 
 async def to_code(config):

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -79,28 +79,27 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   int8_t i = 0;
   uint8_t data[5] = {0, 0, 0, 0, 0};
 
+  this->pin_->digital_write(false);
+  this->pin_->pin_mode(gpio::FLAG_OUTPUT);
+  this->pin_->digital_write(false);
+
+  if (this->model_ == DHT_MODEL_DHT11) {
+    delayMicroseconds(18000);
+  } else if (this->model_ == DHT_MODEL_SI7021) {
+    delayMicroseconds(500);
+    this->pin_->digital_write(true);
+    delayMicroseconds(40);
+  } else if (this->model_ == DHT_MODEL_DHT22_TYPE2) {
+    delayMicroseconds(2000);
+  } else if (this->model_ == DHT_MODEL_AM2302) {
+    delayMicroseconds(1000);
+  } else {
+    delayMicroseconds(800);
+  }
+  this->pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+
   {
     InterruptLock lock;
-
-    this->pin_->digital_write(false);
-    this->pin_->pin_mode(gpio::FLAG_OUTPUT);
-    this->pin_->digital_write(false);
-
-    if (this->model_ == DHT_MODEL_DHT11) {
-      delayMicroseconds(18000);
-    } else if (this->model_ == DHT_MODEL_SI7021) {
-      delayMicroseconds(500);
-      this->pin_->digital_write(true);
-      delayMicroseconds(40);
-    } else if (this->model_ == DHT_MODEL_DHT22_TYPE2) {
-      delayMicroseconds(2000);
-    } else if (this->model_ == DHT_MODEL_AM2302) {
-      delayMicroseconds(1000);
-    } else {
-      delayMicroseconds(800);
-    }
-    this->pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
-
     // Host pull up 20-40us then DHT response 80us
     // Start waiting for initial rising edge at the center when we
     // expect the DHT response (30us+40us)

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -350,7 +350,7 @@ std::string hexencode(const uint8_t *data, uint32_t len) {
 IRAM_ATTR InterruptLock::InterruptLock() { xt_state_ = xt_rsil(15); }
 IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(xt_state_); }
 #endif
-#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+#ifdef USE_ESP32
 IRAM_ATTR InterruptLock::InterruptLock() { portDISABLE_INTERRUPTS(); }
 IRAM_ATTR InterruptLock::~InterruptLock() { portENABLE_INTERRUPTS(); }
 #endif


### PR DESCRIPTION
# What does this implement/fix? 

- Fix InterruptLock not defined with esp-idf
- esp-idf (the framework, not us) logs when calling `pin_mode`. But when `InterruptLock` is active during that time the log writing crashes (because the uart interrupt is disabled too). On DHT fix by moving interruptlock further (should be fine I think, at least in my experience the first delay is somewhat forgiving); on dallas mark the component as not supporting esp-idf at this time

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
