### PR TITLE
String manipulation filters for text sensors!

### DIFF
--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_ID,
     CONF_INTERNAL,
     CONF_ON_VALUE,
+    CONF_ON_RAW_VALUE,
     CONF_TRIGGER_ID,
     CONF_MQTT_ID,
     CONF_NAME,
@@ -29,6 +30,9 @@ TextSensorPtr = TextSensor.operator("ptr")
 
 TextSensorStateTrigger = text_sensor_ns.class_(
     "TextSensorStateTrigger", automation.Trigger.template(cg.std_string)
+)
+TextSensorStateRawTrigger = text_sensor_ns.class_(
+    "TextSensorStateRawTrigger", automation.Trigger.template(cg.std_string)
 )
 TextSensorPublishAction = text_sensor_ns.class_(
     "TextSensorPublishAction", automation.Action
@@ -117,6 +121,13 @@ TEXT_SENSOR_SCHEMA = cv.NAMEABLE_SCHEMA.extend(cv.MQTT_COMPONENT_SCHEMA).extend(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(TextSensorStateTrigger),
             }
         ),
+        cv.Optional(CONF_ON_RAW_VALUE): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                    TextSensorStateRawTrigger
+                ),
+            }
+        ),
     }
 )
 
@@ -138,6 +149,10 @@ async def setup_text_sensor_core_(var, config):
         cg.add(var.set_filters(filters))
 
     for conf in config.get(CONF_ON_VALUE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
+    for conf in config.get(CONF_ON_RAW_VALUE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -44,6 +44,7 @@ validate_filters = cv.validate_registry("filter", FILTER_REGISTRY)
 Filter = text_sensor_ns.class_("Filter")
 LambdaFilter = text_sensor_ns.class_("LambdaFilter", Filter)
 ToUpperFilter = text_sensor_ns.class_("ToUpperFilter", Filter)
+ToLowerFilter = text_sensor_ns.class_("ToLowerFilter", Filter)
 AppendFilter = text_sensor_ns.class_("AppendFilter", Filter)
 PrependFilter = text_sensor_ns.class_("PrependFilter", Filter)
 SubstituteFilter = text_sensor_ns.class_("SubstituteFilter", Filter)
@@ -57,12 +58,14 @@ async def lambda_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id, lambda_)
 
 
-# @FILTER_REGISTRY.register("to_upper", ToUpperFilter, cv.Schema({}))
-@FILTER_REGISTRY.register("to_upper", ToUpperFilter, cv.string)
-# @FILTER_REGISTRY.register("to_upper", ToUpperFilter, cv.Schema())
-# @FILTER_REGISTRY.register("to_upper", ToUpperFilter, cv.has_none_or_all_keys({}))
+@FILTER_REGISTRY.register("to_upper", ToUpperFilter, {})
 async def to_upper_filter_to_code(config, filter_id):
-    return cg.new_Pvariable(filter_id, config)
+    return cg.new_Pvariable(filter_id)
+
+
+@FILTER_REGISTRY.register("to_lower", ToLowerFilter, {})
+async def to_lower_filter_to_code(config, filter_id):
+    return cg.new_Pvariable(filter_id)
 
 
 @FILTER_REGISTRY.register("append", AppendFilter, cv.string)
@@ -94,10 +97,7 @@ def validate_substitute(value):
 @FILTER_REGISTRY.register(
     "substitute",
     SubstituteFilter,
-    cv.All(
-        cv.ensure_list(validate_substitute),
-        cv.Length(min=2)
-    ),
+    cv.All(cv.ensure_list(validate_substitute), cv.Length(min=2)),
 )
 async def substitute_filter_to_code(config, filter_id):
     from_strings = [conf[CONF_FROM] for conf in config]

--- a/esphome/components/text_sensor/automation.h
+++ b/esphome/components/text_sensor/automation.h
@@ -16,6 +16,13 @@ class TextSensorStateTrigger : public Trigger<std::string> {
   }
 };
 
+class TextSensorStateRawTrigger : public Trigger<std::string> {
+ public:
+  explicit TextSensorStateRawTrigger(TextSensor *parent) {
+    parent->add_on_raw_state_callback([this](std::string value) { this->trigger(std::move(value)); });
+  }
+};
+
 template<typename... Ts> class TextSensorStateCondition : public Condition<Ts...> {
  public:
   explicit TextSensorStateCondition(TextSensor *parent) : parent_(parent) {}

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -37,7 +37,7 @@ void LambdaFilter::set_lambda_filter(const lambda_filter_t &lambda_filter) { thi
 
 optional<std::string> LambdaFilter::new_value(std::string value) {
   auto it = this->lambda_filter_(value);
-  ESP_LOGVV(TAG, "LambdaFilter(%p)::new_value(%s) -> %s", this, value.c_str(), it.value_or(INFINITY));
+  ESP_LOGVV(TAG, "LambdaFilter(%p)::new_value(%s) -> %s", this, value.c_str(), it.value_or("").c_str());
   return it;
 }
 

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "sensor.filter";
 
 // Filter
 void Filter::input(const std::string &value) {
-  ESP_LOGVV(TAG, "Filter(%p)::input(%f)", this, value);
+  ESP_LOGVV(TAG, "Filter(%p)::input(%s)", this, value);
   optional<std::string> out = this->new_value(value);
   if (out.has_value())
     this->output(*out);

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -42,9 +42,14 @@ optional<std::string> LambdaFilter::new_value(std::string value) {
 }
 
 // ToUpperFilter
-// ToUpperFilter::ToUpperFilter(std::string dummy){};
 optional<std::string> ToUpperFilter::new_value(std::string value) {
   std::for_each(value.begin(), value.end(), [](char &c) { c = ::toupper(c); });
+  return value;
+}
+
+// ToLowerFilter
+optional<std::string> ToLowerFilter::new_value(std::string value) {
+  std::for_each(value.begin(), value.end(), [](char &c) { c = ::tolower(c); });
   return value;
 }
 

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -17,10 +17,10 @@ void Filter::input(std::string value) {
 }
 void Filter::output(std::string value) {
   if (this->next_ == nullptr) {
-    ESP_LOGVV(TAG, "Filter(%p)::output(%f) -> SENSOR", this, value);
+    ESP_LOGVV(TAG, "Filter(%p)::output(%s) -> SENSOR", this, value.c_str());
     this->parent_->internal_send_state_to_frontend(value);
   } else {
-    ESP_LOGVV(TAG, "Filter(%p)::output(%f) -> %p", this, value, this->next_);
+    ESP_LOGVV(TAG, "Filter(%p)::output(%s) -> %p", this, value.c_str(), this->next_);
     this->next_->input(value);
   }
 }
@@ -37,7 +37,7 @@ void LambdaFilter::set_lambda_filter(const lambda_filter_t &lambda_filter) { thi
 
 optional<std::string> LambdaFilter::new_value(std::string value) {
   auto it = this->lambda_filter_(value);
-  ESP_LOGVV(TAG, "LambdaFilter(%p)::new_value(%f) -> %f", this, value, it.value_or(INFINITY));
+  ESP_LOGVV(TAG, "LambdaFilter(%p)::new_value(%s) -> %s", this, value.c_str(), it.value_or(INFINITY));
   return it;
 }
 

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -42,9 +42,24 @@ optional<std::string> LambdaFilter::new_value(std::string value) {
 }
 
 // ToUpperFilter
-ToUpperFilter::ToUpperFilter(std::string dummy){};
+// ToUpperFilter::ToUpperFilter(std::string dummy){};
 optional<std::string> ToUpperFilter::new_value(std::string value) {
   std::for_each(value.begin(), value.end(), [](char &c) { c = ::toupper(c); });
+  return value;
+}
+
+// Append
+optional<std::string> AppendFilter::new_value(std::string value) { return value + this->suffix_; }
+
+// Prepend
+optional<std::string> PrependFilter::new_value(std::string value) { return this->prefix_ + value; }
+
+// Substitute
+optional<std::string> SubstituteFilter::new_value(std::string value) {
+  std::size_t pos;
+  for (int i = 0; i < this->from_strings_.size(); i++)
+    while ((pos = value.find(this->from_strings_[i])) != std::string::npos)
+      value.replace(pos, this->from_strings_[i].size(), this->to_strings_[i]);
   return value;
 }
 

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace text_sensor {
 
-static const char *const TAG = "sensor.filter";
+static const char *const TAG = "text_sensor.filter";
 
 // Filter
 void Filter::input(const std::string &value) {
@@ -43,13 +43,15 @@ optional<std::string> LambdaFilter::new_value(std::string value) {
 
 // ToUpperFilter
 optional<std::string> ToUpperFilter::new_value(std::string value) {
-  std::for_each(value.begin(), value.end(), [](char &c) { c = ::toupper(c); });
+  for (char &c : value)
+    c = ::toupper(c);
   return value;
 }
 
 // ToLowerFilter
 optional<std::string> ToLowerFilter::new_value(std::string value) {
-  std::for_each(value.begin(), value.end(), [](char &c) { c = ::tolower(c); });
+  for (char &c : value)
+    c = ::toupper(c);
   return value;
 }
 

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -9,13 +9,13 @@ namespace text_sensor {
 static const char *const TAG = "sensor.filter";
 
 // Filter
-void Filter::input(const std::string& value) {
+void Filter::input(const std::string &value) {
   ESP_LOGVV(TAG, "Filter(%p)::input(%f)", this, value);
   optional<std::string> out = this->new_value(value);
   if (out.has_value())
     this->output(*out);
 }
-void Filter::output(const std::string& value) {
+void Filter::output(const std::string &value) {
   if (this->next_ == nullptr) {
     ESP_LOGVV(TAG, "Filter(%p)::output(%s) -> SENSOR", this, value.c_str());
     this->parent_->internal_send_state_to_frontend(value);

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "sensor.filter";
 
 // Filter
 void Filter::input(const std::string &value) {
-  ESP_LOGVV(TAG, "Filter(%p)::input(%s)", this, value);
+  ESP_LOGVV(TAG, "Filter(%p)::input(%s)", this, value.c_str());
   optional<std::string> out = this->new_value(value);
   if (out.has_value())
     this->output(*out);

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -1,0 +1,52 @@
+#include "filter.h"
+#include "text_sensor.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace text_sensor {
+
+static const char *const TAG = "sensor.filter";
+
+// Filter
+void Filter::input(std::string value) {
+  ESP_LOGVV(TAG, "Filter(%p)::input(%f)", this, value);
+  optional<std::string> out = this->new_value(value);
+  if (out.has_value())
+    this->output(*out);
+}
+void Filter::output(std::string value) {
+  if (this->next_ == nullptr) {
+    ESP_LOGVV(TAG, "Filter(%p)::output(%f) -> SENSOR", this, value);
+    this->parent_->internal_send_state_to_frontend(value);
+  } else {
+    ESP_LOGVV(TAG, "Filter(%p)::output(%f) -> %p", this, value, this->next_);
+    this->next_->input(value);
+  }
+}
+void Filter::initialize(TextSensor *parent, Filter *next) {
+  ESP_LOGVV(TAG, "Filter(%p)::initialize(parent=%p next=%p)", this, parent, next);
+  this->parent_ = parent;
+  this->next_ = next;
+}
+
+// LambdaFilter
+LambdaFilter::LambdaFilter(lambda_filter_t lambda_filter) : lambda_filter_(std::move(lambda_filter)) {}
+const lambda_filter_t &LambdaFilter::get_lambda_filter() const { return this->lambda_filter_; }
+void LambdaFilter::set_lambda_filter(const lambda_filter_t &lambda_filter) { this->lambda_filter_ = lambda_filter; }
+
+optional<std::string> LambdaFilter::new_value(std::string value) {
+  auto it = this->lambda_filter_(value);
+  ESP_LOGVV(TAG, "LambdaFilter(%p)::new_value(%f) -> %f", this, value, it.value_or(INFINITY));
+  return it;
+}
+
+// ToUpperFilter
+ToUpperFilter::ToUpperFilter(std::string dummy){};
+optional<std::string> ToUpperFilter::new_value(std::string value) {
+  std::for_each(value.begin(), value.end(), [](char &c) { c = ::toupper(c); });
+  return value;
+}
+
+}  // namespace text_sensor
+}  // namespace esphome

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -9,13 +9,13 @@ namespace text_sensor {
 static const char *const TAG = "sensor.filter";
 
 // Filter
-void Filter::input(std::string value) {
+void Filter::input(const std::string& value) {
   ESP_LOGVV(TAG, "Filter(%p)::input(%f)", this, value);
   optional<std::string> out = this->new_value(value);
   if (out.has_value())
     this->output(*out);
 }
-void Filter::output(std::string value) {
+void Filter::output(const std::string& value) {
   if (this->next_ == nullptr) {
     ESP_LOGVV(TAG, "Filter(%p)::output(%s) -> SENSOR", this, value.c_str());
     this->parent_->internal_send_state_to_frontend(value);

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -67,13 +67,44 @@ class LambdaFilter : public Filter {
 /// A simple filter that converts all text to uppercase
 class ToUpperFilter : public Filter {
  public:
-  explicit ToUpperFilter(std::string dummy);
-  // explicit ToUpperFilter();
-
+  ToUpperFilter(std::string dummy) {}
+  // ToUpperFilter();
   optional<std::string> new_value(std::string value) override;
 
  protected:
 };
 
-}  // namespace sensor
+/// A simple filter that adds a string to the end of another string
+class AppendFilter : public Filter {
+ public:
+  AppendFilter(std::string suffix) : suffix_(suffix) {}
+  optional<std::string> new_value(std::string value) override;
+
+ protected:
+  std::string suffix_;
+};
+
+/// A simple filter that adds a string to the end of another string
+class PrependFilter : public Filter {
+ public:
+  PrependFilter(std::string prefix) : prefix_(prefix) {}
+  optional<std::string> new_value(std::string value) override;
+
+ protected:
+  std::string prefix_;
+};
+
+/// A simple filter that adds a string to the end of another string
+class SubstituteFilter : public Filter {
+ public:
+  SubstituteFilter(std::vector<std::string> from_strings, std::vector<std::string> to_strings)
+      : from_strings_(std::move(from_strings)), to_strings_(std::move(to_strings)) {}
+  optional<std::string> new_value(std::string value) override;
+
+ protected:
+  std::vector<std::string> from_strings_;
+  std::vector<std::string> to_strings_;
+};
+
+}  // namespace text_sensor
 }  // namespace esphome

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -10,7 +10,7 @@ namespace text_sensor {
 
 class TextSensor;
 
-/** Apply a filter to text sensor values such as toUpper.
+/** Apply a filter to text sensor values such as to_upper.
  *
  * This class is purposefully kept quite simple, since more complicated
  * filters should really be done with the filter sensor in Home Assistant.
@@ -46,7 +46,7 @@ using lambda_filter_t = std::function<optional<std::string>(std::string)>;
 
 /** This class allows for creation of simple template filters.
  *
- * The constructor accepts a lambda of the form float -> optional<float>.
+ * The constructor accepts a lambda of the form std::string -> optional<std::string>.
  * It will be called with each new value in the filter chain and returns the modified
  * value that shall be passed down the filter chain. Returning an empty Optional
  * means that the value shall be discarded.
@@ -67,11 +67,13 @@ class LambdaFilter : public Filter {
 /// A simple filter that converts all text to uppercase
 class ToUpperFilter : public Filter {
  public:
-  ToUpperFilter(std::string dummy) {}
-  // ToUpperFilter();
   optional<std::string> new_value(std::string value) override;
+};
 
- protected:
+/// A simple filter that converts all text to lowercase
+class ToLowerFilter : public Filter {
+ public:
+  optional<std::string> new_value(std::string value) override;
 };
 
 /// A simple filter that adds a string to the end of another string
@@ -84,7 +86,7 @@ class AppendFilter : public Filter {
   std::string suffix_;
 };
 
-/// A simple filter that adds a string to the end of another string
+/// A simple filter that adds a string to the start of another string
 class PrependFilter : public Filter {
  public:
   PrependFilter(std::string prefix) : prefix_(prefix) {}
@@ -94,7 +96,7 @@ class PrependFilter : public Filter {
   std::string prefix_;
 };
 
-/// A simple filter that adds a string to the end of another string
+/// A simple filter that replaces a substring with another substring
 class SubstituteFilter : public Filter {
  public:
   SubstituteFilter(std::vector<std::string> from_strings, std::vector<std::string> to_strings)

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -79,7 +79,7 @@ class ToLowerFilter : public Filter {
 /// A simple filter that adds a string to the end of another string
 class AppendFilter : public Filter {
  public:
-  AppendFilter(std::string suffix) : suffix_(suffix) {}
+  AppendFilter(std::string suffix) : suffix_(std::move(suffix)) {}
   optional<std::string> new_value(std::string value) override;
 
  protected:
@@ -89,7 +89,7 @@ class AppendFilter : public Filter {
 /// A simple filter that adds a string to the start of another string
 class PrependFilter : public Filter {
  public:
-  PrependFilter(std::string prefix) : prefix_(prefix) {}
+  PrependFilter(std::string prefix) : prefix_(std::move(prefix)) {}
   optional<std::string> new_value(std::string value) override;
 
  protected:

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -31,9 +31,9 @@ class Filter {
   /// Initialize this filter, please note this can be called more than once.
   virtual void initialize(TextSensor *parent, Filter *next);
 
-  void input(const std::string& value);
+  void input(const std::string &value);
 
-  void output(const std::string& value);
+  void output(const std::string &value);
 
  protected:
   friend TextSensor;

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include <queue>
+#include <utility>
+
+namespace esphome {
+namespace text_sensor {
+
+class TextSensor;
+
+/** Apply a filter to text sensor values such as toUpper.
+ *
+ * This class is purposefully kept quite simple, since more complicated
+ * filters should really be done with the filter sensor in Home Assistant.
+ */
+class Filter {
+ public:
+  /** This will be called every time the filter receives a new value.
+   *
+   * It can return an empty optional to indicate that the filter chain
+   * should stop, otherwise the value in the filter will be passed down
+   * the chain.
+   *
+   * @param value The new value.
+   * @return An optional string, the new value that should be pushed out.
+   */
+  virtual optional<std::string> new_value(std::string value);
+
+  /// Initialize this filter, please note this can be called more than once.
+  virtual void initialize(TextSensor *parent, Filter *next);
+
+  void input(std::string value);
+
+  void output(std::string value);
+
+ protected:
+  friend TextSensor;
+
+  Filter *next_{nullptr};
+  TextSensor *parent_{nullptr};
+};
+
+using lambda_filter_t = std::function<optional<std::string>(std::string)>;
+
+/** This class allows for creation of simple template filters.
+ *
+ * The constructor accepts a lambda of the form float -> optional<float>.
+ * It will be called with each new value in the filter chain and returns the modified
+ * value that shall be passed down the filter chain. Returning an empty Optional
+ * means that the value shall be discarded.
+ */
+class LambdaFilter : public Filter {
+ public:
+  explicit LambdaFilter(lambda_filter_t lambda_filter);
+
+  optional<std::string> new_value(std::string value) override;
+
+  const lambda_filter_t &get_lambda_filter() const;
+  void set_lambda_filter(const lambda_filter_t &lambda_filter);
+
+ protected:
+  lambda_filter_t lambda_filter_;
+};
+
+/// A simple filter that converts all text to uppercase
+class ToUpperFilter : public Filter {
+ public:
+  explicit ToUpperFilter(std::string dummy);
+  // explicit ToUpperFilter();
+
+  optional<std::string> new_value(std::string value) override;
+
+ protected:
+};
+
+}  // namespace sensor
+}  // namespace esphome

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -31,9 +31,9 @@ class Filter {
   /// Initialize this filter, please note this can be called more than once.
   virtual void initialize(TextSensor *parent, Filter *next);
 
-  void input(std::string value);
+  void input(const std::string& value);
 
-  void output(std::string value);
+  void output(const std::string& value);
 
  protected:
   friend TextSensor;

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "text_sensor";
 TextSensor::TextSensor() : TextSensor("") {}
 TextSensor::TextSensor(const std::string &name) : Nameable(name) {}
 
-void TextSensor::publish_state(const std::string& state) {
+void TextSensor::publish_state(const std::string &state) {
   this->raw_state = state;
   this->raw_callback_.call(state);
 
@@ -61,7 +61,7 @@ void TextSensor::add_on_raw_state_callback(std::function<void(std::string)> call
 
 std::string TextSensor::get_state() const { return this->state; }
 std::string TextSensor::get_raw_state() const { return this->raw_state; }
-void TextSensor::internal_send_state_to_frontend(const std::string& state) {
+void TextSensor::internal_send_state_to_frontend(const std::string &state) {
   this->state = this->raw_state;
   this->has_state_ = true;
   ESP_LOGD(TAG, "'%s': Sending state '%s'", this->name_.c_str(), state.c_str());

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "text_sensor";
 TextSensor::TextSensor() : TextSensor("") {}
 TextSensor::TextSensor(const std::string &name) : Nameable(name) {}
 
-void TextSensor::publish_state(std::string state) {
+void TextSensor::publish_state(const std::string& state) {
   this->raw_state = state;
   this->raw_callback_.call(state);
 
@@ -61,7 +61,7 @@ void TextSensor::add_on_raw_state_callback(std::function<void(std::string)> call
 
 std::string TextSensor::get_state() const { return this->state; }
 std::string TextSensor::get_raw_state() const { return this->raw_state; }
-void TextSensor::internal_send_state_to_frontend(std::string state) {
+void TextSensor::internal_send_state_to_frontend(const std::string& state) {
   this->state = this->raw_state;
   this->has_state_ = true;
   ESP_LOGD(TAG, "'%s': Sending state '%s'", this->name_.c_str(), state.c_str());

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -13,7 +13,7 @@ void TextSensor::publish_state(std::string state) {
   this->raw_state = state;
   this->raw_callback_.call(state);
 
-  ESP_LOGV(TAG, "'%s': Received new state %f", this->name_.c_str(), state);
+  ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), state.c_str());
 
   if (this->filter_list_ == nullptr) {
     this->internal_send_state_to_frontend(state);

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -9,22 +9,73 @@ static const char *const TAG = "text_sensor";
 TextSensor::TextSensor() : TextSensor("") {}
 TextSensor::TextSensor(const std::string &name) : Nameable(name) {}
 
-void TextSensor::publish_state(const std::string &state) {
-  this->state = state;
+void TextSensor::publish_state(std::string state) {
+  this->raw_state = state;
+  this->raw_callback_.call(state);
+
+  ESP_LOGV(TAG, "'%s': Received new state %f", this->name_.c_str(), state);
+
+  if (this->filter_list_ == nullptr) {
+    this->internal_send_state_to_frontend(state);
+  } else {
+    this->filter_list_->input(state);
+  }
+}
+
+void TextSensor::add_filter(Filter *filter) {
+  // inefficient, but only happens once on every sensor setup and nobody's going to have massive amounts of
+  // filters
+  ESP_LOGVV(TAG, "TextSensor(%p)::add_filter(%p)", this, filter);
+  if (this->filter_list_ == nullptr) {
+    this->filter_list_ = filter;
+  } else {
+    Filter *last_filter = this->filter_list_;
+    while (last_filter->next_ != nullptr)
+      last_filter = last_filter->next_;
+    last_filter->initialize(this, filter);
+  }
+  filter->initialize(this, nullptr);
+}
+void TextSensor::add_filters(const std::vector<Filter *> &filters) {
+  for (Filter *filter : filters) {
+    this->add_filter(filter);
+  }
+}
+void TextSensor::set_filters(const std::vector<Filter *> &filters) {
+  this->clear_filters();
+  this->add_filters(filters);
+}
+void TextSensor::clear_filters() {
+  if (this->filter_list_ != nullptr) {
+    ESP_LOGVV(TAG, "TextSensor(%p)::clear_filters()", this);
+  }
+  this->filter_list_ = nullptr;
+}
+
+void TextSensor::add_on_state_callback(std::function<void(std::string)> callback) {
+  this->callback_.add(std::move(callback));
+}
+void TextSensor::add_on_raw_state_callback(std::function<void(std::string)> callback) {
+  this->raw_callback_.add(std::move(callback));
+}
+
+std::string TextSensor::get_state() const { return this->state; }
+std::string TextSensor::get_raw_state() const { return this->raw_state; }
+void TextSensor::internal_send_state_to_frontend(std::string state) {
+  this->state = this->raw_state;
   this->has_state_ = true;
   ESP_LOGD(TAG, "'%s': Sending state '%s'", this->name_.c_str(), state.c_str());
   this->callback_.call(state);
 }
+
 void TextSensor::set_icon(const std::string &icon) { this->icon_ = icon; }
-void TextSensor::add_on_state_callback(std::function<void(std::string)> callback) {
-  this->callback_.add(std::move(callback));
-}
 std::string TextSensor::get_icon() {
   if (this->icon_.has_value())
     return *this->icon_;
   return this->icon();
 }
 std::string TextSensor::icon() { return ""; }
+
 std::string TextSensor::unique_id() { return ""; }
 bool TextSensor::has_state() { return this->has_state_; }
 uint32_t TextSensor::hash_base() { return 334300109UL; }

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/components/text_sensor/filter.h"
 
 namespace esphome {
 namespace text_sensor {
@@ -22,13 +23,33 @@ class TextSensor : public Nameable {
   explicit TextSensor();
   explicit TextSensor(const std::string &name);
 
-  void publish_state(const std::string &state);
+  /// Getter-syntax for .state.
+  std::string get_state() const;
+  /// Getter-syntax for .raw_state
+  std::string get_raw_state() const;
+
+  void publish_state(std::string state);
 
   void set_icon(const std::string &icon);
 
+  /// Add a filter to the filter chain. Will be appended to the back.
+  void add_filter(Filter *filter);
+
+  /// Add a list of vectors to the back of the filter chain.
+  void add_filters(const std::vector<Filter *> &filters);
+
+  /// Clear the filters and replace them by filters.
+  void set_filters(const std::vector<Filter *> &filters);
+
+  /// Clear the entire filter chain.
+  void clear_filters();
+
   void add_on_state_callback(std::function<void(std::string)> callback);
+  /// Add a callback that will be called every time the sensor sends a raw value.
+  void add_on_raw_state_callback(std::function<void(std::string)> callback);
 
   std::string state;
+  std::string raw_state;
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -40,10 +61,16 @@ class TextSensor : public Nameable {
 
   bool has_state();
 
+  void internal_send_state_to_frontend(std::string state);
+
  protected:
   uint32_t hash_base() override;
 
-  CallbackManager<void(std::string)> callback_;
+  CallbackManager<void(std::string)> raw_callback_;  ///< Storage for raw state callbacks.
+  CallbackManager<void(std::string)> callback_;      ///< Storage for filtered state callbacks.
+
+  Filter *filter_list_{nullptr};  ///< Store all active filters.
+
   optional<std::string> icon_;
   bool has_state_{false};
 };

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -28,7 +28,7 @@ class TextSensor : public Nameable {
   /// Getter-syntax for .raw_state
   std::string get_raw_state() const;
 
-  void publish_state(const std::string& state);
+  void publish_state(const std::string &state);
 
   void set_icon(const std::string &icon);
 
@@ -61,7 +61,7 @@ class TextSensor : public Nameable {
 
   bool has_state();
 
-  void internal_send_state_to_frontend(const std::string& state);
+  void internal_send_state_to_frontend(const std::string &state);
 
  protected:
   uint32_t hash_base() override;

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -28,7 +28,7 @@ class TextSensor : public Nameable {
   /// Getter-syntax for .raw_state
   std::string get_raw_state() const;
 
-  void publish_state(std::string state);
+  void publish_state(const std::string& state);
 
   void set_icon(const std::string &icon);
 
@@ -61,7 +61,7 @@ class TextSensor : public Nameable {
 
   bool has_state();
 
-  void internal_send_state_to_frontend(std::string state);
+  void internal_send_state_to_frontend(const std::string& state);
 
  protected:
   uint32_t hash_base() override;


### PR DESCRIPTION
# What does this implement/fix? 

Adds the ability to manipulate text_sensor strings, much like sensor filters.
Most code has simply been ported from the sensor filters code.
Currently can:

- lambda
- append
- prepend
- to_upper
- to_lower
- substitute

A use case from Discord:

> I hope you are familiar with MAX7219 matrix displays. I have added some custom icons to the font library by generating a new font. I the font instead of the small letter alphabets, I have added these custom icons as I don't need small letter alphabets for MAX7219 display. But the problem is that it is difficult to remember which alphabet is assigned to which icon so instead of remembering the alphabet, I am going to use codes like  /love or /skull in the text that is being passed to display which in esphome will be found and replaced with the assigned alphabet.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1497

## Test Environment

- [ ] ESP32
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
text_sensor:
  - platform: template
    name: "Template Text Sensor"
    update_interval: 5s
    lambda: |-
      return {""};
    filters:
      - lambda: return {"Hello World"};
      - to_upper:
#      - to_lower:
      - append: "_prefix"
      - prepend: "suffix_"
      - substitute:
        - "suf -> foo"
        - "pre -> bar"
 # returns 'foofix_HELLO WORLD_barfix'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
