### PR TITLE
Remove default initializations from tuya cover

### DIFF
--- a/esphome/components/tuya/cover/tuya_cover.h
+++ b/esphome/components/tuya/cover/tuya_cover.h
@@ -23,10 +23,10 @@ class TuyaCover : public cover::Cover, public Component {
 
   Tuya *parent_;
   optional<uint8_t> position_id_{};
-  uint32_t min_value_ = 0;
-  uint32_t max_value_ = 100;
+  uint32_t min_value_;
+  uint32_t max_value_;
   uint32_t value_range_;
-  bool invert_position_ = false;
+  bool invert_position_;
 };
 
 }  // namespace tuya


### PR DESCRIPTION
# What does this implement/fix? 

Remove default initializations from tuya cover as they are all set in code generation

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
