### PR TITLE
Fix AQI index calculator

### DIFF
--- a/esphome/components/hm3301/abstract_aqi_calculator.h
+++ b/esphome/components/hm3301/abstract_aqi_calculator.h
@@ -8,7 +8,7 @@ namespace hm3301 {
 
 class AbstractAQICalculator {
  public:
-  virtual uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) = 0;
+  virtual uint8_t get_aqi(uint16_t pm10_value) = 0;
 };
 
 }  // namespace hm3301

--- a/esphome/components/hm3301/aqi_calculator.h
+++ b/esphome/components/hm3301/aqi_calculator.h
@@ -19,7 +19,7 @@ class AQICalculator : public AbstractAQICalculator {
   int aqi_index_[AMOUNT_OF_LEVELS][2] = {{0, 51}, {51, 100}, {101, 150}, {151, 200}, {201, 300}, {301, 500}};
 
   int pm10_concentration_breakpoints_[AMOUNT_OF_LEVELS][2] = {{0, 54},    {55, 154},  {155, 254},
-                                                       {255, 354}, {355, 424}, {425, 604}};
+                                                              {255, 354}, {355, 424}, {425, 604}};
 
   int calculate_aqi_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
     int grid_index = get_concentration_breakpoint_level_(value, array);

--- a/esphome/components/hm3301/aqi_calculator.h
+++ b/esphome/components/hm3301/aqi_calculator.h
@@ -9,34 +9,29 @@ namespace hm3301 {
 
 class AQICalculator : public AbstractAQICalculator {
  public:
-  uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
-    int pm2_5_index = calculate_index_(pm2_5_value, pm2_5_calculation_grid_);
-    int pm10_0_index = calculate_index_(pm10_0_value, pm10_0_calculation_grid_);
-
-    return (pm2_5_index < pm10_0_index) ? pm10_0_index : pm2_5_index;
+  uint8_t get_aqi(uint16_t pm10_value) override {
+    return calculate_aqi_index_(pm10_value, pm10_concentration_breakpoints_);
   }
 
  protected:
   static const int AMOUNT_OF_LEVELS = 6;
 
-  int index_grid_[AMOUNT_OF_LEVELS][2] = {{0, 51}, {51, 100}, {101, 150}, {151, 200}, {201, 300}, {301, 500}};
+  int aqi_index_[AMOUNT_OF_LEVELS][2] = {{0, 51}, {51, 100}, {101, 150}, {151, 200}, {201, 300}, {301, 500}};
 
-  int pm2_5_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 12}, {13, 35}, {36, 55}, {56, 150}, {151, 250}, {251, 500}};
-
-  int pm10_0_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 54},    {55, 154},  {155, 254},
+  int pm10_concentration_breakpoints_[AMOUNT_OF_LEVELS][2] = {{0, 54},    {55, 154},  {155, 254},
                                                        {255, 354}, {355, 424}, {425, 604}};
 
-  int calculate_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
-    int grid_index = get_grid_index_(value, array);
-    int aqi_lo = index_grid_[grid_index][0];
-    int aqi_hi = index_grid_[grid_index][1];
+  int calculate_aqi_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
+    int grid_index = get_concentration_breakpoint_level_(value, array);
+    int aqi_lo = aqi_index_[grid_index][0];
+    int aqi_hi = aqi_index_[grid_index][1];
     int conc_lo = array[grid_index][0];
     int conc_hi = array[grid_index][1];
 
     return ((aqi_hi - aqi_lo) / (conc_hi - conc_lo)) * (value - conc_lo) + aqi_lo;
   }
 
-  int get_grid_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
+  int get_concentration_breakpoint_level_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
     for (int i = 0; i < AMOUNT_OF_LEVELS; i++) {
       if (value >= array[i][0] && value <= array[i][1]) {
         return i;

--- a/esphome/components/hm3301/caqi_calculator.h
+++ b/esphome/components/hm3301/caqi_calculator.h
@@ -10,39 +10,34 @@ namespace hm3301 {
 
 class CAQICalculator : public AbstractAQICalculator {
  public:
-  uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
-    int pm2_5_index = calculate_index_(pm2_5_value, pm2_5_calculation_grid_);
-    int pm10_0_index = calculate_index_(pm10_0_value, pm10_0_calculation_grid_);
-
-    return (pm2_5_index < pm10_0_index) ? pm10_0_index : pm2_5_index;
+  uint8_t get_aqi(uint16_t pm10_value) override {
+    return calculate_aqi_index_(pm10_value, pm10_concentration_breakpoints_);
   }
 
  protected:
   static const int AMOUNT_OF_LEVELS = 5;
 
-  int index_grid_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 75}, {76, 100}, {101, 400}};
+  int aqi_index_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 75}, {76, 100}, {101, 400}};
 
-  int pm2_5_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 15}, {16, 30}, {31, 55}, {56, 110}, {111, 400}};
+  int pm10_concentration_breakpoints_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 90}, {91, 180}, {181, 400}};
 
-  int pm10_0_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 90}, {91, 180}, {181, 400}};
-
-  int calculate_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
-    int grid_index = get_grid_index_(value, array);
-    if (grid_index == -1) {
+  int calculate_aqi_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
+    int conc_breakpoint_level = get_concentration_breakpoint_level_(value, array);
+    if (conc_breakpoint_level == -1) {
       return -1;
     }
 
-    int aqi_lo = index_grid_[grid_index][0];
-    int aqi_hi = index_grid_[grid_index][1];
-    int conc_lo = array[grid_index][0];
-    int conc_hi = array[grid_index][1];
+    int aqi_lo = aqi_index_[conc_breakpoint_level][0];
+    int aqi_hi = aqi_index_[conc_breakpoint_level][1];
+    int conc_lo = array[conc_breakpoint_level][0];
+    int conc_hi = array[conc_breakpoint_level][1];
 
     int aqi = ((aqi_hi - aqi_lo) / (conc_hi - conc_lo)) * (value - conc_lo) + aqi_lo;
 
     return aqi;
   }
 
-  int get_grid_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
+  int get_concentration_breakpoint_level_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
     for (int i = 0; i < AMOUNT_OF_LEVELS; i++) {
       if (value >= array[i][0] && value <= array[i][1]) {
         return i;

--- a/esphome/components/hm3301/hm3301.cpp
+++ b/esphome/components/hm3301/hm3301.cpp
@@ -66,9 +66,9 @@ void HM3301Component::update() {
   }
 
   int8_t aqi_value = -1;
-  if (this->aqi_sensor_ != nullptr && pm_2_5_value != -1 && pm_10_0_value != -1) {
+  if (this->aqi_sensor_ != nullptr && pm_10_0_value != -1) {
     AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
-    aqi_value = calculator->get_aqi(pm_2_5_value, pm_10_0_value);
+    aqi_value = calculator->get_aqi(pm_10_0_value);
   }
 
   if (pm_1_0_value != -1) {

--- a/esphome/components/hm3301/sensor.py
+++ b/esphome/components/hm3301/sensor.py
@@ -34,8 +34,6 @@ AQI_CALCULATION_TYPE = {
 
 
 def _validate(config):
-    if CONF_AQI in config and CONF_PM_2_5 not in config:
-        raise cv.Invalid("AQI sensor requires PM 2.5")
     if CONF_AQI in config and CONF_PM_10_0 not in config:
         raise cv.Invalid("AQI sensor requires PM 10 sensors")
     return config


### PR DESCRIPTION
# What does this implement/fix? 

AQI index should be based just on PM >10 particles.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1608

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
