### PR TITLE
Add mDNS config dump

### DIFF
--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -13,15 +13,16 @@
 namespace esphome {
 namespace mdns {
 
+static const char *const TAG = "mdns";
+
 #ifndef WEBSERVER_PORT
 #define WEBSERVER_PORT 80  // NOLINT
 #endif
 
-std::vector<MDNSService> MDNSComponent::compile_services_() {
-  if (!this->services_.empty()) {
-    return this->services_;
-  }
+void MDNSComponent::compile_records_() {
+  this->hostname_ = App.get_name();
 
+  this->services_.clear();
 #ifdef USE_API
   if (api::global_api_server != nullptr) {
     MDNSService service{};
@@ -76,10 +77,19 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
     service.txt_records.push_back({"version", ESPHOME_VERSION});
     this->services_.push_back(service);
   }
-  return this->services_;
 }
 
-std::string MDNSComponent::compile_hostname_() { return App.get_name(); }
+void MDNSComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "mDNS:");
+  ESP_LOGCONFIG(TAG, "  Hostname: %s", this->hostname_.c_str());
+  ESP_LOGV(TAG, "  Services:");
+  for (const auto &service : this->services_) {
+    ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
+    for (const auto &record : service.txt_records) {
+      ESP_LOGV(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
+    }
+  }
+}
 
 }  // namespace mdns
 }  // namespace esphome

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -18,7 +18,9 @@ namespace mdns {
 #endif
 
 std::vector<MDNSService> MDNSComponent::compile_services_() {
-  this->services_.clear();
+  if (!this->services_.empty()) {
+    return this->services_;
+  }
 
 #ifdef USE_API
   if (api::global_api_server != nullptr) {

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -18,7 +18,7 @@ namespace mdns {
 #endif
 
 std::vector<MDNSService> MDNSComponent::compile_services_() {
-  std::vector<MDNSService> res;
+  this->services_.clear();
 
 #ifdef USE_API
   if (api::global_api_server != nullptr) {
@@ -50,7 +50,7 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
     service.txt_records.push_back({"package_import_url", dashboard_import::get_package_import_url()});
 #endif
 
-    res.push_back(service);
+    this->services_.push_back(service);
   }
 #endif  // USE_API
 
@@ -60,11 +60,11 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
     service.service_type = "_prometheus-http";
     service.proto = "_tcp";
     service.port = WEBSERVER_PORT;
-    res.push_back(service);
+    this->services_.push_back(service);
   }
 #endif
 
-  if (res.empty()) {
+  if (this->services_.empty()) {
     // Publish "http" service if not using native API
     // This is just to have *some* mDNS service so that .local resolution works
     MDNSService service{};
@@ -72,10 +72,11 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
     service.proto = "_tcp";
     service.port = WEBSERVER_PORT;
     service.txt_records.push_back({"version", ESPHOME_VERSION});
-    res.push_back(service);
+    this->services_.push_back(service);
   }
-  return res;
+  return this->services_;
 }
+
 std::string MDNSComponent::compile_hostname_() { return App.get_name(); }
 
 }  // namespace mdns

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -35,8 +35,8 @@ class MDNSComponent : public Component {
 
  protected:
   std::vector<MDNSService> services_{};
-  std::vector<MDNSService> compile_services_();
-  std::string compile_hostname_();
+  std::string hostname_;
+  void compile_records_();
 };
 
 }  // namespace mdns

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -34,6 +34,7 @@ class MDNSComponent : public Component {
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
  protected:
+  std::vector<MDNSService> services_{};
   std::vector<MDNSService> compile_services_();
   std::string compile_hostname_();
 };

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -26,6 +26,7 @@ struct MDNSService {
 class MDNSComponent : public Component {
  public:
   void setup() override;
+  void dump_config() override;
 
 #if defined(USE_ESP8266) && defined(USE_ARDUINO)
   void loop() override;

--- a/esphome/components/mdns/mdns_esp32_arduino.cpp
+++ b/esphome/components/mdns/mdns_esp32_arduino.cpp
@@ -12,11 +12,23 @@ static const char *const TAG = "mdns";
 void MDNSComponent::setup() {
   MDNS.begin(compile_hostname_().c_str());
 
-  auto services = compile_services_();
-  for (const auto &service : services) {
+  this->compile_services_();
+  for (const auto &service : this->services_) {
     MDNS.addService(service.service_type.c_str(), service.proto.c_str(), service.port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service.service_type.c_str(), service.proto.c_str(), record.key.c_str(), record.value.c_str());
+    }
+  }
+}
+
+void MDNSComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "MDNS:");
+  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
+  ESP_LOGCONFIG(TAG, "  Services:");
+  for (const auto &service : this->services_) {
+    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
+    for (const auto &record : service.txt_records) {
+      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp32_arduino.cpp
+++ b/esphome/components/mdns/mdns_esp32_arduino.cpp
@@ -12,8 +12,8 @@ static const char *const TAG = "mdns";
 void MDNSComponent::setup() {
   MDNS.begin(compile_hostname_().c_str());
 
-  this->compile_services_();
-  for (const auto &service : this->services_) {
+  auto services = this->compile_services_();
+  for (const auto &service : services) {
     MDNS.addService(service.service_type.c_str(), service.proto.c_str(), service.port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service.service_type.c_str(), service.proto.c_str(), record.key.c_str(), record.value.c_str());
@@ -22,10 +22,11 @@ void MDNSComponent::setup() {
 }
 
 void MDNSComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "MDNS:");
+  ESP_LOGCONFIG(TAG, "mDNS:");
   ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
   ESP_LOGCONFIG(TAG, "  Services:");
-  for (const auto &service : this->services_) {
+  auto services = this->compile_services_();
+  for (const auto &service : services) {
     ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
     for (const auto &record : service.txt_records) {
       ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());

--- a/esphome/components/mdns/mdns_esp32_arduino.cpp
+++ b/esphome/components/mdns/mdns_esp32_arduino.cpp
@@ -7,29 +7,15 @@
 namespace esphome {
 namespace mdns {
 
-static const char *const TAG = "mdns";
-
 void MDNSComponent::setup() {
-  MDNS.begin(compile_hostname_().c_str());
+  this->compile_records_();
 
-  auto services = this->compile_services_();
-  for (const auto &service : services) {
+  MDNS.begin(this->hostname_.c_str());
+
+  for (const auto &service : this->services_) {
     MDNS.addService(service.service_type.c_str(), service.proto.c_str(), service.port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service.service_type.c_str(), service.proto.c_str(), record.key.c_str(), record.value.c_str());
-    }
-  }
-}
-
-void MDNSComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "mDNS:");
-  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
-  ESP_LOGCONFIG(TAG, "  Services:");
-  auto services = this->compile_services_();
-  for (const auto &service : services) {
-    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
-    for (const auto &record : service.txt_records) {
-      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -11,6 +11,19 @@ namespace mdns {
 
 static const char *const TAG = "mdns";
 
+void MDNSComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "MDNS:");
+  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
+  auto services = compile_services_();
+  ESP_LOGCONFIG(TAG, "  Services:");
+  for (const auto &service : services) {
+    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
+    for (const auto &record : service.txt_records) {
+      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
+    }
+  }
+}
+
 void MDNSComponent::setup() {
   network::IPAddress addr = network::get_ip_address();
   MDNS.begin(compile_hostname_().c_str(), (uint32_t) addr);

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -11,19 +11,6 @@ namespace mdns {
 
 static const char *const TAG = "mdns";
 
-void MDNSComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "MDNS:");
-  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
-  auto services = compile_services_();
-  ESP_LOGCONFIG(TAG, "  Services:");
-  for (const auto &service : services) {
-    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
-    for (const auto &record : service.txt_records) {
-      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
-    }
-  }
-}
-
 void MDNSComponent::setup() {
   network::IPAddress addr = network::get_ip_address();
   MDNS.begin(compile_hostname_().c_str(), (uint32_t) addr);
@@ -45,6 +32,18 @@ void MDNSComponent::setup() {
     MDNS.addService(service_type, proto, service.port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, record.key.c_str(), record.value.c_str());
+    }
+  }
+}
+
+void MDNSComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "mDNS:");
+  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
+  ESP_LOGCONFIG(TAG, "  Services:");
+  for (const auto &service : this->services_) {
+    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
+    for (const auto &record : service.txt_records) {
+      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -9,14 +9,13 @@
 namespace esphome {
 namespace mdns {
 
-static const char *const TAG = "mdns";
-
 void MDNSComponent::setup() {
-  network::IPAddress addr = network::get_ip_address();
-  MDNS.begin(compile_hostname_().c_str(), (uint32_t) addr);
+  this->compile_records_();
 
-  auto services = this->compile_services_();
-  for (const auto &service : services) {
+  network::IPAddress addr = network::get_ip_address();
+  MDNS.begin(this->hostname_.c_str(), (uint32_t) addr);
+
+  for (const auto &service : this->services_) {
     // Strip the leading underscore from the proto and service_type. While it is
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
@@ -32,19 +31,6 @@ void MDNSComponent::setup() {
     MDNS.addService(service_type, proto, service.port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, record.key.c_str(), record.value.c_str());
-    }
-  }
-}
-
-void MDNSComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "mDNS:");
-  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
-  ESP_LOGCONFIG(TAG, "  Services:");
-  auto services = this->compile_services_();
-  for (const auto &service : services) {
-    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
-    for (const auto &record : service.txt_records) {
-      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -15,7 +15,7 @@ void MDNSComponent::setup() {
   network::IPAddress addr = network::get_ip_address();
   MDNS.begin(compile_hostname_().c_str(), (uint32_t) addr);
 
-  auto services = compile_services_();
+  auto services = this->compile_services_();
   for (const auto &service : services) {
     // Strip the leading underscore from the proto and service_type. While it is
     // part of the wire protocol to have an underscore, and for example ESP-IDF

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -40,7 +40,8 @@ void MDNSComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "mDNS:");
   ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
   ESP_LOGCONFIG(TAG, "  Services:");
-  for (const auto &service : this->services_) {
+  auto services = this->compile_services_();
+  for (const auto &service : services) {
     ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
     for (const auto &record : service.txt_records) {
       ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());

--- a/esphome/components/mdns/mdns_esp_idf.cpp
+++ b/esphome/components/mdns/mdns_esp_idf.cpp
@@ -11,6 +11,8 @@ namespace mdns {
 static const char *const TAG = "mdns";
 
 void MDNSComponent::setup() {
+  this->compile_records_();
+
   esp_err_t err = mdns_init();
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "mDNS init failed: %s", esp_err_to_name(err));
@@ -18,11 +20,10 @@ void MDNSComponent::setup() {
     return;
   }
 
-  mdns_hostname_set(compile_hostname_().c_str());
-  mdns_instance_name_set(compile_hostname_().c_str());
+  mdns_hostname_set(this->hostname_.c_str());
+  mdns_instance_name_set(this->hostname_.c_str());
 
-  auto services = this->compile_services_();
-  for (const auto &service : services) {
+  for (const auto &service : this->services_) {
     std::vector<mdns_txt_item_t> txt_records;
     for (const auto &record : service.txt_records) {
       mdns_txt_item_t it{};
@@ -42,19 +43,6 @@ void MDNSComponent::setup() {
 
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "Failed to register mDNS service %s: %s", service.service_type.c_str(), esp_err_to_name(err));
-    }
-  }
-}
-
-void MDNSComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "mDNS:");
-  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
-  ESP_LOGCONFIG(TAG, "  Services:");
-  auto services = this->compile_services_();
-  for (const auto &service : services) {
-    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
-    for (const auto &record : service.txt_records) {
-      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp_idf.cpp
+++ b/esphome/components/mdns/mdns_esp_idf.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "mdns";
 void MDNSComponent::setup() {
   esp_err_t err = mdns_init();
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "MDNS init failed: %s", esp_err_to_name(err));
+    ESP_LOGW(TAG, "mDNS init failed: %s", esp_err_to_name(err));
     this->mark_failed();
     return;
   }
@@ -21,8 +21,8 @@ void MDNSComponent::setup() {
   mdns_hostname_set(compile_hostname_().c_str());
   mdns_instance_name_set(compile_hostname_().c_str());
 
-  this->compile_services_();
-  for (const auto &service : this->services_) {
+  auto services = this->compile_services_();
+  for (const auto &service : services) {
     std::vector<mdns_txt_item_t> txt_records;
     for (const auto &record : service.txt_records) {
       mdns_txt_item_t it{};
@@ -46,17 +46,17 @@ void MDNSComponent::setup() {
   }
 }
 
-void MDNSComponent::setup() {
-  this->compile_services_();
-  for (const auto &service : this->services_) {
-    MDNS.addService(service.service_type.c_str(), service.proto.c_str(), service.port);
+void MDNSComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "mDNS:");
+  ESP_LOGCONFIG(TAG, "  Hostname: %s", compile_hostname_().c_str());
+  ESP_LOGCONFIG(TAG, "  Services:");
+  auto services = this->compile_services_();
+  for (const auto &service : services) {
+    ESP_LOGCONFIG(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service.service_type.c_str(), service.proto.c_str(), record.key.c_str(), record.value.c_str());
+      ESP_LOGCONFIG(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
     }
   }
-
-  network::IPAddress addr = network::get_ip_address();
-  MDNS.begin(compile_hostname_().c_str(), (uint32_t) addr);
 }
 
 }  // namespace mdns


### PR DESCRIPTION
# What does this implement/fix? 

Now mDNS is turned into a proper component, it would be good to make the component setup visible in the configuration dump. This PR adds this config dump.

Example output:
```
[11:42:30][C][mdns:040]: mDNS:
[11:42:30][C][mdns:041]:   Hostname: test-esp8266
[11:42:30][C][mdns:042]:   Services:
[11:42:30][C][mdns:045]:   - _esphomelib, _tcp, 6053
[11:42:30][C][mdns:047]:     TXT: version = 2021.11.0-dev
[11:42:30][C][mdns:047]:     TXT: mac = f4cfa2f75c84
[11:42:30][C][mdns:047]:     TXT: platform = ESP8266
[11:42:30][C][mdns:047]:     TXT: board = nodemcuv2
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
