### PR TITLE
use no hold master mode for si7021/htu21d

### DIFF
--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -9,8 +9,8 @@ static const char *const TAG = "htu21d";
 
 static const uint8_t HTU21D_ADDRESS = 0x40;
 static const uint8_t HTU21D_REGISTER_RESET = 0xFE;
-static const uint8_t HTU21D_REGISTER_TEMPERATURE = 0xE3;
-static const uint8_t HTU21D_REGISTER_HUMIDITY = 0xE5;
+static const uint8_t HTU21D_REGISTER_TEMPERATURE = 0xF3;
+static const uint8_t HTU21D_REGISTER_HUMIDITY = 0xF5;
 static const uint8_t HTU21D_REGISTER_STATUS = 0xE7;
 
 void HTU21DComponent::setup() {


### PR DESCRIPTION
# What does this implement/fix? 

Temperature/humidity measurements in si7021/htu21d can be started in two modes: "hold master" and "no hold master", see the [datasheet](https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf). In the "hold master" mode the I2C bus is blocked during the measurement time (~50 ms). Which is not a problem if si7021/htu21d is the only device connected. But with other devices attached undesired collisions can occur. The [Sparkfun library](https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library) is also using "no hold" mode, for example. This PR replaces "hold master" mode with the "no hold master".

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
