### PR TITLE
Hotfix for encrypted DSMR regression

### DIFF
--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -76,9 +76,10 @@ void Dsmr::receive_telegram_() {
     }
     // Check for the end of the hex checksum, i.e. a newline.
     if (footer_found_ && c == '\n') {
-      header_found_ = false;
       // Parse the telegram and publish sensor values.
       parse_telegram();
+
+      header_found_ = false;
       return;
     }
   }
@@ -105,11 +106,11 @@ void Dsmr::receive_encrypted_() {
 
     // Find a new telegram start byte.
     if (!header_found_) {
-      if ((uint8_t) c == 0xDB) {
-        ESP_LOGV(TAG, "Start byte 0xDB of encrypted telegram found");
-        header_found_ = true;
+      if ((uint8_t) c != 0xDB) {
+        continue;
       }
-      continue;
+      ESP_LOGV(TAG, "Start byte 0xDB of encrypted telegram found");
+      header_found_ = true;
     }
 
     // Check for buffer overflow.
@@ -147,10 +148,10 @@ void Dsmr::receive_encrypted_() {
       ESP_LOGV(TAG, "Decrypted telegram size: %d bytes", telegram_len_);
       ESP_LOGVV(TAG, "Decrypted telegram: %s", this->telegram_);
 
+      parse_telegram();
+
       header_found_ = false;
       telegram_len_ = 0;
-
-      parse_telegram();
       return;
     }
   }


### PR DESCRIPTION
# What does this implement/fix? 

PR https://github.com/esphome/esphome/pull/2622 introduced a regression in the encrypted DSMR telegram functionality. It looks like I made an error when merging my changes for enrypted and plain text DSMR telegrams.

Thanks to @glmnet for finding the issue and proposing a fix, and for providing me with some actual encrypted test data, so I was able to run tests on the component!

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
