### PR TITLE
Fix MDNS for ESP8266 devices

### DIFF
--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -23,8 +23,8 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
 #ifdef USE_API
   if (api::global_api_server != nullptr) {
     MDNSService service{};
-    service.service_type = "esphomelib";
-    service.proto = "tcp";
+    service.service_type = "_esphomelib";
+    service.proto = "_tcp";
     service.port = api::global_api_server->get_port();
     service.txt_records.push_back({"version", ESPHOME_VERSION});
     service.txt_records.push_back({"mac", get_mac_address()});
@@ -57,8 +57,8 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
 #ifdef USE_PROMETHEUS
   {
     MDNSService service{};
-    service.service_type = "prometheus-http";
-    service.proto = "tcp";
+    service.service_type = "_prometheus-http";
+    service.proto = "_tcp";
     service.port = WEBSERVER_PORT;
     res.push_back(service);
   }
@@ -68,8 +68,8 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
     // Publish "http" service if not using native API
     // This is just to have *some* mDNS service so that .local resolution works
     MDNSService service{};
-    service.service_type = "http";
-    service.proto = "tcp";
+    service.service_type = "_http";
+    service.proto = "_tcp";
     service.port = WEBSERVER_PORT;
     service.txt_records.push_back({"version", ESPHOME_VERSION});
     res.push_back(service);

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -24,7 +24,7 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
   if (api::global_api_server != nullptr) {
     MDNSService service{};
     service.service_type = "esphomelib";
-    service.proto = "_tcp";
+    service.proto = "tcp";
     service.port = api::global_api_server->get_port();
     service.txt_records.push_back({"version", ESPHOME_VERSION});
     service.txt_records.push_back({"mac", get_mac_address()});
@@ -58,7 +58,7 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
   {
     MDNSService service{};
     service.service_type = "prometheus-http";
-    service.proto = "_tcp";
+    service.proto = "tcp";
     service.port = WEBSERVER_PORT;
     res.push_back(service);
   }
@@ -69,7 +69,7 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
     // This is just to have *some* mDNS service so that .local resolution works
     MDNSService service{};
     service.service_type = "http";
-    service.proto = "_tcp";
+    service.proto = "tcp";
     service.port = WEBSERVER_PORT;
     service.txt_records.push_back({"version", ESPHOME_VERSION});
     res.push_back(service);

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -13,7 +13,11 @@ struct MDNSTXTRecord {
 };
 
 struct MDNSService {
+  // service name _including_ underscore character prefix
+  // as defined in RFC6763 Section 7
   std::string service_type;
+  // second label indicating protocol _including_ underscore character prefix
+  // as defined in RFC6763 Section 7, like "_tcp" or "_udp"
   std::string proto;
   uint16_t port;
   std::vector<MDNSTXTRecord> txt_records;

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -18,7 +18,9 @@ void MDNSComponent::setup() {
   auto services = compile_services_();
   for (const auto &service : services) {
     auto proto = service.proto.c_str();
-    while (*proto == '_') { proto++; }
+    while (*proto == '_') {
+      proto++;
+    }
     MDNS.addService(service.service_type.c_str(), proto, service.port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service.service_type.c_str(), proto, record.key.c_str(), record.value.c_str());

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -17,9 +17,11 @@ void MDNSComponent::setup() {
 
   auto services = compile_services_();
   for (const auto &service : services) {
-    MDNS.addService(service.service_type.c_str(), service.proto.c_str(), service.port);
+    auto proto = service.proto.c_str();
+    while (*proto == '_') { proto++; }
+    MDNS.addService(service.service_type.c_str(), proto, service.port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service.service_type.c_str(), service.proto.c_str(), record.key.c_str(), record.value.c_str());
+      MDNS.addServiceTxt(service.service_type.c_str(), proto, record.key.c_str(), record.value.c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -17,13 +17,21 @@ void MDNSComponent::setup() {
 
   auto services = compile_services_();
   for (const auto &service : services) {
+    // Strip the leading underscore from the proto and service_type. While it is
+    // part of the wire protocol to have an underscore, and for example ESP-IDF
+    // expects the underscore to be there, the ESP8266 implementation always adds
+    // the underscore itself.
     auto proto = service.proto.c_str();
     while (*proto == '_') {
       proto++;
     }
-    MDNS.addService(service.service_type.c_str(), proto, service.port);
+    auto service_type = service.service_type.c_str();
+    while (*service_type == '_') {
+      service_type++;
+    }
+    MDNS.addService(service_type, proto, service.port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service.service_type.c_str(), proto, record.key.c_str(), record.value.c_str());
+      MDNS.addServiceTxt(service_type, proto, record.key.c_str(), record.value.c_str());
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix? 

The mDNS implementation doesn't work correctly for ESP8266, causing for example failing log viewing via the API.
With this fix, I can view logs about instantly, and the devices also show up again when doing an `mdns-scan` on the Linux prompt.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2551

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
