### PR TITLE
Fix socket abstraction for ESP-IDF v4

### DIFF
--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -96,6 +96,9 @@ class BSDSocketImpl : public Socket {
         break;
     }
     return ret;
+#elif defined(ARDUINO_ARCH_ESP32)
+    // ESP-IDF v4 only has symbol lwip_readv
+    return ::lwip_readv(fd_, iov, iovcnt);
 #else
     return ::readv(fd_, iov, iovcnt);
 #endif
@@ -120,6 +123,9 @@ class BSDSocketImpl : public Socket {
         break;
     }
     return ret;
+#elif defined(ARDUINO_ARCH_ESP32)
+    // ESP-IDF v4 only has symbol lwip_writev
+    return ::lwip_writev(fd_, iov, iovcnt);
 #else
     return ::writev(fd_, iov, iovcnt);
 #endif


### PR DESCRIPTION
ESP-IDF v4 only has symbol lwip_readv/writev. This allows to compile for
ESP32-C3 again.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2482

Fixes: https://github.com/esphome/esphome/pull/2342

Already in dev, part of https://github.com/esphome/esphome/pull/2303. This is essentially a backport of that particular fix.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
