### PR TITLE
Fix tuya cover lint checks

### DIFF
--- a/esphome/components/tuya/cover/__init__.py
+++ b/esphome/components/tuya/cover/__init__.py
@@ -19,9 +19,7 @@ TuyaCover = tuya_ns.class_("TuyaCover", cover.Cover, cg.Component)
 def validate_range(config):
     if config[CONF_MIN_VALUE] > config[CONF_MAX_VALUE]:
         raise cv.Invalid(
-            "min_value({}) cannot be greater than max_value({})".format(
-                config[CONF_MIN_VALUE], config[CONF_MAX_VALUE]
-            )
+            f"min_value ({config[CONF_MIN_VALUE]}) cannot be greater than max_value ({config[CONF_MAX_VALUE]})"
         )
     return config
 


### PR DESCRIPTION
# What does this implement/fix? 

Fixes lint checks after https://github.com/esphome/esphome/pull/2279

```
 Error: esphome/components/tuya/cover/__init__.py:22 - [C0209(consider-using-f-string), validate_range] Formatting a regular string which could be a f-string
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
