### PR TITLE
Sgp40 fix

### DIFF
--- a/esphome/components/sgp40/sensor.py
+++ b/esphome/components/sgp40/sensor.py
@@ -22,7 +22,6 @@ CONF_HUMIDITY_SOURCE = "humidity_source"
 CONF_TEMPERATURE_SOURCE = "temperature_source"
 CONF_STORE_BASELINE = "store_baseline"
 CONF_VOC_BASELINE = "voc_baseline"
-CONF_OPTIMAL_SAMPLING = "optimal_sampling"
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(
@@ -35,7 +34,6 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(SGP40Component),
             cv.Optional(CONF_STORE_BASELINE, default=True): cv.boolean,
-            cv.Optional(CONF_OPTIMAL_SAMPLING, default=True): cv.boolean,
             cv.Optional(CONF_VOC_BASELINE): cv.hex_uint16_t,
             cv.Optional(CONF_COMPENSATION): cv.Schema(
                 {
@@ -64,7 +62,6 @@ async def to_code(config):
         cg.add(var.set_temperature_sensor(sens))
 
     cg.add(var.set_store_baseline(config[CONF_STORE_BASELINE]))
-    cg.add(var.set_use_optimal_sampling(config[CONF_OPTIMAL_SAMPLING]))
 
     if CONF_VOC_BASELINE in config:
         cg.add(var.set_voc_baseline(CONF_VOC_BASELINE))

--- a/esphome/components/sgp40/sensor.py
+++ b/esphome/components/sgp40/sensor.py
@@ -22,6 +22,7 @@ CONF_HUMIDITY_SOURCE = "humidity_source"
 CONF_TEMPERATURE_SOURCE = "temperature_source"
 CONF_STORE_BASELINE = "store_baseline"
 CONF_VOC_BASELINE = "voc_baseline"
+CONF_OPTIMAL_SAMPLING = "optimal_sampling"
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(
@@ -34,6 +35,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(SGP40Component),
             cv.Optional(CONF_STORE_BASELINE, default=True): cv.boolean,
+            cv.Optional(CONF_OPTIMAL_SAMPLING, default=True): cv.boolean,
             cv.Optional(CONF_VOC_BASELINE): cv.hex_uint16_t,
             cv.Optional(CONF_COMPENSATION): cv.Schema(
                 {
@@ -62,6 +64,7 @@ async def to_code(config):
         cg.add(var.set_temperature_sensor(sens))
 
     cg.add(var.set_store_baseline(config[CONF_STORE_BASELINE]))
+    cg.add(var.set_use_optimal_sampling(config[CONF_OPTIMAL_SAMPLING]))
 
     if CONF_VOC_BASELINE in config:
         cg.add(var.set_voc_baseline(CONF_VOC_BASELINE))

--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -279,6 +279,8 @@ void SGP40Component::dump_config() {
   ESP_LOGCONFIG(TAG, "SGP40:");
   LOG_I2C_DEVICE(this);
   ESP_LOGCONFIG(TAG, "  optimal_samping: %d", this->optimal_sampling_);
+  ESP_LOGCONFIG(TAG, "  store_baseline: %d", this->store_baseline_);
+
   if (this->is_failed()) {
     switch (this->error_code_) {
       case COMMUNICATION_FAILED:

--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -90,7 +90,7 @@ void SGP40Component::setup() {
   number of records reported from being overwhelming.
   */
   ESP_LOGD(TAG, "Component requires sampling of 1Hz, setting up background sampler");
-  this->set_interval(1000, [this](){ this->update_voc_index(); });
+  this->set_interval(1000, [this]() { this->update_voc_index(); });
 }
 
 void SGP40Component::self_test_() {

--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -90,7 +90,7 @@ void SGP40Component::setup() {
   number of records reported from being overwhelming.
   */
   ESP_LOGD(TAG, "Component requires sampling of 1Hz, setting up background sampler");
-  this->set_interval(1000, [this](){this->update_voc_index();});
+  this->set_interval(1000, [this](){ this->update_voc_index(); });
 }
 
 void SGP40Component::self_test_() {
@@ -248,7 +248,6 @@ void SGP40Component::update_voc_index() {
              this->samples_to_stabalize_, this->voc_index_);
     return;
   }
-
 }
 
 void SGP40Component::update() {

--- a/esphome/components/sgp40/sgp40.h
+++ b/esphome/components/sgp40/sgp40.h
@@ -46,9 +46,12 @@ class SGP40Component : public PollingComponent, public sensor::Sensor, public i2
 
   void setup() override;
   void update() override;
+  void update_voc_index();
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
   void set_store_baseline(bool store_baseline) { store_baseline_ = store_baseline; }
+  void set_use_optimal_sampling(bool optimal_sampling) {optimal_sampling_ = optimal_sampling; }
+  bool get_use_optimal_sampling() const { return optimal_sampling_; }
 
  protected:
   /// Input sensor for humidity and temperature compensation.
@@ -70,8 +73,10 @@ class SGP40Component : public PollingComponent, public sensor::Sensor, public i2
   VocAlgorithmParams voc_algorithm_params_;
   bool self_test_complete_;
   bool store_baseline_;
+  bool optimal_sampling_ = 1;
   int32_t state0_;
   int32_t state1_;
+  int32_t voc_index_ = 0;
   uint8_t samples_read_ = 0;
   uint8_t samples_to_stabalize_ = static_cast<int8_t>(VOC_ALGORITHM_INITIAL_BLACKOUT) * 2;
 

--- a/esphome/components/sgp40/sgp40.h
+++ b/esphome/components/sgp40/sgp40.h
@@ -50,8 +50,6 @@ class SGP40Component : public PollingComponent, public sensor::Sensor, public i2
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
   void set_store_baseline(bool store_baseline) { store_baseline_ = store_baseline; }
-  void set_use_optimal_sampling(bool optimal_sampling) {optimal_sampling_ = optimal_sampling; }
-  bool get_use_optimal_sampling() const { return optimal_sampling_; }
 
  protected:
   /// Input sensor for humidity and temperature compensation.
@@ -73,7 +71,6 @@ class SGP40Component : public PollingComponent, public sensor::Sensor, public i2
   VocAlgorithmParams voc_algorithm_params_;
   bool self_test_complete_;
   bool store_baseline_;
-  bool optimal_sampling_ = 1;
   int32_t state0_;
   int32_t state1_;
   int32_t voc_index_ = 0;


### PR DESCRIPTION
# What does this implement/fix? 
The spg40 air quality sensor was incorrectly using the manufacturers algorithm. The documentation [here](https://docs.rs-online.com/1956/A700000007055193.pdf) indicates that to get a correct VOC index, this sensor must be sampled and supplied to their algorithm at 1Hz (With discussion [here](https://github.com/Sensirion/embedded-sgp/issues/136) suggesting tolerances should allow slight differences that would make software timing loops sufficient).

Previously this sensor (and related value) were only sampled at the update interval, which would lead to an incorrect VOC index of unknown magnitude. This change introduces a separate timer for reading the sensor and updating the VOC index at the correct cadence. The update interval is then used only to publish this state to other components or the front end, saving power with the wifi module, or limiting the number of samples supplied to the front end. To allow the old behavior a new config parameter is introduced, *optimal_sampling*, which can be set to `false`.

In a separate commit, a fix is made to the dump_config method, adding missing config entries.

This is a breaking change not in the sense that a user needs to make a change to benefit from the fix. However, since the sensor will be read out at the correct interval, it may cause more wake-ups or power consumption on a device when a user is not expecting it.

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1515

## Test Environment

- [ ] ESP32
- [x ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
New config parameter defaults to new correct behavior. To restore the old
incorrect behavior the config would look like:
```
sensor:
  - platform: sgp40
    name: "Air Quality"
    optimal_sampling: false
```

```yaml
# Example config.yaml

```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
