### PR TITLE
[ms5611]: Re-implement conversion from ADC readings to sensor values

### DIFF
--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -85,10 +85,10 @@ void MS5611Component::calculate_values_(uint32_t raw_temperature, uint32_t raw_p
   const uint32_t c2 = uint32_t(this->prom_[1]);
   const uint16_t c3 = uint16_t(this->prom_[2]);
   const uint16_t c4 = uint16_t(this->prom_[3]);
-  const int32_t  c5 = int32_t (this->prom_[4]);
+  const int32_t c5 = int32_t(this->prom_[4]);
   const uint16_t c6 = uint16_t(this->prom_[5]);
   const uint32_t d1 = raw_pressure;
-  const int32_t  d2 = raw_temperature;
+  const int32_t d2 = raw_temperature;
 
   // Promote dt to 64 bit here to make the math below cleaner
   const int64_t dt = d2 - (c5 << 8);

--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -79,44 +79,44 @@ void MS5611Component::read_pressure_(uint32_t raw_temperature) {
 // Calculations are taken from the datasheet which can be found here:
 // https://www.te.com/commerce/DocumentDelivery/DDEController?Action=showdoc&DocId=Data+Sheet%7FMS5611-01BA03%7FB3%7Fpdf%7FEnglish%7FENG_DS_MS5611-01BA03_B3.pdf%7FCAT-BLPS0036
 // Sections PRESSURE AND TEMPERATURE CALCULATION and SECOND ORDER TEMPERATURE COMPENSATION
-// Variable names below match variable names from the datasheet
+// Variable names below match variable names from the datasheet but lowercased
 void MS5611Component::calculate_values_(uint32_t raw_temperature, uint32_t raw_pressure) {
-  const uint32_t C1 = uint32_t(this->prom_[0]);
-  const uint32_t C2 = uint32_t(this->prom_[1]);
-  const uint16_t C3 = uint16_t(this->prom_[2]);
-  const uint16_t C4 = uint16_t(this->prom_[3]);
-  const int32_t  C5 = int32_t (this->prom_[4]);
-  const uint16_t C6 = uint16_t(this->prom_[5]);
-  const uint32_t D1 = raw_pressure;
-  const int32_t  D2 = raw_temperature;
+  const uint32_t c1 = uint32_t(this->prom_[0]);
+  const uint32_t c2 = uint32_t(this->prom_[1]);
+  const uint16_t c3 = uint16_t(this->prom_[2]);
+  const uint16_t c4 = uint16_t(this->prom_[3]);
+  const int32_t  c5 = int32_t (this->prom_[4]);
+  const uint16_t c6 = uint16_t(this->prom_[5]);
+  const uint32_t d1 = raw_pressure;
+  const int32_t  d2 = raw_temperature;
 
-  // Promote dT to 64 bit here to make the math below cleaner
-  const int64_t dT = D2 - (C5 << 8);
-  int32_t TEMP = (2000 + ((dT * C6) >> 23));
-  
-  int64_t OFF = (C2 << 16) + ((dT * C4) >> 7);
-  int64_t SENS = (C1 << 15) + ((dT * C3) >> 8);
+  // Promote dt to 64 bit here to make the math below cleaner
+  const int64_t dt = d2 - (c5 << 8);
+  int32_t temp = (2000 + ((dt * c6) >> 23));
 
-  if (TEMP < 2000) {
-    const int32_t T2 = (dT * dT) >> 31;
-    int32_t OFF2 = ((5 * (TEMP - 2000) * (TEMP - 2000)) >> 1);
-    int32_t SENS2 = ((5 * (TEMP - 2000) * (TEMP - 2000)) >> 2);
-    if (TEMP < -1500) {
-      OFF2 = (OFF2 + 7 * (TEMP + 1500) * (TEMP + 1500));
-      SENS2 = SENS2 + ((11 * (TEMP + 1500) * (TEMP + 1500)) >> 1);
+  int64_t off = (c2 << 16) + ((dt * c4) >> 7);
+  int64_t sens = (c1 << 15) + ((dt * c3) >> 8);
+
+  if (temp < 2000) {
+    const int32_t t2 = (dt * dt) >> 31;
+    int32_t off2 = ((5 * (temp - 2000) * (temp - 2000)) >> 1);
+    int32_t sens2 = ((5 * (temp - 2000) * (temp - 2000)) >> 2);
+    if (temp < -1500) {
+      off2 = (off2 + 7 * (temp + 1500) * (temp + 1500));
+      sens2 = sens2 + ((11 * (temp + 1500) * (temp + 1500)) >> 1);
     }
-    TEMP = TEMP - T2;
-    OFF = OFF - OFF2;
-    SENS = SENS - SENS2;
+    temp = temp - t2;
+    off = off - off2;
+    sens = sens - sens2;
   }
 
   // Here we multiply unsigned 32-bit by signed 64-bit using signed 64-bit math.
-  // Possible ranges of D1 and SENS from the datasheet guarantee 
+  // Possible ranges of D1 and SENS from the datasheet guarantee
   // that this multiplication does not overflow
-  const int32_t P = ((((D1 * SENS) >> 21) - OFF) >> 15);
+  const int32_t p = ((((d1 * sens) >> 21) - off) >> 15);
 
-  const float temperature = TEMP / 100.0f;
-  const float pressure = P / 100.0f;
+  const float temperature = temp / 100.0f;
+  const float pressure = p / 100.0f;
   ESP_LOGD(TAG, "Got temperature=%0.02f°C pressure=%0.01fhPa", temperature, pressure);
 
   if (this->temperature_sensor_ != nullptr)

--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -75,30 +75,48 @@ void MS5611Component::read_pressure_(uint32_t raw_temperature) {
   const uint32_t raw_pressure = (uint32_t(bytes[0]) << 16) | (uint32_t(bytes[1]) << 8) | (uint32_t(bytes[2]));
   this->calculate_values_(raw_temperature, raw_pressure);
 }
+
+// Calculations are taken from the datasheet which can be found here:
+// https://www.te.com/commerce/DocumentDelivery/DDEController?Action=showdoc&DocId=Data+Sheet%7FMS5611-01BA03%7FB3%7Fpdf%7FEnglish%7FENG_DS_MS5611-01BA03_B3.pdf%7FCAT-BLPS0036
+// Sections PRESSURE AND TEMPERATURE CALCULATION and SECOND ORDER TEMPERATURE COMPENSATION
+// Variable names below match variable names from the datasheet
 void MS5611Component::calculate_values_(uint32_t raw_temperature, uint32_t raw_pressure) {
-  const int32_t d_t = int32_t(raw_temperature) - (uint32_t(this->prom_[4]) << 8);
-  float temperature = (2000 + (int64_t(d_t) * this->prom_[5]) / 8388608.0f) / 100.0f;
+  const uint32_t C1 = uint32_t(this->prom_[0]);
+  const uint32_t C2 = uint32_t(this->prom_[1]);
+  const uint16_t C3 = uint16_t(this->prom_[2]);
+  const uint16_t C4 = uint16_t(this->prom_[3]);
+  const int32_t  C5 = int32_t (this->prom_[4]);
+  const uint16_t C6 = uint16_t(this->prom_[5]);
+  const uint32_t D1 = raw_pressure;
+  const int32_t  D2 = raw_temperature;
 
-  float pressure_offset = (uint32_t(this->prom_[1]) << 16) + ((this->prom_[3] * d_t) >> 7);
-  float pressure_sensitivity = (uint32_t(this->prom_[0]) << 15) + ((this->prom_[2] * d_t) >> 8);
+  // Promote dT to 64 bit here to make the math below cleaner
+  const int64_t dT = D2 - (C5 << 8);
+  int32_t TEMP = (2000 + ((dT * C6) >> 23));
+  
+  int64_t OFF = (C2 << 16) + ((dT * C4) >> 7);
+  int64_t SENS = (C1 << 15) + ((dT * C3) >> 8);
 
-  if (temperature < 20.0f) {
-    const float t2 = (d_t * d_t) / 2147483648.0f;
-    const float temp20 = (temperature - 20.0f) * 100.0f;
-    float pressure_offset_2 = 2.5f * temp20 * temp20;
-    float pressure_sensitivity_2 = 1.25f * temp20 * temp20;
-    if (temp20 < -15.0f) {
-      const float temp15 = (temperature + 15.0f) * 100.0f;
-      pressure_offset_2 += 7.0f * temp15;
-      pressure_sensitivity_2 += 5.5f * temp15;
+  if (TEMP < 2000) {
+    const int32_t T2 = (dT * dT) >> 31;
+    int32_t OFF2 = ((5 * (TEMP - 2000) * (TEMP - 2000)) >> 1);
+    int32_t SENS2 = ((5 * (TEMP - 2000) * (TEMP - 2000)) >> 2);
+    if (TEMP < -1500) {
+      OFF2 = (OFF2 + 7 * (TEMP + 1500) * (TEMP + 1500));
+      SENS2 = SENS2 + ((11 * (TEMP + 1500) * (TEMP + 1500)) >> 1);
     }
-    temperature -= t2;
-    pressure_offset -= pressure_offset_2;
-    pressure_sensitivity -= pressure_sensitivity_2;
+    TEMP = TEMP - T2;
+    OFF = OFF - OFF2;
+    SENS = SENS - SENS2;
   }
 
-  const float pressure = ((raw_pressure * pressure_sensitivity) / 2097152.0f - pressure_offset) / 3276800.0f;
+  // Here we multiply unsigned 32-bit by signed 64-bit using signed 64-bit math.
+  // Possible ranges of D1 and SENS from the datasheet guarantee 
+  // that this multiplication does not overflow
+  const int32_t P = ((((D1 * SENS) >> 21) - OFF) >> 15);
 
+  const float temperature = TEMP / 100.0f;
+  const float pressure = P / 100.0f;
   ESP_LOGD(TAG, "Got temperature=%0.02f°C pressure=%0.01fhPa", temperature, pressure);
 
   if (this->temperature_sensor_ != nullptr)


### PR DESCRIPTION
Re-implement conversion from raw temperature / pressure ADC readings of MS5611 to sensor values.

# What does this implement/fix? 

This fixes behavior of MS5611 Barometric Pressure Sensor in ESPHome. 

Previous implementation suffered from several integer overflows inside calculations thus causing artifacts described in https://github.com/esphome/issues/issues/1004. That ticket mentions unsuccessful attempts to fix the previous implementation. So, I decided to re-implement the entire conversion process carefully following the algorithm described in the datasheet and making it as close to the spec as possible (the downside of this is some violations of ESPHome naming conventions for variables). The key to the correct implementation is proper handling of data ranges and selection of proper data types.

Datasheet can be found here: https://www.te.com/commerce/DocumentDelivery/DDEController?Action=showdoc&DocId=Data+Sheet%7FMS5611-01BA03%7FB3%7Fpdf%7FEnglish%7FENG_DS_MS5611-01BA03_B3.pdf%7FCAT-BLPS0036
Actual description is in sections PRESSURE AND TEMPERATURE CALCULATION and SECOND ORDER TEMPERATURE COMPENSATION.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/1004
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: ms5611
    temperature:
      name: Temperature
      id: ms5611_temperature
      unit_of_measurement: "°C"
      device_class: temperature
      state_class: measurement
      accuracy_decimals: 1      
    pressure:
      name: Pressure
      id: pressure
      filters:
        - multiply: 0.75006157584566
      device_class: pressure
      state_class: measurement
      accuracy_decimals: 1
      unit_of_measurement: "mmHg"
    address: 0x77
    update_interval: 1s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
