### PR TITLE
Correct I2C read() return val check in bh1750 component.

### DIFF
--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -71,7 +71,7 @@ void BH1750Sensor::update() {
 float BH1750Sensor::get_setup_priority() const { return setup_priority::DATA; }
 void BH1750Sensor::read_data_() {
   uint16_t raw_value;
-  if (!this->read(reinterpret_cast<uint8_t *>(&raw_value), 2)) {
+  if (this->read(reinterpret_cast<uint8_t *>(&raw_value), 2) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }


### PR DESCRIPTION
# What does this implement/fix? 

While checking out an issue (see the issue link below), @OttoWinter noticed a wrong return value handling for an I2C device read call. This PR corrects the return value check.

Notes:
* It most likely won't fix the reported issue with the bh1750 component. 
* I don't have a bh1750 sensor myself, so I couldn't test anything but bare compilation of the code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** partial fix for https://github.com/esphome/issues/issues/2512

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
