### PR TITLE
Fix old-style `arduino_version` on ESP8266 and with magic values

### DIFF
--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,10 @@ __version__ = "2021.11.0-dev"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 
-TARGET_PLATFORMS = ["esp32", "esp8266"]
+PLATFORM_ESP32 = "esp32"
+PLATFORM_ESP8266 = "esp8266"
+
+TARGET_PLATFORMS = [PLATFORM_ESP32, PLATFORM_ESP8266]
 TARGET_FRAMEWORKS = ["arduino", "esp-idf"]
 
 # See also https://github.com/platformio/platform-espressif8266/releases

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -188,7 +188,8 @@ def preload_core_config(config, result):
                 plat_conf[CONF_FRAMEWORK][CONF_TYPE] = "arduino"
 
             try:
-                cv.Version.parse(conf[CONF_ARDUINO_VERSION])
+                if conf[CONF_ARDUINO_VERSION] not in ("recommended", "latest", "dev"):
+                    cv.Version.parse(conf[CONF_ARDUINO_VERSION])
                 plat_conf[CONF_FRAMEWORK][CONF_VERSION] = conf.pop(CONF_ARDUINO_VERSION)
             except ValueError:
                 plat_conf[CONF_FRAMEWORK][CONF_SOURCE] = conf.pop(CONF_ARDUINO_VERSION)

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -29,6 +29,7 @@ from esphome.const import (
     CONF_VERSION,
     KEY_CORE,
     TARGET_PLATFORMS,
+    PLATFORM_ESP8266,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, walk_files
@@ -182,7 +183,10 @@ def preload_core_config(config, result):
         if CONF_BOARD_FLASH_MODE in conf:
             plat_conf[CONF_BOARD_FLASH_MODE] = conf.pop(CONF_BOARD_FLASH_MODE)
         if CONF_ARDUINO_VERSION in conf:
-            plat_conf[CONF_FRAMEWORK] = {CONF_TYPE: "arduino"}
+            plat_conf[CONF_FRAMEWORK] = {}
+            if plat != PLATFORM_ESP8266:
+                plat_conf[CONF_FRAMEWORK][CONF_TYPE] = "arduino"
+
             try:
                 cv.Version.parse(conf[CONF_ARDUINO_VERSION])
                 plat_conf[CONF_FRAMEWORK][CONF_VERSION] = conf.pop(CONF_ARDUINO_VERSION)


### PR DESCRIPTION
# What does this implement/fix? 

```yaml
esphome:
  platform: ESP8266
  arduino_version: latest
```
is currently converted to
```yaml
esp8266:
  framework:
    type: arduino
    source: latest
```

This is broken for two reasons: esp8266 doesn't have the type option, and the magic values latest, recommended and dev should be put under version instead of source. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
