### PR TITLE
Always upload using esptool

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -542,6 +542,9 @@ class EsphomeCore:
         path_ = os.path.expanduser(os.path.join(*path))
         return os.path.join(self.config_dir, path_)
 
+    def relative_internal_path(self, *path: str) -> str:
+        return self.relative_config_path(".esphome", *path)
+
     def relative_build_path(self, *path):
         # pylint: disable=no-value-for-parameter
         path_ = os.path.expanduser(os.path.join(*path))

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def storage_path():  # type: () -> str
-    return CORE.relative_config_path(".esphome", f"{CORE.config_filename}.json")
+    return CORE.relative_internal_path(f"{CORE.config_filename}.json")
 
 
 def ext_storage_path(base_path, config_filename):  # type: (str, str) -> str


### PR DESCRIPTION
# What does this implement/fix? 

Previously we weren't able to USB upload to ESP32s because we didn't know the FS paths of the extra images needed to flash (partitions, bootloader etc)

Now we can fetch that data from platformio's idedata command.

Results in faster USB uploads (no need to re-run `pio run` every time, which takes a bit of time), and we can use our "try to upload fast first, then upload with slow baud rate" logic

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
