### PR TITLE
Replace deprecated COLOR_BLACK constant

### DIFF
--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -142,7 +142,7 @@ void ILI9341Display::fill(Color color) {
 }
 
 void ILI9341Display::fill_internal_(Color color) {
-  if (color.raw_32 == COLOR_BLACK.raw_32) {
+  if (color.raw_32 == Color::BLACK.raw_32) {
     memset(transfer_buffer_, 0, sizeof(transfer_buffer_));
   } else {
     uint8_t *dst = transfer_buffer_;


### PR DESCRIPTION
# What does this implement/fix? 
replace deprecated CONST to remove warning.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
