### PR TITLE
Fix BME680_BSEC compilation issue with ESP32

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -63,6 +63,7 @@ async def to_code(config):
     )
 
     if CORE.is_esp32:
+        # Although this component does not use SPI, the BSEC library requires the SPI library
         cg.add_library("SPI", None)
 
     cg.add_define("USE_BSEC")

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c
 from esphome.const import CONF_ID
+from esphome.core import CORE
 
 CODEOWNERS = ["@trvrnrth"]
 DEPENDENCIES = ["i2c"]
@@ -44,7 +45,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(
             CONF_STATE_SAVE_INTERVAL, default="6hours"
         ): cv.positive_time_period_minutes,
-    }
+    },
+    cv.only_with_arduino,
 ).extend(i2c.i2c_device_schema(0x76))
 
 
@@ -59,6 +61,9 @@ async def to_code(config):
     cg.add(
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
     )
+
+    if CORE.is_esp32:
+        cg.add_library("SPI", None)
 
     cg.add_define("USE_BSEC")
     cg.add_library("BSEC Software Library", "1.6.1480")

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -265,6 +265,9 @@ wled:
 
 adalight:
 
+bme680_bsec:
+  i2c_id: i2c_bus
+
 esp32_ble_tracker:
 
 ble_client:
@@ -478,6 +481,19 @@ sensor:
       duration: 150ms
     update_interval: 15s
     i2c_id: i2c_bus
+  - platform: bme680_bsec
+    temperature:
+      name: "BME680 Temperature"
+    pressure:
+      name: "BME680 Pressure"
+    humidity:
+      name: "BME680 Humidity"
+    iaq:
+      name: "BME680 IAQ"
+    co2_equivalent:
+      name: "BME680 CO2 Equivalent"
+    breath_voc_equivalent:
+      name: "BME680 Breath VOC Equivalent"
   - platform: bmp085
     temperature:
       name: 'Outside Temperature'


### PR DESCRIPTION
# What does this implement/fix? 

Component `bme680_bsec` has a dependency on SPI despite it not being used. Fixed by including the SPI library regardless.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
