### PR TITLE
Autodetect flash size

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -226,6 +226,8 @@ def upload_using_esptool(config, port):
             mcu,
             "write_flash",
             "-z",
+            "--flash_size",
+            "detect",
         ]
         for img in flash_images:
             cmd += [img.offset, img.path]


### PR DESCRIPTION
# What does this implement/fix? 

With "Always upload using esptool (#2433)" ESPHome launches esptool.py
directly. It seems that this broke flashing of the ESP32-C3-DevKitM-1
which comes with 4MB flash. It seems that esptool.py is by default
configured to assume 2MB of flash.

Before, the Platform IO target "upload" has been used, which was passing
--flash_size detect as well. Replicate that behavior too.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: office-sensor
  platformio_options:
    board_build.flash_mode: dio
    platform: https://github.com/platformio/platform-espressif32#feature/arduino-idf-master
    platform_packages:
      - framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.0

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: arduino
  variant: esp32c3
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
