### PR TITLE
Only ping once every two seconds

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -582,7 +582,7 @@ class MDNSStatusThread(threading.Thread):
 class PingStatusThread(threading.Thread):
     def run(self):
         with multiprocessing.Pool(processes=8) as pool:
-            while not STOP_EVENT.is_set():
+            while not STOP_EVENT.wait(2):
                 # Only do pings if somebody has the dashboard open
 
                 def callback(ret):


### PR DESCRIPTION
# What does this implement/fix? 

Don't try to ping all available devices every two seconds for each opened dashboard, but rather only once every two seconds regardless of the number of dashboards opened.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2440

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
