### PR TITLE
Fix senseair component uart read timeout

### DIFF
--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -141,9 +141,9 @@ void SenseAirComponent::abc_get_period() {
 }
 
 bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t *response, uint8_t response_length) {
-  short retry = 0;
+  int16 retry = 0;
   this->flush();
-   
+
   while (!this->available()) {
     retry ++;
     this->write_array(command, SENSEAIR_REQUEST_LENGTH);

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -141,7 +141,7 @@ void SenseAirComponent::abc_get_period() {
 }
 
 bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t *response, uint8_t response_length) {
-  int16 retry = 0;
+  int retry = 0;
   this->flush();
 
   while (!this->available()) {

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -148,9 +148,8 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
     retry ++;
     this->write_array(command, SENSEAIR_REQUEST_LENGTH);
     delay(20); // NOLINT
-    if (retry > 10) {
+    if (retry > 10)
       break;
-    }
   }
 
   if (response == nullptr)

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -141,8 +141,17 @@ void SenseAirComponent::abc_get_period() {
 }
 
 bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t *response, uint8_t response_length) {
+  short retry = 0;
   this->flush();
-  this->write_array(command, SENSEAIR_REQUEST_LENGTH);
+   
+  while (!this->available()) {
+    retry ++;
+    this->write_array(command, SENSEAIR_REQUEST_LENGTH);
+    delay(20); // NOLINT
+    if (retry > 10) {
+      break;
+    }
+  }
 
   if (response == nullptr)
     return true;


### PR DESCRIPTION
# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/795>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:
  rx_pin: D6
  tx_pin: D5
  baud_rate: 9600
  
sensor:    
  - platform: senseair
    co2:
      name: "SenseAir CO2 Value"
    update_interval: 30s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
