### PR TITLE
Remove my.ha links from improv

### DIFF
--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -124,8 +124,13 @@ void ESP32ImprovComponent::loop() {
         this->cancel_timeout("wifi-connect-timeout");
         this->set_state_(improv::STATE_PROVISIONED);
 
-        std::string url = "https://my.home-assistant.io/redirect/config_flow_start?domain=esphome";
-        std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, {url});
+        std::vector<std::string> urls;
+#ifdef USE_WEBSERVER
+        auto ip = wifi::global_wifi_component->wifi_sta_ip();
+        std::string webserver_url = "http://" + ip.str() + ":" + to_string(WEBSERVER_PORT);
+        urls.push_back(webserver_url);
+#endif
+        std::vector<uint8_t> data = improv::build_rpc_response(command, urls);
         this->send_response_(data);
         this->set_timeout("end-service", 1000, [this] {
           this->service_->stop();

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -11,6 +11,7 @@ namespace esphome {
 namespace esp32_improv {
 
 static const char *const TAG = "esp32_improv.component";
+static const char *const ESPHOME_MY_LINK = "https://my.home-assistant.io/redirect/config_flow_start?domain=esphome";
 
 ESP32ImprovComponent::ESP32ImprovComponent() { global_improv_component = this; }
 
@@ -124,13 +125,13 @@ void ESP32ImprovComponent::loop() {
         this->cancel_timeout("wifi-connect-timeout");
         this->set_state_(improv::STATE_PROVISIONED);
 
-        std::vector<std::string> urls;
+        std::vector<std::string> urls = {ESPHOME_MY_LINK};
 #ifdef USE_WEBSERVER
         auto ip = wifi::global_wifi_component->wifi_sta_ip();
         std::string webserver_url = "http://" + ip.str() + ":" + to_string(WEBSERVER_PORT);
         urls.push_back(webserver_url);
 #endif
-        std::vector<uint8_t> data = improv::build_rpc_response(command, urls);
+        std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, urls);
         this->send_response_(data);
         this->set_timeout("end-service", 1000, [this] {
           this->service_->stop();

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -92,8 +92,7 @@ void ImprovSerialComponent::loop() {
 }
 
 std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv::Command command) {
-  std::string url = "https://my.home-assistant.io/redirect/config_flow_start?domain=esphome";
-  std::vector<std::string> urls = {url};
+  std::vector<std::string> urls;
 #ifdef USE_WEBSERVER
   auto ip = wifi::global_wifi_component->wifi_sta_ip();
   std::string webserver_url = "http://" + ip.str() + ":" + to_string(WEBSERVER_PORT);


### PR DESCRIPTION
# What does this implement/fix? 

Remove my.ha links from improv responses
They can be inferred in the client side tooling with firmware detection.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
