### PR TITLE
Add restore_mode to rotary_encoder

### DIFF
--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -10,6 +10,12 @@
 namespace esphome {
 namespace rotary_encoder {
 
+/// All possible restore modes for the rotary encoder
+enum RotaryEncoderRestoreMode {
+  ROTARY_ENCODER_RESTORE_DEFAULT_ZERO,  /// try to restore counter, otherwise set to zero
+  ROTARY_ENCODER_ALWAYS_ZERO,           /// do not restore counter, always set to zero
+};
+
 /// All possible resolutions for the rotary encoder
 enum RotaryEncoderResolution {
   ROTARY_ENCODER_1_PULSE_PER_CYCLE =
@@ -39,6 +45,15 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
  public:
   void set_pin_a(InternalGPIOPin *pin_a) { pin_a_ = pin_a; }
   void set_pin_b(InternalGPIOPin *pin_b) { pin_b_ = pin_b; }
+
+  /** Set the restore mode of the rotary encoder.
+   *
+   * By default (if possible) the last known counter state is restored. Otherwise the value 0 is used.
+   * Restoring the state can also be turned off.
+   *
+   * @param restore_mode The restore mode to use.
+   */
+  void set_restore_mode(RotaryEncoderRestoreMode restore_mode);
 
   /** Set the resolution of the rotary encoder.
    *
@@ -81,6 +96,8 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
   InternalGPIOPin *pin_b_;
   GPIOPin *pin_i_{nullptr};  /// Index pin, if this is not nullptr, the counter will reset to 0 once this pin is HIGH.
   bool publish_initial_value_;
+  ESPPreferenceObject rtc_;
+  RotaryEncoderRestoreMode restore_mode_{ROTARY_ENCODER_RESTORE_DEFAULT_ZERO};
 
   RotaryEncoderSensorStore store_{};
 

--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -14,9 +14,17 @@ from esphome.const import (
     CONF_PIN_A,
     CONF_PIN_B,
     CONF_TRIGGER_ID,
+    CONF_RESTORE_MODE,
 )
 
 rotary_encoder_ns = cg.esphome_ns.namespace("rotary_encoder")
+
+RotaryEncoderRestoreMode = rotary_encoder_ns.enum("RotaryEncoderRestoreMode")
+RESTORE_MODES = {
+    "RESTORE_DEFAULT_ZERO": RotaryEncoderRestoreMode.ROTARY_ENCODER_RESTORE_DEFAULT_ZERO,
+    "ALWAYS_ZERO": RotaryEncoderRestoreMode.ROTARY_ENCODER_ALWAYS_ZERO,
+}
+
 RotaryEncoderResolution = rotary_encoder_ns.enum("RotaryEncoderResolution")
 RESOLUTIONS = {
     1: RotaryEncoderResolution.ROTARY_ENCODER_1_PULSE_PER_CYCLE,
@@ -72,6 +80,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MIN_VALUE): cv.int_,
             cv.Optional(CONF_MAX_VALUE): cv.int_,
             cv.Optional(CONF_PUBLISH_INITIAL_VALUE, default=False): cv.boolean,
+            cv.Optional(CONF_RESTORE_MODE, default="RESTORE_DEFAULT_ZERO"): cv.enum(
+                RESTORE_MODES, upper=True, space="_"
+            ),
             cv.Optional(CONF_ON_CLOCKWISE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -102,6 +113,7 @@ async def to_code(config):
     pin_b = await cg.gpio_pin_expression(config[CONF_PIN_B])
     cg.add(var.set_pin_b(pin_b))
     cg.add(var.set_publish_initial_value(config[CONF_PUBLISH_INITIAL_VALUE]))
+    cg.add(var.set_restore_mode(config[CONF_RESTORE_MODE]))
 
     if CONF_PIN_RESET in config:
         pin_i = await cg.gpio_pin_expression(config[CONF_PIN_RESET])


### PR DESCRIPTION
# What does this implement/fix? 

Add optional variable ``restore_mode`` to rotary_encoder to save counter (to flash). Possible options are
- ``RESTORE_DEFAULT_ZERO`` (Attempt to restore state and default to zero if not possible to restore)
- ``ALWAYS_ZERO`` (Always set counter to zero on bootup)

**Defaults to RESTORE_DEFAULT_ZERO.**
Previously the value was always 0 on boot. Therefore the default behavior changes now (if saving to flash is enabled). However many components save their state by default and I think this should be the default. It should be mentioned. Setting restore_mode to ALWAYS_ZERO brings back the previous behavior. Besides the value on boot, nothing changes. When ALWAYS_ZERO is made the default, this would be a non-breaking change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** x

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1584

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test
  platform: ESP32
  board: esp-wrover-kit

# Enable logging
logger:

# Enable Home Assistant API
api:
  password: ""

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

sensor:
  - platform: rotary_encoder
    id: rotary1
    name: Rotary Encoder
    publish_initial_value: True
    restore_mode: RESTORE_DEFAULT_ZERO
    pin_a:
      number: 23
    pin_b:
      number: 22

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
