### PR TITLE
Continue ethernet setup if hostname fails

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -168,7 +168,9 @@ void EthernetComponent::start_connect_() {
 
   esp_err_t err;
   err = tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_ETH, App.get_name().c_str());
-  ESPHL_ERROR_CHECK(err, "ETH set hostname error");
+  if (err != ERR_OK) {
+    ESP_LOGW(TAG, "tcpip_adapter_set_hostname failed: %s", esp_err_to_name(err));
+  }
 
   tcpip_adapter_ip_info_t info;
   if (this->manual_ip_.has_value()) {


### PR DESCRIPTION
# What does this implement/fix? 
I was switching over some of my boards from WiFi to Ethernet, nothing changed in the config other than swapping out the needed network component. Some of the ethernet board got an IP address and seemingly network activity (flashing lights on the network ports), but ESPHome failed to come online.
After directly showing the logs after an upload, using esphome-flasher, I got the following logs:
```
[11:42:16][I][logger:174]: Log initialized
[11:42:16][I][app:029]: Running through setup()...
[11:42:17][I][ethernet:089]: Starting ethernet connection
[11:42:17][E][ethernet:177]: ETH set hostname error: (20481) ESP_ERR_TCPIP_ADAPTER_INVALID_PARAMS
[11:42:17][E][component:102]: Component ethernet was marked as failed.
```

I have adjusted the behavior to be similar to how the [WiFi check happens](
https://github.com/esphome/esphome/blob/dev/esphome/components/wifi/wifi_component_esp_idf.cpp#L589), it tries to set the hostname, but doesn't fail the network setup if it can't. After all, the device is online, juts not reachable via it's hostname. The reason why it fails for me was that some device names were longer than 32bytes, the method used has a limit of 32bytes.

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** No logged issue (afaik)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** /

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
