### PR TITLE
Fix gpio validation for esp32 variants

### DIFF
--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -118,7 +118,7 @@ def validate_supports(value):
     is_pullup = mode[CONF_PULLUP]
     is_pulldown = mode[CONF_PULLDOWN]
     variant = CORE.data[KEY_ESP32][KEY_VARIANT]
-    if variant not in VARIANTS:
+    if variant not in _esp32_validations:
         raise cv.Invalid("Unsupported ESP32 variant {variant}")
 
     if is_open_drain and not is_output:

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import Any
+
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
@@ -24,7 +27,6 @@ from .const import (
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
     VARIANT_ESP32H2,
-    VARIANTS,
     esp32_ns,
 )
 
@@ -79,22 +81,22 @@ class ESP32ValidationFunctions:
 
 
 _esp32_validations = {
-    VARIANT_ESP32: Esp32ValidationFunctions(
+    VARIANT_ESP32: ESP32ValidationFunctions(
         pin_validation=esp32_validate_gpio_pin, usage_validation=esp32_validate_supports
     ),
-    VARIANT_ESP32S2: Esp32ValidationFunctions(
+    VARIANT_ESP32S2: ESP32ValidationFunctions(
         pin_validation=esp32_s2_validate_gpio_pin,
         usage_validation=esp32_s2_validate_supports,
     ),
-    VARIANT_ESP32C3: Esp32ValidationFunctions(
+    VARIANT_ESP32C3: ESP32ValidationFunctions(
         pin_validation=esp32_c3_validate_gpio_pin,
         usage_validation=esp32_c3_validate_supports,
     ),
-    VARIANT_ESP32S3: Esp32ValidationFunctions(
+    VARIANT_ESP32S3: ESP32ValidationFunctions(
         pin_validation=esp32_s3_validate_gpio_pin,
         usage_validation=esp32_s3_validate_supports,
     ),
-    VARIANT_ESP32H2: Esp32ValidationFunctions(
+    VARIANT_ESP32H2: ESP32ValidationFunctions(
         pin_validation=esp32_h2_validate_gpio_pin,
         usage_validation=esp32_h2_validate_supports,
     ),

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -72,10 +72,10 @@ def _translate_pin(value):
     return _lookup_pin(value)
 
 
-class Esp32ValidationFunctions:
-    def __init__(self, pin_validation, usage_validation):
-        self.pin_validation = pin_validation
-        self.usage_validation = usage_validation
+@dataclass
+class ESP32ValidationFunctions:
+    pin_validation: Any
+    usage_validation: Any
 
 
 _esp32_validations = {

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -72,29 +72,29 @@ def _translate_pin(value):
     return _lookup_pin(value)
 
 
-class VALIDATION_FUNCTIONS:
+class Esp32ValidationFunctions:
     def __init__(self, pin_validation, usage_validation):
         self.pin_validation = pin_validation
         self.usage_validation = usage_validation
 
 
 _esp32_validations = {
-    VARIANT_ESP32: VALIDATION_FUNCTIONS(
+    VARIANT_ESP32: Esp32ValidationFunctions(
         pin_validation=esp32_validate_gpio_pin, usage_validation=esp32_validate_supports
     ),
-    VARIANT_ESP32S2: VALIDATION_FUNCTIONS(
+    VARIANT_ESP32S2: Esp32ValidationFunctions(
         pin_validation=esp32_s2_validate_gpio_pin,
         usage_validation=esp32_s2_validate_supports,
     ),
-    VARIANT_ESP32C3: VALIDATION_FUNCTIONS(
+    VARIANT_ESP32C3: Esp32ValidationFunctions(
         pin_validation=esp32_c3_validate_gpio_pin,
         usage_validation=esp32_c3_validate_supports,
     ),
-    VARIANT_ESP32S3: VALIDATION_FUNCTIONS(
+    VARIANT_ESP32S3: Esp32ValidationFunctions(
         pin_validation=esp32_s3_validate_gpio_pin,
         usage_validation=esp32_s3_validate_supports,
     ),
-    VARIANT_ESP32H2: VALIDATION_FUNCTIONS(
+    VARIANT_ESP32H2: Esp32ValidationFunctions(
         pin_validation=esp32_h2_validate_gpio_pin,
         usage_validation=esp32_h2_validate_supports,
     ),

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -1,5 +1,3 @@
-import logging
-
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
@@ -17,11 +15,20 @@ import esphome.config_validation as cv
 import esphome.codegen as cg
 
 from . import boards
-from .const import KEY_BOARD, KEY_ESP32, esp32_ns
+from .const import (
+    KEY_BOARD,
+    KEY_ESP32,
+    KEY_VARIANT,
+    VARIANT_ESP32,
+    VARIANT_ESP32C3,
+    VARIANT_ESP32S2,
+    esp32_ns,
+)
 
 
-_LOGGER = logging.getLogger(__name__)
-
+from .gpio_esp32 import esp32_validate_gpio_pin, esp32_validate_supports
+from .gpio_esp32_s2 import esp32_s2_validate_gpio_pin, esp32_s2_validate_supports
+from .gpio_esp32_c3 import esp32_c3_validate_gpio_pin, esp32_c3_validate_supports
 
 IDFInternalGPIOPin = esp32_ns.class_("IDFInternalGPIOPin", cg.InternalGPIOPin)
 ArduinoInternalGPIOPin = esp32_ns.class_("ArduinoInternalGPIOPin", cg.InternalGPIOPin)
@@ -59,65 +66,48 @@ def _translate_pin(value):
     return _lookup_pin(value)
 
 
-_ESP_SDIO_PINS = {
-    6: "Flash Clock",
-    7: "Flash Data 0",
-    8: "Flash Data 1",
-    11: "Flash Command",
+class VALIDATION_FUNCTIONS:
+    def __init__(self, pin_validation, usage_validation):
+        self.pin_validation = pin_validation
+        self.usage_validation = usage_validation
+
+
+_esp32_validations = {
+    VARIANT_ESP32: VALIDATION_FUNCTIONS(
+        pin_validation=esp32_validate_gpio_pin, usage_validation=esp32_validate_supports
+    ),
+    VARIANT_ESP32S2: VALIDATION_FUNCTIONS(
+        pin_validation=esp32_s2_validate_gpio_pin,
+        usage_validation=esp32_s2_validate_supports,
+    ),
+    VARIANT_ESP32C3: VALIDATION_FUNCTIONS(
+        pin_validation=esp32_c3_validate_gpio_pin,
+        usage_validation=esp32_c3_validate_supports,
+    ),
 }
 
 
 def validate_gpio_pin(value):
     value = _translate_pin(value)
-    if value < 0 or value > 39:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-39)")
-    if value in _ESP_SDIO_PINS:
-        raise cv.Invalid(
-            f"This pin cannot be used on ESP32s and is already used by the flash interface (function: {_ESP_SDIO_PINS[value]})"
-        )
-    if 9 <= value <= 10:
-        _LOGGER.warning(
-            "Pin %s (9-10) might already be used by the "
-            "flash interface in QUAD IO flash mode.",
-            value,
-        )
-    if value in (20, 24, 28, 29, 30, 31):
-        # These pins are not exposed in GPIO mux (reason unknown)
-        # but they're missing from IO_MUX list in datasheet
-        raise cv.Invalid(f"The pin GPIO{value} is not usable on ESP32s.")
-    return value
+    variant = CORE.data[KEY_ESP32][KEY_VARIANT]
+    if variant not in (VARIANT_ESP32, VARIANT_ESP32S2, VARIANT_ESP32C3):
+        raise cv.Invalid("Unsupported ESP32 variant {variant}")
+
+    return _esp32_validations[variant].pin_validation(value)
 
 
 def validate_supports(value):
-    num = value[CONF_NUMBER]
     mode = value[CONF_MODE]
     is_input = mode[CONF_INPUT]
     is_output = mode[CONF_OUTPUT]
     is_open_drain = mode[CONF_OPEN_DRAIN]
     is_pullup = mode[CONF_PULLUP]
     is_pulldown = mode[CONF_PULLDOWN]
+    variant = CORE.data[KEY_ESP32][KEY_VARIANT]
+    if variant not in (VARIANT_ESP32, VARIANT_ESP32S2, VARIANT_ESP32C3):
+        raise cv.Invalid("Unsupported ESP32 variant {variant}")
 
-    if is_input:
-        # All ESP32 pins support input mode
-        pass
-    if is_output and 34 <= num <= 39:
-        raise cv.Invalid(
-            f"GPIO{num} (34-39) does not support output pin mode.",
-            [CONF_MODE, CONF_OUTPUT],
-        )
-    if is_open_drain and not is_output:
-        raise cv.Invalid(
-            "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
-        )
-    if is_pullup and 34 <= num <= 39:
-        raise cv.Invalid(
-            f"GPIO{num} (34-39) does not support pullups.", [CONF_MODE, CONF_PULLUP]
-        )
-    if is_pulldown and 34 <= num <= 39:
-        raise cv.Invalid(
-            f"GPIO{num} (34-39) does not support pulldowns.", [CONF_MODE, CONF_PULLDOWN]
-        )
-
+    value = _esp32_validations[variant].usage_validation(value)
     if CORE.using_arduino:
         # (input, output, open_drain, pullup, pulldown)
         supported_modes = {
@@ -138,7 +128,6 @@ def validate_supports(value):
                 "This pin mode is not supported on ESP32 for arduino frameworks",
                 [CONF_MODE],
             )
-
     return value
 
 

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -104,7 +104,7 @@ _esp32_validations = {
 def validate_gpio_pin(value):
     value = _translate_pin(value)
     variant = CORE.data[KEY_ESP32][KEY_VARIANT]
-    if variant not in VARIANTS:
+    if variant not in _esp32_validations:
         raise cv.Invalid("Unsupported ESP32 variant {variant}")
 
     return _esp32_validations[variant].pin_validation(value)

--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -18,6 +18,7 @@ _ESP_SDIO_PINS = {
     11: "Flash Command",
 }
 
+_ESP32_STRAPPING_PINS = {0, 2, 4, 15}
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -32,6 +33,13 @@ def esp32_validate_gpio_pin(value):
         _LOGGER.warning(
             "Pin %s (9-10) might already be used by the "
             "flash interface in QUAD IO flash mode.",
+            value,
+        )
+    if value in _ESP32_STRAPPING_PINS:
+        _LOGGER.warning(
+            "GPIO%d is a Strapping PIN and should be avoided.\n"
+            "Attaching external pullup/down resistors to strapping pins can cause unexpected failures.\n"
+            "See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins",
             value,
         )
     if value in (20, 24, 28, 29, 30, 31):

--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -4,7 +4,6 @@ from esphome.const import (
     CONF_INPUT,
     CONF_MODE,
     CONF_NUMBER,
-    CONF_OPEN_DRAIN,
     CONF_OUTPUT,
     CONF_PULLDOWN,
     CONF_PULLUP,
@@ -47,7 +46,6 @@ def esp32_validate_supports(value):
     mode = value[CONF_MODE]
     is_input = mode[CONF_INPUT]
     is_output = mode[CONF_OUTPUT]
-    is_open_drain = mode[CONF_OPEN_DRAIN]
     is_pullup = mode[CONF_PULLUP]
     is_pulldown = mode[CONF_PULLDOWN]
 
@@ -58,10 +56,6 @@ def esp32_validate_supports(value):
         raise cv.Invalid(
             f"GPIO{num} (34-39) does not support output pin mode.",
             [CONF_MODE, CONF_OUTPUT],
-        )
-    if is_open_drain and not is_output:
-        raise cv.Invalid(
-            "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
         )
     if is_pullup and 34 <= num <= 39:
         raise cv.Invalid(

--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -1,0 +1,75 @@
+import logging
+
+from esphome.const import (
+    CONF_INPUT,
+    CONF_MODE,
+    CONF_NUMBER,
+    CONF_OPEN_DRAIN,
+    CONF_OUTPUT,
+    CONF_PULLDOWN,
+    CONF_PULLUP,
+)
+import esphome.config_validation as cv
+
+
+_ESP_SDIO_PINS = {
+    6: "Flash Clock",
+    7: "Flash Data 0",
+    8: "Flash Data 1",
+    11: "Flash Command",
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def esp32_validate_gpio_pin(value):
+    if value < 0 or value > 39:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-39)")
+    if value in _ESP_SDIO_PINS:
+        raise cv.Invalid(
+            f"This pin cannot be used on ESP32s and is already used by the flash interface (function: {_ESP_SDIO_PINS[value]})"
+        )
+    if 9 <= value <= 10:
+        _LOGGER.warning(
+            "Pin %s (9-10) might already be used by the "
+            "flash interface in QUAD IO flash mode.",
+            value,
+        )
+    if value in (20, 24, 28, 29, 30, 31):
+        # These pins are not exposed in GPIO mux (reason unknown)
+        # but they're missing from IO_MUX list in datasheet
+        raise cv.Invalid(f"The pin GPIO{value} is not usable on ESP32s.")
+    return value
+
+
+def esp32_validate_supports(value):
+    num = value[CONF_NUMBER]
+    mode = value[CONF_MODE]
+    is_input = mode[CONF_INPUT]
+    is_output = mode[CONF_OUTPUT]
+    is_open_drain = mode[CONF_OPEN_DRAIN]
+    is_pullup = mode[CONF_PULLUP]
+    is_pulldown = mode[CONF_PULLDOWN]
+
+    if is_input:
+        # All ESP32 pins support input mode
+        pass
+    if is_output and 34 <= num <= 39:
+        raise cv.Invalid(
+            f"GPIO{num} (34-39) does not support output pin mode.",
+            [CONF_MODE, CONF_OUTPUT],
+        )
+    if is_open_drain and not is_output:
+        raise cv.Invalid(
+            "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
+        )
+    if is_pullup and 34 <= num <= 39:
+        raise cv.Invalid(
+            f"GPIO{num} (34-39) does not support pullups.", [CONF_MODE, CONF_PULLUP]
+        )
+    if is_pulldown and 34 <= num <= 39:
+        raise cv.Invalid(
+            f"GPIO{num} (34-39) does not support pulldowns.", [CONF_MODE, CONF_PULLDOWN]
+        )
+
+    return value

--- a/esphome/components/esp32/gpio_esp32_c3.py
+++ b/esphome/components/esp32/gpio_esp32_c3.py
@@ -4,8 +4,6 @@ from esphome.const import (
     CONF_INPUT,
     CONF_MODE,
     CONF_NUMBER,
-    CONF_PULLDOWN,
-    CONF_PULLUP,
 )
 import esphome.config_validation as cv
 
@@ -26,12 +24,17 @@ _LOGGER = logging.getLogger(__name__)
 def esp32_c3_validate_gpio_pin(value):
     if value < 0 or value > 21:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
-    if value in _ESP_32_C3_SPI_PSRAM_PINS:
+    if value in _ESP32C3_SPI_PSRAM_PINS:
         raise cv.Invalid(
-            f"This pin cannot be used on ESP32-C3s and is already used by the SPI/PSRAM interface (function: {_ESP_32_C3_SPI_PSRAM_PINS[value]})"
+            f"This pin cannot be used on ESP32-C3s and is already used by the SPI/PSRAM interface (function: {_ESP32C3_SPI_PSRAM_PINS[value]})"
         )
-    if value in _ESP_32_C3_STRAPPING_PINS:
-        _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)
+    if value in _ESP32C3_STRAPPING_PINS:
+        _LOGGER.warning(
+            "GPIO%d is a Strapping PIN and should be avoided.\n"
+            "Attaching external pullup/down resistors to strapping pins can cause unexpected failures.\n"
+            "See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins",
+            value,
+        )
 
     return value
 
@@ -40,8 +43,6 @@ def esp32_c3_validate_supports(value):
     num = value[CONF_NUMBER]
     mode = value[CONF_MODE]
     is_input = mode[CONF_INPUT]
-    is_pullup = mode[CONF_PULLUP]
-    is_pulldown = mode[CONF_PULLDOWN]
 
     if num < 0 or num > 21:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
@@ -49,13 +50,4 @@ def esp32_c3_validate_supports(value):
     if is_input:
         # All ESP32 pins support input mode
         pass
-    if is_pullup and num == 21:
-        raise cv.Invalid(
-            f"GPIO{num} does not support pullups.", [CONF_MODE, CONF_PULLUP]
-        )
-    if is_pulldown and num == 21:
-        raise cv.Invalid(
-            f"GPIO{num} does not support pulldowns.", [CONF_MODE, CONF_PULLDOWN]
-        )
-
     return value

--- a/esphome/components/esp32/gpio_esp32_c3.py
+++ b/esphome/components/esp32/gpio_esp32_c3.py
@@ -9,7 +9,7 @@ from esphome.const import (
 )
 import esphome.config_validation as cv
 
-_ESP_32_C3_SPI_PSRAM_PINS = {
+_ESP32C3_SPI_PSRAM_PINS = {
     12: "SPIHD",
     13: "SPIWP",
     14: "SPICS0",

--- a/esphome/components/esp32/gpio_esp32_c3.py
+++ b/esphome/components/esp32/gpio_esp32_c3.py
@@ -18,7 +18,7 @@ _ESP32C3_SPI_PSRAM_PINS = {
     17: "SPIQ",
 }
 
-_ESP_32_C3_STRAPPING_PINS = {2, 8, 9}
+_ESP32C3_STRAPPING_PINS = {2, 8, 9}
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome/components/esp32/gpio_esp32_c3.py
+++ b/esphome/components/esp32/gpio_esp32_c3.py
@@ -1,0 +1,51 @@
+import logging
+
+from esphome.const import (
+    CONF_INPUT,
+    CONF_MODE,
+    CONF_NUMBER,
+    CONF_OPEN_DRAIN,
+    CONF_OUTPUT,
+    CONF_PULLDOWN,
+    CONF_PULLUP,
+)
+import esphome.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def esp32_c3_validate_gpio_pin(value):
+    if value < 0 or value > 21:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
+    return value
+
+
+def esp32_c3_validate_supports(value):
+    num = value[CONF_NUMBER]
+    mode = value[CONF_MODE]
+    is_input = mode[CONF_INPUT]
+    is_output = mode[CONF_OUTPUT]
+    is_open_drain = mode[CONF_OPEN_DRAIN]
+    is_pullup = mode[CONF_PULLUP]
+    is_pulldown = mode[CONF_PULLDOWN]
+
+    if num < 0 or num > 21:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
+
+    if is_input:
+        # All ESP32 pins support input mode
+        pass
+    if is_open_drain and not is_output:
+        raise cv.Invalid(
+            "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
+        )
+    if is_pullup and num == 21:
+        raise cv.Invalid(
+            f"GPIO{num} does not support pullups.", [CONF_MODE, CONF_PULLUP]
+        )
+    if is_pulldown and num == 21:
+        raise cv.Invalid(
+            f"GPIO{num} does not support pulldowns.", [CONF_MODE, CONF_PULLDOWN]
+        )
+
+    return value

--- a/esphome/components/esp32/gpio_esp32_c3.py
+++ b/esphome/components/esp32/gpio_esp32_c3.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome.const import (
     CONF_INPUT,
     CONF_MODE,
@@ -7,10 +9,30 @@ from esphome.const import (
 )
 import esphome.config_validation as cv
 
+_ESP_32_C3_SPI_PSRAM_PINS = {
+    12: "SPIHD",
+    13: "SPIWP",
+    14: "SPICS0",
+    15: "SPICLK",
+    16: "SPID",
+    17: "SPIQ",
+}
+
+_ESP_32_C3_STRAPPING_PINS = {2, 8, 9}
+
+_LOGGER = logging.getLogger(__name__)
+
 
 def esp32_c3_validate_gpio_pin(value):
     if value < 0 or value > 21:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
+    if value in _ESP_32_C3_SPI_PSRAM_PINS:
+        raise cv.Invalid(
+            f"This pin cannot be used on ESP32-C3s and is already used by the SPI/PSRAM interface (function: {_ESP_32_C3_SPI_PSRAM_PINS[value]})"
+        )
+    if value in _ESP_32_C3_STRAPPING_PINS:
+        _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)
+
     return value
 
 

--- a/esphome/components/esp32/gpio_esp32_c3.py
+++ b/esphome/components/esp32/gpio_esp32_c3.py
@@ -1,17 +1,11 @@
-import logging
-
 from esphome.const import (
     CONF_INPUT,
     CONF_MODE,
     CONF_NUMBER,
-    CONF_OPEN_DRAIN,
-    CONF_OUTPUT,
     CONF_PULLDOWN,
     CONF_PULLUP,
 )
 import esphome.config_validation as cv
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def esp32_c3_validate_gpio_pin(value):
@@ -24,8 +18,6 @@ def esp32_c3_validate_supports(value):
     num = value[CONF_NUMBER]
     mode = value[CONF_MODE]
     is_input = mode[CONF_INPUT]
-    is_output = mode[CONF_OUTPUT]
-    is_open_drain = mode[CONF_OPEN_DRAIN]
     is_pullup = mode[CONF_PULLUP]
     is_pulldown = mode[CONF_PULLDOWN]
 
@@ -35,10 +27,6 @@ def esp32_c3_validate_supports(value):
     if is_input:
         # All ESP32 pins support input mode
         pass
-    if is_open_drain and not is_output:
-        raise cv.Invalid(
-            "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
-        )
     if is_pullup and num == 21:
         raise cv.Invalid(
             f"GPIO{num} does not support pullups.", [CONF_MODE, CONF_PULLUP]

--- a/esphome/components/esp32/gpio_esp32_h2.py
+++ b/esphome/components/esp32/gpio_esp32_h2.py
@@ -6,7 +6,7 @@ import esphome.config_validation as cv
 
 
 def esp32_h2_validate_gpio_pin(value):
-    # Not yet supported
+    # ESP32-H2 not yet supported
     if value > 0:
         raise cv.Invalid("ESP32-H2 isn't supported yet")
     if value < 0 or value > 21:
@@ -15,6 +15,10 @@ def esp32_h2_validate_gpio_pin(value):
 
 
 def esp32_h2_validate_supports(value):
+    # ESP32-H2 not yet supported
+    if value > 0:
+        raise cv.Invalid("ESP32-H2 isn't supported yet")
+
     num = value[CONF_NUMBER]
     if num < 0 or num > 21:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")

--- a/esphome/components/esp32/gpio_esp32_h2.py
+++ b/esphome/components/esp32/gpio_esp32_h2.py
@@ -1,0 +1,21 @@
+from esphome.const import (
+    CONF_NUMBER,
+)
+
+import esphome.config_validation as cv
+
+
+def esp32_h2_validate_gpio_pin(value):
+    # Not yet supported
+    if value > 0:
+        raise cv.Invalid("ESP32-H2 isn't supported yet")
+    if value < 0 or value > 21:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
+    return value
+
+
+def esp32_h2_validate_supports(value):
+    num = value[CONF_NUMBER]
+    if num < 0 or num > 21:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
+    return value

--- a/esphome/components/esp32/gpio_esp32_h2.py
+++ b/esphome/components/esp32/gpio_esp32_h2.py
@@ -1,7 +1,3 @@
-from esphome.const import (
-    CONF_NUMBER,
-)
-
 import esphome.config_validation as cv
 
 

--- a/esphome/components/esp32/gpio_esp32_h2.py
+++ b/esphome/components/esp32/gpio_esp32_h2.py
@@ -12,10 +12,4 @@ def esp32_h2_validate_gpio_pin(value):
 
 def esp32_h2_validate_supports(value):
     # ESP32-H2 not yet supported
-    if value > 0:
-        raise cv.Invalid("ESP32-H2 isn't supported yet")
-
-    num = value[CONF_NUMBER]
-    if num < 0 or num > 21:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
-    return value
+    raise cv.Invalid("ESP32-H2 isn't supported yet")

--- a/esphome/components/esp32/gpio_esp32_h2.py
+++ b/esphome/components/esp32/gpio_esp32_h2.py
@@ -7,11 +7,7 @@ import esphome.config_validation as cv
 
 def esp32_h2_validate_gpio_pin(value):
     # ESP32-H2 not yet supported
-    if value > 0:
-        raise cv.Invalid("ESP32-H2 isn't supported yet")
-    if value < 0 or value > 21:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-21)")
-    return value
+    raise cv.Invalid("ESP32-H2 isn't supported yet")
 
 
 def esp32_h2_validate_supports(value):

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -1,18 +1,13 @@
-import logging
-
 from esphome.const import (
     CONF_INPUT,
     CONF_MODE,
     CONF_NUMBER,
-    CONF_OPEN_DRAIN,
     CONF_OUTPUT,
     CONF_PULLDOWN,
     CONF_PULLUP,
 )
 
 import esphome.config_validation as cv
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def esp32_s2_validate_gpio_pin(value):
@@ -22,12 +17,10 @@ def esp32_s2_validate_gpio_pin(value):
 
 
 def esp32_s2_validate_supports(value):
-
     num = value[CONF_NUMBER]
     mode = value[CONF_MODE]
     is_input = mode[CONF_INPUT]
     is_output = mode[CONF_OUTPUT]
-    is_open_drain = mode[CONF_OPEN_DRAIN]
     is_pullup = mode[CONF_PULLUP]
     is_pulldown = mode[CONF_PULLDOWN]
 
@@ -41,10 +34,6 @@ def esp32_s2_validate_supports(value):
         raise cv.Invalid(
             f"GPIO{num} does not support output pin mode.",
             [CONF_MODE, CONF_OUTPUT],
-        )
-    if is_open_drain and not is_output:
-        raise cv.Invalid(
-            "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
         )
     if is_pullup and num == 46:
         raise cv.Invalid(

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -34,7 +34,7 @@ def esp32_s2_validate_gpio_pin(value):
         raise cv.Invalid(
             f"This pin cannot be used on ESP32-S2s and is already used by the SPI/PSRAM interface (function: {_ESP_32_S2_SPI_PSRAM_PINS[value]})"
         )
-    if value in _ESP_32_S2_STRAPPING_PINS:
+    if value in _ESP32S2_STRAPPING_PINS:
         _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)
 
     if value in (22, 23, 24, 25):

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -1,0 +1,58 @@
+import logging
+
+from esphome.const import (
+    CONF_INPUT,
+    CONF_MODE,
+    CONF_NUMBER,
+    CONF_OPEN_DRAIN,
+    CONF_OUTPUT,
+    CONF_PULLDOWN,
+    CONF_PULLUP,
+)
+
+import esphome.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def esp32_s2_validate_gpio_pin(value):
+    if value < 0 or value > 46:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-46)")
+    return value
+
+
+def esp32_s2_validate_supports(value):
+
+    num = value[CONF_NUMBER]
+    mode = value[CONF_MODE]
+    is_input = mode[CONF_INPUT]
+    is_output = mode[CONF_OUTPUT]
+    is_open_drain = mode[CONF_OPEN_DRAIN]
+    is_pullup = mode[CONF_PULLUP]
+    is_pulldown = mode[CONF_PULLDOWN]
+
+    if num < 0 or num > 46:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-46)")
+
+    if is_input:
+        # All ESP32 pins support input mode
+        pass
+    if is_output and num == 46:
+        raise cv.Invalid(
+            f"GPIO{num} does not support output pin mode.",
+            [CONF_MODE, CONF_OUTPUT],
+        )
+    if is_open_drain and not is_output:
+        raise cv.Invalid(
+            "Open-drain only works with output mode", [CONF_MODE, CONF_OPEN_DRAIN]
+        )
+    if is_pullup and num == 46:
+        raise cv.Invalid(
+            f"GPIO{num} does not support pullups.", [CONF_MODE, CONF_PULLUP]
+        )
+    if is_pulldown and num == 46:
+        raise cv.Invalid(
+            f"GPIO{num} does not support pulldowns.", [CONF_MODE, CONF_PULLDOWN]
+        )
+
+    return value

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -32,7 +32,7 @@ def esp32_s2_validate_gpio_pin(value):
 
     if value in _ESP_32_S2_SPI_PSRAM_PINS:
         raise cv.Invalid(
-            f"This pin cannot be used on ESP32-S2s and is already used by the SPI/PSRAM interface(function: {_ESP_32_S2_SPI_PSRAM_PINS[value]})"
+            f"This pin cannot be used on ESP32-S2s and is already used by the SPI/PSRAM interface (function: {_ESP_32_S2_SPI_PSRAM_PINS[value]})"
         )
     if value in _ESP_32_S2_STRAPPING_PINS:
         _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -11,7 +11,7 @@ from esphome.const import (
 
 import esphome.config_validation as cv
 
-_ESP_32_S2_SPI_PSRAM_PINS = {
+_ESP32S2_SPI_PSRAM_PINS = {
     26: "SPICS1",
     27: "SPIHD",
     28: "SPIWP",
@@ -32,10 +32,15 @@ def esp32_s2_validate_gpio_pin(value):
 
     if value in _ESP32S2_SPI_PSRAM_PINS:
         raise cv.Invalid(
-            f"This pin cannot be used on ESP32-S2s and is already used by the SPI/PSRAM interface (function: {_ESP_32_S2_SPI_PSRAM_PINS[value]})"
+            f"This pin cannot be used on ESP32-S2s and is already used by the SPI/PSRAM interface (function: {_ESP32S2_SPI_PSRAM_PINS[value]})"
         )
     if value in _ESP32S2_STRAPPING_PINS:
-        _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)
+        _LOGGER.warning(
+            "GPIO%d is a Strapping PIN and should be avoided.\n"
+            "Attaching external pullup/down resistors to strapping pins can cause unexpected failures.\n"
+            "See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins",
+            value,
+        )
 
     if value in (22, 23, 24, 25):
         # These pins are not exposed in GPIO mux (reason unknown)

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome.const import (
     CONF_INPUT,
     CONF_MODE,
@@ -9,10 +11,37 @@ from esphome.const import (
 
 import esphome.config_validation as cv
 
+_ESP_32_S2_SPI_PSRAM_PINS = {
+    26: "SPICS1",
+    27: "SPIHD",
+    28: "SPIWP",
+    29: "SPICS0",
+    30: "SPICLK",
+    31: "SPIQ",
+    32: "SPID",
+}
+
+_ESP_32_S2_STRAPPING_PINS = {0, 45, 46}
+
+_LOGGER = logging.getLogger(__name__)
+
 
 def esp32_s2_validate_gpio_pin(value):
     if value < 0 or value > 46:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-46)")
+
+    if value in _ESP_32_S2_SPI_PSRAM_PINS:
+        raise cv.Invalid(
+            f"This pin cannot be used on ESP32-S2s and is already used by the SPI/PSRAM interface(function: {_ESP_32_S2_SPI_PSRAM_PINS[value]})"
+        )
+    if value in _ESP_32_S2_STRAPPING_PINS:
+        _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)
+
+    if value in (22, 23, 24, 25):
+        # These pins are not exposed in GPIO mux (reason unknown)
+        # but they're missing from IO_MUX list in datasheet
+        raise cv.Invalid(f"The pin GPIO{value} is not usable on ESP32-S2s.")
+
     return value
 
 
@@ -25,8 +54,7 @@ def esp32_s2_validate_supports(value):
     is_pulldown = mode[CONF_PULLDOWN]
 
     if num < 0 or num > 46:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-46)")
-
+        raise cv.Invalid(f"Invalid pin number: {num} (must be 0-46)")
     if is_input:
         # All ESP32 pins support input mode
         pass

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -30,7 +30,7 @@ def esp32_s2_validate_gpio_pin(value):
     if value < 0 or value > 46:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-46)")
 
-    if value in _ESP_32_S2_SPI_PSRAM_PINS:
+    if value in _ESP32S2_SPI_PSRAM_PINS:
         raise cv.Invalid(
             f"This pin cannot be used on ESP32-S2s and is already used by the SPI/PSRAM interface (function: {_ESP_32_S2_SPI_PSRAM_PINS[value]})"
         )

--- a/esphome/components/esp32/gpio_esp32_s2.py
+++ b/esphome/components/esp32/gpio_esp32_s2.py
@@ -21,7 +21,7 @@ _ESP_32_S2_SPI_PSRAM_PINS = {
     32: "SPID",
 }
 
-_ESP_32_S2_STRAPPING_PINS = {0, 45, 46}
+_ESP32S2_STRAPPING_PINS = {0, 45, 46}
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome/components/esp32/gpio_esp32_s3.py
+++ b/esphome/components/esp32/gpio_esp32_s3.py
@@ -1,0 +1,21 @@
+from esphome.const import (
+    CONF_NUMBER,
+)
+
+import esphome.config_validation as cv
+
+
+def esp32_s3_validate_gpio_pin(value):
+    # Not yet supported
+    if value > 0:
+        raise cv.Invalid("ESP32-S3 isn't supported yet")
+    if value < 0 or value > 48:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-48)")
+    return value
+
+
+def esp32_s3_validate_supports(value):
+    num = value[CONF_NUMBER]
+    if num < 0 or num > 48:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-48)")
+    return value

--- a/esphome/components/esp32/gpio_esp32_s3.py
+++ b/esphome/components/esp32/gpio_esp32_s3.py
@@ -41,7 +41,7 @@ def esp32_s3_validate_gpio_pin(value):
         )
     if value in _ESP_32_ESP32_S3R8_PSRAM_PINS:
         _LOGGER.warning(
-            "GPIO%d is by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V boad and should be avoided on these models",
+            "GPIO%d is used by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V and should be avoided on these models",
             value,
         )
 

--- a/esphome/components/esp32/gpio_esp32_s3.py
+++ b/esphome/components/esp32/gpio_esp32_s3.py
@@ -8,7 +8,7 @@ from esphome.const import (
 
 import esphome.config_validation as cv
 
-_ESP_32_S3_SPI_PSRAM_PINS = {
+_ESP_32S3_SPI_PSRAM_PINS = {
     26: "SPICS1",
     27: "SPIHD",
     28: "SPIWP",
@@ -26,7 +26,7 @@ _ESP_32_ESP32_S3R8_PSRAM_PINS = {
     37: "SPIDQS",
 }
 
-_ESP_32_S3_STRAPPING_PINS = {0, 3, 45, 46}
+_ESP_32S3_STRAPPING_PINS = {0, 3, 45, 46}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,9 +35,9 @@ def esp32_s3_validate_gpio_pin(value):
     if value < 0 or value > 48:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-46)")
 
-    if value in _ESP_32_S3_SPI_PSRAM_PINS:
+    if value in _ESP_32S3_SPI_PSRAM_PINS:
         raise cv.Invalid(
-            f"This pin cannot be used on ESP32-S3s and is already used by the SPI/PSRAM interface(function: {_ESP_32_S3_SPI_PSRAM_PINS[value]})"
+            f"This pin cannot be used on ESP32-S3s and is already used by the SPI/PSRAM interface(function: {_ESP_32S3_SPI_PSRAM_PINS[value]})"
         )
     if value in _ESP_32_ESP32_S3R8_PSRAM_PINS:
         _LOGGER.warning(
@@ -45,8 +45,13 @@ def esp32_s3_validate_gpio_pin(value):
             value,
         )
 
-    if value in _ESP_32_S3_STRAPPING_PINS:
-        _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)
+    if value in _ESP_32S3_STRAPPING_PINS:
+        _LOGGER.warning(
+            "GPIO%d is a Strapping PIN and should be avoided.\n"
+            "Attaching external pullup/down resistors to strapping pins can cause unexpected failures.\n"
+            "See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins",
+            value,
+        )
 
     if value in (22, 23, 24, 25):
         # These pins are not exposed in GPIO mux (reason unknown)

--- a/esphome/components/esp32/gpio_esp32_s3.py
+++ b/esphome/components/esp32/gpio_esp32_s3.py
@@ -1,21 +1,69 @@
+import logging
+
 from esphome.const import (
+    CONF_INPUT,
+    CONF_MODE,
     CONF_NUMBER,
 )
 
 import esphome.config_validation as cv
 
+_ESP_32_S3_SPI_PSRAM_PINS = {
+    26: "SPICS1",
+    27: "SPIHD",
+    28: "SPIWP",
+    29: "SPICS0",
+    30: "SPICLK",
+    31: "SPIQ",
+    32: "SPID",
+}
+
+_ESP_32_ESP32_S3R8_PSRAM_PINS = {
+    33: "SPIIO4",
+    34: "SPIIO5",
+    35: "SPIIO6",
+    36: "SPIIO7",
+    37: "SPIDQS",
+}
+
+_ESP_32_S3_STRAPPING_PINS = {0, 3, 45, 46}
+
+_LOGGER = logging.getLogger(__name__)
+
 
 def esp32_s3_validate_gpio_pin(value):
-    # Not yet supported
-    if value > 0:
-        raise cv.Invalid("ESP32-S3 isn't supported yet")
     if value < 0 or value > 48:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-48)")
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-46)")
+
+    if value in _ESP_32_S3_SPI_PSRAM_PINS:
+        raise cv.Invalid(
+            f"This pin cannot be used on ESP32-S3s and is already used by the SPI/PSRAM interface(function: {_ESP_32_S3_SPI_PSRAM_PINS[value]})"
+        )
+    if value in _ESP_32_ESP32_S3R8_PSRAM_PINS:
+        _LOGGER.warning(
+            "GPIO%d is by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V boad and should be avoided on these models",
+            value,
+        )
+
+    if value in _ESP_32_S3_STRAPPING_PINS:
+        _LOGGER.warning("GPIO%d is a Strapping PIN and should be avoided", value)
+
+    if value in (22, 23, 24, 25):
+        # These pins are not exposed in GPIO mux (reason unknown)
+        # but they're missing from IO_MUX list in datasheet
+        raise cv.Invalid(f"The pin GPIO{value} is not usable on ESP32-S3s.")
+
     return value
 
 
 def esp32_s3_validate_supports(value):
     num = value[CONF_NUMBER]
+    mode = value[CONF_MODE]
+    is_input = mode[CONF_INPUT]
+
     if num < 0 or num > 48:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-48)")
+        raise cv.Invalid(f"Invalid pin number: {num} (must be 0-46)")
+    if is_input:
+        # All ESP32 pins support input mode
+        pass
     return value


### PR DESCRIPTION
# What does this implement/fix? 

Add/fix gpio pin validations for ESP32-S2 and ESP-C3
Move validation for each esp32 variant to a separate routine 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2591

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
  See https://github.com/esphome/esphome-docs/pull/1576
