### PR TITLE
Feature/sensor cse7761

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,6 +39,7 @@ esphome/components/color_temperature/* @jesserockz
 esphome/components/coolix/* @glmnet
 esphome/components/cover/* @esphome/core
 esphome/components/cs5460a/* @balrog-kun
+esphome/components/cse7761/* @berfenger
 esphome/components/ct_clamp/* @jesserockz
 esphome/components/current_based/* @djwmarcx
 esphome/components/daly_bms/* @s1lvi0

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -84,7 +84,7 @@ void CSE7761Component::loop() {
     } else if (1 == this->data_.init) {
       if (1 == this->data_.ready) {
         this->write_(CSE7761_SPECIAL_COMMAND, CSE7761_CMD_CLOSE_WRITE);
-        ESP_LOGD(TAG, "C61: CSE7761 found");
+        ESP_LOGD(TAG, "CSE7761 found");
         this->data_.ready = 2;
       }
     }
@@ -154,11 +154,11 @@ bool CSE7761Component::read_once_(uint32_t reg, uint32_t size, uint32_t *value) 
   }
 
   if (!rcvd) {
-    ESP_LOGD(TAG, PSTR("C61: Rx none"));
+    ESP_LOGD(TAG, "Rx none");
     return false;
   }
   if (rcvd > 5) {
-    ESP_LOGD(TAG, PSTR("C61: Rx overflow"));
+    ESP_LOGD(TAG, "Rx overflow");
     return false;
   }
 
@@ -206,7 +206,7 @@ bool CSE7761Component::chip_init_() {
   calc_chksum = ~calc_chksum;
   uint16_t coeff_chksum = this->read_(CSE7761_REG_COEFFCHKSUM, 2);
   if ((calc_chksum != coeff_chksum) || (!calc_chksum)) {
-    ESP_LOGD(TAG, PSTR("C61: Default calibration"));
+    ESP_LOGD(TAG, "Default calibration");
     this->data_.coefficient[RMS_IAC] = CSE7761_IREF;
     this->data_.coefficient[RMS_UC] = CSE7761_UREF;
     this->data_.coefficient[POWER_PAC] = CSE7761_PREF;
@@ -223,7 +223,7 @@ bool CSE7761Component::chip_init_() {
     this->write_(CSE7761_REG_EMUCON2 | 0x80, 0x0FC1);  // Sonoff Dual R3 Pow
     this->write_(CSE7761_REG_PULSE1SEL | 0x80, 0x3290);
   } else {
-    ESP_LOGD(TAG, PSTR("C61: Write failed"));
+    ESP_LOGD(TAG, "Write failed");
     return false;
   }
   return true;
@@ -248,7 +248,7 @@ void CSE7761Component::get_data_() {
   value = this->read_fallback_(CSE7761_REG_POWERPB, this->data_.active_power[1], 4);
   this->data_.active_power[1] = (0 == this->data_.current_rms[1]) ? 0 : (value & 0x80000000) ? (~value) + 1 : value;
 
-  ESP_LOGD(TAG, PSTR("C61: F%d, U%d, I%d/%d, P%d/%d"), this->data_.frequency, this->data_.voltage_rms,
+  ESP_LOGD(TAG, "F%d, U%d, I%d/%d, P%d/%d", this->data_.frequency, this->data_.voltage_rms,
            this->data_.current_rms[0], this->data_.current_rms[1], this->data_.active_power[0],
            this->data_.active_power[1]);
 
@@ -263,7 +263,7 @@ void CSE7761Component::get_data_() {
     // Active power = PowerPA * PowerPAC * 1000 / 0x80000000
     float active_power = (float) this->data_.active_power[channel] / cse7761ref(POWER_PAC, &this->data_);  // W
     float amps = (float) this->data_.current_rms[channel] / cse7761ref(RMS_IAC, &this->data_);             // A
-    ESP_LOGD(TAG, PSTR("C61: Channel %d power %f W, current %f A"), channel, active_power, amps);
+    ESP_LOGD(TAG, "Channel %d power %f W, current %f A", channel, active_power, amps);
     if (channel == 0) {
       if (this->power_sensor_1_ != nullptr) {
         this->power_sensor_1_->publish_state(active_power);

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -41,7 +41,7 @@ static const uint8_t CSE7761_CMD_RESET = 0x96;  // Reset command, after receivin
 
 enum CSE7761 { RMS_IAC, RMS_IBC, RMS_UC, POWER_PAC, POWER_PBC, POWER_SC, ENERGY_AC, ENERGY_BC };
 
-inline int32_t time_difference(uint32_t prev, uint32_t next) { return ((int32_t) (next - prev)); }
+inline int32_t time_difference(uint32_t prev, uint32_t next) { return ((int32_t)(next - prev)); }
 
 int32_t time_passed_since(uint32_t timestamp) {
   // Compute the number of milliSeconds passed since timestamp given.
@@ -248,9 +248,8 @@ void CSE7761Component::get_data_() {
   value = this->read_fallback_(CSE7761_REG_POWERPB, this->data_.active_power[1], 4);
   this->data_.active_power[1] = (0 == this->data_.current_rms[1]) ? 0 : (value & 0x80000000) ? (~value) + 1 : value;
 
-  ESP_LOGD(TAG, "F%d, U%d, I%d/%d, P%d/%d", this->data_.frequency, this->data_.voltage_rms,
-           this->data_.current_rms[0], this->data_.current_rms[1], this->data_.active_power[0],
-           this->data_.active_power[1]);
+  ESP_LOGD(TAG, "F%d, U%d, I%d/%d, P%d/%d", this->data_.frequency, this->data_.voltage_rms, this->data_.current_rms[0],
+           this->data_.current_rms[1], this->data_.active_power[0], this->data_.active_power[1]);
 
   // convert values and publish to sensors
 

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -1,0 +1,286 @@
+#include "cse7761.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace cse7761 {
+
+static const char *const TAG = "cse7761";
+
+/*********************************************************************************************\
+ * CSE7761 - Energy  (Sonoff Dual R3 Pow v1.x)
+ *
+ * Based on Tasmota source code
+ * See https://github.com/arendst/Tasmota/discussions/10793
+ * https://github.com/arendst/Tasmota/blob/development/tasmota/xnrg_19_cse7761.ino
+\*********************************************************************************************/
+
+static const int CSE7761_UREF = 42563;  // RmsUc
+static const int CSE7761_IREF = 52241;  // RmsIAC
+static const int CSE7761_PREF = 44513;  // PowerPAC
+
+static const uint8_t CSE7761_REG_SYSCON = 0x00;   // (2) System Control Register (0x0A04)
+static const uint8_t CSE7761_REG_EMUCON = 0x01;   // (2) Metering control register (0x0000)
+static const uint8_t CSE7761_REG_EMUCON2 = 0x13;  // (2) Metering control register 2 (0x0001)
+#define CSE7761_REG_PULSE1SEL 0x1D                // (2) Pin function output select register (0x3210)
+
+static const uint8_t CSE7761_REG_RMSIA = 0x24;      // (3) The effective value of channel A current (0x000000)
+static const uint8_t CSE7761_REG_RMSIB = 0x25;      // (3) The effective value of channel B current (0x000000)
+static const uint8_t CSE7761_REG_RMSU = 0x26;       // (3) Voltage RMS (0x000000)
+#define CSE7761_REG_POWERPA 0x2C                    // (4) Channel A active power, update rate 27.2Hz (0x00000000)
+#define CSE7761_REG_POWERPB 0x2D                    // (4) Channel B active power, update rate 27.2Hz (0x00000000)
+static const uint8_t CSE7761_REG_SYSSTATUS = 0x43;  // (1) System status register
+
+#define CSE7761_REG_COEFFCHKSUM 0x6F             // (2) Coefficient checksum
+static const uint8_t CSE7761_REG_RMSIAC = 0x70;  // (2) Channel A effective current conversion coefficient
+
+#define CSE7761_SPECIAL_COMMAND 0xEA            // Start special command
+static const uint8_t CSE7761_CMD_RESET = 0x96;  // Reset command, after receiving the command, the chip resets
+#define CSE7761_CMD_CLOSE_WRITE 0xDC            // Close write operation
+#define CSE7761_CMD_ENABLE_WRITE 0xE5           // Enable write operation
+
+enum CSE7761 { RMS_IAC, RMS_IBC, RMS_UC, POWER_PAC, POWER_PBC, POWER_SC, ENERGY_AC, ENERGY_BC };
+
+inline int32_t time_difference(uint32_t prev, uint32_t next) { return ((int32_t) (next - prev)); }
+
+int32_t time_passed_since(uint32_t timestamp) {
+  // Compute the number of milliSeconds passed since timestamp given.
+  // Note: value can be negative if the timestamp has not yet been reached.
+  return time_difference(timestamp, millis());
+}
+
+bool time_reached(uint32_t timer) {
+  // Check if a certain timeout has been reached.
+  const int32_t passed = time_passed_since(timer);
+  return (passed >= 0);
+}
+
+uint32_t cse7761ref(uint32_t unit, CSE7761DataStruct *data) {
+  switch (unit) {
+    case RMS_UC:
+      return 0x400000 * 100 / data->coefficient[RMS_UC];
+    case RMS_IAC:
+      return (0x800000 * 100 / data->coefficient[RMS_IAC]) * 10;  // Stay within 32 bits
+    case POWER_PAC:
+      return 0x80000000 / data->coefficient[POWER_PAC];
+  }
+  return 0;
+}
+
+void CSE7761Component::setup() { ESP_LOGCONFIG(TAG, "Setting up CSE7761..."); }
+
+void CSE7761Component::loop() {
+  if (this->data_.init && millis() > this->last_init_ + 1000) {
+    this->last_init_ = millis();
+    if (3 == this->data_.init) {
+      this->write_(CSE7761_SPECIAL_COMMAND, CSE7761_CMD_RESET);
+    } else if (2 == this->data_.init) {
+      uint16_t syscon = this->read_(0x00, 2);  // Default 0x0A04
+      if ((0x0A04 == syscon) && this->chip_init_()) {
+        this->data_.ready = 1;
+      } else {
+        this->mark_failed();
+      }
+    } else if (1 == this->data_.init) {
+      if (1 == this->data_.ready) {
+        this->write_(CSE7761_SPECIAL_COMMAND, CSE7761_CMD_CLOSE_WRITE);
+        ESP_LOGD(TAG, "C61: CSE7761 found");
+        this->data_.ready = 2;
+      }
+    }
+    this->data_.init--;
+  }
+}
+
+void CSE7761Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "CSE7761:");
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with CSE7761 failed!");
+  }
+  LOG_UPDATE_INTERVAL(this);
+  this->check_uart_settings(38400, 1, uart::UART_CONFIG_PARITY_EVEN, 8);
+}
+
+float CSE7761Component::get_setup_priority() const { return setup_priority::DATA; }
+
+void CSE7761Component::update() {
+  if (2 == this->data_.ready) {
+    this->get_data_();
+  }
+}
+
+void CSE7761Component::write_(uint32_t reg, uint32_t data) {
+  uint8_t buffer[5];
+
+  buffer[0] = 0xA5;
+  buffer[1] = reg;
+  uint32_t len = 2;
+  if (data) {
+    if (data < 0xFF) {
+      buffer[2] = data & 0xFF;
+      len = 3;
+    } else {
+      buffer[2] = (data >> 8) & 0xFF;
+      buffer[3] = data & 0xFF;
+      len = 4;
+    }
+    uint8_t crc = 0;
+    for (uint32_t i = 0; i < len; i++) {
+      crc += buffer[i];
+    }
+    buffer[len] = ~crc;
+    len++;
+  }
+
+  this->write_array(buffer, len);
+}
+
+bool CSE7761Component::read_once_(uint32_t reg, uint32_t size, uint32_t *value) {
+  while (this->available()) {
+    this->read();
+  }
+
+  this->write_(reg, 0);
+
+  uint8_t buffer[8] = {0};
+  uint32_t rcvd = 0;
+  uint32_t timeout = millis() + 3;
+
+  while (!time_reached(timeout) && (rcvd <= size)) {
+    int value = this->read();
+    if ((value > -1) && (rcvd < sizeof(buffer) - 1)) {
+      buffer[rcvd++] = value;
+    }
+  }
+
+  if (!rcvd) {
+    ESP_LOGD(TAG, PSTR("C61: Rx none"));
+    return false;
+  }
+  if (rcvd > 5) {
+    ESP_LOGD(TAG, PSTR("C61: Rx overflow"));
+    return false;
+  }
+
+  rcvd--;
+  uint32_t result = 0;
+  uint8_t crc = 0xA5 + reg;
+  for (uint32_t i = 0; i < rcvd; i++) {
+    result = (result << 8) | buffer[i];
+    crc += buffer[i];
+  }
+  crc = ~crc;
+  if (crc != buffer[rcvd]) {
+    return false;
+  }
+
+  *value = result;
+  return true;
+}
+
+uint32_t CSE7761Component::read_(uint32_t reg, uint32_t size) {
+  bool result = false;  // Start loop
+  uint32_t retry = 3;   // Retry up to three times
+  uint32_t value = 0;   // Default no value
+  while (!result && retry) {
+    retry--;
+    result = this->read_once_(reg, size, &value);
+  }
+  return value;
+}
+
+uint32_t CSE7761Component::read_fallback_(uint32_t reg, uint32_t prev, uint32_t size) {
+  uint32_t value = this->read_(reg, size);
+  if (!value) {  // Error so use previous value read
+    value = prev;
+  }
+  return value;
+}
+
+bool CSE7761Component::chip_init_() {
+  uint16_t calc_chksum = 0xFFFF;
+  for (uint32_t i = 0; i < 8; i++) {
+    this->data_.coefficient[i] = this->read_(CSE7761_REG_RMSIAC + i, 2);
+    calc_chksum += this->data_.coefficient[i];
+  }
+  calc_chksum = ~calc_chksum;
+  uint16_t coeff_chksum = this->read_(CSE7761_REG_COEFFCHKSUM, 2);
+  if ((calc_chksum != coeff_chksum) || (!calc_chksum)) {
+    ESP_LOGD(TAG, PSTR("C61: Default calibration"));
+    this->data_.coefficient[RMS_IAC] = CSE7761_IREF;
+    this->data_.coefficient[RMS_UC] = CSE7761_UREF;
+    this->data_.coefficient[POWER_PAC] = CSE7761_PREF;
+  }
+
+  this->write_(CSE7761_SPECIAL_COMMAND, CSE7761_CMD_ENABLE_WRITE);
+
+  uint8_t sys_status = this->read_(CSE7761_REG_SYSSTATUS, 1);
+  if (sys_status & 0x10) {  // Write enable to protected registers (WREN)
+    this->write_(CSE7761_REG_SYSCON | 0x80, 0xFF04);
+    this->write_(CSE7761_REG_EMUCON | 0x80,
+                 0x1183);                              // Tasmota enable zero cross detection on both
+                                                       // positive and negative signal
+    this->write_(CSE7761_REG_EMUCON2 | 0x80, 0x0FC1);  // Sonoff Dual R3 Pow
+    this->write_(CSE7761_REG_PULSE1SEL | 0x80, 0x3290);
+  } else {
+    ESP_LOGD(TAG, PSTR("C61: Write failed"));
+    return false;
+  }
+  return true;
+}
+
+void CSE7761Component::get_data_() {
+  // The effective value of current and voltage Rms is a 24-bit signed number,
+  // the highest bit is 0 for valid data,
+  //   and when the highest bit is 1, the reading will be processed as zero
+  // The active power parameter PowerA/B is in two’s complement format, 32-bit
+  // data, the highest bit is Sign bit.
+  uint32_t value = this->read_fallback_(CSE7761_REG_RMSU, this->data_.voltage_rms, 3);
+  this->data_.voltage_rms = (value >= 0x800000) ? 0 : value;
+
+  value = this->read_fallback_(CSE7761_REG_RMSIA, this->data_.current_rms[0], 3);
+  this->data_.current_rms[0] = ((value >= 0x800000) || (value < 1600)) ? 0 : value;  // No load threshold of 10mA
+  value = this->read_fallback_(CSE7761_REG_POWERPA, this->data_.active_power[0], 4);
+  this->data_.active_power[0] = (0 == this->data_.current_rms[0]) ? 0 : (value & 0x80000000) ? (~value) + 1 : value;
+
+  value = this->read_fallback_(CSE7761_REG_RMSIB, this->data_.current_rms[1], 3);
+  this->data_.current_rms[1] = ((value >= 0x800000) || (value < 1600)) ? 0 : value;  // No load threshold of 10mA
+  value = this->read_fallback_(CSE7761_REG_POWERPB, this->data_.active_power[1], 4);
+  this->data_.active_power[1] = (0 == this->data_.current_rms[1]) ? 0 : (value & 0x80000000) ? (~value) + 1 : value;
+
+  ESP_LOGD(TAG, PSTR("C61: F%d, U%d, I%d/%d, P%d/%d"), this->data_.frequency, this->data_.voltage_rms,
+           this->data_.current_rms[0], this->data_.current_rms[1], this->data_.active_power[0],
+           this->data_.active_power[1]);
+
+  // convert values and publish to sensors
+
+  float voltage = (float) this->data_.voltage_rms / cse7761ref(RMS_UC, &this->data_);
+  if (this->voltage_sensor_ != nullptr) {
+    this->voltage_sensor_->publish_state(voltage);
+  }
+
+  for (uint32_t channel = 0; channel < 2; channel++) {
+    // Active power = PowerPA * PowerPAC * 1000 / 0x80000000
+    float active_power = (float) this->data_.active_power[channel] / cse7761ref(POWER_PAC, &this->data_);  // W
+    float amps = (float) this->data_.current_rms[channel] / cse7761ref(RMS_IAC, &this->data_);             // A
+    ESP_LOGD(TAG, PSTR("C61: Channel %d power %f W, current %f A"), channel, active_power, amps);
+    if (channel == 0) {
+      if (this->power_sensor_1_ != nullptr) {
+        this->power_sensor_1_->publish_state(active_power);
+      }
+      if (this->current_sensor_1_ != nullptr) {
+        this->current_sensor_1_->publish_state(amps);
+      }
+    } else if (channel == 1) {
+      if (this->power_sensor_2_ != nullptr) {
+        this->power_sensor_2_->publish_state(active_power);
+      }
+      if (this->current_sensor_2_ != nullptr) {
+        this->current_sensor_2_->publish_state(amps);
+      }
+    }
+  }
+}
+
+}  // namespace cse7761
+}  // namespace esphome

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -115,7 +115,7 @@ bool CSE7761Component::read_once_(uint8_t reg, uint8_t size, uint32_t *value) {
   }
 
   if (!rcvd) {
-    ESP_LOGD(TAG, "Rx none");
+    ESP_LOGD(TAG, "Received 0 bytes for register %hhu", reg);
     return false;
   }
 
@@ -185,7 +185,7 @@ bool CSE7761Component::chip_init_() {
     this->write_(CSE7761_REG_EMUCON2 | 0x80, 0x0FC1);
     this->write_(CSE7761_REG_PULSE1SEL | 0x80, 0x3290);
   } else {
-    ESP_LOGD(TAG, "Write failed");
+    ESP_LOGD(TAG, "Write failed at chip_init");
     return false;
   }
   return true;

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -140,10 +140,12 @@ uint32_t CSE7761Component::read_(uint8_t reg, uint8_t size) {
   bool result = false;  // Start loop
   uint8_t retry = 3;    // Retry up to three times
   uint32_t value = 0;   // Default no value
-  while (!result && retry) {
+  while (!result && retry > 0) {
     retry--;
-    result = this->read_once_(reg, size, &value);
+    if (this->read_once_(reg, size, &value))
+      return value;
   }
+  ESP_LOGE(TAG, "Reading register %hhu failed!", reg);
   return value;
 }
 

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -63,7 +63,7 @@ void CSE7761Component::dump_config() {
   this->check_uart_settings(38400, 1, uart::UART_CONFIG_PARITY_EVEN, 8);
 }
 
-float CSE7761Component::get_setup_priority() const { return setup_priority::HARDWARE; }
+float CSE7761Component::get_setup_priority() const { return setup_priority::DATA; }
 
 void CSE7761Component::update() {
   if (this->data_.ready) {

--- a/esphome/components/cse7761/cse7761.h
+++ b/esphome/components/cse7761/cse7761.h
@@ -15,8 +15,7 @@ struct CSE7761DataStruct {
   uint32_t active_power[2] = {0};
   uint16_t coefficient[8] = {0};
   uint8_t energy_update = 0;
-  uint8_t init = 4;
-  uint8_t ready = 0;
+  bool ready = false;
 };
 
 /// This class implements support for the CSE7761 UART power sensor.
@@ -28,7 +27,6 @@ class CSE7761Component : public PollingComponent, public uart::UARTDevice {
   void set_active_power_2_sensor(sensor::Sensor *power_sensor_2) { power_sensor_2_ = power_sensor_2; }
   void set_current_2_sensor(sensor::Sensor *current_sensor_2) { current_sensor_2_ = current_sensor_2; }
   void setup() override;
-  void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
   void update() override;
@@ -40,13 +38,12 @@ class CSE7761Component : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *current_sensor_1_{nullptr};
   sensor::Sensor *power_sensor_2_{nullptr};
   sensor::Sensor *current_sensor_2_{nullptr};
-  int32_t last_init_ = 0;
   CSE7761DataStruct data_;
 
-  void write_(uint32_t reg, uint32_t data);
-  bool read_once_(uint32_t reg, uint32_t size, uint32_t *value);
-  uint32_t read_(uint32_t reg, uint32_t size);
-  uint32_t read_fallback_(uint32_t reg, uint32_t prev, uint32_t size);
+  void write_(uint8_t reg, uint16_t data);
+  bool read_once_(uint8_t reg, uint8_t size, uint32_t *value);
+  uint32_t read_(uint8_t reg, uint8_t size);
+  uint32_t coefficient_by_unit_(uint32_t unit);
   bool chip_init_();
   void get_data_();
 };

--- a/esphome/components/cse7761/cse7761.h
+++ b/esphome/components/cse7761/cse7761.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace cse7761 {
+
+struct CSE7761DataStruct {
+  uint32_t frequency = 0;
+  uint32_t voltage_rms = 0;
+  uint32_t current_rms[2] = {0};
+  uint32_t energy[2] = {0};
+  uint32_t active_power[2] = {0};
+  uint16_t coefficient[8] = {0};
+  uint8_t energy_update = 0;
+  uint8_t init = 4;
+  uint8_t ready = 0;
+};
+
+/// This class implements support for the CSE7761 UART power sensor.
+class CSE7761Component : public PollingComponent, public uart::UARTDevice {
+ public:
+  void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
+  void set_active_power_1_sensor(sensor::Sensor *power_sensor_1) { power_sensor_1_ = power_sensor_1; }
+  void set_current_1_sensor(sensor::Sensor *current_sensor_1) { current_sensor_1_ = current_sensor_1; }
+  void set_active_power_2_sensor(sensor::Sensor *power_sensor_2) { power_sensor_2_ = power_sensor_2; }
+  void set_current_2_sensor(sensor::Sensor *current_sensor_2) { current_sensor_2_ = current_sensor_2; }
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  void update() override;
+
+ protected:
+  // Sensors
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *power_sensor_1_{nullptr};
+  sensor::Sensor *current_sensor_1_{nullptr};
+  sensor::Sensor *power_sensor_2_{nullptr};
+  sensor::Sensor *current_sensor_2_{nullptr};
+  int32_t last_init_ = 0;
+  CSE7761DataStruct data_;
+
+  void write_(uint32_t reg, uint32_t data);
+  bool read_once_(uint32_t reg, uint32_t size, uint32_t *value);
+  uint32_t read_(uint32_t reg, uint32_t size);
+  uint32_t read_fallback_(uint32_t reg, uint32_t prev, uint32_t size);
+  bool chip_init_();
+  void get_data_();
+};
+
+}  // namespace cse7761
+}  // namespace esphome

--- a/esphome/components/cse7761/sensor.py
+++ b/esphome/components/cse7761/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
+CODEOWNERS = ["@berfenger"]
 DEPENDENCIES = ["uart"]
 
 cse7761_ns = cg.esphome_ns.namespace("cse7761")

--- a/esphome/components/cse7761/sensor.py
+++ b/esphome/components/cse7761/sensor.py
@@ -1,0 +1,89 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, uart
+from esphome.const import (
+    CONF_ID,
+    CONF_VOLTAGE,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_VOLT,
+    UNIT_AMPERE,
+    UNIT_WATT,
+)
+
+DEPENDENCIES = ["uart"]
+
+cse7761_ns = cg.esphome_ns.namespace("cse7761")
+CSE7761Component = cse7761_ns.class_(
+    "CSE7761Component", cg.PollingComponent, uart.UARTDevice
+)
+
+CONF_CURRENT_1 = "current_1"
+CONF_CURRENT_2 = "current_2"
+CONF_ACTIVE_POWER_1 = "active_power_1"
+CONF_ACTIVE_POWER_2 = "active_power_2"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(CSE7761Component),
+            cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ACTIVE_POWER_1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ACTIVE_POWER_2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "cse7761", baud_rate=38400, require_rx=True, require_tx=True
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    for key in [
+        CONF_VOLTAGE,
+        CONF_CURRENT_1,
+        CONF_CURRENT_2,
+        CONF_ACTIVE_POWER_1,
+        CONF_ACTIVE_POWER_2,
+    ]:
+        if key not in config:
+            continue
+        conf = config[key]
+        sens = await sensor.new_sensor(conf)
+        cg.add(getattr(var, f"set_{key}_sensor")(sens))

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -250,6 +250,10 @@ uart:
     tx_pin: GPIO4
     rx_pin: GPIO5
     baud_rate: 9600
+  - id: uart7
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 38400
 
 modbus:
   uart_id: uart1
@@ -549,6 +553,18 @@ sensor:
       name: 'PMS Humidity'
     formaldehyde:
       name: 'PMS Formaldehyde Concentration'
+  - platform: cse7761
+    uart_id: uart7
+    voltage:
+      name: 'CSE7761 Voltage'
+    current_1:
+      name: 'CSE7761 Current 1'
+    current_2:
+      name: 'CSE7761 Current 2'
+    active_power_1:
+      name: 'CSE7761 Active Power 1'
+    active_power_2:
+      name: 'CSE7761 Active Power 2'
   - platform: cse7766
     uart_id: uart3
     voltage:


### PR DESCRIPTION
# What does this implement/fix? 

Adds CSE7761 power sensor component, a power sensor present on Sonoff Dual R3 v1.x 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1151

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1541

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  tx_pin: GPIO25
  rx_pin: GPIO26
  baud_rate: 38400
  parity: EVEN
  stop_bits: 1

sensor:
  platform: cse7761
  voltage:
    name: 'CSE7761 Voltage'
  current_1:
    name: 'CSE7761 Current 1'
  current_2:
    name: 'CSE7761 Current 2'
  active_power_1:
    name: 'CSE7761 Active Power 1'
  active_power_2:
    name: 'CSE7761 Active Power 2'
  update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
