### PR TITLE
A few esp32_ble_server/improv fixes

### DIFF
--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -154,7 +154,7 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
   }
 }
 
-float BLEServer::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
+float BLEServer::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH + 10; }
 
 void BLEServer::dump_config() { ESP_LOGCONFIG(TAG, "ESP32 BLE Server:"); }
 

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -152,7 +152,7 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
       break;
   }
 
-  for (auto service : this->services_) {
+  for (const auto &service : this->services_) {
     service->gatts_event_handler(event, gatts_if, param);
   }
 }

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -109,10 +109,8 @@ std::shared_ptr<BLEService> BLEServer::create_service(const std::string &uuid, b
 }
 std::shared_ptr<BLEService> BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t num_handles,
                                                       uint8_t inst_id) {
-  ESP_LOGD(TAG, "Creating service - %s", uuid.to_string().c_str());
+  ESP_LOGV(TAG, "Creating service - %s", uuid.to_string().c_str());
   std::shared_ptr<BLEService> service = std::make_shared<BLEService>(uuid, num_handles, inst_id);
-  ESP_LOGD(TAG, "Created service - %s", service->get_uuid().to_string().c_str());
-  ESP_LOGD(TAG, "services size - %d", this->services_.size());
   this->services_.emplace_back(service);
   if (advertise) {
     esp32_ble::global_ble->get_advertising()->add_service_uuid(uuid);

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -11,6 +11,7 @@
 #include "esphome/core/preferences.h"
 
 #include <map>
+#include <memory>
 
 #ifdef USE_ESP32
 
@@ -43,10 +44,11 @@ class BLEServer : public Component {
   void set_manufacturer(const std::string &manufacturer) { this->manufacturer_ = manufacturer; }
   void set_model(const std::string &model) { this->model_ = model; }
 
-  BLEService *create_service(const uint8_t *uuid, bool advertise = false);
-  BLEService *create_service(uint16_t uuid, bool advertise = false);
-  BLEService *create_service(const std::string &uuid, bool advertise = false);
-  BLEService *create_service(ESPBTUUID uuid, bool advertise = false, uint16_t num_handles = 15, uint8_t inst_id = 0);
+  std::shared_ptr<BLEService> create_service(const uint8_t *uuid, bool advertise = false);
+  std::shared_ptr<BLEService> create_service(uint16_t uuid, bool advertise = false);
+  std::shared_ptr<BLEService> create_service(const std::string &uuid, bool advertise = false);
+  std::shared_ptr<BLEService> create_service(ESPBTUUID uuid, bool advertise = false, uint16_t num_handles = 15,
+                                             uint8_t inst_id = 0);
 
   esp_gatt_if_t get_gatts_if() { return this->gatts_if_; }
   uint32_t get_connected_client_count() { return this->connected_clients_; }
@@ -74,8 +76,8 @@ class BLEServer : public Component {
   uint32_t connected_clients_{0};
   std::map<uint16_t, void *> clients_;
 
-  std::vector<BLEService *> services_;
-  BLEService *device_information_service_;
+  std::vector<std::shared_ptr<BLEService>> services_;
+  std::shared_ptr<BLEService> device_information_service_;
 
   std::vector<BLEServiceComponent *> service_components_;
 

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -48,7 +48,7 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
   std::vector<uint8_t> incoming_data_;
   wifi::WiFiAP connecting_sta_;
 
-  BLEService *service_;
+  std::shared_ptr<BLEService> service_;
   BLECharacteristic *status_;
   BLECharacteristic *error_;
   BLECharacteristic *rpc_;


### PR DESCRIPTION
# What does this implement/fix? 

- Fix `esp32_ble_server` `setup_priority` 
  This was the same as `esp32_improv` and causing issues
- Utilize `shared_ptr` in `ble_server` for services

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
