### PR TITLE
modbus_controller: remove hard coded register size

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -260,35 +260,11 @@ struct SensorItem {
   virtual void parse_and_publish(const std::vector<uint8_t> &data) = 0;
 
   uint64_t getkey() const { return calc_key(register_type, start_address, offset, bitmask); }
-
   size_t virtual get_register_size() const {
-    size_t size = 0;
-    switch (sensor_value_type) {
-      case SensorValueType::BIT:
-        size = 1;
-        break;
-      case SensorValueType::U_WORD:
-      case SensorValueType::S_WORD:
-        size = 2;
-        break;
-      case SensorValueType::U_DWORD:
-      case SensorValueType::S_DWORD:
-      case SensorValueType::U_DWORD_R:
-      case SensorValueType::S_DWORD_R:
-      case SensorValueType::FP32:
-      case SensorValueType::FP32_R:
-        size = 4;
-        break;
-      case SensorValueType::U_QWORD:
-      case SensorValueType::U_QWORD_R:
-      case SensorValueType::S_QWORD:
-      case SensorValueType::S_QWORD_R:
-        size = 8;
-        break;
-      case SensorValueType::RAW:
-        size = this->register_count * 2;
-    }
-    return size;
+    if (register_type == ModbusRegisterType::COIL || register_type == ModbusRegisterType::DISCRETE_INPUT)
+      return 1;
+    else
+      return register_count * 2;
   }
 };
 

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -25,13 +25,6 @@ class ModbusTextSensor : public Component, public text_sensor::TextSensor, publi
     this->sensor_value_type = SensorValueType::RAW;
     this->force_new_range = force_new_range;
   }
-  size_t get_register_size() const override {
-    if (sensor_value_type == SensorValueType::RAW) {
-      return this->response_bytes_;
-    } else {
-      return SensorItem::get_register_size();
-    }
-  }
 
   void dump_config() override;
 


### PR DESCRIPTION
# What does this implement/fix? 

this fix removes the hardcoded register sizes from the C++ code. 
Actually this is a left over before refactoring the code and should have removed after moving the register size calculation to python.


## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).