### PR TITLE
Fix ESP8266 OTA compression only starting framework v2.7.0

### DIFF
--- a/esphome/components/ota/ota_backend_arduino_esp8266.h
+++ b/esphome/components/ota/ota_backend_arduino_esp8266.h
@@ -5,6 +5,7 @@
 
 #include "ota_component.h"
 #include "ota_backend.h"
+#include "esphome/core/macros.h"
 
 namespace esphome {
 namespace ota {

--- a/esphome/components/ota/ota_backend_arduino_esp8266.h
+++ b/esphome/components/ota/ota_backend_arduino_esp8266.h
@@ -16,7 +16,11 @@ class ArduinoESP8266OTABackend : public OTABackend {
   OTAResponseTypes write(uint8_t *data, size_t len) override;
   OTAResponseTypes end() override;
   void abort() override;
+#if ARDUINO_VERSION_CODE >= VERSION_CODE(2, 7, 0)
   bool supports_compression() override { return true; }
+#else
+  bool supports_compression() override { return false; }
+#endif
 };
 
 }  // namespace ota


### PR DESCRIPTION
# What does this implement/fix? 

Small follow-up to https://github.com/esphome/esphome/pull/2601. Did some more testing and update compression was only added in framework 2.7.0: https://github.com/esp8266/Arduino/releases/tag/2.7.0

So only enable it if at least that framework version is used (it is by default)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
