### PR TITLE
Support HSV-based color support on tuya light

### DIFF
--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -22,6 +22,7 @@ CONF_COLOR_TEMPERATURE_DATAPOINT = "color_temperature_datapoint"
 CONF_COLOR_TEMPERATURE_INVERT = "color_temperature_invert"
 CONF_COLOR_TEMPERATURE_MAX_VALUE = "color_temperature_max_value"
 CONF_RGB_DATAPOINT = "rgb_datapoint"
+CONF_HSV_DATAPOINT = "hsv_datapoint"
 
 TuyaLight = tuya_ns.class_("TuyaLight", light.LightOutput, cg.Component)
 
@@ -33,7 +34,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DIMMER_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_MIN_VALUE_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
-            cv.Optional(CONF_RGB_DATAPOINT): cv.uint8_t,
+            cv.Exclusive(CONF_RGB_DATAPOINT, "color"): cv.uint8_t,
+            cv.Exclusive(CONF_HSV_DATAPOINT, "color"): cv.uint8_t,
             cv.Optional(CONF_COLOR_INTERLOCK, default=False): cv.boolean,
             cv.Inclusive(
                 CONF_COLOR_TEMPERATURE_DATAPOINT, "color_temperature"
@@ -57,7 +59,10 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(
-        CONF_DIMMER_DATAPOINT, CONF_SWITCH_DATAPOINT, CONF_RGB_DATAPOINT
+        CONF_DIMMER_DATAPOINT,
+        CONF_SWITCH_DATAPOINT,
+        CONF_RGB_DATAPOINT,
+        CONF_HSV_DATAPOINT,
     ),
 )
 
@@ -75,6 +80,8 @@ async def to_code(config):
         cg.add(var.set_switch_id(config[CONF_SWITCH_DATAPOINT]))
     if CONF_RGB_DATAPOINT in config:
         cg.add(var.set_rgb_id(config[CONF_RGB_DATAPOINT]))
+    elif CONF_HSV_DATAPOINT in config:
+        cg.add(var.set_hsv_id(config[CONF_HSV_DATAPOINT]))
     if CONF_COLOR_TEMPERATURE_DATAPOINT in config:
         cg.add(var.set_color_temperature_id(config[CONF_COLOR_TEMPERATURE_DATAPOINT]))
         cg.add(var.set_color_temperature_invert(config[CONF_COLOR_TEMPERATURE_INVERT]))

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -46,6 +46,19 @@ void TuyaLight::setup() {
         call.perform();
       }
     });
+  } else if (hsv_id_.has_value()) {
+    this->parent_->register_listener(*this->hsv_id_, [this](const TuyaDatapoint &datapoint) {
+      auto hue = parse_hex(datapoint.value_string, 0, 4);
+      auto saturation = parse_hex(datapoint.value_string, 4, 4);
+      auto value = parse_hex(datapoint.value_string, 8, 4);
+      if (hue.has_value() && saturation.has_value() && value.has_value()) {
+        float red, green, blue;
+        hsv_to_rgb(*hue, float(*saturation) / 1000, float(*value) / 1000, red, green, blue);
+        auto call = this->state_->make_call();
+        call.set_rgb(red, green, blue);
+        call.perform();
+      }
+    });
   }
   if (min_value_datapoint_id_.has_value()) {
     parent_->set_integer_datapoint_value(*this->min_value_datapoint_id_, this->min_value_);
@@ -60,12 +73,14 @@ void TuyaLight::dump_config() {
     ESP_LOGCONFIG(TAG, "   Switch has datapoint ID %u", *this->switch_id_);
   if (this->rgb_id_.has_value())
     ESP_LOGCONFIG(TAG, "   RGB has datapoint ID %u", *this->rgb_id_);
+  else if (this->hsv_id_.has_value())
+    ESP_LOGCONFIG(TAG, "   HSV has datapoint ID %u", *this->hsv_id_);
 }
 
 light::LightTraits TuyaLight::get_traits() {
   auto traits = light::LightTraits();
   if (this->color_temperature_id_.has_value() && this->dimmer_id_.has_value()) {
-    if (this->rgb_id_.has_value()) {
+    if (this->rgb_id_.has_value() || this->hsv_id_.has_value()) {
       if (this->color_interlock_)
         traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE});
       else
@@ -75,7 +90,7 @@ light::LightTraits TuyaLight::get_traits() {
       traits.set_supported_color_modes({light::ColorMode::COLOR_TEMPERATURE});
     traits.set_min_mireds(this->cold_white_temperature_);
     traits.set_max_mireds(this->warm_white_temperature_);
-  } else if (this->rgb_id_.has_value()) {
+  } else if (this->rgb_id_.has_value() || this->hsv_id_.has_value()) {
     if (this->dimmer_id_.has_value()) {
       if (this->color_interlock_)
         traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::WHITE});
@@ -97,7 +112,7 @@ void TuyaLight::write_state(light::LightState *state) {
   float red = 0.0f, green = 0.0f, blue = 0.0f;
   float color_temperature = 0.0f, brightness = 0.0f;
 
-  if (this->rgb_id_.has_value()) {
+  if (this->rgb_id_.has_value() || this->hsv_id_.has_value()) {
     if (this->color_temperature_id_.has_value()) {
       state->current_values_as_rgbct(&red, &green, &blue, &color_temperature, &brightness);
     } else if (this->dimmer_id_.has_value()) {
@@ -137,8 +152,16 @@ void TuyaLight::write_state(light::LightState *state) {
     if (this->rgb_id_.has_value()) {
       char buffer[7];
       sprintf(buffer, "%02X%02X%02X", int(red * 255), int(green * 255), int(blue * 255));
-      std::string value = buffer;
-      this->parent_->set_string_datapoint_value(*this->rgb_id_, value);
+      std::string rgb_value = buffer;
+      this->parent_->set_string_datapoint_value(*this->rgb_id_, rgb_value);
+    } else if (this->hsv_id_.has_value()) {
+      int hue;
+      float saturation, value;
+      rgb_to_hsv(red, green, blue, hue, saturation, value);
+      char buffer[13];
+      sprintf(buffer, "%04X%04X%04X", hue, int(saturation * 1000), int(value * 1000));
+      std::string hsv_value = buffer;
+      this->parent_->set_string_datapoint_value(*this->hsv_id_, hsv_value);
     }
   }
 

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -111,7 +111,7 @@ void TuyaLight::write_state(light::LightState *state) {
     state->current_values_as_brightness(&brightness);
   }
 
-  if (!state->current_values.is_on() && this->switch_id_.has_value())
+  if (!state->current_values.is_on() && this->switch_id_.has_value()) {
     parent_->set_boolean_datapoint_value(*this->switch_id_, false);
     return;
   }

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -111,6 +111,11 @@ void TuyaLight::write_state(light::LightState *state) {
     state->current_values_as_brightness(&brightness);
   }
 
+  if (!state->current_values.is_on() && this->switch_id_.has_value())
+    parent_->set_boolean_datapoint_value(*this->switch_id_, false);
+    return;
+  }
+
   if (brightness > 0.0f || !color_interlock_) {
     if (this->color_temperature_id_.has_value()) {
       uint32_t color_temp_int = static_cast<uint32_t>(color_temperature * this->color_temperature_max_value_);
@@ -138,7 +143,7 @@ void TuyaLight::write_state(light::LightState *state) {
   }
 
   if (this->switch_id_.has_value()) {
-    parent_->set_boolean_datapoint_value(*this->switch_id_, state->current_values.is_on());
+    parent_->set_boolean_datapoint_value(*this->switch_id_, true);
   }
 }
 

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -17,6 +17,7 @@ class TuyaLight : public Component, public light::LightOutput {
   }
   void set_switch_id(uint8_t switch_id) { this->switch_id_ = switch_id; }
   void set_rgb_id(uint8_t rgb_id) { this->rgb_id_ = rgb_id; }
+  void set_hsv_id(uint8_t hsv_id) { this->hsv_id_ = hsv_id; }
   void set_color_temperature_id(uint8_t color_temperature_id) { this->color_temperature_id_ = color_temperature_id; }
   void set_color_temperature_invert(bool color_temperature_invert) {
     this->color_temperature_invert_ = color_temperature_invert;
@@ -48,6 +49,7 @@ class TuyaLight : public Component, public light::LightOutput {
   optional<uint8_t> min_value_datapoint_id_{};
   optional<uint8_t> switch_id_{};
   optional<uint8_t> rgb_id_{};
+  optional<uint8_t> hsv_id_{};
   optional<uint8_t> color_temperature_id_{};
   uint32_t min_value_ = 0;
   uint32_t max_value_ = 255;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -379,6 +379,69 @@ std::string hexencode(const uint8_t *data, uint32_t len) {
   return res;
 }
 
+void rgb_to_hsv(float red, float green, float blue, int& hue, float& saturation, float& value) {
+  float maxRGorB = max(max(red, green), blue);
+  float minRGorB = min(min(red, green), blue);
+  float delta = maxRGorB - minRGorB;
+
+  if(delta == 0)
+    hue = 0;
+  else if(maxRGorB == red)
+    hue = int(fmod(((60*((green-blue)/delta))+360), 360));
+  else if(maxRGorB == green)
+    hue = int(fmod(((60*((blue-red)/delta))+120), 360));
+  else if(maxRGorB == blue)
+    hue = int(fmod(((60*((red-green)/delta))+240), 360));
+
+  if(maxRGorB == 0)
+    saturation = 0;
+  else
+    saturation = delta/maxRGorB;
+
+  value = maxRGorB;
+}
+
+void hsv_to_rgb(int hue, float saturation, float value, float& red, float& green, float& blue) {
+  float chroma = value * saturation;
+  float huePrime = fmod(hue / 60.0, 6);
+  float intermediate = chroma * (1 - fabs(fmod(huePrime, 2) - 1));
+  float delta = value - chroma;
+
+  if(0 <= huePrime && huePrime < 1) {
+    red = chroma;
+    green = intermediate;
+    blue = 0;
+  } else if(1 <= huePrime && huePrime < 2) {
+    red = intermediate;
+    green = chroma;
+    blue = 0;
+  } else if(2 <= huePrime && huePrime < 3) {
+    red = 0;
+    green = chroma;
+    blue = intermediate;
+  } else if(3 <= huePrime && huePrime < 4) {
+    red = 0;
+    green = intermediate;
+    blue = chroma;
+  } else if(4 <= huePrime && huePrime < 5) {
+    red = intermediate;
+    green = 0;
+    blue = chroma;
+  } else if(5 <= huePrime && huePrime < 6) {
+    red = chroma;
+    green = 0;
+    blue = intermediate;
+  } else {
+    red = 0;
+    green = 0;
+    blue = 0;
+  }
+
+  red += delta;
+  green += delta;
+  blue += delta;
+}
+
 #ifdef USE_ESP8266
 IRAM_ATTR InterruptLock::InterruptLock() { xt_state_ = xt_rsil(15); }
 IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(xt_state_); }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -379,55 +379,55 @@ std::string hexencode(const uint8_t *data, uint32_t len) {
   return res;
 }
 
-void rgb_to_hsv(float red, float green, float blue, int& hue, float& saturation, float& value) {
-  float maxRGorB = max(max(red, green), blue);
-  float minRGorB = min(min(red, green), blue);
-  float delta = maxRGorB - minRGorB;
+void rgb_to_hsv(float red, float green, float blue, int &hue, float &saturation, float &value) {
+  float max_color_value = std::max(std::max(red, green), blue);
+  float min_color_value = std::min(std::min(red, green), blue);
+  float delta = max_color_value - min_color_value;
 
-  if(delta == 0)
+  if (delta == 0)
     hue = 0;
-  else if(maxRGorB == red)
-    hue = int(fmod(((60*((green-blue)/delta))+360), 360));
-  else if(maxRGorB == green)
-    hue = int(fmod(((60*((blue-red)/delta))+120), 360));
-  else if(maxRGorB == blue)
-    hue = int(fmod(((60*((red-green)/delta))+240), 360));
+  else if (max_color_value == red)
+    hue = int(fmod(((60 * ((green - blue) / delta)) + 360), 360));
+  else if (max_color_value == green)
+    hue = int(fmod(((60 * ((blue - red) / delta)) + 120), 360));
+  else if (max_color_value == blue)
+    hue = int(fmod(((60 * ((red - green) / delta)) + 240), 360));
 
-  if(maxRGorB == 0)
+  if (max_color_value == 0)
     saturation = 0;
   else
-    saturation = delta/maxRGorB;
+    saturation = delta / max_color_value;
 
-  value = maxRGorB;
+  value = max_color_value;
 }
 
-void hsv_to_rgb(int hue, float saturation, float value, float& red, float& green, float& blue) {
+void hsv_to_rgb(int hue, float saturation, float value, float &red, float &green, float &blue) {
   float chroma = value * saturation;
-  float huePrime = fmod(hue / 60.0, 6);
-  float intermediate = chroma * (1 - fabs(fmod(huePrime, 2) - 1));
+  float hue_prime = fmod(hue / 60.0, 6);
+  float intermediate = chroma * (1 - fabs(fmod(hue_prime, 2) - 1));
   float delta = value - chroma;
 
-  if(0 <= huePrime && huePrime < 1) {
+  if (0 <= hue_prime && hue_prime < 1) {
     red = chroma;
     green = intermediate;
     blue = 0;
-  } else if(1 <= huePrime && huePrime < 2) {
+  } else if (1 <= hue_prime && hue_prime < 2) {
     red = intermediate;
     green = chroma;
     blue = 0;
-  } else if(2 <= huePrime && huePrime < 3) {
+  } else if (2 <= hue_prime && hue_prime < 3) {
     red = 0;
     green = chroma;
     blue = intermediate;
-  } else if(3 <= huePrime && huePrime < 4) {
+  } else if (3 <= hue_prime && hue_prime < 4) {
     red = 0;
     green = intermediate;
     blue = chroma;
-  } else if(4 <= huePrime && huePrime < 5) {
+  } else if (4 <= hue_prime && hue_prime < 5) {
     red = intermediate;
     green = 0;
     blue = chroma;
-  } else if(5 <= huePrime && huePrime < 6) {
+  } else if (5 <= hue_prime && hue_prime < 6) {
     red = chroma;
     green = 0;
     blue = intermediate;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -147,9 +147,9 @@ std::array<uint8_t, 2> decode_uint16(uint16_t value);
 uint32_t encode_uint32(uint8_t msb, uint8_t byte2, uint8_t byte3, uint8_t lsb);
 
 /// Convert RGB floats (0-1) to hue (0-360) & saturation/value percentage (0-1)
-void rgb_to_hsv(float red, float green, float blue, int& hue, float& saturation, float& value);
+void rgb_to_hsv(float red, float green, float blue, int &hue, float &saturation, float &value);
 /// Convert hue (0-360) & saturation/value percentage (0-1) to RGB floats (0-1)
-void hsv_to_rgb(int hue, float saturation, float value, float& red, float& green, float& blue);
+void hsv_to_rgb(int hue, float saturation, float value, float &red, float &green, float &blue);
 
 /***
  * An interrupt helper class.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -146,6 +146,11 @@ std::array<uint8_t, 2> decode_uint16(uint16_t value);
 /// Encode a 32-bit unsigned integer given four bytes in MSB -> LSB order
 uint32_t encode_uint32(uint8_t msb, uint8_t byte2, uint8_t byte3, uint8_t lsb);
 
+/// Convert RGB floats (0-1) to hue (0-360) & saturation/value percentage (0-1)
+void rgb_to_hsv(float red, float green, float blue, int& hue, float& saturation, float& value);
+/// Convert hue (0-360) & saturation/value percentage (0-1) to RGB floats (0-1)
+void hsv_to_rgb(int hue, float saturation, float value, float& red, float& green, float& blue);
+
 /***
  * An interrupt helper class.
  *


### PR DESCRIPTION
# What does this implement/fix? 

Some tuya lights use HHHHSSSSVVVV for color instead of RRGGBB that I previously added.  This PR adds support for this alternative color mode.

Specification of Tuya's HHHHSSSSVVVV:-
- hue = 0-360 encoded as 4 digit hex
- saturation = 0-1000 encoded as 4 digit hex
- value = 0-1000 encoded as 4 digit hex

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1495

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
light:
  - platform: tuya
    name: "${friendly_name}"
    switch_datapoint: 1
    hsv_datapoint: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
