### PR TITLE
Fix esp32 no longer has Hash internal lib

### DIFF
--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -102,7 +102,6 @@ async def to_code(config):
         cg.add_library("Update", None)
     elif CORE.is_esp32 and CORE.using_arduino:
         cg.add_library("Update", None)
-        cg.add_library("Hash", None)
 
     use_state_callback = False
     for conf in config.get(CONF_ON_STATE_CHANGE, []):

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -342,6 +342,8 @@ async def to_code(config):
 
     if CORE.is_esp8266:
         cg.add_library("ESP8266WiFi", None)
+    elif CORE.is_esp32 and CORE.using_arduino:
+        cg.add_library("WiFi", None)
 
     cg.add_define("USE_WIFI")
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -89,7 +89,6 @@ framework = arduino
 board = nodemcu-32s
 lib_deps =
     ${common:arduino.lib_deps}
-    Hash                            ; ota (Arduino built-in)
     esphome/AsyncTCP-esphome@1.2.2  ; async_tcp
 build_flags =
     ${common:arduino.build_flags}


### PR DESCRIPTION
# What does this implement/fix? 

When offline, the pio install blocks for a long time.

Not sure why we needed it before, but Hash is not an internal arduino lib (anymore?), and the MD5 header we need is in core.

-> Remove the lib_dep

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
