### PR TITLE
[ESP32] ADC auto-range setting

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -199,10 +199,10 @@ float ADCSensor::sample() {
       }
       this->set_attenuation(ADC_ATTEN_DB_11);
     }                                                // Contribution coefficients:
-    float c11 = min(raw11, 2048) / 2048.0f;          // high 1, middle 1, low 0
+    float c11 = _min(raw11, 2048) / 2048.0f;          // high 1, middle 1, low 0
     float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
     float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
-    float c0 = min(4095 - raw0, 2048) / 2048.0f;     // high 0, middle 1, low 1
+    float c0 = _min(4095 - raw0, 2048) / 2048.0f;     // high 0, middle 1, low 1
     float csum = c11 + c6 + c2 + c0;                // sum to normalize the result
     if (csum > 0) {
       v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -59,7 +59,7 @@ void ADCSensor::set_attenuation(adc_atten_t attenuation) {
   this->attenuation_ = attenuation;
   adc1_config_channel_atten(gpio_to_adc1(pin_->get_pin()), attenuation_);
 }
-void ADCSensor::set_autorange(bool autorange) {
+void ADCSensor::set_autorange(bool autorange = true) {
   this->autorange_ = autorange;
   if (autorange)
     this->set_attenuation(ADC_ATTEN_DB_11);
@@ -202,14 +202,14 @@ float ADCSensor::sample() {
       this->set_attenuation(ADC_ATTEN_DB_11);
     }
     // Triangular coefficient ponderation. 1 at middle, 0 at limits.
-    float c11 = (float)abs(2048 - raw11) / 2048.f;
-    float c6 = (float)abs(2048 - raw6) / 2048.f;
-    float c2 = (float)abs(2048 - raw2) / 2048.f;
-    float c0 = (float)abs(2048 - raw0) / 2048.f;
+    float c11 = (2048 - abs(raw11 - 2048)) / 2048.f;
+    float c6 = (2048 - abs(raw6 - 2048)) / 2048.f;
+    float c2 = (2048 - abs(raw2 - 2048)) / 2048.f;
+    float c0 = (2048 - abs(raw0 - 2048)) / 2048.f;
     float csum = c11 + c6 + c2 + c0;  // To normalize the result
     if (csum > 0) {
       value_v = this->raw_to_voltage_(raw11) * c11 + this->raw_to_voltage_(raw6) * c6 +
-                this->raw_to_voltage_(raw2) * c2 + this->raw_to_voltage_(raw0) * c0);
+                this->raw_to_voltage_(raw2) * c2 + this->raw_to_voltage_(raw0) * c0;
       value_v /= csum;
     }
   }

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -189,22 +189,25 @@ float ADCSensor::sample() {
     float v11 = v, v6 = v, v2 = v, v0 = v;
     if (raw11 < 4095) {  // Progressively read all attenuation ranges
       this->set_attenuation(ADC_ATTEN_DB_6);
-      raw6 = this->read_raw_(); v6 = this->raw_to_voltage_(raw6);
+      raw6 = this->read_raw_();
+      v6 = this->raw_to_voltage_(raw6);
       if (raw6 < 4095) {
         this->set_attenuation(ADC_ATTEN_DB_2_5);
-        raw2 = this->read_raw_(); v2 = this->raw_to_voltage_(raw2);
+        raw2 = this->read_raw_();
+        v2 = this->raw_to_voltage_(raw2);
         if (raw2 < 4095) {
           this->set_attenuation(ADC_ATTEN_DB_0);
-          raw0 = this->read_raw_(); v0 = this->raw_to_voltage_(raw0);
+          raw0 = this->read_raw_();
+          v0 = this->raw_to_voltage_(raw0);
         }
       }
       this->set_attenuation(ADC_ATTEN_DB_11);
-    }                                                 // Contribution coefficients:
-    float c11 = clamp(raw11 / 2048.0f, 0, 1);         // high 1, middle 1, low 0
-    float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;   // high 0, middle 1, low 0
-    float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;   // high 0, middle 1, low 0
-    float c0 = clamp((4095 - raw0) / 2048.0f, 0, 1);  // high 0, middle 1, low 1
-    float csum = c11 + c6 + c2 + c0;  // sum to normalize the result
+    }                                                // Contribution coefficients:
+    float c11 = clamp(raw11, 0, 2048) / 2048.0f;     // high 1, middle 1, low 0
+    float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
+    float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
+    float c0 = clamp(4095 - raw0, 0, 2048) / 2048f;  // high 0, middle 1, low 1
+    float csum = c11 + c6 + c2 + c0;                 // sum to normalize the result
     if (csum > 0) {
       v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);
       v /= csum;

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -181,47 +181,36 @@ float ADCSensor::raw_to_voltage_(int raw) {
 }
 float ADCSensor::sample() {
   int raw = this->read_raw_();
-  float value_v = this->raw_to_voltage_(raw);
+  float v = this->raw_to_voltage_(raw);
 #ifdef USE_ESP32
   if (autorange_) {
-    int raw11 = raw;
-    int raw6 = 4095;
-    int raw2 = 4095;
-    int raw0 = 4095;
+    int raw11 = raw, raw6 = 4095, raw2 = 4095, raw0 = 4095;
+    float v11 = v, v6 = v, v2 = v, v0 = v;
     if (raw11 < 4095) {  // Progressively read all attenuation ranges
       this->set_attenuation(ADC_ATTEN_DB_6);
-      raw6 = this->read_raw_();
+      raw6 = this->read_raw_(); v6 = this->raw_to_voltage_(raw6);
       if (raw6 < 4095) {
         this->set_attenuation(ADC_ATTEN_DB_2_5);
-        raw2 = this->read_raw_();
+        raw2 = this->read_raw_(); v2 = this->raw_to_voltage_(raw2);
         if (raw2 < 4095) {
           this->set_attenuation(ADC_ATTEN_DB_0);
-          raw0 = this->read_raw_();
+          raw0 = this->read_raw_(); v0 = this->raw_to_voltage_(raw0);
         }
       }
       this->set_attenuation(ADC_ATTEN_DB_11);
-    }
-    float c11 = raw11 / 4095.f;                     // 1 at max, 0 at min
-    float c6 = (2048 - abs(raw6 - 2048)) / 2048.f;  // 1 at middle, 0 at limits
-    float c2 = (2048 - abs(raw2 - 2048)) / 2048.f;  // 1 at middle, 0 at limits
-    float c0 = (4095 - raw11) / 4095.f;             // 0 at max, 1 at min
-    float csum = c11 + c6 + c2 + c0;                // to normalize the result
+    }                                                // Contribution coefficients:
+    float c11 = min(raw11, 2048) / 2048.0f;          // high 1, middle 1, low 0
+    float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
+    float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
+    float c0 = min(4095 - raw0, 2048) / 2048.0f;     // high 0, middle 1, low 1
+    float csum = c11 + c6 + c2 + c0;                // sum to normalize the result
     if (csum > 0) {
-      this->attenuation_ = ADC_ATTEN_DB_11;  // TO-DO: Cleanup
-      float v11 = this->raw_to_voltage_(raw11);
-      this->attenuation_ = ADC_ATTEN_DB_6;
-      float v6 = this->raw_to_voltage_(raw6);
-      this->attenuation_ = ADC_ATTEN_DB_2_5;
-      float v2 = this->raw_to_voltage_(raw2);
-      this->attenuation_ = ADC_ATTEN_DB_0;
-      float v0 = this->raw_to_voltage_(raw0);
-      this->attenuation_ = ADC_ATTEN_DB_11;
-      value_v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);
-      value_v /= csum;
+      v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);
+      v /= csum;
     }
   }
 #endif
-  return value_v;
+  return v;
 }
 #ifdef USE_ESP8266
 std::string ADCSensor::unique_id() { return get_mac_address() + "-adc"; }

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -16,8 +16,10 @@ namespace adc {
 static const char *const TAG = "adc";
 
 #ifdef USE_ESP32
-void ADCSensor::set_attenuation(adc_atten_t attenuation) { this->attenuation_ = attenuation; }
-
+void ADCSensor::set_attenuation(adc_atten_t attenuation) {
+  this->attenuation_ = attenuation;
+  adc1_config_channel_atten(gpio_to_adc1(pin_->get_pin()), attenuation_);
+}
 inline adc1_channel_t gpio_to_adc1(uint8_t pin) {
 #if CONFIG_IDF_TARGET_ESP32
   switch (pin) {
@@ -66,6 +68,8 @@ void ADCSensor::setup() {
 #endif
 
 #ifdef USE_ESP32
+  if (auto_range_)
+    this->attenuation_ = ADC_ATTEN_DB_11;
   adc1_config_channel_atten(gpio_to_adc1(pin_->get_pin()), attenuation_);
   adc1_config_width(ADC_WIDTH_BIT_12);
 #if !CONFIG_IDF_TARGET_ESP32C3 && !CONFIG_IDF_TARGET_ESP32H2
@@ -84,22 +88,25 @@ void ADCSensor::dump_config() {
 #endif
 #ifdef USE_ESP32
   LOG_PIN("  Pin: ", pin_);
-  switch (this->attenuation_) {
-    case ADC_ATTEN_DB_0:
-      ESP_LOGCONFIG(TAG, " Attenuation: 0db (max 1.1V)");
-      break;
-    case ADC_ATTEN_DB_2_5:
-      ESP_LOGCONFIG(TAG, " Attenuation: 2.5db (max 1.5V)");
-      break;
-    case ADC_ATTEN_DB_6:
-      ESP_LOGCONFIG(TAG, " Attenuation: 6db (max 2.2V)");
-      break;
-    case ADC_ATTEN_DB_11:
-      ESP_LOGCONFIG(TAG, " Attenuation: 11db (max 3.9V)");
-      break;
-    default:  // This is to satisfy the unused ADC_ATTEN_MAX
-      break;
-  }
+  if (auto_range_) 
+    ESP_LOGCONFIG(TAG, " Attenuation: auto-range");
+  else
+    switch (this->attenuation_) {
+      case ADC_ATTEN_DB_0:
+        ESP_LOGCONFIG(TAG, " Attenuation: 0db (max 1.1V)");
+        break;
+      case ADC_ATTEN_DB_2_5:
+        ESP_LOGCONFIG(TAG, " Attenuation: 2.5db (max 1.5V)");
+        break;
+      case ADC_ATTEN_DB_6:
+        ESP_LOGCONFIG(TAG, " Attenuation: 6db (max 2.2V)");
+        break;
+      case ADC_ATTEN_DB_11:
+        ESP_LOGCONFIG(TAG, " Attenuation: 11db (max 3.9V)");
+        break;
+      default:  // This is to satisfy the unused ADC_ATTEN_MAX
+        break;
+    }
 #endif
   LOG_UPDATE_INTERVAL(this);
 }
@@ -109,10 +116,25 @@ void ADCSensor::update() {
   ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);
   this->publish_state(value_v);
 }
-float ADCSensor::sample() {
+int ADCSensor::read_raw() {
+  int raw = 0;
+  #ifdef USE_ESP32
+    raw = adc1_get_raw(gpio_to_adc1(pin_->get_pin()));
+  #endif
+  
+  #ifdef USE_ESP8266
+  #ifdef USE_ADC_SENSOR_VCC
+    raw = ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
+  #else
+    raw = analogRead(this->pin_->get_pin());  // NOLINT
+  #endif
+  #endif
+  return raw;
+}
+float ADCSensor::raw_to_voltage(int raw) {
+  float value_v = 0;
 #ifdef USE_ESP32
-  int raw = adc1_get_raw(gpio_to_adc1(pin_->get_pin()));
-  float value_v = raw / 4095.0f;
+  value_v = raw / 4095.0f;
 #if CONFIG_IDF_TARGET_ESP32
   switch (this->attenuation_) {
     case ADC_ATTEN_DB_0:
@@ -147,17 +169,54 @@ float ADCSensor::sample() {
     default:  // This is to satisfy the unused ADC_ATTEN_MAX
       break;
   }
-#endif
-  return value_v;
-#endif
+# endif
+# endif
 
 #ifdef USE_ESP8266
-#ifdef USE_ADC_SENSOR_VCC
-  return ESP.getVcc() / 1024.0f;  // NOLINT(readability-static-accessed-through-instance)
-#else
-  return analogRead(this->pin_->get_pin()) / 1024.0f;  // NOLINT
+  value_v = raw / 1024.0f;
 #endif
+  return value_v;
+}
+float ADCSensor::sample() {
+  int raw = this->read_raw();
+  float value_v = this->raw_to_voltage(raw);
+#ifdef USE_ESP32
+  if (auto_range_) {
+    float v_acc = 0;   // Accumulator for valid ADC samples (>0 && <4095)
+    int nsamples = 0;  // TO-DO: Work only with the linear range limits?
+    if (raw < 4095) {
+      if (raw > 0) {
+        v_acc += value_v;
+        nsamples++;
+      }
+      this->set_attenuation(ADC_ATTEN_DB_6);
+      raw = this->read_raw();
+      if (raw < 4095) {
+        if (raw > 0) {
+          v_acc += this->raw_to_voltage(raw);
+          nsamples++;
+        }
+        this->set_attenuation(ADC_ATTEN_DB_2_5);
+        raw = this->read_raw();
+        if (raw < 4095) {
+          if (raw > 0) {
+            v_acc += this->raw_to_voltage(raw);
+            nsamples++;
+          }
+          this->set_attenuation(ADC_ATTEN_DB_0);
+          raw = this->read_raw();
+          if (raw < 4095) {
+            v_acc += this->raw_to_voltage(raw);
+            nsamples++;
+          }
+        }
+      }
+      value_v = v_acc / (float)nsamples;  // Average the valid samples
+    }
+    this->set_attenuation(ADC_ATTEN_DB_11);
+  }
 #endif
+  return value_v;
 }
 #ifdef USE_ESP8266
 std::string ADCSensor::unique_id() { return get_mac_address() + "-adc"; }

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -119,7 +119,7 @@ void ADCSensor::dump_config() {
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 void ADCSensor::update() {
   float value_v = this->sample();
-  ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);  TO-DO: uncomment
+  ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);
   this->publish_state(value_v);
 }
 int ADCSensor::read_raw_() {

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -60,7 +60,7 @@ void ADCSensor::set_attenuation(adc_atten_t attenuation) {
   this->attenuation_ = attenuation;
   adc1_config_channel_atten(gpio_to_adc1(pin_->get_pin()), attenuation_);
 }
-void ADCSensor::set_autorange(bool autorange = true) {
+void ADCSensor::set_autorange(bool autorange) {
   this->autorange_ = autorange;
   if (autorange)
     this->set_attenuation(ADC_ATTEN_DB_11);
@@ -119,7 +119,7 @@ void ADCSensor::dump_config() {
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 void ADCSensor::update() {
   float value_v = this->sample();
-  // ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);  TO-DO: uncomment
+  ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);  TO-DO: uncomment
   this->publish_state(value_v);
 }
 int ADCSensor::read_raw_() {

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -1,5 +1,6 @@
 #include "adc_sensor.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 #ifdef USE_ESP8266
 #ifdef USE_ADC_SENSOR_VCC
@@ -198,13 +199,11 @@ float ADCSensor::sample() {
         }
       }
       this->set_attenuation(ADC_ATTEN_DB_11);
-    }
-    float c11 = raw11 / 2048.0f;                     // Contribution coefficients:
-    if (c11 > 1) c11 = 1.0f;                         // high 1, middle 1, low 0
-    float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
-    float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
-    float c0 = (4095 - raw0) / 2048.0f;              // high 0, middle 1, low 1
-    if (c0 > 1) c0 = 1.0f;
+    }                                                 // Contribution coefficients:
+    float c11 = clamp(raw11 / 2048.0f, 0, 1);         // high 1, middle 1, low 0
+    float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;   // high 0, middle 1, low 0
+    float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;   // high 0, middle 1, low 0
+    float c0 = clamp((4095 - raw0) / 2048.0f, 0, 1);  // high 0, middle 1, low 1
     float csum = c11 + c6 + c2 + c0;  // sum to normalize the result
     if (csum > 0) {
       v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -202,12 +202,12 @@ float ADCSensor::sample() {
         }
       }
       this->set_attenuation(ADC_ATTEN_DB_11);
-    }                                                // Contribution coefficients:
-    float c11 = clamp(raw11, 0, 2048) / 2048.0f;     // high 1, middle 1, low 0
-    float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
-    float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
-    float c0 = clamp(4095 - raw0, 0, 2048) / 2048f;  // high 0, middle 1, low 1
-    float csum = c11 + c6 + c2 + c0;                 // sum to normalize the result
+    }                                                  // Contribution coefficients:
+    float c11 = clamp(raw11, 0, 2048) / 2048.0f;       // high 1, middle 1, low 0
+    float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;    // high 0, middle 1, low 0
+    float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;    // high 0, middle 1, low 0
+    float c0 = clamp(4095 - raw0, 0, 2048) / 2048.0f;  // high 0, middle 1, low 1
+    float csum = c11 + c6 + c2 + c0;                   // sum to normalize the result
     if (csum > 0) {
       v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);
       v /= csum;

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -198,12 +198,14 @@ float ADCSensor::sample() {
         }
       }
       this->set_attenuation(ADC_ATTEN_DB_11);
-    }                                                // Contribution coefficients:
-    float c11 = _min(raw11, 2048) / 2048.0f;          // high 1, middle 1, low 0
+    }
+    float c11 = raw11 / 2048.0f;                     // Contribution coefficients:
+    if (c11 > 1) c11 = 1.0f;                         // high 1, middle 1, low 0
     float c6 = (2048 - abs(raw6 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
     float c2 = (2048 - abs(raw2 - 2048)) / 2048.0f;  // high 0, middle 1, low 0
-    float c0 = _min(4095 - raw0, 2048) / 2048.0f;     // high 0, middle 1, low 1
-    float csum = c11 + c6 + c2 + c0;                // sum to normalize the result
+    float c0 = (4095 - raw0) / 2048.0f;              // high 0, middle 1, low 1
+    if (c0 > 1) c0 = 1.0f;
+    float csum = c11 + c6 + c2 + c0;  // sum to normalize the result
     if (csum > 0) {
       v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);
       v /= csum;

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -68,9 +68,12 @@ void ADCSensor::setup() {
 #endif
 
 #ifdef USE_ESP32
+#ifdef USE_ADC_AUTORANGE
+  auto_range_ = true;
+#endif
   if (auto_range_)
-    this->attenuation_ = ADC_ATTEN_DB_11;
-  adc1_config_channel_atten(gpio_to_adc1(pin_->get_pin()), attenuation_);
+    attenuation_ = ADC_ATTEN_DB_11;
+  this->set_attenuation(attenuation_);
   adc1_config_width(ADC_WIDTH_BIT_12);
 #if !CONFIG_IDF_TARGET_ESP32C3 && !CONFIG_IDF_TARGET_ESP32H2
   adc_gpio_init(ADC_UNIT_1, (adc_channel_t) gpio_to_adc1(pin_->get_pin()));

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -95,7 +95,7 @@ void ADCSensor::dump_config() {
 #ifdef USE_ESP32
   LOG_PIN("  Pin: ", pin_);
   if (autorange_)
-    ESP_LOGCONFIG(TAG, " Attenuation: auto-range (max 3.9V)");
+    ESP_LOGCONFIG(TAG, " Attenuation: auto");
   else
     switch (this->attenuation_) {
       case ADC_ATTEN_DB_0:
@@ -186,7 +186,7 @@ float ADCSensor::sample() {
 #ifdef USE_ESP32
   if (autorange_) {
     int raw11 = raw, raw6 = 4095, raw2 = 4095, raw0 = 4095;
-    float v11 = v, v6 = v, v2 = v, v0 = v;
+    float v11 = v, v6 = 0, v2 = 0, v0 = 0;
     if (raw11 < 4095) {  // Progressively read all attenuation ranges
       this->set_attenuation(ADC_ATTEN_DB_6);
       raw6 = this->read_raw_();

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -16,7 +16,6 @@ namespace adc {
 static const char *const TAG = "adc";
 
 #ifdef USE_ESP32
-#define ADC_MAX 4095
 inline adc1_channel_t gpio_to_adc1(uint8_t pin) {
 #if CONFIG_IDF_TARGET_ESP32
   switch (pin) {
@@ -135,7 +134,7 @@ int ADCSensor::read_raw_() {
 }
 float ADCSensor::raw_to_voltage_(int raw) {
 #ifdef USE_ESP32
-  float value_v = raw / (float) ADC_MAX;
+  float value_v = raw / 4095.0f;
 #if CONFIG_IDF_TARGET_ESP32
   switch (this->attenuation_) {
     case ADC_ATTEN_DB_0:
@@ -184,16 +183,16 @@ float ADCSensor::sample() {
 #ifdef USE_ESP32
   if (auto_range_) {
     int raw11 = raw;
-    int raw6 = ADC_MAX;
-    int raw2 = ADC_MAX;
-    int raw0 = ADC_MAX;
-    if (raw11 < ADC_MAX) {  // Progressively read all attenuation ranges
+    int raw6 = 4095;
+    int raw2 = 4095;
+    int raw0 = 4095;
+    if (raw11 < 4095) {  // Progressively read all attenuation ranges
       this->set_attenuation(ADC_ATTEN_DB_6);
       raw6 = this->read_raw_();
-      if (raw6 < ADC_MAX) {
+      if (raw6 < 4095) {
         this->set_attenuation(ADC_ATTEN_DB_2_5);
         raw2 = this->read_raw_();
-        if (raw2 < ADC_MAX) {
+        if (raw2 < 4095) {
           this->set_attenuation(ADC_ATTEN_DB_0);
           raw0 = this->read_raw_();
         }
@@ -201,13 +200,13 @@ float ADCSensor::sample() {
       this->set_attenuation(ADC_ATTEN_DB_11);
     }
     // TO-DO: Cleanup the next part
-    float c11 = (float)(2048-abs(raw11-2048)) / 2048.f;  // Triangular coefficient ponderation. 1 at middle, 0 at limits.
-    float c6 = (float)(2048-abs(raw6-2048)) / 2048.f;
-    float c2 = (float)(2048-abs(raw2-2048)) / 2048.f;
-    float c0 = (float)(2048-abs(raw0-2048)) / 2048.f;
+    float c11 = (float)(2048 - abs(raw11 - 2048)) / 2048.f;  // Triangular coefficient ponderation. 1 at middle, 0 at limits.
+    float c6 = (float)(2048 - abs(raw6 - 2048)) / 2048.f;
+    float c2 = (float)(2048 - abs(raw2 - 2048)) / 2048.f;
+    float c0 = (float)(2048 - abs(raw0 - 2048)) / 2048.f;
     float csum = c11 + c6 + c2 + c0;  // To normalize the result
     if (csum > 0)
-      value_v = (this->raw_to_voltage(raw11)*c11 + this->raw_to_voltage(raw6)*c6 + this->raw_to_voltage(raw2)*c2 + this->raw_to_voltage(raw0)*c0) / csum;
+      value_v = (this->raw_to_voltage_(raw11) * c11 + this->raw_to_voltage_(raw6) * c6 + this->raw_to_voltage_(raw2) * c2 + this->raw_to_voltage_(raw0) * c0) / csum;
   }
 #endif
   return value_v;

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -208,8 +208,16 @@ float ADCSensor::sample() {
     float c0 = (2048 - abs(raw0 - 2048)) / 2048.f;
     float csum = c11 + c6 + c2 + c0;  // To normalize the result
     if (csum > 0) {
-      value_v = this->raw_to_voltage_(raw11) * c11 + this->raw_to_voltage_(raw6) * c6 +
-                this->raw_to_voltage_(raw2) * c2 + this->raw_to_voltage_(raw0) * c0;
+      this->attenuation_ = ADC_ATTEN_DB_11;  // TO-DO: Cleanup
+      float v11 = this->raw_to_voltage_(raw11);
+      this->attenuation_ = ADC_ATTEN_DB_6;
+      float v6 = this->raw_to_voltage_(raw6);
+      this->attenuation_ = ADC_ATTEN_DB_2_5;
+      float v2 = this->raw_to_voltage_(raw2);
+      this->attenuation_ = ADC_ATTEN_DB_0;
+      float v0 = this->raw_to_voltage_(raw0);
+      this->attenuation_ = ADC_ATTEN_DB_11;
+      value_v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);
       value_v /= csum;
     }
   }

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -118,7 +118,7 @@ void ADCSensor::dump_config() {
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 void ADCSensor::update() {
   float value_v = this->sample();
-  //ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);
+  // ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);  TO-DO: uncomment
   this->publish_state(value_v);
 }
 int ADCSensor::read_raw_() {
@@ -201,12 +201,11 @@ float ADCSensor::sample() {
       }
       this->set_attenuation(ADC_ATTEN_DB_11);
     }
-    // Triangular coefficient ponderation. 1 at middle, 0 at limits.
-    float c11 = (2048 - abs(raw11 - 2048)) / 2048.f;
-    float c6 = (2048 - abs(raw6 - 2048)) / 2048.f;
-    float c2 = (2048 - abs(raw2 - 2048)) / 2048.f;
-    float c0 = (2048 - abs(raw0 - 2048)) / 2048.f;
-    float csum = c11 + c6 + c2 + c0;  // To normalize the result
+    float c11 = raw11 / 4095.f;                     // 1 at max, 0 at min
+    float c6 = (2048 - abs(raw6 - 2048)) / 2048.f;  // 1 at middle, 0 at limits
+    float c2 = (2048 - abs(raw2 - 2048)) / 2048.f;  // 1 at middle, 0 at limits
+    float c0 = (4095 - raw11) / 4095.f;             // 0 at max, 1 at min
+    float csum = c11 + c6 + c2 + c0;                // to normalize the result
     if (csum > 0) {
       this->attenuation_ = ADC_ATTEN_DB_11;  // TO-DO: Cleanup
       float v11 = this->raw_to_voltage_(raw11);

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -118,7 +118,7 @@ void ADCSensor::dump_config() {
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 void ADCSensor::update() {
   float value_v = this->sample();
-  ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);
+  //ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);
   this->publish_state(value_v);
 }
 int ADCSensor::read_raw_() {

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -88,7 +88,7 @@ void ADCSensor::dump_config() {
 #endif
 #ifdef USE_ESP32
   LOG_PIN("  Pin: ", pin_);
-  if (auto_range_) 
+  if (auto_range_)
     ESP_LOGCONFIG(TAG, " Attenuation: auto-range");
   else
     switch (this->attenuation_) {
@@ -117,24 +117,21 @@ void ADCSensor::update() {
   this->publish_state(value_v);
 }
 int ADCSensor::read_raw() {
-  int raw = 0;
-  #ifdef USE_ESP32
-    raw = adc1_get_raw(gpio_to_adc1(pin_->get_pin()));
-  #endif
-  
-  #ifdef USE_ESP8266
-  #ifdef USE_ADC_SENSOR_VCC
-    raw = ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
-  #else
-    raw = analogRead(this->pin_->get_pin());  // NOLINT
-  #endif
-  #endif
-  return raw;
+#ifdef USE_ESP32
+  return adc1_get_raw(gpio_to_adc1(pin_->get_pin()));
+#endif
+
+#ifdef USE_ESP8266
+#ifdef USE_ADC_SENSOR_VCC
+  return ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
+#else
+  return analogRead(this->pin_->get_pin());  // NOLINT
+#endif
+#endif
 }
 float ADCSensor::raw_to_voltage(int raw) {
-  float value_v = 0;
 #ifdef USE_ESP32
-  value_v = raw / 4095.0f;
+  float value_v = raw / 4095.0f;
 #if CONFIG_IDF_TARGET_ESP32
   switch (this->attenuation_) {
     case ADC_ATTEN_DB_0:
@@ -169,13 +166,13 @@ float ADCSensor::raw_to_voltage(int raw) {
     default:  // This is to satisfy the unused ADC_ATTEN_MAX
       break;
   }
-# endif
-# endif
-
-#ifdef USE_ESP8266
-  value_v = raw / 1024.0f;
 #endif
   return value_v;
+#endif
+
+#ifdef USE_ESP8266
+  return raw / 1024.0f;
+#endif
 }
 float ADCSensor::sample() {
   int raw = this->read_raw();
@@ -211,7 +208,7 @@ float ADCSensor::sample() {
           }
         }
       }
-      value_v = v_acc / (float)nsamples;  // Average the valid samples
+      value_v = v_acc / (float) nsamples;  // Average the valid samples
     }
     this->set_attenuation(ADC_ATTEN_DB_11);
   }

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -193,13 +193,13 @@ float ADCSensor::sample() {
     uint32_t csum = c11 + c6 + c2 + c0;         // sum to normalize the final result
     if (csum > 0)
       v = (v11 * c11) + (v6 * c6) + (v2 * c2) + (v0 * c0);
-    else
-      csum = 1;   // in case of error, keep the 11db output
-    csum *= 1e6;  // include the microvolts->volts conversion factor
-    return (float) v / (float) csum;  // Normalize & convert
+    else  // in case of error, this keeps the 11db output (v)
+      csum = 1;
+    csum *= 1e6;                      // include the 1e6 microvolts->volts conversion factor
+    return (float) v / (float) csum;  // normalize, convert & return
   }
 #endif
-  return v / (float) 1e6;  // Convert from microvolts to volts
+  return v / (float) 1e6;  // convert from microvolts to volts
 }
 #ifdef USE_ESP8266
 std::string ADCSensor::unique_id() { return get_mac_address() + "-adc"; }

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -36,8 +36,8 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 
  protected:
   InternalGPIOPin *pin_;
-  int read_raw();
-  float raw_to_voltage(int raw);
+  int read_raw_();
+  float raw_to_voltage_(int raw);
 
 #ifdef USE_ESP32
   adc_atten_t attenuation_{ADC_ATTEN_DB_0};

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -18,6 +18,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 #ifdef USE_ESP32
   /// Set the attenuation for this pin. Only available on the ESP32.
   void set_attenuation(adc_atten_t attenuation);
+  void set_autorange(bool autorange);
 #endif
 
   /// Update adc values.
@@ -41,7 +42,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 
 #ifdef USE_ESP32
   adc_atten_t attenuation_{ADC_ATTEN_DB_0};
-  bool auto_range_{false};
+  bool autorange_{false};
 #endif
 };
 

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -37,8 +37,8 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 
  protected:
   InternalGPIOPin *pin_;
-  int read_raw_();
-  float raw_to_voltage_(int raw);
+  uint16_t read_raw_();
+  uint32_t raw_to_microvolts_(uint16_t raw);
 
 #ifdef USE_ESP32
   adc_atten_t attenuation_{ADC_ATTEN_DB_0};

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -36,9 +36,12 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 
  protected:
   InternalGPIOPin *pin_;
+  int read_raw();
+  float raw_to_voltage(int raw);
 
 #ifdef USE_ESP32
   adc_atten_t attenuation_{ADC_ATTEN_DB_0};
+  bool auto_range_{false};
 #endif
 };
 

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -21,6 +21,7 @@ ATTENUATION_MODES = {
     "2.5db": cg.global_ns.ADC_ATTEN_DB_2_5,
     "6db": cg.global_ns.ADC_ATTEN_DB_6,
     "11db": cg.global_ns.ADC_ATTEN_DB_11,
+    "auto": "auto",
 }
 
 
@@ -92,4 +93,7 @@ async def to_code(config):
         cg.add(var.set_pin(pin))
 
     if CONF_ATTENUATION in config:
-        cg.add(var.set_attenuation(config[CONF_ATTENUATION]))
+        if CONF_ATTENUATION == "auto":
+            cg.add_define("USE_ADC_AUTORANGE")
+        else:
+            cg.add(var.set_attenuation(config[CONF_ATTENUATION]))

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -94,6 +94,6 @@ async def to_code(config):
 
     if CONF_ATTENUATION in config:
         if config[CONF_ATTENUATION] == "auto":
-            cg.add(var.set_autorange(cg.true))
+            cg.add(var.set_autorange(cg.global_ns.true))
         else:
             cg.add(var.set_attenuation(config[CONF_ATTENUATION]))

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -94,6 +94,6 @@ async def to_code(config):
 
     if CONF_ATTENUATION in config:
         if config[CONF_ATTENUATION] == "auto":
-            cg.add(var.set_autorange())
+            cg.add(var.set_autorange(true))
         else:
             cg.add(var.set_attenuation(config[CONF_ATTENUATION]))

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -94,6 +94,6 @@ async def to_code(config):
 
     if CONF_ATTENUATION in config:
         if config[CONF_ATTENUATION] == "auto":
-            cg.add(var.set_autorange(true))
+            cg.add(var.set_autorange(cg.true))
         else:
             cg.add(var.set_attenuation(config[CONF_ATTENUATION]))

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -93,7 +93,7 @@ async def to_code(config):
         cg.add(var.set_pin(pin))
 
     if CONF_ATTENUATION in config:
-        if CONF_ATTENUATION == "auto":
+        if config[CONF_ATTENUATION] == "auto":
             cg.add(var.set_autorange())
         else:
             cg.add(var.set_attenuation(config[CONF_ATTENUATION]))

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -21,7 +21,7 @@ ATTENUATION_MODES = {
     "2.5db": cg.global_ns.ADC_ATTEN_DB_2_5,
     "6db": cg.global_ns.ADC_ATTEN_DB_6,
     "11db": cg.global_ns.ADC_ATTEN_DB_11,
-    "auto": "auto",
+    "auto": true,
 }
 
 
@@ -94,6 +94,6 @@ async def to_code(config):
 
     if CONF_ATTENUATION in config:
         if CONF_ATTENUATION == "auto":
-            cg.add_define("USE_ADC_AUTORANGE")
+            cg.add(var.set_autorange(true))
         else:
             cg.add(var.set_attenuation(config[CONF_ATTENUATION]))

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -21,7 +21,7 @@ ATTENUATION_MODES = {
     "2.5db": cg.global_ns.ADC_ATTEN_DB_2_5,
     "6db": cg.global_ns.ADC_ATTEN_DB_6,
     "11db": cg.global_ns.ADC_ATTEN_DB_11,
-    "auto": true,
+    "auto": "auto",
 }
 
 
@@ -94,6 +94,6 @@ async def to_code(config):
 
     if CONF_ATTENUATION in config:
         if CONF_ATTENUATION == "auto":
-            cg.add(var.set_autorange(true))
+            cg.add(var.set_autorange())
         else:
             cg.add(var.set_attenuation(config[CONF_ATTENUATION]))


### PR DESCRIPTION
An implementation of dynamic range for the voltage readings on ESP32, where configurable attenuation is available.
This allows for an ADC that doesn't saturate at high voltages, while also allowing for the best resolution at lower input levels.

Updated method:

- The approach is to set the highest attenuation first, and then iteratively reduce it.
- Measurements are then interpolated using "triangular ponderation" where each range is considered optimal at the middle of the 0-4095 scale, and then tapers out its contribution at either high and low values.

This allows for a continuous/seamless transition between ranges, making it as linear as possible. ADC calibration would still be done downstream at the signal processing stage.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1547

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration entry
sensor:
  - platform: adc
    pin: GPIO33
    name: "Gas sensor"
    attenuation: auto # Automatic range
    accuracy_decimals: 5
    update_interval: 60s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
