### PR TITLE
Fix handling of timestamps in Teleinfo component.

### DIFF
--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -108,9 +108,19 @@ void TeleInfo::loop() {
        * 0xa | Tag | 0x9 | Data | 0x9 | CRC | 0xd
        *     ^^^^^^^^^^^^^^^^^^^^^^^^^
        * Checksum is computed on the above in standard mode.
+       *
+       * Note that some Tag may have a timestamp in Standard mode. In this case
+       * the frame would looks like this:
+       * 0xa | Tag | 0x9 | Timestamp | 0x9 | Data | 0x9 | CRC | 0xd
+       *
        */
       while ((buf_finger = static_cast<char *>(memchr(buf_finger, (int) 0xa, buf_index_ - 1))) &&
              ((buf_finger - buf_) < buf_index_)) {
+        /*
+         * Make sure timesamp is nullified between each tag as some tags don't
+         * have a timestamp
+         */
+        timestamp_[0] = '\0';
         /* Point to the first char of the group after 0xa */
         buf_finger += 1;
 
@@ -134,7 +144,21 @@ void TeleInfo::loop() {
         /* Advance buf_finger to after the tag and the separator. */
         buf_finger += field_len + 1;
 
-        /* Get value (after next separator) */
+        /* 
+         * If there is two separator, it means there is a timestamp to read
+         * first.
+         */
+        if (std::count(buf_finger, grp_end, separator_) == 2) {
+          field_len = get_field(timestamp_, buf_finger, grp_end, separator_, MAX_TIMESTAMP_SIZE);
+          if (!field_len || field_len >= MAX_TIMESTAMP_SIZE) {
+            ESP_LOGE(TAG, "Invalid Value");
+            break;
+          }
+
+          /* Advance buf_finger to after the first data and the separator. */
+          buf_finger += field_len + 1;
+        }
+
         field_len = get_field(val_, buf_finger, grp_end, separator_, MAX_VAL_SIZE);
         if (!field_len || field_len >= MAX_VAL_SIZE) {
           ESP_LOGE(TAG, "Invalid Value");

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -109,9 +109,12 @@ void TeleInfo::loop() {
        *     ^^^^^^^^^^^^^^^^^^^^^^^^^
        * Checksum is computed on the above in standard mode.
        *
-       * Note that some Tag may have a timestamp in Standard mode. In this case
-       * the frame would looks like this:
+       * Note that some Tags may have a timestamp in Standard mode. In this case
+       * the group would looks like this:
        * 0xa | Tag | 0x9 | Timestamp | 0x9 | Data | 0x9 | CRC | 0xd
+       *
+       * The DATE tag is a special case. The group looks like this
+       * 0xa | Tag | 0x9 | Timestamp | 0x9 | 0x9 | CRC | 0xd
        *
        */
       while ((buf_finger = static_cast<char *>(memchr(buf_finger, (int) 0xa, buf_index_ - 1))) &&
@@ -144,14 +147,14 @@ void TeleInfo::loop() {
         /* Advance buf_finger to after the tag and the separator. */
         buf_finger += field_len + 1;
 
-        /* 
-         * If there is two separator, it means there is a timestamp to read
-         * first.
+        /*
+         * If there is two separators and the tag is not equal to "DATE",
+         * it means there is a timestamp to read first.
          */
-        if (std::count(buf_finger, grp_end, separator_) == 2) {
+        if (std::count(buf_finger, grp_end, separator_) == 2 && strcmp(tag_, "DATE") != 0) {
           field_len = get_field(timestamp_, buf_finger, grp_end, separator_, MAX_TIMESTAMP_SIZE);
           if (!field_len || field_len >= MAX_TIMESTAMP_SIZE) {
-            ESP_LOGE(TAG, "Invalid Value");
+            ESP_LOGE(TAG, "Invalid Timestamp");
             break;
           }
 

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -7,7 +7,7 @@ namespace teleinfo {
 static const char *const TAG = "teleinfo";
 
 /* Helpers */
-static int get_field(char *dest, char *buf_start, char *buf_end, int sep) {
+static int get_field(char *dest, char *buf_start, char *buf_end, int sep, int max_len) {
   char *field_end;
   int len;
 
@@ -15,6 +15,8 @@ static int get_field(char *dest, char *buf_start, char *buf_end, int sep) {
   if (!field_end)
     return 0;
   len = field_end - buf_start;
+  if (len >= max_len)
+    return len;
   strncpy(dest, buf_start, len);
   dest[len] = '\0';
 
@@ -123,7 +125,7 @@ void TeleInfo::loop() {
           continue;
 
         /* Get tag */
-        field_len = get_field(tag_, buf_finger, grp_end, separator_);
+        field_len = get_field(tag_, buf_finger, grp_end, separator_, MAX_TAG_SIZE);
         if (!field_len || field_len >= MAX_TAG_SIZE) {
           ESP_LOGE(TAG, "Invalid tag.");
           break;
@@ -133,7 +135,7 @@ void TeleInfo::loop() {
         buf_finger += field_len + 1;
 
         /* Get value (after next separator) */
-        field_len = get_field(val_, buf_finger, grp_end, separator_);
+        field_len = get_field(val_, buf_finger, grp_end, separator_, MAX_VAL_SIZE);
         if (!field_len || field_len >= MAX_VAL_SIZE) {
           ESP_LOGE(TAG, "Invalid Value");
           break;

--- a/esphome/components/teleinfo/teleinfo.h
+++ b/esphome/components/teleinfo/teleinfo.h
@@ -12,6 +12,7 @@ namespace teleinfo {
 static const uint8_t MAX_TAG_SIZE = 64;
 static const uint16_t MAX_VAL_SIZE = 256;
 static const uint16_t MAX_BUF_SIZE = 1024;
+static const uint16_t MAX_TIMESTAMP_SIZE = 14;
 
 class TeleInfoListener {
  public:
@@ -36,6 +37,7 @@ class TeleInfo : public PollingComponent, public uart::UARTDevice {
   uint32_t buf_index_{0};
   char tag_[MAX_TAG_SIZE];
   char val_[MAX_VAL_SIZE];
+  char timestamp_[MAX_TIMESTAMP_SIZE];
   enum State {
     OFF,
     ON,

--- a/esphome/components/teleinfo/teleinfo.h
+++ b/esphome/components/teleinfo/teleinfo.h
@@ -11,7 +11,7 @@ namespace teleinfo {
  */
 static const uint8_t MAX_TAG_SIZE = 64;
 static const uint16_t MAX_VAL_SIZE = 256;
-static const uint16_t MAX_BUF_SIZE = 1024;
+static const uint16_t MAX_BUF_SIZE = 2048;
 static const uint16_t MAX_TIMESTAMP_SIZE = 14;
 
 class TeleInfoListener {


### PR DESCRIPTION
# What does this implement/fix? 
Some teleinfo tags are using timestamps and have a different frame format.
Those tags are currently breaking the component when enabled.
To unblock user using this tag, simply read the timestamp for now but don't publish it.

While at here, fix a buffer overflow and increase `MAX_BUF_SIZE` to handle 3-phase Linky in Standard mode.

Commits are inspired by the work from #1829 or directly copied from there when the commit was applying correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2060

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
teleinfo:
  id: myteleinfo
  update_interval: 60s
  historical_mode: true

sensor:
  - platform: teleinfo
    tag_name: "DATE"
    name: "date"
    icon: mdi:flash
    teleinfo_id: myteleinfo

text_sensor:
  - platform: teleinfo
    tag_name: "OPTARIF"
    name: "optarif"
    teleinfo_id: myteleinfo

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
