### PR TITLE
fix: stop tuya light state getting reset

### DIFF
--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -111,7 +111,7 @@ void TuyaLight::write_state(light::LightState *state) {
     state->current_values_as_brightness(&brightness);
   }
 
-  if (!state->current_values.is_on() && this->switch_id_.has_value())
+  if (!state->current_values.is_on() && this->switch_id_.has_value()) {
     parent_->set_boolean_datapoint_value(*this->switch_id_, false);
     return;
   }

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -111,6 +111,11 @@ void TuyaLight::write_state(light::LightState *state) {
     state->current_values_as_brightness(&brightness);
   }
 
+  if (!state->current_values.is_on() && this->switch_id_.has_value())
+    parent_->set_boolean_datapoint_value(*this->switch_id_, false);
+    return;
+  }
+
   if (brightness > 0.0f || !color_interlock_) {
     if (this->color_temperature_id_.has_value()) {
       uint32_t color_temp_int = static_cast<uint32_t>(color_temperature * this->color_temperature_max_value_);
@@ -138,7 +143,7 @@ void TuyaLight::write_state(light::LightState *state) {
   }
 
   if (this->switch_id_.has_value()) {
-    parent_->set_boolean_datapoint_value(*this->switch_id_, state->current_values.is_on());
+    parent_->set_boolean_datapoint_value(*this->switch_id_, true);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix? 

When turning off tuya lights with a switch datapoint, the dimmer & RGB datapoints get reset to 0 unnecessarily.  This change allows the dimmer & RGB to be left alone if there is a switch.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
