### PR TITLE
esp32_ble_beacon: Allow updating advertisement UUID

### DIFF
--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -113,15 +113,14 @@ void ESP32BLEBeacon::ble_setup() {
     return;
   }
 
-  esp_ble_ibeacon_t ibeacon_adv_data;
-  memcpy(&ibeacon_adv_data.ibeacon_head, &IBEACON_COMMON_HEAD, sizeof(esp_ble_ibeacon_head_t));
-  memcpy(&ibeacon_adv_data.ibeacon_vendor.proximity_uuid, global_esp32_ble_beacon->uuid_.data(),
-         sizeof(ibeacon_adv_data.ibeacon_vendor.proximity_uuid));
-  ibeacon_adv_data.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->minor_);
-  ibeacon_adv_data.ibeacon_vendor.major = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->major_);
-  ibeacon_adv_data.ibeacon_vendor.measured_power = 0xC5;
+  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_head, &IBEACON_COMMON_HEAD, sizeof(esp_ble_ibeacon_head_t));
+  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid, global_esp32_ble_beacon->uuid_.data(),
+         sizeof(global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid));
+  global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->minor_);
+  global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.major = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->major_);
+  global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.measured_power = 0xC5;
 
-  esp_ble_gap_config_adv_data_raw((uint8_t *) &ibeacon_adv_data, sizeof(ibeacon_adv_data));
+  esp_ble_gap_config_adv_data_raw((uint8_t *) &global_esp32_ble_beacon->ibeacon_adv_data_, sizeof(global_esp32_ble_beacon->ibeacon_adv_data_));
 }
 
 void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
@@ -153,6 +152,14 @@ void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap
     default:
       break;
   }
+}
+
+void ESP32BLEBeacon::update_advertisement(const std::array<uint8_t, 16> &uuid) {
+  if (global_esp32_ble_beacon == nullptr) return;
+  global_esp32_ble_beacon->uuid_ = uuid;
+  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid, global_esp32_ble_beacon->uuid_.data(),
+         sizeof(global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid));
+  esp_ble_gap_config_adv_data_raw((uint8_t *) &global_esp32_ble_beacon->ibeacon_adv_data_, sizeof(global_esp32_ble_beacon->ibeacon_adv_data_));
 }
 
 ESP32BLEBeacon *global_esp32_ble_beacon = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -113,14 +113,17 @@ void ESP32BLEBeacon::ble_setup() {
     return;
   }
 
-  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_head, &IBEACON_COMMON_HEAD, sizeof(esp_ble_ibeacon_head_t));
-  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid, global_esp32_ble_beacon->uuid_.data(),
+  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_head, &IBEACON_COMMON_HEAD,
+         sizeof(esp_ble_ibeacon_head_t));
+  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid,
+         global_esp32_ble_beacon->uuid_.data(),
          sizeof(global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid));
   global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->minor_);
   global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.major = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->major_);
   global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.measured_power = 0xC5;
 
-  esp_ble_gap_config_adv_data_raw((uint8_t *) &global_esp32_ble_beacon->ibeacon_adv_data_, sizeof(global_esp32_ble_beacon->ibeacon_adv_data_));
+  esp_ble_gap_config_adv_data_raw((uint8_t *) &global_esp32_ble_beacon->ibeacon_adv_data_,
+                                  sizeof(global_esp32_ble_beacon->ibeacon_adv_data_));
 }
 
 void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
@@ -155,11 +158,14 @@ void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap
 }
 
 void ESP32BLEBeacon::update_advertisement(const std::array<uint8_t, 16> &uuid) {
-  if (global_esp32_ble_beacon == nullptr) return;
+  if (global_esp32_ble_beacon == nullptr)
+    return;
   global_esp32_ble_beacon->uuid_ = uuid;
-  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid, global_esp32_ble_beacon->uuid_.data(),
+  memcpy(&global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid,
+         global_esp32_ble_beacon->uuid_.data(),
          sizeof(global_esp32_ble_beacon->ibeacon_adv_data_.ibeacon_vendor.proximity_uuid));
-  esp_ble_gap_config_adv_data_raw((uint8_t *) &global_esp32_ble_beacon->ibeacon_adv_data_, sizeof(global_esp32_ble_beacon->ibeacon_adv_data_));
+  esp_ble_gap_config_adv_data_raw((uint8_t *) &global_esp32_ble_beacon->ibeacon_adv_data_,
+                                  sizeof(global_esp32_ble_beacon->ibeacon_adv_data_));
 }
 
 ESP32BLEBeacon *global_esp32_ble_beacon = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -43,6 +43,8 @@ class ESP32BLEBeacon : public Component {
   void set_major(uint16_t major) { this->major_ = major; }
   void set_minor(uint16_t minor) { this->minor_ = minor; }
 
+  void update_advertisement(const std::array<uint8_t, 16> &uuid);
+
  protected:
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
   static void ble_core_task(void *params);
@@ -51,6 +53,7 @@ class ESP32BLEBeacon : public Component {
   std::array<uint8_t, 16> uuid_;
   uint16_t major_{};
   uint16_t minor_{};
+  esp_ble_ibeacon_t ibeacon_adv_data_;
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix? 

This pull request enhances ESP32 BLE beacon component with an API method `update_advertisement` for changing BLE advertisement UUID after the initial value has been specified in YAML. Beacon can now be used for broadcasting sensor values to other nearby devices without wi-fi capabilities (e.g. battery powered e-paper screen, etc.).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1494

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# BLE beacon
esp32_ble_beacon:
  id: beacon
  type: iBeacon
  uuid: '00000000-0000-0000-0000-000000000000'

sensor:
  - platform: template
    id: counter
    update_interval: 10s
    lambda: |-
      static float counter = 0;
      return counter++;
    on_value:
      - lambda: |-
          auto val = lroundf(x);
          std::array<unsigned char, 16> uuid = {(uint8_t) (val >> 24), (uint8_t) (val >> 16), (uint8_t) (val >> 8), (uint8_t) val, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
          id(beacon)->update_advertisement(uuid);
```

## Checklist:
  - [X] The code change is tested and works locally.  (please see the NOTE below)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

NOTE: I was able to test this functionality on the latest stable build of ESPHome (2021.9.1) and I ported it to the latest /dev branch. Unfortunately, due to the changed BLE initialization (HAL vs. btStart), I cannot test it as my node is crashing with `[00:31:43][E][esp32_ble_beacon:079]: esp_bt_controller_init failed: ESP_ERR_INVALID_STATE`.
