### PR TITLE
2021.9.3

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -121,7 +121,7 @@ async def to_code(config):
         decoded = base64.b64decode(conf[CONF_KEY])
         cg.add(var.set_noise_psk(list(decoded)))
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.1")
+        cg.add_library("esphome/noise-c", "0.1.3")
     else:
         cg.add_define("USE_API_PLAINTEXT")
 

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -126,6 +126,14 @@ APIError APINoiseFrameHelper::init() {
     return APIError::TCP_NONBLOCKING_FAILED;
   }
 
+  int enable = 1;
+  err = socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nodelay failed with errno %d", errno);
+    return APIError::TCP_NODELAY_FAILED;
+  }
+
   // init prologue
   prologue_.insert(prologue_.end(), PROLOGUE_INIT, PROLOGUE_INIT + strlen(PROLOGUE_INIT));
 
@@ -720,6 +728,13 @@ APIError APIPlaintextFrameHelper::init() {
     state_ = State::FAILED;
     HELPER_LOG("Setting nonblocking failed with errno %d", errno);
     return APIError::TCP_NONBLOCKING_FAILED;
+  }
+  int enable = 1;
+  err = socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nodelay failed with errno %d", errno);
+    return APIError::TCP_NODELAY_FAILED;
   }
 
   state_ = State::DATA;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -134,6 +134,11 @@ void APIServer::loop() {
 void APIServer::dump_config() {
   ESP_LOGCONFIG(TAG, "API Server:");
   ESP_LOGCONFIG(TAG, "  Address: %s:%u", network_get_address().c_str(), this->port_);
+#ifdef USE_API_NOISE
+  ESP_LOGCONFIG(TAG, "  Using noise encryption: YES");
+#else
+  ESP_LOGCONFIG(TAG, "  Using noise encryption: NO");
+#endif
 }
 bool APIServer::uses_password() const { return !this->password_.empty(); }
 bool APIServer::check_password(const std::string &password) const {

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -256,7 +256,7 @@ class LWIPRawImpl : public Socket {
         errno = EINVAL;
         return -1;
       }
-      *reinterpret_cast<int *>(optval) = tcp_nagle_disabled(pcb_);
+      *reinterpret_cast<int *>(optval) = nodelay_;
       *optlen = 4;
       return 0;
     }
@@ -285,11 +285,7 @@ class LWIPRawImpl : public Socket {
         return -1;
       }
       int val = *reinterpret_cast<const int *>(optval);
-      if (val != 0) {
-        tcp_nagle_disable(pcb_);
-      } else {
-        tcp_nagle_enable(pcb_);
-      }
+      nodelay_ = val;
       return 0;
     }
 
@@ -443,9 +439,11 @@ class LWIPRawImpl : public Socket {
     if (written == 0)
       // no need to output if nothing written
       return 0;
-    int err = internal_output();
-    if (err == -1)
-      return -1;
+    if (nodelay_) {
+      int err = internal_output();
+      if (err == -1)
+        return -1;
+    }
     return written;
   }
   ssize_t writev(const struct iovec *iov, int iovcnt) override {
@@ -465,9 +463,11 @@ class LWIPRawImpl : public Socket {
     if (written == 0)
       // no need to output if nothing written
       return 0;
-    int err = internal_output();
-    if (err == -1)
-      return -1;
+    if (nodelay_) {
+      int err = internal_output();
+      if (err == -1)
+        return -1;
+    }
     return written;
   }
   int setblocking(bool blocking) override {
@@ -549,6 +549,9 @@ class LWIPRawImpl : public Socket {
   bool rx_closed_ = false;
   pbuf *rx_buf_ = nullptr;
   size_t rx_buf_offset_ = 0;
+  // don't use lwip nodelay flag, it sometimes causes reconnect
+  // instead use it for determining whether to call lwip_output
+  bool nodelay_ = false;
 };
 
 std::unique_ptr<Socket> socket(int domain, int type, int protocol) {

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2021.9.2"
+__version__ = "2021.9.3"
 
 ESP_PLATFORM_ESP32 = "ESP32"
 ESP_PLATFORM_ESP8266 = "ESP8266"

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ lib_deps =
     6306@1.0.3  ; HM3301
     glmnet/Dsmr@0.3        ; used by dsmr
     rweather/Crypto@0.2.0  ; used by dsmr
-    esphome/noise-c@0.1.1  ; used by api
+    esphome/noise-c@0.1.3  ; used by api
     dudanov/MideaUART@1.1.8  ; used by midea
 
 build_flags =

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ platformio==5.2.0
 esptool==3.1
 click==7.1.2
 esphome-dashboard==20210908.0
-aioesphomeapi==9.1.2
+aioesphomeapi==9.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ platformio==5.2.0
 esptool==3.1
 click==7.1.2
 esphome-dashboard==20210908.0
-aioesphomeapi==9.1.1
+aioesphomeapi==9.1.2


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"We should forget about small efficiencies, say about 97% of the time: premature optimization is the root of all evil."_

~ C. A. R. Hoare
- Re-enable TCP nodelay for ESP32 [esphome#2390](https://github.com/esphome/esphome/pull/2390)
- Bump aioesphomeapi from 9.1.1 to 9.1.2 [esphome#2426](https://github.com/esphome/esphome/pull/2426)
- Fix socket abstraction for ESP-IDF v4 [esphome#2434](https://github.com/esphome/esphome/pull/2434)
- Bump aioesphomeapi from 9.1.2 to 9.1.4 [esphome#2443](https://github.com/esphome/esphome/pull/2443)
- Add log line to show if API encryption is being used [esphome#2450](https://github.com/esphome/esphome/pull/2450)
- API encryption switch to libsodium backend [esphome#2456](https://github.com/esphome/esphome/pull/2456)
