### PR TITLE
Fix Bluetooth setup_priorities

### DIFF
--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -11,6 +11,8 @@ namespace ble_client {
 
 static const char *const TAG = "ble_client";
 
+float ESP32BLETracker::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
+
 void BLEClient::setup() {
   auto ret = esp_ble_gattc_app_register(this->app_id);
   if (ret) {

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -11,7 +11,7 @@ namespace ble_client {
 
 static const char *const TAG = "ble_client";
 
-float ESP32BLETracker::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
+float BLEClient::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
 void BLEClient::setup() {
   auto ret = esp_ble_gattc_app_register(this->app_id);

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -81,6 +81,7 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   void setup() override;
   void dump_config() override;
   void loop() override;
+  float get_setup_priority() const override;
 
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -53,7 +53,7 @@ void ESP32BLEBeacon::setup() {
   );
 }
 
-float ESP32BLEBeacon::get_setup_priority() const { return setup_priority::DATA; }
+float ESP32BLEBeacon::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 void ESP32BLEBeacon::ble_core_task(void *params) {
   ble_setup();
 

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -154,7 +154,7 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
   }
 }
 
-float BLEServer::get_setup_priority() const { return setup_priority::BLUETOOTH - 10; }
+float BLEServer::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
 void BLEServer::dump_config() { ESP_LOGCONFIG(TAG, "ESP32 BLE Server:"); }
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.coroutine import coroutine_with_priority
 
 DEPENDENCIES = ["esp32"]
 AUTO_LOAD = ["xiaomi_ble", "ruuvi_ble"]
@@ -179,6 +180,7 @@ ESP_BLE_DEVICE_SCHEMA = cv.Schema(
 )
 
 
+@coroutine_with_priority(20.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -16,7 +16,6 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
-from esphome.coroutine import coroutine_with_priority
 
 DEPENDENCIES = ["esp32"]
 AUTO_LOAD = ["xiaomi_ble", "ruuvi_ble"]
@@ -180,7 +179,6 @@ ESP_BLE_DEVICE_SCHEMA = cv.Schema(
 )
 
 
-@coroutine_with_priority(20.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -40,6 +40,8 @@ uint64_t ble_addr_to_uint64(const esp_bd_addr_t address) {
   return u;
 }
 
+float ESP32BLETracker::get_setup_priority() const { return setup_priority::BLUETOOTH; }
+
 void ESP32BLETracker::setup() {
   global_esp32_ble_tracker = this;
   this->scan_result_lock_ = xSemaphoreCreateMutex();

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -169,6 +169,7 @@ class ESP32BLETracker : public Component {
   /// Setup the FreeRTOS task and the Bluetooth stack.
   void setup() override;
   void dump_config() override;
+  float get_setup_priority() const override;
 
   void loop() override;
 


### PR DESCRIPTION
# What does this implement/fix? 

Set ble_tracker codegen priority so it gets added before clients

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2471

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
