### PR TITLE
Add HA Entity Category support to MQTT

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -76,8 +76,10 @@ bool MQTTComponent::send_discovery_() {
           root[MQTT_ENABLED_BY_DEFAULT] = false;
         if (!this->get_icon().empty())
           root[MQTT_ICON] = this->get_icon();
-        
+
         switch (this->get_entity()->get_entity_category()) {
+          case ENTITY_CATEGORY_NONE:
+            break;
           case ENTITY_CATEGORY_CONFIG:
             root[MQTT_ENTITY_CATEGORY] = "config";
             break;
@@ -85,7 +87,6 @@ bool MQTTComponent::send_discovery_() {
             root[MQTT_ENTITY_CATEGORY] = "diagnostic";
             break;
         }
-        
 
         if (config.state_topic)
           root[MQTT_STATE_TOPIC] = this->get_state_topic_();

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -76,6 +76,16 @@ bool MQTTComponent::send_discovery_() {
           root[MQTT_ENABLED_BY_DEFAULT] = false;
         if (!this->get_icon().empty())
           root[MQTT_ICON] = this->get_icon();
+        
+        switch (this->get_entity()->get_entity_category()) {
+          case ENTITY_CATEGORY_CONFIG:
+            root[MQTT_ENTITY_CATEGORY] = "config";
+            break;
+          case ENTITY_CATEGORY_DIAGNOSTIC:
+            root[MQTT_ENTITY_CATEGORY] = "diagnostic";
+            break;
+        }
+        
 
         if (config.state_topic)
           root[MQTT_STATE_TOPIC] = this->get_state_topic_();

--- a/esphome/components/mqtt/mqtt_const.h
+++ b/esphome/components/mqtt/mqtt_const.h
@@ -512,6 +512,9 @@ constexpr const char *const MQTT_DEVICE_SW_VERSION = "sw_version";
 constexpr const char *const MQTT_DEVICE_SUGGESTED_AREA = "suggested_area";
 #endif
 
+// Additional MQTT fields where no abbreviation is defined in HA source
+constexpr const char *const MQTT_ENTITY_CATEGORY = "entity_category";
+
 }  // namespace mqtt
 }  // namespace esphome
 


### PR DESCRIPTION
# What does this implement/fix? 

Following #2636, this PR adds support for `entity_category` via MQTT.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
