### PR TITLE
Fix dashboard imports for adoption

### DIFF
--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -29,6 +29,14 @@ CONFIG_SCHEMA = cv.Schema(
     }
 )
 
+WIFI_MESSAGE = """
+
+# Do not forget to add your own wifi configuration before installing this configuration
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password
+"""
+
 
 async def to_code(config):
     cg.add_define("USE_DASHBOARD_IMPORT")
@@ -41,5 +49,12 @@ def import_config(path: str, name: str, project_name: str, import_url: str) -> N
     if p.exists():
         raise FileExistsError
 
-    config = {"substitutions": {"name": name}, "packages": {project_name: import_url}}
-    p.write_text(dump(config), encoding="utf8")
+    config = {
+        "substitutions": {"name": name},
+        "packages": {project_name: import_url},
+        "esphome": {"name_add_mac_suffix": False},
+    }
+    p.write_text(
+        dump(config) + WIFI_MESSAGE,
+        encoding="utf8",
+    )


### PR DESCRIPTION
# What does this implement/fix? 

- Set `name_add_mac_suffix` to false for adoption
- Add commented yaml with wifi secrets

With these additions it allows updating of the device to a user compiled firmware using the package and the hardcoded name with the mac suffix in it. If the user wants to change the name then they can follow the steps on the website until we have an automated mechanism.



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
