### PR TITLE
Fix uninitialised use of ESPPreferenceObject.backend_

### DIFF
--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -30,7 +30,7 @@ class ESPPreferenceObject {
   }
 
  protected:
-  ESPPreferenceBackend *backend_;
+  ESPPreferenceBackend *backend_{nullptr};
 };
 
 class ESPPreferences {


### PR DESCRIPTION
# What does this implement/fix? 

`ESPPreferenceObject.save()` checks that the `backend_` is not null before proceeding to save a preference; however, this variable was not initialised.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
