### PR TITLE
Reduce IRAM usage in test3

### DIFF
--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -61,6 +61,12 @@ mcp3008:
   - id: 'mcp3008_hub'
     cs_pin: GPIO12
 
+output:
+  - platform: ac_dimmer
+    id: dimmer1
+    gate_pin: GPIO5
+    zero_cross_pin: GPIO12
+
 sensor:
   - platform: homeassistant
     entity_id: sensor.hello_world

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -261,8 +261,6 @@ logger:
   level: DEBUG
   esp8266_store_log_strings_in_flash: true
 
-web_server:
-
 deep_sleep:
   run_duration: 20s
   sleep_duration: 50s
@@ -1092,10 +1090,6 @@ output:
       return {s};
     outputs:
       - id: custom_float
-  - platform: ac_dimmer
-    id: dimmer1
-    gate_pin: GPIO5
-    zero_cross_pin: GPIO12
   - platform: slow_pwm
     pin: GPIO5
     id: my_slow_pwm


### PR DESCRIPTION
# What does this implement/fix? 

Reduce IRAM usage in test3 a bit by (re-)moving some tests, so that not every change will kick it over the limit, as seen in #2282 and #2492. We should probably reorganize all tests sometime, but that's a lot more work...

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
