### PR TITLE
Fix light state remaining on after turn off with transition

### DIFF
--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -18,10 +18,13 @@ class LightTransitionTransformer : public LightTransformer {
       this->start_values_.set_brightness(0.0f);
     }
 
-    // When turning light off from on state, use source state and only decrease brightness to zero.
+    // When turning light off from on state, use source state and only decrease brightness to zero. Use a second
+    // variable for transition end state, as overwriting target_values breaks LightState logic.
     if (this->start_values_.is_on() && !this->target_values_.is_on()) {
-      this->target_values_ = LightColorValues(this->start_values_);
-      this->target_values_.set_brightness(0.0f);
+      this->end_values_ = LightColorValues(this->start_values_);
+      this->end_values_.set_brightness(0.0f);
+    } else {
+      this->end_values_ = LightColorValues(this->target_values_);
     }
 
     // When changing color mode, go through off state, as color modes are orthogonal and there can't be two active.
@@ -43,7 +46,7 @@ class LightTransitionTransformer : public LightTransformer {
     }
 
     LightColorValues &start = this->changing_color_mode_ && p > 0.5f ? this->intermediate_values_ : this->start_values_;
-    LightColorValues &end = this->changing_color_mode_ && p < 0.5f ? this->intermediate_values_ : this->target_values_;
+    LightColorValues &end = this->changing_color_mode_ && p < 0.5f ? this->intermediate_values_ : this->end_values_;
     if (this->changing_color_mode_)
       p = p < 0.5f ? p * 2 : (p - 0.5) * 2;
 
@@ -57,6 +60,7 @@ class LightTransitionTransformer : public LightTransformer {
   static float smoothed_progress(float x) { return x * x * x * (x * (x * 6.0f - 15.0f) + 10.0f); }
 
   bool changing_color_mode_{false};
+  LightColorValues end_values_{};
   LightColorValues intermediate_values_{};
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

The `state` property of the `LightColorValues` of a light remained on after the light was turned off with a transition. This happens because the transition transformer changed the `target_values`, which are set as the state of the light after the transition has completed.

- Fixes esphome/issues#2458
- Fixes esphome/issues#2489
- Fixes esphome/issues#2499
- Fixes esphome/issues#2533

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
