### PR TITLE
Revert nextion clang-tidy changes

### DIFF
--- a/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
+++ b/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
@@ -33,7 +33,7 @@ void NextionBinarySensor::update() {
   if (this->variable_name_.empty())  // This is a touch component
     return;
 
-  this->nextion_->add_to_get_queue(shared_from_this());
+  this->nextion_->add_to_get_queue(this);
 }
 
 void NextionBinarySensor::set_state(bool state, bool publish, bool send_to_nextion) {
@@ -48,7 +48,7 @@ void NextionBinarySensor::set_state(bool state, bool publish, bool send_to_nexti
       this->needs_to_send_update_ = true;
     } else {
       this->needs_to_send_update_ = false;
-      this->nextion_->add_no_result_to_queue_with_set(shared_from_this(), (int) state);
+      this->nextion_->add_no_result_to_queue_with_set(this, (int) state);
     }
   }
 

--- a/esphome/components/nextion/binary_sensor/nextion_binarysensor.h
+++ b/esphome/components/nextion/binary_sensor/nextion_binarysensor.h
@@ -10,8 +10,7 @@ class NextionBinarySensor;
 
 class NextionBinarySensor : public NextionComponent,
                             public binary_sensor::BinarySensorInitiallyOff,
-                            public PollingComponent,
-                            public std::enable_shared_from_this<NextionBinarySensor> {
+                            public PollingComponent {
  public:
   NextionBinarySensor(NextionBase *nextion) { this->nextion_ = nextion; }
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -196,7 +196,7 @@ void Nextion::print_queue_members_() {
   ESP_LOGN(TAG, "print_queue_members_ (top 10) size %zu", this->nextion_queue_.size());
   ESP_LOGN(TAG, "*******************************************");
   int count = 0;
-  for (auto &i : this->nextion_queue_) {
+  for (auto *i : this->nextion_queue_) {
     if (count++ == 10)
       break;
 
@@ -257,9 +257,8 @@ bool Nextion::remove_from_q_(bool report_empty) {
     return false;
   }
 
-  auto nb = std::move(this->nextion_queue_.front());
-  this->nextion_queue_.pop_front();
-  auto &component = nb->component;
+  NextionQueue *nb = this->nextion_queue_.front();
+  NextionComponentBase *component = nb->component;
 
   ESP_LOGN(TAG, "Removing %s from the queue", component->get_variable_name().c_str());
 
@@ -267,8 +266,10 @@ bool Nextion::remove_from_q_(bool report_empty) {
     if (component->get_variable_name() == "sleep_wake") {
       this->is_sleeping_ = false;
     }
+    delete component;
   }
-
+  delete nb;
+  this->nextion_queue_.pop_front();
   return true;
 }
 
@@ -357,7 +358,7 @@ void Nextion::process_nextion_commands_() {
           int index = 0;
           int found = -1;
           for (auto &nb : this->nextion_queue_) {
-            auto &component = nb->component;
+            NextionComponentBase *component = nb->component;
 
             if (component->get_queue_type() == NextionQueueType::WAVEFORM_SENSOR) {
               ESP_LOGW(TAG, "Nextion reported invalid Waveform ID %d or Channel # %d was used!",
@@ -367,6 +368,9 @@ void Nextion::process_nextion_commands_() {
                        component->get_component_id(), component->get_wave_channel_id());
 
               found = index;
+
+              delete component;
+              delete nb;
 
               break;
             }
@@ -464,9 +468,8 @@ void Nextion::process_nextion_commands_() {
           break;
         }
 
-        auto nb = std::move(this->nextion_queue_.front());
-        this->nextion_queue_.pop_front();
-        auto &component = nb->component;
+        NextionQueue *nb = this->nextion_queue_.front();
+        NextionComponentBase *component = nb->component;
 
         if (component->get_queue_type() != NextionQueueType::TEXT_SENSOR) {
           ESP_LOGE(TAG, "ERROR: Received string return but next in queue \"%s\" is not a text sensor",
@@ -476,6 +479,9 @@ void Nextion::process_nextion_commands_() {
                    component->get_variable_name().c_str(), component->get_queue_type_string().c_str());
           component->set_state_from_string(to_process, true, false);
         }
+
+        delete nb;
+        this->nextion_queue_.pop_front();
 
         break;
       }
@@ -505,9 +511,8 @@ void Nextion::process_nextion_commands_() {
           ++dataindex;
         }
 
-        auto nb = std::move(this->nextion_queue_.front());
-        this->nextion_queue_.pop_front();
-        auto &component = nb->component;
+        NextionQueue *nb = this->nextion_queue_.front();
+        NextionComponentBase *component = nb->component;
 
         if (component->get_queue_type() != NextionQueueType::SENSOR &&
             component->get_queue_type() != NextionQueueType::BINARY_SENSOR &&
@@ -520,6 +525,9 @@ void Nextion::process_nextion_commands_() {
                    component->get_queue_type_string().c_str(), value);
           component->set_state_from_int(value, true, false);
         }
+
+        delete nb;
+        this->nextion_queue_.pop_front();
 
         break;
       }
@@ -682,7 +690,7 @@ void Nextion::process_nextion_commands_() {
         int index = 0;
         int found = -1;
         for (auto &nb : this->nextion_queue_) {
-          auto &component = nb->component;
+          auto component = nb->component;
           if (component->get_queue_type() == NextionQueueType::WAVEFORM_SENSOR) {
             size_t buffer_to_send = component->get_wave_buffer().size() < 255 ? component->get_wave_buffer().size()
                                                                               : 255;  // ADDT command can only send 255
@@ -699,6 +707,8 @@ void Nextion::process_nextion_commands_() {
                                                  component->get_wave_buffer().begin() + buffer_to_send);
             }
             found = index;
+            delete component;
+            delete nb;
             break;
           }
           ++index;
@@ -727,7 +737,7 @@ void Nextion::process_nextion_commands_() {
 
   if (!this->nextion_queue_.empty() && this->nextion_queue_.front()->queue_time + this->max_q_age_ms_ < ms) {
     for (int i = 0; i < this->nextion_queue_.size(); i++) {
-      auto &component = this->nextion_queue_[i]->component;
+      NextionComponentBase *component = this->nextion_queue_[i]->component;
       if (this->nextion_queue_[i]->queue_time + this->max_q_age_ms_ < ms) {
         if (this->nextion_queue_[i]->queue_time == 0)
           ESP_LOGD(TAG, "Removing old queue type \"%s\" name \"%s\" queue_time 0",
@@ -744,10 +754,12 @@ void Nextion::process_nextion_commands_() {
           if (component->get_variable_name() == "sleep_wake") {
             this->is_sleeping_ = false;
           }
+          delete component;
         }
 
+        delete this->nextion_queue_[i];
+
         this->nextion_queue_.erase(this->nextion_queue_.begin() + i);
-        i--;
 
       } else {
         break;
@@ -899,16 +911,16 @@ uint16_t Nextion::recv_ret_string_(std::string &response, uint32_t timeout, bool
  * @param variable_name Name for the queue
  */
 void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
-  auto nextion_queue = make_unique<nextion::NextionQueue>();
+  nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
 
-  nextion_queue->component = make_unique<nextion::NextionComponentBase>();
+  nextion_queue->component = new nextion::NextionComponentBase;
   nextion_queue->component->set_variable_name(variable_name);
 
   nextion_queue->queue_time = millis();
 
-  ESP_LOGN(TAG, "Add to queue type: NORESULT component %s", nextion_queue->component->get_variable_name().c_str());
+  this->nextion_queue_.push_back(nextion_queue);
 
-  this->nextion_queue_.push_back(std::move(nextion_queue));
+  ESP_LOGN(TAG, "Add to queue type: NORESULT component %s", nextion_queue->component->get_variable_name().c_str());
 }
 
 /**
@@ -979,7 +991,7 @@ bool Nextion::add_no_result_to_queue_with_printf_(const std::string &variable_na
  * @param is_sleep_safe The command is safe to send when the Nextion is sleeping
  */
 
-void Nextion::add_no_result_to_queue_with_set(std::shared_ptr<NextionComponentBase> component, int state_value) {
+void Nextion::add_no_result_to_queue_with_set(NextionComponentBase *component, int state_value) {
   this->add_no_result_to_queue_with_set(component->get_variable_name(), component->get_variable_name_to_send(),
                                         state_value);
 }
@@ -1007,8 +1019,7 @@ void Nextion::add_no_result_to_queue_with_set_internal_(const std::string &varia
  * @param state_value String value to set
  * @param is_sleep_safe The command is safe to send when the Nextion is sleeping
  */
-void Nextion::add_no_result_to_queue_with_set(std::shared_ptr<NextionComponentBase> component,
-                                              const std::string &state_value) {
+void Nextion::add_no_result_to_queue_with_set(NextionComponentBase *component, const std::string &state_value) {
   this->add_no_result_to_queue_with_set(component->get_variable_name(), component->get_variable_name_to_send(),
                                         state_value);
 }
@@ -1028,11 +1039,11 @@ void Nextion::add_no_result_to_queue_with_set_internal_(const std::string &varia
                                             state_value.c_str());
 }
 
-void Nextion::add_to_get_queue(std::shared_ptr<NextionComponentBase> component) {
+void Nextion::add_to_get_queue(NextionComponentBase *component) {
   if ((!this->is_setup() && !this->ignore_is_setup_))
     return;
 
-  auto nextion_queue = make_unique<nextion::NextionQueue>();
+  nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
 
   nextion_queue->component = component;
   nextion_queue->queue_time = millis();
@@ -1043,7 +1054,7 @@ void Nextion::add_to_get_queue(std::shared_ptr<NextionComponentBase> component) 
   std::string command = "get " + component->get_variable_name_to_send();
 
   if (this->send_command_(command)) {
-    this->nextion_queue_.push_back(std::move(nextion_queue));
+    this->nextion_queue_.push_back(nextion_queue);
   }
 }
 
@@ -1055,13 +1066,13 @@ void Nextion::add_to_get_queue(std::shared_ptr<NextionComponentBase> component) 
  * @param buffer_to_send The buffer size
  * @param buffer_size The buffer data
  */
-void Nextion::add_addt_command_to_queue(std::shared_ptr<NextionComponentBase> component) {
+void Nextion::add_addt_command_to_queue(NextionComponentBase *component) {
   if ((!this->is_setup() && !this->ignore_is_setup_) || this->is_sleeping())
     return;
 
-  auto nextion_queue = make_unique<nextion::NextionQueue>();
+  nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
 
-  nextion_queue->component = std::make_shared<nextion::NextionComponentBase>();
+  nextion_queue->component = new nextion::NextionComponentBase;
   nextion_queue->queue_time = millis();
 
   size_t buffer_to_send = component->get_wave_buffer_size() < 255 ? component->get_wave_buffer_size()
@@ -1070,7 +1081,7 @@ void Nextion::add_addt_command_to_queue(std::shared_ptr<NextionComponentBase> co
   std::string command = "addt " + to_string(component->get_component_id()) + "," +
                         to_string(component->get_wave_channel_id()) + "," + to_string(buffer_to_send);
   if (this->send_command_(command)) {
-    this->nextion_queue_.push_back(std::move(nextion_queue));
+    this->nextion_queue_.push_back(nextion_queue);
   }
 }
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -266,9 +266,9 @@ bool Nextion::remove_from_q_(bool report_empty) {
     if (component->get_variable_name() == "sleep_wake") {
       this->is_sleeping_ = false;
     }
-    delete component;
+    delete component;  // NOLINT(cppcoreguidelines-owning-memory)
   }
-  delete nb;
+  delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
   this->nextion_queue_.pop_front();
   return true;
 }
@@ -369,8 +369,8 @@ void Nextion::process_nextion_commands_() {
 
               found = index;
 
-              delete component;
-              delete nb;
+              delete component;  // NOLINT(cppcoreguidelines-owning-memory)
+              delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
 
               break;
             }
@@ -480,7 +480,7 @@ void Nextion::process_nextion_commands_() {
           component->set_state_from_string(to_process, true, false);
         }
 
-        delete nb;
+        delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
         this->nextion_queue_.pop_front();
 
         break;
@@ -526,7 +526,7 @@ void Nextion::process_nextion_commands_() {
           component->set_state_from_int(value, true, false);
         }
 
-        delete nb;
+        delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
         this->nextion_queue_.pop_front();
 
         break;
@@ -707,8 +707,8 @@ void Nextion::process_nextion_commands_() {
                                                  component->get_wave_buffer().begin() + buffer_to_send);
             }
             found = index;
-            delete component;
-            delete nb;
+            delete component;  // NOLINT(cppcoreguidelines-owning-memory)
+            delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
             break;
           }
           ++index;
@@ -754,10 +754,10 @@ void Nextion::process_nextion_commands_() {
           if (component->get_variable_name() == "sleep_wake") {
             this->is_sleeping_ = false;
           }
-          delete component;
+          delete component;  // NOLINT(cppcoreguidelines-owning-memory)
         }
 
-        delete this->nextion_queue_[i];
+        delete this->nextion_queue_[i];  // NOLINT(cppcoreguidelines-owning-memory)
 
         this->nextion_queue_.erase(this->nextion_queue_.begin() + i);
 
@@ -911,8 +911,10 @@ uint16_t Nextion::recv_ret_string_(std::string &response, uint32_t timeout, bool
  * @param variable_name Name for the queue
  */
 void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   nextion_queue->component = new nextion::NextionComponentBase;
   nextion_queue->component->set_variable_name(variable_name);
 
@@ -1043,6 +1045,7 @@ void Nextion::add_to_get_queue(NextionComponentBase *component) {
   if ((!this->is_setup() && !this->ignore_is_setup_))
     return;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
 
   nextion_queue->component = component;
@@ -1070,8 +1073,10 @@ void Nextion::add_addt_command_to_queue(NextionComponentBase *component) {
   if ((!this->is_setup() && !this->ignore_is_setup_) || this->is_sleeping())
     return;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   nextion_queue->component = new nextion::NextionComponentBase;
   nextion_queue->queue_time = millis();
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -760,6 +760,7 @@ void Nextion::process_nextion_commands_() {
         delete this->nextion_queue_[i];  // NOLINT(cppcoreguidelines-owning-memory)
 
         this->nextion_queue_.erase(this->nextion_queue_.begin() + i);
+        i--;
 
       } else {
         break;

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -370,7 +370,7 @@ void Nextion::process_nextion_commands_() {
               found = index;
 
               delete component;  // NOLINT(cppcoreguidelines-owning-memory)
-              delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
+              delete nb;         // NOLINT(cppcoreguidelines-owning-memory)
 
               break;
             }
@@ -708,7 +708,7 @@ void Nextion::process_nextion_commands_() {
             }
             found = index;
             delete component;  // NOLINT(cppcoreguidelines-owning-memory)
-            delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
+            delete nb;         // NOLINT(cppcoreguidelines-owning-memory)
             break;
           }
           ++index;

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -707,18 +707,17 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   void set_nextion_sensor_state(NextionQueueType queue_type, const std::string &name, float state);
   void set_nextion_text_state(const std::string &name, const std::string &state);
 
-  void add_no_result_to_queue_with_set(std::shared_ptr<NextionComponentBase> component, int state_value) override;
+  void add_no_result_to_queue_with_set(NextionComponentBase *component, int state_value) override;
   void add_no_result_to_queue_with_set(const std::string &variable_name, const std::string &variable_name_to_send,
                                        int state_value) override;
 
-  void add_no_result_to_queue_with_set(std::shared_ptr<NextionComponentBase> component,
-                                       const std::string &state_value) override;
+  void add_no_result_to_queue_with_set(NextionComponentBase *component, const std::string &state_value) override;
   void add_no_result_to_queue_with_set(const std::string &variable_name, const std::string &variable_name_to_send,
                                        const std::string &state_value) override;
 
-  void add_to_get_queue(std::shared_ptr<NextionComponentBase> component) override;
+  void add_to_get_queue(NextionComponentBase *component) override;
 
-  void add_addt_command_to_queue(std::shared_ptr<NextionComponentBase> component) override;
+  void add_addt_command_to_queue(NextionComponentBase *component) override;
 
   void update_components_by_prefix(const std::string &prefix);
 
@@ -729,7 +728,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   void set_auto_wake_on_touch_internal(bool auto_wake_on_touch) { this->auto_wake_on_touch_ = auto_wake_on_touch; }
 
  protected:
-  std::deque<std::unique_ptr<NextionQueue>> nextion_queue_;
+  std::deque<NextionQueue *> nextion_queue_;
   uint16_t recv_ret_string_(std::string &response, uint32_t timeout, bool recv_flag);
   void all_components_send_state_(bool force_update = false);
   uint64_t comok_sent_ = 0;

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -24,19 +24,18 @@ class NextionBase;
 
 class NextionBase {
  public:
-  virtual void add_no_result_to_queue_with_set(std::shared_ptr<NextionComponentBase> component, int state_value) = 0;
+  virtual void add_no_result_to_queue_with_set(NextionComponentBase *component, int state_value) = 0;
   virtual void add_no_result_to_queue_with_set(const std::string &variable_name,
                                                const std::string &variable_name_to_send, int state_value) = 0;
 
-  virtual void add_no_result_to_queue_with_set(std::shared_ptr<NextionComponentBase> component,
-                                               const std::string &state_value) = 0;
+  virtual void add_no_result_to_queue_with_set(NextionComponentBase *component, const std::string &state_value) = 0;
   virtual void add_no_result_to_queue_with_set(const std::string &variable_name,
                                                const std::string &variable_name_to_send,
                                                const std::string &state_value) = 0;
 
-  virtual void add_addt_command_to_queue(std::shared_ptr<NextionComponentBase> component) = 0;
+  virtual void add_addt_command_to_queue(NextionComponentBase *component) = 0;
 
-  virtual void add_to_get_queue(std::shared_ptr<NextionComponentBase> component) = 0;
+  virtual void add_to_get_queue(NextionComponentBase *component) = 0;
 
   virtual void set_component_background_color(const char *component, Color color) = 0;
   virtual void set_component_pressed_background_color(const char *component, Color color) = 0;

--- a/esphome/components/nextion/nextion_component_base.h
+++ b/esphome/components/nextion/nextion_component_base.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <utility>
-#include <memory>
 #include "esphome/core/defines.h"
 
 namespace esphome {
@@ -23,7 +22,7 @@ class NextionComponentBase;
 class NextionQueue {
  public:
   virtual ~NextionQueue() = default;
-  std::shared_ptr<NextionComponentBase> component;
+  NextionComponentBase *component;
   uint32_t queue_time = 0;
 };
 

--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -281,12 +281,12 @@ void Nextion::upload_tft() {
 #endif
       // NOLINTNEXTLINE(readability-static-accessed-through-instance)
       ESP_LOGD(TAG, "Allocating buffer size %d, Heap size is %u", chunk_size, ESP.getFreeHeap());
-      this->transfer_buffer_ = new (std::nothrow) uint8_t[chunk_size];  // NOLINT(cppcoreguidelines-owning-memory)
-      if (this->transfer_buffer_ == nullptr) {                          // Try a smaller size
+      this->transfer_buffer_ = new (std::nothrow) uint8_t[chunk_size];
+      if (this->transfer_buffer_ == nullptr) {  // Try a smaller size
         ESP_LOGD(TAG, "Could not allocate buffer size: %d trying 4096 instead", chunk_size);
         chunk_size = 4096;
         ESP_LOGD(TAG, "Allocating %d buffer", chunk_size);
-        this->transfer_buffer_ = new (std::nothrow) uint8_t[chunk_size];  // NOLINT(cppcoreguidelines-owning-memory)
+        this->transfer_buffer_ = new uint8_t[chunk_size];
 
         if (!this->transfer_buffer_)
           this->upload_end_();
@@ -330,7 +330,7 @@ void Nextion::upload_end_() {
 WiFiClient *Nextion::get_wifi_client_() {
   if (this->tft_url_.compare(0, 6, "https:") == 0) {
     if (this->wifi_client_secure_ == nullptr) {
-      this->wifi_client_secure_ = new BearSSL::WiFiClientSecure();  // NOLINT(cppcoreguidelines-owning-memory)
+      this->wifi_client_secure_ = new BearSSL::WiFiClientSecure();
       this->wifi_client_secure_->setInsecure();
       this->wifi_client_secure_->setBufferSizes(512, 512);
     }
@@ -338,7 +338,7 @@ WiFiClient *Nextion::get_wifi_client_() {
   }
 
   if (this->wifi_client_ == nullptr) {
-    this->wifi_client_ = new WiFiClient();  // NOLINT(cppcoreguidelines-owning-memory)
+    this->wifi_client_ = new WiFiClient();
   }
   return this->wifi_client_;
 }

--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -281,11 +281,13 @@ void Nextion::upload_tft() {
 #endif
       // NOLINTNEXTLINE(readability-static-accessed-through-instance)
       ESP_LOGD(TAG, "Allocating buffer size %d, Heap size is %u", chunk_size, ESP.getFreeHeap());
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
       this->transfer_buffer_ = new (std::nothrow) uint8_t[chunk_size];
       if (this->transfer_buffer_ == nullptr) {  // Try a smaller size
         ESP_LOGD(TAG, "Could not allocate buffer size: %d trying 4096 instead", chunk_size);
         chunk_size = 4096;
         ESP_LOGD(TAG, "Allocating %d buffer", chunk_size);
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         this->transfer_buffer_ = new uint8_t[chunk_size];
 
         if (!this->transfer_buffer_)
@@ -330,6 +332,7 @@ void Nextion::upload_end_() {
 WiFiClient *Nextion::get_wifi_client_() {
   if (this->tft_url_.compare(0, 6, "https:") == 0) {
     if (this->wifi_client_secure_ == nullptr) {
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
       this->wifi_client_secure_ = new BearSSL::WiFiClientSecure();
       this->wifi_client_secure_->setInsecure();
       this->wifi_client_secure_->setBufferSizes(512, 512);
@@ -338,6 +341,7 @@ WiFiClient *Nextion::get_wifi_client_() {
   }
 
   if (this->wifi_client_ == nullptr) {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     this->wifi_client_ = new WiFiClient();
   }
   return this->wifi_client_;

--- a/esphome/components/nextion/sensor/nextion_sensor.cpp
+++ b/esphome/components/nextion/sensor/nextion_sensor.cpp
@@ -34,7 +34,7 @@ void NextionSensor::update() {
     return;
 
   if (this->wave_chan_id_ == UINT8_MAX) {
-    this->nextion_->add_to_get_queue(shared_from_this());
+    this->nextion_->add_to_get_queue(this);
   } else {
     if (this->send_last_value_) {
       this->add_to_wave_buffer(this->last_value_);
@@ -62,9 +62,9 @@ void NextionSensor::set_state(float state, bool publish, bool send_to_nextion) {
           double to_multiply = pow(10, this->precision_);
           int state_value = (int) (state * to_multiply);
 
-          this->nextion_->add_no_result_to_queue_with_set(shared_from_this(), (int) state_value);
+          this->nextion_->add_no_result_to_queue_with_set(this, (int) state_value);
         } else {
-          this->nextion_->add_no_result_to_queue_with_set(shared_from_this(), (int) state);
+          this->nextion_->add_no_result_to_queue_with_set(this, (int) state);
         }
       }
     }
@@ -103,7 +103,7 @@ void NextionSensor::wave_update_() {
            buffer_to_send, this->wave_buffer_.size(), this->component_id_, this->wave_chan_id_);
 #endif
 
-  this->nextion_->add_addt_command_to_queue(shared_from_this());
+  this->nextion_->add_addt_command_to_queue(this);
 }
 
 }  // namespace nextion

--- a/esphome/components/nextion/sensor/nextion_sensor.h
+++ b/esphome/components/nextion/sensor/nextion_sensor.h
@@ -8,10 +8,7 @@ namespace esphome {
 namespace nextion {
 class NextionSensor;
 
-class NextionSensor : public NextionComponent,
-                      public sensor::Sensor,
-                      public PollingComponent,
-                      public std::enable_shared_from_this<NextionSensor> {
+class NextionSensor : public NextionComponent, public sensor::Sensor, public PollingComponent {
  public:
   NextionSensor(NextionBase *nextion) { this->nextion_ = nextion; }
   void send_state_to_nextion() override { this->set_state(this->state, false, true); };

--- a/esphome/components/nextion/switch/nextion_switch.cpp
+++ b/esphome/components/nextion/switch/nextion_switch.cpp
@@ -20,7 +20,7 @@ void NextionSwitch::process_bool(const std::string &variable_name, bool on) {
 void NextionSwitch::update() {
   if (!this->nextion_->is_setup())
     return;
-  this->nextion_->add_to_get_queue(shared_from_this());
+  this->nextion_->add_to_get_queue(this);
 }
 
 void NextionSwitch::set_state(bool state, bool publish, bool send_to_nextion) {
@@ -32,7 +32,7 @@ void NextionSwitch::set_state(bool state, bool publish, bool send_to_nextion) {
       this->needs_to_send_update_ = true;
     } else {
       this->needs_to_send_update_ = false;
-      this->nextion_->add_no_result_to_queue_with_set(shared_from_this(), (int) state);
+      this->nextion_->add_no_result_to_queue_with_set(this, (int) state);
     }
   }
   if (publish) {

--- a/esphome/components/nextion/switch/nextion_switch.h
+++ b/esphome/components/nextion/switch/nextion_switch.h
@@ -8,10 +8,7 @@ namespace esphome {
 namespace nextion {
 class NextionSwitch;
 
-class NextionSwitch : public NextionComponent,
-                      public switch_::Switch,
-                      public PollingComponent,
-                      public std::enable_shared_from_this<NextionSwitch> {
+class NextionSwitch : public NextionComponent, public switch_::Switch, public PollingComponent {
  public:
   NextionSwitch(NextionBase *nextion) { this->nextion_ = nextion; }
 

--- a/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
+++ b/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
@@ -18,7 +18,7 @@ void NextionTextSensor::process_text(const std::string &variable_name, const std
 void NextionTextSensor::update() {
   if (!this->nextion_->is_setup())
     return;
-  this->nextion_->add_to_get_queue(shared_from_this());
+  this->nextion_->add_to_get_queue(this);
 }
 
 void NextionTextSensor::set_state(const std::string &state, bool publish, bool send_to_nextion) {
@@ -29,7 +29,7 @@ void NextionTextSensor::set_state(const std::string &state, bool publish, bool s
     if (this->nextion_->is_sleeping() || !this->visible_) {
       this->needs_to_send_update_ = true;
     } else {
-      this->nextion_->add_no_result_to_queue_with_set(shared_from_this(), state);
+      this->nextion_->add_no_result_to_queue_with_set(this, state);
     }
   }
 

--- a/esphome/components/nextion/text_sensor/nextion_textsensor.h
+++ b/esphome/components/nextion/text_sensor/nextion_textsensor.h
@@ -8,10 +8,7 @@ namespace esphome {
 namespace nextion {
 class NextionTextSensor;
 
-class NextionTextSensor : public NextionComponent,
-                          public text_sensor::TextSensor,
-                          public PollingComponent,
-                          public std::enable_shared_from_this<NextionTextSensor> {
+class NextionTextSensor : public NextionComponent, public text_sensor::TextSensor, public PollingComponent {
  public:
   NextionTextSensor(NextionBase *nextion) { this->nextion_ = nextion; }
   void update() override;


### PR DESCRIPTION
# What does this implement/fix? 

Nextion broke after #1891 due to not every `enable_shared_from_this` object having a containing `shared_ptr`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
