### PR TITLE
fix modbus output

### DIFF
--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -61,6 +61,21 @@ SENSOR_VALUE_TYPE = {
     "FP32_R": SensorValueType.FP32_R,
 }
 
+TYPE_REGISTER_MAP = {
+    "RAW": 1,
+    "U_WORD": 1,
+    "S_WORD": 1,
+    "U_DWORD": 2,
+    "U_DWORD_R": 2,
+    "S_DWORD": 2,
+    "S_DWORD_R": 2,
+    "U_QWORD": 4,
+    "U_QWORDU_R": 4,
+    "S_QWORD": 4,
+    "U_QWORD_R": 4,
+    "FP32": 2,
+    "FP32_R": 2,
+}
 
 MULTI_CONF = True
 

--- a/esphome/components/modbus_controller/number/__init__.py
+++ b/esphome/components/modbus_controller/number/__init__.py
@@ -17,6 +17,7 @@ from .. import (
     ModbusController,
     SENSOR_VALUE_TYPE,
     SensorItem,
+    TYPE_REGISTER_MAP,
 )
 
 
@@ -38,22 +39,6 @@ CODEOWNERS = ["@martgras"]
 ModbusNumber = modbus_controller_ns.class_(
     "ModbusNumber", cg.Component, number.Number, SensorItem
 )
-
-TYPE_REGISTER_MAP = {
-    "RAW": 1,
-    "U_WORD": 1,
-    "S_WORD": 1,
-    "U_DWORD": 2,
-    "U_DWORD_R": 2,
-    "S_DWORD": 2,
-    "S_DWORD_R": 2,
-    "U_QWORD": 4,
-    "U_QWORDU_R": 4,
-    "S_QWORD": 4,
-    "U_QWORD_R": 4,
-    "FP32": 2,
-    "FP32_R": 2,
-}
 
 
 def validate_min_max(config):

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -11,12 +11,13 @@ using value_to_data_t = std::function<float>(float);
 
 class ModbusOutput : public output::FloatOutput, public Component, public SensorItem {
  public:
-  ModbusOutput(uint16_t start_address, uint8_t offset, SensorValueType value_type)
+  ModbusOutput(uint16_t start_address, uint8_t offset, SensorValueType value_type, int register_count)
       : output::FloatOutput(), Component() {
     this->register_type = ModbusRegisterType::HOLDING;
     this->start_address = start_address;
     this->offset = offset;
     this->bitmask = bitmask;
+    this->register_count = register_count;
     this->sensor_value_type = value_type;
     this->skip_updates = 0;
     this->start_address += offset;

--- a/esphome/components/modbus_controller/sensor/__init__.py
+++ b/esphome/components/modbus_controller/sensor/__init__.py
@@ -9,6 +9,7 @@ from .. import (
     ModbusController,
     MODBUS_REGISTER_TYPE,
     SENSOR_VALUE_TYPE,
+    TYPE_REGISTER_MAP,
 )
 from ..const import (
     CONF_BITMASK,
@@ -28,23 +29,6 @@ CODEOWNERS = ["@martgras"]
 ModbusSensor = modbus_controller_ns.class_(
     "ModbusSensor", cg.Component, sensor.Sensor, SensorItem
 )
-
-TYPE_REGISTER_MAP = {
-    "RAW": 1,
-    "U_WORD": 1,
-    "S_WORD": 1,
-    "U_DWORD": 2,
-    "U_DWORD_R": 2,
-    "S_DWORD": 2,
-    "S_DWORD_R": 2,
-    "U_QWORD": 4,
-    "U_QWORDU_R": 4,
-    "S_QWORD": 4,
-    "U_QWORD_R": 4,
-    "FP32": 2,
-    "FP32_R": 2,
-}
-
 
 CONFIG_SCHEMA = cv.All(
     sensor.SENSOR_SCHEMA.extend(


### PR DESCRIPTION
# What does this implement/fix? 

register_count is not initialized in the output component and has random values
CONF_REGISTER_COUNT is missing in the schema. The fix corrects these problems.
Also moved TYPE_REGISTER_MAP to the main component and import it instead of duplication  in sensors, numbers and output

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2635

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
