### PR TITLE
Fix senseair component uart read timeout

### DIFF
--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -141,20 +141,16 @@ void SenseAirComponent::abc_get_period() {
 }
 
 bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t *response, uint8_t response_length) {
-  int retry = 0;
-  this->flush();
-
-  do {
-    this->write_array(command, SENSEAIR_REQUEST_LENGTH);
-    delay(20); // NOLINT
-    retry ++;
-    if (retry > 10)
-      break;
+  // Verify we have somewhere to store the response
+  if (response == nullptr) {
+    return false;
   }
-  while (!this->available());
-
-  if (response == nullptr)
-    return true;
+  
+  this->flush();
+  // Write wake up byte required by some S8 sensor model
+  this->write_byte(0);
+  delay(5); // NOLINT
+  this->write_array(command, SENSEAIR_REQUEST_LENGTH);
 
   bool ret = this->read_array(response, response_length);
   this->flush();

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -145,6 +145,9 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
   this->flush();
 
   while (!this->available()) {
+    retry ++;
+    this->write_array(command, SENSEAIR_REQUEST_LENGTH);
+    delay(20); // NOLINT
   }
 
   if (response == nullptr)

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -148,6 +148,8 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
     retry ++;
     this->write_array(command, SENSEAIR_REQUEST_LENGTH);
     delay(20); // NOLINT
+    if (retry > 10)
+      break;
   }
 
   if (response == nullptr)

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -145,7 +145,6 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
   if (response == nullptr) {
     return false;
   }
-  
   // Write wake up byte required by some S8 sensor models
   this->write_byte(0);
   this->flush();

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -148,7 +148,7 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
   // Write wake up byte required by some S8 sensor models
   this->write_byte(0);
   this->flush();
-  delay(5); // NOLINT
+  delay(5);  // NOLINT
   this->write_array(command, SENSEAIR_REQUEST_LENGTH);
 
   bool ret = this->read_array(response, response_length);

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -141,8 +141,11 @@ void SenseAirComponent::abc_get_period() {
 }
 
 bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t *response, uint8_t response_length) {
+  int retry = 0;
   this->flush();
-  this->write_array(command, SENSEAIR_REQUEST_LENGTH);
+
+  while (!this->available()) {
+  }
 
   if (response == nullptr)
     return true;

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -146,9 +146,9 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
     return false;
   }
   
-  this->flush();
-  // Write wake up byte required by some S8 sensor model
+  // Write wake up byte required by some S8 sensor models
   this->write_byte(0);
+  this->flush();
   delay(5); // NOLINT
   this->write_array(command, SENSEAIR_REQUEST_LENGTH);
 

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -148,7 +148,7 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
   // Write wake up byte required by some S8 sensor models
   this->write_byte(0);
   this->flush();
-  delay(5);  // NOLINT
+  delay(5);
   this->write_array(command, SENSEAIR_REQUEST_LENGTH);
 
   bool ret = this->read_array(response, response_length);

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -144,13 +144,14 @@ bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t 
   int retry = 0;
   this->flush();
 
-  while (!this->available()) {
-    retry ++;
+  do {
     this->write_array(command, SENSEAIR_REQUEST_LENGTH);
     delay(20); // NOLINT
+    retry ++;
     if (retry > 10)
       break;
   }
+  while (!this->available());
 
   if (response == nullptr)
     return true;


### PR DESCRIPTION
# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/1965>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:
  rx_pin: D6
  tx_pin: D5
  baud_rate: 9600
  
sensor:   
  - platform: senseair
    co2:
      name: "SenseAir CO2 Value"
    update_interval: 30s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
