### PR TITLE
fixed dependency for pca9685 component

### DIFF
--- a/esphome/components/pca9685/pca9685_output.cpp
+++ b/esphome/components/pca9685/pca9685_output.cpp
@@ -1,6 +1,7 @@
 #include "pca9685_output.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/hal.h"
 
 namespace esphome {
 namespace pca9685 {
@@ -69,7 +70,7 @@ void PCA9685Output::setup() {
     this->mark_failed();
     return;
   }
-  delayMicroseconds(500);
+  esphome::delayMicroseconds(500);
 
   this->loop();
 }

--- a/esphome/components/pca9685/pca9685_output.cpp
+++ b/esphome/components/pca9685/pca9685_output.cpp
@@ -70,7 +70,7 @@ void PCA9685Output::setup() {
     this->mark_failed();
     return;
   }
-  esphome::delayMicroseconds(500);
+  delayMicroseconds(500);
 
   this->loop();
 }


### PR DESCRIPTION
# What does this implement/fix? 

fixes compile dependency for delayMicrosecond function
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2602

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
