### PR TITLE
ignore exception when not waiting for a response

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -96,23 +96,27 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     ESP_LOGW(TAG, "Modbus CRC Check failed! %02X!=%02X", computed_crc, remote_crc);
     return false;
   }
-
-  waiting_for_response = 0;
   std::vector<uint8_t> data(this->rx_buffer_.begin() + data_offset, this->rx_buffer_.begin() + data_offset + data_len);
-
   bool found = false;
   for (auto *device : this->devices_) {
     if (device->address_ == address) {
       // Is it an error response?
       if ((function_code & 0x80) == 0x80) {
-        ESP_LOGW(TAG, "Modbus error function code: 0x%X exception: %d", function_code, raw[2]);
-        device->on_modbus_error(function_code & 0x7F, raw[2]);
+        ESP_LOGD(TAG, "Modbus error function code: 0x%X exception: %d", function_code, raw[2]);
+        if (waiting_for_response != 0) {
+          device->on_modbus_error(function_code & 0x7F, raw[2]);
+        } else {
+          // Ignore modbus exception not related to a pending command
+          ESP_LOGD(TAG, "Ignoring Modbus error - not expecting a response");
+        }
       } else {
         device->on_modbus_data(data);
       }
       found = true;
     }
   }
+  waiting_for_response = 0;
+
   if (!found) {
     ESP_LOGW(TAG, "Got Modbus frame from unknown address 0x%02X! ", address);
   }
@@ -196,6 +200,7 @@ void Modbus::send_raw(const std::vector<uint8_t> &payload) {
   if (this->flow_control_pin_ != nullptr)
     this->flow_control_pin_->digital_write(false);
   waiting_for_response = payload[0];
+  ESP_LOGV(TAG, "Modbus write raw: %s", hexencode(payload).c_str());
   last_send_ = millis();
 }
 


### PR DESCRIPTION
# What does this implement/fix? 
Improve handling modbus exceptions. 
If a modbus exceptions is received without waiting for a response the next pending command is removed from the send queue. 
This fix prevents the incorrect removal of unrelated commands 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
