### PR TITLE
Fix color temperature persistence on CWWW lights

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -532,7 +532,8 @@ LightCall &LightCall::set_white_if_supported(float white) {
   return *this;
 }
 LightCall &LightCall::set_color_temperature_if_supported(float color_temperature) {
-  if (this->get_active_color_mode_() & ColorCapability::COLOR_TEMPERATURE)
+  if (this->get_active_color_mode_() & ColorCapability::COLOR_TEMPERATURE ||
+      this->get_active_color_mode_() & ColorCapability::COLD_WARM_WHITE)
     this->set_color_temperature(color_temperature);
   return *this;
 }


### PR DESCRIPTION
# What does this implement/fix? 

This PR is supposed to fix esphome/issues#2532 - caused because the color temperature of CWWW lights is controlled via `color_temperature` value since #2138 - yet they don't have the `COLOR_TEMPERATURE` capability. In that case it wasn't restored when saved data was loaded from RTC, although the value was persisted.

I was able to test it only on a CWWW light, but it appears it should apply also for RGBWW referred in the linked issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
