### PR TITLE
Hotfix for ESP8266 OTA issue: ERROR Error binary size

### DIFF
--- a/esphome/components/ota/ota_backend_arduino_esp8266.cpp
+++ b/esphome/components/ota/ota_backend_arduino_esp8266.cpp
@@ -16,6 +16,7 @@ OTAResponseTypes ArduinoESP8266OTABackend::begin(size_t image_size) {
   bool ret = Update.begin(image_size, U_FLASH);
   if (ret) {
     esp8266::preferences_prevent_write(true);
+    return OTA_RESPONSE_OK;
   }
 
   uint8_t error = Update.getError();


### PR DESCRIPTION
# What does this implement/fix? 

At the start of flashing ESP8266:

```
ERROR Error binary size: Unknown error from ESP
```

In my refactoring work on the OTA backends, this regression was introduced for the ESP8266 Arduino backend. I already fixed this issue during development and testing, but I'm afraid I had multiple editors open, pushing the unfixed version. Sorry for that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
