### PR TITLE
Fix: Color modes not being correctly used in light partitions

### DIFF
--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -71,6 +71,12 @@ class AddressableLightWrapper : public light::AddressableLight {
   }
 
   void write_state(light::LightState *state) override {
+    // Don't overwrite state if the underlying light is turned on
+    if (this->light_state_->remote_values.is_on()) {
+      this->mark_shown_();
+      return;
+    }
+
     float gamma = this->light_state_->get_gamma_correct();
     float r = gamma_uncorrect(this->wrapper_state_[0] / 255.0f, gamma);
     float g = gamma_uncorrect(this->wrapper_state_[1] / 255.0f, gamma);


### PR DESCRIPTION
# What does this implement/fix? 
The changes introduced in #2256 allowed non-addressable RGB lights to be used in light partitions, however the behavior when used with other color modes was incorrect. Symptoms included leaving warm/cool white channels turned on with RGBWW lights, not setting brightness for monochromatic lights, and not setting state for binary lights. This PR addresses those changes.

Tested with:

- Binary Light
- Monochromatic Light
- Cold + Warm White
- Color Temperature
- RGB
- RGBW
- RGBWW
- RGBCT

**Limitations**
This works within the current implementation of addressable lights, which stores pixel color as RGBW, 8 bits per channel. As a result, lights that support warm/cool white or color temperature are not fully supported in light partitions. These cases are handled as follows:

- CW/WW are treated as a single channel, i.e. setting a white value in a partition sets both CW and WW to that value
- CT is not changed; setting a white value in a partition changes only the brightness


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
