### PR TITLE
Replace framework version_hint with source option

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -7,6 +7,7 @@ from esphome.helpers import write_file_if_changed
 from esphome.const import (
     CONF_BOARD,
     CONF_FRAMEWORK,
+    CONF_SOURCE,
     CONF_TYPE,
     CONF_VARIANT,
     CONF_VERSION,
@@ -53,7 +54,7 @@ def set_core_data(config):
     elif conf[CONF_TYPE] == FRAMEWORK_ARDUINO:
         CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "arduino"
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
-        config[CONF_FRAMEWORK][CONF_VERSION_HINT]
+        config[CONF_FRAMEWORK][CONF_VERSION]
     )
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]
     CORE.data[KEY_ESP32][KEY_VARIANT] = config[CONF_VARIANT]
@@ -94,6 +95,13 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
     return f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
 
 
+def _format_framework_espidf_version(ver: cv.Version) -> str:
+    # format the given arduino (https://github.com/espressif/esp-idf/releases) version to
+    # a PIO platformio/framework-espidf value
+    # List of package versions: https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
+    return f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
+
+
 # NOTE: Keep this in mind when updating the recommended version:
 #  * New framework historically have had some regressions, especially for WiFi.
 #    The new version needs to be thoroughly validated before changing the
@@ -123,119 +131,97 @@ ESP_IDF_PLATFORM_VERSION = cv.Version(3, 3, 2)
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": ("https://github.com/espressif/arduino-esp32.git", cv.Version(2, 0, 0)),
-        "latest": ("", cv.Version(1, 0, 3)),
-        "recommended": (
-            _format_framework_arduino_version(RECOMMENDED_ARDUINO_FRAMEWORK_VERSION),
-            RECOMMENDED_ARDUINO_FRAMEWORK_VERSION,
-        ),
+        "dev": (cv.Version(2, 0, 0), "https://github.com/espressif/arduino-esp32.git"),
+        "latest": (cv.Version(1, 0, 6), None),
+        "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
-    ver_value = value[CONF_VERSION]
-    default_ver_hint = None
-    if ver_value.lower() in lookups:
-        default_ver_hint = str(lookups[ver_value.lower()][1])
-        ver_value = lookups[ver_value.lower()][0]
+
+    if value[CONF_VERSION] in lookups:
+        if CONF_SOURCE in value:
+            raise cv.Invalid(
+                "Framework version needs to be explicitly specified when custom source is used."
+            )
+
+        version, source = lookups[value[CONF_VERSION]]
     else:
-        with cv.suppress_invalid():
-            ver = cv.Version.parse(cv.version_number(value))
-            if ver <= cv.Version(1, 0, 3):
-                ver_value = f"~2.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            else:
-                ver_value = f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            default_ver_hint = str(ver)
-    value[CONF_VERSION] = ver_value
+        version = cv.Version.parse(cv.version_number(value[CONF_VERSION]))
+        source = value.get(CONF_SOURCE, None)
 
-    if CONF_VERSION_HINT not in value and default_ver_hint is None:
-        raise cv.Invalid("Needs a version hint to understand the framework version")
+    value[CONF_VERSION] = str(version)
+    value[CONF_SOURCE] = source or _format_framework_arduino_version(version)
 
-    ver_hint_s = value.get(CONF_VERSION_HINT, default_ver_hint)
-    value[CONF_VERSION_HINT] = ver_hint_s
-    plat_ver = value.get(CONF_PLATFORM_VERSION, ARDUINO_PLATFORM_VERSION)
-    value[CONF_PLATFORM_VERSION] = str(plat_ver)
+    platform_version = value.get(CONF_PLATFORM_VERSION, ARDUINO_PLATFORM_VERSION)
+    value[CONF_PLATFORM_VERSION] = str(platform_version)
 
-    if cv.Version.parse(ver_hint_s) != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
+    if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
         _LOGGER.warning(
-            "The selected arduino framework version is not the recommended one"
-        )
-        _LOGGER.warning(
-            "If there are connectivity or build issues please remove the manual version"
+            "The selected Arduino framework version is not the recommended one. "
+            "If there are connectivity or build issues please remove the manual version."
         )
 
     return value
-
-
-def _format_framework_espidf_version(ver: cv.Version) -> str:
-    # format the given arduino (https://github.com/espressif/esp-idf/releases) version to
-    # a PIO platformio/framework-espidf value
-    # List of package versions: https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
-    return f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
 
 
 def _esp_idf_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": ("https://github.com/espressif/esp-idf.git", cv.Version(4, 3, 1)),
-        "latest": ("", cv.Version(4, 3, 0)),
-        "recommended": (
-            _format_framework_espidf_version(RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION),
-            RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION,
-        ),
+        "dev": (cv.Version(4, 3, 1), "https://github.com/espressif/esp-idf.git"),
+        "latest": (cv.Version(4, 3, 0), None),
+        "recommended": (RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION, None),
     }
-    ver_value = value[CONF_VERSION]
-    default_ver_hint = None
-    if ver_value.lower() in lookups:
-        default_ver_hint = str(lookups[ver_value.lower()][1])
-        ver_value = lookups[ver_value.lower()][0]
+
+    if value[CONF_VERSION] in lookups:
+        if CONF_SOURCE in value:
+            raise cv.Invalid(
+                "Framework version needs to be explicitly specified when custom source is used."
+            )
+
+        version, source = lookups[value[CONF_VERSION]]
     else:
-        with cv.suppress_invalid():
-            ver = cv.Version.parse(cv.version_number(value))
-            ver_value = f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            default_ver_hint = str(ver)
-    value[CONF_VERSION] = ver_value
+        version = cv.Version.parse(cv.version_number(value[CONF_VERSION]))
+        source = value.get(CONF_SOURCE, None)
 
-    if CONF_VERSION_HINT not in value and default_ver_hint is None:
-        raise cv.Invalid("Needs a version hint to understand the framework version")
+    if version < cv.Version(4, 0, 0):
+        raise cv.Invalid("Only ESP-IDF 4.0+ is supported.")
 
-    ver_hint_s = value.get(CONF_VERSION_HINT, default_ver_hint)
-    value[CONF_VERSION_HINT] = ver_hint_s
-    if cv.Version.parse(ver_hint_s) < cv.Version(4, 0, 0):
-        raise cv.Invalid("Only ESP-IDF 4.0+ is supported")
-    if cv.Version.parse(ver_hint_s) != RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION:
+    value[CONF_VERSION] = str(version)
+    value[CONF_SOURCE] = source or _format_framework_espidf_version(version)
+
+    platform_version = value.get(CONF_PLATFORM_VERSION, ESP_IDF_PLATFORM_VERSION)
+    value[CONF_PLATFORM_VERSION] = str(platform_version)
+
+    if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
         _LOGGER.warning(
-            "The selected esp-idf framework version is not the recommended one"
+            "The selected ESP-IDF framework version is not the recommended one. "
+            "If there are connectivity or build issues please remove the manual version."
         )
-        _LOGGER.warning(
-            "If there are connectivity or build issues please remove the manual version"
-        )
-
-    plat_ver = value.get(CONF_PLATFORM_VERSION, ESP_IDF_PLATFORM_VERSION)
-    value[CONF_PLATFORM_VERSION] = str(plat_ver)
 
     return value
 
 
-CONF_VERSION_HINT = "version_hint"
 CONF_PLATFORM_VERSION = "platform_version"
+
 ARDUINO_FRAMEWORK_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_VERSION_HINT): cv.version_number,
+            cv.Optional(CONF_SOURCE): cv.string_strict,
             cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
         }
     ),
     _arduino_check_versions,
 )
+
 CONF_SDKCONFIG_OPTIONS = "sdkconfig_options"
 ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_VERSION_HINT): cv.version_number,
+            cv.Optional(CONF_SOURCE): cv.string_strict,
+            cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
             cv.Optional(CONF_SDKCONFIG_OPTIONS, default={}): {
                 cv.string_strict: cv.string_strict
             },
-            cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
             cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
                 {
                     cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC, default=False): cv.boolean,
@@ -293,7 +279,7 @@ async def to_code(config):
         cg.add_build_flag("-Wno-nonnull-compare")
         cg.add_platformio_option(
             "platform_packages",
-            [f"platformio/framework-espidf @ {conf[CONF_VERSION]}"],
+            [f"platformio/framework-espidf @ {conf[CONF_SOURCE]}"],
         )
         add_idf_sdkconfig_option("CONFIG_PARTITION_TABLE_SINGLE_APP", False)
         add_idf_sdkconfig_option("CONFIG_PARTITION_TABLE_CUSTOM", True)
@@ -323,7 +309,7 @@ async def to_code(config):
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ARDUINO")
         cg.add_platformio_option(
             "platform_packages",
-            [f"platformio/framework-arduinoespressif32 @ {conf[CONF_VERSION]}"],
+            [f"platformio/framework-arduinoespressif32 @ {conf[CONF_SOURCE]}"],
         )
 
         cg.add_platformio_option("board_build.partitions", "partitions.csv")

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -4,6 +4,7 @@ from esphome.const import (
     CONF_BOARD,
     CONF_BOARD_FLASH_MODE,
     CONF_FRAMEWORK,
+    CONF_SOURCE,
     CONF_VERSION,
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
@@ -31,7 +32,7 @@ def set_core_data(config):
     CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = "esp8266"
     CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "arduino"
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
-        config[CONF_FRAMEWORK][CONF_VERSION_HINT]
+        config[CONF_FRAMEWORK][CONF_VERSION]
     )
     CORE.data[KEY_ESP8266][KEY_BOARD] = config[CONF_BOARD]
     return config
@@ -70,66 +71,50 @@ ARDUINO_3_PLATFORM_VERSION = cv.Version(3, 0, 2)
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": ("https://github.com/esp8266/Arduino.git", cv.Version(3, 0, 2)),
-        "latest": ("", cv.Version(3, 0, 2)),
-        "recommended": (
-            _format_framework_arduino_version(RECOMMENDED_ARDUINO_FRAMEWORK_VERSION),
-            RECOMMENDED_ARDUINO_FRAMEWORK_VERSION,
-        ),
+        "dev": (cv.Version(3, 0, 2), "https://github.com/esp8266/Arduino.git"),
+        "latest": (cv.Version(3, 0, 2), None),
+        "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
-    ver_value = value[CONF_VERSION]
-    default_ver_hint = None
-    if ver_value.lower() in lookups:
-        default_ver_hint = str(lookups[ver_value.lower()][1])
-        ver_value = lookups[ver_value.lower()][0]
+
+    if value[CONF_VERSION] in lookups:
+        if CONF_SOURCE in value:
+            raise cv.Invalid(
+                "Framework version needs to be explicitly specified when custom source is used."
+            )
+
+        version, source = lookups[value[CONF_VERSION]]
     else:
-        with cv.suppress_invalid():
-            ver = cv.Version.parse(cv.version_number(value))
-            if ver <= cv.Version(2, 4, 1):
-                ver_value = f"~1.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            elif ver <= cv.Version(2, 6, 2):
-                ver_value = f"~2.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            else:
-                ver_value = f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            default_ver_hint = str(ver)
+        version = cv.Version.parse(cv.version_number(value[CONF_VERSION]))
+        source = value.get(CONF_SOURCE, None)
 
-    value[CONF_VERSION] = ver_value
+    value[CONF_VERSION] = str(version)
+    value[CONF_SOURCE] = source or _format_framework_arduino_version(version)
 
-    if CONF_VERSION_HINT not in value and default_ver_hint is None:
-        raise cv.Invalid("Needs a version hint to understand the framework version")
-
-    ver_hint_s = value.get(CONF_VERSION_HINT, default_ver_hint)
-    value[CONF_VERSION_HINT] = ver_hint_s
-    plat_ver = value.get(CONF_PLATFORM_VERSION)
-
-    if plat_ver is None:
-        ver_hint = cv.Version.parse(ver_hint_s)
-        if ver_hint >= cv.Version(3, 0, 0):
-            plat_ver = ARDUINO_3_PLATFORM_VERSION
-        elif ver_hint >= cv.Version(2, 5, 0):
-            plat_ver = ARDUINO_2_PLATFORM_VERSION
+    platform_version = value.get(CONF_PLATFORM_VERSION)
+    if platform_version is None:
+        if version >= cv.Version(3, 0, 0):
+            platform_version = ARDUINO_3_PLATFORM_VERSION
+        elif version >= cv.Version(2, 5, 0):
+            platform_version = ARDUINO_2_PLATFORM_VERSION
         else:
-            plat_ver = cv.Version(1, 8, 0)
-    value[CONF_PLATFORM_VERSION] = str(plat_ver)
+            platform_version = cv.Version(1, 8, 0)
+    value[CONF_PLATFORM_VERSION] = str(platform_version)
 
-    if cv.Version.parse(ver_hint_s) != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
+    if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
         _LOGGER.warning(
-            "The selected arduino framework version is not the recommended one"
-        )
-        _LOGGER.warning(
-            "If there are connectivity or build issues please remove the manual version"
+            "The selected Arduino framework version is not the recommended one. "
+            "If there are connectivity or build issues please remove the manual version."
         )
 
     return value
 
 
-CONF_VERSION_HINT = "version_hint"
 CONF_PLATFORM_VERSION = "platform_version"
 ARDUINO_FRAMEWORK_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_VERSION_HINT): cv.version_number,
+            cv.Optional(CONF_SOURCE): cv.string_strict,
             cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
         }
     ),
@@ -167,7 +152,7 @@ async def to_code(config):
     cg.add_build_flag("-DUSE_ESP8266_FRAMEWORK_ARDUINO")
     cg.add_platformio_option(
         "platform_packages",
-        [f"platformio/framework-arduinoespressif8266 @ {conf[CONF_VERSION]}"],
+        [f"platformio/framework-arduinoespressif8266 @ {conf[CONF_SOURCE]}"],
     )
     cg.add_platformio_option(
         "platform", f"platformio/espressif8266 @ {conf[CONF_PLATFORM_VERSION]}"

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -23,6 +23,7 @@ from esphome.const import (
     CONF_PLATFORMIO_OPTIONS,
     CONF_PRIORITY,
     CONF_PROJECT,
+    CONF_SOURCE,
     CONF_TRIGGER_ID,
     CONF_TYPE,
     CONF_VERSION,
@@ -181,10 +182,12 @@ def preload_core_config(config, result):
         if CONF_BOARD_FLASH_MODE in conf:
             plat_conf[CONF_BOARD_FLASH_MODE] = conf.pop(CONF_BOARD_FLASH_MODE)
         if CONF_ARDUINO_VERSION in conf:
-            plat_conf[CONF_FRAMEWORK] = {
-                CONF_TYPE: "arduino",
-                CONF_VERSION: conf.pop(CONF_ARDUINO_VERSION),
-            }
+            plat_conf[CONF_FRAMEWORK] = {CONF_TYPE: "arduino"}
+            try:
+                cv.Version.parse(conf[CONF_ARDUINO_VERSION])
+                plat_conf[CONF_FRAMEWORK][CONF_VERSION] = conf.pop(CONF_ARDUINO_VERSION)
+            except ValueError:
+                plat_conf[CONF_FRAMEWORK][CONF_SOURCE] = conf.pop(CONF_ARDUINO_VERSION)
         if CONF_BOARD in conf:
             plat_conf[CONF_BOARD] = conf.pop(CONF_BOARD)
         # Insert generated target platform config to main config


### PR DESCRIPTION
# What does this implement/fix? 

Currently, in (new-style config) the framework version can either be specified by setting a version number under `version`, or setting an URL to a custom version under `version` and specifying the version of the package under `version_hint`:
```yaml
esp32:
  framework:
    type: arduino

    version: 1.0.6
# or
    version: https://github.com/espressif/arduino-esp32#idf-release/v3.3
    version_hint: 1.0.6
```

I find this dual-purpose of `version`, and the silent ignore of `version_hint` if `version` isn't set to be confusing. Instead, always require `version` to be the version number, and allow a fork to be set using the new `source` option.

```yaml
esp32:
  framework:
    type: arduino

    version: 1.0.6
# or
    version: 1.0.6
    source: https://github.com/espressif/arduino-esp32#idf-release/v3.3
```

The magic `dev`, `recommended` and `latest` options remain valid for `version`, but cannot be used in combination with `source`.

Also fix the `latest` magic option, currently it generates an empty version number, and bump it to use 1.0.6 instead of 1.0.3 on ESP32 (no packages for Arduino 2 on PlatformIO yet).

If we want to do this, we should merge it into the 2021.10 release, to avoid breaking new configurations into the next release.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
