### PR TITLE
Fix LoadProhibited crash for logger baud_rate 0 on esp-idf

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -111,14 +111,15 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
   this->set_null_terminator_();
 
   const char *msg = this->tx_buffer_ + offset;
+  if (this->baud_rate_ > 0) {
 #ifdef USE_ARDUINO
-  if (this->baud_rate_ > 0)
     this->hw_serial_->println(msg);
 #endif  // USE_ARDUINO
 #ifdef USE_ESP_IDF
-  uart_write_bytes(uart_num_, msg, strlen(msg));
-  uart_write_bytes(uart_num_, "\n", 1);
+    uart_write_bytes(uart_num_, msg, strlen(msg));
+    uart_write_bytes(uart_num_, "\n", 1);
 #endif
+  }
 
 #ifdef USE_ESP32
   // Suppress network-logging if memory constrained, but still log to serial


### PR DESCRIPTION
# What does this implement/fix? 

On esp-idf, baud rate zero for the logger triggers an endless reboot loop (cause: LoadProhibited).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: crash-it

esp32:
  board: esp32doit-devkit-v1
  framework:
    type: esp-idf

logger:
  baud_rate: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
