### PR TITLE
Fix platformio version in Dockerfile doesn't match requirements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --no-cache-dir \
         wheel==0.36.2 \
-        platformio==5.2.0 \
+        platformio==5.2.1 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_libraries_interval 1000000 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tornado==6.1
 tzlocal==3.0    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
-platformio==5.2.1
+platformio==5.2.1  # When updating platformio, also update Dockerfile
 esptool==3.1
 click==8.0.3
 esphome-dashboard==20211021.0


### PR DESCRIPTION
# What does this implement/fix? 

requirements.txt specified 5.2.1, but Dockerfile still had 5.2.0

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
