### PR TITLE
Replace std::move() with const references where possible

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -40,7 +40,7 @@ class HttpRequestComponent : public Component {
   void set_method(const char *method) { this->method_ = method; }
   void set_useragent(const char *useragent) { this->useragent_ = useragent; }
   void set_timeout(uint16_t timeout) { this->timeout_ = timeout; }
-  void set_body(const std::string& body) { this->body_ = body; }
+  void set_body(const std::string &body) { this->body_ = body; }
   void set_headers(std::list<Header> headers) { this->headers_ = std::move(headers); }
   void send(const std::vector<HttpRequestResponseTrigger *> &response_triggers);
   void close();

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -40,7 +40,7 @@ class HttpRequestComponent : public Component {
   void set_method(const char *method) { this->method_ = method; }
   void set_useragent(const char *useragent) { this->useragent_ = useragent; }
   void set_timeout(uint16_t timeout) { this->timeout_ = timeout; }
-  void set_body(std::string body) { this->body_ = std::move(body); }
+  void set_body(const std::string& body) { this->body_ = body; }
   void set_headers(std::list<Header> headers) { this->headers_ = std::move(headers); }
   void send(const std::vector<HttpRequestResponseTrigger *> &response_triggers);
   void close();

--- a/esphome/components/pipsolar/output/pipsolar_output.h
+++ b/esphome/components/pipsolar/output/pipsolar_output.h
@@ -13,7 +13,7 @@ class PipsolarOutput : public output::FloatOutput {
  public:
   PipsolarOutput() {}
   void set_parent(Pipsolar *parent) { this->parent_ = parent; }
-  void set_set_command(const std::string& command) { this->set_command_ = command; };
+  void set_set_command(const std::string &command) { this->set_command_ = command; };
   void set_possible_values(std::vector<float> possible_values) { this->possible_values_ = std::move(possible_values); }
   void set_value(float value) { this->write_state(value); };
 

--- a/esphome/components/pipsolar/output/pipsolar_output.h
+++ b/esphome/components/pipsolar/output/pipsolar_output.h
@@ -13,7 +13,7 @@ class PipsolarOutput : public output::FloatOutput {
  public:
   PipsolarOutput() {}
   void set_parent(Pipsolar *parent) { this->parent_ = parent; }
-  void set_set_command(std::string command) { this->set_command_ = std::move(command); };
+  void set_set_command(const std::string& command) { this->set_command_ = command; };
   void set_possible_values(std::vector<float> possible_values) { this->possible_values_ = std::move(possible_values); }
   void set_value(float value) { this->write_state(value); };
 

--- a/esphome/components/pipsolar/switch/pipsolar_switch.h
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.h
@@ -10,8 +10,8 @@ class Pipsolar;
 class PipsolarSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(Pipsolar *parent) { this->parent_ = parent; };
-  void set_on_command(std::string command) { this->on_command_ = std::move(command); };
-  void set_off_command(std::string command) { this->off_command_ = std::move(command); };
+  void set_on_command(const std::string& command) { this->on_command_ = command; };
+  void set_off_command(const std::string& command) { this->off_command_ = command; };
   void dump_config() override;
 
  protected:

--- a/esphome/components/pipsolar/switch/pipsolar_switch.h
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.h
@@ -10,8 +10,8 @@ class Pipsolar;
 class PipsolarSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(Pipsolar *parent) { this->parent_ = parent; };
-  void set_on_command(const std::string& command) { this->on_command_ = command; };
-  void set_off_command(const std::string& command) { this->off_command_ = command; };
+  void set_on_command(const std::string &command) { this->on_command_ = command; };
+  void set_off_command(const std::string &command) { this->off_command_ = command; };
   void dump_config() override;
 
  protected:

--- a/esphome/components/rf_bridge/rf_bridge.h
+++ b/esphome/components/rf_bridge/rf_bridge.h
@@ -85,8 +85,7 @@ class RFBridgeReceivedCodeTrigger : public Trigger<RFBridgeData> {
 class RFBridgeReceivedAdvancedCodeTrigger : public Trigger<RFBridgeAdvancedData> {
  public:
   explicit RFBridgeReceivedAdvancedCodeTrigger(RFBridgeComponent *parent) {
-    parent->add_on_advanced_code_received_callback(
-        [this](const RFBridgeAdvancedData& data) { this->trigger(data); });
+    parent->add_on_advanced_code_received_callback([this](const RFBridgeAdvancedData &data) { this->trigger(data); });
   }
 };
 

--- a/esphome/components/rf_bridge/rf_bridge.h
+++ b/esphome/components/rf_bridge/rf_bridge.h
@@ -86,7 +86,7 @@ class RFBridgeReceivedAdvancedCodeTrigger : public Trigger<RFBridgeAdvancedData>
  public:
   explicit RFBridgeReceivedAdvancedCodeTrigger(RFBridgeComponent *parent) {
     parent->add_on_advanced_code_received_callback(
-        [this](RFBridgeAdvancedData data) { this->trigger(std::move(data)); });
+        [this](const RFBridgeAdvancedData& data) { this->trigger(data); });
   }
 };
 

--- a/esphome/components/select/automation.h
+++ b/esphome/components/select/automation.h
@@ -10,7 +10,7 @@ namespace select {
 class SelectStateTrigger : public Trigger<std::string> {
  public:
   explicit SelectStateTrigger(Select *parent) {
-    parent->add_on_state_callback([this](std::string value) { this->trigger(std::move(value)); });
+    parent->add_on_state_callback([this](const std::string& value) { this->trigger(value); });
   }
 };
 

--- a/esphome/components/select/automation.h
+++ b/esphome/components/select/automation.h
@@ -10,7 +10,7 @@ namespace select {
 class SelectStateTrigger : public Trigger<std::string> {
  public:
   explicit SelectStateTrigger(Select *parent) {
-    parent->add_on_state_callback([this](const std::string& value) { this->trigger(value); });
+    parent->add_on_state_callback([this](const std::string &value) { this->trigger(value); });
   }
 };
 

--- a/esphome/components/sim800l/sim800l.h
+++ b/esphome/components/sim800l/sim800l.h
@@ -74,7 +74,7 @@ class Sim800LReceivedMessageTrigger : public Trigger<std::string, std::string> {
  public:
   explicit Sim800LReceivedMessageTrigger(Sim800LComponent *parent) {
     parent->add_on_sms_received_callback(
-        [this](std::string message, std::string sender) { this->trigger(std::move(message), std::move(sender)); });
+        [this](const std::string& message, const std::string& sender) { this->trigger(message, sender); });
   }
 };
 

--- a/esphome/components/sim800l/sim800l.h
+++ b/esphome/components/sim800l/sim800l.h
@@ -74,7 +74,7 @@ class Sim800LReceivedMessageTrigger : public Trigger<std::string, std::string> {
  public:
   explicit Sim800LReceivedMessageTrigger(Sim800LComponent *parent) {
     parent->add_on_sms_received_callback(
-        [this](const std::string& message, const std::string& sender) { this->trigger(message, sender); });
+        [this](const std::string &message, const std::string &sender) { this->trigger(message, sender); });
   }
 };
 

--- a/esphome/components/template/select/template_select.h
+++ b/esphome/components/template/select/template_select.h
@@ -19,7 +19,7 @@ class TemplateSelect : public select::Select, public PollingComponent {
 
   Trigger<std::string> *get_set_trigger() const { return this->set_trigger_; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-  void set_initial_option(const std::string& initial_option) { this->initial_option_ = initial_option; }
+  void set_initial_option(const std::string &initial_option) { this->initial_option_ = initial_option; }
   void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
 
  protected:

--- a/esphome/components/template/select/template_select.h
+++ b/esphome/components/template/select/template_select.h
@@ -19,7 +19,7 @@ class TemplateSelect : public select::Select, public PollingComponent {
 
   Trigger<std::string> *get_set_trigger() const { return this->set_trigger_; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-  void set_initial_option(std::string initial_option) { this->initial_option_ = std::move(initial_option); }
+  void set_initial_option(const std::string& initial_option) { this->initial_option_ = initial_option; }
   void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
 
  protected:

--- a/esphome/components/text_sensor/automation.h
+++ b/esphome/components/text_sensor/automation.h
@@ -12,14 +12,14 @@ namespace text_sensor {
 class TextSensorStateTrigger : public Trigger<std::string> {
  public:
   explicit TextSensorStateTrigger(TextSensor *parent) {
-    parent->add_on_state_callback([this](std::string value) { this->trigger(std::move(value)); });
+    parent->add_on_state_callback([this](const std::string& value) { this->trigger(value); });
   }
 };
 
 class TextSensorStateRawTrigger : public Trigger<std::string> {
  public:
   explicit TextSensorStateRawTrigger(TextSensor *parent) {
-    parent->add_on_raw_state_callback([this](std::string value) { this->trigger(std::move(value)); });
+    parent->add_on_raw_state_callback([this](const std::string& value) { this->trigger(value); });
   }
 };
 

--- a/esphome/components/text_sensor/automation.h
+++ b/esphome/components/text_sensor/automation.h
@@ -12,14 +12,14 @@ namespace text_sensor {
 class TextSensorStateTrigger : public Trigger<std::string> {
  public:
   explicit TextSensorStateTrigger(TextSensor *parent) {
-    parent->add_on_state_callback([this](const std::string& value) { this->trigger(value); });
+    parent->add_on_state_callback([this](const std::string &value) { this->trigger(value); });
   }
 };
 
 class TextSensorStateRawTrigger : public Trigger<std::string> {
  public:
   explicit TextSensorStateRawTrigger(TextSensor *parent) {
-    parent->add_on_raw_state_callback([this](const std::string& value) { this->trigger(value); });
+    parent->add_on_raw_state_callback([this](const std::string &value) { this->trigger(value); });
   }
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

This replaces usage of `std::move()` with a const reference parameter, which has the same effect, to fix clang-tidy warnings in the esp8266-tidy environment. Not sure why they arent' generated in the esp32-tidy environment.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
