### PR TITLE
Add local MAC address to WiFi info

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -350,7 +350,8 @@ void WiFiComponent::print_connect_params_() {
   bssid_t bssid = wifi_bssid();
 
   std::string m = get_mac_address();
-  ESP_LOGCONFIG(TAG, "  Local MAC: %c%c:%c%c:%c%c:%c%c:%c%c:%c%c", m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
+  ESP_LOGCONFIG(TAG, "  Local MAC: %c%c:%c%c:%c%c:%c%c:%c%c:%c%c", m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8],
+                m[9], m[10], m[11]);
   ESP_LOGCONFIG(TAG, "  SSID: " LOG_SECRET("'%s'"), wifi_ssid().c_str());
   ESP_LOGCONFIG(TAG, "  IP Address: %s", wifi_sta_ip().str().c_str());
   ESP_LOGCONFIG(TAG, "  BSSID: " LOG_SECRET("%02X:%02X:%02X:%02X:%02X:%02X"), bssid[0], bssid[1], bssid[2], bssid[3],

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -349,6 +349,8 @@ const LogString *get_signal_bars(int8_t rssi) {
 void WiFiComponent::print_connect_params_() {
   bssid_t bssid = wifi_bssid();
 
+  std::string m = get_mac_address();
+  ESP_LOGCONFIG(TAG, "  Local MAC: %c%c:%c%c:%c%c:%c%c:%c%c:%c%c", m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
   ESP_LOGCONFIG(TAG, "  SSID: " LOG_SECRET("'%s'"), wifi_ssid().c_str());
   ESP_LOGCONFIG(TAG, "  IP Address: %s", wifi_sta_ip().str().c_str());
   ESP_LOGCONFIG(TAG, "  BSSID: " LOG_SECRET("%02X:%02X:%02X:%02X:%02X:%02X"), bssid[0], bssid[1], bssid[2], bssid[3],

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -349,9 +349,7 @@ const LogString *get_signal_bars(int8_t rssi) {
 void WiFiComponent::print_connect_params_() {
   bssid_t bssid = wifi_bssid();
 
-  std::string m = get_mac_address();
-  ESP_LOGCONFIG(TAG, "  Local MAC: %c%c:%c%c:%c%c:%c%c:%c%c:%c%c", m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8],
-                m[9], m[10], m[11]);
+  ESP_LOGCONFIG(TAG, "  Local MAC: %s", get_mac_address_pretty().c_str());
   ESP_LOGCONFIG(TAG, "  SSID: " LOG_SECRET("'%s'"), wifi_ssid().c_str());
   ESP_LOGCONFIG(TAG, "  IP Address: %s", wifi_sta_ip().str().c_str());
   ESP_LOGCONFIG(TAG, "  BSSID: " LOG_SECRET("%02X:%02X:%02X:%02X:%02X:%02X"), bssid[0], bssid[1], bssid[2], bssid[3],


### PR DESCRIPTION
When connecting to an AP, it is sometimes necessary to know the local MAC of the ESP device to add it to the network. This info is now printed in the log.

# What does this implement/fix? 

This adds the ESP device local MAC address to the WiFi information printed to the log files.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
