### PR TITLE
ccs811: Skip reading data if it is not available/ready

### DIFF
--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -86,8 +86,11 @@ void CCS811Component::setup() {
   }
 }
 void CCS811Component::update() {
-  if (!this->status_has_data_())
+  if (!this->status_has_data_()) {
+    ESP_LOGD(TAG, "Status indicates no data ready!");
     this->status_set_warning();
+    return;
+  }
 
   // page 12 - alg result data
   auto alg_data = this->read_bytes<4>(0x02);


### PR DESCRIPTION
# What does this implement/fix? 

On bootup the ccs811 reports that no data is available. No error flag is set in that case. The status register is 0x90 at the beginning of the first `update()` call.The current implementation ignores this, reads and publishes the invalid data, which is 0xFDFD for both tvoc and co2 in my case.
This commit fixes this and does not read and publish invalid data.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

This is the sensor configuration i use:

```yaml
sensor:
  - platform: hdc1080
    temperature:
      name: "Room Temperature"
      id: room_temperature
    humidity:
      name: "Room Humidity"
      id: room_humidity
    update_interval: 60s
    
  - platform: ccs811
    eco2:
      name: "Room eCO2 Value"
    tvoc:
      name: "Room Total Volatile Organic Compound"
    address: 0x5A
    update_interval: 60s
    
    temperature: room_temperature
    humidity: room_humidity
    baseline: 0xF474

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
