### PR TITLE
BH1750: Fix a too high default H-res2 mode value

### DIFF
--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -81,7 +81,6 @@ void BH1750Sensor::read_data_() {
   lx *= 69.0f / this->measurement_duration_;
   if (this->resolution_ == BH1750_RESOLUTION_0P5_LX) {
     lx /= 2.0f;
-    ESP_LOGW(TAG, "Potentially breaking change: H-res2 value corrected. Check related automations!");
   }
   ESP_LOGD(TAG, "'%s': Got illuminance=%.1flx", this->get_name().c_str(), lx);
   this->publish_state(lx);

--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -79,6 +79,10 @@ void BH1750Sensor::read_data_() {
 
   float lx = float(raw_value) / 1.2f;
   lx *= 69.0f / this->measurement_duration_;
+  if (this->resolution_ == BH1750_RESOLUTION_0P5_LX) {
+    lx /= 2.0f;
+    ESP_LOGW(TAG, "Potentially breaking change: H-res2 value corrected. Check related automations!");
+  }
   ESP_LOGD(TAG, "'%s': Got illuminance=%.1flx", this->get_name().c_str(), lx);
   this->publish_state(lx);
   this->status_clear_warning();


### PR DESCRIPTION
The BH1750 integration gives double the realistic lx value for the default H-res2 mode (resolution 0.5).
The BH1750 datasheet specifies that the lx value has to be divided by 2 to get a realistic value in the H-res2 mode, which is not yet done in the ESPHome code.
See this GitHub report and this community post for more background info.
https://github.com/esphome/issues/issues/2357
https://community.home-assistant.io/t/esphome-node-for-bh1750-problem-at-the-default-h-resolution-mode2/332385/3

This correction might be a breaking change when the H-res2 resolution mode value is used as trigger in an automation.
Therefore I added a warning log entry to indicate this.

Note: Since this is my first ever pull-request, any comments or corrections are welcome.

# What does this implement/fix? 

This fix corrects the currently unrealistically high H-res2 mode value, so resolves esphome/issues#2357.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
