### PR TITLE
Add SPI lib for ESP8266 and only add lib for ESP32 when using Arduino

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -63,10 +63,7 @@ async def to_code(config):
     )
 
     # Although this component does not use SPI, the BSEC library requires the SPI library
-    if CORE.is_esp32 and CORE.using_arduino:
-        cg.add_library("SPI", None)
-    if CORE.is_esp8266:
-        cg.add_library("SPI", None)
+    cg.add_library("SPI", None)
 
     cg.add_define("USE_BSEC")
     cg.add_library("boschsensortec/BSEC Software Library", "1.6.1480")

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c
 from esphome.const import CONF_ID
-from esphome.core import CORE
 
 CODEOWNERS = ["@trvrnrth"]
 DEPENDENCIES = ["i2c"]

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -62,8 +62,10 @@ async def to_code(config):
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
     )
 
-    if CORE.is_esp32:
-        # Although this component does not use SPI, the BSEC library requires the SPI library
+    # Although this component does not use SPI, the BSEC library requires the SPI library
+    if CORE.is_esp32 and CORE.using_arduino:
+        cg.add_library("SPI", None)
+    if CORE.is_esp8266:
         cg.add_library("SPI", None)
 
     cg.add_define("USE_BSEC")


### PR DESCRIPTION
# What does this implement/fix? 

Compiling with bme680_bsec on ESP8266 results in an error message:

```
fatal error: SPI.h: No such file or directory

*************************************************************
* Looking for SPI.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:SPI.h"
* Web  > https://platformio.org/lib/search?query=header:SPI.h
*
*************************************************************

 #include "SPI.h"
                 ^
compilation terminated.
```

A fix was done before to include the SPI library, because the external bme680_bsec library expects it, even when SPI is not actively used. However, that fix was only done for platform ESP32. This PR adds the library inclusion for ESP8266 as well.

I also updated the ESP32 logic for including the SPI library.
It now only includes SPI when using the Arduino framework and no longer when using ESP-IDF.
This now fully matches the logic from the `spi` component itself. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
