### PR TITLE
Fix ESP8266 GPIO0 Pullup Validation

### DIFF
--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -107,9 +107,9 @@ def validate_supports(value):
         raise cv.Invalid(
             "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
         )
-    if is_pullup and num == 0:
+    if is_pullup and num == 16:
         raise cv.Invalid(
-            "GPIO Pin 0 does not support pullup pin mode. "
+            "GPIO Pin 16 does not support pullup pin mode. "
             "Please choose another pin.",
             [CONF_MODE, CONF_PULLUP],
         )

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1150,7 +1150,7 @@ servo:
 ttp229_lsf:
 
 ttp229_bsf:
-  sdo_pin: D0
+  sdo_pin: D2
   scl_pin: D1
 
 sim800l:


### PR DESCRIPTION
# What does this implement/fix? 

ESP8266 _does_ have a internal pullup resistors on pin GPIO0 that can
be toggled. But GPIO16 doesn't have any. I'm not sure whether there was a reason for this,
but from all reference material I could find it's like this:

- GPIO 0-15 support internal pullups, but not pulldowns
- GPIO 16 supports internal pulldown, but not pullup

Worth mentioning however is that GPIO0 _usually_ has additional pullups anyway, because that's one of the strapping pins during boot and must be held high during that time.

Section 4.1 ESP8266EX Datasheet: https://espressif.com/sites/default/files/documentation/0a-esp8266ex_datasheet_en.pdf
TTAPA github guide: https://tttapa.github.io/ESP8266/Chap04%20-%20Microcontroller.html

Fixes https://github.com/esphome/issues/issues/2574

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
