### PR TITLE
Fix attach_interrupt(...) for esp-idf framework

### DIFF
--- a/esphome/components/esp32/gpio_idf.cpp
+++ b/esphome/components/esp32/gpio_idf.cpp
@@ -37,13 +37,9 @@ void IDFInternalGPIOPin::pin_mode(gpio::Flags flags) {
   gpio_config(&conf);
 }
 
-bool IDFInternalGPIOPin::digital_read() {
-  return bool(gpio_get_level(pin_)) != inverted_;
-}
+bool IDFInternalGPIOPin::digital_read() { return bool(gpio_get_level(pin_)) != inverted_; }
 
-void IDFInternalGPIOPin::digital_write(bool value) {
-  gpio_set_level(pin_, value != inverted_ ? 1 : 0);
-}
+void IDFInternalGPIOPin::digital_write(bool value) { gpio_set_level(pin_, value != inverted_ ? 1 : 0); }
 
 gpio_mode_t IDFInternalGPIOPin::flags_to_mode(gpio::Flags flags) {
   flags = (gpio::Flags)(flags & ~(gpio::FLAG_PULLUP | gpio::FLAG_PULLDOWN));
@@ -96,7 +92,6 @@ void IDFInternalGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio:
   }
   gpio_isr_handler_add(pin_, func, arg);
 }
-
 
 std::string IDFInternalGPIOPin::dump_summary() const {
   char buffer[32];

--- a/esphome/components/esp32/gpio_idf.cpp
+++ b/esphome/components/esp32/gpio_idf.cpp
@@ -45,7 +45,7 @@ void IDFInternalGPIOPin::digital_write(bool value) {
   gpio_set_level(pin_, value != inverted_ ? 1 : 0);
 }
 
-static gpio_mode_t IDFInternalGPIOPin::flags_to_mode(gpio::Flags flags) {
+gpio_mode_t IDFInternalGPIOPin::flags_to_mode(gpio::Flags flags) {
   flags = (gpio::Flags)(flags & ~(gpio::FLAG_PULLUP | gpio::FLAG_PULLDOWN));
   if (flags == gpio::FLAG_NONE) {
     return GPIO_MODE_DISABLE;
@@ -65,7 +65,7 @@ static gpio_mode_t IDFInternalGPIOPin::flags_to_mode(gpio::Flags flags) {
   }
 }
 
-void IDFInternalGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override {
+void IDFInternalGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const {
   gpio_int_type_t idf_type = GPIO_INTR_ANYEDGE;
   switch (type) {
     case gpio::INTERRUPT_RISING_EDGE:

--- a/esphome/components/esp32/gpio_idf.cpp
+++ b/esphome/components/esp32/gpio_idf.cpp
@@ -22,6 +22,82 @@ ISRInternalGPIOPin IDFInternalGPIOPin::to_isr() const {
   return ISRInternalGPIOPin((void *) arg);
 }
 
+void IDFInternalGPIOPin::setup() {
+  pin_mode(flags_);
+  gpio_set_drive_capability(pin_, drive_strength_);
+}
+
+void IDFInternalGPIOPin::pin_mode(gpio::Flags flags) {
+  gpio_config_t conf{};
+  conf.pin_bit_mask = 1ULL << static_cast<uint32_t>(pin_);
+  conf.mode = flags_to_mode(flags);
+  conf.pull_up_en = flags & gpio::FLAG_PULLUP ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
+  conf.pull_down_en = flags & gpio::FLAG_PULLDOWN ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE;
+  conf.intr_type = GPIO_INTR_DISABLE;
+  gpio_config(&conf);
+}
+
+bool IDFInternalGPIOPin::digital_read() {
+  return bool(gpio_get_level(pin_)) != inverted_;
+}
+
+void IDFInternalGPIOPin::digital_write(bool value) {
+  gpio_set_level(pin_, value != inverted_ ? 1 : 0);
+}
+
+static gpio_mode_t IDFInternalGPIOPin::flags_to_mode(gpio::Flags flags) {
+  flags = (gpio::Flags)(flags & ~(gpio::FLAG_PULLUP | gpio::FLAG_PULLDOWN));
+  if (flags == gpio::FLAG_NONE) {
+    return GPIO_MODE_DISABLE;
+  } else if (flags == gpio::FLAG_INPUT) {
+    return GPIO_MODE_INPUT;
+  } else if (flags == gpio::FLAG_OUTPUT) {
+    return GPIO_MODE_OUTPUT;
+  } else if (flags == (gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
+    return GPIO_MODE_OUTPUT_OD;
+  } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
+    return GPIO_MODE_INPUT_OUTPUT_OD;
+  } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_OUTPUT)) {
+    return GPIO_MODE_INPUT_OUTPUT;
+  } else {
+    // unsupported
+    return GPIO_MODE_DISABLE;
+  }
+}
+
+void IDFInternalGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override {
+  gpio_int_type_t idf_type = GPIO_INTR_ANYEDGE;
+  switch (type) {
+    case gpio::INTERRUPT_RISING_EDGE:
+      idf_type = inverted_ ? GPIO_INTR_NEGEDGE : GPIO_INTR_POSEDGE;
+      break;
+    case gpio::INTERRUPT_FALLING_EDGE:
+      idf_type = inverted_ ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE;
+      break;
+    case gpio::INTERRUPT_ANY_EDGE:
+      idf_type = GPIO_INTR_ANYEDGE;
+      break;
+    case gpio::INTERRUPT_LOW_LEVEL:
+      idf_type = inverted_ ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL;
+      break;
+    case gpio::INTERRUPT_HIGH_LEVEL:
+      idf_type = inverted_ ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL;
+      break;
+  }
+  gpio_set_intr_type(pin_, idf_type);
+  gpio_intr_enable(pin_);
+  if (!isr_service_installed) {
+    auto res = gpio_install_isr_service(ESP_INTR_FLAG_LEVEL3);
+    if (res != ESP_OK) {
+      ESP_LOGE(TAG, "attach_interrupt(): call to gpio_install_isr_service() failed, error code: %d", res);
+      return;
+    }
+    isr_service_installed = true;
+  }
+  gpio_isr_handler_add(pin_, func, arg);
+}
+
+
 std::string IDFInternalGPIOPin::dump_summary() const {
   char buffer[32];
   snprintf(buffer, sizeof(buffer), "GPIO%u", static_cast<uint32_t>(pin_));

--- a/esphome/components/esp32/gpio_idf.h
+++ b/esphome/components/esp32/gpio_idf.h
@@ -77,7 +77,7 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
     gpio_set_intr_type(pin_, idf_type);
     gpio_intr_enable(pin_);
     if (!isr_service_installed) {
-      gpio_install_isr_service(ESP_INTR_FLAG_LEVEL5);
+      gpio_install_isr_service(ESP_INTR_FLAG_LEVEL3);
       isr_service_installed = true;
     }
     gpio_isr_handler_add(pin_, func, arg);

--- a/esphome/components/esp32/gpio_idf.h
+++ b/esphome/components/esp32/gpio_idf.h
@@ -77,7 +77,9 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
     gpio_set_intr_type(pin_, idf_type);
     gpio_intr_enable(pin_);
     if (!isr_service_installed) {
-      gpio_install_isr_service(ESP_INTR_FLAG_LEVEL3);
+      if (gpio_install_isr_service(ESP_INTR_FLAG_LEVEL3) != ESP_OK) {
+        return;
+      }
       isr_service_installed = true;
     }
     gpio_isr_handler_add(pin_, func, arg);

--- a/esphome/components/esp32/gpio_idf.h
+++ b/esphome/components/esp32/gpio_idf.h
@@ -13,22 +13,10 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
   void set_inverted(bool inverted) { inverted_ = inverted; }
   void set_drive_strength(gpio_drive_cap_t drive_strength) { drive_strength_ = drive_strength; }
   void set_flags(gpio::Flags flags) { flags_ = flags; }
-
-  void setup() override {
-    pin_mode(flags_);
-    gpio_set_drive_capability(pin_, drive_strength_);
-  }
-  void pin_mode(gpio::Flags flags) override {
-    gpio_config_t conf{};
-    conf.pin_bit_mask = 1ULL << static_cast<uint32_t>(pin_);
-    conf.mode = flags_to_mode(flags);
-    conf.pull_up_en = flags & gpio::FLAG_PULLUP ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
-    conf.pull_down_en = flags & gpio::FLAG_PULLDOWN ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE;
-    conf.intr_type = GPIO_INTR_DISABLE;
-    gpio_config(&conf);
-  }
-  bool digital_read() override { return bool(gpio_get_level(pin_)) != inverted_; }
-  void digital_write(bool value) override { gpio_set_level(pin_, value != inverted_ ? 1 : 0); }
+  void setup() override;
+  void pin_mode(gpio::Flags flags) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
   std::string dump_summary() const override;
   void detach_interrupt() const override { gpio_intr_disable(pin_); }
   ISRInternalGPIOPin to_isr() const override;
@@ -36,54 +24,8 @@ class IDFInternalGPIOPin : public InternalGPIOPin {
   bool is_inverted() const override { return inverted_; }
 
  protected:
-  static gpio_mode_t flags_to_mode(gpio::Flags flags) {
-    flags = (gpio::Flags)(flags & ~(gpio::FLAG_PULLUP | gpio::FLAG_PULLDOWN));
-    if (flags == gpio::FLAG_NONE) {
-      return GPIO_MODE_DISABLE;
-    } else if (flags == gpio::FLAG_INPUT) {
-      return GPIO_MODE_INPUT;
-    } else if (flags == gpio::FLAG_OUTPUT) {
-      return GPIO_MODE_OUTPUT;
-    } else if (flags == (gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
-      return GPIO_MODE_OUTPUT_OD;
-    } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
-      return GPIO_MODE_INPUT_OUTPUT_OD;
-    } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_OUTPUT)) {
-      return GPIO_MODE_INPUT_OUTPUT;
-    } else {
-      // unsupported
-      return GPIO_MODE_DISABLE;
-    }
-  }
-  void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override {
-    gpio_int_type_t idf_type = GPIO_INTR_ANYEDGE;
-    switch (type) {
-      case gpio::INTERRUPT_RISING_EDGE:
-        idf_type = inverted_ ? GPIO_INTR_NEGEDGE : GPIO_INTR_POSEDGE;
-        break;
-      case gpio::INTERRUPT_FALLING_EDGE:
-        idf_type = inverted_ ? GPIO_INTR_POSEDGE : GPIO_INTR_NEGEDGE;
-        break;
-      case gpio::INTERRUPT_ANY_EDGE:
-        idf_type = GPIO_INTR_ANYEDGE;
-        break;
-      case gpio::INTERRUPT_LOW_LEVEL:
-        idf_type = inverted_ ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL;
-        break;
-      case gpio::INTERRUPT_HIGH_LEVEL:
-        idf_type = inverted_ ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL;
-        break;
-    }
-    gpio_set_intr_type(pin_, idf_type);
-    gpio_intr_enable(pin_);
-    if (!isr_service_installed) {
-      if (gpio_install_isr_service(ESP_INTR_FLAG_LEVEL3) != ESP_OK) {
-        return;
-      }
-      isr_service_installed = true;
-    }
-    gpio_isr_handler_add(pin_, func, arg);
-  }
+  static gpio_mode_t flags_to_mode(gpio::Flags flags);
+  void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
   gpio_num_t pin_;
   bool inverted_;


### PR DESCRIPTION
# What does this implement/fix? 

The `attach_interrupt(...)` implementation for the esp32 component uses `ESP_INTR_FLAG_LEVEL5` for `gpio_install_isr_service(...)`. This interrupt level requires handlers that are written in assembly. Therefore C-code handler are not acceptable and using those results in a failed interrupt setup.

Additionally, the return value of `gpio_install_isr_service(...)` was not checked, resulting in a `LoadProhibited` abort, because of a NULL pointer exception. further down the road. I added a check to see if it actually returns `ESP_OK`.

**Note:**
Adding some logging in case of a fail would be a nice to have, but this code currently lives in the `gpio_idf.h` file and not the `gpio_idf.cpp` file. That makes the structure different from the other .h files and I shouldn't define a `TAG` in this .h file for logging purposes. 
Is there a reason why this code is in the .h file or is it okay if I split declaration and implementation between respectively the .h and the .cpp file here?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2483

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32   (unicore, not 100% sure if that matters)
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esp32:
  board: esp32doit-devkit-v1
  framework:
    type: esp-idf
    sdkconfig_options:
      CONFIG_FREERTOS_UNICORE: y

# Just an example, I saw the behavior with all code that attached a pin interrupt.
sensor:
  - platform: rotary_encoder
    name: "Rotary Encoder"
    pin_a: GPIO16
    pin_b: GPIO17
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
