### PR TITLE
atm90e32: make the total_increasing class sensors actually be increasing totals.

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -7,13 +7,6 @@ namespace atm90e32 {
 
 static const char *const TAG = "atm90e32";
 
-static float cumulative_forward_active_energy_a;
-static float cumulative_forward_active_energy_b;
-static float cumulative_forward_active_energy_c;
-static float cumulative_reverse_active_energy_a;
-static float cumulative_reverse_active_energy_b;
-static float cumulative_reverse_active_energy_c;
-
 void ATM90E32Component::update() {
   if (this->read16_(ATM90E32_REGISTER_METEREN) != 1) {
     this->status_set_warning();
@@ -272,33 +265,57 @@ float ATM90E32Component::get_power_factor_c_() {
 }
 float ATM90E32Component::get_forward_active_energy_a_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_APENERGYA);
-  cumulative_forward_active_energy_a += ((float) val * 10 / 3200);
-  return cumulative_forward_active_energy_a;
+  if ((UINT32_MAX - this->phase_[0].cumulative_forward_active_energy_) > val) {
+    this->phase_[0].cumulative_forward_active_energy_ += val;
+  } else {
+    this->phase_[0].cumulative_forward_active_energy_ = val;
+  }
+  return ((float) this->phase_[0].cumulative_forward_active_energy_ * 10 / 3200);
 }
 float ATM90E32Component::get_forward_active_energy_b_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_APENERGYB);
-  cumulative_forward_active_energy_b += ((float) val * 10 / 3200);
-  return cumulative_forward_active_energy_b;
+  if (UINT32_MAX - this->phase_[1].cumulative_forward_active_energy_ > val) {
+    this->phase_[1].cumulative_forward_active_energy_ += val;
+  } else {
+    this->phase_[1].cumulative_forward_active_energy_ = val;
+  }
+  return ((float) this->phase_[1].cumulative_forward_active_energy_ * 10 / 3200);
 }
 float ATM90E32Component::get_forward_active_energy_c_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_APENERGYC);
-  cumulative_forward_active_energy_c += ((float) val * 10 / 3200);
-  return cumulative_forward_active_energy_c;
+  if (UINT32_MAX - this->phase_[2].cumulative_forward_active_energy_ > val) {
+    this->phase_[2].cumulative_forward_active_energy_ += val;
+  } else {
+    this->phase_[2].cumulative_forward_active_energy_ = val;
+  }
+  return ((float) this->phase_[2].cumulative_forward_active_energy_ * 10 / 3200);
 }
 float ATM90E32Component::get_reverse_active_energy_a_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_ANENERGYA);
-  cumulative_reverse_active_energy_a += ((float) val * 10 / 3200);
-  return cumulative_reverse_active_energy_a;
+  if (UINT32_MAX - this->phase_[0].cumulative_reverse_active_energy_ > val) {
+    this->phase_[0].cumulative_reverse_active_energy_ += val;
+  } else {
+    this->phase_[0].cumulative_reverse_active_energy_ = val;
+  }
+  return ((float) this->phase_[0].cumulative_reverse_active_energy_ * 10 / 3200);
 }
 float ATM90E32Component::get_reverse_active_energy_b_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_ANENERGYB);
-  cumulative_reverse_active_energy_b += ((float) val * 10 / 3200);
-  return cumulative_reverse_active_energy_b;
+  if (UINT32_MAX - this->phase_[1].cumulative_reverse_active_energy_ > val) {
+    this->phase_[1].cumulative_reverse_active_energy_ += val;
+  } else {
+    this->phase_[1].cumulative_reverse_active_energy_ = val;
+  }
+  return ((float) this->phase_[1].cumulative_reverse_active_energy_ * 10 / 3200);
 }
 float ATM90E32Component::get_reverse_active_energy_c_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_ANENERGYC);
-  cumulative_reverse_active_energy_c += ((float) val * 10 / 3200);
-  return cumulative_reverse_active_energy_c;
+  if (UINT32_MAX - this->phase_[2].cumulative_reverse_active_energy_ > val) {
+    this->phase_[2].cumulative_reverse_active_energy_ += val;
+  } else {
+    this->phase_[2].cumulative_reverse_active_energy_ = val;
+  }
+  return ((float) this->phase_[2].cumulative_reverse_active_energy_ * 10 / 3200);
 }
 float ATM90E32Component::get_frequency_() {
   uint16_t freq = this->read16_(ATM90E32_REGISTER_FREQ);

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -7,6 +7,13 @@ namespace atm90e32 {
 
 static const char *const TAG = "atm90e32";
 
+static float cumulative_forward_active_energy_a;
+static float cumulative_forward_active_energy_b;
+static float cumulative_forward_active_energy_c;
+static float cumulative_reverse_active_energy_a;
+static float cumulative_reverse_active_energy_b;
+static float cumulative_reverse_active_energy_c;
+
 void ATM90E32Component::update() {
   if (this->read16_(ATM90E32_REGISTER_METEREN) != 1) {
     this->status_set_warning();
@@ -265,27 +272,33 @@ float ATM90E32Component::get_power_factor_c_() {
 }
 float ATM90E32Component::get_forward_active_energy_a_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_APENERGYA);
-  return (float) val * 10 / 3200;  // convert register value to WattHours
+  cumulative_forward_active_energy_a += ((float) val * 10 / 3200);
+  return cumulative_forward_active_energy_a;
 }
 float ATM90E32Component::get_forward_active_energy_b_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_APENERGYB);
-  return (float) val * 10 / 3200;
+  cumulative_forward_active_energy_b += ((float) val * 10 / 3200);
+  return cumulative_forward_active_energy_b;
 }
 float ATM90E32Component::get_forward_active_energy_c_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_APENERGYC);
-  return (float) val * 10 / 3200;
+  cumulative_forward_active_energy_c += ((float) val * 10 / 3200);
+  return cumulative_forward_active_energy_c;
 }
 float ATM90E32Component::get_reverse_active_energy_a_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_ANENERGYA);
-  return (float) val * 10 / 3200;
+  cumulative_reverse_active_energy_a += ((float) val * 10 / 3200);
+  return cumulative_reverse_active_energy_a;
 }
 float ATM90E32Component::get_reverse_active_energy_b_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_ANENERGYB);
-  return (float) val * 10 / 3200;
+  cumulative_reverse_active_energy_b += ((float) val * 10 / 3200);
+  return cumulative_reverse_active_energy_b;
 }
 float ATM90E32Component::get_reverse_active_energy_c_() {
   uint16_t val = this->read16_(ATM90E32_REGISTER_ANENERGYC);
-  return (float) val * 10 / 3200;
+  cumulative_reverse_active_energy_c += ((float) val * 10 / 3200);
+  return cumulative_reverse_active_energy_c;
 }
 float ATM90E32Component::get_frequency_() {
   uint16_t freq = this->read16_(ATM90E32_REGISTER_FREQ);

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -77,6 +77,8 @@ class ATM90E32Component : public PollingComponent,
     sensor::Sensor *power_factor_sensor_{nullptr};
     sensor::Sensor *forward_active_energy_sensor_{nullptr};
     sensor::Sensor *reverse_active_energy_sensor_{nullptr};
+    uint32_t cumulative_forward_active_energy_{0};
+    uint32_t cumulative_reverse_active_energy_{0};
   } phase_[3];
   sensor::Sensor *freq_sensor_{nullptr};
   sensor::Sensor *chip_temperature_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix? 

Changes the atm90e32 forward/reverse active energy sensors to be cumulative totals as expected by home-assistant for a sensor with the TOTAL_INCREASING state class

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2523

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: atm90e32
    cs_pin: 5
    phase_a:
      voltage:
        name: "EMON Line Voltage A"
      current:
        name: "EMON CT1 Current"
      power:
        name: "EMON Active Power CT1"
      reactive_power:
        name: "EMON Reactive Power CT1"
      power_factor:
        name: "EMON Power Factor CT1"
      forward_active_energy:
        name: "EMON Foward Active Energy CT1"
      reverse_active_energy:
        name: "EMON Reverse Active Energy CT1"
      gain_voltage: 8080
      gain_ct: 24270
    phase_c:
      voltage:
        name: "EMON Line Voltage B"
      current:
        name: "EMON CT2 Current"
      power:
        name: "EMON Active Power CT2"
      reactive_power:
        name: "EMON Reactive Power CT2"
      power_factor:
        name: "EMON Power Factor CT2"
      forward_active_energy:
        name: "EMON Foward Active Energy CT2"
      reverse_active_energy:
        name: "EMON Reverse Active Energy CT2"
      gain_voltage: 8080
      gain_ct: 24270
    frequency:
      name: "EMON Line Frequency"
    chip_temperature:
      name: "EMON Chip Temperature"
    line_frequency: 50Hz
    current_phases: 2
    gain_pga: 2X
    update_interval: 30s

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
