### PR TITLE
Bump ESPAsyncWebServer to 2.1.0

### DIFF
--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -28,4 +28,4 @@ async def to_code(config):
         cg.add_library("FS", None)
         cg.add_library("Update", None)
     # https://github.com/esphome/ESPAsyncWebServer/blob/master/library.json
-    cg.add_library("esphome/ESPAsyncWebServer-esphome", "2.0.1")
+    cg.add_library("esphome/ESPAsyncWebServer-esphome", "2.1.0")

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,7 +41,7 @@ lib_deps =
     ${common.lib_deps}
     ottowinter/AsyncMqttClient-esphome@0.8.6              ; mqtt
     ottowinter/ArduinoJson-esphomelib@5.13.3              ; json
-    esphome/ESPAsyncWebServer-esphome@2.0.1               ; web_server_base
+    esphome/ESPAsyncWebServer-esphome@2.1.0               ; web_server_base
     fastled/FastLED@3.3.2                                 ; fastled_base
     mikalhart/TinyGPSPlus@1.0.2                           ; gps
     freekode/TM1651@1.0.1                                 ; tm1651


### PR DESCRIPTION
# What does this implement/fix? 

https://github.com/esphome/ESPAsyncWebServer/releases/tag/v2.1.0


## Previous info

When the captive portal was stopping, there is a heap corruption exception.

I am unfamiliar with this low level memory management and the `DNSServer` comes from the arduino lib.

```text
[10:59:14]CORRUPT HEAP: Bad head at 0x3ffd149c. Expected 0xabba1234 got 0x3ffd161c
[10:59:14]abort() was called at PC 0x40086d35 on core 1
[10:59:14]
[10:59:14]ELF file SHA256: 0000000000000000
[10:59:14]
[10:59:14]Backtrace: 0x40088b3c:0x3ffb1a30 0x40088db9:0x3ffb1a50 0x40086d35:0x3ffb1a70 0x40086e61:0x3ffb1aa0 0x40106d33:0x3ffb1ac0 0x40103019:0x3ffb1d80 0x40102f89:0x3ffb1dd0 0x4008d495:0x3ffb1e00 0x40081f82:0x3ffb1e20 0x40086c2d:0x3ffb1e40 0x4000bec7:0x3ffb1e60 0x40157cc9:0x3ffb1e80 0x400db1cd:0x3ffb1ea0 0x400db23a:0x3ffb1ec0 0x400db361:0x3ffb1f00 0x40161f49:0x3ffb1f20 0x40161fed:0x3ffb1f40 0x400dc3da:0x3ffb1f60 0x400de482:0x3ffb1f90 0x400e874d:0x3ffb1fb0 0x40089dca:0x3ffb1fd0
WARNING Found stack trace! Trying to decode it
WARNING Decoded 0x40088b3c: invoke_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/panic.c:715
WARNING Decoded 0x40088db9: abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/panic.c:715
WARNING Decoded 0x40086d35: lock_acquire_generic at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/locks.c:143
WARNING Decoded 0x40086e61: _lock_acquire_recursive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/locks.c:171
WARNING Decoded 0x40106d33: _vfiprintf_r at /Users/ivan/e/newlib_xtensa-2.2.0-bin/newlib_xtensa-2.2.0/xtensa-esp32-elf/newlib/libc/stdio/../../../.././newlib/libc/stdio/vfprintf.c:860 (discriminator 2)
WARNING Decoded 0x40103019: fiprintf at /Users/ivan/e/newlib_xtensa-2.2.0-bin/newlib_xtensa-2.2.0/xtensa-esp32-elf/newlib/libc/stdio/../../../.././newlib/libc/stdio/fiprintf.c:50
WARNING Decoded 0x40102f89: __assert_func at /Users/ivan/e/newlib_xtensa-2.2.0-bin/newlib_xtensa-2.2.0/xtensa-esp32-elf/newlib/libc/stdlib/../../../.././newlib/libc/stdlib/assert.c:59 (discriminator 8)
WARNING Decoded 0x4008d495: multi_heap_free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap_poisoning.c:321
WARNING Decoded 0x40081f82: heap_caps_free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps.c:232
WARNING Decoded 0x40086c2d: _free_r at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/syscalls.c:42
WARNING Decoded 0x40157cc9: operator delete(void*) at /builds/idf/crosstool-NG/.build/src/gcc-5.2.0/libstdc++-v3/libsupc++/del_op.cc:46
WARNING Decoded 0x400db1cd: std::default_delete<DNSServer>::operator()(DNSServer*) const at .../esp-web-tools-example-esp32/src/esphome/components/wifi/wifi_component.cpp:689
 (inlined by) std::unique_ptr<DNSServer, std::default_delete<DNSServer> >::reset(DNSServer*) at ~/.platformio/packages/toolchain-xtensa32@2.50200.97/xtensa-esp32-elf/include/c++/5.2.0/bits/unique_ptr.h:344
 (inlined by) std::unique_ptr<DNSServer, std::default_delete<DNSServer> >::operator=(decltype(nullptr)) at ~/.platformio/packages/toolchain-xtensa32@2.50200.97/xtensa-esp32-elf/include/c++/5.2.0/bits/unique_ptr.h:280
 (inlined by) esphome::captive_portal::CaptivePortal::end() at .../esp-web-tools-example-esp32/src/esphome/components/captive_portal/captive_portal.h:37
WARNING Decoded 0x400db23a: esphome::wifi::WiFiComponent::check_connecting_finished() at .../esp-web-tools-example-esp32/src/esphome/components/wifi/wifi_component.cpp:689
WARNING Decoded 0x400db361: esphome::wifi::WiFiComponent::loop() at .../esp-web-tools-example-esp32/src/esphome/components/wifi/wifi_component.cpp:689
WARNING Decoded 0x40161f49: esphome::Component::call_loop() at ~/.platformio/packages/toolchain-xtensa32@2.50200.97/xtensa-esp32-elf/include/c++/5.2.0/functional:1754
WARNING Decoded 0x40161fed: esphome::Component::call() at .../esp-web-tools-example-esp32/src/esphome/core/component.cpp:88
WARNING Decoded 0x400dc3da: esphome::Application::loop() at .../esp-web-tools-example-esp32/src/esphome/core/application.cpp:71
WARNING Decoded 0x400de482: loop() at .../esp-web-tools-example-esp32/src/esphome/core/gpio.h:62
WARNING Decoded 0x400e874d: loopTask(void*) at ~/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:23
WARNING Decoded 0x40089dca: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
