### PR TITLE
Add timestamp to ESPHome dashboard/cli logs

### DIFF
--- a/esphome/log.py
+++ b/esphome/log.py
@@ -50,7 +50,7 @@ def color(col: str, msg: str, reset: bool = True) -> bool:
 
 class ESPHomeLogFormatter(logging.Formatter):
     def __init__(self):
-        super().__init__(fmt="%(levelname)s %(message)s", datefmt="%H:%M:%S", style="%")
+        super().__init__(fmt="%(asctime)s %(levelname)s %(message)s", style="%")
 
     def format(self, record):
         formatted = super().format(record)


### PR DESCRIPTION
# What does this implement/fix? 

This adds the date and time to log messages generated by esphome. This is useful for debugging and logging purposes. I think the original intention was to do this (`datefmt` was already defined), but `asctime` was missing from the `fmt` string.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
