### PR TITLE
Allow setting URL as platform_version

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -280,10 +280,15 @@ async def to_code(config):
     cg.add_platformio_option("lib_ldf_mode", "off")
 
     conf = config[CONF_FRAMEWORK]
-    if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
+
+    if "://" in conf[CONF_PLATFORM_VERSION]:  # url, don't need to supply package name
+        cg.add_platformio_option("platform", conf[CONF_PLATFORM_VERSION])
+    else:
         cg.add_platformio_option(
-            "platform", f"espressif32 @ {conf[CONF_PLATFORM_VERSION]}"
+            "platform", f"platformio/espressif32 @ {conf[CONF_PLATFORM_VERSION]}"
         )
+
+    if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_platformio_option("framework", "espidf")
         cg.add_build_flag("-DUSE_ESP_IDF")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ESP_IDF")
@@ -314,9 +319,6 @@ async def to_code(config):
             )
 
     elif conf[CONF_TYPE] == FRAMEWORK_ARDUINO:
-        cg.add_platformio_option(
-            "platform", f"espressif32 @ {conf[CONF_PLATFORM_VERSION]}"
-        )
         cg.add_platformio_option("framework", "arduino")
         cg.add_build_flag("-DUSE_ARDUINO")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ARDUINO")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -147,8 +147,9 @@ def _arduino_check_versions(value):
     value[CONF_VERSION] = str(version)
     value[CONF_SOURCE] = source or _format_framework_arduino_version(version)
 
-    platform_version = value.get(CONF_PLATFORM_VERSION, ARDUINO_PLATFORM_VERSION)
-    value[CONF_PLATFORM_VERSION] = str(platform_version)
+    value[CONF_PLATFORM_VERSION] = value.get(
+        CONF_PLATFORM_VERSION, _parse_platform_version(str(ARDUINO_PLATFORM_VERSION))
+    )
 
     if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
         _LOGGER.warning(
@@ -184,8 +185,9 @@ def _esp_idf_check_versions(value):
     value[CONF_VERSION] = str(version)
     value[CONF_SOURCE] = source or _format_framework_espidf_version(version)
 
-    platform_version = value.get(CONF_PLATFORM_VERSION, ESP_IDF_PLATFORM_VERSION)
-    value[CONF_PLATFORM_VERSION] = str(platform_version)
+    value[CONF_PLATFORM_VERSION] = value.get(
+        CONF_PLATFORM_VERSION, _parse_platform_version(str(ESP_IDF_PLATFORM_VERSION))
+    )
 
     if version != RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION:
         _LOGGER.warning(
@@ -194,6 +196,15 @@ def _esp_idf_check_versions(value):
         )
 
     return value
+
+
+def _parse_platform_version(value):
+    try:
+        # if platform version is a valid version constraint, prefix the default package
+        cv.platformio_version_constraint(value)
+        return f"platformio/espressif32 @ {value}"
+    except cv.Invalid:
+        return value
 
 
 def _detect_variant(value):
@@ -218,7 +229,7 @@ ARDUINO_FRAMEWORK_SCHEMA = cv.All(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
             cv.Optional(CONF_SOURCE): cv.string_strict,
-            cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
+            cv.Optional(CONF_PLATFORM_VERSION): _parse_platform_version,
         }
     ),
     _arduino_check_versions,
@@ -230,7 +241,7 @@ ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
         {
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
             cv.Optional(CONF_SOURCE): cv.string_strict,
-            cv.Optional(CONF_PLATFORM_VERSION): cv.string_strict,
+            cv.Optional(CONF_PLATFORM_VERSION): _parse_platform_version,
             cv.Optional(CONF_SDKCONFIG_OPTIONS, default={}): {
                 cv.string_strict: cv.string_strict
             },
@@ -280,13 +291,7 @@ async def to_code(config):
     cg.add_platformio_option("lib_ldf_mode", "off")
 
     conf = config[CONF_FRAMEWORK]
-
-    if "://" in conf[CONF_PLATFORM_VERSION]:  # url, don't need to supply package name
-        cg.add_platformio_option("platform", conf[CONF_PLATFORM_VERSION])
-    else:
-        cg.add_platformio_option(
-            "platform", f"platformio/espressif32 @ {conf[CONF_PLATFORM_VERSION]}"
-        )
+    cg.add_platformio_option("platform", conf[CONF_PLATFORM_VERSION])
 
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_platformio_option("framework", "espidf")

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -154,9 +154,13 @@ async def to_code(config):
         "platform_packages",
         [f"platformio/framework-arduinoespressif8266 @ {conf[CONF_SOURCE]}"],
     )
-    cg.add_platformio_option(
-        "platform", f"platformio/espressif8266 @ {conf[CONF_PLATFORM_VERSION]}"
-    )
+
+    if "://" in conf[CONF_PLATFORM_VERSION]:  # url, don't need to supply package name
+        cg.add_platformio_option("platform", conf[CONF_PLATFORM_VERSION])
+    else:
+        cg.add_platformio_option(
+            "platform", f"platformio/espressif8266 @ {conf[CONF_PLATFORM_VERSION]}"
+        )
 
     # Default for platformio is LWIP2_LOW_MEMORY with:
     #  - MSS=536

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1683,7 +1683,7 @@ def version_number(value):
 def platformio_version_constraint(value):
     # for documentation on valid version constraints:
     # https://docs.platformio.org/en/latest/core/userguide/platforms/cmd_install.html#cmd-platform-install
-    
+
     value = string_strict(value)
     constraints = []
     for item in value.split(","):
@@ -1692,7 +1692,7 @@ def platformio_version_constraint(value):
         for test_op in ("^", "~", ">=", ">", "<=", "<", "!="):
             if item.startswith(test_op):
                 op = test_op
-                item = item[len(test_op):]
+                item = item[len(test_op) :]
                 break
 
         constraints.append((op, version_number(item)))

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1680,6 +1680,23 @@ def version_number(value):
         raise Invalid("Not a version number") from e
 
 
+def platformio_version_constraint(value):
+    value = string_strict(value)
+    constraints = []
+    for item in value.split(","):
+        print(item)
+        # find and strip prefix operator
+        op = None
+        for test_op in ("^", "~", ">=", ">", "<=", "<", "!="):
+            if item.startswith(test_op):
+                op = test_op
+                item = item[len(test_op):]
+                break
+
+        constraints.append((op, version_number(item)))
+    return constraints
+
+
 def require_framework_version(
     *,
     esp_idf=None,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1681,10 +1681,12 @@ def version_number(value):
 
 
 def platformio_version_constraint(value):
+    # for documentation on valid version constraints:
+    # https://docs.platformio.org/en/latest/core/userguide/platforms/cmd_install.html#cmd-platform-install
+    
     value = string_strict(value)
     constraints = []
     for item in value.split(","):
-        print(item)
         # find and strip prefix operator
         op = None
         for test_op in ("^", "~", ">=", ">", "<=", "<", "!="):


### PR DESCRIPTION
# What does this implement/fix? 

Allow setting an URL to a custom repository or branch as `platform_version` as well:
```yaml
esp32:
    board: esp32-c3-devkitm-1
    framework:
        type: arduino
        version: 2.0.0
        source: https://github.com/espressif/arduino-esp32.git#2.0.0
        platform_version: https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
```

I'm not really fond of how URLs are detected, but this is the same way we use for `libraries`. Suggestions welcome.

Also explicitly specify the owner for the espressif32 platform by default, hopefully cuts down on the ambiguous package name warnings a bit.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
