### PR TITLE
Add publish_initial_value option to rotary encoder

### DIFF
--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -189,9 +189,10 @@ void RotaryEncoderSensor::loop() {
     this->store_.counter = 0;
   }
   int counter = this->store_.counter;
-  if (this->store_.last_read != counter) {
+  if (this->store_.last_read != counter || this->publish_initial_value_) {
     this->store_.last_read = counter;
     this->publish_state(counter);
+    this->publish_initial_value_ = false;
   }
 }
 

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -26,7 +26,7 @@ struct RotaryEncoderSensorStore {
   RotaryEncoderResolution resolution{ROTARY_ENCODER_1_PULSE_PER_CYCLE};
   int32_t min_value{INT32_MIN};
   int32_t max_value{INT32_MAX};
-  int32_t last_read{-1};
+  int32_t last_read{0};
   uint8_t state{0};
 
   std::array<int8_t, 8> rotation_events{};
@@ -58,6 +58,7 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
   void set_reset_pin(GPIOPin *pin_i) { this->pin_i_ = pin_i; }
   void set_min_value(int32_t min_value);
   void set_max_value(int32_t max_value);
+  void set_publish_initial_value(bool publish_initial_value) { publish_initial_value_ = publish_initial_value; }
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -79,6 +80,7 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
   InternalGPIOPin *pin_a_;
   InternalGPIOPin *pin_b_;
   GPIOPin *pin_i_{nullptr};  /// Index pin, if this is not nullptr, the counter will reset to 0 once this pin is HIGH.
+  bool publish_initial_value_;
 
   RotaryEncoderSensorStore store_{};
 

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -26,7 +26,7 @@ struct RotaryEncoderSensorStore {
   RotaryEncoderResolution resolution{ROTARY_ENCODER_1_PULSE_PER_CYCLE};
   int32_t min_value{INT32_MIN};
   int32_t max_value{INT32_MAX};
-  int32_t last_read{0};
+  int32_t last_read{-1};
   uint8_t state{0};
 
   std::array<int8_t, 8> rotation_events{};

--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -27,6 +27,7 @@ RESOLUTIONS = {
 CONF_PIN_RESET = "pin_reset"
 CONF_ON_CLOCKWISE = "on_clockwise"
 CONF_ON_ANTICLOCKWISE = "on_anticlockwise"
+CONF_PUBLISH_INITIAL_VALUE = "publish_initial_value"
 
 RotaryEncoderSensor = rotary_encoder_ns.class_(
     "RotaryEncoderSensor", sensor.Sensor, cg.Component
@@ -70,6 +71,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_RESOLUTION, default=1): cv.enum(RESOLUTIONS, int=True),
             cv.Optional(CONF_MIN_VALUE): cv.int_,
             cv.Optional(CONF_MAX_VALUE): cv.int_,
+            cv.Optional(CONF_PUBLISH_INITIAL_VALUE, default=False): cv.boolean,
             cv.Optional(CONF_ON_CLOCKWISE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -99,6 +101,7 @@ async def to_code(config):
     cg.add(var.set_pin_a(pin_a))
     pin_b = await cg.gpio_pin_expression(config[CONF_PIN_B])
     cg.add(var.set_pin_b(pin_b))
+    cg.add(var.set_publish_initial_value(config[CONF_PUBLISH_INITIAL_VALUE]))
 
     if CONF_PIN_RESET in config:
         pin_i = await cg.gpio_pin_expression(config[CONF_PIN_RESET])


### PR DESCRIPTION
# What does this implement/fix? 

After boot, the state of a rotary encoder is unknown. With this fix, the initial state after boot is 0.

The state is unknown because it is not published until user input is provided (the encoder is turned). 
The counter is initialized with 0 and the previous counter value (last_read) with 0 as well. At the end of the loop of the rotary_encoder component a check takes place whether the counter changed. If both values are the same, publish_state is not called. However, initializing last_read with something other than counter causes the state to be updated once on start (and on user input, as before).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2535

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
...
sensor:
  - platform: rotary_encoder
    id: rotary1
    name: Rotary Encoder
    pin_a:
      number: D1
    pin_b:
      number: D2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs) (https://github.com/esphome/esphome-docs/pull/1565).
