### PR TITLE
Allow downloading all bin files from backend in dashboard

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -458,6 +458,21 @@ def command_update_all(args):
     return failed
 
 
+def command_idedata(args, config):
+    from esphome import platformio_api
+    import json
+
+    logging.disable(logging.INFO)
+    logging.disable(logging.WARNING)
+
+    idedata = platformio_api.get_idedata(config)
+    if idedata is None:
+        return 1
+
+    print(json.dumps(idedata.raw, indent=2) + "\n")
+    return 0
+
+
 PRE_CONFIG_ACTIONS = {
     "wizard": command_wizard,
     "version": command_version,
@@ -475,6 +490,7 @@ POST_CONFIG_ACTIONS = {
     "clean-mqtt": command_clean_mqtt,
     "mqtt-fingerprint": command_mqtt_fingerprint,
     "clean": command_clean,
+    "idedata": command_idedata,
 }
 
 
@@ -648,6 +664,13 @@ def parse_args(argv):
     parser_update = subparsers.add_parser("update-all")
     parser_update.add_argument(
         "configuration", help="Your YAML configuration file directories.", nargs="+"
+    )
+
+    parser_idedata = subparsers.add_parser(
+        "idedata", help="Fetch or generate the idedata and spit it out."
+    )
+    parser_idedata.add_argument(
+        "configuration", help="Your YAML configuration file(s).", nargs=1
     )
 
     # Keep backward compatibility with the old command line format of

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -762,7 +762,7 @@ def run_esphome(argv):
 
         config = read_config(dict(args.substitution) if args.substitution else {})
         if config is None:
-            return 1
+            return 2
         CORE.config = config
 
         if args.command not in POST_CONFIG_ACTIONS:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -670,9 +670,7 @@ def parse_args(argv):
         "configuration", help="Your YAML configuration file directories.", nargs="+"
     )
 
-    parser_idedata = subparsers.add_parser(
-        "idedata", help="Fetch or generate the idedata and spit it out."
-    )
+    parser_idedata = subparsers.add_parser("idedata")
     parser_idedata.add_argument(
         "configuration", help="Your YAML configuration file(s).", nargs=1
     )

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -180,7 +180,11 @@ def compile_program(args, config):
     from esphome import platformio_api
 
     _LOGGER.info("Compiling app...")
-    return platformio_api.run_compile(config, CORE.verbose)
+    rc = platformio_api.run_compile(config, CORE.verbose)
+    if rc != 0:
+        return rc
+    idedata = platformio_api.get_idedata(config)
+    return 0 if idedata is not None else 1
 
 
 def upload_using_esptool(config, port):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -10,7 +10,6 @@ import logging
 import multiprocessing
 import os
 from pathlib import Path
-from posixpath import basename
 import secrets
 import shutil
 import subprocess
@@ -467,7 +466,7 @@ class ManifestRequestHandler(BaseHandler):
             }
         ] + [
             {
-                "path": f"./download.bin?configuration={configuration}&type={basename(image.path)}",
+                "path": f"./download.bin?configuration={configuration}&type={os.path.basename(image.path)}",
                 "offset": image.offset,
             }
             for image in idedata.extra_flash_images


### PR DESCRIPTION
# What does this implement/fix? 

- Add /manifest.json endpoint
- Add type to /download.bin to fetch other flash files as per manifest

This is mostly a bugfix as esp-idf builds would not be install-able from browser without the changes

Combines with esphome/dashboard#91 which is in #2515 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
