### PR TITLE
Fix Nextion HTTPClient error for ESP32

### DIFF
--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -8,7 +8,7 @@ from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_TRIGGER_ID,
 )
-
+from esphome.core import CORE
 from . import Nextion, nextion_ns, nextion_ref
 from .base_component import (
     CONF_ON_SLEEP,
@@ -76,6 +76,9 @@ async def to_code(config):
     if CONF_TFT_URL in config:
         cg.add_define("USE_NEXTION_TFT_UPLOAD")
         cg.add(var.set_tft_url(config[CONF_TFT_URL]))
+        if CORE.is_esp32:
+            cg.add_library("WiFiClientSecure", None)
+            cg.add_library("HTTPClient", None)
 
     if CONF_TOUCH_SLEEP_TIMEOUT in config:
         cg.add(var.set_touch_sleep_timeout_internal(config[CONF_TOUCH_SLEEP_TIMEOUT]))


### PR DESCRIPTION
# What does this implement/fix?

Quick fix so the Nextion display component will build correctly when the `tft_url` config parameter is used on ESP32.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). **N/A**