### PR TITLE
Enable addressable light power supply based on raw values

### DIFF
--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -87,7 +87,7 @@ class AddressableLight : public LightOutput, public Component {
   void mark_shown_() {
 #ifdef USE_POWER_SUPPLY
     for (const auto &c : *this) {
-      if (c.get().is_on()) {
+      if (c.get_red_raw() > 0 || c.get_green_raw() > 0 || c.get_blue_raw() > 0 || c.get_white_raw() > 0) {
         this->power_.request();
         return;
       }


### PR DESCRIPTION
# What does this implement/fix? 

Enable the power supply for addressable light based on the raw output values, instead of the user-friendly values (which go through `ESPColorCorrection`). Since color correction is dependent upon the local brightness of the light, and the local brightness isn't tracked for partitioned lights, this broke power supplies for partitioned lamps.

This isn't really pretty, but it's an easy and working solution pending a refactor of addressable lights.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2688

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
