### PR TITLE
Fix rom/rtc.h deprecation compile warning for debug component

### DIFF
--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -4,22 +4,21 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/version.h"
 
-#ifdef USE_ESP32
-#ifdef USE_ARDUINO
-#include <rom/rtc.h>
-#elif defined(USE_ESP_IDF)
-#include <esp32/rom/rtc.h>
+#ifdef USE_ESP_IDF
+#include <esp_heap_caps.h>
+#include <esp_system.h>
 #endif
-#include <esp_idf_version.h>
+
+#ifdef USE_ESP32
+#if ESP_IDF_VERSION_MAJOR >= 4
+#include <esp32/rom/rtc.h>
+#else
+#include <rom/rtc.h>
+#endif
 #endif
 
 #ifdef USE_ARDUINO
 #include <Esp.h>
-#endif
-
-#ifdef USE_ESP_IDF
-#include <esp_heap_caps.h>
-#include <esp_system.h>
 #endif
 
 namespace esphome {

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -5,7 +5,12 @@
 #include "esphome/core/version.h"
 
 #ifdef USE_ESP32
+#ifdef USE_ARDUINO
+#include <rom/rtc.h>
+#endif
+#ifdef USE_ESP_IDF
 #include <esp32/rom/rtc.h>
+#endif
 #include <esp_idf_version.h>
 #endif
 

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -7,8 +7,7 @@
 #ifdef USE_ESP32
 #ifdef USE_ARDUINO
 #include <rom/rtc.h>
-#endif
-#ifdef USE_ESP_IDF
+#elif defined(USE_ESP_IDF)
 #include <esp32/rom/rtc.h>
 #endif
 #include <esp_idf_version.h>

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -5,7 +5,7 @@
 #include "esphome/core/version.h"
 
 #ifdef USE_ESP32
-#include <rom/rtc.h>
+#include <esp32/rom/rtc.h>
 #include <esp_idf_version.h>
 #endif
 


### PR DESCRIPTION
# What does this implement/fix? 

The debug component triggers a compile warning:
```
In file included from src/esphome/components/debug/debug_component.cpp:8:
.../.platformio/packages/framework-espidf/components/esp32/include/rom/rtc.h:1:2:
warning: #warning rom/rtc.h is deprecated, please use esp32/rom/rtc.h instead
[-#warning rom/rtc.h is deprecated, please use esp32/rom/rtc.h instead
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
debug:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
