### PR TITLE
Fix reset on http_request without network connection

### DIFF
--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -3,6 +3,7 @@
 #include "http_request.h"
 #include "esphome/core/macros.h"
 #include "esphome/core/log.h"
+#include "esphome/components/network/util.h"
 
 namespace esphome {
 namespace http_request {
@@ -28,6 +29,13 @@ void HttpRequestComponent::set_url(std::string url) {
 }
 
 void HttpRequestComponent::send(const std::vector<HttpRequestResponseTrigger *> &response_triggers) {
+  if(!network::is_connected()) {
+    this->client_.end();
+    this->status_set_warning();
+    ESP_LOGW(TAG, "HTTP Request failed; Not connected to network");
+    return;
+  }
+
   bool begin_status = false;
   const String url = this->url_.c_str();
 #ifdef USE_ESP32

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -29,7 +29,7 @@ void HttpRequestComponent::set_url(std::string url) {
 }
 
 void HttpRequestComponent::send(const std::vector<HttpRequestResponseTrigger *> &response_triggers) {
-  if(!network::is_connected()) {
+  if (!network::is_connected()) {
     this->client_.end();
     this->status_set_warning();
     ESP_LOGW(TAG, "HTTP Request failed; Not connected to network");


### PR DESCRIPTION
# What does this implement/fix? 

Validate network connection before sending http_request to avoid reset.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2501

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: test
  platform: ESP32
  board: esp-wrover-kit

# Enable logging
logger:

# Enable Home Assistant API
api:
  password: ""

ota:
  password: ""

wifi:
  ssid: "....."
  password: "....."

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "....."
    password: "....."

captive_portal:

http_request:

switch:
  - platform: gpio
    pin:
      number: GPIO0
      inverted: yes
    name: "Mesita Marilena"
    restore_mode: RESTORE_DEFAULT_OFF
    on_turn_off:
      then:
        http_request.post: http://192.168.33.42/switch/lamparita_peques/turn_off
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
