### PR TITLE
Fix for noise in pulse_counter and duty_cycle components

### DIFF
--- a/esphome/components/duty_cycle/duty_cycle_sensor.cpp
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.cpp
@@ -12,7 +12,6 @@ void DutyCycleSensor::setup() {
   this->pin_->setup();
   this->store_.pin = this->pin_->to_isr();
   this->store_.last_level = this->pin_->digital_read();
-  this->last_update_ = micros();
   this->store_.last_interrupt = micros();
 
   this->pin_->attach_interrupt(DutyCycleSensorStore::gpio_intr, &this->store_, gpio::INTERRUPT_ANY_EDGE);
@@ -24,19 +23,20 @@ void DutyCycleSensor::dump_config() {
 }
 void DutyCycleSensor::update() {
   const uint32_t now = micros();
-  const bool level = this->store_.last_level;
-  const uint32_t last_interrupt = this->store_.last_interrupt;
-  uint32_t on_time = this->store_.on_time;
+  if (this->last_update_ != 0) {
+    const bool level = this->store_.last_level;
+    const uint32_t last_interrupt = this->store_.last_interrupt;
+    uint32_t on_time = this->store_.on_time;
 
-  if (level)
-    on_time += now - last_interrupt;
+    if (level)
+      on_time += now - last_interrupt;
 
-  const float total_time = float(now - this->last_update_);
+    const float total_time = float(now - this->last_update_);
 
-  const float value = (on_time / total_time) * 100.0f;
-  ESP_LOGD(TAG, "'%s' Got duty cycle=%.1f%%", this->get_name().c_str(), value);
-  this->publish_state(value);
-
+    const float value = (on_time / total_time) * 100.0f;
+    ESP_LOGD(TAG, "'%s' Got duty cycle=%.1f%%", this->get_name().c_str(), value);
+    this->publish_state(value);
+  }
   this->store_.on_time = 0;
   this->store_.last_interrupt = now;
   this->last_update_ = now;

--- a/esphome/components/duty_cycle/duty_cycle_sensor.h
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.h
@@ -30,7 +30,7 @@ class DutyCycleSensor : public sensor::Sensor, public PollingComponent {
   InternalGPIOPin *pin_;
 
   DutyCycleSensorStore store_{};
-  uint32_t last_update_;
+  uint32_t last_update_{0};
 };
 
 }  // namespace duty_cycle

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -154,11 +154,13 @@ void PulseCounterSensor::dump_config() {
 }
 
 void PulseCounterSensor::update() {
+  bool first = this->last_value == 0;
   pulse_counter_t raw = this->storage_.read_raw_value();
-  float value = (60000.0f * raw) / float(this->get_update_interval());  // per minute
-
-  ESP_LOGD(TAG, "'%s': Retrieved counter: %0.2f pulses/min", this->get_name().c_str(), value);
-  this->publish_state(value);
+  if(!first) {
+    float value = (60000.0f * raw) / float(this->get_update_interval());  // per minute
+    ESP_LOGD(TAG, "'%s': Retrieved counter: %0.2f pulses/min", this->get_name().c_str(), value);
+    this->publish_state(value);
+  }
 
   if (this->total_sensor_ != nullptr) {
     current_total_ += raw;

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -155,7 +155,7 @@ void PulseCounterSensor::dump_config() {
 
 void PulseCounterSensor::update() {
   pulse_counter_t raw = this->storage_.read_raw_value();
-  if(this->initialized_) {
+  if (this->initialized_) {
     float value = (60000.0f * raw) / float(this->get_update_interval());  // per minute
     ESP_LOGD(TAG, "'%s': Retrieved counter: %0.2f pulses/min", this->get_name().c_str(), value);
     this->publish_state(value);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -155,18 +155,20 @@ void PulseCounterSensor::dump_config() {
 
 void PulseCounterSensor::update() {
   pulse_counter_t raw = this->storage_.read_raw_value();
-  if (this->initialized_) {
-    float value = (60000.0f * raw) / float(this->get_update_interval());  // per minute
+  uint32_t now = millis();
+  if (this->last_time_ != 0) {
+    uint32_t interval = now - this->last_time_;
+    float value = (60000.0f * raw) / float(interval);  // per minute
     ESP_LOGD(TAG, "'%s': Retrieved counter: %0.2f pulses/min", this->get_name().c_str(), value);
     this->publish_state(value);
-  } else
-    this->initialized_ = true;
+  }
 
   if (this->total_sensor_ != nullptr) {
     current_total_ += raw;
     ESP_LOGD(TAG, "'%s': Total : %i pulses", this->get_name().c_str(), current_total_);
     this->total_sensor_->publish_state(current_total_);
   }
+  this->last_time_ = now;
 }
 
 }  // namespace pulse_counter

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -154,13 +154,13 @@ void PulseCounterSensor::dump_config() {
 }
 
 void PulseCounterSensor::update() {
-  bool first = this->last_value == 0;
   pulse_counter_t raw = this->storage_.read_raw_value();
-  if(!first) {
+  if(this->initialized_) {
     float value = (60000.0f * raw) / float(this->get_update_interval());  // per minute
     ESP_LOGD(TAG, "'%s': Retrieved counter: %0.2f pulses/min", this->get_name().c_str(), value);
     this->publish_state(value);
-  }
+  } else
+    this->initialized_ = true;
 
   if (this->total_sensor_ != nullptr) {
     current_total_ += raw;

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -65,7 +65,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
  protected:
   InternalGPIOPin *pin_;
   PulseCounterStorage storage_;
-  bool initialized_{false};
+  uint32_t last_time_{0};
   uint32_t current_total_{0};
   sensor::Sensor *total_sensor_;
 };

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -65,7 +65,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
  protected:
   InternalGPIOPin *pin_;
   PulseCounterStorage storage_;
-  bool initialized_{0};
+  bool initialized_{false};
   uint32_t current_total_{0};
   sensor::Sensor *total_sensor_;
 };

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -65,7 +65,8 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
  protected:
   InternalGPIOPin *pin_;
   PulseCounterStorage storage_;
-  uint32_t current_total_ = 0;
+  bool initialized_{0};
+  uint32_t current_total_{0};
   sensor::Sensor *total_sensor_;
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

**1) Noisy initial sample:**
The `duty_cycle` and `pulse_counter` components would send a "too early" first sample that didn't account for the specified update interval. Hence the first sample was always noisy, and it would distort the time series upon each reboot.

![image](https://user-images.githubusercontent.com/1636266/139539724-439cd61b-2242-48b3-8ddc-30f10b5c9b81.png)

This PR corrects this by waiting for the full `update_interval` period to be completed before sending the sample.

**2) Noisy pulse_counter due to ideal division:**
Also, for `pulse_counter` the division was being performed with the _ideal_ time period, but in reality the exact timing varies. So this PR also corrects for this, making `pulse_counter` more accurate for both ESP8266 & ESP32.
![Screenshot_20211101_180531](https://user-images.githubusercontent.com/1636266/139711061-3cac7a1f-4002-4a26-80e4-85c156556435.png)
See the comment below with more information.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
