### PR TITLE
2021.10.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --no-cache-dir \
         wheel==0.36.2 \
-        platformio==5.2.0 \
+        platformio==5.2.1 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_libraries_interval 1000000 \

--- a/docker/platformio_install_deps.py
+++ b/docker/platformio_install_deps.py
@@ -8,6 +8,23 @@ import sys
 
 config = configparser.ConfigParser(inline_comment_prefixes=(';', ))
 config.read(sys.argv[1])
-libs = [x for x in config['common']['lib_deps'].splitlines() if len(x) != 0]
+
+libs = []
+# Extract from every lib_deps key in all sections
+for section in config.sections():
+    conf = config[section]
+    if "lib_deps" not in conf:
+        continue
+    for lib_dep in conf["lib_deps"].splitlines():
+        if not lib_dep:
+            # Empty line or comment
+            continue
+        if lib_dep.startswith("${"):
+            # Extending from another section
+            continue
+        if "@" not in lib_dep:
+            # No version pinned, this is an internal lib
+            continue
+        libs.append(lib_dep)
 
 subprocess.check_call(['platformio', 'lib', '-g', 'install', *libs])

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -50,6 +50,13 @@ void ESP8266GPIOPin::pin_mode(gpio::Flags flags) {
     mode = OUTPUT;
   } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
     mode = INPUT_PULLUP;
+    if (pin_ == 16) {
+      // GPIO16 doesn't have a pullup, so pinMode would fail.
+      // However, sometimes this method is called with pullup mode anyway
+      // for example from dallas one_wire. For those cases convert this
+      // to a INPUT mode.
+      mode = INPUT;
+    }
   } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLDOWN)) {
     mode = INPUT_PULLDOWN_16;
   } else if (flags == (gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {

--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -107,9 +107,9 @@ def validate_supports(value):
         raise cv.Invalid(
             "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
         )
-    if is_pullup and num == 0:
+    if is_pullup and num == 16:
         raise cv.Invalid(
-            "GPIO Pin 0 does not support pullup pin mode. "
+            "GPIO Pin 16 does not support pullup pin mode. "
             "Please choose another pin.",
             [CONF_MODE, CONF_PULLUP],
         )

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -23,7 +23,7 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
 #ifdef USE_API
   if (api::global_api_server != nullptr) {
     MDNSService service{};
-    service.service_type = "esphomelib";
+    service.service_type = "_esphomelib";
     service.proto = "_tcp";
     service.port = api::global_api_server->get_port();
     service.txt_records.push_back({"version", ESPHOME_VERSION});
@@ -57,7 +57,7 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
 #ifdef USE_PROMETHEUS
   {
     MDNSService service{};
-    service.service_type = "prometheus-http";
+    service.service_type = "_prometheus-http";
     service.proto = "_tcp";
     service.port = WEBSERVER_PORT;
     res.push_back(service);
@@ -68,7 +68,7 @@ std::vector<MDNSService> MDNSComponent::compile_services_() {
     // Publish "http" service if not using native API
     // This is just to have *some* mDNS service so that .local resolution works
     MDNSService service{};
-    service.service_type = "http";
+    service.service_type = "_http";
     service.proto = "_tcp";
     service.port = WEBSERVER_PORT;
     service.txt_records.push_back({"version", ESPHOME_VERSION});

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -13,7 +13,11 @@ struct MDNSTXTRecord {
 };
 
 struct MDNSService {
+  // service name _including_ underscore character prefix
+  // as defined in RFC6763 Section 7
   std::string service_type;
+  // second label indicating protocol _including_ underscore character prefix
+  // as defined in RFC6763 Section 7, like "_tcp" or "_udp"
   std::string proto;
   uint16_t port;
   std::vector<MDNSTXTRecord> txt_records;

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -17,9 +17,21 @@ void MDNSComponent::setup() {
 
   auto services = compile_services_();
   for (const auto &service : services) {
-    MDNS.addService(service.service_type.c_str(), service.proto.c_str(), service.port);
+    // Strip the leading underscore from the proto and service_type. While it is
+    // part of the wire protocol to have an underscore, and for example ESP-IDF
+    // expects the underscore to be there, the ESP8266 implementation always adds
+    // the underscore itself.
+    auto proto = service.proto.c_str();
+    while (*proto == '_') {
+      proto++;
+    }
+    auto service_type = service.service_type.c_str();
+    while (*service_type == '_') {
+      service_type++;
+    }
+    MDNS.addService(service_type, proto, service.port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service.service_type.c_str(), service.proto.c_str(), record.key.c_str(), record.value.c_str());
+      MDNS.addServiceTxt(service_type, proto, record.key.c_str(), record.value.c_str());
     }
   }
 }

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -90,9 +90,7 @@ async def to_code(config):
         )
         cg.add(RawExpression(f"if ({condition}) return"))
 
-    if CORE.is_esp8266:
-        cg.add_library("Update", None)
-    elif CORE.is_esp32 and CORE.using_arduino:
+    if CORE.is_esp32 and CORE.using_arduino:
         cg.add_library("Update", None)
 
     use_state_callback = False

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -159,8 +159,15 @@ def final_validate_power_esp32_ble(value):
         "esp32_ble_server",
         "esp32_ble_tracker",
     ]:
+        if conflicting not in fv.full_config.get():
+            continue
+
         try:
-            cv.require_framework_version(esp32_arduino=cv.Version(1, 0, 5))(None)
+            # Only arduino 1.0.5+ and esp-idf impacted
+            cv.require_framework_version(
+                esp32_arduino=cv.Version(1, 0, 5),
+                esp_idf=cv.Version(4, 0, 0),
+            )(None)
         except cv.Invalid:
             pass
         else:

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2021.10.0"
+__version__ = "2021.10.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -206,6 +206,31 @@ def include_file(path, basename):
         cg.add_global(cg.RawStatement(f'#include "{basename}"'))
 
 
+ARDUINO_GLUE_CODE = """\
+#define yield() esphome::yield()
+#define millis() esphome::millis()
+#define delay(x) esphome::delay(x)
+#define delayMicroseconds(x) esphome::delayMicroseconds(x)
+"""
+
+
+@coroutine_with_priority(-999.0)
+async def add_arduino_global_workaround():
+    # The Arduino framework defined these itself in the global
+    # namespace. For the esphome codebase that is not a problem,
+    # but when custom code
+    #   1. writes `millis()` for example AND
+    #   2. has `using namespace esphome;` like our guides suggest
+    # Then the compiler will complain that the call is ambiguous
+    # Define a hacky macro so that the call is never ambiguous
+    # and always uses the esphome namespace one.
+    # See also https://github.com/esphome/issues/issues/2510
+    # Priority -999 so that it runs before adding includes, as those
+    # also might reference these symbols
+    for line in ARDUINO_GLUE_CODE.splitlines():
+        cg.add_global(cg.RawStatement(line))
+
+
 @coroutine_with_priority(-1000.0)
 async def add_includes(includes):
     # Add includes at the very end, so that the included files can access global variables
@@ -286,6 +311,9 @@ async def to_code(config):
     cg.add_build_flag("-Wno-unused-variable")
     cg.add_build_flag("-Wno-unused-but-set-variable")
     cg.add_build_flag("-Wno-sign-compare")
+
+    if CORE.using_arduino:
+        CORE.add_job(add_arduino_global_workaround)
 
     if config[CONF_INCLUDES]:
         CORE.add_job(add_includes, config[CONF_INCLUDES])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tornado==6.1
 tzlocal==3.0    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
-platformio==5.2.1
+platformio==5.2.1  # When updating platformio, also update Dockerfile
 esptool==3.1
 click==8.0.3
 esphome-dashboard==20211021.0

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1150,7 +1150,7 @@ servo:
 ttp229_lsf:
 
 ttp229_bsf:
-  sdo_pin: D0
+  sdo_pin: D2
   scl_pin: D1
 
 sim800l:


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Documentation is like sex; when it's good, it's very, very good, and when it's bad, it's better than nothing."_

~ Dick Brandon
- Fix MDNS for ESP8266 devices [esphome#2571](https://github.com/esphome/esphome/pull/2571)
- Fix ESP8266 GPIO0 Pullup Validation [esphome#2572](https://github.com/esphome/esphome/pull/2572)
- Fix wifi ble coexistence check [esphome#2573](https://github.com/esphome/esphome/pull/2573)
- Arduino global delay/millis/... symbols workaround [esphome#2575](https://github.com/esphome/esphome/pull/2575)
- Fix ESP8266 OTA adds unnecessary Update library [esphome#2579](https://github.com/esphome/esphome/pull/2579)
- Fix ESP8266 dallas GPIO16 INPUT_PULLUP [esphome#2581](https://github.com/esphome/esphome/pull/2581)
- Fix platformio version in Dockerfile doesn't match requirements [esphome#2582](https://github.com/esphome/esphome/pull/2582)
- Fix platformio_install_deps no longer installing all lib_deps [esphome#2584](https://github.com/esphome/esphome/pull/2584)
