### PR TITLE
Use size_t to fix comparision using RISC-V toolchain

### DIFF
--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -109,11 +109,11 @@ void OTAComponent::loop() {
 void OTAComponent::handle_() {
   OTAResponseTypes error_code = OTA_RESPONSE_ERROR_UNKNOWN;
   bool update_started = false;
-  uint32_t total = 0;
+  size_t total = 0;
   uint32_t last_progress = 0;
   uint8_t buf[1024];
   char *sbuf = reinterpret_cast<char *>(buf);
-  uint32_t ota_size;
+  size_t ota_size;
   uint8_t ota_features;
   std::unique_ptr<OTABackend> backend;
   (void) ota_features;


### PR DESCRIPTION
# What does this implement/fix? 

The RISC-V compiler complains about missmatching types otherwise:
```
src/esphome/components/ota/ota_component.cpp: In member function 'void esphome::ota::OTAComponent::handle_()':
src/esphome/components/ota/ota_component.cpp:271:62: error: no matching function for call to 'min(unsigned int, uint32_t)'
     size_t requested = std::min(sizeof(buf), ota_size - total);
                                                              ^
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32 (C3)
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
