### PR TITLE
Add throttle_average sensor filter

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -418,7 +418,9 @@ async def heartbeat_filter_to_code(config, filter_id):
 
 
 @FILTER_REGISTRY.register(
-    "periodical_average", PeriodicalAverageFilter, cv.positive_time_period_milliseconds
+    "periodical_average", 
+    PeriodicalAverageFilter, 
+    cv.positive_time_period_milliseconds
 )
 async def periodical_average_filter_to_code(config, filter_id):
     var = cg.new_Pvariable(filter_id, config)

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -160,6 +160,9 @@ SlidingWindowMovingAverageFilter = sensor_ns.class_(
 ExponentialMovingAverageFilter = sensor_ns.class_(
     "ExponentialMovingAverageFilter", Filter
 )
+PeriodicalAverageFilter = sensor_ns.class_(
+    "PeriodicalAverageFilter", Filter, cg.Component
+)
 LambdaFilter = sensor_ns.class_("LambdaFilter", Filter)
 OffsetFilter = sensor_ns.class_("OffsetFilter", Filter)
 MultiplyFilter = sensor_ns.class_("MultiplyFilter", Filter)
@@ -167,9 +170,6 @@ FilterOutValueFilter = sensor_ns.class_("FilterOutValueFilter", Filter)
 ThrottleFilter = sensor_ns.class_("ThrottleFilter", Filter)
 DebounceFilter = sensor_ns.class_("DebounceFilter", Filter, cg.Component)
 HeartbeatFilter = sensor_ns.class_("HeartbeatFilter", Filter, cg.Component)
-PeriodicalAverageFilter = sensor_ns.class_(
-    "PeriodicalAverageFilter", Filter, cg.Component
-)
 DeltaFilter = sensor_ns.class_("DeltaFilter", Filter)
 OrFilter = sensor_ns.class_("OrFilter", Filter)
 CalibrateLinearFilter = sensor_ns.class_("CalibrateLinearFilter", Filter)
@@ -384,6 +384,15 @@ async def exponential_moving_average_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id, config[CONF_ALPHA], config[CONF_SEND_EVERY])
 
 
+@FILTER_REGISTRY.register(
+    "periodical_average", PeriodicalAverageFilter, cv.positive_time_period_milliseconds
+)
+async def periodical_average_filter_to_code(config, filter_id):
+    var = cg.new_Pvariable(filter_id, config)
+    await cg.register_component(var, {})
+    return var
+
+
 @FILTER_REGISTRY.register("lambda", LambdaFilter, cv.returning_lambda)
 async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
@@ -414,15 +423,6 @@ async def throttle_filter_to_code(config, filter_id):
     "heartbeat", HeartbeatFilter, cv.positive_time_period_milliseconds
 )
 async def heartbeat_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
-    await cg.register_component(var, {})
-    return var
-
-
-@FILTER_REGISTRY.register(
-    "periodical_average", PeriodicalAverageFilter, cv.positive_time_period_milliseconds
-)
-async def periodical_average_filter_to_code(config, filter_id):
     var = cg.new_Pvariable(filter_id, config)
     await cg.register_component(var, {})
     return var

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -167,6 +167,7 @@ FilterOutValueFilter = sensor_ns.class_("FilterOutValueFilter", Filter)
 ThrottleFilter = sensor_ns.class_("ThrottleFilter", Filter)
 DebounceFilter = sensor_ns.class_("DebounceFilter", Filter, cg.Component)
 HeartbeatFilter = sensor_ns.class_("HeartbeatFilter", Filter, cg.Component)
+PeriodicalAverageFilter = sensor_ns.class_("PeriodicalAverageFilter", Filter, cg.Component)
 DeltaFilter = sensor_ns.class_("DeltaFilter", Filter)
 OrFilter = sensor_ns.class_("OrFilter", Filter)
 CalibrateLinearFilter = sensor_ns.class_("CalibrateLinearFilter", Filter)
@@ -411,6 +412,15 @@ async def throttle_filter_to_code(config, filter_id):
     "heartbeat", HeartbeatFilter, cv.positive_time_period_milliseconds
 )
 async def heartbeat_filter_to_code(config, filter_id):
+    var = cg.new_Pvariable(filter_id, config)
+    await cg.register_component(var, {})
+    return var
+
+
+@FILTER_REGISTRY.register(
+    "periodical_average", PeriodicalAverageFilter, cv.positive_time_period_milliseconds
+)
+async def periodical_average_filter_to_code(config, filter_id):
     var = cg.new_Pvariable(filter_id, config)
     await cg.register_component(var, {})
     return var

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -160,9 +160,7 @@ SlidingWindowMovingAverageFilter = sensor_ns.class_(
 ExponentialMovingAverageFilter = sensor_ns.class_(
     "ExponentialMovingAverageFilter", Filter
 )
-PeriodicalAverageFilter = sensor_ns.class_(
-    "PeriodicalAverageFilter", Filter, cg.Component
-)
+ThrottleAverageFilter = sensor_ns.class_("ThrottleAverageFilter", Filter, cg.Component)
 LambdaFilter = sensor_ns.class_("LambdaFilter", Filter)
 OffsetFilter = sensor_ns.class_("OffsetFilter", Filter)
 MultiplyFilter = sensor_ns.class_("MultiplyFilter", Filter)
@@ -385,9 +383,9 @@ async def exponential_moving_average_filter_to_code(config, filter_id):
 
 
 @FILTER_REGISTRY.register(
-    "periodical_average", PeriodicalAverageFilter, cv.positive_time_period_milliseconds
+    "throttle_average", ThrottleAverageFilter, cv.positive_time_period_milliseconds
 )
-async def periodical_average_filter_to_code(config, filter_id):
+async def throttle_average_filter_to_code(config, filter_id):
     var = cg.new_Pvariable(filter_id, config)
     await cg.register_component(var, {})
     return var

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -418,8 +418,8 @@ async def heartbeat_filter_to_code(config, filter_id):
 
 
 @FILTER_REGISTRY.register(
-    "periodical_average", 
-    PeriodicalAverageFilter, 
+    "periodical_average",
+    PeriodicalAverageFilter,
     cv.positive_time_period_milliseconds
 )
 async def periodical_average_filter_to_code(config, filter_id):

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -167,7 +167,9 @@ FilterOutValueFilter = sensor_ns.class_("FilterOutValueFilter", Filter)
 ThrottleFilter = sensor_ns.class_("ThrottleFilter", Filter)
 DebounceFilter = sensor_ns.class_("DebounceFilter", Filter, cg.Component)
 HeartbeatFilter = sensor_ns.class_("HeartbeatFilter", Filter, cg.Component)
-PeriodicalAverageFilter = sensor_ns.class_("PeriodicalAverageFilter", Filter, cg.Component)
+PeriodicalAverageFilter = sensor_ns.class_(
+    "PeriodicalAverageFilter", Filter, cg.Component
+)
 DeltaFilter = sensor_ns.class_("DeltaFilter", Filter)
 OrFilter = sensor_ns.class_("OrFilter", Filter)
 CalibrateLinearFilter = sensor_ns.class_("CalibrateLinearFilter", Filter)
@@ -418,9 +420,7 @@ async def heartbeat_filter_to_code(config, filter_id):
 
 
 @FILTER_REGISTRY.register(
-    "periodical_average",
-    PeriodicalAverageFilter,
-    cv.positive_time_period_milliseconds
+    "periodical_average", PeriodicalAverageFilter, cv.positive_time_period_milliseconds
 )
 async def periodical_average_filter_to_code(config, filter_id):
     var = cg.new_Pvariable(filter_id, config)

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -187,20 +187,20 @@ optional<float> ExponentialMovingAverageFilter::new_value(float value) {
 void ExponentialMovingAverageFilter::set_send_every(size_t send_every) { this->send_every_ = send_every; }
 void ExponentialMovingAverageFilter::set_alpha(float alpha) { this->alpha_ = alpha; }
 
-// PeriodicalAverageFilter
-PeriodicalAverageFilter::PeriodicalAverageFilter(uint32_t time_period) : time_period_(time_period) {}
+// ThrottleAverageFilter
+ThrottleAverageFilter::ThrottleAverageFilter(uint32_t time_period) : time_period_(time_period) {}
 
-optional<float> PeriodicalAverageFilter::new_value(float value) {
-  ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::new_value(value=%f)", this, value);
+optional<float> ThrottleAverageFilter::new_value(float value) {
+  ESP_LOGVV(TAG, "ThrottleAverageFilter(%p)::new_value(value=%f)", this, value);
   if (!std::isnan(value)) {
     this->sum_ += value;
     this->n_++;
   }
   return {};
 }
-void PeriodicalAverageFilter::setup() {
-  this->set_interval("periodical_average", this->time_period_, [this]() {
-    ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::interval(sum=%f, n=%i)", this, this->sum_, this->n_);
+void ThrottleAverageFilter::setup() {
+  this->set_interval("throttle_average", this->time_period_, [this]() {
+    ESP_LOGVV(TAG, "ThrottleAverageFilter(%p)::interval(sum=%f, n=%i)", this, this->sum_, this->n_);
     if (this->n_ == 0) {
       this->output(NAN);
     } else {
@@ -210,7 +210,7 @@ void PeriodicalAverageFilter::setup() {
     }
   });
 }
-float PeriodicalAverageFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
+float ThrottleAverageFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 // LambdaFilter
 LambdaFilter::LambdaFilter(lambda_filter_t lambda_filter) : lambda_filter_(std::move(lambda_filter)) {}

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -192,16 +192,17 @@ PeriodicalAverageFilter::PeriodicalAverageFilter(uint32_t time_period) : time_pe
 
 optional<float> PeriodicalAverageFilter::new_value(float value) {
   ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::new_value(value=%f)", this, value);
-  this->sum_ += value;
-  this->n_++;
-
+  if (!std::isnan(value)) {
+    this->sum_ += value;
+    this->n_++;
+  }
   return {};
 }
 void PeriodicalAverageFilter::setup() {
   this->set_interval("periodical_average", this->time_period_, [this]() {
     ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::interval(sum=%f, n=%i)", this, this->sum_, this->n_);
     if (this->n_ == 0)
-      return;
+      return NAN;
 
     this->output(this->sum_ / this->n_);
     this->sum_ = 0.0f;

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -322,7 +322,7 @@ optional<float> PeriodicalAverageFilter::new_value(float value) {
 }
 void PeriodicalAverageFilter::setup() {
   this->set_interval("periodical_average", this->time_period_, [this]() {
-    ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::interval(sum=%f, n=%zu)", this, this->sum_, this->n_);
+    ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::interval(sum=%f, n=%i)", this, this->sum_, this->n_);
     if (this->n_ == 0)
       return;
 

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -201,12 +201,13 @@ optional<float> PeriodicalAverageFilter::new_value(float value) {
 void PeriodicalAverageFilter::setup() {
   this->set_interval("periodical_average", this->time_period_, [this]() {
     ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::interval(sum=%f, n=%i)", this, this->sum_, this->n_);
-    if (this->n_ == 0)
-      return NAN;
-
-    this->output(this->sum_ / this->n_);
-    this->sum_ = 0.0f;
-    this->n_ = 0;
+    if (this->n_ == 0) {
+      this->output(NAN);
+    } else {
+      this->output(this->sum_ / this->n_);
+      this->sum_ = 0.0f;
+      this->n_ = 0;
+    }
   });
 }
 float PeriodicalAverageFilter::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -310,6 +310,28 @@ void HeartbeatFilter::setup() {
 }
 float HeartbeatFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
+// PeriodicalAverageFilter
+PeriodicalAverageFilter::PeriodicalAverageFilter(uint32_t time_period) : time_period_(time_period), last_input_(NAN) {}
+
+optional<float> PeriodicalAverageFilter::new_value(float value) {
+  ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::new_value(value=%f)", this, value);
+  this->last_input_ = value;
+  this->has_value_ = true;
+
+  return {};
+}
+void PeriodicalAverageFilter::setup() {
+  this->set_interval("periodical_average", this->time_period_, [this]() {
+    ESP_LOGVV(TAG, "PeriodicalAverageFilter(%p)::interval(has_value=%s, last_input=%f)", this, YESNO(this->has_value_),
+              this->last_input_);
+    if (!this->has_value_)
+      return;
+
+    this->output(this->last_input_);
+  });
+}
+float PeriodicalAverageFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
+
 optional<float> CalibrateLinearFilter::new_value(float value) { return value * this->slope_ + this->bias_; }
 CalibrateLinearFilter::CalibrateLinearFilter(float slope, float bias) : slope_(slope), bias_(bias) {}
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -178,13 +178,13 @@ class ExponentialMovingAverageFilter : public Filter {
   float alpha_;
 };
 
-/** Simple periodical average filter.
+/** Simple throttle average filter.
  *
  * It takes the average of all the values received in a period of time.
  */
-class PeriodicalAverageFilter : public Filter, public Component {
+class ThrottleAverageFilter : public Filter, public Component {
  public:
-  explicit PeriodicalAverageFilter(uint32_t time_period);
+  explicit ThrottleAverageFilter(uint32_t time_period);
 
   void setup() override;
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -285,7 +285,7 @@ class PeriodicalAverageFilter : public Filter, public Component {
  protected:
   uint32_t time_period_;
   float sum_{0.0f};
-  size_t n_{0};
+  unsigned int n_{0};
 };
 
 class DeltaFilter : public Filter {

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -178,6 +178,26 @@ class ExponentialMovingAverageFilter : public Filter {
   float alpha_;
 };
 
+/** Simple periodical average filter.
+ *
+ * It takes the average of all the values received in a period of time.
+ */
+class PeriodicalAverageFilter : public Filter, public Component {
+ public:
+  explicit PeriodicalAverageFilter(uint32_t time_period);
+
+  void setup() override;
+
+  optional<float> new_value(float value) override;
+
+  float get_setup_priority() const override;
+
+ protected:
+  uint32_t time_period_;
+  float sum_{0.0f};
+  unsigned int n_{0};
+};
+
 using lambda_filter_t = std::function<optional<float>(float)>;
 
 /** This class allows for creation of simple template filters.
@@ -270,22 +290,6 @@ class HeartbeatFilter : public Filter, public Component {
   uint32_t time_period_;
   float last_input_;
   bool has_value_{false};
-};
-
-class PeriodicalAverageFilter : public Filter, public Component {
- public:
-  explicit PeriodicalAverageFilter(uint32_t time_period);
-
-  void setup() override;
-
-  optional<float> new_value(float value) override;
-
-  float get_setup_priority() const override;
-
- protected:
-  uint32_t time_period_;
-  float sum_{0.0f};
-  unsigned int n_{0};
 };
 
 class DeltaFilter : public Filter {

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -272,6 +272,22 @@ class HeartbeatFilter : public Filter, public Component {
   bool has_value_{false};
 };
 
+class PeriodicalAverageFilter : public Filter, public Component {
+ public:
+  explicit PeriodicalAverageFilter(uint32_t time_period);
+
+  void setup() override;
+
+  optional<float> new_value(float value) override;
+
+  float get_setup_priority() const override;
+
+ protected:
+  uint32_t time_period_;
+  float sum_{0.0f};
+  size_t n_{0};
+};
+
 class DeltaFilter : public Filter {
  public:
   explicit DeltaFilter(float min_delta);

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -343,9 +343,9 @@ sensor:
       - exponential_moving_average:
           alpha: 0.1
           send_every: 15
+      - throttle_average: 60s
       - throttle: 1s
       - heartbeat: 5s
-      - periodical_average: 60s
       - debounce: 0.1s
       - delta: 5.0
       - or:

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -345,6 +345,7 @@ sensor:
           send_every: 15
       - throttle: 1s
       - heartbeat: 5s
+      - periodical_average: 60s
       - debounce: 0.1s
       - delta: 5.0
       - or:


### PR DESCRIPTION
# What does this implement/fix? 

A way to get the average of a sensor periodically. For example, a thermometer that reports data every 120 seconds, and that the reported data is the average of all the values read in that period.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/569

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1521

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: xiaomi_lywsdcgq
    mac_address: 58:2D:34:38:3D:CB
    temperature:
      name: "Kitchen Temperature"
      accuracy_decimals: 2
      filters:
        - throttle_average: 120s
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
