### PR TITLE
relax max entities checking

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -139,7 +139,9 @@ void Modbus::send(uint8_t address, uint8_t function_code, uint16_t start_address
                   uint8_t payload_len, const uint8_t *payload) {
   static const size_t MAX_VALUES = 128;
 
-  if (number_of_entities > MAX_VALUES) {
+  // Only check max number of registers for standard function codes
+  // Some devices use non standard codes like 0x43
+  if (number_of_entities > MAX_VALUES && function_code <= 0x10) {
     ESP_LOGE(TAG, "send too many values %d max=%zu", number_of_entities, MAX_VALUES);
     return;
   }


### PR DESCRIPTION
# What does this implement/fix? 

This change removes checking for the max number of registers in a modbus command. 
Some devices use function codes not included in the standard and may interpret the value different. 
Checking is now done only for function codes <= 16

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2630

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
