### PR TITLE
2021.10.0b4

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -180,7 +180,11 @@ def compile_program(args, config):
     from esphome import platformio_api
 
     _LOGGER.info("Compiling app...")
-    return platformio_api.run_compile(config, CORE.verbose)
+    rc = platformio_api.run_compile(config, CORE.verbose)
+    if rc != 0:
+        return rc
+    idedata = platformio_api.get_idedata(config)
+    return 0 if idedata is not None else 1
 
 
 def upload_using_esptool(config, port):
@@ -458,6 +462,21 @@ def command_update_all(args):
     return failed
 
 
+def command_idedata(args, config):
+    from esphome import platformio_api
+    import json
+
+    logging.disable(logging.INFO)
+    logging.disable(logging.WARNING)
+
+    idedata = platformio_api.get_idedata(config)
+    if idedata is None:
+        return 1
+
+    print(json.dumps(idedata.raw, indent=2) + "\n")
+    return 0
+
+
 PRE_CONFIG_ACTIONS = {
     "wizard": command_wizard,
     "version": command_version,
@@ -475,6 +494,7 @@ POST_CONFIG_ACTIONS = {
     "clean-mqtt": command_clean_mqtt,
     "mqtt-fingerprint": command_mqtt_fingerprint,
     "clean": command_clean,
+    "idedata": command_idedata,
 }
 
 
@@ -650,6 +670,11 @@ def parse_args(argv):
         "configuration", help="Your YAML configuration file directories.", nargs="+"
     )
 
+    parser_idedata = subparsers.add_parser("idedata")
+    parser_idedata.add_argument(
+        "configuration", help="Your YAML configuration file(s).", nargs=1
+    )
+
     # Keep backward compatibility with the old command line format of
     # esphome <config> <command>.
     #
@@ -762,7 +787,7 @@ def run_esphome(argv):
 
         config = read_config(dict(args.substitution) if args.substitution else {})
         if config is None:
-            return 1
+            return 2
         CORE.config = config
 
         if args.command not in POST_CONFIG_ACTIONS:

--- a/esphome/components/ade7953/ade7953.h
+++ b/esphome/components/ade7953/ade7953.h
@@ -76,9 +76,9 @@ class ADE7953 : public i2c::I2CDevice, public PollingComponent {
       return err;
     *value = 0;
     *value |= ((uint32_t) recv[0]) << 24;
-    *value |= ((uint32_t) recv[1]) << 24;
-    *value |= ((uint32_t) recv[2]) << 24;
-    *value |= ((uint32_t) recv[3]) << 24;
+    *value |= ((uint32_t) recv[1]) << 16;
+    *value |= ((uint32_t) recv[2]) << 8;
+    *value |= ((uint32_t) recv[3]);
     return i2c::ERROR_OK;
   }
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -7,6 +7,7 @@ from esphome.helpers import write_file_if_changed
 from esphome.const import (
     CONF_BOARD,
     CONF_FRAMEWORK,
+    CONF_SOURCE,
     CONF_TYPE,
     CONF_VARIANT,
     CONF_VERSION,
@@ -53,7 +54,7 @@ def set_core_data(config):
     elif conf[CONF_TYPE] == FRAMEWORK_ARDUINO:
         CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "arduino"
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
-        config[CONF_FRAMEWORK][CONF_VERSION_HINT]
+        config[CONF_FRAMEWORK][CONF_VERSION]
     )
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]
     CORE.data[KEY_ESP32][KEY_VARIANT] = config[CONF_VARIANT]
@@ -94,6 +95,13 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
     return f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
 
 
+def _format_framework_espidf_version(ver: cv.Version) -> str:
+    # format the given arduino (https://github.com/espressif/esp-idf/releases) version to
+    # a PIO platformio/framework-espidf value
+    # List of package versions: https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
+    return f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
+
+
 # NOTE: Keep this in mind when updating the recommended version:
 #  * New framework historically have had some regressions, especially for WiFi.
 #    The new version needs to be thoroughly validated before changing the
@@ -123,119 +131,97 @@ ESP_IDF_PLATFORM_VERSION = cv.Version(3, 3, 2)
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": ("https://github.com/espressif/arduino-esp32.git", cv.Version(2, 0, 0)),
-        "latest": ("", cv.Version(1, 0, 3)),
-        "recommended": (
-            _format_framework_arduino_version(RECOMMENDED_ARDUINO_FRAMEWORK_VERSION),
-            RECOMMENDED_ARDUINO_FRAMEWORK_VERSION,
-        ),
+        "dev": (cv.Version(2, 0, 0), "https://github.com/espressif/arduino-esp32.git"),
+        "latest": (cv.Version(1, 0, 6), None),
+        "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
-    ver_value = value[CONF_VERSION]
-    default_ver_hint = None
-    if ver_value.lower() in lookups:
-        default_ver_hint = str(lookups[ver_value.lower()][1])
-        ver_value = lookups[ver_value.lower()][0]
+
+    if value[CONF_VERSION] in lookups:
+        if CONF_SOURCE in value:
+            raise cv.Invalid(
+                "Framework version needs to be explicitly specified when custom source is used."
+            )
+
+        version, source = lookups[value[CONF_VERSION]]
     else:
-        with cv.suppress_invalid():
-            ver = cv.Version.parse(cv.version_number(value))
-            if ver <= cv.Version(1, 0, 3):
-                ver_value = f"~2.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            else:
-                ver_value = f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            default_ver_hint = str(ver)
-    value[CONF_VERSION] = ver_value
+        version = cv.Version.parse(cv.version_number(value[CONF_VERSION]))
+        source = value.get(CONF_SOURCE, None)
 
-    if CONF_VERSION_HINT not in value and default_ver_hint is None:
-        raise cv.Invalid("Needs a version hint to understand the framework version")
+    value[CONF_VERSION] = str(version)
+    value[CONF_SOURCE] = source or _format_framework_arduino_version(version)
 
-    ver_hint_s = value.get(CONF_VERSION_HINT, default_ver_hint)
-    value[CONF_VERSION_HINT] = ver_hint_s
-    plat_ver = value.get(CONF_PLATFORM_VERSION, ARDUINO_PLATFORM_VERSION)
-    value[CONF_PLATFORM_VERSION] = str(plat_ver)
+    platform_version = value.get(CONF_PLATFORM_VERSION, ARDUINO_PLATFORM_VERSION)
+    value[CONF_PLATFORM_VERSION] = str(platform_version)
 
-    if cv.Version.parse(ver_hint_s) != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
+    if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
         _LOGGER.warning(
-            "The selected arduino framework version is not the recommended one"
-        )
-        _LOGGER.warning(
-            "If there are connectivity or build issues please remove the manual version"
+            "The selected Arduino framework version is not the recommended one. "
+            "If there are connectivity or build issues please remove the manual version."
         )
 
     return value
-
-
-def _format_framework_espidf_version(ver: cv.Version) -> str:
-    # format the given arduino (https://github.com/espressif/esp-idf/releases) version to
-    # a PIO platformio/framework-espidf value
-    # List of package versions: https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
-    return f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
 
 
 def _esp_idf_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": ("https://github.com/espressif/esp-idf.git", cv.Version(4, 3, 1)),
-        "latest": ("", cv.Version(4, 3, 0)),
-        "recommended": (
-            _format_framework_espidf_version(RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION),
-            RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION,
-        ),
+        "dev": (cv.Version(4, 3, 1), "https://github.com/espressif/esp-idf.git"),
+        "latest": (cv.Version(4, 3, 0), None),
+        "recommended": (RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION, None),
     }
-    ver_value = value[CONF_VERSION]
-    default_ver_hint = None
-    if ver_value.lower() in lookups:
-        default_ver_hint = str(lookups[ver_value.lower()][1])
-        ver_value = lookups[ver_value.lower()][0]
+
+    if value[CONF_VERSION] in lookups:
+        if CONF_SOURCE in value:
+            raise cv.Invalid(
+                "Framework version needs to be explicitly specified when custom source is used."
+            )
+
+        version, source = lookups[value[CONF_VERSION]]
     else:
-        with cv.suppress_invalid():
-            ver = cv.Version.parse(cv.version_number(value))
-            ver_value = f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            default_ver_hint = str(ver)
-    value[CONF_VERSION] = ver_value
+        version = cv.Version.parse(cv.version_number(value[CONF_VERSION]))
+        source = value.get(CONF_SOURCE, None)
 
-    if CONF_VERSION_HINT not in value and default_ver_hint is None:
-        raise cv.Invalid("Needs a version hint to understand the framework version")
+    if version < cv.Version(4, 0, 0):
+        raise cv.Invalid("Only ESP-IDF 4.0+ is supported.")
 
-    ver_hint_s = value.get(CONF_VERSION_HINT, default_ver_hint)
-    value[CONF_VERSION_HINT] = ver_hint_s
-    if cv.Version.parse(ver_hint_s) < cv.Version(4, 0, 0):
-        raise cv.Invalid("Only ESP-IDF 4.0+ is supported")
-    if cv.Version.parse(ver_hint_s) != RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION:
+    value[CONF_VERSION] = str(version)
+    value[CONF_SOURCE] = source or _format_framework_espidf_version(version)
+
+    platform_version = value.get(CONF_PLATFORM_VERSION, ESP_IDF_PLATFORM_VERSION)
+    value[CONF_PLATFORM_VERSION] = str(platform_version)
+
+    if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
         _LOGGER.warning(
-            "The selected esp-idf framework version is not the recommended one"
+            "The selected ESP-IDF framework version is not the recommended one. "
+            "If there are connectivity or build issues please remove the manual version."
         )
-        _LOGGER.warning(
-            "If there are connectivity or build issues please remove the manual version"
-        )
-
-    plat_ver = value.get(CONF_PLATFORM_VERSION, ESP_IDF_PLATFORM_VERSION)
-    value[CONF_PLATFORM_VERSION] = str(plat_ver)
 
     return value
 
 
-CONF_VERSION_HINT = "version_hint"
 CONF_PLATFORM_VERSION = "platform_version"
+
 ARDUINO_FRAMEWORK_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_VERSION_HINT): cv.version_number,
+            cv.Optional(CONF_SOURCE): cv.string_strict,
             cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
         }
     ),
     _arduino_check_versions,
 )
+
 CONF_SDKCONFIG_OPTIONS = "sdkconfig_options"
 ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_VERSION_HINT): cv.version_number,
+            cv.Optional(CONF_SOURCE): cv.string_strict,
+            cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
             cv.Optional(CONF_SDKCONFIG_OPTIONS, default={}): {
                 cv.string_strict: cv.string_strict
             },
-            cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
             cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
                 {
                     cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC, default=False): cv.boolean,
@@ -293,7 +279,7 @@ async def to_code(config):
         cg.add_build_flag("-Wno-nonnull-compare")
         cg.add_platformio_option(
             "platform_packages",
-            [f"platformio/framework-espidf @ {conf[CONF_VERSION]}"],
+            [f"platformio/framework-espidf @ {conf[CONF_SOURCE]}"],
         )
         add_idf_sdkconfig_option("CONFIG_PARTITION_TABLE_SINGLE_APP", False)
         add_idf_sdkconfig_option("CONFIG_PARTITION_TABLE_CUSTOM", True)
@@ -323,7 +309,7 @@ async def to_code(config):
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ARDUINO")
         cg.add_platformio_option(
             "platform_packages",
-            [f"platformio/framework-arduinoespressif32 @ {conf[CONF_VERSION]}"],
+            [f"platformio/framework-arduinoespressif32 @ {conf[CONF_SOURCE]}"],
         )
 
         cg.add_platformio_option("board_build.partitions", "partitions.csv")

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -4,6 +4,7 @@ from esphome.const import (
     CONF_BOARD,
     CONF_BOARD_FLASH_MODE,
     CONF_FRAMEWORK,
+    CONF_SOURCE,
     CONF_VERSION,
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
@@ -31,7 +32,7 @@ def set_core_data(config):
     CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = "esp8266"
     CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "arduino"
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
-        config[CONF_FRAMEWORK][CONF_VERSION_HINT]
+        config[CONF_FRAMEWORK][CONF_VERSION]
     )
     CORE.data[KEY_ESP8266][KEY_BOARD] = config[CONF_BOARD]
     return config
@@ -70,66 +71,50 @@ ARDUINO_3_PLATFORM_VERSION = cv.Version(3, 0, 2)
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": ("https://github.com/esp8266/Arduino.git", cv.Version(3, 0, 2)),
-        "latest": ("", cv.Version(3, 0, 2)),
-        "recommended": (
-            _format_framework_arduino_version(RECOMMENDED_ARDUINO_FRAMEWORK_VERSION),
-            RECOMMENDED_ARDUINO_FRAMEWORK_VERSION,
-        ),
+        "dev": (cv.Version(3, 0, 2), "https://github.com/esp8266/Arduino.git"),
+        "latest": (cv.Version(3, 0, 2), None),
+        "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
-    ver_value = value[CONF_VERSION]
-    default_ver_hint = None
-    if ver_value.lower() in lookups:
-        default_ver_hint = str(lookups[ver_value.lower()][1])
-        ver_value = lookups[ver_value.lower()][0]
+
+    if value[CONF_VERSION] in lookups:
+        if CONF_SOURCE in value:
+            raise cv.Invalid(
+                "Framework version needs to be explicitly specified when custom source is used."
+            )
+
+        version, source = lookups[value[CONF_VERSION]]
     else:
-        with cv.suppress_invalid():
-            ver = cv.Version.parse(cv.version_number(value))
-            if ver <= cv.Version(2, 4, 1):
-                ver_value = f"~1.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            elif ver <= cv.Version(2, 6, 2):
-                ver_value = f"~2.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            else:
-                ver_value = f"~3.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
-            default_ver_hint = str(ver)
+        version = cv.Version.parse(cv.version_number(value[CONF_VERSION]))
+        source = value.get(CONF_SOURCE, None)
 
-    value[CONF_VERSION] = ver_value
+    value[CONF_VERSION] = str(version)
+    value[CONF_SOURCE] = source or _format_framework_arduino_version(version)
 
-    if CONF_VERSION_HINT not in value and default_ver_hint is None:
-        raise cv.Invalid("Needs a version hint to understand the framework version")
-
-    ver_hint_s = value.get(CONF_VERSION_HINT, default_ver_hint)
-    value[CONF_VERSION_HINT] = ver_hint_s
-    plat_ver = value.get(CONF_PLATFORM_VERSION)
-
-    if plat_ver is None:
-        ver_hint = cv.Version.parse(ver_hint_s)
-        if ver_hint >= cv.Version(3, 0, 0):
-            plat_ver = ARDUINO_3_PLATFORM_VERSION
-        elif ver_hint >= cv.Version(2, 5, 0):
-            plat_ver = ARDUINO_2_PLATFORM_VERSION
+    platform_version = value.get(CONF_PLATFORM_VERSION)
+    if platform_version is None:
+        if version >= cv.Version(3, 0, 0):
+            platform_version = ARDUINO_3_PLATFORM_VERSION
+        elif version >= cv.Version(2, 5, 0):
+            platform_version = ARDUINO_2_PLATFORM_VERSION
         else:
-            plat_ver = cv.Version(1, 8, 0)
-    value[CONF_PLATFORM_VERSION] = str(plat_ver)
+            platform_version = cv.Version(1, 8, 0)
+    value[CONF_PLATFORM_VERSION] = str(platform_version)
 
-    if cv.Version.parse(ver_hint_s) != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
+    if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
         _LOGGER.warning(
-            "The selected arduino framework version is not the recommended one"
-        )
-        _LOGGER.warning(
-            "If there are connectivity or build issues please remove the manual version"
+            "The selected Arduino framework version is not the recommended one. "
+            "If there are connectivity or build issues please remove the manual version."
         )
 
     return value
 
 
-CONF_VERSION_HINT = "version_hint"
 CONF_PLATFORM_VERSION = "platform_version"
 ARDUINO_FRAMEWORK_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_VERSION_HINT): cv.version_number,
+            cv.Optional(CONF_SOURCE): cv.string_strict,
             cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
         }
     ),
@@ -167,7 +152,7 @@ async def to_code(config):
     cg.add_build_flag("-DUSE_ESP8266_FRAMEWORK_ARDUINO")
     cg.add_platformio_option(
         "platform_packages",
-        [f"platformio/framework-arduinoespressif8266 @ {conf[CONF_VERSION]}"],
+        [f"platformio/framework-arduinoespressif8266 @ {conf[CONF_SOURCE]}"],
     )
     cg.add_platformio_option(
         "platform", f"platformio/espressif8266 @ {conf[CONF_PLATFORM_VERSION]}"

--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -38,7 +38,7 @@ ModbusRegisterType_ns = modbus_controller_ns.namespace("ModbusRegisterType")
 ModbusRegisterType = ModbusRegisterType_ns.enum("ModbusRegisterType")
 MODBUS_REGISTER_TYPE = {
     "coil": ModbusRegisterType.COIL,
-    "discrete_input": ModbusRegisterType.DISCRETE,
+    "discrete_input": ModbusRegisterType.DISCRETE_INPUT,
     "holding": ModbusRegisterType.HOLDING,
     "read": ModbusRegisterType.READ,
 }

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -8,7 +8,7 @@ from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_TRIGGER_ID,
 )
-
+from esphome.core import CORE
 from . import Nextion, nextion_ns, nextion_ref
 from .base_component import (
     CONF_ON_SLEEP,
@@ -76,6 +76,9 @@ async def to_code(config):
     if CONF_TFT_URL in config:
         cg.add_define("USE_NEXTION_TFT_UPLOAD")
         cg.add(var.set_tft_url(config[CONF_TFT_URL]))
+        if CORE.is_esp32:
+            cg.add_library("WiFiClientSecure", None)
+            cg.add_library("HTTPClient", None)
 
     if CONF_TOUCH_SLEEP_TIMEOUT in config:
         cg.add(var.set_touch_sleep_timeout_internal(config[CONF_TOUCH_SLEEP_TIMEOUT]))

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -1,4 +1,5 @@
 #include "scd4x.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -38,6 +39,7 @@ void SCD4XComponent::setup() {
       return;
     }
 
+    uint32_t stop_measurement_delay = 0;
     // In order to query the device periodic measurement must be ceased
     if (raw_read_status[0]) {
       ESP_LOGD(TAG, "Sensor has data available, stopping periodic measurement");
@@ -46,68 +48,72 @@ void SCD4XComponent::setup() {
         this->mark_failed();
         return;
       }
+      // According to the SCD4x datasheet the sensor will only respond to other commands after waiting 500 ms after
+      // issuing the stop_periodic_measurement command
+      stop_measurement_delay = 500;
     }
+    this->set_timeout(stop_measurement_delay, [this]() {
+      if (!this->write_command_(SCD4X_CMD_GET_SERIAL_NUMBER)) {
+        ESP_LOGE(TAG, "Failed to write get serial command");
+        this->error_code_ = COMMUNICATION_FAILED;
+        this->mark_failed();
+        return;
+      }
 
-    if (!this->write_command_(SCD4X_CMD_GET_SERIAL_NUMBER)) {
-      ESP_LOGE(TAG, "Failed to write get serial command");
-      this->error_code_ = COMMUNICATION_FAILED;
-      this->mark_failed();
-      return;
-    }
+      uint16_t raw_serial_number[3];
+      if (!this->read_data_(raw_serial_number, 3)) {
+        ESP_LOGE(TAG, "Failed to read serial number");
+        this->error_code_ = SERIAL_NUMBER_IDENTIFICATION_FAILED;
+        this->mark_failed();
+        return;
+      }
+      ESP_LOGD(TAG, "Serial number %02d.%02d.%02d", (uint16_t(raw_serial_number[0]) >> 8),
+               uint16_t(raw_serial_number[0] & 0xFF), (uint16_t(raw_serial_number[1]) >> 8));
 
-    uint16_t raw_serial_number[3];
-    if (!this->read_data_(raw_serial_number, 3)) {
-      ESP_LOGE(TAG, "Failed to read serial number");
-      this->error_code_ = SERIAL_NUMBER_IDENTIFICATION_FAILED;
-      this->mark_failed();
-      return;
-    }
-    ESP_LOGD(TAG, "Serial number %02d.%02d.%02d", (uint16_t(raw_serial_number[0]) >> 8),
-             uint16_t(raw_serial_number[0] & 0xFF), (uint16_t(raw_serial_number[1]) >> 8));
-
-    if (!this->write_command_(SCD4X_CMD_TEMPERATURE_OFFSET,
-                              (uint16_t)(temperature_offset_ * SCD4X_TEMPERATURE_OFFSET_MULTIPLIER))) {
-      ESP_LOGE(TAG, "Error setting temperature offset.");
-      this->error_code_ = MEASUREMENT_INIT_FAILED;
-      this->mark_failed();
-      return;
-    }
-
-    // If pressure compensation available use it
-    // else use altitude
-    if (ambient_pressure_compensation_) {
-      if (!this->write_command_(SCD4X_CMD_AMBIENT_PRESSURE_COMPENSATION, ambient_pressure_compensation_)) {
-        ESP_LOGE(TAG, "Error setting ambient pressure compensation.");
+      if (!this->write_command_(SCD4X_CMD_TEMPERATURE_OFFSET,
+                                (uint16_t)(temperature_offset_ * SCD4X_TEMPERATURE_OFFSET_MULTIPLIER))) {
+        ESP_LOGE(TAG, "Error setting temperature offset.");
         this->error_code_ = MEASUREMENT_INIT_FAILED;
         this->mark_failed();
         return;
       }
-    } else {
-      if (!this->write_command_(SCD4X_CMD_ALTITUDE_COMPENSATION, altitude_compensation_)) {
-        ESP_LOGE(TAG, "Error setting altitude compensation.");
+
+      // If pressure compensation available use it
+      // else use altitude
+      if (ambient_pressure_compensation_) {
+        if (!this->update_ambient_pressure_compensation_(ambient_pressure_)) {
+          ESP_LOGE(TAG, "Error setting ambient pressure compensation.");
+          this->error_code_ = MEASUREMENT_INIT_FAILED;
+          this->mark_failed();
+          return;
+        }
+      } else {
+        if (!this->write_command_(SCD4X_CMD_ALTITUDE_COMPENSATION, altitude_compensation_)) {
+          ESP_LOGE(TAG, "Error setting altitude compensation.");
+          this->error_code_ = MEASUREMENT_INIT_FAILED;
+          this->mark_failed();
+          return;
+        }
+      }
+
+      if (!this->write_command_(SCD4X_CMD_AUTOMATIC_SELF_CALIBRATION, enable_asc_ ? 1 : 0)) {
+        ESP_LOGE(TAG, "Error setting automatic self calibration.");
         this->error_code_ = MEASUREMENT_INIT_FAILED;
         this->mark_failed();
         return;
       }
-    }
 
-    if (!this->write_command_(SCD4X_CMD_AUTOMATIC_SELF_CALIBRATION, enable_asc_ ? 1 : 0)) {
-      ESP_LOGE(TAG, "Error setting automatic self calibration.");
-      this->error_code_ = MEASUREMENT_INIT_FAILED;
-      this->mark_failed();
-      return;
-    }
+      // Finally start sensor measurements
+      if (!this->write_command_(SCD4X_CMD_START_CONTINUOUS_MEASUREMENTS)) {
+        ESP_LOGE(TAG, "Error starting continuous measurements.");
+        this->error_code_ = MEASUREMENT_INIT_FAILED;
+        this->mark_failed();
+        return;
+      }
 
-    // Finally start sensor measurements
-    if (!this->write_command_(SCD4X_CMD_START_CONTINUOUS_MEASUREMENTS)) {
-      ESP_LOGE(TAG, "Error starting continuous measurements.");
-      this->error_code_ = MEASUREMENT_INIT_FAILED;
-      this->mark_failed();
-      return;
-    }
-
-    initialized_ = true;
-    ESP_LOGD(TAG, "Sensor initialized");
+      initialized_ = true;
+      ESP_LOGD(TAG, "Sensor initialized");
+    });
   });
 }
 
@@ -150,6 +156,13 @@ void SCD4XComponent::update() {
     return;
   }
 
+  if (this->ambient_pressure_source_ != nullptr) {
+    float pressure = this->ambient_pressure_source_->state / 1000.0f;
+    if (!std::isnan(pressure)) {
+      set_ambient_pressure_compensation(this->ambient_pressure_source_->state / 1000.0f);
+    }
+  }
+
   // Check if data is ready
   if (!this->write_command_(SCD4X_CMD_GET_DATA_READY_STATUS)) {
     this->status_set_warning();
@@ -190,6 +203,28 @@ void SCD4XComponent::update() {
   }
 
   this->status_clear_warning();
+}
+// Note pressure in bar here. Convert to hPa
+void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
+  ambient_pressure_compensation_ = true;
+  uint16_t new_ambient_pressure = (uint16_t)(pressure_in_bar * 1000);
+  // remove millibar from comparison to avoid frequent updates +/- 10 millibar doesn't matter
+  if (initialized_ && (new_ambient_pressure / 10 != ambient_pressure_ / 10)) {
+    update_ambient_pressure_compensation_(new_ambient_pressure);
+    ambient_pressure_ = new_ambient_pressure;
+  } else {
+    ESP_LOGD(TAG, "ambient pressure compensation skipped - no change required");
+  }
+}
+
+bool SCD4XComponent::update_ambient_pressure_compensation_(uint16_t pressure_in_hpa) {
+  if (this->write_command_(SCD4X_CMD_AMBIENT_PRESSURE_COMPENSATION, pressure_in_hpa)) {
+    ESP_LOGD(TAG, "setting ambient pressure compensation to %d hPa", pressure_in_hpa);
+    return true;
+  } else {
+    ESP_LOGE(TAG, "Error setting ambient pressure compensation.");
+    return false;
+  }
 }
 
 uint8_t SCD4XComponent::sht_crc_(uint8_t data1, uint8_t data2) {

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -18,10 +18,8 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
 
   void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
   void set_altitude_compensation(uint16_t altitude) { altitude_compensation_ = altitude; }
-  void set_ambient_pressure_compensation(float pressure) {
-    ambient_pressure_compensation_ = true;
-    ambient_pressure_ = (uint16_t)(pressure * 1000);
-  }
+  void set_ambient_pressure_compensation(float pressure_in_bar);
+  void set_ambient_pressure_source(sensor::Sensor *pressure) { ambient_pressure_source_ = pressure; }
   void set_temperature_offset(float offset) { temperature_offset_ = offset; };
 
   void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
@@ -33,6 +31,7 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   bool read_data_(uint16_t *data, uint8_t len);
   bool write_command_(uint16_t command);
   bool write_command_(uint16_t command, uint16_t data);
+  bool update_ambient_pressure_compensation_(uint16_t pressure_in_hpa);
 
   ERRORCODE error_code_;
 
@@ -47,6 +46,8 @@ class SCD4XComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
+  // used for compensation
+  sensor::Sensor *ambient_pressure_source_{nullptr};
 };
 
 }  // namespace scd4x

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2021.10.0b3"
+__version__ = "2021.10.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -23,6 +23,7 @@ from esphome.const import (
     CONF_PLATFORMIO_OPTIONS,
     CONF_PRIORITY,
     CONF_PROJECT,
+    CONF_SOURCE,
     CONF_TRIGGER_ID,
     CONF_TYPE,
     CONF_VERSION,
@@ -181,10 +182,12 @@ def preload_core_config(config, result):
         if CONF_BOARD_FLASH_MODE in conf:
             plat_conf[CONF_BOARD_FLASH_MODE] = conf.pop(CONF_BOARD_FLASH_MODE)
         if CONF_ARDUINO_VERSION in conf:
-            plat_conf[CONF_FRAMEWORK] = {
-                CONF_TYPE: "arduino",
-                CONF_VERSION: conf.pop(CONF_ARDUINO_VERSION),
-            }
+            plat_conf[CONF_FRAMEWORK] = {CONF_TYPE: "arduino"}
+            try:
+                cv.Version.parse(conf[CONF_ARDUINO_VERSION])
+                plat_conf[CONF_FRAMEWORK][CONF_VERSION] = conf.pop(CONF_ARDUINO_VERSION)
+            except ValueError:
+                plat_conf[CONF_FRAMEWORK][CONF_SOURCE] = conf.pop(CONF_ARDUINO_VERSION)
         if CONF_BOARD in conf:
             plat_conf[CONF_BOARD] = conf.pop(CONF_BOARD)
         # Insert generated target platform config to main config

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -9,6 +9,7 @@ import json
 import logging
 import multiprocessing
 import os
+from pathlib import Path
 import secrets
 import shutil
 import subprocess
@@ -26,7 +27,7 @@ import tornado.process
 import tornado.web
 import tornado.websocket
 
-from esphome import const, util
+from esphome import const, platformio_api, util
 from esphome.helpers import mkdir_p, get_bool_env, run_system_command
 from esphome.storage_json import (
     EsphomeStorageJSON,
@@ -398,23 +399,83 @@ class DownloadBinaryRequestHandler(BaseHandler):
     @authenticated
     @bind_config
     def get(self, configuration=None):
-        # pylint: disable=no-value-for-parameter
-        storage_path = ext_storage_path(settings.config_dir, configuration)
-        storage_json = StorageJSON.load(storage_path)
-        if storage_json is None:
-            self.send_error()
+        type = self.get_argument("type", "firmware.bin")
+
+        if type == "firmware.bin":
+            storage_path = ext_storage_path(settings.config_dir, configuration)
+            storage_json = StorageJSON.load(storage_path)
+            if storage_json is None:
+                self.send_error(404)
+                return
+            filename = f"{storage_json.name}.bin"
+            path = storage_json.firmware_bin_path
+
+        else:
+            args = ["esphome", "idedata", settings.rel_path(configuration)]
+            rc, stdout, _ = run_system_command(*args)
+
+            if rc != 0:
+                self.send_error(404 if rc == 2 else 500)
+                return
+
+            idedata = platformio_api.IDEData(json.loads(stdout))
+
+            found = False
+            for image in idedata.extra_flash_images:
+                if image.path.endswith(type):
+                    path = image.path
+                    filename = type
+                    found = True
+                    break
+
+            if not found:
+                self.send_error(404)
+                return
+
+        self.set_header("Content-Type", "application/octet-stream")
+        self.set_header("Content-Disposition", f'attachment; filename="{filename}"')
+        if not Path(path).is_file():
+            self.send_error(404)
             return
 
-        path = storage_json.firmware_bin_path
-        self.set_header("Content-Type", "application/octet-stream")
-        filename = f"{storage_json.name}.bin"
-        self.set_header("Content-Disposition", f'attachment; filename="{filename}"')
         with open(path, "rb") as f:
             while True:
                 data = f.read(16384)
                 if not data:
                     break
                 self.write(data)
+        self.finish()
+
+
+class ManifestRequestHandler(BaseHandler):
+    @authenticated
+    @bind_config
+    def get(self, configuration=None):
+        args = ["esphome", "idedata", settings.rel_path(configuration)]
+        rc, stdout, _ = run_system_command(*args)
+
+        if rc != 0:
+            self.send_error(404 if rc == 2 else 500)
+            return
+
+        idedata = platformio_api.IDEData(json.loads(stdout))
+
+        firmware_offset = "0x10000" if idedata.extra_flash_images else "0x0"
+        flash_images = [
+            {
+                "path": f"./download.bin?configuration={configuration}&type=firmware.bin",
+                "offset": firmware_offset,
+            }
+        ] + [
+            {
+                "path": f"./download.bin?configuration={configuration}&type={os.path.basename(image.path)}",
+                "offset": image.offset,
+            }
+            for image in idedata.extra_flash_images
+        ]
+
+        self.set_header("Content-Type", "application/json")
+        self.write(json.dumps(flash_images))
         self.finish()
 
 
@@ -862,6 +923,7 @@ def make_app(debug=get_bool_env(ENV_DEV)):
             (f"{rel}info", InfoRequestHandler),
             (f"{rel}edit", EditRequestHandler),
             (f"{rel}download.bin", DownloadBinaryRequestHandler),
+            (f"{rel}manifest.json", ManifestRequestHandler),
             (f"{rel}serial-ports", SerialPortRequestHandler),
             (f"{rel}ping", PingRequestHandler),
             (f"{rel}delete", DeleteRequestHandler),

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyserial==3.5
 platformio==5.2.1
 esptool==3.1
 click==8.0.3
-esphome-dashboard==20211011.1
+esphome-dashboard==20211015.0
 aioesphomeapi==9.1.5
 
 # esp-idf requires this, but doesn't bundle it by default


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"In software, we rarely have meaningful requirements. Even if we do, the only measure of success that matters is whether our solution solves the customer’s shifting idea of what their problem is."_

~ Jeff Atwood
- Add pressure compensation during runtime [esphome#2493](https://github.com/esphome/esphome/pull/2493)
- Fix Nextion HTTPClient error for ESP32 [esphome#2524](https://github.com/esphome/esphome/pull/2524)
- Fix bug in register name definition [esphome#2526](https://github.com/esphome/esphome/pull/2526)
- Replace framework version_hint with source option [esphome#2529](https://github.com/esphome/esphome/pull/2529)
- Fix bitshift on read in ADE7953 [esphome#2537](https://github.com/esphome/esphome/pull/2537)
- Allow downloading all bin files from backend in dashboard [esphome#2514](https://github.com/esphome/esphome/pull/2514)
- Bump dashboard to 20211015.0 [esphome#2525](https://github.com/esphome/esphome/pull/2525)
