### PR TITLE
Expose web_server port via the API

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_USE_ADDRESS,
     CONF_ETHERNET,
     CONF_WIFI,
+    CONF_PORT,
     KEY_CORE,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
@@ -516,6 +517,19 @@ class EsphomeCore:
 
         if CONF_ETHERNET in self.config:
             return self.config[CONF_ETHERNET][CONF_USE_ADDRESS]
+
+        return None
+
+    @property
+    def web_port(self) -> Optional[int]:
+        if self.config is None:
+            raise ValueError("Config has not been loaded yet")
+
+        if "web_server" in self.config:
+            try:
+                return self.config["web_server"][CONF_PORT]
+            except KeyError:
+                return 80
 
         return None
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -510,6 +510,12 @@ class DashboardEntry:
         return self.storage.address
 
     @property
+    def web_port(self):
+        if self.storage is None:
+            return None
+        return self.storage.web_port
+
+    @property
     def name(self):
         if self.storage is None:
             return self.filename.replace(".yml", "").replace(".yaml", "")
@@ -569,6 +575,7 @@ class ListDevicesHandler(BaseHandler):
                             "path": entry.path,
                             "comment": entry.comment,
                             "address": entry.address,
+                            "web_port": entry.web_port,
                             "target_platform": entry.target_platform,
                         }
                         for entry in entries

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -41,6 +41,7 @@ class StorageJSON:
         esphome_version,
         src_version,
         address,
+        web_port,
         target_platform,
         build_path,
         firmware_bin_path,
@@ -60,6 +61,9 @@ class StorageJSON:
         self.src_version = src_version  # type: int
         # Address of the ESP, for example livingroom.local or a static IP
         self.address = address  # type: str
+        # Web server port of the ESP, for example 80
+        assert web_port is None or isinstance(web_port, int)
+        self.web_port = web_port  # type: int
         # The type of ESP in use, either ESP32 or ESP8266
         self.target_platform = target_platform  # type: str
         # The absolute path to the platformio project
@@ -78,6 +82,7 @@ class StorageJSON:
             "esphome_version": self.esphome_version,
             "src_version": self.src_version,
             "address": self.address,
+            "web_port": self.web_port,
             "esp_platform": self.target_platform,
             "build_path": self.build_path,
             "firmware_bin_path": self.firmware_bin_path,
@@ -101,6 +106,7 @@ class StorageJSON:
             esphome_version=const.__version__,
             src_version=1,
             address=esph.address,
+            web_port=esph.web_port,
             target_platform=esph.target_platform,
             build_path=esph.build_path,
             firmware_bin_path=esph.firmware_bin,
@@ -117,6 +123,7 @@ class StorageJSON:
             esphome_version=const.__version__,
             src_version=1,
             address=address,
+            web_port=None,
             target_platform=esp_platform,
             build_path=None,
             firmware_bin_path=None,
@@ -135,6 +142,7 @@ class StorageJSON:
         )
         src_version = storage.get("src_version")
         address = storage.get("address")
+        web_port = storage.get("web_port")
         esp_platform = storage.get("esp_platform")
         build_path = storage.get("build_path")
         firmware_bin_path = storage.get("firmware_bin_path")
@@ -146,6 +154,7 @@ class StorageJSON:
             esphome_version,
             src_version,
             address,
+            web_port,
             esp_platform,
             build_path,
             firmware_bin_path,


### PR DESCRIPTION
# What does this implement/fix? 

This fixes https://github.com/esphome/issues/issues/1490.  It needs to be merged alongside https://github.com/esphome/dashboard/pull/89.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1490

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
