### PR TITLE
Move TemplatableValue helper class to automation.h

### DIFF
--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -8,6 +8,18 @@
 namespace esphome {
 namespace api {
 
+template<typename... X> class TemplatableStringValue : public TemplatableValue<std::string, X...> {
+ public:
+  TemplatableStringValue() : TemplatableValue<std::string, X...>() {}
+
+  template<typename F, enable_if_t<!is_callable<F, X...>::value, int> = 0>
+  TemplatableStringValue(F value) : TemplatableValue<std::string, X...>(value) {}
+
+  template<typename F, enable_if_t<is_callable<F, X...>::value, int> = 0>
+  TemplatableStringValue(F f)
+      : TemplatableValue<std::string, X...>([f](X... x) -> std::string { return to_string(f(x...)); }) {}
+};
+
 template<typename... Ts> class TemplatableKeyValuePair {
  public:
   template<typename T> TemplatableKeyValuePair(std::string key, T value) : key(std::move(key)), value(value) {}
@@ -19,7 +31,8 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
  public:
   explicit HomeAssistantServiceCallAction(APIServer *parent, bool is_event) : parent_(parent), is_event_(is_event) {}
 
-  TEMPLATABLE_STRING_VALUE(service);
+  template<typename T> void set_service(T service) { this->service_ = service; }
+
   template<typename T> void add_data(std::string key, T value) {
     this->data_.push_back(TemplatableKeyValuePair<Ts...>(key, value));
   }
@@ -58,6 +71,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
  protected:
   APIServer *parent_;
   bool is_event_;
+  TemplatableStringValue<Ts...> service_{};
   std::vector<TemplatableKeyValuePair<Ts...>> data_;
   std::vector<TemplatableKeyValuePair<Ts...>> data_template_;
   std::vector<TemplatableKeyValuePair<Ts...>> variables_;

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -17,15 +17,6 @@ namespace esphome {
 
 #define TEMPLATABLE_VALUE(type, name) TEMPLATABLE_VALUE_(type, name)
 
-#define TEMPLATABLE_STRING_VALUE_(name) \
- protected: \
-  TemplatableStringValue<Ts...> name##_{}; \
-\
- public: \
-  template<typename V> void set_##name(V name) { this->name##_ = name; }
-
-#define TEMPLATABLE_STRING_VALUE(name) TEMPLATABLE_STRING_VALUE_(name)
-
 /** Base class for all automation conditions.
  *
  * @tparam Ts The template parameters to pass when executing.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -300,18 +300,6 @@ template<typename T, typename... X> class TemplatableValue {
   std::function<T(X...)> f_{};
 };
 
-template<typename... X> class TemplatableStringValue : public TemplatableValue<std::string, X...> {
- public:
-  TemplatableStringValue() : TemplatableValue<std::string, X...>() {}
-
-  template<typename F, enable_if_t<!is_callable<F, X...>::value, int> = 0>
-  TemplatableStringValue(F value) : TemplatableValue<std::string, X...>(value) {}
-
-  template<typename F, enable_if_t<is_callable<F, X...>::value, int> = 0>
-  TemplatableStringValue(F f)
-      : TemplatableValue<std::string, X...>([f](X... x) -> std::string { return to_string(f(x...)); }) {}
-};
-
 void delay_microseconds_accurate(uint32_t usec);
 
 template<typename T> class Deduplicator {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -255,51 +255,6 @@ struct is_callable  // NOLINT
   static constexpr auto value = decltype(test<T>(nullptr))::value;  // NOLINT
 };
 
-template<typename T, typename... X> class TemplatableValue {
- public:
-  TemplatableValue() : type_(EMPTY) {}
-
-  template<typename F, enable_if_t<!is_callable<F, X...>::value, int> = 0>
-  TemplatableValue(F value) : type_(VALUE), value_(value) {}
-
-  template<typename F, enable_if_t<is_callable<F, X...>::value, int> = 0>
-  TemplatableValue(F f) : type_(LAMBDA), f_(f) {}
-
-  bool has_value() { return this->type_ != EMPTY; }
-
-  T value(X... x) {
-    if (this->type_ == LAMBDA) {
-      return this->f_(x...);
-    }
-    // return value also when empty
-    return this->value_;
-  }
-
-  optional<T> optional_value(X... x) {
-    if (!this->has_value()) {
-      return {};
-    }
-    return this->value(x...);
-  }
-
-  T value_or(X... x, T default_value) {
-    if (!this->has_value()) {
-      return default_value;
-    }
-    return this->value(x...);
-  }
-
- protected:
-  enum {
-    EMPTY,
-    VALUE,
-    LAMBDA,
-  } type_;
-
-  T value_{};
-  std::function<T(X...)> f_{};
-};
-
 void delay_microseconds_accurate(uint32_t usec);
 
 template<typename T> class Deduplicator {


### PR DESCRIPTION
# What does this implement/fix? 

First PR in a series to clean-up and reorganize `helpers.h` a bit. 

Move `TemplatableValue` helper class to `automation.h` from `helpers.h`. 

Also drop `TEMPLATABLE_STRING_VALUE()`, whose purpose seemed to be to allow lambdas to return non-string values and have them converted to strings. However, it was used in only one place, while all others used the regular `TEMPLATABLE_VALUE()` macro with std::string type.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
