### PR TITLE
Fix NEC protocol implementation

### DIFF
--- a/esphome/components/remote_base/nec_protocol.cpp
+++ b/esphome/components/remote_base/nec_protocol.cpp
@@ -17,14 +17,14 @@ void NECProtocol::encode(RemoteTransmitData *dst, const NECData &data) {
   dst->set_carrier_frequency(38000);
 
   dst->item(HEADER_HIGH_US, HEADER_LOW_US);
-  for (uint32_t mask = 1UL << 15; mask; mask >>= 1) {
+  for (uint16_t mask = 1; mask; mask <<= 1) {
     if (data.address & mask)
       dst->item(BIT_HIGH_US, BIT_ONE_LOW_US);
     else
       dst->item(BIT_HIGH_US, BIT_ZERO_LOW_US);
   }
 
-  for (uint32_t mask = 1UL << 15; mask; mask >>= 1) {
+  for (uint16_t mask = 1; mask; mask <<= 1) {
     if (data.command & mask)
       dst->item(BIT_HIGH_US, BIT_ONE_LOW_US);
     else
@@ -41,7 +41,7 @@ optional<NECData> NECProtocol::decode(RemoteReceiveData src) {
   if (!src.expect_item(HEADER_HIGH_US, HEADER_LOW_US))
     return {};
 
-  for (uint32_t mask = 1UL << 15; mask != 0; mask >>= 1) {
+  for (uint16_t mask = 1; mask; mask <<= 1) {
     if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
       data.address |= mask;
     } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
@@ -51,7 +51,7 @@ optional<NECData> NECProtocol::decode(RemoteReceiveData src) {
     }
   }
 
-  for (uint32_t mask = 1UL << 15; mask != 0; mask >>= 1) {
+  for (uint16_t mask = 1; mask; mask <<= 1) {
     if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
       data.command |= mask;
     } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {


### PR DESCRIPTION
# Fix NEC protocol implementation

Correcting the order of bits from MSB to LSB in accordance with the [standard](https://techdocs.altium.com/display/FPGA/NEC+Infrared+Transmission+Protocol).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1618

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
