### PR TITLE
Fix HeatpumpIR pin

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -49,7 +49,7 @@ lib_deps =
     glmnet/Dsmr@0.5                                       ; dsmr
     rweather/Crypto@0.2.0                                 ; dsmr
     dudanov/MideaUART@1.1.8                               ; midea
-    tonia/HeatpumpIR@^1.0.15                              ; heatpumpir
+    tonia/HeatpumpIR@1.0.15                               ; heatpumpir
 build_flags =
     ${common.build_flags}
     -DUSE_ARDUINO


### PR DESCRIPTION
# What does this implement/fix? 

1. We generally pin all requirements, like HA does.
2. The python code pins it too: https://github.com/esphome/esphome/blob/dev/esphome/components/heatpumpir/climate.py#L114

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
