### PR TITLE
Teleinfo ptec

### DIFF
--- a/esphome/components/teleinfo/sensor/teleinfo_sensor.cpp
+++ b/esphome/components/teleinfo/sensor/teleinfo_sensor.cpp
@@ -9,6 +9,6 @@ void TeleInfoSensor::publish_val(const std::string &val) {
   auto newval = parse_float(val);
   publish_state(*newval);
 }
-void TeleInfoSensor::dump_config() { LOG_SENSOR("  ", tag.c_str(), this); }
+void TeleInfoSensor::dump_config() { LOG_SENSOR("  ", "Teleinfo Sensor", this); }
 }  // namespace teleinfo
 }  // namespace esphome

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -141,21 +141,22 @@ void TeleInfo::loop() {
         field_len = get_field(tag_, buf_finger, grp_end, separator_, MAX_TAG_SIZE);
         if (!field_len || field_len >= MAX_TAG_SIZE) {
           ESP_LOGE(TAG, "Invalid tag.");
-          break;
+          continue;
         }
 
         /* Advance buf_finger to after the tag and the separator. */
         buf_finger += field_len + 1;
 
         /*
-         * If there is two separators and the tag is not equal to "DATE",
-         * it means there is a timestamp to read first.
+         * If there is two separators and the tag is not equal to "DATE" or
+         * historical mode is not in use (separator_ != 0x20), it means there is a
+         * timestamp to read first.
          */
-        if (std::count(buf_finger, grp_end, separator_) == 2 && strcmp(tag_, "DATE") != 0) {
+        if (std::count(buf_finger, grp_end, separator_) == 2 && strcmp(tag_, "DATE") != 0 && separator_ != 0x20) {
           field_len = get_field(timestamp_, buf_finger, grp_end, separator_, MAX_TIMESTAMP_SIZE);
           if (!field_len || field_len >= MAX_TIMESTAMP_SIZE) {
-            ESP_LOGE(TAG, "Invalid Timestamp");
-            break;
+            ESP_LOGE(TAG, "Invalid timestamp for tag %s", timestamp_);
+            continue;
           }
 
           /* Advance buf_finger to after the first data and the separator. */
@@ -164,8 +165,8 @@ void TeleInfo::loop() {
 
         field_len = get_field(val_, buf_finger, grp_end, separator_, MAX_VAL_SIZE);
         if (!field_len || field_len >= MAX_VAL_SIZE) {
-          ESP_LOGE(TAG, "Invalid Value");
-          break;
+          ESP_LOGE(TAG, "Invalid value for tag %s", tag_);
+          continue;
         }
 
         /* Advance buf_finger to end of group */

--- a/esphome/components/teleinfo/text_sensor/teleinfo_text_sensor.cpp
+++ b/esphome/components/teleinfo/text_sensor/teleinfo_text_sensor.cpp
@@ -6,6 +6,6 @@ namespace teleinfo {
 static const char *const TAG = "teleinfo_text_sensor";
 TeleInfoTextSensor::TeleInfoTextSensor(const char *tag) { this->tag = std::string(tag); }
 void TeleInfoTextSensor::publish_val(const std::string &val) { publish_state(val); }
-void TeleInfoTextSensor::dump_config() { LOG_TEXT_SENSOR("  ", tag.c_str(), this); }
+void TeleInfoTextSensor::dump_config() { LOG_TEXT_SENSOR("  ", "Teleinfo Text Sensor", this); }
 }  // namespace teleinfo
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 

In historical mode, tags like PTEC leads to an issue where we detect a
timestamp whereas this is not possible in historical mode.

PTEC teleinfo tag looks like:
```
    PTEC HP..
```
Instead of the usual format
```
    IINST1 001 I
```

This make our data parsing fails.

While at here, make sure we continue parsing other tags even if parsing one of the tag fails.
And fix a build issue when loglevel is set to debug.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2585

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:
  id: uart_bus
  rx_pin: GPIO3
  tx_pin: GPIO1
  baud_rate: 1200
  parity: EVEN
  data_bits: 7

teleinfo:
  id: myteleinfo
  update_interval: 60s
  historical_mode: true

sensor:
  - platform: teleinfo
    tag_name: "HCHC"
    name: "hchc"
    unit_of_measurement: "Wh"
    icon: mdi:flash
    teleinfo_id: myteleinfo
  - platform: teleinfo
    tag_name: "HCHP"
    name: "hchp"
    unit_of_measurement: "Wh"
    icon: mdi:flash
    teleinfo_id: myteleinfo
  - platform: teleinfo
    tag_name: "PAPP"
    name: "papp"
    unit_of_measurement: "VA"
    icon: mdi:flash
    teleinfo_id: myteleinfo

text_sensor:
  - platform: teleinfo
    tag_name: "OPTARIF"
    name: "optarif"
    teleinfo_id: myteleinfo

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
