### PR TITLE
Add pressure compensation during runtime

### DIFF
--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -157,7 +157,7 @@ void SCD4XComponent::update() {
   }
 
   if (this->pressure_sensor_ != nullptr) {
-    float pressure = this->pressure_sensor_->state / 1000.0;
+    float pressure = this->pressure_sensor_->state / 1000.0f;
     if (!std::isnan(pressure)) {
       set_ambient_pressure_compensation(this->pressure_sensor_->state / 1000.0);
     }

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -161,13 +161,6 @@ void SCD4XComponent::update() {
     if (!std::isnan(pressure)) {
       set_ambient_pressure_compensation(this->pressure_sensor_->state / 1000.0f);
     }
-  } else {
-    if (this->altidute_sensor_ != nullptr) {
-      float altidute = this->altidute_sensor_->state;
-      if (!std::isnan(altidute)) {
-        set_altitude_compensation(this->altidute_sensor_->state);
-      }
-    }
   }
 
   // Check if data is ready
@@ -212,17 +205,6 @@ void SCD4XComponent::update() {
   this->status_clear_warning();
 }
 
-void SCD4XComponent::set_altitude_compensation(uint16_t altitude) {
-  // setting an ambient pressure overrides altitude compensation
-  // divide by 10 for change detection +/- 10m doesn't make a difference
-  if (initialized_ && !ambient_pressure_compensation_ && (altitude / 10 != altitude_compensation_ / 10)) {
-    update_altitude_compensation_(altitude);
-    altitude_compensation_ = altitude;
-  } else {
-    ESP_LOGD(TAG, "altitude compensation skipped no change required");
-  }
-}
-
 void SCD4XComponent::set_ambient_pressure_compensation(float pressure) {
   ambient_pressure_compensation_ = true;
   uint16_t new_ambient_pressure = (uint16_t)(pressure * 1000);
@@ -232,16 +214,6 @@ void SCD4XComponent::set_ambient_pressure_compensation(float pressure) {
     ambient_pressure_ = new_ambient_pressure;
   } else {
     ESP_LOGD(TAG, "ambient pressure compensation skipped - no change required");
-  }
-}
-
-bool SCD4XComponent::update_altitude_compensation_(uint16_t altitude) {
-  if (this->write_command_(SCD4X_CMD_ALTITUDE_COMPENSATION, altitude)) {
-    ESP_LOGD(TAG, "setting altitude compensation to %d m", altitude);
-    return true;
-  } else {
-    ESP_LOGE(TAG, "Error setting altitude compensation.");
-    return false;
   }
 }
 

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -159,7 +159,7 @@ void SCD4XComponent::update() {
   if (this->pressure_sensor_ != nullptr) {
     float pressure = this->pressure_sensor_->state / 1000.0f;
     if (!std::isnan(pressure)) {
-      set_ambient_pressure_compensation(this->pressure_sensor_->state / 1000.0);
+      set_ambient_pressure_compensation(this->pressure_sensor_->state / 1000.0f);
     }
   } else {
     if (this->altidute_sensor_ != nullptr) {

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -165,7 +165,7 @@ void SCD4XComponent::update() {
     if (this->altidute_sensor_ != nullptr) {
       float altidute = this->altidute_sensor_->state;
       if (!std::isnan(altidute)) {
-        set_ambient_pressure_compensation(this->altidute_sensor_->state);
+        set_altitude_compensation(this->altidute_sensor_->state);
       }
     }
   }

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -18,13 +18,13 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
 
   void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
   void set_altitude_compensation(uint16_t altitude) { altitude_compensation_ = altitude; }
-  void set_ambient_pressure_compensation(float pressure);
+  void set_ambient_pressure_compensation(float pressure_in_bar);
+  void set_ambient_pressure_source(sensor::Sensor *pressure) { ambient_pressure_source_ = pressure; }
   void set_temperature_offset(float offset) { temperature_offset_ = offset; };
 
   void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
   void set_temperature_sensor(sensor::Sensor *temperature) { temperature_sensor_ = temperature; };
   void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
-  void set_pressure_sensor(sensor::Sensor *pressure) { pressure_sensor_ = pressure; }
 
  protected:
   uint8_t sht_crc_(uint8_t data1, uint8_t data2);
@@ -47,7 +47,7 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   // used for compensation
-  sensor::Sensor *pressure_sensor_{nullptr};
+  sensor::Sensor *ambient_pressure_source_{nullptr};
 };
 
 }  // namespace scd4x

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -17,14 +17,13 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   void update() override;
 
   void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
-  void set_altitude_compensation(uint16_t altitude);
+  void set_altitude_compensation(uint16_t altitude) { altitude_compensation_ = altitude; }
   void set_ambient_pressure_compensation(float pressure);
   void set_temperature_offset(float offset) { temperature_offset_ = offset; };
 
   void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
   void set_temperature_sensor(sensor::Sensor *temperature) { temperature_sensor_ = temperature; };
   void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
-  void set_altidute_sensor(sensor::Sensor *altidute) { altidute_sensor_ = altidute; }
   void set_pressure_sensor(sensor::Sensor *pressure) { pressure_sensor_ = pressure; }
 
  protected:
@@ -33,7 +32,6 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   bool write_command_(uint16_t command);
   bool write_command_(uint16_t command, uint16_t data);
   bool update_ambient_pressure_compensation_(uint16_t pressure_in_hpa);
-  bool update_altitude_compensation_(uint16_t altitude);
 
   ERRORCODE error_code_;
 
@@ -49,7 +47,6 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   // used for compensation
-  sensor::Sensor *altidute_sensor_{nullptr};
   sensor::Sensor *pressure_sensor_{nullptr};
 };
 

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -17,27 +17,15 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   void update() override;
 
   void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
-  void set_altitude_compensation(uint16_t altitude) {
-    // setting an ambient pressure overrides altitude compensation
-    if (initialized_ && !ambient_pressure_compensation_ && (altitude != altitude_compensation_)) {
-      update_altitude_compensation_(altitude);
-      altitude_compensation_ = altitude;
-    }
-  }
-
-  void set_ambient_pressure_compensation(float pressure) {
-    ambient_pressure_compensation_ = true;
-    uint16_t new_ambient_pressure = (uint16_t)(pressure * 1000);
-    if (initialized_ && (new_ambient_pressure != ambient_pressure_)) {
-      update_ambient_pressure_compensation_(new_ambient_pressure);
-      ambient_pressure_ = new_ambient_pressure;
-    }
-  }
+  void set_altitude_compensation(uint16_t altitude);
+  void set_ambient_pressure_compensation(float pressure);
   void set_temperature_offset(float offset) { temperature_offset_ = offset; };
 
   void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
   void set_temperature_sensor(sensor::Sensor *temperature) { temperature_sensor_ = temperature; };
   void set_humidity_sensor(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
+  void set_altidute_sensor(sensor::Sensor *altidute) { altidute_sensor_ = altidute; }
+  void set_pressure_sensor(sensor::Sensor *pressure) { pressure_sensor_ = pressure; }
 
  protected:
   uint8_t sht_crc_(uint8_t data1, uint8_t data2);
@@ -60,6 +48,9 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
+  // used for compensation
+  sensor::Sensor *altidute_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
 };
 
 }  // namespace scd4x

--- a/esphome/components/scd4x/sensor.py
+++ b/esphome/components/scd4x/sensor.py
@@ -29,6 +29,9 @@ CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
 CONF_ALTITUDE_COMPENSATION = "altitude_compensation"
 CONF_AMBIENT_PRESSURE_COMPENSATION = "ambient_pressure_compensation"
 CONF_TEMPERATURE_OFFSET = "temperature_offset"
+CONF_COMPENSATION = "compensation"
+CONF_PRESSURE_SOURCE = "pressure_source"
+CONF_ALTITUDE_SOURCE = "altitude_source"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -62,6 +65,12 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION): cv.pressure,
             cv.Optional(CONF_TEMPERATURE_OFFSET, default="4°C"): cv.temperature,
+            cv.Optional(CONF_COMPENSATION): cv.Schema(
+                {
+                    cv.Optional(CONF_PRESSURE_SOURCE): cv.use_id(sensor.Sensor),
+                    cv.Optional(CONF_ALTITUDE_SOURCE): cv.use_id(sensor.Sensor),
+                }
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -92,7 +101,15 @@ async def to_code(config):
             cg.add(getattr(var, funcName)(config[key]))
 
     for key, funcName in SENSOR_MAP.items():
-
         if key in config:
             sens = await sensor.new_sensor(config[key])
             cg.add(getattr(var, funcName)(sens))
+
+    if CONF_COMPENSATION in config:
+        compensation_config = config[CONF_COMPENSATION]
+        if CONF_PRESSURE_SOURCE in compensation_config:
+            sens = await cg.get_variable(compensation_config[CONF_PRESSURE_SOURCE])
+            cg.add(var.set_pressure_sensor(sens))
+        if CONF_ALTITUDE_SOURCE in compensation_config:
+            sens = await cg.get_variable(compensation_config[CONF_ALTITUDE_SOURCE])
+            cg.add(var.set_altitude_sensor(sens))

--- a/esphome/components/scd4x/sensor.py
+++ b/esphome/components/scd4x/sensor.py
@@ -102,4 +102,4 @@ async def to_code(config):
 
     if CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE in config:
         sens = await cg.get_variable(config[CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE])
-        cg.add(var.set_pressure_sensor(sens))
+        cg.add(var.set_ambient_pressure_source(sens))

--- a/esphome/components/scd4x/sensor.py
+++ b/esphome/components/scd4x/sensor.py
@@ -29,9 +29,7 @@ CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
 CONF_ALTITUDE_COMPENSATION = "altitude_compensation"
 CONF_AMBIENT_PRESSURE_COMPENSATION = "ambient_pressure_compensation"
 CONF_TEMPERATURE_OFFSET = "temperature_offset"
-CONF_COMPENSATION = "compensation"
-CONF_PRESSURE_SOURCE = "pressure_source"
-CONF_ALTITUDE_SOURCE = "altitude_source"
+CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE = "ambient_pressure_compensation_source"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -65,11 +63,8 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION): cv.pressure,
             cv.Optional(CONF_TEMPERATURE_OFFSET, default="4°C"): cv.temperature,
-            cv.Optional(CONF_COMPENSATION): cv.Schema(
-                {
-                    cv.Optional(CONF_PRESSURE_SOURCE): cv.use_id(sensor.Sensor),
-                    cv.Optional(CONF_ALTITUDE_SOURCE): cv.use_id(sensor.Sensor),
-                }
+            cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE): cv.use_id(
+                sensor.Sensor
             ),
         }
     )
@@ -105,11 +100,6 @@ async def to_code(config):
             sens = await sensor.new_sensor(config[key])
             cg.add(getattr(var, funcName)(sens))
 
-    if CONF_COMPENSATION in config:
-        compensation_config = config[CONF_COMPENSATION]
-        if CONF_PRESSURE_SOURCE in compensation_config:
-            sens = await cg.get_variable(compensation_config[CONF_PRESSURE_SOURCE])
-            cg.add(var.set_pressure_sensor(sens))
-        if CONF_ALTITUDE_SOURCE in compensation_config:
-            sens = await cg.get_variable(compensation_config[CONF_ALTITUDE_SOURCE])
-            cg.add(var.set_altitude_sensor(sens))
+    if CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE in config:
+        sens = await cg.get_variable(config[CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE])
+        cg.add(var.set_pressure_sensor(sens))


### PR DESCRIPTION
Allow pressure and altitude compensation during runtime

# What does this implement/fix? 

**Add required delay after stop_periodic_measurement**
According to the [datasheet](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.5_CO2/Sensirion_CO2_Sensors_SCD4x_Datasheet.pdf) a 500 ms delay is required after a stop_periodic_measurement command.
Without this delay initialization may fail with 
```
[11:13:39][D][scd4x:044]: Sensor has data available, stopping periodic measurement
[11:13:39][E][scd4x:056]: Failed to write get serial command
[11:13:39][E][component:103]: Component scd4x.sensor was marked as failed.
```

**Add pressure compensation during runtime**
To increase the measurement accuracy ambient pressure compensation can used. 
With this change ambient pressure compensation can be used from a lambda instead of a fixed value during setup. 
Main use case is using a pressure sensor to provide up to date pressure information to scd4x







## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1526

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: scd4x
    id: scd41
    i2c_id: bus_a
    co2:
      name: co2
      id: co2

  - platform: bme280
    pressure:
      name: "BME280-Pressure"
      id: bme280_pressure
      oversampling: 1x
      on_value:
        then:
          - lambda: "id(scd41)->set_ambient_pressure_compensation(x / 1000.0);"

```
Or set another sensor as the source for the pressure data 
```yaml
   sensor:
  - platform: scd4x
    setup_priority: -10
    id: scd41
    i2c_id: bus_a
    altitude_compensation: 418m
    co2:
      name: co2
      id: co2
    ambient_pressure_compensation_source: bme280_pressure
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
