### PR TITLE
[ESP32 ADC] Add option for raw uncalibrated output

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -98,10 +98,14 @@ void ADCSensor::update() {
 #ifdef USE_ESP8266
 float ADCSensor::sample() {
 #ifdef USE_ADC_SENSOR_VCC
-  return ESP.getVcc() / 1024.0f;  // NOLINT(readability-static-accessed-through-instance)
+  int raw = ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
 #else
-  return analogRead(this->pin_->get_pin()) / 1024.0f;  // NOLINT
+  int raw = analogRead(this->pin_->get_pin());  // NOLINT
 #endif
+  if (output_raw_) {
+    return raw;
+  }
+  return raw / 1024.0f;
 }
 #endif
 
@@ -111,6 +115,9 @@ float ADCSensor::sample() {
     int raw = adc1_get_raw(channel_);
     if (raw == -1) {
       return NAN;
+    }
+    if (output_raw_) {
+      return raw;
     }
     uint32_t mv = esp_adc_cal_raw_to_voltage(raw, &cal_characteristics_[(int) attenuation_]);
     return mv / 1000.0f;
@@ -134,10 +141,6 @@ float ADCSensor::sample() {
 
   if (raw0 == -1 || raw2 == -1 || raw6 == -1 || raw11 == -1) {
     return NAN;
-  }
-  // prevent divide by zero
-  if (raw0 == 0 && raw2 == 0 && raw6 == 0 && raw11 == 0) {
-    return 0;
   }
 
   uint32_t mv11 = esp_adc_cal_raw_to_voltage(raw11, &cal_characteristics_[(int) ADC_ATTEN_DB_11]);

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -91,7 +91,7 @@ void ADCSensor::dump_config() {
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 void ADCSensor::update() {
   float value_v = this->sample();
-  ESP_LOGD(TAG, "'%s': Got voltage=%.2fV", this->get_name().c_str(), value_v);
+  ESP_LOGD(TAG, "'%s': Got voltage=%.4fV", this->get_name().c_str(), value_v);
   this->publish_state(value_v);
 }
 

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -40,6 +40,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 
  protected:
   InternalGPIOPin *pin_;
+  bool output_raw_{false};
 
 #ifdef USE_ESP32
   adc_atten_t attenuation_{ADC_ATTEN_DB_0};

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -21,6 +21,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   void set_attenuation(adc_atten_t attenuation) { attenuation_ = attenuation; }
   void set_channel(adc1_channel_t channel) { channel_ = channel; }
   void set_autorange(bool autorange) { autorange_ = autorange; }
+  void set_raw(bool output_raw) { output_raw_ = output_raw; }
 #endif
 
   /// Update adc values.
@@ -39,8 +40,6 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 
  protected:
   InternalGPIOPin *pin_;
-  uint16_t read_raw_();
-  uint32_t raw_to_microvolts_(uint16_t raw);
 
 #ifdef USE_ESP32
   adc_atten_t attenuation_{ADC_ATTEN_DB_0};

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -21,7 +21,6 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   void set_attenuation(adc_atten_t attenuation) { attenuation_ = attenuation; }
   void set_channel(adc1_channel_t channel) { channel_ = channel; }
   void set_autorange(bool autorange) { autorange_ = autorange; }
-  void set_raw(bool output_raw) { output_raw_ = output_raw; }
 #endif
 
   /// Update adc values.
@@ -32,6 +31,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   /// `HARDWARE_LATE` setup priority.
   float get_setup_priority() const override;
   void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
+  void set_raw(bool output_raw) { output_raw_ = output_raw; }
   float sample() override;
 
 #ifdef USE_ESP8266

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -31,7 +31,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   /// `HARDWARE_LATE` setup priority.
   float get_setup_priority() const override;
   void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
-  void set_raw(bool output_raw) { output_raw_ = output_raw; }
+  void set_output_raw(bool output_raw) { output_raw_ = output_raw; }
   float sample() override;
 
 #ifdef USE_ESP8266

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -119,10 +119,12 @@ def validate_adc_pin(value):
 
     raise NotImplementedError
 
+
 def validate_config(config):
     if config[CONF_ATTENUATION] == "auto" and config[CONF_RAW] is True:
         raise cv.Invalid("Automatic attenuation cannot be used when raw output is set.")
     return config
+
 
 adc_ns = cg.esphome_ns.namespace("adc")
 ADCSensor = adc_ns.class_(

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -163,7 +163,7 @@ async def to_code(config):
     if CONF_ATTENUATION in config:
         if config[CONF_ATTENUATION] == "auto":
             if CONF_RAW in config and config[CONF_RAW] == True:
-                return  // TO-DO: Notify user that "attenuation: auto" cannot be used with "raw: true"
+                return  # TO-DO: Notify user that "attenuation: auto" cannot be used with "raw: true"
             cg.add(var.set_autorange(cg.global_ns.true))
         else:
             cg.add(var.set_attenuation(config[CONF_ATTENUATION]))

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -162,7 +162,7 @@ async def to_code(config):
 
     if CONF_ATTENUATION in config:
         if config[CONF_ATTENUATION] == "auto":
-            if CONF_RAW in config and config[CONF_RAW] == True:
+            if CONF_RAW in config and config[CONF_RAW] is True:
                 return  # TO-DO: Notify user that "attenuation: auto" cannot be used with "raw: true"
             cg.add(var.set_autorange(cg.global_ns.true))
         else:

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -162,7 +162,7 @@ async def to_code(config):
 
     if CONF_ATTENUATION in config:
         if config[CONF_ATTENUATION] == "auto":
-            if CONF_RAW in config && config[CONF_RAW] == True:
+            if CONF_RAW in config and config[CONF_RAW] == True:
                 return  // TO-DO: Notify user that "attenuation: auto" cannot be used with "raw: true"
             cg.add(var.set_autorange(cg.global_ns.true))
         else:

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -147,8 +147,7 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
-    .extend(cv.polling_component_schema("60s"))
-), validate_config)
+    .extend(cv.polling_component_schema("60s")), validate_config)
 
 
 async def to_code(config):

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -121,12 +121,7 @@ def validate_adc_pin(value):
 
 
 def validate_config(config):
-    if (
-        CONF_RAW in config
-        and config[CONF_RAW] is True
-        and CONF_ATTENUATION in config
-        and config[CONF_ATTENUATION] == "auto"
-    ):
+    if config[CONF_RAW] and config.get(CONF_ATTENUATION, None) == "auto":
         raise cv.Invalid("Automatic attenuation cannot be used when raw output is set.")
     return config
 
@@ -170,7 +165,7 @@ async def to_code(config):
         cg.add(var.set_pin(pin))
 
     if CONF_RAW in config:
-        cg.add(var.set_raw(config[CONF_RAW]))
+        cg.add(var.set_output_raw(config[CONF_RAW]))
 
     if CONF_ATTENUATION in config:
         if config[CONF_ATTENUATION] == "auto":

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -122,7 +122,6 @@ def validate_adc_pin(value):
 def validate_config(config):
     if config[CONF_ATTENUATION] == "auto" and config[CONF_RAW] is True:
         raise cv.Invalid("Automatic attenuation cannot be used when raw output is set.")
-    config.setdefault(CONF_SCAN_INTERVAL, cv.update_interval("never"))
     return config
 
 adc_ns = cg.esphome_ns.namespace("adc")

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -121,7 +121,12 @@ def validate_adc_pin(value):
 
 
 def validate_config(config):
-    if config[CONF_ATTENUATION] == "auto" and config[CONF_RAW] is True:
+    if (
+        CONF_RAW in config
+        and config[CONF_RAW] is True
+        and CONF_ATTENUATION in config
+        and config[CONF_ATTENUATION] == "auto"
+    ):
         raise cv.Invalid("Automatic attenuation cannot be used when raw output is set.")
     return config
 
@@ -148,7 +153,9 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
-    .extend(cv.polling_component_schema("60s")), validate_config)
+    .extend(cv.polling_component_schema("60s")),
+    validate_config,
+)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix? 

The ADC output is accurate since https://github.com/esphome/esphome/pull/2574, however some users might prefer to keep using the uncalibrated values: i.e. people with a manually calibrated setup that don't want to repeat the process.

Adding this "raw" output option allows to have the raw ADC values (0-4095) prior to manufacturer calibration. This way, users can achieve the old measurements with a simple filter multiplier:
```yaml
# To replicate old uncalibrated output, set raw:true and keep only one of the multiplier lines.
raw: true
filters:
  - multiply: 0.00026862 # 1.1/4095, for attenuation 0db
  - multiply: 0.00036630 # 1.5/4095, for attenuation 2.5db
  - multiply: 0.00053724 # 2.2/4095, for attenuation 6db
  - multiply: 0.00095238 # 3.9/4095, for attenuation 11db
  # your existing filters would go here
```

It would be nice to merge this PR (and doc update) before next release with the calibrated ADC, so users can adapt their code if necessary.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1592

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
