### PR TITLE
Expose webserver_port to the native API

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -183,7 +183,7 @@ message DeviceInfoResponse {
   string project_name = 8;
   string project_version = 9;
 
-  int32 webserver_port = 10;
+  uint32 webserver_port = 10;
 }
 
 message ListEntitiesRequest {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -182,6 +182,8 @@ message DeviceInfoResponse {
   // The esphome project details if set
   string project_name = 8;
   string project_version = 9;
+
+  int32 webserver_port = 10;
 }
 
 message ListEntitiesRequest {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -760,6 +760,9 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.project_name = ESPHOME_PROJECT_NAME;
   resp.project_version = ESPHOME_PROJECT_VERSION;
 #endif
+#ifdef USE_WEBSERVER
+  resp.webserver_port = WEBSERVER_PORT;
+#endif
   return resp;
 }
 void APIConnection::on_home_assistant_state_response(const HomeAssistantStateResponse &msg) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -397,7 +397,7 @@ bool DeviceInfoResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 10: {
-      this->webserver_port = value.as_int32();
+      this->webserver_port = value.as_uint32();
       return true;
     }
     default:
@@ -448,7 +448,7 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(7, this->has_deep_sleep);
   buffer.encode_string(8, this->project_name);
   buffer.encode_string(9, this->project_version);
-  buffer.encode_int32(10, this->webserver_port);
+  buffer.encode_uint32(10, this->webserver_port);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoResponse::dump_to(std::string &out) const {
@@ -491,7 +491,7 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  webserver_port: ");
-  sprintf(buffer, "%d", this->webserver_port);
+  sprintf(buffer, "%u", this->webserver_port);
   out.append(buffer);
   out.append("\n");
   out.append("}");

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -396,6 +396,10 @@ bool DeviceInfoResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->has_deep_sleep = value.as_bool();
       return true;
     }
+    case 10: {
+      this->webserver_port = value.as_int32();
+      return true;
+    }
     default:
       return false;
   }
@@ -444,6 +448,7 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(7, this->has_deep_sleep);
   buffer.encode_string(8, this->project_name);
   buffer.encode_string(9, this->project_version);
+  buffer.encode_int32(10, this->webserver_port);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoResponse::dump_to(std::string &out) const {
@@ -483,6 +488,11 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 
   out.append("  project_version: ");
   out.append("'").append(this->project_version).append("'");
+  out.append("\n");
+
+  out.append("  webserver_port: ");
+  sprintf(buffer, "%d", this->webserver_port);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -224,7 +224,7 @@ class DeviceInfoResponse : public ProtoMessage {
   bool has_deep_sleep{false};
   std::string project_name{};
   std::string project_version{};
-  int32_t webserver_port{0};
+  uint32_t webserver_port{0};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -224,6 +224,7 @@ class DeviceInfoResponse : public ProtoMessage {
   bool has_deep_sleep{false};
   std::string project_name{};
   std::string project_version{};
+  int32_t webserver_port{0};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -54,6 +54,7 @@ async def to_code(config):
 
     cg.add(paren.set_port(config[CONF_PORT]))
     cg.add_define("WEBSERVER_PORT", config[CONF_PORT])
+    cg.add_define("USE_WEBSERVER")
     cg.add(var.set_css_url(config[CONF_CSS_URL]))
     cg.add(var.set_js_url(config[CONF_JS_URL]))
     if CONF_AUTH in config:

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -36,7 +36,10 @@
 #define USE_SWITCH
 #define USE_TEXT_SENSOR
 #define USE_TIME
+#define USE_WEBSERVER
 #define USE_WIFI
+
+#define WEBSERVER_PORT 80
 
 // Arduino-specific feature flags
 #ifdef USE_ARDUINO

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -39,7 +39,7 @@
 #define USE_WEBSERVER
 #define USE_WIFI
 
-#define WEBSERVER_PORT 80
+#define WEBSERVER_PORT 80  // NOLINT
 
 // Arduino-specific feature flags
 #ifdef USE_ARDUINO


### PR DESCRIPTION
# What does this implement/fix? 

This will allow for the HA device page to link to an ESPHome device that has the web_server enabled.

- https://github.com/esphome/aioesphomeapi/pull/131
- https://github.com/home-assistant/core/pull/58565

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
