### PR TITLE
Add DS3231 component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,6 +47,7 @@ esphome/components/debug/* @OttoWinter
 esphome/components/dfplayer/* @glmnet
 esphome/components/dht/* @OttoWinter
 esphome/components/ds1307/* @badbadc0ffee
+esphome/components/ds3231/* @nuttytree
 esphome/components/dsmr/* @glmnet @zuidwijk
 esphome/components/esp32/* @esphome/core
 esphome/components/esp32_ble/* @jesserockz

--- a/esphome/components/ds3231/__init__.py
+++ b/esphome/components/ds3231/__init__.py
@@ -123,7 +123,7 @@ async def to_code(config):
 
 RESET_ALARM_SCHEMA = maybe_simple_id(
     {
-        cv.Required(CONF_ID): cv.use_id(DS3231Component),
+        cv.GenerateID(CONF_ID): cv.use_id(DS3231Component),
     }
 )
 
@@ -133,7 +133,7 @@ RESET_ALARM_SCHEMA = maybe_simple_id(
     SetAlarm1Action,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(DS3231Component),
+            cv.GenerateID(CONF_ID): cv.use_id(DS3231Component),
             cv.Required(CONF_TYPE): cv.templatable(
                 cv.enum(ALARM_1_TYPE_ENUM, upper=True)
             ),
@@ -174,7 +174,7 @@ async def reset_alarm_1_to_code(config, action_id, template_arg, args):
     SetAlarm2Action,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(DS3231Component),
+            cv.GenerateID(CONF_ID): cv.use_id(DS3231Component),
             cv.Required(CONF_TYPE): cv.templatable(
                 cv.enum(ALARM_2_TYPE_ENUM, upper=True)
             ),
@@ -212,7 +212,7 @@ async def reset_alarm_2_to_code(config, action_id, template_arg, args):
     SetSquareWaveModeAction,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(DS3231Component),
+            cv.GenerateID(CONF_ID): cv.use_id(DS3231Component),
             cv.Required(CONF_MODE): cv.templatable(
                 cv.enum(SQUARE_WAVE_MODE_ENUM, upper=True)
             ),
@@ -232,7 +232,7 @@ async def set_square_wave_mode_to_code(config, action_id, template_arg, args):
     SetSquareWaveFrequencyAction,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(DS3231Component),
+            cv.GenerateID(CONF_ID): cv.use_id(DS3231Component),
             cv.Required(CONF_FREQUENCY): cv.templatable(
                 cv.enum(SQUARE_WAVE_FREQUENCY_ENUM, upper=True)
             ),

--- a/esphome/components/ds3231/__init__.py
+++ b/esphome/components/ds3231/__init__.py
@@ -84,6 +84,7 @@ Alarm2Trigger = ds3231_ns.class_("Alarm2Trigger", automation.Trigger.template())
 CONF_DAY = "day"
 CONF_ON_ALARM_1 = "on_alarm_1"
 CONF_ON_ALARM_2 = "on_alarm_2"
+CONF_DS3231_ID = "ds3231_id"
 
 CONFIG_SCHEMA = (
     cv.Schema(

--- a/esphome/components/ds3231/__init__.py
+++ b/esphome/components/ds3231/__init__.py
@@ -6,11 +6,10 @@ from esphome.components import i2c
 from esphome.const import (
     CONF_ID,
     CONF_TRIGGER_ID,
-    CONF_TYPE,
+    CONF_MODE,
     CONF_SECOND,
     CONF_MINUTE,
     CONF_HOUR,
-    CONF_MODE,
     CONF_FREQUENCY,
 )
 
@@ -23,34 +22,34 @@ DS3231Component = ds3231_ns.class_(
     "DS3231Component", cg.PollingComponent, i2c.I2CDevice
 )
 
-Alarm1Type = ds3231_ns.enum("DS3231Alarm1Type")
-ALARM_1_TYPE_ENUM = {
-    "EVERY_SECOND": Alarm1Type.EVERY_SECOND,
-    "EVERY_SECOND_WITH_INTERRUPT": Alarm1Type.EVERY_SECOND_WITH_INTERRUPT,
-    "MATCH_SECOND": Alarm1Type.MATCH_SECOND,
-    "MATCH_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_SECOND_WITH_INTERRUPT,
-    "MATCH_MINUTE_SECOND": Alarm1Type.MATCH_MINUTE_SECOND,
-    "MATCH_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_MINUTE_SECOND_WITH_INTERRUPT,
-    "MATCH_HOUR_MINUTE_SECOND": Alarm1Type.MATCH_HOUR_MINUTE_SECOND,
-    "MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
-    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND": Alarm1Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND,
-    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
-    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND": Alarm1Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND,
-    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
+Alarm1Mode = ds3231_ns.enum("DS3231Alarm1Mode")
+ALARM_1_MODE_ENUM = {
+    "EVERY_SECOND": Alarm1Mode.EVERY_SECOND,
+    "EVERY_SECOND_WITH_INTERRUPT": Alarm1Mode.EVERY_SECOND_WITH_INTERRUPT,
+    "MATCH_SECOND": Alarm1Mode.MATCH_SECOND,
+    "MATCH_SECOND_WITH_INTERRUPT": Alarm1Mode.MATCH_SECOND_WITH_INTERRUPT,
+    "MATCH_MINUTE_SECOND": Alarm1Mode.MATCH_MINUTE_SECOND,
+    "MATCH_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Mode.MATCH_MINUTE_SECOND_WITH_INTERRUPT,
+    "MATCH_HOUR_MINUTE_SECOND": Alarm1Mode.MATCH_HOUR_MINUTE_SECOND,
+    "MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Mode.MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND": Alarm1Mode.MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Mode.MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND": Alarm1Mode.MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Mode.MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
 }
 
-Alarm2Type = ds3231_ns.enum("DS3231Alarm2Type")
-ALARM_2_TYPE_ENUM = {
-    "EVERY_MINUTE": Alarm2Type.EVERY_MINUTE,
-    "EVERY_MINUTE_WITH_INTERRUPT": Alarm2Type.EVERY_MINUTE_WITH_INTERRUPT,
-    "MATCH_MINUTE": Alarm2Type.MATCH_MINUTE,
-    "MATCH_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_MINUTE_WITH_INTERRUPT,
-    "MATCH_HOUR_MINUTE": Alarm2Type.MATCH_HOUR_MINUTE,
-    "MATCH_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_HOUR_MINUTE_WITH_INTERRUPT,
-    "MATCH_DAY_OF_MONTH_HOUR_MINUTE": Alarm2Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE,
-    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT,
-    "MATCH_DAY_OF_WEEK_HOUR_MINUTE": Alarm2Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE,
-    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT,
+Alarm2Mode = ds3231_ns.enum("DS3231Alarm2Mode")
+ALARM_2_MODE_ENUM = {
+    "EVERY_MINUTE": Alarm2Mode.EVERY_MINUTE,
+    "EVERY_MINUTE_WITH_INTERRUPT": Alarm2Mode.EVERY_MINUTE_WITH_INTERRUPT,
+    "MATCH_MINUTE": Alarm2Mode.MATCH_MINUTE,
+    "MATCH_MINUTE_WITH_INTERRUPT": Alarm2Mode.MATCH_MINUTE_WITH_INTERRUPT,
+    "MATCH_HOUR_MINUTE": Alarm2Mode.MATCH_HOUR_MINUTE,
+    "MATCH_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Mode.MATCH_HOUR_MINUTE_WITH_INTERRUPT,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE": Alarm2Mode.MATCH_DAY_OF_MONTH_HOUR_MINUTE,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Mode.MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE": Alarm2Mode.MATCH_DAY_OF_WEEK_HOUR_MINUTE,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Mode.MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT,
 }
 
 SquareWaveMode = ds3231_ns.enum("DS3231SquareWaveMode")
@@ -92,7 +91,7 @@ CONF_DS3231_ID = "ds3231_id"
 
 CONFIG_ALARM_1_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_TYPE): cv.templatable(cv.enum(ALARM_1_TYPE_ENUM, upper=True)),
+        cv.Required(CONF_MODE): cv.templatable(cv.enum(ALARM_1_MODE_ENUM, upper=True)),
         cv.Optional(CONF_SECOND, default="0"): cv.int_range(0, 59),
         cv.Optional(CONF_MINUTE, default="0"): cv.int_range(0, 59),
         cv.Optional(CONF_HOUR, default="0"): cv.int_range(0, 23),
@@ -102,7 +101,7 @@ CONFIG_ALARM_1_SCHEMA = cv.Schema(
 
 CONFIG_ALARM_2_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_TYPE): cv.templatable(cv.enum(ALARM_2_TYPE_ENUM, upper=True)),
+        cv.Required(CONF_MODE): cv.templatable(cv.enum(ALARM_2_MODE_ENUM, upper=True)),
         cv.Optional(CONF_MINUTE, default="0"): cv.int_range(0, 59),
         cv.Optional(CONF_HOUR, default="0"): cv.int_range(0, 23),
         cv.Optional(CONF_DAY, default="1"): cv.int_range(1, 31),
@@ -148,7 +147,7 @@ async def to_code(config):
         alrm1 = config[CONF_ALARM_1]
         cg.add(
             var.set_default_alarm_1(
-                alrm1[CONF_TYPE],
+                alrm1[CONF_MODE],
                 alrm1[CONF_SECOND],
                 alrm1[CONF_MINUTE],
                 alrm1[CONF_HOUR],
@@ -159,7 +158,7 @@ async def to_code(config):
         alrm2 = config[CONF_ALARM_2]
         cg.add(
             var.set_default_alarm_2(
-                alrm2[CONF_TYPE], alrm2[CONF_MINUTE], alrm2[CONF_HOUR], alrm2[CONF_DAY]
+                alrm2[CONF_MODE], alrm2[CONF_MINUTE], alrm2[CONF_HOUR], alrm2[CONF_DAY]
             )
         )
     if CONF_SQUARE_WAVE_MODE in config:
@@ -196,7 +195,7 @@ RESET_ALARM_SCHEMA = maybe_simple_id(
 async def set_alarm_1_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    alarm_type = await cg.templatable(config[CONF_TYPE], args, Alarm1Type)
+    alarm_type = await cg.templatable(config[CONF_MODE], args, Alarm1Mode)
     cg.add(var.set_alarm_type(alarm_type))
     second = await cg.templatable(config[CONF_SECOND], args, int)
     cg.add(var.set_second(second))
@@ -230,7 +229,7 @@ async def reset_alarm_1_to_code(config, action_id, template_arg, args):
 async def set_alarm_2_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    alarm_type = await cg.templatable(config[CONF_TYPE], args, Alarm2Type)
+    alarm_type = await cg.templatable(config[CONF_MODE], args, Alarm2Mode)
     cg.add(var.set_alarm_type(alarm_type))
     minute = await cg.templatable(config[CONF_MINUTE], args, int)
     cg.add(var.set_minute(minute))

--- a/esphome/components/ds3231/__init__.py
+++ b/esphome/components/ds3231/__init__.py
@@ -15,7 +15,9 @@ CODEOWNERS = ["@nuttytree"]
 DEPENDENCIES = ["i2c"]
 
 ds3231_ns = cg.esphome_ns.namespace("ds3231")
-DS3231Component = ds3231_ns.class_("DS3231Component", cg.PollingComponent, i2c.I2CDevice)
+DS3231Component = ds3231_ns.class_(
+    "DS3231Component", cg.PollingComponent, i2c.I2CDevice
+)
 
 Alarm1Type = ds3231_ns.enum("DS3231Alarm1Type")
 ALARM_1_TYPE_ENUM = {
@@ -127,11 +129,14 @@ async def set_alarm_1_to_code(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action("ds3231.reset_alarm_1", ResetAlarm1Action, RESET_ALARM_SCHEMA)
+@automation.register_action(
+    "ds3231.reset_alarm_1", ResetAlarm1Action, RESET_ALARM_SCHEMA
+)
 async def reset_alarm_1_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
+
 
 @automation.register_action(
     "ds3231.set_alarm_2",
@@ -162,7 +167,9 @@ async def set_alarm_2_to_code(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action("ds3231.reset_alarm_2", ResetAlarm2Action, RESET_ALARM_SCHEMA)
+@automation.register_action(
+    "ds3231.reset_alarm_2", ResetAlarm2Action, RESET_ALARM_SCHEMA
+)
 async def reset_alarm_2_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/ds3231/__init__.py
+++ b/esphome/components/ds3231/__init__.py
@@ -1,0 +1,169 @@
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome import automation
+from esphome.automation import maybe_simple_id
+from esphome.components import i2c
+from esphome.const import (
+    CONF_ID,
+    CONF_SECOND,
+    CONF_MINUTE,
+    CONF_HOUR,
+)
+
+
+CODEOWNERS = ["@nuttytree"]
+DEPENDENCIES = ["i2c"]
+
+ds3231_ns = cg.esphome_ns.namespace("ds3231")
+DS3231Component = ds3231_ns.class_("DS3231Component", cg.PollingComponent, i2c.I2CDevice)
+
+Alarm1Type = ds3231_ns.enum("DS3231Alarm1Type")
+ALARM_1_TYPE_ENUM = {
+    "EVERY_SECOND": Alarm1Type.EVERY_SECOND,
+    "EVERY_SECOND_WITH_INTERRUPT": Alarm1Type.EVERY_SECOND_WITH_INTERRUPT,
+    "MATCH_SECOND": Alarm1Type.MATCH_SECOND,
+    "MATCH_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_SECOND_WITH_INTERRUPT,
+    "MATCH_MINUTE_SECOND": Alarm1Type.MATCH_MINUTE_SECOND,
+    "MATCH_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_MINUTE_SECOND_WITH_INTERRUPT,
+    "MATCH_HOUR_MINUTE_SECOND": Alarm1Type.MATCH_HOUR_MINUTE_SECOND,
+    "MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND": Alarm1Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND": Alarm1Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT": Alarm1Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT,
+}
+
+Alarm2Type = ds3231_ns.enum("DS3231Alarm2Type")
+ALARM_2_TYPE_ENUM = {
+    "EVERY_MINUTE": Alarm2Type.EVERY_MINUTE,
+    "EVERY_MINUTE_WITH_INTERRUPT": Alarm2Type.EVERY_MINUTE_WITH_INTERRUPT,
+    "MATCH_MINUTE": Alarm2Type.MATCH_MINUTE,
+    "MATCH_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_MINUTE_WITH_INTERRUPT,
+    "MATCH_HOUR_MINUTE": Alarm2Type.MATCH_HOUR_MINUTE,
+    "MATCH_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_HOUR_MINUTE_WITH_INTERRUPT,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE": Alarm2Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE,
+    "MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE": Alarm2Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE,
+    "MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT": Alarm2Type.MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT,
+}
+
+SquareWaveMode = ds3231_ns.enum("DS3231SquareWaveMode")
+SQUARE_WAVE_MODE_ENUM = {
+    "SQUARE_WAVE": SquareWaveMode.SQUARE_WAVE_MODE,
+    "INTERRUPT": SquareWaveMode.INTERRUPT_MODE,
+}
+
+SquareWaveFrequency = ds3231_ns.enum("DS3231SquareWaveFrequency")
+SQUARE_WAVE_FREQUENCY_ENUM = {
+    "FREQUENCY_1_HZ": SquareWaveFrequency.FREQUENCY_1_HZ,
+    "FREQUENCY_1024_HZ": SquareWaveFrequency.FREQUENCY_1024_HZ,
+    "FREQUENCY_4096_HZ": SquareWaveFrequency.FREQUENCY_4096_HZ,
+    "FREQUENCY_8192_HZ": SquareWaveFrequency.FREQUENCY_8192_HZ,
+}
+
+# Actions
+SetAlarm1Action = ds3231_ns.class_("SetAlarm1Action", automation.Action)
+ResetAlarm1Action = ds3231_ns.class_("ResetAlarm1Action", automation.Action)
+SetAlarm2Action = ds3231_ns.class_("SetAlarm2Action", automation.Action)
+ResetAlarm2Action = ds3231_ns.class_("ResetAlarm2Action", automation.Action)
+
+CONF_ALARM_TYPE = "alarm_type"
+CONF_DAY = "day"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DS3231Component),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x68))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+
+RESET_ALARM_SCHEMA = maybe_simple_id(
+    {
+        cv.Required(CONF_ID): cv.use_id(DS3231Component),
+    }
+)
+
+
+@automation.register_action(
+    "ds3231.set_alarm_1",
+    SetAlarm1Action,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(DS3231Component),
+            cv.Required(CONF_ALARM_TYPE): cv.templatable(
+                cv.enum(ALARM_1_TYPE_ENUM, upper=True)
+            ),
+            cv.Optional(CONF_SECOND, default="0"): cv.int_range(0, 59),
+            cv.Optional(CONF_MINUTE, default="0"): cv.int_range(0, 59),
+            cv.Optional(CONF_HOUR, default="0"): cv.int_range(0, 23),
+            cv.Optional(CONF_DAY, default="1"): cv.int_range(1, 31),
+        }
+    ),
+)
+async def set_alarm_1_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    alarm_type = await cg.templatable(config[CONF_ALARM_TYPE], args, Alarm1Type)
+    cg.add(var.set_alarm_type(alarm_type))
+    second = await cg.templatable(config[CONF_SECOND], args, int)
+    cg.add(var.set_second(second))
+    minute = await cg.templatable(config[CONF_MINUTE], args, int)
+    cg.add(var.set_minute(minute))
+    hour = await cg.templatable(config[CONF_HOUR], args, int)
+    cg.add(var.set_hour(hour))
+    day = await cg.templatable(config[CONF_DAY], args, int)
+    cg.add(var.set_day(day))
+    return var
+
+
+@automation.register_action("ds3231.reset_alarm_1", ResetAlarm1Action, RESET_ALARM_SCHEMA)
+async def reset_alarm_1_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+@automation.register_action(
+    "ds3231.set_alarm_2",
+    SetAlarm2Action,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(DS3231Component),
+            cv.Required(CONF_ALARM_TYPE): cv.templatable(
+                cv.enum(ALARM_2_TYPE_ENUM, upper=True)
+            ),
+            cv.Optional(CONF_MINUTE, default="0"): cv.int_range(0, 59),
+            cv.Optional(CONF_HOUR, default="0"): cv.int_range(0, 23),
+            cv.Optional(CONF_DAY, default="1"): cv.int_range(1, 31),
+        }
+    ),
+)
+async def set_alarm_2_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    alarm_type = await cg.templatable(config[CONF_ALARM_TYPE], args, Alarm2Type)
+    cg.add(var.set_alarm_type(alarm_type))
+    minute = await cg.templatable(config[CONF_MINUTE], args, int)
+    cg.add(var.set_minute(minute))
+    hour = await cg.templatable(config[CONF_HOUR], args, int)
+    cg.add(var.set_hour(hour))
+    day = await cg.templatable(config[CONF_DAY], args, int)
+    cg.add(var.set_day(day))
+    return var
+
+
+@automation.register_action("ds3231.reset_alarm_2", ResetAlarm2Action, RESET_ALARM_SCHEMA)
+async def reset_alarm_2_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var

--- a/esphome/components/ds3231/automation.h
+++ b/esphome/components/ds3231/automation.h
@@ -7,7 +7,6 @@
 namespace esphome {
 namespace ds3231 {
 
-
 template<typename... Ts> class SetAlarm1Action : public Action<Ts...>, public Parented<DS3231Component> {
  public:
   TEMPLATABLE_VALUE(DS3231Alarm1Type, alarm_type)

--- a/esphome/components/ds3231/automation.h
+++ b/esphome/components/ds3231/automation.h
@@ -54,5 +54,25 @@ template<typename... Ts> class ReadTimeAction : public Action<Ts...>, public Par
   void play(Ts... x) override { this->parent_->read_time(); }
 };
 
+class Alarm1Trigger : public Trigger<> {
+ public:
+  explicit Alarm1Trigger(DS3231Component *parent) {
+    parent->add_on_alarm_callback([this](uint8_t alarm) {
+      if (alarm == 1)
+        this->trigger();
+    });
+  }
+};
+
+class Alarm2Trigger : public Trigger<> {
+ public:
+  explicit Alarm2Trigger(DS3231Component *parent) {
+    parent->add_on_alarm_callback([this](uint8_t alarm) {
+      if (alarm == 2)
+        this->trigger();
+    });
+  }
+};
+
 }  // namespace ds3231
 }  // namespace esphome

--- a/esphome/components/ds3231/automation.h
+++ b/esphome/components/ds3231/automation.h
@@ -17,12 +17,8 @@ template<typename... Ts> class SetAlarm1Action : public Action<Ts...>, public Pa
   TEMPLATABLE_VALUE(int, day)
 
   void play(Ts... x) override {
-    this->parent_->set_alarm_1(
-      this->alarm_type_.value(x...),
-      this->second_.value(x...),
-      this->minute_.value(x...),
-      this->hour_.value(x...),
-      this->day_.value(x...));
+    this->parent_->set_alarm_1(this->alarm_type_.value(x...), this->second_.value(x...), this->minute_.value(x...),
+                               this->hour_.value(x...), this->day_.value(x...));
   }
 };
 
@@ -39,11 +35,8 @@ template<typename... Ts> class SetAlarm2Action : public Action<Ts...>, public Pa
   TEMPLATABLE_VALUE(int, day)
 
   void play(Ts... x) override {
-    this->parent_->set_alarm_2(
-      this->alarm_type_.value(x...),
-      this->minute_.value(x...),
-      this->hour_.value(x...),
-      this->day_.value(x...));
+    this->parent_->set_alarm_2(this->alarm_type_.value(x...), this->minute_.value(x...), this->hour_.value(x...),
+                               this->day_.value(x...));
   }
 };
 

--- a/esphome/components/ds3231/automation.h
+++ b/esphome/components/ds3231/automation.h
@@ -9,15 +9,16 @@ namespace ds3231 {
 
 template<typename... Ts> class SetAlarm1Action : public Action<Ts...>, public Parented<DS3231Component> {
  public:
-  TEMPLATABLE_VALUE(DS3231Alarm1Type, alarm_type)
+  TEMPLATABLE_VALUE(DS3231Alarm1Mode, mode)
+  TEMPLATABLE_VALUE(bool, int_enabled)
   TEMPLATABLE_VALUE(int, second)
   TEMPLATABLE_VALUE(int, minute)
   TEMPLATABLE_VALUE(int, hour)
   TEMPLATABLE_VALUE(int, day)
 
   void play(Ts... x) override {
-    this->parent_->set_alarm_1(this->alarm_type_.value(x...), this->second_.value(x...), this->minute_.value(x...),
-                               this->hour_.value(x...), this->day_.value(x...));
+    this->parent_->set_alarm_1(this->mode_.value(x...), this->int_enabled_.value(x...), this->second_.value(x...),
+                               this->minute_.value(x...), this->hour_.value(x...), this->day_.value(x...));
   }
 };
 
@@ -28,14 +29,15 @@ template<typename... Ts> class ResetAlarm1Action : public Action<Ts...>, public 
 
 template<typename... Ts> class SetAlarm2Action : public Action<Ts...>, public Parented<DS3231Component> {
  public:
-  TEMPLATABLE_VALUE(DS3231Alarm2Type, alarm_type)
+  TEMPLATABLE_VALUE(DS3231Alarm2Mode, mode)
+  TEMPLATABLE_VALUE(bool, int_enabled)
   TEMPLATABLE_VALUE(int, minute)
   TEMPLATABLE_VALUE(int, hour)
   TEMPLATABLE_VALUE(int, day)
 
   void play(Ts... x) override {
-    this->parent_->set_alarm_2(this->alarm_type_.value(x...), this->minute_.value(x...), this->hour_.value(x...),
-                               this->day_.value(x...));
+    this->parent_->set_alarm_2(this->mode_.value(x...), this->int_enabled_.value(x...), this->minute_.value(x...),
+                               this->hour_.value(x...), this->day_.value(x...));
   }
 };
 

--- a/esphome/components/ds3231/automation.h
+++ b/esphome/components/ds3231/automation.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "ds3231.h"
+
+namespace esphome {
+namespace ds3231 {
+
+
+template<typename... Ts> class SetAlarm1Action : public Action<Ts...>, public Parented<DS3231Component> {
+ public:
+  TEMPLATABLE_VALUE(DS3231Alarm1Type, alarm_type)
+  TEMPLATABLE_VALUE(int, second)
+  TEMPLATABLE_VALUE(int, minute)
+  TEMPLATABLE_VALUE(int, hour)
+  TEMPLATABLE_VALUE(int, day)
+
+  void play(Ts... x) override {
+    this->parent_->set_alarm_1(
+      this->alarm_type_.value(x...),
+      this->second_.value(x...),
+      this->minute_.value(x...),
+      this->hour_.value(x...),
+      this->day_.value(x...));
+  }
+};
+
+template<typename... Ts> class ResetAlarm1Action : public Action<Ts...>, public Parented<DS3231Component> {
+ public:
+  void play(Ts... x) override { this->parent_->reset_alarm_1(); }
+};
+
+template<typename... Ts> class SetAlarm2Action : public Action<Ts...>, public Parented<DS3231Component> {
+ public:
+  TEMPLATABLE_VALUE(DS3231Alarm2Type, alarm_type)
+  TEMPLATABLE_VALUE(int, minute)
+  TEMPLATABLE_VALUE(int, hour)
+  TEMPLATABLE_VALUE(int, day)
+
+  void play(Ts... x) override {
+    this->parent_->set_alarm_2(
+      this->alarm_type_.value(x...),
+      this->minute_.value(x...),
+      this->hour_.value(x...),
+      this->day_.value(x...));
+  }
+};
+
+template<typename... Ts> class ResetAlarm2Action : public Action<Ts...>, public Parented<DS3231Component> {
+ public:
+  void play(Ts... x) override { this->parent_->reset_alarm_2(); }
+};
+
+template<typename... Ts> class WriteTimeAction : public Action<Ts...>, public Parented<DS3231RTC> {
+ public:
+  void play(Ts... x) override { this->parent_->write_time(); }
+};
+
+template<typename... Ts> class ReadTimeAction : public Action<Ts...>, public Parented<DS3231RTC> {
+ public:
+  void play(Ts... x) override { this->parent_->read_time(); }
+};
+
+}  // namespace ds3231
+}  // namespace esphome

--- a/esphome/components/ds3231/automation.h
+++ b/esphome/components/ds3231/automation.h
@@ -44,6 +44,20 @@ template<typename... Ts> class ResetAlarm2Action : public Action<Ts...>, public 
   void play(Ts... x) override { this->parent_->reset_alarm_2(); }
 };
 
+template<typename... Ts> class SetSquareWaveModeAction : public Action<Ts...>, public Parented<DS3231Component> {
+ public:
+  TEMPLATABLE_VALUE(DS3231SquareWaveMode, mode)
+
+  void play(Ts... x) override { this->parent_->set_square_wave_mode(this->mode_.value(x...)); }
+};
+
+template<typename... Ts> class SetSquareWaveFrequencyAction : public Action<Ts...>, public Parented<DS3231Component> {
+ public:
+  TEMPLATABLE_VALUE(DS3231SquareWaveFrequency, frequency)
+
+  void play(Ts... x) override { this->parent_->set_square_wave_frequency(this->frequency_.value(x...)); }
+};
+
 template<typename... Ts> class WriteTimeAction : public Action<Ts...>, public Parented<DS3231RTC> {
  public:
   void play(Ts... x) override { this->parent_->write_time(); }

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -218,7 +218,7 @@ bool DS3231Component::read_status_(bool initial_read) {
   ESP_LOGD(TAG, "Read  A1:%s A2:%s BSY:%s 32K:%s OSC:%s", ONOFF(this->ds3231_.stat.reg.alrm_1_act),
            ONOFF(this->ds3231_.stat.reg.alrm_2_act), YESNO(this->ds3231_.stat.reg.busy),
            ONOFF(this->ds3231_.stat.reg.en32khz), ONOFF(!this->ds3231_.stat.reg.osc_stop));
-  
+
   if (!initial_read && alarm_1_act != this->ds3231_.stat.reg.alrm_1_act) {
     this->alarm_callback_.call(1);
   }

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -26,7 +26,7 @@ static const uint8_t DS3231_MASK_ALARM_TYPE_DAY_MODE = 0x10;
 void DS3231Component::set_default_alarm_1(DS3231Alarm1Mode mode, bool int_enabled, uint8_t second, uint8_t minute,
                                           uint8_t hour, uint8_t day) {
   this->alarm_1_mode_ = mode;
-  this->alarm_1_interrupt_anabled = int_enabled;
+  this->alarm_1_interrupt_anabled_ = int_enabled;
   this->alarm_1_second_ = second;
   this->alarm_1_minute_ = minute;
   this->alarm_1_hour_ = hour;
@@ -36,7 +36,7 @@ void DS3231Component::set_default_alarm_1(DS3231Alarm1Mode mode, bool int_enable
 void DS3231Component::set_default_alarm_2(DS3231Alarm2Mode mode, bool int_enabled, uint8_t minute, uint8_t hour,
                                           uint8_t day) {
   this->alarm_2_mode_ = mode;
-  this->alarm_2_interrupt_anabled = int_enabled;
+  this->alarm_2_interrupt_anabled_ = int_enabled;
   this->alarm_2_minute_ = minute;
   this->alarm_2_hour_ = hour;
   this->alarm_2_day_ = day;
@@ -62,11 +62,11 @@ void DS3231Component::setup() {
   }
 
   if (this->alarm_1_mode_.has_value()) {
-    this->set_alarm_1(this->alarm_1_mode_.value(), this->alarm_1_interrupt_anabled, this->alarm_1_second_,
+    this->set_alarm_1(this->alarm_1_mode_.value(), this->alarm_1_interrupt_anabled_, this->alarm_1_second_,
                       this->alarm_1_minute_, this->alarm_1_hour_, this->alarm_1_day_);
   }
   if (this->alarm_2_mode_.has_value()) {
-    this->set_alarm_2(this->alarm_2_mode_.value(), this->alarm_2_interrupt_anabled, this->alarm_2_minute_,
+    this->set_alarm_2(this->alarm_2_mode_.value(), this->alarm_2_interrupt_anabled_, this->alarm_2_minute_,
                       this->alarm_2_hour_, this->alarm_2_day_);
   }
   if (this->square_wave_frequency_.has_value()) {

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -1,0 +1,257 @@
+#include "ds3231.h"
+#include "esphome/core/log.h"
+
+// Datasheet:
+// - https://datasheets.maximintegrated.com/en/ds/DS1307.pdf
+
+namespace esphome {
+namespace ds3231 {
+
+static const char *const TAG = "ds3231";
+
+// DS3231 Register Addresses
+static const uint8_t DS3231_REGISTER_ADDRESS_RTC = 0x00;
+static const uint8_t DS3231_REGISTER_ADDRESS_ALARM = 0x07;
+static const uint8_t DS3231_REGISTER_ADDRESS_CONTROL = 0x0E;
+static const uint8_t DS3231_REGISTER_ADDRESS_STATUS = 0x0F;
+
+// Alarm Type Bit Masks
+static const uint8_t DS3231_MASK_ALARM_TYPE_M1 = 0x01;
+static const uint8_t DS3231_MASK_ALARM_TYPE_M2 = 0x02;
+static const uint8_t DS3231_MASK_ALARM_TYPE_M3 = 0x04;
+static const uint8_t DS3231_MASK_ALARM_TYPE_M4 = 0x08;
+static const uint8_t DS3231_MASK_ALARM_TYPE_DAY_MODE = 0x10;
+static const uint8_t DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE = 0x40;
+
+void DS3231Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up DS3231...");
+  if (!this->read_rtc_()) {
+    this->mark_failed();
+  }
+  if(!this->read_alarm_()) {
+    this->mark_failed();
+  }
+  if(!this->read_control_()) {
+    this->mark_failed();
+  }
+
+  if(!this->read_status_()) {
+    this->mark_failed();
+  }
+}
+
+void DS3231Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "DS3231:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with DS3231 failed!");
+  }
+}
+
+void DS3231Component::set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day) {
+  ds3231_.alrm.reg.a1_second = second % 10;
+  ds3231_.alrm.reg.a1_second_10 = second / 10;
+  ds3231_.alrm.reg.a1_m1 = alarm_type & DS3231_MASK_ALARM_TYPE_M1;
+  ds3231_.alrm.reg.a1_minute = minute % 10;
+  ds3231_.alrm.reg.a1_minute_10 = minute / 10;
+  ds3231_.alrm.reg.a1_m2 = alarm_type & DS3231_MASK_ALARM_TYPE_M2;
+  ds3231_.alrm.reg.a1_hour = hour % 10;
+  ds3231_.alrm.reg.a1_hour_10 = hour / 10;
+  ds3231_.alrm.reg.a1_m3 = alarm_type & DS3231_MASK_ALARM_TYPE_M3;
+  ds3231_.alrm.reg.a1_day = day % 10;
+  ds3231_.alrm.reg.a1_day_10 = day / 10;
+  ds3231_.alrm.reg.a1_day_mode = alarm_type & DS3231_MASK_ALARM_TYPE_DAY_MODE;
+  ds3231_.alrm.reg.a1_m4 = alarm_type & DS3231_MASK_ALARM_TYPE_M4;
+  this->write_alarm_();
+  if (ds3231_.ctrl.reg.alrm_1_int != bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE)) {
+    ds3231_.ctrl.reg.alrm_1_int = bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE);
+    this->write_control_();
+  }
+}
+
+void DS3231Component::reset_alarm_1() {
+  read_status_();
+  if (ds3231_.stat.reg.alrm_1_act) {
+    ds3231_.stat.reg.alrm_1_act = false;
+    write_status_();
+  }
+}
+
+void DS3231Component::set_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day) {
+  ds3231_.alrm.reg.a2_minute = minute % 10;
+  ds3231_.alrm.reg.a2_minute_10 = minute / 10;
+  ds3231_.alrm.reg.a2_m2 = alarm_type & DS3231_MASK_ALARM_TYPE_M2;
+  ds3231_.alrm.reg.a2_hour = hour % 10;
+  ds3231_.alrm.reg.a2_hour_10 = hour / 10;
+  ds3231_.alrm.reg.a2_m3 = alarm_type & DS3231_MASK_ALARM_TYPE_M3;
+  ds3231_.alrm.reg.a2_day = day % 10;
+  ds3231_.alrm.reg.a2_day_10 = day / 10;
+  ds3231_.alrm.reg.a2_day_mode = alarm_type & DS3231_MASK_ALARM_TYPE_DAY_MODE;
+  ds3231_.alrm.reg.a2_m4 = alarm_type & DS3231_MASK_ALARM_TYPE_M4;
+  this->write_alarm_();
+  if (ds3231_.ctrl.reg.alrm_2_int != bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE)) {
+    ds3231_.ctrl.reg.alrm_2_int = bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE);
+    this->write_control_();
+  }
+}
+
+void DS3231Component::reset_alarm_2() {
+  read_status_();
+  if (ds3231_.stat.reg.alrm_2_act) {
+    ds3231_.stat.reg.alrm_2_act = false;
+    write_status_();
+  }
+}
+
+void DS3231Component::set_square_wave_mode(DS3231SquareWaveMode mode) {
+  if (mode == DS3231SquareWaveMode::Interupt && !ds3231_.ctrl.reg.int_ctrl) {
+    ds3231_.ctrl.reg.int_ctrl = true;
+    this->write_control_();
+  }
+  else if (mode == DS3231SquareWaveMode::SquareWave && ds3231_.ctrl.reg.int_ctrl) {
+    ds3231_.ctrl.reg.int_ctrl = false;
+    this->write_control_();
+  }
+}
+
+void DS3231Component::set_square_wave_frequency(DS3231SquareWaveFrequency frequency) {
+  if (ds3231_.ctrl.reg.rs != frequency) {
+    ds3231_.ctrl.reg.rs = frequency;
+    this->write_control_();
+  }
+}
+
+bool DS3231Component::read_rtc_() {
+  if (!this->read_bytes(DS3231_REGISTER_ADDRESS_RTC, this->ds3231_.rtc.raw, sizeof(this->ds3231_.rtc.raw))) {
+    ESP_LOGE(TAG, "Can't read I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Read  %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u",
+           ds3231_.rtc.reg.hour_10, ds3231_.rtc.reg.hour,
+           ds3231_.rtc.reg.minute_10, ds3231_.rtc.reg.minute,
+           ds3231_.rtc.reg.second_10, ds3231_.rtc.reg.second,
+           ds3231_.rtc.reg.year_10, ds3231_.rtc.reg.year,
+           ds3231_.rtc.reg.month_10, ds3231_.rtc.reg.month,
+           ds3231_.rtc.reg.day_10, ds3231_.rtc.reg.day);
+  return true;
+}
+
+bool DS3231Component::write_rtc_() {
+  if (!this->write_bytes(DS3231_REGISTER_ADDRESS_RTC, this->ds3231_.rtc.raw, sizeof(this->ds3231_.rtc.raw))) {
+    ESP_LOGE(TAG, "Can't write I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Write %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u",
+           ds3231_.rtc.reg.hour_10, ds3231_.rtc.reg.hour,
+           ds3231_.rtc.reg.minute_10, ds3231_.rtc.reg.minute,
+           ds3231_.rtc.reg.second_10, ds3231_.rtc.reg.second,
+           ds3231_.rtc.reg.year_10, ds3231_.rtc.reg.year,
+           ds3231_.rtc.reg.month_10, ds3231_.rtc.reg.month,
+           ds3231_.rtc.reg.day_10, ds3231_.rtc.reg.day);
+  return true;
+}
+
+bool DS3231Component::read_alarm_() {
+  if (!this->read_bytes(DS3231_REGISTER_ADDRESS_ALARM, this->ds3231_.alrm.raw, sizeof(this->ds3231_.alrm.raw))) {
+    ESP_LOGE(TAG, "Can't read I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Read  Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
+           ds3231_.alrm.reg.a1_hour_10, ds3231_.alrm.reg.a1_hour,
+           ds3231_.alrm.reg.a1_minute_10, ds3231_.alrm.reg.a1_minute,
+           ds3231_.alrm.reg.a1_second_10, ds3231_.alrm.reg.a1_second,
+           ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
+           ds3231_.alrm.reg.a1_day_10, ds3231_.alrm.reg.a1_day,
+           ds3231_.alrm.reg.a1_m1, ds3231_.alrm.reg.a1_m2, ds3231_.alrm.reg.a1_m3, ds3231_.alrm.reg.a1_m4);
+  ESP_LOGD(TAG, "Read  Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u",
+           ds3231_.alrm.reg.a2_hour_10, ds3231_.alrm.reg.a2_hour,
+           ds3231_.alrm.reg.a2_minute_10, ds3231_.alrm.reg.a2_minute,
+           ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
+           ds3231_.alrm.reg.a2_day_10, ds3231_.alrm.reg.a2_day,
+           ds3231_.alrm.reg.a2_m2, ds3231_.alrm.reg.a2_m3, ds3231_.alrm.reg.a2_m4);
+  return true;
+}
+
+bool DS3231Component::write_alarm_() {
+  if (!this->write_bytes(DS3231_REGISTER_ADDRESS_ALARM, this->ds3231_.alrm.raw, sizeof(this->ds3231_.alrm.raw))) {
+    ESP_LOGE(TAG, "Can't write I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Write Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
+           ds3231_.alrm.reg.a1_hour_10, ds3231_.alrm.reg.a1_hour,
+           ds3231_.alrm.reg.a1_minute_10, ds3231_.alrm.reg.a1_minute,
+           ds3231_.alrm.reg.a1_second_10, ds3231_.alrm.reg.a1_second,
+           ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
+           ds3231_.alrm.reg.a1_day_10, ds3231_.alrm.reg.a1_day,
+           ds3231_.alrm.reg.a1_m1, ds3231_.alrm.reg.a1_m2, ds3231_.alrm.reg.a1_m3, ds3231_.alrm.reg.a1_m4);
+  ESP_LOGD(TAG, "Write Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u",
+           ds3231_.alrm.reg.a2_hour_10, ds3231_.alrm.reg.a2_hour,
+           ds3231_.alrm.reg.a2_minute_10, ds3231_.alrm.reg.a2_minute,
+           ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
+           ds3231_.alrm.reg.a2_day_10, ds3231_.alrm.reg.a2_day,
+           ds3231_.alrm.reg.a2_m2, ds3231_.alrm.reg.a2_m3, ds3231_.alrm.reg.a2_m4);
+  return true;
+}
+
+bool DS3231Component::read_control_() {
+  if (!this->read_bytes(DS3231_REGISTER_ADDRESS_CONTROL, this->ds3231_.ctrl.raw, sizeof(this->ds3231_.ctrl.raw))) {
+    ESP_LOGE(TAG, "Can't read I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Read  A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
+           ONOFF(ds3231_.ctrl.reg.alrm_1_int),
+           ONOFF(ds3231_.ctrl.reg.alrm_2_int),
+           ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
+           ds3231_.ctrl.reg.rs,
+           ONOFF(ds3231_.ctrl.reg.conv_tmp),
+           ONOFF(ds3231_.ctrl.reg.bat_sqw),
+           ONOFF(!ds3231_.ctrl.reg.osc_dis));
+  return true;
+}
+
+bool DS3231Component::write_control_() {
+  if (!this->write_bytes(DS3231_REGISTER_ADDRESS_CONTROL, this->ds3231_.ctrl.raw, sizeof(this->ds3231_.ctrl.raw))) {
+    ESP_LOGE(TAG, "Can't write I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Write A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
+           ONOFF(ds3231_.ctrl.reg.alrm_1_int),
+           ONOFF(ds3231_.ctrl.reg.alrm_2_int),
+           ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
+           ds3231_.ctrl.reg.rs,
+           ONOFF(ds3231_.ctrl.reg.conv_tmp),
+           ONOFF(ds3231_.ctrl.reg.bat_sqw),
+           ONOFF(!ds3231_.ctrl.reg.osc_dis));
+  return true;
+}
+
+bool DS3231Component::read_status_() {
+  if (!this->read_bytes(DS3231_REGISTER_ADDRESS_STATUS, this->ds3231_.stat.raw, sizeof(this->ds3231_.stat.raw))) {
+    ESP_LOGE(TAG, "Can't read I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Read  A1:%s A2:%s BSY:%s 32K:%s OSC:%s",
+           ONOFF(ds3231_.stat.reg.alrm_1_act),
+           ONOFF(ds3231_.stat.reg.alrm_2_act),
+           YESNO(ds3231_.stat.reg.busy),
+           ONOFF(ds3231_.stat.reg.en32khz),
+           ONOFF(!ds3231_.stat.reg.osc_stop));
+  return true;
+}
+
+bool DS3231Component::write_status_() {
+  if (!this->write_bytes(DS3231_REGISTER_ADDRESS_STATUS, this->ds3231_.stat.raw, sizeof(this->ds3231_.stat.raw))) {
+    ESP_LOGE(TAG, "Can't write I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Write A1:%s A2:%s BSY:%s 32K:%s OSC:%s",
+           ONOFF(ds3231_.stat.reg.alrm_1_act),
+           ONOFF(ds3231_.stat.reg.alrm_2_act),
+           YESNO(ds3231_.stat.reg.busy),
+           ONOFF(ds3231_.stat.reg.en32khz),
+           ONOFF(!ds3231_.stat.reg.osc_stop));
+  return true;
+}
+
+}  // namespace ds3231
+}  // namespace esphome

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -103,10 +103,10 @@ void DS3231Component::reset_alarm_2() {
 }
 
 void DS3231Component::set_square_wave_mode(DS3231SquareWaveMode mode) {
-  if (mode == DS3231SquareWaveMode::INTERRUPT_MODE && !this->ds3231_.ctrl.reg.int_ctrl) {
+  if (mode == DS3231SquareWaveMode::MODE_INTERRUPT && !this->ds3231_.ctrl.reg.int_ctrl) {
     this->ds3231_.ctrl.reg.int_ctrl = true;
     this->write_control_();
-  } else if (mode == DS3231SquareWaveMode::SQUARE_WAVE_MODE && this->ds3231_.ctrl.reg.int_ctrl) {
+  } else if (mode == DS3231SquareWaveMode::MODE_SQUARE_WAVE && this->ds3231_.ctrl.reg.int_ctrl) {
     this->ds3231_.ctrl.reg.int_ctrl = false;
     this->write_control_();
   }

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 // Datasheet:
-// - https://datasheets.maximintegrated.com/en/ds/DS1307.pdf
+// - https://datasheets.maximintegrated.com/en/ds/DS3231.pdf
 
 namespace esphome {
 namespace ds3231 {
@@ -49,74 +49,74 @@ void DS3231Component::dump_config() {
 }
 
 void DS3231Component::set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day) {
-  ds3231_.alrm.reg.a1_second = second % 10;
-  ds3231_.alrm.reg.a1_second_10 = second / 10;
-  ds3231_.alrm.reg.a1_m1 = alarm_type & DS3231_MASK_ALARM_TYPE_M1;
-  ds3231_.alrm.reg.a1_minute = minute % 10;
-  ds3231_.alrm.reg.a1_minute_10 = minute / 10;
-  ds3231_.alrm.reg.a1_m2 = alarm_type & DS3231_MASK_ALARM_TYPE_M2;
-  ds3231_.alrm.reg.a1_hour = hour % 10;
-  ds3231_.alrm.reg.a1_hour_10 = hour / 10;
-  ds3231_.alrm.reg.a1_m3 = alarm_type & DS3231_MASK_ALARM_TYPE_M3;
-  ds3231_.alrm.reg.a1_day = day % 10;
-  ds3231_.alrm.reg.a1_day_10 = day / 10;
-  ds3231_.alrm.reg.a1_day_mode = alarm_type & DS3231_MASK_ALARM_TYPE_DAY_MODE;
-  ds3231_.alrm.reg.a1_m4 = alarm_type & DS3231_MASK_ALARM_TYPE_M4;
+  this->ds3231_.alrm.reg.a1_second = second % 10;
+  this->ds3231_.alrm.reg.a1_second_10 = second / 10;
+  this->ds3231_.alrm.reg.a1_m1 = alarm_type & DS3231_MASK_ALARM_TYPE_M1;
+  this->ds3231_.alrm.reg.a1_minute = minute % 10;
+  this->ds3231_.alrm.reg.a1_minute_10 = minute / 10;
+  this->ds3231_.alrm.reg.a1_m2 = alarm_type & DS3231_MASK_ALARM_TYPE_M2;
+  this->ds3231_.alrm.reg.a1_hour = hour % 10;
+  this->ds3231_.alrm.reg.a1_hour_10 = hour / 10;
+  this->ds3231_.alrm.reg.a1_m3 = alarm_type & DS3231_MASK_ALARM_TYPE_M3;
+  this->ds3231_.alrm.reg.a1_day = day % 10;
+  this->ds3231_.alrm.reg.a1_day_10 = day / 10;
+  this->ds3231_.alrm.reg.a1_day_mode = alarm_type & DS3231_MASK_ALARM_TYPE_DAY_MODE;
+  this->ds3231_.alrm.reg.a1_m4 = alarm_type & DS3231_MASK_ALARM_TYPE_M4;
   this->write_alarm_();
-  if (ds3231_.ctrl.reg.alrm_1_int != bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE)) {
-    ds3231_.ctrl.reg.alrm_1_int = bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE);
+  if (this->ds3231_.ctrl.reg.alrm_1_int != bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE)) {
+    this->ds3231_.ctrl.reg.alrm_1_int = bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE);
     this->write_control_();
   }
 }
 
 void DS3231Component::reset_alarm_1() {
-  read_status_();
-  if (ds3231_.stat.reg.alrm_1_act) {
-    ds3231_.stat.reg.alrm_1_act = false;
-    write_status_();
+  this->read_status_();
+  if (this->ds3231_.stat.reg.alrm_1_act) {
+    this->ds3231_.stat.reg.alrm_1_act = false;
+    this->write_status_();
   }
 }
 
 void DS3231Component::set_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day) {
-  ds3231_.alrm.reg.a2_minute = minute % 10;
-  ds3231_.alrm.reg.a2_minute_10 = minute / 10;
-  ds3231_.alrm.reg.a2_m2 = alarm_type & DS3231_MASK_ALARM_TYPE_M2;
-  ds3231_.alrm.reg.a2_hour = hour % 10;
-  ds3231_.alrm.reg.a2_hour_10 = hour / 10;
-  ds3231_.alrm.reg.a2_m3 = alarm_type & DS3231_MASK_ALARM_TYPE_M3;
-  ds3231_.alrm.reg.a2_day = day % 10;
-  ds3231_.alrm.reg.a2_day_10 = day / 10;
-  ds3231_.alrm.reg.a2_day_mode = alarm_type & DS3231_MASK_ALARM_TYPE_DAY_MODE;
-  ds3231_.alrm.reg.a2_m4 = alarm_type & DS3231_MASK_ALARM_TYPE_M4;
+  this->ds3231_.alrm.reg.a2_minute = minute % 10;
+  this->ds3231_.alrm.reg.a2_minute_10 = minute / 10;
+  this->ds3231_.alrm.reg.a2_m2 = alarm_type & DS3231_MASK_ALARM_TYPE_M2;
+  this->ds3231_.alrm.reg.a2_hour = hour % 10;
+  this->ds3231_.alrm.reg.a2_hour_10 = hour / 10;
+  this->ds3231_.alrm.reg.a2_m3 = alarm_type & DS3231_MASK_ALARM_TYPE_M3;
+  this->ds3231_.alrm.reg.a2_day = day % 10;
+  this->ds3231_.alrm.reg.a2_day_10 = day / 10;
+  this->ds3231_.alrm.reg.a2_day_mode = alarm_type & DS3231_MASK_ALARM_TYPE_DAY_MODE;
+  this->ds3231_.alrm.reg.a2_m4 = alarm_type & DS3231_MASK_ALARM_TYPE_M4;
   this->write_alarm_();
-  if (ds3231_.ctrl.reg.alrm_2_int != bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE)) {
-    ds3231_.ctrl.reg.alrm_2_int = bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE);
+  if (this->ds3231_.ctrl.reg.alrm_2_int != bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE)) {
+    this->ds3231_.ctrl.reg.alrm_2_int = bool(alarm_type & DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE);
     this->write_control_();
   }
 }
 
 void DS3231Component::reset_alarm_2() {
-  read_status_();
-  if (ds3231_.stat.reg.alrm_2_act) {
-    ds3231_.stat.reg.alrm_2_act = false;
-    write_status_();
+  this->read_status_();
+  if (this->ds3231_.stat.reg.alrm_2_act) {
+    this->ds3231_.stat.reg.alrm_2_act = false;
+    this->write_status_();
   }
 }
 
 void DS3231Component::set_square_wave_mode(DS3231SquareWaveMode mode) {
-  if (mode == DS3231SquareWaveMode::Interupt && !ds3231_.ctrl.reg.int_ctrl) {
-    ds3231_.ctrl.reg.int_ctrl = true;
+  if (mode == DS3231SquareWaveMode::INTERRUPT_MODE && !this->ds3231_.ctrl.reg.int_ctrl) {
+    this->ds3231_.ctrl.reg.int_ctrl = true;
     this->write_control_();
   }
-  else if (mode == DS3231SquareWaveMode::SquareWave && ds3231_.ctrl.reg.int_ctrl) {
-    ds3231_.ctrl.reg.int_ctrl = false;
+  else if (mode == DS3231SquareWaveMode::SQUARE_WAVE_MODE && this->ds3231_.ctrl.reg.int_ctrl) {
+    this->ds3231_.ctrl.reg.int_ctrl = false;
     this->write_control_();
   }
 }
 
 void DS3231Component::set_square_wave_frequency(DS3231SquareWaveFrequency frequency) {
-  if (ds3231_.ctrl.reg.rs != frequency) {
-    ds3231_.ctrl.reg.rs = frequency;
+  if (this->ds3231_.ctrl.reg.rs != frequency) {
+    this->ds3231_.ctrl.reg.rs = frequency;
     this->write_control_();
   }
 }
@@ -127,12 +127,12 @@ bool DS3231Component::read_rtc_() {
     return false;
   }
   ESP_LOGD(TAG, "Read  %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u",
-           ds3231_.rtc.reg.hour_10, ds3231_.rtc.reg.hour,
-           ds3231_.rtc.reg.minute_10, ds3231_.rtc.reg.minute,
-           ds3231_.rtc.reg.second_10, ds3231_.rtc.reg.second,
-           ds3231_.rtc.reg.year_10, ds3231_.rtc.reg.year,
-           ds3231_.rtc.reg.month_10, ds3231_.rtc.reg.month,
-           ds3231_.rtc.reg.day_10, ds3231_.rtc.reg.day);
+           this->ds3231_.rtc.reg.hour_10, this->ds3231_.rtc.reg.hour,
+           this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
+           this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second,
+           this->ds3231_.rtc.reg.year_10, this->ds3231_.rtc.reg.year,
+           this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
+           this->ds3231_.rtc.reg.day_10, this->ds3231_.rtc.reg.day);
   return true;
 }
 
@@ -142,12 +142,12 @@ bool DS3231Component::write_rtc_() {
     return false;
   }
   ESP_LOGD(TAG, "Write %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u",
-           ds3231_.rtc.reg.hour_10, ds3231_.rtc.reg.hour,
-           ds3231_.rtc.reg.minute_10, ds3231_.rtc.reg.minute,
-           ds3231_.rtc.reg.second_10, ds3231_.rtc.reg.second,
-           ds3231_.rtc.reg.year_10, ds3231_.rtc.reg.year,
-           ds3231_.rtc.reg.month_10, ds3231_.rtc.reg.month,
-           ds3231_.rtc.reg.day_10, ds3231_.rtc.reg.day);
+           this->ds3231_.rtc.reg.hour_10, this->ds3231_.rtc.reg.hour,
+           this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
+           this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second,
+           this->ds3231_.rtc.reg.year_10, this->ds3231_.rtc.reg.year,
+           this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
+           this->ds3231_.rtc.reg.day_10, this->ds3231_.rtc.reg.day);
   return true;
 }
 
@@ -157,18 +157,19 @@ bool DS3231Component::read_alarm_() {
     return false;
   }
   ESP_LOGD(TAG, "Read  Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
-           ds3231_.alrm.reg.a1_hour_10, ds3231_.alrm.reg.a1_hour,
-           ds3231_.alrm.reg.a1_minute_10, ds3231_.alrm.reg.a1_minute,
-           ds3231_.alrm.reg.a1_second_10, ds3231_.alrm.reg.a1_second,
-           ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
-           ds3231_.alrm.reg.a1_day_10, ds3231_.alrm.reg.a1_day,
-           ds3231_.alrm.reg.a1_m1, ds3231_.alrm.reg.a1_m2, ds3231_.alrm.reg.a1_m3, ds3231_.alrm.reg.a1_m4);
+           this->ds3231_.alrm.reg.a1_hour_10, this->ds3231_.alrm.reg.a1_hour,
+           this->ds3231_.alrm.reg.a1_minute_10, this->ds3231_.alrm.reg.a1_minute,
+           this->ds3231_.alrm.reg.a1_second_10, this->ds3231_.alrm.reg.a1_second,
+           this->ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
+           this->ds3231_.alrm.reg.a1_day_10, this->ds3231_.alrm.reg.a1_day,
+           this->ds3231_.alrm.reg.a1_m1, this->ds3231_.alrm.reg.a1_m2,
+           this->ds3231_.alrm.reg.a1_m3, this->ds3231_.alrm.reg.a1_m4);
   ESP_LOGD(TAG, "Read  Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u",
-           ds3231_.alrm.reg.a2_hour_10, ds3231_.alrm.reg.a2_hour,
-           ds3231_.alrm.reg.a2_minute_10, ds3231_.alrm.reg.a2_minute,
-           ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
-           ds3231_.alrm.reg.a2_day_10, ds3231_.alrm.reg.a2_day,
-           ds3231_.alrm.reg.a2_m2, ds3231_.alrm.reg.a2_m3, ds3231_.alrm.reg.a2_m4);
+           this->ds3231_.alrm.reg.a2_hour_10, this->ds3231_.alrm.reg.a2_hour,
+           this->ds3231_.alrm.reg.a2_minute_10, this->ds3231_.alrm.reg.a2_minute,
+           this->ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
+           this->ds3231_.alrm.reg.a2_day_10, this->ds3231_.alrm.reg.a2_day,
+           this->ds3231_.alrm.reg.a2_m2, this->ds3231_.alrm.reg.a2_m3, this->ds3231_.alrm.reg.a2_m4);
   return true;
 }
 
@@ -178,18 +179,19 @@ bool DS3231Component::write_alarm_() {
     return false;
   }
   ESP_LOGD(TAG, "Write Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
-           ds3231_.alrm.reg.a1_hour_10, ds3231_.alrm.reg.a1_hour,
-           ds3231_.alrm.reg.a1_minute_10, ds3231_.alrm.reg.a1_minute,
-           ds3231_.alrm.reg.a1_second_10, ds3231_.alrm.reg.a1_second,
-           ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
-           ds3231_.alrm.reg.a1_day_10, ds3231_.alrm.reg.a1_day,
-           ds3231_.alrm.reg.a1_m1, ds3231_.alrm.reg.a1_m2, ds3231_.alrm.reg.a1_m3, ds3231_.alrm.reg.a1_m4);
+           this->ds3231_.alrm.reg.a1_hour_10, this->ds3231_.alrm.reg.a1_hour,
+           this->ds3231_.alrm.reg.a1_minute_10, this->ds3231_.alrm.reg.a1_minute,
+           this->ds3231_.alrm.reg.a1_second_10, this->ds3231_.alrm.reg.a1_second,
+           this->ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
+           this->ds3231_.alrm.reg.a1_day_10, this->ds3231_.alrm.reg.a1_day,
+           this->ds3231_.alrm.reg.a1_m1, this->ds3231_.alrm.reg.a1_m2,
+           this->ds3231_.alrm.reg.a1_m3, this->ds3231_.alrm.reg.a1_m4);
   ESP_LOGD(TAG, "Write Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u",
-           ds3231_.alrm.reg.a2_hour_10, ds3231_.alrm.reg.a2_hour,
-           ds3231_.alrm.reg.a2_minute_10, ds3231_.alrm.reg.a2_minute,
-           ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
-           ds3231_.alrm.reg.a2_day_10, ds3231_.alrm.reg.a2_day,
-           ds3231_.alrm.reg.a2_m2, ds3231_.alrm.reg.a2_m3, ds3231_.alrm.reg.a2_m4);
+           this->ds3231_.alrm.reg.a2_hour_10, this->ds3231_.alrm.reg.a2_hour,
+           this->ds3231_.alrm.reg.a2_minute_10, this->ds3231_.alrm.reg.a2_minute,
+           this->ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
+           this->ds3231_.alrm.reg.a2_day_10, this->ds3231_.alrm.reg.a2_day,
+           this->ds3231_.alrm.reg.a2_m2, this->ds3231_.alrm.reg.a2_m3, this->ds3231_.alrm.reg.a2_m4);
   return true;
 }
 
@@ -199,13 +201,13 @@ bool DS3231Component::read_control_() {
     return false;
   }
   ESP_LOGD(TAG, "Read  A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
-           ONOFF(ds3231_.ctrl.reg.alrm_1_int),
-           ONOFF(ds3231_.ctrl.reg.alrm_2_int),
-           ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
-           ds3231_.ctrl.reg.rs,
-           ONOFF(ds3231_.ctrl.reg.conv_tmp),
-           ONOFF(ds3231_.ctrl.reg.bat_sqw),
-           ONOFF(!ds3231_.ctrl.reg.osc_dis));
+           ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
+           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int),
+           this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
+           this->ds3231_.ctrl.reg.rs,
+           ONOFF(this->ds3231_.ctrl.reg.conv_tmp),
+           ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
+           ONOFF(!this->ds3231_.ctrl.reg.osc_dis));
   return true;
 }
 
@@ -215,13 +217,13 @@ bool DS3231Component::write_control_() {
     return false;
   }
   ESP_LOGD(TAG, "Write A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
-           ONOFF(ds3231_.ctrl.reg.alrm_1_int),
-           ONOFF(ds3231_.ctrl.reg.alrm_2_int),
-           ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
-           ds3231_.ctrl.reg.rs,
-           ONOFF(ds3231_.ctrl.reg.conv_tmp),
-           ONOFF(ds3231_.ctrl.reg.bat_sqw),
-           ONOFF(!ds3231_.ctrl.reg.osc_dis));
+           ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
+           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int),
+           this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
+           this->ds3231_.ctrl.reg.rs,
+           ONOFF(this->ds3231_.ctrl.reg.conv_tmp),
+           ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
+           ONOFF(!this->ds3231_.ctrl.reg.osc_dis));
   return true;
 }
 
@@ -231,11 +233,11 @@ bool DS3231Component::read_status_() {
     return false;
   }
   ESP_LOGD(TAG, "Read  A1:%s A2:%s BSY:%s 32K:%s OSC:%s",
-           ONOFF(ds3231_.stat.reg.alrm_1_act),
-           ONOFF(ds3231_.stat.reg.alrm_2_act),
-           YESNO(ds3231_.stat.reg.busy),
-           ONOFF(ds3231_.stat.reg.en32khz),
-           ONOFF(!ds3231_.stat.reg.osc_stop));
+           ONOFF(this->ds3231_.stat.reg.alrm_1_act),
+           ONOFF(this->ds3231_.stat.reg.alrm_2_act),
+           YESNO(this->ds3231_.stat.reg.busy),
+           ONOFF(this->ds3231_.stat.reg.en32khz),
+           ONOFF(!this->ds3231_.stat.reg.osc_stop));
   return true;
 }
 
@@ -245,11 +247,11 @@ bool DS3231Component::write_status_() {
     return false;
   }
   ESP_LOGD(TAG, "Write A1:%s A2:%s BSY:%s 32K:%s OSC:%s",
-           ONOFF(ds3231_.stat.reg.alrm_1_act),
-           ONOFF(ds3231_.stat.reg.alrm_2_act),
-           YESNO(ds3231_.stat.reg.busy),
-           ONOFF(ds3231_.stat.reg.en32khz),
-           ONOFF(!ds3231_.stat.reg.osc_stop));
+           ONOFF(this->ds3231_.stat.reg.alrm_1_act),
+           ONOFF(this->ds3231_.stat.reg.alrm_2_act),
+           YESNO(this->ds3231_.stat.reg.busy),
+           ONOFF(this->ds3231_.stat.reg.en32khz),
+           ONOFF(!this->ds3231_.stat.reg.osc_stop));
   return true;
 }
 

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -24,6 +24,22 @@ static const uint8_t DS3231_MASK_ALARM_TYPE_M4 = 0x08;
 static const uint8_t DS3231_MASK_ALARM_TYPE_DAY_MODE = 0x10;
 static const uint8_t DS3231_MASK_ALARM_TYPE_INTERRUPT_ENABLE = 0x40;
 
+void DS3231Component::set_default_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour,
+                                          uint8_t day) {
+  this->alarm_1_type_ = alarm_type;
+  this->alarm_1_second_ = second;
+  this->alarm_1_minute_ = minute;
+  this->alarm_1_hour_ = hour;
+  this->alarm_1_day_ = day;
+}
+
+void DS3231Component::set_default_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day) {
+  this->alarm_2_type_ = alarm_type;
+  this->alarm_2_minute_ = minute;
+  this->alarm_2_hour_ = hour;
+  this->alarm_2_day_ = day;
+}
+
 void DS3231Component::add_on_alarm_callback(std::function<void(uint8_t)> &&callback) {
   this->alarm_callback_.add(std::move(callback));
 }
@@ -39,9 +55,22 @@ void DS3231Component::setup() {
   if (!this->read_control_()) {
     this->mark_failed();
   }
-
   if (!this->read_status_()) {
     this->mark_failed();
+  }
+
+  if (this->alarm_1_type_.has_value()) {
+    this->set_alarm_1(this->alarm_1_type_.value(), this->alarm_1_second_, this->alarm_1_minute_, this->alarm_1_hour_,
+                      this->alarm_1_day_);
+  }
+  if (this->alarm_2_type_.has_value()) {
+    this->set_alarm_2(this->alarm_2_type_.value(), this->alarm_2_minute_, this->alarm_2_hour_, this->alarm_2_day_);
+  }
+  if (this->square_wave_frequency_.has_value()) {
+    this->set_square_wave_frequency(this->square_wave_frequency_.value());
+  }
+  if (this->square_wave_mode_.has_value()) {
+    this->set_square_wave_mode(this->square_wave_mode_.value());
   }
 }
 
@@ -104,7 +133,7 @@ void DS3231Component::reset_alarm_2() {
 }
 
 void DS3231Component::set_square_wave_mode(DS3231SquareWaveMode mode) {
-  if (mode == DS3231SquareWaveMode::MODE_INTERRUPT && !this->ds3231_.ctrl.reg.int_ctrl) {
+  if (mode == DS3231SquareWaveMode::MODE_ALARM_INTERRUPT && !this->ds3231_.ctrl.reg.int_ctrl) {
     this->ds3231_.ctrl.reg.int_ctrl = true;
     this->write_control_();
   } else if (mode == DS3231SquareWaveMode::MODE_SQUARE_WAVE && this->ds3231_.ctrl.reg.int_ctrl) {

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -189,9 +189,10 @@ bool DS3231Component::read_control_() {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read Control - A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s", ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
-           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int), this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
-           this->ds3231_.ctrl.reg.rs, ONOFF(this->ds3231_.ctrl.reg.conv_tmp), ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
+  ESP_LOGD(TAG, "Read Control - A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
+           ONOFF(this->ds3231_.ctrl.reg.alrm_1_int), ONOFF(this->ds3231_.ctrl.reg.alrm_2_int),
+           this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW", this->ds3231_.ctrl.reg.rs,
+           ONOFF(this->ds3231_.ctrl.reg.conv_tmp), ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
            ONOFF(!this->ds3231_.ctrl.reg.osc_dis));
   return true;
 }

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -14,6 +14,7 @@ static const uint8_t DS3231_REGISTER_ADDRESS_RTC = 0x00;
 static const uint8_t DS3231_REGISTER_ADDRESS_ALARM = 0x07;
 static const uint8_t DS3231_REGISTER_ADDRESS_CONTROL = 0x0E;
 static const uint8_t DS3231_REGISTER_ADDRESS_STATUS = 0x0F;
+static const uint8_t DS3231_REGISTER_ADDRESS_TEMP = 0x11;
 
 // Alarm Type Bit Masks
 static const uint8_t DS3231_MASK_ALARM_TYPE_M1 = 0x01;
@@ -124,7 +125,7 @@ bool DS3231Component::read_rtc_() {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read  %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u", this->ds3231_.rtc.reg.hour_10,
+  ESP_LOGD(TAG, "Read Time - %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u", this->ds3231_.rtc.reg.hour_10,
            this->ds3231_.rtc.reg.hour, this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
            this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second, this->ds3231_.rtc.reg.year_10,
            this->ds3231_.rtc.reg.year, this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
@@ -137,7 +138,7 @@ bool DS3231Component::write_rtc_() {
     ESP_LOGE(TAG, "Can't write I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Write %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u", this->ds3231_.rtc.reg.hour_10,
+  ESP_LOGD(TAG, "Write Time - %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u", this->ds3231_.rtc.reg.hour_10,
            this->ds3231_.rtc.reg.hour, this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
            this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second, this->ds3231_.rtc.reg.year_10,
            this->ds3231_.rtc.reg.year, this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
@@ -150,13 +151,13 @@ bool DS3231Component::read_alarm_() {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read  Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
+  ESP_LOGD(TAG, "Read Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
            this->ds3231_.alrm.reg.a1_hour_10, this->ds3231_.alrm.reg.a1_hour, this->ds3231_.alrm.reg.a1_minute_10,
            this->ds3231_.alrm.reg.a1_minute, this->ds3231_.alrm.reg.a1_second_10, this->ds3231_.alrm.reg.a1_second,
            this->ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW", this->ds3231_.alrm.reg.a1_day_10,
            this->ds3231_.alrm.reg.a1_day, this->ds3231_.alrm.reg.a1_m1, this->ds3231_.alrm.reg.a1_m2,
            this->ds3231_.alrm.reg.a1_m3, this->ds3231_.alrm.reg.a1_m4);
-  ESP_LOGD(TAG, "Read  Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u", this->ds3231_.alrm.reg.a2_hour_10,
+  ESP_LOGD(TAG, "Read Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u", this->ds3231_.alrm.reg.a2_hour_10,
            this->ds3231_.alrm.reg.a2_hour, this->ds3231_.alrm.reg.a2_minute_10, this->ds3231_.alrm.reg.a2_minute,
            this->ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW", this->ds3231_.alrm.reg.a2_day_10,
            this->ds3231_.alrm.reg.a2_day, this->ds3231_.alrm.reg.a2_m2, this->ds3231_.alrm.reg.a2_m3,
@@ -188,7 +189,7 @@ bool DS3231Component::read_control_() {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read  A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s", ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
+  ESP_LOGD(TAG, "Read Control - A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s", ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
            ONOFF(this->ds3231_.ctrl.reg.alrm_2_int), this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
            this->ds3231_.ctrl.reg.rs, ONOFF(this->ds3231_.ctrl.reg.conv_tmp), ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
            ONOFF(!this->ds3231_.ctrl.reg.osc_dis));
@@ -200,9 +201,10 @@ bool DS3231Component::write_control_() {
     ESP_LOGE(TAG, "Can't write I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Write A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s", ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
-           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int), this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
-           this->ds3231_.ctrl.reg.rs, ONOFF(this->ds3231_.ctrl.reg.conv_tmp), ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
+  ESP_LOGD(TAG, "Write Control -  A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
+           ONOFF(this->ds3231_.ctrl.reg.alrm_1_int), ONOFF(this->ds3231_.ctrl.reg.alrm_2_int),
+           this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW", this->ds3231_.ctrl.reg.rs,
+           ONOFF(this->ds3231_.ctrl.reg.conv_tmp), ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
            ONOFF(!this->ds3231_.ctrl.reg.osc_dis));
   return true;
 }
@@ -215,7 +217,7 @@ bool DS3231Component::read_status_(bool initial_read) {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read  A1:%s A2:%s BSY:%s 32K:%s OSC:%s", ONOFF(this->ds3231_.stat.reg.alrm_1_act),
+  ESP_LOGD(TAG, "Read Status - A1:%s A2:%s BSY:%s 32K:%s OSC:%s", ONOFF(this->ds3231_.stat.reg.alrm_1_act),
            ONOFF(this->ds3231_.stat.reg.alrm_2_act), YESNO(this->ds3231_.stat.reg.busy),
            ONOFF(this->ds3231_.stat.reg.en32khz), ONOFF(!this->ds3231_.stat.reg.osc_stop));
 
@@ -234,9 +236,18 @@ bool DS3231Component::write_status_() {
     ESP_LOGE(TAG, "Can't write I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Write A1:%s A2:%s BSY:%s 32K:%s OSC:%s", ONOFF(this->ds3231_.stat.reg.alrm_1_act),
+  ESP_LOGD(TAG, "Write Status - A1:%s A2:%s BSY:%s 32K:%s OSC:%s", ONOFF(this->ds3231_.stat.reg.alrm_1_act),
            ONOFF(this->ds3231_.stat.reg.alrm_2_act), YESNO(this->ds3231_.stat.reg.busy),
            ONOFF(this->ds3231_.stat.reg.en32khz), ONOFF(!this->ds3231_.stat.reg.osc_stop));
+  return true;
+}
+
+bool DS3231Component::read_temperature_() {
+  if (!this->read_bytes(DS3231_REGISTER_ADDRESS_TEMP, this->ds3231_.temp.raw, sizeof(this->ds3231_.temp.raw))) {
+    ESP_LOGE(TAG, "Can't read I2C data.");
+    return false;
+  }
+  ESP_LOGD(TAG, "Read Temperature - INT:%d FRAC:%d", this->ds3231_.temp.reg.upper, this->ds3231_.temp.reg.lower);
   return true;
 }
 

--- a/esphome/components/ds3231/ds3231.cpp
+++ b/esphome/components/ds3231/ds3231.cpp
@@ -28,14 +28,14 @@ void DS3231Component::setup() {
   if (!this->read_rtc_()) {
     this->mark_failed();
   }
-  if(!this->read_alarm_()) {
+  if (!this->read_alarm_()) {
     this->mark_failed();
   }
-  if(!this->read_control_()) {
+  if (!this->read_control_()) {
     this->mark_failed();
   }
 
-  if(!this->read_status_()) {
+  if (!this->read_status_()) {
     this->mark_failed();
   }
 }
@@ -48,7 +48,8 @@ void DS3231Component::dump_config() {
   }
 }
 
-void DS3231Component::set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day) {
+void DS3231Component::set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, 
+                                  uint8_t day) {
   this->ds3231_.alrm.reg.a1_second = second % 10;
   this->ds3231_.alrm.reg.a1_second_10 = second / 10;
   this->ds3231_.alrm.reg.a1_m1 = alarm_type & DS3231_MASK_ALARM_TYPE_M1;
@@ -107,8 +108,7 @@ void DS3231Component::set_square_wave_mode(DS3231SquareWaveMode mode) {
   if (mode == DS3231SquareWaveMode::INTERRUPT_MODE && !this->ds3231_.ctrl.reg.int_ctrl) {
     this->ds3231_.ctrl.reg.int_ctrl = true;
     this->write_control_();
-  }
-  else if (mode == DS3231SquareWaveMode::SQUARE_WAVE_MODE && this->ds3231_.ctrl.reg.int_ctrl) {
+  } else if (mode == DS3231SquareWaveMode::SQUARE_WAVE_MODE && this->ds3231_.ctrl.reg.int_ctrl) {
     this->ds3231_.ctrl.reg.int_ctrl = false;
     this->write_control_();
   }
@@ -126,12 +126,10 @@ bool DS3231Component::read_rtc_() {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read  %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u",
-           this->ds3231_.rtc.reg.hour_10, this->ds3231_.rtc.reg.hour,
-           this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
-           this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second,
-           this->ds3231_.rtc.reg.year_10, this->ds3231_.rtc.reg.year,
-           this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
+  ESP_LOGD(TAG, "Read  %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u", this->ds3231_.rtc.reg.hour_10,
+           this->ds3231_.rtc.reg.hour, this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
+           this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second, this->ds3231_.rtc.reg.year_10,
+           this->ds3231_.rtc.reg.year, this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
            this->ds3231_.rtc.reg.day_10, this->ds3231_.rtc.reg.day);
   return true;
 }
@@ -141,12 +139,10 @@ bool DS3231Component::write_rtc_() {
     ESP_LOGE(TAG, "Can't write I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Write %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u",
-           this->ds3231_.rtc.reg.hour_10, this->ds3231_.rtc.reg.hour,
-           this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
-           this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second,
-           this->ds3231_.rtc.reg.year_10, this->ds3231_.rtc.reg.year,
-           this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
+  ESP_LOGD(TAG, "Write %0u%0u:%0u%0u:%0u%0u 20%0u%0u-%0u%0u-%0u%0u", this->ds3231_.rtc.reg.hour_10,
+           this->ds3231_.rtc.reg.hour, this->ds3231_.rtc.reg.minute_10, this->ds3231_.rtc.reg.minute,
+           this->ds3231_.rtc.reg.second_10, this->ds3231_.rtc.reg.second, this->ds3231_.rtc.reg.year_10,
+           this->ds3231_.rtc.reg.year, this->ds3231_.rtc.reg.month_10, this->ds3231_.rtc.reg.month,
            this->ds3231_.rtc.reg.day_10, this->ds3231_.rtc.reg.day);
   return true;
 }
@@ -157,19 +153,16 @@ bool DS3231Component::read_alarm_() {
     return false;
   }
   ESP_LOGD(TAG, "Read  Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
-           this->ds3231_.alrm.reg.a1_hour_10, this->ds3231_.alrm.reg.a1_hour,
-           this->ds3231_.alrm.reg.a1_minute_10, this->ds3231_.alrm.reg.a1_minute,
-           this->ds3231_.alrm.reg.a1_second_10, this->ds3231_.alrm.reg.a1_second,
-           this->ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
-           this->ds3231_.alrm.reg.a1_day_10, this->ds3231_.alrm.reg.a1_day,
-           this->ds3231_.alrm.reg.a1_m1, this->ds3231_.alrm.reg.a1_m2,
+           this->ds3231_.alrm.reg.a1_hour_10, this->ds3231_.alrm.reg.a1_hour, this->ds3231_.alrm.reg.a1_minute_10,
+           this->ds3231_.alrm.reg.a1_minute, this->ds3231_.alrm.reg.a1_second_10, this->ds3231_.alrm.reg.a1_second,
+           this->ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW", this->ds3231_.alrm.reg.a1_day_10,
+           this->ds3231_.alrm.reg.a1_day, this->ds3231_.alrm.reg.a1_m1, this->ds3231_.alrm.reg.a1_m2,
            this->ds3231_.alrm.reg.a1_m3, this->ds3231_.alrm.reg.a1_m4);
-  ESP_LOGD(TAG, "Read  Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u",
-           this->ds3231_.alrm.reg.a2_hour_10, this->ds3231_.alrm.reg.a2_hour,
-           this->ds3231_.alrm.reg.a2_minute_10, this->ds3231_.alrm.reg.a2_minute,
-           this->ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
-           this->ds3231_.alrm.reg.a2_day_10, this->ds3231_.alrm.reg.a2_day,
-           this->ds3231_.alrm.reg.a2_m2, this->ds3231_.alrm.reg.a2_m3, this->ds3231_.alrm.reg.a2_m4);
+  ESP_LOGD(TAG, "Read  Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u", this->ds3231_.alrm.reg.a2_hour_10,
+           this->ds3231_.alrm.reg.a2_hour, this->ds3231_.alrm.reg.a2_minute_10, this->ds3231_.alrm.reg.a2_minute,
+           this->ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW", this->ds3231_.alrm.reg.a2_day_10,
+           this->ds3231_.alrm.reg.a2_day, this->ds3231_.alrm.reg.a2_m2, this->ds3231_.alrm.reg.a2_m3,
+           this->ds3231_.alrm.reg.a2_m4);
   return true;
 }
 
@@ -179,19 +172,16 @@ bool DS3231Component::write_alarm_() {
     return false;
   }
   ESP_LOGD(TAG, "Write Alarm1 - %0u%0u:%0u%0u:%0u%0u %s:%0u%0u M1:%0u M2:%0u M3:%0u M4:%0u",
-           this->ds3231_.alrm.reg.a1_hour_10, this->ds3231_.alrm.reg.a1_hour,
-           this->ds3231_.alrm.reg.a1_minute_10, this->ds3231_.alrm.reg.a1_minute,
-           this->ds3231_.alrm.reg.a1_second_10, this->ds3231_.alrm.reg.a1_second,
-           this->ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW",
-           this->ds3231_.alrm.reg.a1_day_10, this->ds3231_.alrm.reg.a1_day,
-           this->ds3231_.alrm.reg.a1_m1, this->ds3231_.alrm.reg.a1_m2,
+           this->ds3231_.alrm.reg.a1_hour_10, this->ds3231_.alrm.reg.a1_hour, this->ds3231_.alrm.reg.a1_minute_10,
+           this->ds3231_.alrm.reg.a1_minute, this->ds3231_.alrm.reg.a1_second_10, this->ds3231_.alrm.reg.a1_second,
+           this->ds3231_.alrm.reg.a1_day_mode == 0 ? "DoM" : "DoW", this->ds3231_.alrm.reg.a1_day_10,
+           this->ds3231_.alrm.reg.a1_day, this->ds3231_.alrm.reg.a1_m1, this->ds3231_.alrm.reg.a1_m2,
            this->ds3231_.alrm.reg.a1_m3, this->ds3231_.alrm.reg.a1_m4);
-  ESP_LOGD(TAG, "Write Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u",
-           this->ds3231_.alrm.reg.a2_hour_10, this->ds3231_.alrm.reg.a2_hour,
-           this->ds3231_.alrm.reg.a2_minute_10, this->ds3231_.alrm.reg.a2_minute,
-           this->ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW",
-           this->ds3231_.alrm.reg.a2_day_10, this->ds3231_.alrm.reg.a2_day,
-           this->ds3231_.alrm.reg.a2_m2, this->ds3231_.alrm.reg.a2_m3, this->ds3231_.alrm.reg.a2_m4);
+  ESP_LOGD(TAG, "Write Alarm2 - %0u%0u:%0u%0u %s:%0u%0u M2:%0u M3:%0u M4:%0u", this->ds3231_.alrm.reg.a2_hour_10,
+           this->ds3231_.alrm.reg.a2_hour, this->ds3231_.alrm.reg.a2_minute_10, this->ds3231_.alrm.reg.a2_minute,
+           this->ds3231_.alrm.reg.a2_day_mode == 0 ? "DoM" : "DoW", this->ds3231_.alrm.reg.a2_day_10,
+           this->ds3231_.alrm.reg.a2_day, this->ds3231_.alrm.reg.a2_m2, this->ds3231_.alrm.reg.a2_m3,
+           this->ds3231_.alrm.reg.a2_m4);
   return true;
 }
 
@@ -200,13 +190,9 @@ bool DS3231Component::read_control_() {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read  A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
-           ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
-           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int),
-           this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
-           this->ds3231_.ctrl.reg.rs,
-           ONOFF(this->ds3231_.ctrl.reg.conv_tmp),
-           ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
+  ESP_LOGD(TAG, "Read  A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s", ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
+           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int), this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
+           this->ds3231_.ctrl.reg.rs, ONOFF(this->ds3231_.ctrl.reg.conv_tmp), ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
            ONOFF(!this->ds3231_.ctrl.reg.osc_dis));
   return true;
 }
@@ -216,13 +202,9 @@ bool DS3231Component::write_control_() {
     ESP_LOGE(TAG, "Can't write I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Write A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s",
-           ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
-           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int),
-           this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
-           this->ds3231_.ctrl.reg.rs,
-           ONOFF(this->ds3231_.ctrl.reg.conv_tmp),
-           ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
+  ESP_LOGD(TAG, "Write A1I:%s A2I:%s INT_SQW:%s RS:%0u CT:%s BSQW:%s OSC:%s", ONOFF(this->ds3231_.ctrl.reg.alrm_1_int),
+           ONOFF(this->ds3231_.ctrl.reg.alrm_2_int), this->ds3231_.ctrl.reg.int_ctrl ? "INT" : "SQW",
+           this->ds3231_.ctrl.reg.rs, ONOFF(this->ds3231_.ctrl.reg.conv_tmp), ONOFF(this->ds3231_.ctrl.reg.bat_sqw),
            ONOFF(!this->ds3231_.ctrl.reg.osc_dis));
   return true;
 }
@@ -232,12 +214,9 @@ bool DS3231Component::read_status_() {
     ESP_LOGE(TAG, "Can't read I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Read  A1:%s A2:%s BSY:%s 32K:%s OSC:%s",
-           ONOFF(this->ds3231_.stat.reg.alrm_1_act),
-           ONOFF(this->ds3231_.stat.reg.alrm_2_act),
-           YESNO(this->ds3231_.stat.reg.busy),
-           ONOFF(this->ds3231_.stat.reg.en32khz),
-           ONOFF(!this->ds3231_.stat.reg.osc_stop));
+  ESP_LOGD(TAG, "Read  A1:%s A2:%s BSY:%s 32K:%s OSC:%s", ONOFF(this->ds3231_.stat.reg.alrm_1_act),
+           ONOFF(this->ds3231_.stat.reg.alrm_2_act), YESNO(this->ds3231_.stat.reg.busy),
+           ONOFF(this->ds3231_.stat.reg.en32khz), ONOFF(!this->ds3231_.stat.reg.osc_stop));
   return true;
 }
 
@@ -246,12 +225,9 @@ bool DS3231Component::write_status_() {
     ESP_LOGE(TAG, "Can't write I2C data.");
     return false;
   }
-  ESP_LOGD(TAG, "Write A1:%s A2:%s BSY:%s 32K:%s OSC:%s",
-           ONOFF(this->ds3231_.stat.reg.alrm_1_act),
-           ONOFF(this->ds3231_.stat.reg.alrm_2_act),
-           YESNO(this->ds3231_.stat.reg.busy),
-           ONOFF(this->ds3231_.stat.reg.en32khz),
-           ONOFF(!this->ds3231_.stat.reg.osc_stop));
+  ESP_LOGD(TAG, "Write A1:%s A2:%s BSY:%s 32K:%s OSC:%s", ONOFF(this->ds3231_.stat.reg.alrm_1_act),
+           ONOFF(this->ds3231_.stat.reg.alrm_2_act), YESNO(this->ds3231_.stat.reg.busy),
+           ONOFF(this->ds3231_.stat.reg.en32khz), ONOFF(!this->ds3231_.stat.reg.osc_stop));
   return true;
 }
 

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -51,6 +51,7 @@ class DS3231RTC;
 
 class DS3231Component : public PollingComponent, public i2c::I2CDevice {
  public:
+  void add_on_alarm_callback(std::function<void(uint8_t)> &&callback);
   float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
@@ -71,8 +72,11 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
   bool write_alarm_();
   bool read_control_();
   bool write_control_();
-  bool read_status_();
+  bool read_status_(bool initial_read = false);
   bool write_status_();
+  CallbackManager<void(uint8_t)> alarm_callback_{};
+  bool alarm_1_act_;
+  bool alarm_2_act_;
   struct DS3231Reg {
     union DS3231RTC {
       struct {

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -8,32 +8,21 @@
 namespace esphome {
 namespace ds3231 {
 
-enum DS3231Alarm1Type {
+enum DS3231Alarm1Mode {
   EVERY_SECOND = 0x0F,
-  EVERY_SECOND_WITH_INTERRUPT = 0x4F,
   MATCH_SECOND = 0x0E,
-  MATCH_SECOND_WITH_INTERRUPT = 0x4E,
   MATCH_MINUTE_SECOND = 0x0C,
-  MATCH_MINUTE_SECOND_WITH_INTERRUPT = 0x4C,
   MATCH_HOUR_MINUTE_SECOND = 0x08,
-  MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT = 0x48,
   MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND = 0x00,
-  MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT = 0x40,
   MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND = 0x10,
-  MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT = 0x50,
 };
 
-enum DS3231Alarm2Type {
+enum DS3231Alarm2Mode {
   EVERY_MINUTE = 0x0E,
-  EVERY_MINUTE_WITH_INTERRUPT = 0x4E,
   MATCH_MINUTE = 0x0C,
-  MATCH_MINUTE_WITH_INTERRUPT = 0x4C,
   MATCH_HOUR_MINUTE = 0x08,
-  MATCH_HOUR_MINUTE_WITH_INTERRUPT = 0x48,
   MATCH_DAY_OF_MONTH_HOUR_MINUTE = 0x00,
-  MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT = 0x40,
   MATCH_DAY_OF_WEEK_HOUR_MINUTE = 0x10,
-  MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT = 0x50,
 };
 
 enum DS3231SquareWaveMode {
@@ -54,8 +43,9 @@ class DS3231Sensor;
 
 class DS3231Component : public PollingComponent, public i2c::I2CDevice {
  public:
-  void set_default_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day);
-  void set_default_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day);
+  void set_default_alarm_1(DS3231Alarm1Mode mode, bool int_enabled, uint8_t second, uint8_t minute, uint8_t hour,
+                           uint8_t day);
+  void set_default_alarm_2(DS3231Alarm2Mode mode, bool int_enabled, uint8_t minute, uint8_t hour, uint8_t day);
   void set_default_square_wave_mode(DS3231SquareWaveMode mode) { this->square_wave_mode_ = mode; }
   void set_default_square_wave_frequency(DS3231SquareWaveFrequency frequency) {
     this->square_wave_frequency_ = frequency;
@@ -66,9 +56,9 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   void update() override { this->read_status_(); }
 
-  void set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day);
+  void set_alarm_1(DS3231Alarm1Mode mode, bool int_enabled, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day);
   void reset_alarm_1();
-  void set_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day);
+  void set_alarm_2(DS3231Alarm2Mode mode, bool int_enabled, uint8_t minute, uint8_t hour, uint8_t day);
   void reset_alarm_2();
   void set_square_wave_mode(DS3231SquareWaveMode mode);
   void set_square_wave_frequency(DS3231SquareWaveFrequency frequency);
@@ -88,12 +78,14 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
   bool read_temperature_();
   CallbackManager<void(uint8_t)> alarm_callback_{};
 
-  optional<DS3231Alarm1Type> alarm_1_type_{};
+  optional<DS3231Alarm1Mode> alarm_1_mode_{};
+  bool alarm_1_interrupt_anabled;
   uint8_t alarm_1_second_;
   uint8_t alarm_1_minute_;
   uint8_t alarm_1_hour_;
   uint8_t alarm_1_day_;
-  optional<DS3231Alarm2Type> alarm_2_type_{};
+  optional<DS3231Alarm2Mode> alarm_2_mode_{};
+  bool alarm_2_interrupt_anabled;
   uint8_t alarm_2_minute_;
   uint8_t alarm_2_hour_;
   uint8_t alarm_2_day_;

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -38,7 +38,7 @@ enum DS3231Alarm2Type {
 
 enum DS3231SquareWaveMode {
   MODE_SQUARE_WAVE,
-  MODE_INTERRUPT,
+  MODE_ALARM_INTERRUPT,
 };
 
 enum DS3231SquareWaveFrequency {
@@ -54,6 +54,12 @@ class DS3231Sensor;
 
 class DS3231Component : public PollingComponent, public i2c::I2CDevice {
  public:
+  void set_default_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day);
+  void set_default_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day);
+  void set_default_square_wave_mode(DS3231SquareWaveMode mode) { this->square_wave_mode_ = mode; }
+  void set_default_square_wave_frequency(DS3231SquareWaveFrequency frequency) {
+    this->square_wave_frequency_ = frequency;
+  }
   void add_on_alarm_callback(std::function<void(uint8_t)> &&callback);
   float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
@@ -70,6 +76,7 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   friend DS3231RTC;
   friend DS3231Sensor;
+
   bool read_rtc_();
   bool write_rtc_();
   bool read_alarm_();
@@ -80,6 +87,18 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
   bool write_status_();
   bool read_temperature_();
   CallbackManager<void(uint8_t)> alarm_callback_{};
+
+  optional<DS3231Alarm1Type> alarm_1_type_{};
+  uint8_t alarm_1_second_;
+  uint8_t alarm_1_minute_;
+  uint8_t alarm_1_hour_;
+  uint8_t alarm_1_day_;
+  optional<DS3231Alarm2Type> alarm_2_type_{};
+  uint8_t alarm_2_minute_;
+  uint8_t alarm_2_hour_;
+  uint8_t alarm_2_day_;
+  optional<DS3231SquareWaveMode> square_wave_mode_;
+  optional<DS3231SquareWaveFrequency> square_wave_frequency_;
   bool alarm_1_act_;
   bool alarm_2_act_;
   struct DS3231Reg {

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -79,13 +79,13 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
   CallbackManager<void(uint8_t)> alarm_callback_{};
 
   optional<DS3231Alarm1Mode> alarm_1_mode_{};
-  bool alarm_1_interrupt_anabled;
+  bool alarm_1_interrupt_anabled_;
   uint8_t alarm_1_second_;
   uint8_t alarm_1_minute_;
   uint8_t alarm_1_hour_;
   uint8_t alarm_1_day_;
   optional<DS3231Alarm2Mode> alarm_2_mode_{};
-  bool alarm_2_interrupt_anabled;
+  bool alarm_2_interrupt_anabled_;
   uint8_t alarm_2_minute_;
   uint8_t alarm_2_hour_;
   uint8_t alarm_2_day_;

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -8,53 +8,54 @@ namespace esphome {
 namespace ds3231 {
 
 enum DS3231Alarm1Type {
-  EverySecond = 0x0F,
-  EverySecondWithInterupt = 0x4F,
-  MatchSecond = 0x0E,
-  MatchSecondWithInterupt = 0x4E,
-  MatchMinuteSecond = 0x0C,
-  MatchMinuteSecondWithInterupt = 0x4C,
-  MatchHourMinuteSecond = 0x08,
-  MatchHourMinuteSecondWithInterupt = 0x48,
-  MatchDayOfMonthHourMinuteSecond = 0x00,
-  MatchDayOfMonthHourMinuteSecondWithInterupt = 0x40,
-  MatchDayOfWeekHourMinuteSecond = 0x10,
-  MatchDayOfWeekHourMinuteSecondWithInterupt = 0x50,
+  EVERY_SECOND = 0x0F,
+  EVERY_SECOND_WITH_INTERRUPT = 0x4F,
+  MATCH_SECOND = 0x0E,
+  MATCH_SECOND_WITH_INTERRUPT = 0x4E,
+  MATCH_MINUTE_SECOND = 0x0C,
+  MATCH_MINUTE_SECOND_WITH_INTERRUPT = 0x4C,
+  MATCH_HOUR_MINUTE_SECOND = 0x08,
+  MATCH_HOUR_MINUTE_SECOND_WITH_INTERRUPT = 0x48,
+  MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND = 0x00,
+  MATCH_DAY_OF_MONTH_HOUR_MINUTE_SECOND_WITH_INTERRUPT = 0x40,
+  MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND = 0x10,
+  MATCH_DAY_OF_WEEK_HOUR_MINUTE_SECOND_WITH_INTERRUPT = 0x50,
 };
 
 enum DS3231Alarm2Type {
-  EveryMinute = 0x0E,
-  EveryMinuteWithInterupt = 0x4E,
-  MatchMinute = 0x0C,
-  MatchMinuteWithInterupt = 0x4C,
-  MatchHourMinute = 0x08,
-  MatchHourMinuteWithInterupt = 0x48,
-  MatchDayOfMonthHourMinute = 0x00,
-  MatchDayOfMonthHourMinuteWithInterupt = 0x40,
-  MatchDayOfWeekHourMinute = 0x10,
-  MatchDayOfWeekHourMinuteWithInterupt = 0x50,
+  EVERY_MINUTE = 0x0E,
+  EVERY_MINUTE_WITH_INTERRUPT = 0x4E,
+  MATCH_MINUTE = 0x0C,
+  MATCH_MINUTE_WITH_INTERRUPT = 0x4C,
+  MATCH_HOUR_MINUTE = 0x08,
+  MATCH_HOUR_MINUTE_WITH_INTERRUPT = 0x48,
+  MATCH_DAY_OF_MONTH_HOUR_MINUTE = 0x00,
+  MATCH_DAY_OF_MONTH_HOUR_MINUTE_WITH_INTERRUPT = 0x40,
+  MATCH_DAY_OF_WEEK_HOUR_MINUTE = 0x10,
+  MATCH_DAY_OF_WEEK_HOUR_MINUTE_WITH_INTERRUPT = 0x50,
 };
 
 enum DS3231SquareWaveMode {
-  SquareWave,
-  Interupt,
+  SQUARE_WAVE_MODE,
+  INTERRUPT_MODE,
 };
 
 enum DS3231SquareWaveFrequency {
-  Frequency1Hz = 0x00,
-  Frequency1024Hz = 0x01,
-  Frequency4096Hz = 0x02,
-  Frequency8192Hz = 0x03,
+  FREQUENCY_1_HZ = 0x00,
+  FREQUENCY_1024_HZ = 0x01,
+  FREQUENCY_4096_HZ = 0x02,
+  FREQUENCY_8192_HZ = 0x03,
 };
 
 class DS3231RTC;
 
 class DS3231Component : public PollingComponent, public i2c::I2CDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; };
+  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override { this->read_status_(); }
+  
   void set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day);
   void reset_alarm_1();
   void set_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day);
@@ -169,7 +170,7 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
 class DS3231RTC : public time::RealTimeClock {
  public:
   void set_ds3231_parent(DS3231Component *parent) { this->parent_ = parent; }
-  float get_setup_priority() const override { return setup_priority::DATA; };
+  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
   void update() override { this->read_time(); }
   void read_time();
@@ -177,16 +178,6 @@ class DS3231RTC : public time::RealTimeClock {
 
  protected:
   DS3231Component *parent_;
-};
-
-template<typename... Ts> class WriteTimeAction : public Action<Ts...>, public Parented<DS3231RTC> {
- public:
-  void play(Ts... x) override { this->parent_->write_time(); }
-};
-
-template<typename... Ts> class ReadTimeAction : public Action<Ts...>, public Parented<DS3231RTC> {
- public:
-  void play(Ts... x) override { this->parent_->read_time(); }
 };
 
 }  // namespace ds3231

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/time/real_time_clock.h"
+
+namespace esphome {
+namespace ds3231 {
+
+enum DS3231Alarm1Type {
+  EverySecond = 0x0F,
+  EverySecondWithInterupt = 0x4F,
+  MatchSecond = 0x0E,
+  MatchSecondWithInterupt = 0x4E,
+  MatchMinuteSecond = 0x0C,
+  MatchMinuteSecondWithInterupt = 0x4C,
+  MatchHourMinuteSecond = 0x08,
+  MatchHourMinuteSecondWithInterupt = 0x48,
+  MatchDayOfMonthHourMinuteSecond = 0x00,
+  MatchDayOfMonthHourMinuteSecondWithInterupt = 0x40,
+  MatchDayOfWeekHourMinuteSecond = 0x10,
+  MatchDayOfWeekHourMinuteSecondWithInterupt = 0x50,
+};
+
+enum DS3231Alarm2Type {
+  EveryMinute = 0x0E,
+  EveryMinuteWithInterupt = 0x4E,
+  MatchMinute = 0x0C,
+  MatchMinuteWithInterupt = 0x4C,
+  MatchHourMinute = 0x08,
+  MatchHourMinuteWithInterupt = 0x48,
+  MatchDayOfMonthHourMinute = 0x00,
+  MatchDayOfMonthHourMinuteWithInterupt = 0x40,
+  MatchDayOfWeekHourMinute = 0x10,
+  MatchDayOfWeekHourMinuteWithInterupt = 0x50,
+};
+
+enum DS3231SquareWaveMode {
+  SquareWave,
+  Interupt,
+};
+
+enum DS3231SquareWaveFrequency {
+  Frequency1Hz = 0x00,
+  Frequency1024Hz = 0x01,
+  Frequency4096Hz = 0x02,
+  Frequency8192Hz = 0x03,
+};
+
+class DS3231RTC;
+
+class DS3231Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  float get_setup_priority() const override { return setup_priority::DATA; };
+  void setup() override;
+  void dump_config() override;
+  void update() override { this->read_status_(); }
+  void set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day);
+  void reset_alarm_1();
+  void set_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day);
+  void reset_alarm_2();
+  void set_square_wave_mode(DS3231SquareWaveMode mode);
+  void set_square_wave_frequency(DS3231SquareWaveFrequency frequency);
+
+ protected:
+  friend DS3231RTC;
+  bool read_rtc_();
+  bool write_rtc_();
+  bool read_alarm_();
+  bool write_alarm_();
+  bool read_control_();
+  bool write_control_();
+  bool read_status_();
+  bool write_status_();
+  struct DS3231Reg {
+    union DS3231RTC {
+      struct {
+        uint8_t second : 4;
+        uint8_t second_10 : 3;
+        uint8_t unused_1 : 1;
+
+        uint8_t minute : 4;
+        uint8_t minute_10 : 3;
+        uint8_t unused_2 : 1;
+
+        uint8_t hour : 4;
+        uint8_t hour_10 : 2;
+        uint8_t unused_3 : 2;
+
+        uint8_t weekday : 3;
+        uint8_t unused_4 : 5;
+
+        uint8_t day : 4;
+        uint8_t day_10 : 2;
+        uint8_t unused_5 : 2;
+
+        uint8_t month : 4;
+        uint8_t month_10 : 1;
+        uint8_t unused_6 : 2;
+        uint8_t cent : 1;
+
+        uint8_t year : 4;
+        uint8_t year_10 : 4;
+      } reg;
+      mutable uint8_t raw[sizeof(reg)];
+    } rtc;
+    union DS3231Alrm {
+      struct {
+        uint8_t a1_second : 4;
+        uint8_t a1_second_10 : 3;
+        bool a1_m1 : 1;
+
+        uint8_t a1_minute : 4;
+        uint8_t a1_minute_10 : 3;
+        bool a1_m2 : 1;
+
+        uint8_t a1_hour : 4;
+        uint8_t a1_hour_10 : 2;
+        uint8_t unused_1 : 1;
+        bool a1_m3 : 1;
+
+        uint8_t a1_day : 4;
+        uint8_t a1_day_10 : 2;
+        uint8_t a1_day_mode : 1;
+        bool a1_m4 : 1;
+
+        uint8_t a2_minute : 4;
+        uint8_t a2_minute_10 : 3;
+        bool a2_m2 : 1;
+
+        uint8_t a2_hour : 4;
+        uint8_t a2_hour_10 : 2;
+        uint8_t unused_2 : 1;
+        bool a2_m3 : 1;
+
+        uint8_t a2_day : 4;
+        uint8_t a2_day_10 : 2;
+        uint8_t a2_day_mode : 1;
+        bool a2_m4 : 1;
+      } reg;
+      mutable uint8_t raw[sizeof(reg)];
+    } alrm;
+    union DS3231Ctrl {
+      struct {
+        bool alrm_1_int : 1;
+        bool alrm_2_int : 1;
+        bool int_ctrl : 1;
+        uint8_t rs : 2;
+        bool conv_tmp : 1;
+        bool bat_sqw : 1;
+        bool osc_dis : 1;
+      } reg;
+      mutable uint8_t raw[sizeof(reg)];
+    } ctrl;
+    union DS3231Stat {
+      struct {
+        bool alrm_1_act : 1;
+        bool alrm_2_act : 1;
+        bool busy : 1;
+        bool en32khz : 1;
+        uint8_t unused : 3;
+        bool osc_stop : 1;
+      } reg;
+    mutable uint8_t raw[sizeof(reg)];
+    } stat;
+  } ds3231_;
+};
+
+class DS3231RTC : public time::RealTimeClock {
+ public:
+  void set_ds3231_parent(DS3231Component *parent) { this->parent_ = parent; }
+  float get_setup_priority() const override { return setup_priority::DATA; };
+  void dump_config() override;
+  void update() override { this->read_time(); }
+  void read_time();
+  void write_time();
+
+ protected:
+  DS3231Component *parent_;
+};
+
+template<typename... Ts> class WriteTimeAction : public Action<Ts...>, public Parented<DS3231RTC> {
+ public:
+  void play(Ts... x) override { this->parent_->write_time(); }
+};
+
+template<typename... Ts> class ReadTimeAction : public Action<Ts...>, public Parented<DS3231RTC> {
+ public:
+  void play(Ts... x) override { this->parent_->read_time(); }
+};
+
+}  // namespace ds3231
+}  // namespace esphome

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -36,8 +36,8 @@ enum DS3231Alarm2Type {
 };
 
 enum DS3231SquareWaveMode {
-  SQUARE_WAVE_MODE,
-  INTERRUPT_MODE,
+  MODE_SQUARE_WAVE,
+  MODE_INTERRUPT,
 };
 
 enum DS3231SquareWaveFrequency {

--- a/esphome/components/ds3231/ds3231.h
+++ b/esphome/components/ds3231/ds3231.h
@@ -55,7 +55,7 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   void update() override { this->read_status_(); }
-  
+
   void set_alarm_1(DS3231Alarm1Type alarm_type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day);
   void reset_alarm_1();
   void set_alarm_2(DS3231Alarm2Type alarm_type, uint8_t minute, uint8_t hour, uint8_t day);
@@ -162,7 +162,7 @@ class DS3231Component : public PollingComponent, public i2c::I2CDevice {
         uint8_t unused : 3;
         bool osc_stop : 1;
       } reg;
-    mutable uint8_t raw[sizeof(reg)];
+      mutable uint8_t raw[sizeof(reg)];
     } stat;
   } ds3231_;
 };

--- a/esphome/components/ds3231/ds3231_rtc.cpp
+++ b/esphome/components/ds3231/ds3231_rtc.cpp
@@ -6,9 +6,7 @@ namespace ds3231 {
 
 static const char *const TAG = "ds3231.rtc";
 
-void DS3231RTC::dump_config() {
-  ESP_LOGCONFIG(TAG, "DS3231 Timezone: '%s'", this->timezone_.c_str());
-}
+void DS3231RTC::dump_config() { ESP_LOGCONFIG(TAG, "DS3231 Timezone: '%s'", this->timezone_.c_str()); }
 
 void DS3231RTC::read_time() {
   if (!this->parent_->read_status_()) {
@@ -24,14 +22,14 @@ void DS3231RTC::read_time() {
     return;
   }
   time::ESPTime rtc_time{
-    .second = uint8_t(this->parent_->ds3231_.rtc.reg.second + 10 * this->parent_->ds3231_.rtc.reg.second_10),
-    .minute = uint8_t(this->parent_->ds3231_.rtc.reg.minute + 10u * this->parent_->ds3231_.rtc.reg.minute_10),
-    .hour = uint8_t(this->parent_->ds3231_.rtc.reg.hour + 10u * this->parent_->ds3231_.rtc.reg.hour_10),
-    .day_of_week = uint8_t(this->parent_->ds3231_.rtc.reg.weekday),
-    .day_of_month = uint8_t(this->parent_->ds3231_.rtc.reg.day + 10u * this->parent_->ds3231_.rtc.reg.day_10),
-    .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
-    .month = uint8_t(this->parent_->ds3231_.rtc.reg.month + 10u * this->parent_->ds3231_.rtc.reg.month_10),
-    .year = uint16_t(this->parent_->ds3231_.rtc.reg.year + 10u * this->parent_->ds3231_.rtc.reg.year_10 + 2000)
+      .second = uint8_t(this->parent_->ds3231_.rtc.reg.second + 10 * this->parent_->ds3231_.rtc.reg.second_10),
+      .minute = uint8_t(this->parent_->ds3231_.rtc.reg.minute + 10u * this->parent_->ds3231_.rtc.reg.minute_10),
+      .hour = uint8_t(this->parent_->ds3231_.rtc.reg.hour + 10u * this->parent_->ds3231_.rtc.reg.hour_10),
+      .day_of_week = uint8_t(this->parent_->ds3231_.rtc.reg.weekday),
+      .day_of_month = uint8_t(this->parent_->ds3231_.rtc.reg.day + 10u * this->parent_->ds3231_.rtc.reg.day_10),
+      .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
+      .month = uint8_t(this->parent_->ds3231_.rtc.reg.month + 10u * this->parent_->ds3231_.rtc.reg.month_10),
+      .year = uint16_t(this->parent_->ds3231_.rtc.reg.year + 10u * this->parent_->ds3231_.rtc.reg.year_10 + 2000)
   };
   rtc_time.recalc_timestamp_utc(false);
   if (!rtc_time.is_valid()) {

--- a/esphome/components/ds3231/ds3231_rtc.cpp
+++ b/esphome/components/ds3231/ds3231_rtc.cpp
@@ -1,0 +1,82 @@
+#include "ds3231.h"
+#include "esphome/core/log.h"
+
+// Datasheet:
+// - https://datasheets.maximintegrated.com/en/ds/DS1307.pdf
+
+namespace esphome {
+namespace ds3231 {
+
+static const char *const TAG = "ds3231.rtc";
+
+void DS3231RTC::dump_config() {
+  ESP_LOGCONFIG(TAG, "  Timezone: '%s'", this->timezone_.c_str());
+}
+
+void DS3231RTC::read_time() {
+  if (!this->parent_->read_stat_()) {
+    ESP_LOGE(TAG, "Failed to read status, not syncing to system clock.");
+    return;
+  }
+  if (this->parent_->ds3231_.stat.reg.osc_stop) {
+    ESP_LOGW(TAG, "RTC halted, not syncing to system clock.");
+    return;
+  }
+  if (!this->parent_->read_rtc_()) {
+    ESP_LOGE(TAG, "Failed to read rtc, not syncing to system clock.");
+    return;
+  }
+  time::ESPTime rtc_time{
+    .second = uint8_t(this->parent_->ds3231_.rtc.reg.second + 10 * this->parent_->ds3231_.rtc.reg.second_10),
+    .minute = uint8_t(this->parent_->ds3231_.rtc.reg.minute + 10u * this->parent_->ds3231_.rtc.reg.minute_10),
+    .hour = uint8_t(this->parent_->ds3231_.rtc.reg.hour + 10u * this->parent_->ds3231_.rtc.reg.hour_10),
+    .day_of_week = uint8_t(this->parent_->ds3231_.rtc.reg.weekday),
+    .day_of_month = uint8_t(this->parent_->ds3231_.rtc.reg.day + 10u * this->parent_->ds3231_.rtc.reg.day_10),
+    .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
+    .month = uint8_t(this->parent_->ds3231_.rtc.reg.month + 10u * this->parent_->ds3231_.rtc.reg.month_10),
+    .year = uint16_t(this->parent_->ds3231_.rtc.reg.year + 10u * this->parent_->ds3231_.rtc.reg.year_10 + 2000)
+  };
+  rtc_time.recalc_timestamp_utc(false);
+  if (!rtc_time.is_valid()) {
+    ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
+    return;
+  }
+  time::RealTimeClock::synchronize_epoch_(rtc_time.timestamp);
+}
+
+void DS3231RTC::write_time() {
+  auto now = time::RealTimeClock::utcnow();
+  if (!now.is_valid()) {
+    ESP_LOGW(TAG, "Invalid system time, not syncing to RTC.");
+    return;
+  }
+  if (!this->parent_->read_stat_()) {
+    ESP_LOGE(TAG, "Failed to read status, not syncing to RTC.");
+    return;
+  }
+  if (this->parent_->ds3231_.stat.reg.osc_stop) {
+    this->parent_->ds3231_.stat.reg.osc_stop = false;
+    if (!this->parent_->write_stat_()) {
+      ESP_LOGE(TAG, "Failed to write status, not syncing to RTC.");
+    }
+  }
+  this->parent_->ds3231_.rtc.reg.second = now.second % 10;
+  this->parent_->ds3231_.rtc.reg.second_10 = now.second / 10;
+  this->parent_->ds3231_.rtc.reg.minute = now.minute % 10;
+  this->parent_->ds3231_.rtc.reg.minute_10 = now.minute / 10;
+  this->parent_->ds3231_.rtc.reg.hour = now.hour % 10;
+  this->parent_->ds3231_.rtc.reg.hour_10 = now.hour / 10;
+  this->parent_->ds3231_.rtc.reg.weekday = now.day_of_week;
+  this->parent_->ds3231_.rtc.reg.day = now.day_of_month % 10;
+  this->parent_->ds3231_.rtc.reg.day_10 = now.day_of_month / 10;
+  this->parent_->ds3231_.rtc.reg.month = now.month % 10;
+  this->parent_->ds3231_.rtc.reg.month_10 = now.month / 10;
+  this->parent_->ds3231_.rtc.reg.year = (now.year - 2000) % 10;
+  this->parent_->ds3231_.rtc.reg.year_10 = (now.year - 2000) / 10 % 10;
+  if (!this->parent_->write_rtc_()) {
+    ESP_LOGE(TAG, "Failed to sync to RTC.");
+  }
+}
+
+}  // namespace ds3231
+}  // namespace esphome

--- a/esphome/components/ds3231/ds3231_rtc.cpp
+++ b/esphome/components/ds3231/ds3231_rtc.cpp
@@ -1,20 +1,17 @@
 #include "ds3231.h"
 #include "esphome/core/log.h"
 
-// Datasheet:
-// - https://datasheets.maximintegrated.com/en/ds/DS1307.pdf
-
 namespace esphome {
 namespace ds3231 {
 
 static const char *const TAG = "ds3231.rtc";
 
 void DS3231RTC::dump_config() {
-  ESP_LOGCONFIG(TAG, "  Timezone: '%s'", this->timezone_.c_str());
+  ESP_LOGCONFIG(TAG, "DS3231 Timezone: '%s'", this->timezone_.c_str());
 }
 
 void DS3231RTC::read_time() {
-  if (!this->parent_->read_stat_()) {
+  if (!this->parent_->read_status_()) {
     ESP_LOGE(TAG, "Failed to read status, not syncing to system clock.");
     return;
   }
@@ -50,13 +47,13 @@ void DS3231RTC::write_time() {
     ESP_LOGW(TAG, "Invalid system time, not syncing to RTC.");
     return;
   }
-  if (!this->parent_->read_stat_()) {
+  if (!this->parent_->read_status_()) {
     ESP_LOGE(TAG, "Failed to read status, not syncing to RTC.");
     return;
   }
   if (this->parent_->ds3231_.stat.reg.osc_stop) {
     this->parent_->ds3231_.stat.reg.osc_stop = false;
-    if (!this->parent_->write_stat_()) {
+    if (!this->parent_->write_status_()) {
       ESP_LOGE(TAG, "Failed to write status, not syncing to RTC.");
     }
   }

--- a/esphome/components/ds3231/ds3231_rtc.cpp
+++ b/esphome/components/ds3231/ds3231_rtc.cpp
@@ -29,8 +29,7 @@ void DS3231RTC::read_time() {
       .day_of_month = uint8_t(this->parent_->ds3231_.rtc.reg.day + 10u * this->parent_->ds3231_.rtc.reg.day_10),
       .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
       .month = uint8_t(this->parent_->ds3231_.rtc.reg.month + 10u * this->parent_->ds3231_.rtc.reg.month_10),
-      .year = uint16_t(this->parent_->ds3231_.rtc.reg.year + 10u * this->parent_->ds3231_.rtc.reg.year_10 + 2000)
-  };
+      .year = uint16_t(this->parent_->ds3231_.rtc.reg.year + 10u * this->parent_->ds3231_.rtc.reg.year_10 + 2000)};
   rtc_time.recalc_timestamp_utc(false);
   if (!rtc_time.is_valid()) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");

--- a/esphome/components/ds3231/ds3231_sensor.cpp
+++ b/esphome/components/ds3231/ds3231_sensor.cpp
@@ -1,0 +1,21 @@
+#include "ds3231.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ds3231 {
+
+static const char *const TAG = "ds3231.sensor";
+
+void DS3231Sensor::dump_config() { LOG_SENSOR("", "DS3231 Temperature", this); }
+
+void DS3231Sensor::update() {
+  if (!this->parent_->read_temperature_()) {
+    ESP_LOGE(TAG, "Failed to read stemperature.");
+    return;
+  }
+  float temp = this->parent_->ds3231_.temp.reg.upper + this->parent_->ds3231_.temp.reg.lower / 100.0f;
+  this->publish_state(temp);
+}
+
+}  // namespace ds3231
+}  // namespace esphome

--- a/esphome/components/ds3231/sensor.py
+++ b/esphome/components/ds3231/sensor.py
@@ -1,0 +1,39 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    CONF_ID,
+)
+from . import DS3231Component, ds3231_ns, CONF_DS3231_ID
+
+
+DEPENDENCIES = ["ds3231"]
+
+DS3231Sensor = ds3231_ns.class_("DS3231Sensor", cg.PollingComponent, sensor.Sensor)
+
+CONFIG_SCHEMA = cv.All(
+    sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(DS3231Sensor),
+            cv.GenerateID(CONF_DS3231_ID): cv.use_id(DS3231Component),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    ds3231 = await cg.get_variable(config[CONF_DS3231_ID])
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_parented(var, ds3231)
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)

--- a/esphome/components/ds3231/time.py
+++ b/esphome/components/ds3231/time.py
@@ -1,12 +1,13 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome import automation
-from esphome.components import i2c, time
+from esphome.components import time
 from esphome.const import CONF_ID
 
 
-CODEOWNERS = ["nuttytree"]
+CODEOWNERS = ["@nuttytree"]
 DEPENDENCIES = ["ds3231"]
+
 ds3231_ns = cg.esphome_ns.namespace("ds3231")
 DS3231RTC = ds3231_ns.class_("DS3231RTC", time.RealTimeClock)
 WriteTimeAction = ds3231_ns.class_("WriteTimeAction", automation.Action)

--- a/esphome/components/ds3231/time.py
+++ b/esphome/components/ds3231/time.py
@@ -3,21 +3,22 @@ import esphome.codegen as cg
 from esphome import automation
 from esphome.components import time
 from esphome.const import CONF_ID
+from . import DS3231Component, ds3231_ns, CONF_DS3231_ID
 
 
-CODEOWNERS = ["@nuttytree"]
 DEPENDENCIES = ["ds3231"]
 
-ds3231_ns = cg.esphome_ns.namespace("ds3231")
 DS3231RTC = ds3231_ns.class_("DS3231RTC", time.RealTimeClock)
 WriteTimeAction = ds3231_ns.class_("WriteTimeAction", automation.Action)
 ReadTimeAction = ds3231_ns.class_("ReadTimeAction", automation.Action)
 
-
-CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(DS3231RTC),
-    }
+CONFIG_SCHEMA = cv.All(
+    time.TIME_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(DS3231RTC),
+            cv.GenerateID(CONF_DS3231_ID): cv.use_id(DS3231Component),
+        }
+    )
 )
 
 
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
     cv.Schema(
         {
             cv.GenerateID(): cv.use_id(DS3231RTC),
+            cv.GenerateID(CONF_DS3231_ID): cv.use_id(DS3231Component),
         }
     ),
 )
@@ -52,7 +54,8 @@ async def ds3231_read_time_to_code(config, action_id, template_arg, args):
 
 
 async def to_code(config):
+    ds3231 = await cg.get_variable(config[CONF_DS3231_ID])
     var = cg.new_Pvariable(config[CONF_ID])
-
+    await cg.register_parented(var, ds3231)
     await cg.register_component(var, config)
     await time.register_time(var, config)

--- a/esphome/components/ds3231/time.py
+++ b/esphome/components/ds3231/time.py
@@ -1,0 +1,57 @@
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome import automation
+from esphome.components import i2c, time
+from esphome.const import CONF_ID
+
+
+CODEOWNERS = ["nuttytree"]
+DEPENDENCIES = ["ds3231"]
+ds3231_ns = cg.esphome_ns.namespace("ds3231")
+DS3231RTC = ds3231_ns.class_("DS3231RTC", time.RealTimeClock)
+WriteTimeAction = ds3231_ns.class_("WriteTimeAction", automation.Action)
+ReadTimeAction = ds3231_ns.class_("ReadTimeAction", automation.Action)
+
+
+CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(DS3231RTC),
+    }
+)
+
+
+@automation.register_action(
+    "ds3231.write_time",
+    WriteTimeAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(DS3231RTC),
+        }
+    ),
+)
+async def ds3231_write_time_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@automation.register_action(
+    "ds3231.read_time",
+    ReadTimeAction,
+    automation.maybe_simple_id(
+        {
+            cv.GenerateID(): cv.use_id(DS3231RTC),
+        }
+    ),
+)
+async def ds3231_read_time_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await time.register_time(var, config)

--- a/esphome/components/ds3231/time.py
+++ b/esphome/components/ds3231/time.py
@@ -25,10 +25,9 @@ CONFIG_SCHEMA = cv.All(
 @automation.register_action(
     "ds3231.write_time",
     WriteTimeAction,
-    cv.Schema(
+    automation.maybe_simple_id(
         {
             cv.GenerateID(): cv.use_id(DS3231RTC),
-            cv.GenerateID(CONF_DS3231_ID): cv.use_id(DS3231Component),
         }
     ),
 )

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -655,13 +655,13 @@ time:
       then:
         - ds3231.write_time:
         - ds3231.set_alarm_1:
-            type: match_day_of_month_hour_minute_second
+            mode: match_day_of_month_hour_minute_second
             second: 5
             minute: 6
             hour: 7
             day: 8
         - ds3231.set_alarm_2:
-            type: match_day_of_month_hour_minute
+            mode: match_day_of_month_hour_minute
             minute: 9
             hour: 10
             day: 11
@@ -678,13 +678,13 @@ time:
 ds3231:
   update_interval: 1s
   alarm_1:
-    type: match_day_of_week_hour_minute_second
+    mode: match_day_of_week_hour_minute_second
     second: 1
     minute: 2
     hour: 3
     day: 4
   alarm_2:
-    type: every_minute
+    mode: every_minute
   square_wave_mode: square_wave
   square_wave_frequency: 1hz
   on_alarm_1:

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -647,46 +647,39 @@ sensor:
     component_id: 2
     wave_channel_id: 1
   - platform: ds3231
-    id: ds3231_sensor
+    id: ds3231_temp
 
 time:
   - platform: homeassistant
     on_time_sync:
       then:
         - ds3231.write_time:
-            id: ds3231_time
         - ds3231.set_alarm_1:
-            id: ds3231_cmp
             type: match_day_of_month_hour_minute_second
             second: 1
             minute: 2
             hour: 3
             day: 4
         - ds3231.set_alarm_2:
-            id: ds3231_cmp
             type: every_minute
         - ds3231.set_square_wave_mode:
-            id: ds3231_cmp
             mode: square_wave
         - ds3231.set_square_wave_frequency:
-            id: ds3231_cmp
             frequency: 4096hz
   - platform: ds3231
-    id: ds3231_time
     update_interval: never
     on_time:
       seconds: 0
       then: ds3231.read_time
 
 ds3231:
-  id: ds3231_cmp
+  update_interval: 1s
   on_alarm_1:
     then:
-      ds3231.reset_alarm_1: ds3231_cmp
+      ds3231.reset_alarm_1:
   on_alarm_2:
     then:
       ds3231.reset_alarm_2:
-        id: ds3231_cmp
 
 apds9960:
   address: 0x20

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -654,14 +654,20 @@ time:
             id: ds3231_time
         - ds3231.set_alarm_1:
             id: ds3231_cmp
-            alarm_type: match_day_of_month_hour_minute_second
+            type: match_day_of_month_hour_minute_second
             second: 1
             minute: 2
             hour: 3
             day: 4
         - ds3231.set_alarm_2:
             id: ds3231_cmp
-            alarm_type: every_minute
+            type: every_minute
+        - ds3231.set_square_wave_mode:
+            id: ds3231_cmp
+            mode: square_wave
+        - ds3231.set_square_wave_frequency:
+            id: ds3231_cmp
+            frequency: 4096hz
   - platform: ds3231
     id: ds3231_time
     update_interval: never

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -656,12 +656,14 @@ time:
         - ds3231.write_time:
         - ds3231.set_alarm_1:
             mode: match_day_of_month_hour_minute_second
+            interrupt_enabled: true
             second: 5
             minute: 6
             hour: 7
             day: 8
         - ds3231.set_alarm_2:
             mode: match_day_of_month_hour_minute
+            interrupt_enabled: true
             minute: 9
             hour: 10
             day: 11

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -656,14 +656,17 @@ time:
         - ds3231.write_time:
         - ds3231.set_alarm_1:
             type: match_day_of_month_hour_minute_second
-            second: 1
-            minute: 2
-            hour: 3
-            day: 4
+            second: 5
+            minute: 6
+            hour: 7
+            day: 8
         - ds3231.set_alarm_2:
-            type: every_minute
+            type: match_day_of_month_hour_minute
+            minute: 9
+            hour: 10
+            day: 11
         - ds3231.set_square_wave_mode:
-            mode: square_wave
+            mode: alarm_interrupt
         - ds3231.set_square_wave_frequency:
             frequency: 4096hz
   - platform: ds3231
@@ -674,6 +677,16 @@ time:
 
 ds3231:
   update_interval: 1s
+  alarm_1:
+    type: match_day_of_week_hour_minute_second
+    second: 1
+    minute: 2
+    hour: 3
+    day: 4
+  alarm_2:
+    type: every_minute
+  square_wave_mode: square_wave
+  square_wave_frequency: 1hz
   on_alarm_1:
     then:
       ds3231.reset_alarm_1:

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -646,6 +646,9 @@ sensor:
     name: 'testwave'
     component_id: 2
     wave_channel_id: 1
+  - platform: ds3231
+    id: ds3231_sensor
+
 time:
   - platform: homeassistant
     on_time_sync:

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -648,6 +648,36 @@ sensor:
     wave_channel_id: 1
 time:
   - platform: homeassistant
+    on_time_sync:
+      then:
+        - ds3231.write_time:
+            id: ds3231_time
+        - ds3231.set_alarm_1:
+            id: ds3231_cmp
+            alarm_type: match_day_of_month_hour_minute_second
+            second: 1
+            minute: 2
+            hour: 3
+            day: 4
+        - ds3231.set_alarm_2:
+            id: ds3231_cmp
+            alarm_type: every_minute
+  - platform: ds3231
+    id: ds3231_time
+    update_interval: never
+    on_time:
+      seconds: 0
+      then: ds3231.read_time
+
+ds3231:
+  id: ds3231_cmp
+  on_alarm_1:
+    then:
+      ds3231.reset_alarm_1: ds3231_cmp
+  on_alarm_2:
+    then:
+      ds3231.reset_alarm_2:
+        id: ds3231_cmp
 
 apds9960:
   address: 0x20


### PR DESCRIPTION
# What does this implement/fix? 

Adds a DS3231 Real Time Clock Component that includes:
- Core component that handles communication with the device
- Options on the core component to setup alarms
- Options on the core component to set the mode and frequency of the square wave output
- Action automations to set the alarms
- Trigger automations for when the alarms are triggered
- Action automations to reset the alarms after they have been triggered
- Action automations to set the mode and frequency of the square wave output
- Time component
- Action automations to read/write the time from/to the RTC
- Temperature sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1531

## Test Environment

- [X] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
ds3231:
  update_interval: 1s
  alarm_1:
    mode: match_day_of_week_hour_minute_second
    second: 1
    minute: 2
    hour: 3
    day: 4
  alarm_2:
    mode: every_minute
  square_wave_mode: square_wave
  square_wave_frequency: 1hz
  on_alarm_1:
    then:
      - logger.log: Alarm 1 was triggered
      - ds3231.reset_alarm_1:
  on_alarm_2:
    then:
      - logger.log: Alarm 2 was triggered
      - ds3231.reset_alarm_2:

time:
  - platform: homeassistant
    on_time_sync:
      then:
        - ds3231.write_time:  
        - ds3231.set_alarm_1:
            mode: match_day_of_month_hour_minute_second
            interrupt_enabled: true
            second: 5
            minute: 6
            hour: 7
            day: 8
        - ds3231.set_alarm_2:
            mode: match_day_of_month_hour_minute
            interrupt_enabled: true
            minute: 9
            hour: 10
            day: 11
        - ds3231.set_square_wave_mode:
            mode: alarm_interrupt
        - ds3231.set_square_wave_frequency:
            frequency: 4096hz
  - platform: ds3231

sensor:
  - platform: ds3231
    name: DS3231 Temperature
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
