### PR TITLE
Re-enable TCP nodelay for ESP32

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -127,6 +127,14 @@ APIError APINoiseFrameHelper::init() {
     return APIError::TCP_NONBLOCKING_FAILED;
   }
 
+  int enable = 1;
+  err = socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nodelay failed with errno %d", errno);
+    return APIError::TCP_NODELAY_FAILED;
+  }
+
   // init prologue
   prologue_.insert(prologue_.end(), PROLOGUE_INIT, PROLOGUE_INIT + strlen(PROLOGUE_INIT));
 
@@ -721,6 +729,13 @@ APIError APIPlaintextFrameHelper::init() {
     state_ = State::FAILED;
     HELPER_LOG("Setting nonblocking failed with errno %d", errno);
     return APIError::TCP_NONBLOCKING_FAILED;
+  }
+  int enable = 1;
+  err = socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nodelay failed with errno %d", errno);
+    return APIError::TCP_NODELAY_FAILED;
   }
 
   state_ = State::DATA;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -257,7 +257,7 @@ class LWIPRawImpl : public Socket {
         errno = EINVAL;
         return -1;
       }
-      *reinterpret_cast<int *>(optval) = tcp_nagle_disabled(pcb_);
+      *reinterpret_cast<int *>(optval) = nodelay_;
       *optlen = 4;
       return 0;
     }
@@ -286,11 +286,7 @@ class LWIPRawImpl : public Socket {
         return -1;
       }
       int val = *reinterpret_cast<const int *>(optval);
-      if (val != 0) {
-        tcp_nagle_disable(pcb_);
-      } else {
-        tcp_nagle_enable(pcb_);
-      }
+      nodelay_ = val;
       return 0;
     }
 
@@ -444,9 +440,11 @@ class LWIPRawImpl : public Socket {
     if (written == 0)
       // no need to output if nothing written
       return 0;
-    int err = internal_output();
-    if (err == -1)
-      return -1;
+    if (nodelay_) {
+      int err = internal_output();
+      if (err == -1)
+        return -1;
+    }
     return written;
   }
   ssize_t writev(const struct iovec *iov, int iovcnt) override {
@@ -466,9 +464,11 @@ class LWIPRawImpl : public Socket {
     if (written == 0)
       // no need to output if nothing written
       return 0;
-    int err = internal_output();
-    if (err == -1)
-      return -1;
+    if (nodelay_) {
+      int err = internal_output();
+      if (err == -1)
+        return -1;
+    }
     return written;
   }
   int setblocking(bool blocking) override {
@@ -550,6 +550,9 @@ class LWIPRawImpl : public Socket {
   bool rx_closed_ = false;
   pbuf *rx_buf_ = nullptr;
   size_t rx_buf_offset_ = 0;
+  // don't use lwip nodelay flag, it sometimes causes reconnect
+  // instead use it for determining whether to call lwip_output
+  bool nodelay_ = false;
 };
 
 std::unique_ptr<Socket> socket(int domain, int type, int protocol) {


### PR DESCRIPTION
# What does this implement/fix? 

Nodelay was disabled in https://github.com/esphome/esphome/pull/2342 because on ESP8266s it looks like lwip has some strange bug where having nodelay enabled causes spurious api errors.

But on some of my ESP32 devices nodelay is really needed (and I suspect I'm not the only one): Without nodelay NAGLE is enabled and my lights take 3+ seconds to report their updated state.

Note that on ESP8266 the implementation is equivalent now. We don't set the _lwip_ nagle flag, but instead use the flag to figure out if we should call `tcp_output` at the end of a write.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
