### PR TITLE
Fix validation of addressable light IDs

### DIFF
--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -22,6 +22,12 @@ using ESPColor ESPDEPRECATED("esphome::light::ESPColor is deprecated, use esphom
 /// Convert the color information from a `LightColorValues` object to a `Color` object (does not apply brightness).
 Color color_from_light_color_values(LightColorValues val);
 
+/// Use a custom state class for addressable lights, to allow type system to discriminate between addressable and
+/// non-addressable lights.
+class AddressableLightState : public LightState {
+  using LightState::LightState;
+};
+
 class AddressableLight : public LightOutput, public Component {
  public:
   virtual int32_t size() const = 0;

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -4,10 +4,9 @@ from esphome import automation
 # Base
 light_ns = cg.esphome_ns.namespace("light")
 LightState = light_ns.class_("LightState", cg.EntityBase, cg.Component)
-# Fake class for addressable lights
-AddressableLightState = light_ns.class_("LightState", LightState)
+AddressableLightState = light_ns.class_("AddressableLightState", LightState)
 LightOutput = light_ns.class_("LightOutput")
-AddressableLight = light_ns.class_("AddressableLight", cg.Component)
+AddressableLight = light_ns.class_("AddressableLight", LightOutput, cg.Component)
 AddressableLightRef = AddressableLight.operator("ref")
 
 Color = cg.esphome_ns.class_("Color")


### PR DESCRIPTION
# What does this implement/fix? 

Currently it's possible to use the id of a non-addressable light where an addressable one is required, because the IDs refer to the `LightState` class, and they're the same type for both. Introduce an actual `AddressableLightState` class, which is empty for now.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2576

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
