### PR TITLE
Disable dependency finder on ESP32

### DIFF
--- a/esphome/components/airthings_wave_plus/sensor.py
+++ b/esphome/components/airthings_wave_plus/sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, ble_client
+from esphome.core import CORE
 
 from esphome.const import (
     DEVICE_CLASS_CARBON_DIOXIDE,
@@ -116,3 +117,6 @@ async def to_code(config):
     if CONF_TVOC in config:
         sens = await sensor.new_sensor(config[CONF_TVOC])
         cg.add(var.set_tvoc(sens))
+
+    if CORE.is_esp32:
+        cg.add_library("ESP32 BLE Arduino", None)

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -3,7 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import web_server_base
 from esphome.components.web_server_base import CONF_WEB_SERVER_BASE_ID
 from esphome.const import CONF_ID
-from esphome.core import coroutine_with_priority
+from esphome.core import coroutine_with_priority, CORE
 
 AUTO_LOAD = ["web_server_base"]
 DEPENDENCIES = ["wifi"]
@@ -32,3 +32,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID], paren)
     await cg.register_component(var, config)
     cg.add_define("USE_CAPTIVE_PORTAL")
+
+    if CORE.is_esp32:
+        cg.add_library("DNSServer", None)
+        cg.add_library("WiFi", None)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -276,6 +276,8 @@ async def to_code(config):
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{config[CONF_VARIANT]}")
 
+    cg.add_platformio_option("lib_ldf_mode", "off")
+
     conf = config[CONF_FRAMEWORK]
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_platformio_option(

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -123,3 +123,6 @@ async def to_code(config):
         cg.add(var.set_manual_ip(manual_ip(config[CONF_MANUAL_IP])))
 
     cg.add_define("USE_ETHERNET")
+
+    if CORE.is_esp32:
+        cg.add_library("WiFi", None)

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -92,6 +92,11 @@ async def to_code(config):
     cg.add(var.set_useragent(config[CONF_USERAGENT]))
     if CORE.is_esp8266 and not config[CONF_ESP8266_DISABLE_SSL_SUPPORT]:
         cg.add_define("USE_HTTP_REQUEST_ESP8266_HTTPS")
+
+    if CORE.is_esp32:
+        cg.add_library("WiFiClientSecure", None)
+        cg.add_library("HTTPClient", None)
+
     await cg.register_component(var, config)
 
 

--- a/esphome/components/mcp3008/__init__.py
+++ b/esphome/components/mcp3008/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import spi
 from esphome.const import CONF_ID
+from esphome.core import CORE
 
 DEPENDENCIES = ["spi"]
 AUTO_LOAD = ["sensor"]
@@ -23,3 +24,6 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
+
+    if CORE.is_esp32:
+        cg.add_library("SPI", None)

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -30,15 +30,16 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
-    if config[CONF_DISABLED]:
-        return
-
-    cg.add_define("USE_MDNS")
     if CORE.using_arduino:
         if CORE.is_esp32:
             cg.add_library("ESPmDNS", None)
         elif CORE.is_esp8266:
             cg.add_library("ESP8266mDNS", None)
+
+    if config[CONF_DISABLED]:
+        return
+
+    cg.add_define("USE_MDNS")
 
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -101,6 +101,7 @@ async def to_code(config):
     if CORE.is_esp8266:
         cg.add_library("Update", None)
     elif CORE.is_esp32 and CORE.using_arduino:
+        cg.add_library("Update", None)
         cg.add_library("Hash", None)
 
     use_state_callback = False

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -10,7 +10,7 @@ from esphome.const import (
     CONF_SPI_ID,
     CONF_CS_PIN,
 )
-from esphome.core import coroutine_with_priority
+from esphome.core import coroutine_with_priority, CORE
 
 CODEOWNERS = ["@esphome/core"]
 spi_ns = cg.esphome_ns.namespace("spi")
@@ -45,6 +45,9 @@ async def to_code(config):
     if CONF_MOSI_PIN in config:
         mosi = await cg.gpio_pin_expression(config[CONF_MOSI_PIN])
         cg.add(var.set_mosi(mosi))
+
+    if CORE.is_esp32:
+        cg.add_library("SPI", None)
 
 
 def spi_device_schema(cs_pin_required=True):

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -24,6 +24,8 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     if CORE.is_esp32:
+        cg.add_library("WiFi", None)
         cg.add_library("FS", None)
+        cg.add_library("Update", None)
     # https://github.com/esphome/ESPAsyncWebServer/blob/master/library.json
     cg.add_library("esphome/ESPAsyncWebServer-esphome", "1.3.0")


### PR DESCRIPTION
# Breaking Change

This change only affects custom components.

Before 2021.10, platformio would automatically look for libraries based on the `#include`s in your custom code.

That had to be disabled because it was causing issues.

When you use a library (even internal ones like `Wire`), you now need to explicitly put them in the `esphome` section like this

```yaml
esphome:
  libraries
    # Any libraries that were implicitly used before
    - Wire
    - SPI
    - EEPROM
    # Note: order is important, core libraries like `Wire` should be placed before external ones
```

More information here: https://github.com/esphome/issues/issues/2587

# What does this implement/fix? 

The platform.io LDF (library dependeny finder) adds libraries based on
header file names. However, this at times causes spurious dependency to
be added to the dependency graph. If a library can't be compiled for a
certain configuration, this blocks certain configurations which would
be buildable otherwise.

Disable the LDF by default for ESP32 targets. Add required libraries
directly to modules.

More information about the LDF:
https://docs.platformio.org/en/latest/librarymanager/ldf.html#ldf-mode

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2474

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
