### PR TITLE
Add repeat action for automations

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -248,7 +248,7 @@ async def while_action_to_code(config, action_id, template_arg, args):
     RepeatAction,
     cv.Schema(
         {
-            cv.Required(CONF_COUNT): cv.positive_not_null_int,
+            cv.Required(CONF_COUNT): cv.templatable(cv.positive_not_null_int),
             cv.Required(CONF_THEN): validate_action_list,
         }
     ),

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_AUTOMATION_ID,
     CONF_CONDITION,
+    CONF_COUNT,
     CONF_ELSE,
     CONF_ID,
     CONF_THEN,
@@ -66,6 +67,7 @@ DelayAction = cg.esphome_ns.class_("DelayAction", Action, cg.Component)
 LambdaAction = cg.esphome_ns.class_("LambdaAction", Action)
 IfAction = cg.esphome_ns.class_("IfAction", Action)
 WhileAction = cg.esphome_ns.class_("WhileAction", Action)
+RepeatAction = cg.esphome_ns.class_("RepeatAction", Action)
 WaitUntilAction = cg.esphome_ns.class_("WaitUntilAction", Action, cg.Component)
 UpdateComponentAction = cg.esphome_ns.class_("UpdateComponentAction", Action)
 Automation = cg.esphome_ns.class_("Automation")
@@ -236,6 +238,25 @@ async def if_action_to_code(config, action_id, template_arg, args):
 async def while_action_to_code(config, action_id, template_arg, args):
     conditions = await build_condition(config[CONF_CONDITION], template_arg, args)
     var = cg.new_Pvariable(action_id, template_arg, conditions)
+    actions = await build_action_list(config[CONF_THEN], template_arg, args)
+    cg.add(var.add_then(actions))
+    return var
+
+
+@register_action(
+    "repeat",
+    RepeatAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_COUNT): cv.positive_not_null_int,
+            cv.Required(CONF_THEN): validate_action_list,
+        }
+    ),
+)
+async def repeat_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    count_template = await cg.templatable(config[CONF_COUNT], args, cg.uint32)
+    cg.add(var.set_count(count_template))
     actions = await build_action_list(config[CONF_THEN], template_arg, args)
     cg.add(var.add_then(actions))
     return var

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -173,3 +173,11 @@ sensor:
     uart_id: uart2
     co2:
       name: CO2 Sensor
+
+script:
+  - id: automation_test
+    then:
+      - repeat:
+          count: 5
+          then:
+            - logger.log: "looping!"


### PR DESCRIPTION
# What does this implement/fix? 

Add a `repeat` action that can be used to create loops in automations:
```yaml
      - repeat:
          count: 5
          then:
            - logger.log: "in loop!"
```

I've to admit that I've implemented this more by pattern-matching with the existing automations than by actually understanding how it works, so **thorough review please**! Especially not sure what the `num_running_` field is for and whether I've used it correctly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/feature-requests#1457 and (partially) esphome/feature-requests#828.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** <!-- esphome/esphome-docs# --> TODO

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
script:
  - id: test_script
    then:
      - repeat:
          count: 5
          then:
            - logger.log: "in loop!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
