### PR TITLE
Fix MQTT cover state when position is supported

### DIFF
--- a/esphome/components/mqtt/mqtt_cover.cpp
+++ b/esphome/components/mqtt/mqtt_cover.cpp
@@ -70,6 +70,7 @@ void MQTTCoverComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryCon
     root["optimistic"] = true;
   }
   if (traits.get_supports_position()) {
+    config.state_topic = false;
     root["position_topic"] = this->get_position_state_topic();
     root["set_position_topic"] = this->get_position_command_topic();
   }


### PR DESCRIPTION
# What does this implement/fix? 
This PR removes state topic when position topic is set. It's needed to fix Home Assistant state because HA doesn't use position if state topic is set - [source](https://github.com/home-assistant/core/blob/b2cfbb7d1e7f81783e88d950a802bc95c82c9b06/homeassistant/components/mqtt/cover.py#L432).

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
