### PR TITLE
Add EntityBase properties to ESP32 Camera

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -701,6 +701,7 @@ message ListEntitiesCameraResponse {
   string name = 3;
   string unique_id = 4;
   bool disabled_by_default = 5;
+  string icon = 6;
 }
 
 message CameraImageResponse {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -678,6 +678,7 @@ bool APIConnection::send_camera_info(esp32_camera::ESP32Camera *camera) {
   msg.name = camera->get_name();
   msg.unique_id = get_default_unique_id("camera", camera);
   msg.disabled_by_default = camera->is_disabled_by_default();
+  msg.icon = camera->get_icon();
   return this->send_list_entities_camera_response(msg);
 }
 void APIConnection::camera_image(const CameraImageRequest &msg) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2910,6 +2910,10 @@ bool ListEntitiesCameraResponse::decode_length(uint32_t field_id, ProtoLengthDel
       this->unique_id = value.as_string();
       return true;
     }
+    case 6: {
+      this->icon = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -2930,6 +2934,7 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(3, this->name);
   buffer.encode_string(4, this->unique_id);
   buffer.encode_bool(5, this->disabled_by_default);
+  buffer.encode_string(6, this->icon);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCameraResponse::dump_to(std::string &out) const {
@@ -2954,6 +2959,10 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
 
   out.append("  disabled_by_default: ");
   out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -803,6 +803,7 @@ class ListEntitiesCameraResponse : public ProtoMessage {
   std::string name{};
   std::string unique_id{};
   bool disabled_by_default{false};
+  std::string icon{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -2,10 +2,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.const import (
-    CONF_DISABLED_BY_DEFAULT,
     CONF_FREQUENCY,
     CONF_ID,
-    CONF_NAME,
     CONF_PIN,
     CONF_SCL,
     CONF_SDA,
@@ -17,6 +15,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.cpp_helpers import setup_entity
 
 DEPENDENCIES = ["esp32", "api"]
 
@@ -63,11 +62,9 @@ CONF_TEST_PATTERN = "test_pattern"
 
 camera_range_param = cv.int_range(min=-2, max=2)
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(ESP32Camera),
-        cv.Required(CONF_NAME): cv.string,
-        cv.Optional(CONF_DISABLED_BY_DEFAULT, default=False): cv.boolean,
         cv.Required(CONF_DATA_PINS): cv.All(
             [pins.internal_gpio_input_pin_number], cv.Length(min=8, max=8)
         ),
@@ -127,8 +124,8 @@ SETTERS = {
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID], config[CONF_NAME])
-    cg.add(var.set_disabled_by_default(config[CONF_DISABLED_BY_DEFAULT]))
+    var = cg.new_Pvariable(config[CONF_ID])
+    await setup_entity(var, config)
     await cg.register_component(var, config)
 
     for key, setter in SETTERS.items():

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -185,6 +185,7 @@ ESP32Camera::ESP32Camera(const std::string &name) : EntityBase(name) {
 
   global_esp32_camera = this;
 }
+ESP32Camera::ESP32Camera() : ESP32Camera("") {}
 void ESP32Camera::set_data_pins(std::array<uint8_t, 8> pins) {
   this->config_.pin_d0 = pins[0];
   this->config_.pin_d1 = pins[1];

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -54,6 +54,7 @@ enum ESP32CameraFrameSize {
 class ESP32Camera : public Component, public EntityBase {
  public:
   ESP32Camera(const std::string &name);
+  ESP32Camera();
   void set_data_pins(std::array<uint8_t, 8> pins);
   void set_vsync_pin(uint8_t pin);
   void set_href_pin(uint8_t pin);


### PR DESCRIPTION
# What does this implement/fix? 

#2418 and esphome/aioesphomeapi#106 added the `icon` property to (nearly) all entities, but the ESP32 Camera did not extend the original `NAMEABLE_SCHEMA` and thus was not included. This oversight has led to problems down the line (home-assistant/core#58124).

This has been fixed in esphome/aioesphomeapi#123 (thanks Jesse and Otto!), and this PR makes the associated changes on the ESPHome side that should have been included in #2418.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1558

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
