### PR TITLE
Fix pin number validation for sn74hc595

### DIFF
--- a/esphome/components/sn74hc595/__init__.py
+++ b/esphome/components/sn74hc595/__init__.py
@@ -60,7 +60,7 @@ SN74HC595_PIN_SCHEMA = cv.All(
     {
         cv.GenerateID(): cv.declare_id(SN74HC595GPIOPin),
         cv.Required(CONF_SN74HC595): cv.use_id(SN74HC595Component),
-        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=7),
+        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=31),
         cv.Optional(CONF_MODE, default={}): cv.All(
             {
                 cv.Optional(CONF_OUTPUT, default=True): cv.All(


### PR DESCRIPTION
# What does this implement/fix? 

Recent changes in #2303 added stricter validation of SN74HC595 output pin numbers, so it's not possible to control daisy-chained registers anymore, where the pin number needs to be higher than 7. Naive fix could be just increasing the maximum number to 31, this PR rather tries to calculate the maximum value from defined `sr_count` value for better feedback. I couldn't come up with a better solution than getting the value from `CORE.raw_config` but it seems to do the trick (is there a better way though?).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
