### PR TITLE
API encryption switch to libsodium backend

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -121,7 +121,7 @@ async def to_code(config):
         decoded = base64.b64decode(conf[CONF_KEY])
         cg.add(var.set_noise_psk(list(decoded)))
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.1")
+        cg.add_library("esphome/noise-c", "0.1.2")
     else:
         cg.add_define("USE_API_PLAINTEXT")
 

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -121,7 +121,7 @@ async def to_code(config):
         decoded = base64.b64decode(conf[CONF_KEY])
         cg.add(var.set_noise_psk(list(decoded)))
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.2")
+        cg.add_library("esphome/noise-c", "0.1.3")
     else:
         cg.add_define("USE_API_PLAINTEXT")
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ build_flags =
 
 [common]
 lib_deps =
-    esphome/noise-c@0.1.1     ; api
+    esphome/noise-c@0.1.2     ; api
     makuna/NeoPixelBus@2.6.7  ; neopixelbus
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ build_flags =
 
 [common]
 lib_deps =
-    esphome/noise-c@0.1.2     ; api
+    esphome/noise-c@0.1.3     ; api
     makuna/NeoPixelBus@2.6.7  ; neopixelbus
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix? 

For API encryption, we use noise-c and the reference base cryptographic operations it ships with.

Two problems with that:
- On ESP8266 (without `build_type: debug`) the x25519 implementation is broken (not sure why and if it may be security-relevant, but see https://github.com/esphome/issues/issues/2502)
- I have less confidence in the correctness of those implementations (or resilience against attacks like timing attacks), they're probably fine but:

libsodium is a well-known library for cryptographic operations and widely used. By using libsodium as the backend, we can be more sure that the base cryptographic operations are correct.

This _does_ come at a cost: libsodium appears to be more focused on speed vs code size. So we can see an increase in code size:

```
ESP8266 no encryption:
Flash: [===       ]  32.9% (used 336804 bytes from 1023984 bytes)

ESP8266 refc:
Flash: [===       ]  34.9% (used 357652 bytes from 1023984 bytes)

ESP8266 libsodium:
Flash: [====      ]  40.4% (used 413868 bytes from 1023984 bytes)
```

On ESP32 it's less of a problem because they generally have more flash size, but for ESP8266 api encryption was already broken so this would not really be a regression.

noise-c changes: https://github.com/esphome/noise-c/commits/esp-port
libsodium port: https://github.com/esphome/libsodium-esphome/


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2502

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
