### PR TITLE
use update_interval for sntp synchronization

### DIFF
--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -3,6 +3,9 @@
 
 #ifdef USE_ESP32
 #include "lwip/apps/sntp.h"
+#ifdef USE_ESP_IDF
+#include "esp_sntp.h"
+#endif
 #endif
 #ifdef USE_ESP8266
 #include "sntp.h"
@@ -37,6 +40,9 @@ void SNTPComponent::setup() {
   if (!this->server_3_.empty()) {
     sntp_setservername(2, strdup(this->server_3_.c_str()));
   }
+#ifdef USE_ESP_IDF
+  sntp_set_sync_interval(this->get_update_interval());
+#endif
 
   sntp_init();
 }
@@ -47,7 +53,16 @@ void SNTPComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Server 3: '%s'", this->server_3_.c_str());
   ESP_LOGCONFIG(TAG, "  Timezone: '%s'", this->timezone_.c_str());
 }
-void SNTPComponent::update() {}
+void SNTPComponent::update() {
+#ifndef USE_ESP_IDF
+  // force resync
+  if (sntp_enabled()) {
+    sntp_stop();
+    this->has_time_ = false;
+    sntp_init();
+  }
+#endif
+}
 void SNTPComponent::loop() {
   if (this->has_time_)
     return;
@@ -56,7 +71,7 @@ void SNTPComponent::loop() {
   if (!time.is_valid())
     return;
 
-  ESP_LOGD(TAG, "Synchronized time: %d-%d-%d %d:%d:%d", time.year, time.month, time.day_of_month, time.hour,
+  ESP_LOGD(TAG, "Synchronized time: %d-%d-%d %d:%02d:%02d", time.year, time.month, time.day_of_month, time.hour,
            time.minute, time.second);
   this->time_sync_callback_.call();
   this->has_time_ = true;

--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -12,14 +12,19 @@ SNTPComponent = sntp_ns.class_("SNTPComponent", time_.RealTimeClock)
 
 DEFAULT_SERVERS = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"]
 
-CONFIG_SCHEMA = time_.TIME_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(SNTPComponent),
-        cv.Optional(CONF_SERVERS, default=DEFAULT_SERVERS): cv.All(
-            cv.ensure_list(cv.Any(cv.domain, cv.hostname)), cv.Length(min=1, max=3)
-        ),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    time_.TIME_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(SNTPComponent),
+            cv.Optional(CONF_SERVERS, default=DEFAULT_SERVERS): cv.All(
+                cv.ensure_list(cv.Any(cv.domain, cv.hostname)), cv.Length(min=1, max=3)
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA)
+    # override 15 min default from TIME_SCHEMA
+    # sntp framework default is 60min
+    .extend(cv.polling_component_schema("60min"))
+)
 
 
 async def to_code(config):

--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -12,19 +12,14 @@ SNTPComponent = sntp_ns.class_("SNTPComponent", time_.RealTimeClock)
 
 DEFAULT_SERVERS = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"]
 
-CONFIG_SCHEMA = (
-    time_.TIME_SCHEMA.extend(
-        {
-            cv.GenerateID(): cv.declare_id(SNTPComponent),
-            cv.Optional(CONF_SERVERS, default=DEFAULT_SERVERS): cv.All(
-                cv.ensure_list(cv.Any(cv.domain, cv.hostname)), cv.Length(min=1, max=3)
-            ),
-        }
-    ).extend(cv.COMPONENT_SCHEMA)
-    # override 15 min default from TIME_SCHEMA
-    # sntp framework default is 60min
-    .extend(cv.polling_component_schema("60min"))
-)
+CONFIG_SCHEMA = time_.TIME_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(SNTPComponent),
+        cv.Optional(CONF_SERVERS, default=DEFAULT_SERVERS): cv.All(
+            cv.ensure_list(cv.Any(cv.domain, cv.hostname)), cv.Length(min=1, max=3)
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix? 

use configured `update_interval` for sntp synchronization
set default update_interval to 60 mins because that is the framework default 


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2556

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

Verified by looking at `chronyc clients -v` output


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
 
