### PR TITLE
Convert time to use tzdata

### DIFF
--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -61,6 +61,7 @@ def convert_iana_key(iana_key: str) -> str:
     try:
         return dat.split(b"\n")[-2].decode()
     except (IndexError, UnicodeDecodeError) as e:
+        _LOGGER.error("%s", dat, exc_info=True)
         raise cv.Invalid(
             f"Could not determine TZ string for timezone '{iana_key}'. "
             "Please report this issue"
@@ -71,7 +72,7 @@ def detect_tz() -> str:
     iana_key = tzlocal.get_localzone().key
     _LOGGER.info("Detected timezone '%s'", iana_key)
     ret = convert_iana_key(iana_key)
-    _LOGGER.debug(" -> TZ string %s", ret)
+    _LOGGER.info(" -> TZ string %s", ret)
     return ret
 
 

--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -49,7 +49,7 @@ def _load_tzdata(iana_key: str) -> Optional[bytes]:
     try:
         return resources.read_binary(package, resource)
     except (FileNotFoundError, ModuleNotFoundError):
-        return None
+        raise
 
 
 def convert_iana_key(iana_key: str) -> str:

--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -63,7 +63,7 @@ def convert_iana_key(iana_key: str) -> str:
     except (IndexError, UnicodeDecodeError) as e:
         raise cv.Invalid(
             f"Could not determine TZ string for timezone '{iana_key}'. "
-            "Please report this issues"
+            "Please report this issue"
         ) from e
 
 

--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -1,6 +1,7 @@
 import logging
 from importlib import resources
 from typing import Optional
+from datetime import timezone
 
 import tzlocal
 
@@ -65,7 +66,14 @@ def _extract_tz_string(tzfile: bytes) -> str:
 
 
 def detect_tz() -> str:
-    iana_key = tzlocal.get_localzone().key
+    localzone = tzlocal.get_localzone()
+    if localzone is timezone.utc:
+        return "UTC0"
+    if not hasattr(localzone, "key"):
+        raise cv.Invalid(
+            "Could not automatically determine timezone, please set timezone manually."
+        )
+    iana_key = localzone.key
     _LOGGER.info("Detected timezone '%s'", iana_key)
     tzfile = _load_tzdata(iana_key)
     if tzfile is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ PyYAML==5.4.1
 paho-mqtt==1.5.1
 colorama==0.4.4
 tornado==6.1
-tzlocal==3.0
-pytz==2021.1
+tzlocal==3.0    # from time
+tzdata>=2021.1  # from time
 pyserial==3.5
 platformio==5.2.0
 esptool==3.1


### PR DESCRIPTION
# What does this implement/fix? 

This concerns esphome's automatic timezone detection/conversion to TZ string.

ESPHome must convert the system's timezone to a [TZ string](https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html). Previously, we did this by manually looking into the tz object and looking for the next DST transitions.

However, the generated TZ string was not 100% correct, there was no good way to figure out common DST rules like "second sunday of november".

Switch to using the official [tzdata](https://pypi.org/project/tzdata/) module for getting the tzdata contents, then extract the TZ string from it ([tzfile format](https://man7.org/linux/man-pages/man5/tzfile.5.html)); I didn't want to write a full tzfile parser, so instead this [-2] should work well (if I understand correctly, everything after the TZ string is the same, and it worked correctly for all current entries in tzdata)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
