### PR TITLE
Change millis() to faster micros() for 3ms check in feed_wdt

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -109,8 +109,8 @@ void Application::loop() {
 
 void IRAM_ATTR HOT Application::feed_wdt() {
   static uint32_t last_feed = 0;
-  uint32_t now = millis();
-  if (now - last_feed > 3) {
+  uint32_t now = micros();
+  if (now - last_feed > 3000) {
     arch_feed_wdt();
     last_feed = now;
 #ifdef USE_STATUS_LED


### PR DESCRIPTION
# What does this implement/fix? 

Simple change for slight speed increase. `feed_wdt()` should be as quick as possible because it is called in high speed loops.

Currently it was using `millis()` https://github.com/esp8266/Arduino/blob/60fe7b4ca8cdca25366af8a7c0a7b70d32c797f8/cores/esp8266/core_esp8266_wiring.cpp#L166-L199
That is much longer than `micros()`, and it's unnecessary for such a short delay.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
