### PR TITLE
Fix compilation error for shutdown component

### DIFF
--- a/esphome/components/shutdown/shutdown_switch.cpp
+++ b/esphome/components/shutdown/shutdown_switch.cpp
@@ -1,4 +1,5 @@
 #include "shutdown_switch.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 


### PR DESCRIPTION
missing hal.h  causes delay() to fail

```
src\esphome\components\shutdown\shutdown_switch.cpp: In member function 'virtual void esphome::shutdown::ShutdownSwitch::write_state(bool)':
src\esphome\components\shutdown\shutdown_switch.cpp:24:5: error: 'delay' is not a member of 'esphome'
     esphome::delay(100);  // NOLINT
     ^
```
# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
esphome:
  name: espsensor
  platform: ESP32
  board: pico32
switch:
  - platform: shutdown
    name: "ESP32_4 Shutdown"
    id: shutdown1
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
