### PR TITLE
Bump noise-c from 0.1.3 to 0.1.4

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -121,7 +121,7 @@ async def to_code(config):
         decoded = base64.b64decode(conf[CONF_KEY])
         cg.add(var.set_noise_psk(list(decoded)))
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.3")
+        cg.add_library("esphome/noise-c", "0.1.4")
     else:
         cg.add_define("USE_API_PLAINTEXT")
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ build_flags =
 
 [common]
 lib_deps =
-    esphome/noise-c@0.1.3     ; api
+    esphome/noise-c@0.1.4     ; api
     makuna/NeoPixelBus@2.6.7  ; neopixelbus
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix? 

Fixes https://github.com/esphome/issues/issues/2593

Changes: https://github.com/esphome/noise-c/compare/3e88feb...esphome:v0.1.4

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
