### PR TITLE
Move running process log line to debug level

### DIFF
--- a/esphome/util.py
+++ b/esphome/util.py
@@ -178,7 +178,7 @@ def run_external_command(
     orig_argv = sys.argv
     orig_exit = sys.exit  # mock sys.exit
     full_cmd = " ".join(shlex_quote(x) for x in cmd)
-    _LOGGER.info("Running:  %s", full_cmd)
+    _LOGGER.debug("Running:  %s", full_cmd)
 
     orig_stdout = sys.stdout
     sys.stdout = RedirectText(sys.stdout, filter_lines=filter_lines)
@@ -214,7 +214,7 @@ def run_external_command(
 
 def run_external_process(*cmd, **kwargs):
     full_cmd = " ".join(shlex_quote(x) for x in cmd)
-    _LOGGER.info("Running:  %s", full_cmd)
+    _LOGGER.debug("Running:  %s", full_cmd)
     filter_lines = kwargs.get("filter_lines")
 
     capture_stdout = kwargs.get("capture_stdout", False)


### PR DESCRIPTION
# What does this implement/fix? 

Move running command log level to debug

Was initially for showing how you could run the platformio commands manually if esphome failed for some reason. But now esphome is supposed to be used directly, so no longer necessary.

Workaround fix for a dashboard change: the long "Running esptool.py" line was breaking dashboard autoscrolling.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
