### PR TITLE
Fix socket connection closed not detected

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -78,6 +78,8 @@ void APIConnection::loop() {
     on_fatal_error();
     if (err == APIError::SOCKET_READ_FAILED && errno == ECONNRESET) {
       ESP_LOGW(TAG, "%s: Connection reset", client_info_.c_str());
+    } else if (err == APIError::CONNECTION_CLOSED) {
+      ESP_LOGW(TAG, "%s: Connection closed", client_info_.c_str());
     } else {
       ESP_LOGW(TAG, "%s: Reading failed: %s errno=%d", client_info_.c_str(), api_error_to_str(err), errno);
     }

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -53,6 +53,7 @@ enum class APIError : int {
   HANDSHAKESTATE_SETUP_FAILED = 1019,
   HANDSHAKESTATE_SPLIT_FAILED = 1020,
   BAD_HANDSHAKE_ERROR_BYTE = 1021,
+  CONNECTION_CLOSED = 1022,
 };
 
 const char *api_error_to_str(APIError err);

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -275,6 +275,12 @@ void OTAComponent::handle_() {
       }
       ESP_LOGW(TAG, "Error receiving data for update, errno: %d", errno);
       goto error;
+    } else if (read == 0) {
+      // $ man recv
+      // "When  a  stream socket peer has performed an orderly shutdown, the return value will
+      // be 0 (the traditional "end-of-file" return)."
+      ESP_LOGW(TAG, "Remote end closed connection");
+      goto error;
     }
 
     error_code = backend->write(buf, read);
@@ -361,6 +367,9 @@ bool OTAComponent::readall_(uint8_t *buf, size_t len) {
         continue;
       }
       ESP_LOGW(TAG, "Failed to read %d bytes of data, errno: %d", len, errno);
+      return false;
+    } else if (read == 0) {
+      ESP_LOGW(TAG, "Remote closed connection");
       return false;
     } else {
       at += read;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -320,8 +320,7 @@ class LWIPRawImpl : public Socket {
       return -1;
     }
     if (rx_closed_ && rx_buf_ == nullptr) {
-      errno = ECONNRESET;
-      return -1;
+      return 0;
     }
     if (len == 0) {
       return 0;
@@ -364,6 +363,11 @@ class LWIPRawImpl : public Socket {
       buf8 += copysize;
       len -= copysize;
       read += copysize;
+    }
+
+    if (read == 0) {
+      errno = EWOULDBLOCK;
+      return -1;
     }
 
     return read;


### PR DESCRIPTION
# What does this implement/fix? 

Random thing I noticed: When aioesphomeapi closes the connection and sends an ACK, the ESPHome side would not close the socket (send back a CLOSE)

That's a bug caused by how we detect `EWOULDBLOCK`. I thought if `read/recv` returns 0 that means the operation would block, but 0 actually means that the connection was closed (EOF).

With this fix I see the correct FIN+ACK+CLOSE sequence, and ESPHome closes the socket.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
