### PR TITLE
Fix CRC error during DSMR chunked message reading

### DIFF
--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -156,12 +156,6 @@ void Dsmr::receive_encrypted_() {
       telegram_len_ = 0;
       return;
     }
-
-    if (!available()) {
-      // baud rate is 115200 for encrypted data, this means a few byte should arrive every time
-      // program runs faster than buffer loading then available() might return false in the middle
-      delay(4);  // Wait for data
-    }
   }
 }
 

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -20,8 +20,25 @@ void Dsmr::loop() {
 }
 
 void Dsmr::receive_telegram_() {
-  int count = MAX_BYTES_PER_LOOP;
-  while (available() && count-- > 0) {
+  while (true) {
+    if (!available()) {
+      if (!header_found_) {
+        return;
+      }
+      uint8_t tries = 20;
+      bool can_read = false;
+      while (tries--) {
+          delay(10);
+          if (available()) {
+              can_read = true;
+              break;
+          }
+      }
+      if (!can_read) {
+          return;
+      }
+    }
+
     const char c = read();
 
     // Find a new telegram header, i.e. forward slash.
@@ -62,8 +79,8 @@ void Dsmr::receive_telegram_() {
     if (footer_found_ && c == '\n') {
       header_found_ = false;
       // Parse the telegram and publish sensor values.
-      if (parse_telegram())
-        return;
+      parse_telegram();
+      return;
     }
   }
 }

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -143,6 +143,7 @@ void Dsmr::receive_encrypted_() {
 }
 
 bool Dsmr::parse_telegram() {
+  auto start = millis();
   MyData data;
   ESP_LOGV(TAG, "Trying to parse");
   ::dsmr::ParseResult<void> res =
@@ -152,10 +153,14 @@ bool Dsmr::parse_telegram() {
     // Parsing error, show it
     auto err_str = res.fullError(telegram_, telegram_ + telegram_len_);
     ESP_LOGE(TAG, "%s", err_str.c_str());
+    auto end = millis();
+    ESP_LOGV(TAG, "Processing time: %d ms", (end-start));
     return false;
   } else {
     this->status_clear_warning();
     publish_sensors(data);
+    auto end = millis();
+    ESP_LOGV(TAG, "Processing time: %d ms", (end-start));
     return true;
   }
 }

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -42,7 +42,7 @@ void Dsmr::receive_telegram_() {
 
     // Find a new telegram header, i.e. forward slash.
     if (c == '/') {
-      ESP_LOGV(TAG, "Header found");
+      ESP_LOGV(TAG, "Header of telegram found");
       header_found_ = true;
       footer_found_ = false;
       telegram_len_ = 0;
@@ -70,7 +70,7 @@ void Dsmr::receive_telegram_() {
 
     // Check for a footer, i.e. exlamation mark, followed by a hex checksum.
     if (c == '!') {
-      ESP_LOGV(TAG, "Footer found");
+      ESP_LOGV(TAG, "Footer of telegram found");
       footer_found_ = true;
       continue;
     }
@@ -103,8 +103,9 @@ void Dsmr::receive_encrypted_() {
 
     const char c = read();
 
+    // Find a new telegram start byte.
     if (!header_found_) {
-      if ((uint8_t) c == 0xdb) {
+      if ((uint8_t) c == 0xDB) {
         ESP_LOGV(TAG, "Start byte 0xDB of encrypted telegram found");
         header_found_ = true;
       }
@@ -121,12 +122,12 @@ void Dsmr::receive_encrypted_() {
     buffer[buffer_length++] = c;
 
     if (packet_size == 0 && buffer_length > 20) {
-      // Complete header + a few bytes of data
-      packet_size = buffer[11] << 8 | buffer[12];
+      // Complete header + data bytes
+      packet_size = 13 + (buffer[11] << 8 | buffer[12]);
+      ESP_LOGV(TAG, "Encrypted telegram size: %d bytes", packet_size);
     }
-    if (buffer_length == packet_size + 13 && packet_size > 0) {
-      ESP_LOGV(TAG, "Encrypted telegram size: %d bytes", buffer_length);
-
+    if (buffer_length == packet_size && packet_size > 0) {
+      ESP_LOGV(TAG, "End of encrypted telegram found");
       GCM<AES128> *gcmaes128{new GCM<AES128>()};
       gcmaes128->setKey(this->decryption_key_.data(), gcmaes128->keySize());
       // the iv is 8 bytes of the system title + 4 bytes frame counter
@@ -143,7 +144,7 @@ void Dsmr::receive_encrypted_() {
       delete gcmaes128;  // NOLINT(cppcoreguidelines-owning-memory)
 
       telegram_len_ = strnlen(this->telegram_, sizeof(this->telegram_));
-      ESP_LOGV(TAG, "Decrypted telegram length: %d", telegram_len_);
+      ESP_LOGV(TAG, "Decrypted telegram size: %d bytes", telegram_len_);
       ESP_LOGVV(TAG, "Decrypted telegram: %s", this->telegram_);
 
       header_found_ = false;
@@ -157,7 +158,7 @@ void Dsmr::receive_encrypted_() {
 
 bool Dsmr::parse_telegram() {
   MyData data;
-  ESP_LOGV(TAG, "Trying to parse");
+  ESP_LOGV(TAG, "Trying to parse telegram");
   ::dsmr::ParseResult<void> res =
       ::dsmr::P1Parser::parse(&data, telegram_, telegram_len_, false,
                               this->crc_check_);  // Parse telegram according to data definition. Ignore unknown values.
@@ -174,7 +175,7 @@ bool Dsmr::parse_telegram() {
 }
 
 void Dsmr::dump_config() {
-  ESP_LOGCONFIG(TAG, "dsmr:");
+  ESP_LOGCONFIG(TAG, "DSMR:");
 
 #define DSMR_LOG_SENSOR(s) LOG_SENSOR("  ", #s, this->s_##s##_);
   DSMR_SENSOR_LIST(DSMR_LOG_SENSOR, )
@@ -191,12 +192,12 @@ void Dsmr::set_decryption_key(const std::string &decryption_key) {
   }
 
   if (decryption_key.length() != 32) {
-    ESP_LOGE(TAG, "Error, decryption key must be 32 character long.");
+    ESP_LOGE(TAG, "Error, decryption key must be 32 character long");
     return;
   }
   this->decryption_key_.clear();
 
-  ESP_LOGI(TAG, "Decryption key is set.");
+  ESP_LOGI(TAG, "Decryption key is set");
   // Verbose level prints decryption key
   ESP_LOGV(TAG, "Using decryption key: %s", decryption_key.c_str());
 

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -19,7 +19,7 @@ void Dsmr::loop() {
     this->receive_encrypted_();
 }
 
-bool Dsmr::available_within_timeout() {
+bool Dsmr::available_within_timeout_() {
   uint8_t tries = READ_TIMEOUT_MS / 5;
   while (tries--) {
     delay(5);
@@ -33,7 +33,7 @@ bool Dsmr::available_within_timeout() {
 void Dsmr::receive_telegram_() {
   while (true) {
     if (!available()) {
-      if (!header_found_ || !available_within_timeout()) {
+      if (!header_found_ || !available_within_timeout_()) {
         return;
       }
     }
@@ -95,7 +95,7 @@ void Dsmr::receive_encrypted_() {
       if (!header_found_) {
         return;
       }
-      if (!available_within_timeout()) {
+      if (!available_within_timeout_()) {
         ESP_LOGW(TAG, "Timeout while reading data for encrypted telegram");
         return;
       }

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -35,14 +35,14 @@ void Dsmr::receive_telegram_() {
       uint8_t tries = READ_TIMEOUT_MS / 10;
       bool can_read = false;
       while (tries--) {
-          delay(10);
-          if (available()) {
-              can_read = true;
-              break;
-          }
+        delay(10);
+        if (available()) {
+          can_read = true;
+          break;
+        }
       }
       if (!can_read) {
-          return;
+        return;
       }
     }
 

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -167,7 +167,6 @@ void Dsmr::receive_encrypted_() {
 }
 
 bool Dsmr::parse_telegram() {
-  auto start = millis();
   MyData data;
   ESP_LOGV(TAG, "Trying to parse");
   ::dsmr::ParseResult<void> res =
@@ -177,14 +176,10 @@ bool Dsmr::parse_telegram() {
     // Parsing error, show it
     auto err_str = res.fullError(telegram_, telegram_ + telegram_len_);
     ESP_LOGE(TAG, "%s", err_str.c_str());
-    auto end = millis();
-    ESP_LOGV(TAG, "Processing time: %d ms", (end-start));
     return false;
   } else {
     this->status_clear_warning();
     publish_sensors(data);
-    auto end = millis();
-    ESP_LOGV(TAG, "Processing time: %d ms", (end-start));
     return true;
   }
 }

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -17,7 +17,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
-static constexpr uint32_t READ_TIMEOUT_MS = 200;
+static constexpr uint32_t READ_TIMEOUT_MS = 900;
 
 using namespace ::dsmr::fields;
 

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -85,6 +85,17 @@ class Dsmr : public Component, public uart::UARTDevice {
   void receive_telegram_();
   void receive_encrypted_();
 
+  /// Wait for UART data to become available within the read timeout.
+  ///
+  /// The smart meter might provide data in chunks, causing available() to
+  /// return 0. When we're already reading a telegram, then we don't return
+  /// right away (to handle further data in an upcoming loop) but wait a
+  /// little while using this method to see if more data are incoming.
+  /// By not returning, we prevent other components from taking so much
+  /// time that the UART RX buffer overflows and bytes of the telegram get
+  /// lost in the process.
+  bool available_within_timeout();
+
   // Telegram buffer
   char telegram_[MAX_TELEGRAM_LENGTH];
   int telegram_len_{0};

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -17,8 +17,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
-static constexpr uint32_t MAX_BYTES_PER_LOOP = 1024;
-static constexpr uint32_t POLL_TIMEOUT = 1000;
+static constexpr uint32_t READ_TIMEOUT_MS = 200;
 
 using namespace ::dsmr::fields;
 

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -17,7 +17,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
-static constexpr uint32_t READ_TIMEOUT_MS = 900;
+static constexpr uint32_t READ_TIMEOUT_MS = 200;
 
 using namespace ::dsmr::fields;
 

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -17,7 +17,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
-static constexpr uint32_t MAX_BYTES_PER_LOOP = 50;
+static constexpr uint32_t MAX_BYTES_PER_LOOP = 500;
 static constexpr uint32_t POLL_TIMEOUT = 1000;
 
 using namespace ::dsmr::fields;

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -94,7 +94,7 @@ class Dsmr : public Component, public uart::UARTDevice {
   /// By not returning, we prevent other components from taking so much
   /// time that the UART RX buffer overflows and bytes of the telegram get
   /// lost in the process.
-  bool available_within_timeout();
+  bool available_within_timeout_();
 
   // Telegram buffer
   char telegram_[MAX_TELEGRAM_LENGTH];

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -17,7 +17,7 @@ namespace esphome {
 namespace dsmr {
 
 static constexpr uint32_t MAX_TELEGRAM_LENGTH = 1500;
-static constexpr uint32_t MAX_BYTES_PER_LOOP = 500;
+static constexpr uint32_t MAX_BYTES_PER_LOOP = 1024;
 static constexpr uint32_t POLL_TIMEOUT = 1000;
 
 using namespace ::dsmr::fields;


### PR DESCRIPTION
# What does this implement/fix? 

People are getting CRC errors with 2021.10.{0,1,2}. This PR fixes the issue.

**The issue**
After some investigation, it turns out that the smart meter might not provide a full telegram in one go, but might be sending the data in chunks. Because that causes `available()` to return `0`, the original read loop would return in such case. The loop would continue reading on the next loop iteration.
The CRC errors occur because between the two loop iterations, the smart meter might have sent more data than fits in the UART RX buffer (256 bytes by default). 

**The fix**
The strategy for fixing this, is to not immediately return when no more data are available, but to wait up to a predefined amount of time (I used 200ms, because on my meter 150ms was about the max pause between bursts) before doing so. By doing this, the component does its best to have full attention for the data coming from the smart meter, and it tries to read the full telegram in one go.

This fix was implemented for both unencrypted and encrypted telegrams.

It is also possible to increase the UART buffer size, to make it overflow less easily. That's not air tight though in case there are other components that block the main loop for too long.
For the encrypted telegram reader, that wouldn't help though, because it currently is written in such way that it either reads the full encrypted message, or it fully fails when that doesn't work out. Unlike the unencrypted read, which can be called multiple times from the main loop to accumulate telegram data. So with the original encrypted reader, the read would fail when the data would pause for too long. The new read mechanism allows for these pauses in the encrypted data flow, making it more likely that the whole telegram can be read.

_Note:
In general, increasing the UART buffer size is not a bad idea. It does fix issues with the start of telegrams getting lost when another component is blocking the main loop the moment that a new telegram comes in. By the time the DSMR component gets to read some data, the telegram header might have been flushed from the UART buffer, because of an overflow._

**What might be a point of discussion here:**
One downside is that the component will take up some more time in the `loop()` than recommended. On my meter, I get warnings that the component takes about 0.82s for processing. IMO that is a good trade-off for getting high quality readings, without having to use a bigger UART RX buffer setting.
On the other hand: for encrypted telegrams, reading everything in one go has always been the strategy.

## Types of changes
O- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes:
  *  https://github.com/esphome/issues/issues/2577
  * https://github.com/esphome/issues/issues/2600
  * https://github.com/esphome/issues/issues/2621
  * https://github.com/esphome/issues/issues/2662

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally. (using DSMR4, others tested using DSMR5)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
