### PR TITLE
Makes long hostname a warning rather than error

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -60,8 +60,11 @@ def validate_hostname(config):
     if config[CONF_NAME_ADD_MAC_SUFFIX]:
         max_length -= 7  # "-AABBCC" is appended when add mac suffix option is used
     if len(config[CONF_NAME]) > max_length:
-        raise cv.Invalid(
-            f"Hostnames can only be {max_length} characters long", path=[CONF_NAME]
+        _LOGGER.warning(
+            "Hostnames greater than {max_length} are discouraged "
+            "as it can cause problems with some DHCP and local name services. "
+            "For more information, see https://esphome.io/guides/faq.html",
+            config[CONF_NAME],
         )
     if "_" in config[CONF_NAME]:
         _LOGGER.warning(

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -61,10 +61,9 @@ def validate_hostname(config):
         max_length -= 7  # "-AABBCC" is appended when add mac suffix option is used
     if len(config[CONF_NAME]) > max_length:
         _LOGGER.warning(
-            "Hostnames greater than {max_length} are discouraged "
+            f"Hostnames greater than {max_length} are discouraged "
             "as it can cause problems with some DHCP and local name services. "
-            "For more information, see https://esphome.io/guides/faq.html",
-            config[CONF_NAME],
+            "For more information, see https://esphome.io/guides/faq.html", path=[CONF_NAME],
         )
     if "_" in config[CONF_NAME]:
         _LOGGER.warning(


### PR DESCRIPTION
# What does this implement/fix? 

While hostnames greater than 31 characters are technically out of spec, there is no clear reason to treat this differently than the underscore warning.  This avoids a breaking change for users that have these hostnames already deployed and working.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes #2661


