### PR TITLE
Only show timestamp for dashboard access logs

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -758,7 +758,12 @@ def run_esphome(argv):
     args = parse_args(argv)
     CORE.dashboard = args.dashboard
 
-    setup_log(args.verbose, args.quiet)
+    setup_log(
+        args.verbose,
+        args.quiet,
+        # Show timestamp for dashboard access logs
+        args.command == "dashboard",
+    )
     if args.deprecated_argv_suggestion is not None and args.command != "vscode":
         _LOGGER.warning(
             "Calling ESPHome with the configuration before the command is deprecated "

--- a/esphome/log.py
+++ b/esphome/log.py
@@ -49,8 +49,10 @@ def color(col: str, msg: str, reset: bool = True) -> bool:
 
 
 class ESPHomeLogFormatter(logging.Formatter):
-    def __init__(self):
-        super().__init__(fmt="%(asctime)s %(levelname)s %(message)s", style="%")
+    def __init__(self, *, include_timestamp: bool):
+        fmt = "%(asctime)s " if include_timestamp else ""
+        fmt += "%(levelname)s %(message)s"
+        super().__init__(fmt=fmt, style="%")
 
     def format(self, record):
         formatted = super().format(record)
@@ -64,7 +66,9 @@ class ESPHomeLogFormatter(logging.Formatter):
         return f"{prefix}{formatted}{Style.RESET_ALL}"
 
 
-def setup_log(debug=False, quiet=False):
+def setup_log(
+    debug: bool = False, quiet: bool = False, include_timestamp: bool = False
+) -> None:
     import colorama
 
     if debug:
@@ -79,4 +83,6 @@ def setup_log(debug=False, quiet=False):
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 
     colorama.init()
-    logging.getLogger().handlers[0].setFormatter(ESPHomeLogFormatter())
+    logging.getLogger().handlers[0].setFormatter(
+        ESPHomeLogFormatter(include_timestamp=include_timestamp)
+    )


### PR DESCRIPTION
# What does this implement/fix? 

Timestamps were introduced in #2455

Personal preference, but I think in the compile/validate/etc logs timestamp doesn't make much sense (all happens quickly anyway, and just adds noise)

Constrain the change to only the part the PR was intended for: dashboard access logs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
