### PR TITLE
Fix platformio_install_deps no longer installing all lib_deps

### DIFF
--- a/docker/platformio_install_deps.py
+++ b/docker/platformio_install_deps.py
@@ -8,6 +8,23 @@ import sys
 
 config = configparser.ConfigParser(inline_comment_prefixes=(';', ))
 config.read(sys.argv[1])
-libs = [x for x in config['common']['lib_deps'].splitlines() if len(x) != 0]
+
+libs = []
+# Extract from every lib_deps key in all sections
+for section in config.sections():
+    conf = config[section]
+    if "lib_deps" not in conf:
+        continue
+    for lib_dep in conf["lib_deps"].splitlines():
+        if not lib_dep:
+            # Empty line or comment
+            continue
+        if lib_dep.startswith("${"):
+            # Extending from another section
+            continue
+        if "@" not in lib_dep:
+            # No version pinned, this is an internal lib
+            continue
+        libs.append(lib_dep)
 
 subprocess.check_call(['platformio', 'lib', '-g', 'install', *libs])


### PR DESCRIPTION
# What does this implement/fix? 

In #2355 the lib_deps parts were moved around a bit, which made the `platformio_install_deps` script only install a couple libraries.

Instead now go through every section in platformio.ini and extract all `lib_deps`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
