### PR TITLE
Set up output_switch at priority DATA instead of HARDWARE.

### DIFF
--- a/esphome/components/output/switch/output_switch.h
+++ b/esphome/components/output/switch/output_switch.h
@@ -12,7 +12,7 @@ class OutputSwitch : public switch_::Switch, public Component {
   void set_output(BinaryOutput *output) { output_ = output; }
 
   void setup() override;
-  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
   void dump_config() override;
 
  protected:


### PR DESCRIPTION
# What does this implement/fix? 

Changes the setup priority for output_switch, so that it runs after HARDWARE, allowing output_switch to set the state for components that need hardware setup support.

output_switch's setup() method restores the saved state of the
switch. If the underlying output device doesn't get set up until stage
HARDWARE (e.g. ledc), it's possible the switch will try to turn the
device on/off before it's ready.

Arguably, we could move this until much later, or find some way of
setting this up dynamically.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1732

(This issue is "fixed" already in that it logs a warning instead of crashing. This PR makes it work as intended by restoring switch state.)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
    # Buzzer connected between 19 and Ground
  - platform: ledc
    pin: 19
    id: buzzer
    frequency: 100Hz
switch:
  - platform: output
    name: Buzzer
    id: buzzer_out
    output: buzzer
    on_turn_on:
    - output.set_level:
        id: buzzer
        level: "50%"
    on_turn_off:
    - output.set_level:
        id: buzzer
        level: "0%"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
