### PR TITLE
Allow using the TM1829 with NeoPixelBus

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -106,6 +106,7 @@ VARIANTS = {
     "SK6812": "Sk6812",
     "800KBPS": "800Kbps",
     "400KBPS": "400Kbps",
+    "TM1829": "Tm1829",
 }
 
 ESP8266_METHODS = {


### PR DESCRIPTION
# What does this implement/fix? 

Allow setting the variant "TM1829" since it's already supported by NeoPixelBus and I couldn't get it to work with FastLED on the ESP32.

I tested it with the following NeoPixelBus methods:
- ESP8266_DMA: unreliable
- ESP8266_UART1: unreliable
- BIT_BANG (with ESP8266): very unreliable
- ESP32_I2S_1: works great

There are more variants that are supported by NeoPixelBus but not accessible in ESPHome, but I can't test them:
- Apa106
- Tm1814
- Tm1914
- Tx1812
- Ws2811


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
light:
  - platform: neopixelbus
    type: BRG
    pin: GPIO13
    num_leds: 10
    name: "TM1829 Test"
    variant: TM1829
    method: ESP32_I2S_1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). esphome/esphome-docs/pull/1599
