### PR TITLE
Fix below freezing temperature for Inkbird sensors

### DIFF
--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -73,6 +73,10 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
 
   // Read bluetooth data into variable
   auto measured_temperature = mnf_data.uuid.get_uuid().uuid.uuid16 / 100.0f;
+  // The temperature rolls back around to 65535 / 100.0f = 655.35 when it reaches zero so adjust accordingly
+  if (measured_temperature > 327.68) {
+    measured_temperature = measured_temperature - 655.35;
+  }
 
   // Set temperature or external_temperature based on which sensor is in use
   if (mnf_data.data[2] == 0) {

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -72,11 +72,7 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
   auto external_temperature = NAN;
 
   // Read bluetooth data into variable
-  auto measured_temperature = mnf_data.uuid.get_uuid().uuid.uuid16 / 100.0f;
-  // The temperature rolls back around to 65535 / 100.0f = 655.35 when it reaches zero so adjust accordingly
-  if (measured_temperature > 327.68) {
-    measured_temperature = measured_temperature - 655.35;
-  }
+  auto measured_temperature = ((int16_t) mnf_data.uuid.get_uuid().uuid.uuid16) / 100.0f;
 
   // Set temperature or external_temperature based on which sensor is in use
   if (mnf_data.data[2] == 0) {


### PR DESCRIPTION
# What does this implement/fix? 

This fixes the incorrect temperature values for Inkbird sensors when the temperature drops below freezing.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2531

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
