### PR TITLE
Improved validation for Addressable Light Partition Segments

### DIFF
--- a/esphome/components/partition/light.py
+++ b/esphome/components/partition/light.py
@@ -33,7 +33,7 @@ def validate_from_to(value):
     return value
 
 
-def validate_segments(config):
+def validate_segment(config):
     fconf = fv.full_config.get()
 
     if CONF_ID in config: # only validate addressable segments
@@ -85,7 +85,7 @@ FINAL_VALIDATE_SCHEMA = cv.Schema(
         cv.Required(CONF_SEGMENTS): cv.ensure_list(
             cv.All(
                 cv.Any(ADDRESSABLE_SEGMENT_SCHEMA, NONADDRESSABLE_SEGMENT_SCHEMA),
-                validate_segments,
+                validate_segment,
             )
         ),
     },

--- a/esphome/components/partition/light.py
+++ b/esphome/components/partition/light.py
@@ -36,16 +36,20 @@ def validate_from_to(value):
 def validate_segment(config):
     fconf = fv.full_config.get()
 
-    if CONF_ID in config: # only validate addressable segments
+    if CONF_ID in config:  # only validate addressable segments
         path = fconf.get_path_for_id(config[CONF_ID])[:-1]
         segment_light_config = fconf.get_config_for_path(path)
 
         if CONF_NUM_LEDS in segment_light_config:
             segment_len = segment_light_config[CONF_NUM_LEDS]
             if config[CONF_FROM] >= segment_len:
-                raise cv.Invalid(f"FROM ({config[CONF_FROM]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})")
+                raise cv.Invalid(
+                    f"FROM ({config[CONF_FROM]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})"
+                )
             if config[CONF_TO] >= segment_len:
-                raise cv.Invalid(f"TO ({config[CONF_TO]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})")
+                raise cv.Invalid(
+                    f"TO ({config[CONF_TO]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})"
+                )
 
 
 ADDRESSABLE_SEGMENT_SCHEMA = cv.Schema(

--- a/esphome/components/partition/light.py
+++ b/esphome/components/partition/light.py
@@ -44,11 +44,13 @@ def validate_segment(config):
             segment_len = segment_light_config[CONF_NUM_LEDS]
             if config[CONF_FROM] >= segment_len:
                 raise cv.Invalid(
-                    f"FROM ({config[CONF_FROM]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})"
+                    f"FROM ({config[CONF_FROM]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})",
+                    [CONF_FROM],
                 )
             if config[CONF_TO] >= segment_len:
                 raise cv.Invalid(
-                    f"TO ({config[CONF_TO]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})"
+                    f"TO ({config[CONF_TO]}) must be less than the number of LEDs in light '{config[CONF_ID]}' ({segment_len})",
+                    [CONF_TO],
                 )
 
 
@@ -86,12 +88,7 @@ CONFIG_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
 
 FINAL_VALIDATE_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_SEGMENTS): cv.ensure_list(
-            cv.All(
-                cv.Any(ADDRESSABLE_SEGMENT_SCHEMA, NONADDRESSABLE_SEGMENT_SCHEMA),
-                validate_segment,
-            )
-        ),
+        cv.Required(CONF_SEGMENTS): [validate_segment],
     },
     extra=cv.ALLOW_EXTRA,
 )


### PR DESCRIPTION
# What does this implement/fix? 
This PR adds an extra validation step that ensures the partition segment properties `from` and `to` are less than the number of LEDs in the light they refer to.

Without this check, if either of these properties are beyond the limits of the light, the current implementation of [`get_view_internal`](https://github.com/esphome/esphome/blob/49f46a7cddec08d169ab23a16d6f97c0f8a8f564/esphome/components/partition/light_partition.h#L61) returns wild pointers. 

Note that this check only runs if the light referenced in the segment uses the `CONF_NUM_LEDS` property; this includes _FastLED_ and _NeoPixelBus_ components, but notably does not include _Light Partition_ itself.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
light:
  - platform: neopixelbus
    id: led1
    num_leds: 100
    #...

  - platform: neopixelbus
    id: led2
    num_leds: 50
    #...

  - platform: partition
    name: ${devicename}_bad_partition_yo
    segments:
      - id: led1
        from: 0
        to: 20000 # much larger than led1, bad things will happen
      - id: led2
        from: 0
        to: 49
    effects:
      - addressable_rainbow
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
