### PR TITLE
Fix I2C recovery ESP32 esp-idf

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -11,7 +11,9 @@ namespace i2c {
 static const char *const TAG = "i2c.arduino";
 
 void ArduinoI2CBus::setup() {
+
   recover_();
+
 #ifdef USE_ESP32
   static uint8_t next_bus_num = 0;
   if (next_bus_num == 0)
@@ -109,10 +111,10 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
 void ArduinoI2CBus::recover_() {
   ESP_LOGI(TAG, "Performing I2C bus recovery");
 
-  // Activate the pull up resistor on the SCL pin. This should make the
-  // signal on the line HIGH. If SCL is pulled low on the I2C bus however,
-  // then some device is interfering with the SCL line. In that case,
-  // the I2C bus cannot be recovered.
+  // Activate input and pull up resistor for the SCL pin. This should make
+  // the signal on the line HIGH. If SCL is pulled low on the I2C bus
+  // however, then some device is interfering with the SCL line. In that
+  // case, the I2C bus cannot be recovered.
   pinMode(scl_pin_, INPUT_PULLUP);     // NOLINT
   if (digitalRead(scl_pin_) == LOW) {  // NOLINT
     ESP_LOGE(TAG, "Recovery failed: SCL is held LOW on the I2C bus");
@@ -133,13 +135,13 @@ void ArduinoI2CBus::recover_() {
   // is no problem.
   const auto half_period_usec = 1000000 / 100000 / 2;
 
-  // Make sure that switching to mode OUTPUT will make SCL low, just in
+  // Make sure that switching to output mode will make SCL low, just in
   // case other code has setup the pin to output a HIGH signal.
   digitalWrite(scl_pin_, LOW);  // NOLINT
 
-  // Activate the pull up resistor for SDA, so after the clock pulse cycle
-  // we can verify if SDA is pulled high. Also make sure that switching to
-  // mode OUTPUT will make SDA low.
+  // Activate input and pull resistor for the SDA pin, so after the clock
+  // pulse cycle we can verify that SDA is pulled high. Also make sure
+  // that switching to output mode will make SDA low.
   pinMode(sda_pin_, INPUT_PULLUP);  // NOLINT
   digitalWrite(sda_pin_, LOW);      // NOLINT
 

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -11,7 +11,6 @@ namespace i2c {
 static const char *const TAG = "i2c.arduino";
 
 void ArduinoI2CBus::setup() {
-
   recover_();
 
 #ifdef USE_ESP32

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -247,7 +247,6 @@ void IDFI2CBus::recover_() {
   // out of this state.
   // SCL and SDA are already high at this point, so we can generate a START
   // condition by making the SDA signal LOW.
-  //gpio_pullup_dis(sda_pin);
   delayMicroseconds(half_period_usec);
   gpio_set_level(sda_pin, 0);
 

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -144,39 +144,122 @@ ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt) {
   return ERROR_OK;
 }
 
+/// Perform I2C bus recovery, see:
+/// https://www.nxp.com/docs/en/user-guide/UM10204.pdf
+/// https://www.analog.com/media/en/technical-documentation/application-notes/54305147357414AN686_0.pdf
 void IDFI2CBus::recover_() {
-  // Perform I2C bus recovery, see
-  // https://www.analog.com/media/en/technical-documentation/application-notes/54305147357414AN686_0.pdf
-  // or see the linux kernel implementation, e.g.
-  // https://elixir.bootlin.com/linux/v5.14.6/source/drivers/i2c/i2c-core-base.c#L200
+  ESP_LOGI(TAG, "Performing I2C bus recovery");
 
-  // try to get about 100kHz toggle frequency
-  const auto half_period_usec = 1000000 / 100000 / 2;
-  const auto recover_scl_periods = 9;
-  const gpio_num_t scl_pin = static_cast<gpio_num_t>(scl_pin_);
-
-  // configure scl as output
-  gpio_config_t conf{};
-  conf.pin_bit_mask = 1ULL << static_cast<uint32_t>(scl_pin_);
-  conf.mode = GPIO_MODE_OUTPUT;
-  conf.pull_up_en = GPIO_PULLUP_DISABLE;
-  conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-  conf.intr_type = GPIO_INTR_DISABLE;
-
-  gpio_config(&conf);
-
-  // set scl high
-  gpio_set_level(scl_pin, 1);
-
-  // in total generate 9 falling-rising edges
-  for (auto i = 0; i < recover_scl_periods; i++) {
-    delayMicroseconds(half_period_usec);
-    gpio_set_level(scl_pin, 0);
-    delayMicroseconds(half_period_usec);
-    gpio_set_level(scl_pin, 1);
+  // Activate input and pull up resistor for the SCL pin. This should make
+  // the signal on the line HIGH. If SCL is pulled low on the I2C bus
+  // however, then some device is interfering with the SCL line. In that
+  // case, the I2C bus cannot be recovered.
+  gpio_config_t scl_conf{};
+  scl_conf.pin_bit_mask = 1ULL << static_cast<uint32_t>(scl_pin_);
+  scl_conf.mode = GPIO_MODE_INPUT;
+  scl_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+  scl_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  scl_conf.intr_type = GPIO_INTR_DISABLE;
+  gpio_config(&scl_conf);
+  if (gpio_get_level((gpio_num_t)scl_pin_) == 0) {
+    ESP_LOGE(TAG, "Recovery failed: SCL is held LOW on the I2C bus");
+    recovery_result_ = RECOVERY_FAILED_SCL_LOW;
+    return;
   }
 
+  // From the specification:
+  // "If the data line (SDA) is stuck LOW, send nine clock pulses. The
+  //  device that held the bus LOW should release it sometime within
+  //  those nine clocks."
+  // We don't really have to detect if SDA is stuck low. We'll simply send
+  // nine clock pulses here, just in case SDA is stuck.
+
+  // Use a 100kHz toggle frequency (i.e. the maximum frequency for I2C
+  // running in standard-mode). The resulting frequency will be lower,
+  // because of the additional function calls that are done, but that
+  // is no problem.
+  const auto half_period_usec = 1000000 / 100000 / 2;
+
+  // Make sure that switching to output mode will make SCL low, just in
+  // case other code has setup the pin to output a HIGH signal.
+  gpio_set_level((gpio_num_t)scl_pin_, 0);
+
+  // Activate input and pull up resistor for the SDA pin, so after the
+  // clock pulse cycle we can verify that SDA is pulled high. Also make
+  // sure that switching to output mode will make SDA low.
+  gpio_config_t sda_conf{};
+  sda_conf.pin_bit_mask = 1ULL << static_cast<uint32_t>(sda_pin_);
+  sda_conf.mode = GPIO_MODE_INPUT;
+  sda_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+  sda_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  sda_conf.intr_type = GPIO_INTR_DISABLE;
+  gpio_config(&sda_conf);
+  gpio_set_level((gpio_num_t)sda_pin_, 0);
+
+  ESP_LOGI(TAG, "Sending 9 clock pulses to drain any stuck device output");
   delayMicroseconds(half_period_usec);
+  for (auto i = 0; i < 9; i++) {
+    // Release pull up resistor and switch to output to make the signal LOW.
+    gpio_pullup_dis((gpio_num_t)scl_pin_);
+    gpio_set_direction((gpio_num_t)scl_pin_, GPIO_MODE_OUTPUT);  
+    delayMicroseconds(half_period_usec);
+
+    // Release output and activate pull up resistor to make the signal HIGH.
+    gpio_set_direction((gpio_num_t)scl_pin_, GPIO_MODE_INPUT);  
+    gpio_pullup_en((gpio_num_t)scl_pin_);
+    delayMicroseconds(half_period_usec);
+
+    // When SCL is kept LOW at this point, we might be looking at a device
+    // that applies clock stretching. Wait for the release of the SCL line,
+    // but not forever. There is no specification for the maximum allowed
+    // time. We'll stick to 500ms here.
+    auto wait = 20;
+    while (wait-- && gpio_get_level((gpio_num_t)scl_pin_) == 0) {
+      delay(25);
+    }
+    if (gpio_get_level((gpio_num_t)scl_pin_) == 0) {
+      ESP_LOGE(TAG, "Recovery failed: SCL is held LOW during clock pulse cycle");
+      recovery_result_ = RECOVERY_FAILED_SCL_LOW;
+      return;
+    }
+  }
+
+  // By now, any stuck device ought to have sent all remaining bits of its
+  // transation, meaning that it should have freed up the SDA line, resulting
+  // in SDA being pulled up.
+  if (gpio_get_level((gpio_num_t)sda_pin_) == 0) {
+    ESP_LOGE(TAG, "Recovery failed: SDA is held LOW after clock pulse cycle");
+    recovery_result_ = RECOVERY_FAILED_SDA_LOW;
+    return;
+  }
+
+  // From the specification:
+  // "I2C-bus compatible devices must reset their bus logic on receipt of
+  //  a START or repeated START condition such that they all anticipate
+  //  the sending of a target address, even if these START conditions are
+  //  not positioned according to the proper format."
+  // While the 9 clock pulses from above might have drained all bits of a
+  // single byte within a transaction, a device might have more bytes to
+  // transmit. So here we'll generate a START condition to snap the device
+  // out of this state.
+  // SCL and SDA are already high at this point, so we can generate a START
+  // condition by making the SDA signal LOW.
+  ESP_LOGI(TAG, "Generate START condition to reset bus logic of I2C devices");
+  gpio_pullup_dis((gpio_num_t)sda_pin_);
+  gpio_set_direction((gpio_num_t)sda_pin_, GPIO_MODE_OUTPUT);  
+  delayMicroseconds(half_period_usec);
+
+  // From the specification:
+  // "A START condition immediately followed by a STOP condition (void
+  //  message) is an illegal format. Many devices however are designed to
+  //  operate properly under this condition."
+  // Finally, we'll bring the I2C bus into a starting state by generating
+  // a STOP condition.
+  ESP_LOGI(TAG, "Generate STOP condition to finalize recovery");
+  gpio_set_direction((gpio_num_t)sda_pin_, GPIO_MODE_INPUT);  
+  gpio_pullup_en((gpio_num_t)sda_pin_);
+
+  recovery_result_ = RECOVERY_COMPLETED;
 }
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -164,11 +164,13 @@ void IDFI2CBus::recover_() {
   const gpio_num_t scl_pin = static_cast<gpio_num_t>(scl_pin_);
   const gpio_num_t sda_pin = static_cast<gpio_num_t>(sda_pin_);
 
-  // For the upcoming operations, target for a 100kHz toggle frequency.
-  // This is the maximum frequency for I2C running in standard-mode.
-  // The actual frequency will be lower, because of the additional
-  // function calls that are done, but that is no problem.
-  const auto half_period_usec = 1000000 / 100000 / 2;
+  // For the upcoming operations, target for a 60kHz toggle frequency.
+  // 1000kHz is the maximum frequency for I2C running in standard-mode,
+  // but lower frequencies are not a problem.
+  // Note: the timing that is used here is chosen manually, to get
+  // results that are close to the timing that can be archieved by the
+  // implementation for the Arduino framework.
+  const auto half_period_usec = 7;
 
   // Configure SCL pin for open drain input/output, with a pull up resistor.
   gpio_set_level(scl_pin, 1);

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -9,6 +9,12 @@
 namespace esphome {
 namespace i2c {
 
+enum RecoveryCode {
+  RECOVERY_FAILED_SCL_LOW,
+  RECOVERY_FAILED_SDA_LOW,
+  RECOVERY_COMPLETED,
+};
+
 class IDFI2CBus : public I2CBus, public Component {
  public:
   void setup() override;
@@ -26,6 +32,7 @@ class IDFI2CBus : public I2CBus, public Component {
 
  private:
   void recover_();
+  RecoveryCode recovery_result_;
 
  protected:
   i2c_port_t port_;


### PR DESCRIPTION
# What does this implement/fix? 

An improved I2C recovery procedure, that:

* does not drive the pins to HIGH/LOW, but uses the proper open drain mode for I2C
* honors devices that make use of clock stretching
* generates an addition START + STOP condition at the end of the 9 clock pulses for draining device output; after these pulses, a device might still have more data to send and a START condition must snap the device out of it according to the I2C specs.

This same kind of change was previously done for the Arduino imlementation.
See: https://github.com/esphome/esphome/pull/2412

Output from my oscilloscope:

![afbeelding](https://user-images.githubusercontent.com/470371/135778092-83e92b3c-888b-4e89-96d5-33247c22bbe6.png)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2486

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
