### PR TITLE
Fix default environment for clang-tidy

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -122,7 +122,7 @@ def main():
     parser.add_argument('-j', '--jobs', type=int,
                         default=multiprocessing.cpu_count(),
                         help='number of tidy instances to be run in parallel.')
-    parser.add_argument('-e', '--environment', default='esp8266-tidy',
+    parser.add_argument('-e', '--environment', default='esp32-tidy',
                         help='the PlatformIO environment to run against (esp8266-tidy or esp32-tidy)')
     parser.add_argument('files', nargs='*', default=[],
                         help='files to be processed (regex on path)')

--- a/script/lint-cpp
+++ b/script/lint-cpp
@@ -3,9 +3,6 @@
 set -e
 
 cd "$(dirname "$0")/.."
-if [[ ! -e ".gcc-flags.json" ]]; then
-  pio init --ide atom
-fi
 
 set -x
 


### PR DESCRIPTION
# What does this implement/fix? 

Default clang-tidy to ESP32 when running the clang-tidy script as well, to be consistent with CI.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
