### PR TITLE
Added a lock so that the ::loop will not run during an interrupt cont…

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -19,7 +19,7 @@ void PulseMeterSensor::loop() {
   const uint32_t now = micros();
 
   // Dont run this function if Interrupt is in progress
-  if (this->busy > 0)
+  if (this->busy_ > 0)
      return;
 
 
@@ -63,14 +63,14 @@ void PulseMeterSensor::dump_config() {
 
 void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
   // This is an interrupt handler - we can't call any virtual method from this method
-   sensor->busy=1;
+   sensor->busy_=1;
 
   // Get the current time before we do anything else so the measurements are consistent
   const uint32_t now = micros();
 
   // We only look at rising edges
   if (!sensor->isr_pin_.digital_read()) {
-    sensor->busy=0;
+    sensor->busy_=0;
     return;
   }
 
@@ -86,7 +86,7 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
   }
 
   sensor->last_detected_edge_us_ = now;
-  sensor->busy=0;
+  sensor->busy_=0;
 }
 
 }  // namespace pulse_meter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -20,7 +20,7 @@ void PulseMeterSensor::loop() {
 
   // Dont run this function if Interrupt is in progress
   if (this->busy_ > 0)
-     return;
+    return;
 
 
   // If we've exceeded our timeout interval without receiving any pulses, assume 0 pulses/min until
@@ -63,7 +63,7 @@ void PulseMeterSensor::dump_config() {
 
 void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
   // This is an interrupt handler - we can't call any virtual method from this method
-   sensor->busy_ = 1;
+  sensor->busy_ = 1;
 
   // Get the current time before we do anything else so the measurements are consistent
   const uint32_t now = micros();

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -22,7 +22,6 @@ void PulseMeterSensor::loop() {
   if (this->busy_ > 0)
     return;
 
-
   // If we've exceeded our timeout interval without receiving any pulses, assume 0 pulses/min until
   // we get at least two valid pulses.
   const uint32_t time_since_valid_edge_us = now - this->last_valid_edge_us_;

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -63,14 +63,14 @@ void PulseMeterSensor::dump_config() {
 
 void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
   // This is an interrupt handler - we can't call any virtual method from this method
-   sensor->busy_=1;
+   sensor->busy_ = 1;
 
   // Get the current time before we do anything else so the measurements are consistent
   const uint32_t now = micros();
 
   // We only look at rising edges
   if (!sensor->isr_pin_.digital_read()) {
-    sensor->busy_=0;
+    sensor->busy_ = 0;
     return;
   }
 
@@ -86,7 +86,7 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
   }
 
   sensor->last_detected_edge_us_ = now;
-  sensor->busy_=0;
+  sensor->busy_ = 0;
 }
 
 }  // namespace pulse_meter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -38,6 +38,7 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   volatile uint32_t last_valid_edge_us_ = 0;
   volatile uint32_t pulse_width_us_ = 0;
   volatile uint32_t total_pulses_ = 0;
+  volatile uint32_t busy = 0;
 };
 
 }  // namespace pulse_meter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -38,7 +38,7 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   volatile uint32_t last_valid_edge_us_ = 0;
   volatile uint32_t pulse_width_us_ = 0;
   volatile uint32_t total_pulses_ = 0;
-  volatile uint32_t busy = 0;
+  volatile uint32_t busy_ = 0;
 };
 
 }  // namespace pulse_meter


### PR DESCRIPTION
…ext.

Currently a volatile as a cheezy mutex

# What does this implement/fix? 
Randomly the sensor reports a 0 Energy reading  

Quick description and explanation of changes
The now variable becomes behind the last_pulse_us variable. this causes the calculations to fail and report an erroneous 'No Pulse' error

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
