### PR TITLE
Add str_sprintf function that returns std::string

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -351,6 +351,21 @@ bool str_startswith(const std::string &full, const std::string &start) { return 
 bool str_endswith(const std::string &full, const std::string &ending) {
   return full.rfind(ending) == (full.size() - ending.size());
 }
+std::string str_sprintf(const char *fmt, ...) {
+  std::string str;
+  va_list args;
+
+  va_start(args, fmt);
+  size_t length = vsnprintf(nullptr, 0, fmt, args);
+  va_end(args);
+
+  str.resize(length);
+  va_start(args, fmt);
+  vsnprintf(&str[0], length + 1, fmt, args);
+  va_end(args);
+
+  return str;
+}
 
 uint16_t encode_uint16(uint8_t msb, uint8_t lsb) { return (uint16_t(msb) << 8) | uint16_t(lsb); }
 std::array<uint8_t, 2> decode_uint16(uint16_t value) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -59,6 +59,9 @@ bool str_equals_case_insensitive(const std::string &a, const std::string &b);
 bool str_startswith(const std::string &full, const std::string &start);
 bool str_endswith(const std::string &full, const std::string &ending);
 
+/// sprintf-like function returning std::string instead of writing to char array.
+std::string __attribute__((format(printf, 1, 2))) str_sprintf(const char *fmt, ...);
+
 class HighFrequencyLoopRequester {
  public:
   void start();


### PR DESCRIPTION
# What does this implement/fix? 

Add a `str_sprintf` function that returns a `std::string` instead of writing to a character array. I noticed that quite often we create a char array, `sprintf` to it, and then convert it to a `std::string`, incurring an unnecessary copy and not being a very ergonomic to use. Introduce a helper for that. 

This one is slightly inefficient when the maximum length of the result is known, as it always uses two `vsnprintf` calls. If that's a problem, we can add an overload that takes a maximum length and uses that instead. Thoughts?

~Draft for now as I haven't verified this works on an ESP yet (but it does work fine on my host system).~ Works fine.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
