### PR TITLE
Allow cloning/fetching Github PR branches in external_components

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -43,19 +43,27 @@ def validate_source_shorthand(value):
     # Regex for GitHub repo name with optional branch/tag
     # Note: git allows other branch/tag names as well, but never seen them used before
     m = re.match(
-        r"github://([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+)(?:@([a-zA-Z0-9\-_.\./]+))?",
+        r"github://(?:([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+)(?:@([a-zA-Z0-9\-_.\./]+))?|pr#([0-9]+))",
         value,
     )
     if m is None:
         raise cv.Invalid(
-            "Source is not a file system path or in expected github://username/name[@branch-or-tag] format!"
+            "Source is not a file system path, in expected github://username/name[@branch-or-tag] or github://pr#1234 format!"
         )
-    conf = {
-        CONF_TYPE: TYPE_GIT,
-        CONF_URL: f"https://github.com/{m.group(1)}/{m.group(2)}.git",
-    }
-    if m.group(3):
-        conf[CONF_REF] = m.group(3)
+    if m.group(4):
+        conf = {
+            CONF_TYPE: TYPE_GIT,
+            CONF_URL: "https://github.com/esphome/esphome.git",
+            CONF_REF: f"pull/{m.group(4)}/head",
+        }
+    else:
+        conf = {
+            CONF_TYPE: TYPE_GIT,
+            CONF_URL: f"https://github.com/{m.group(1)}/{m.group(2)}.git",
+        }
+        if m.group(3):
+            conf[CONF_REF] = m.group(3)
+
     return SOURCE_SCHEMA(conf)
 
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -40,14 +40,22 @@ def clone_or_update(
 ) -> Path:
     key = f"{url}@{ref}"
     repo_dir = _compute_destination_path(key, domain)
+    fetch_pr_branch = ref.startswith("pull/")
     if not repo_dir.is_dir():
         _LOGGER.info("Cloning %s", key)
         _LOGGER.debug("Location: %s", repo_dir)
         cmd = ["git", "clone", "--depth=1"]
-        if ref is not None:
+        if ref is not None and not fetch_pr_branch:
             cmd += ["--branch", ref]
         cmd += ["--", url, str(repo_dir)]
         run_git_command(cmd)
+
+        if fetch_pr_branch:
+            # We need to fetch the PR branch first, otherwise git will complain
+            # about missing objects
+            _LOGGER.info("Fetching %s", ref)
+            run_git_command(["git", "fetch", "--", "origin", ref], str(repo_dir))
+            run_git_command(["git", "reset", "--hard", "FETCH_HEAD"], str(repo_dir))
 
     else:
         # Check refresh needed


### PR DESCRIPTION
# What does this implement/fix? 

Allow cloning/fetching Github PR branches

`github://pr#2543` under the hood is converted into `https://github.com/esphome/esphome.git` with branch `pull/2543/head`. 

Because the magic PR branches cannot be used when cloning, ESPHome will first clone the main branch and fetch and checkout the PR branch in a second command. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1581

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
external_components:
  # - source: github://jesserockz/esphome@esp32-camera-web-server # same as below
  # - source: github://esphome/esphome@pull/2543/head # same as below
  - source: github://pr#2543
    components: ["esp32_camera_web_server"]
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
