### PR TITLE
Fix ESP8266 OTA adds unnecessary Update library

### DIFF
--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -90,9 +90,7 @@ async def to_code(config):
         )
         cg.add(RawExpression(f"if ({condition}) return"))
 
-    if CORE.is_esp8266:
-        cg.add_library("Update", None)
-    elif CORE.is_esp32 and CORE.using_arduino:
+    if CORE.is_esp32 and CORE.using_arduino:
         cg.add_library("Update", None)
 
     use_state_callback = False


### PR DESCRIPTION
# What does this implement/fix? 

We need to add libraries to the platformio.ini when our code uses one, even for internal ones.

For ESP32, that's necessary - the Update library is here: https://github.com/espressif/arduino-esp32/tree/master/libraries/Update

For ESP8266 however the Update.h is part of the core build, so no library import is necessary. https://github.com/esp8266/Arduino/blob/master/cores/esp8266/Updater.h

Fixes (partially) https://github.com/esphome/issues/issues/2576

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
