### PR TITLE
Add support for P1 Data Request pin control

### DIFF
--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import pins
 from esphome.components import uart
 from esphome.const import (
     CONF_ID,
@@ -11,11 +12,13 @@ CODEOWNERS = ["@glmnet", "@zuidwijk"]
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["sensor", "text_sensor"]
 
-CONF_DSMR_ID = "dsmr_id"
-CONF_DECRYPTION_KEY = "decryption_key"
 CONF_CRC_CHECK = "crc_check"
+CONF_DECRYPTION_KEY = "decryption_key"
+CONF_DSMR_ID = "dsmr_id"
 CONF_GAS_MBUS_ID = "gas_mbus_id"
 CONF_MAX_TELEGRAM_LENGTH = "max_telegram_length"
+CONF_REQUEST_INTERVAL = "request_interval"
+CONF_REQUEST_PIN = "request_pin"
 
 # Hack to prevent compile error due to ambiguity with lib namespace
 dsmr_ns = cg.esphome_ns.namespace("esphome::dsmr")
@@ -48,6 +51,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_CRC_CHECK, default=True): cv.boolean,
             cv.Optional(CONF_GAS_MBUS_ID, default=1): cv.int_,
             cv.Optional(CONF_MAX_TELEGRAM_LENGTH, default=1500): cv.int_,
+            cv.Optional(CONF_REQUEST_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_REQUEST_INTERVAL): cv.positive_time_period_milliseconds,
         }
     ).extend(uart.UART_DEVICE_SCHEMA),
     cv.only_with_arduino,
@@ -61,6 +66,14 @@ async def to_code(config):
     if CONF_DECRYPTION_KEY in config:
         cg.add(var.set_decryption_key(config[CONF_DECRYPTION_KEY]))
     await cg.register_component(var, config)
+
+    if CONF_REQUEST_PIN in config:
+        request_pin = await cg.gpio_pin_expression(config[CONF_REQUEST_PIN])
+        cg.add(var.set_request_pin(request_pin))
+    if CONF_REQUEST_INTERVAL in config:
+        cg.add(
+            var.set_request_interval(config[CONF_REQUEST_INTERVAL].total_milliseconds)
+        )
 
     cg.add_define("DSMR_GAS_MBUS_ID", config[CONF_GAS_MBUS_ID])
 

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -125,10 +125,18 @@ void Dsmr::receive_telegram_() {
     }
 
     // Some v2.2 or v3 meters will send a new value which starts with '('
-    // in a new line while the value belongs to the previous ObisId. For
-    // proper parsing remove these new line characters
-    while (c == '(' && (this->telegram_[this->telegram_len_ - 1] == '\n' || this->telegram_[this->telegram_len_ - 1] == '\r'))
-      this->telegram_len_--;
+    // in a new line, while the value belongs to the previous ObisId. For
+    // proper parsing, remove these new line characters.
+    if (c == '(') {
+      while (true) {
+        auto previous_char = this->telegram_[this->telegram_len_ - 1];
+        if (previous_char == '\n' || previous_char == '\r') {
+          this->telegram_len_--;
+        } else {
+          break;
+        }
+      }
+    }
 
     // Store the byte in the buffer.
     this->telegram_[this->telegram_len_] = c;

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -82,7 +82,7 @@ void Dsmr::start_requesting_data_() {
 }
 
 void Dsmr::stop_requesting_data_() {
-  if (this->requesting_data_ == true) {
+  if (this->requesting_data_) {
     if (this->request_pin_ != nullptr) {
       ESP_LOGV(TAG, "Stop requesting data from P1 port");
       this->request_pin_->digital_write(false);

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -52,7 +52,6 @@ class Dsmr : public Component, public uart::UARTDevice {
   Dsmr(uart::UARTComponent *uart, bool crc_check) : uart::UARTDevice(uart), crc_check_(crc_check) {}
 
   void setup() override;
-
   void loop() override;
 
   bool parse_telegram();
@@ -74,6 +73,9 @@ class Dsmr : public Component, public uart::UARTDevice {
   void set_decryption_key(const std::string &decryption_key);
 
   void set_max_telegram_length(size_t length);
+
+  void set_request_pin(GPIOPin *request_pin) { this->request_pin_ = request_pin; }
+  void set_request_interval(uint32_t interval) { this->request_interval_ = interval; }
 
 // Sensor setters
 #define DSMR_SET_SENSOR(s) \
@@ -98,6 +100,16 @@ class Dsmr : public Component, public uart::UARTDevice {
   /// time that the UART RX buffer overflows and bytes of the telegram get
   /// lost in the process.
   bool available_within_timeout_();
+
+  // Data request
+  GPIOPin *request_pin_{nullptr};
+  uint32_t request_interval_{0};
+  uint32_t last_request_time_{0};
+  bool requesting_data_{false};
+  bool ready_to_request_data_();
+  bool request_interval_reached_();
+  void start_requesting_data_();
+  void stop_requesting_data_();
 
   // Telegram buffer
   size_t max_telegram_len_;

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1309,6 +1309,8 @@ dsmr:
   decryption_key: 00112233445566778899aabbccddeeff
   uart_id: uart6
   max_telegram_length: 1000
+  request_pin: D5
+  request_interval: 20s
 
 daly_bms:
   update_interval: 20s


### PR DESCRIPTION
# What does this implement/fix? 

When supported by the circuitry, this PR allows users to configure a GPIO pin that can be used to control the P1 Data Request pin. This pin allows for hardware flow control and additionally provides a clean and easy way to control the data request interval.

The `request_pin` option is used to specify what GPIO to use for controlling the Data Request pin.

The `request_interval` option is used to specify the minimal data request interval.

A fallback mechanism is implemented to make the request interval work without a request pin as well, making this a good way to limit the update frequency. Instead of actually turning the data stream from the smart meter off and on, the fallback code will simply sink all serial data until the next request interval is reached.
Up to now, the way to limit the update frequency, was to add a filter to every single sensor definition, making this a more practical one stop solution.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1596

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
dsmr:
  request_pin: D5
  request_interval: 30s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
