### PR TITLE
fix rc switch protocol 6

### DIFF
--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -101,10 +101,13 @@ bool RCSwitchBase::expect_sync(RemoteReceiveData &src) const {
     if (!src.peek_space(this->sync_low_, 1))
       return false;
   } else {
-    if (!src.peek_space(this->sync_high_))
+    // We cant peek a space at the beginning because signals starts with a low to high transition.
+    // this long space at the beginning is the separation between the transmissions itself, so it is actually
+    // added at the end kind of artificially (by the value given to "idle:" option by the user in the yaml)
+    if (!src.peek_mark(this->sync_low_))
       return false;
-    if (!src.peek_mark(this->sync_low_, 1))
-      return false;
+    src.advance(1);
+    return true;
   }
   src.advance(2);
   return true;


### PR DESCRIPTION
# What does this implement/fix? 

Fixed decoding rc-switch protocol 6

This code is particular because it is inverted.  The sync signal is there when decoding the frame and causing issues, so special case is handled now.

Long explanation:

RF Syncs in rc-switch are supposed to be at the end of the code, not at the beginning, so actually everything is a bit wrong as ESPHome expects the sync at the beginning like in IR codes, the problem is that this sync signal is used to know when the code starts, by ESP32 RMT hardware decoder and also ESP8266 Interrupt decoder which mimics it. In reality the space of the sync is used as code "separator" and it's exact duration information is lost.

So RF sync signals are hard for this IR focused thing. There is no gap between transmissions at all, each transmission is [CODE][Sync]; followed immediately by another transmission, so it can be considered to be [Sync][CODE] and rely on retrieving the 2nd transmission completely (which usually happens unless you press the button really quickly) 
So this behavior of having the Sync at the end causes the last bit to be invalid for most codes (a high / low pair is not matched either 1 or 0) but protocol 6 is inverted, so this sync is actually a long space followed by a short mark, and this mark was being considered part of the (next) code. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
