### PR TITLE
Remove duplicate convert_to_8bit_color_ function.

### DIFF
--- a/esphome/components/display/display_color_utils.h
+++ b/esphome/components/display/display_color_utils.h
@@ -66,6 +66,9 @@ class ColorUtil {
     }
     return color_return;
   }
+  static inline Color rgb332_to_color(uint8_t rgb332_color) {
+    return to_color((uint32_t) rgb332_color, COLOR_ORDER_RGB, COLOR_BITNESS_332);
+  }
   static uint8_t color_to_332(Color color, ColorOrder color_order = ColorOrder::COLOR_ORDER_RGB) {
     uint16_t red_color, green_color, blue_color;
 
@@ -100,23 +103,6 @@ class ColorUtil {
     }
     return 0;
   }
-
-  /***
-   * Converts an 8bit color from rgb 3,3,2 to 16bit rgb 5,6,5 format.
-   * @param[in] The 8bit input color to convert.
-   * @return The 16bit output color.
-   */
-  static uint16_t convert_332_to_565(uint8_t color_8bit) {
-    int r = color_8bit >> 5;
-    int g = (color_8bit >> 2) & 0x07;
-    int b = color_8bit & 0x03;
-    uint16_t color = (r * 0x04) << 11;
-    color |= (g * 0x09) << 5;
-    color |= (b * 0x0A);
-
-    return color;
-  }
-
   static uint32_t color_to_grayscale4(Color color) {
     uint32_t gs4 = esp_scale8(color.white, 15);
     return gs4;

--- a/esphome/components/display/display_color_utils.h
+++ b/esphome/components/display/display_color_utils.h
@@ -101,6 +101,22 @@ class ColorUtil {
     return 0;
   }
 
+  /***
+   * Converts an 8bit color from rgb 3,3,2 to 16bit rgb 5,6,5 format.
+   * @param[in] The 8bit input color to convert.
+   * @return The 16bit output color.
+   */
+  static uint16_t convert_332_to_565(uint8_t color_8bit) {
+    int r = color_8bit >> 5;
+    int g = (color_8bit >> 2) & 0x07;
+    int b = color_8bit & 0x03;
+    uint16_t color = (r * 0x04) << 11;
+    color |= (g * 0x09) << 5;
+    color |= (b * 0x0A);
+
+    return color;
+  }
+
   static uint32_t color_to_grayscale4(Color color) {
     uint32_t gs4 = esp_scale8(color.white, 15);
     return gs4;

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -112,17 +112,6 @@ void ILI9341Display::display_() {
   this->y_high_ = 0;
 }
 
-uint16_t ILI9341Display::convert_to_16bit_color_(uint8_t color_8bit) {
-  int r = color_8bit >> 5;
-  int g = (color_8bit >> 2) & 0x07;
-  int b = color_8bit & 0x03;
-  uint16_t color = (r * 0x04) << 11;
-  color |= (g * 0x09) << 5;
-  color |= (b * 0x0A);
-
-  return color;
-}
-
 void ILI9341Display::fill(Color color) {
   uint8_t color332 = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
   memset(this->buffer_, color332, this->get_buffer_length_());
@@ -238,7 +227,7 @@ uint32_t ILI9341Display::buffer_to_transfer_(uint32_t pos, uint32_t sz) {
   }
 
   for (uint32_t i = 0; i < sz; ++i) {
-    uint16_t color = convert_to_16bit_color_(*src++);
+    uint16_t color = display::ColorUtil::convert_332_to_565(*src++);
     *dst++ = (uint8_t)(color >> 8);
     *dst++ = (uint8_t) color;
   }

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -123,18 +123,9 @@ uint16_t ILI9341Display::convert_to_16bit_color_(uint8_t color_8bit) {
   return color;
 }
 
-uint8_t ILI9341Display::convert_to_8bit_color_(uint16_t color_16bit) {
-  // convert 16bit color to 8 bit buffer
-  uint8_t r = color_16bit >> 11;
-  uint8_t g = (color_16bit >> 5) & 0x3F;
-  uint8_t b = color_16bit & 0x1F;
-
-  return ((b / 0x0A) | ((g / 0x09) << 2) | ((r / 0x04) << 5));
-}
-
 void ILI9341Display::fill(Color color) {
-  auto color565 = display::ColorUtil::color_to_565(color);
-  memset(this->buffer_, convert_to_8bit_color_(color565), this->get_buffer_length_());
+  uint8_t color332 = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
+  memset(this->buffer_, color332, this->get_buffer_length_());
   this->x_low_ = 0;
   this->y_low_ = 0;
   this->x_high_ = this->get_width_internal() - 1;
@@ -181,8 +172,8 @@ void HOT ILI9341Display::draw_absolute_pixel_internal(int x, int y, Color color)
   this->y_high_ = (y > this->y_high_) ? y : this->y_high_;
 
   uint32_t pos = (y * width_) + x;
-  auto color565 = display::ColorUtil::color_to_565(color);
-  buffer_[pos] = convert_to_8bit_color_(color565);
+  uint8_t color332 = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
+  buffer_[pos] = color332;
 }
 
 // should return the total size: return this->get_width_internal() * this->get_height_internal() * 2 // 16bit color

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -227,7 +227,7 @@ uint32_t ILI9341Display::buffer_to_transfer_(uint32_t pos, uint32_t sz) {
   }
 
   for (uint32_t i = 0; i < sz; ++i) {
-    uint16_t color = display::ColorUtil::convert_332_to_565(*src++);
+    uint16_t color = display::ColorUtil::color_to_565(display::ColorUtil::rgb332_to_color(*src++));
     *dst++ = (uint8_t)(color >> 8);
     *dst++ = (uint8_t) color;
   }

--- a/esphome/components/ili9341/ili9341_display.h
+++ b/esphome/components/ili9341/ili9341_display.h
@@ -51,7 +51,6 @@ class ILI9341Display : public PollingComponent,
   void reset_();
   void fill_internal_(Color color);
   void display_();
-  uint16_t convert_to_16bit_color_(uint8_t color_8bit);
 
   ILI9341Model model_;
   int16_t width_{320};   ///< Display width as modified by current rotation

--- a/esphome/components/ili9341/ili9341_display.h
+++ b/esphome/components/ili9341/ili9341_display.h
@@ -52,7 +52,6 @@ class ILI9341Display : public PollingComponent,
   void fill_internal_(Color color);
   void display_();
   uint16_t convert_to_16bit_color_(uint8_t color_8bit);
-  uint8_t convert_to_8bit_color_(uint16_t color_16bit);
 
   ILI9341Model model_;
   int16_t width_{320};   ///< Display width as modified by current rotation


### PR DESCRIPTION
# What does this implement/fix? 
`ILI9341Display::convert_to_8bit_color_` seems to duplicate existing functionality of `display::ColorUtil::color_to_332()`.  This PR moves usage to the existing function.

The functions aren't exactly the same but the only time the old one was used was doing 24bit->16bit->8bit conversion.  With this PR it now only does 24bit->8bit conversion (the 16bit->8bit is now unused and is removed).

Possibly will give a small speed up also.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
