### PR TITLE
Add climate on_state trigger

### DIFF
--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -42,5 +42,14 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
   Climate *climate_;
 };
 
+class StateTrigger : public Trigger<> {
+ public:
+  StateTrigger(Climate *climate) {
+    climate->add_on_state_callback([this]() {
+      this->trigger();
+    });
+  }
+};
+
 }  // namespace climate
 }  // namespace esphome

--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -45,9 +45,7 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
 class StateTrigger : public Trigger<> {
  public:
   StateTrigger(Climate *climate) {
-    climate->add_on_state_callback([this]() {
-      this->trigger();
-    });
+    climate->add_on_state_callback([this]() { this->trigger(); });
   }
 };
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1694,6 +1694,8 @@ climate:
     min_temperature: 18
     max_temperature: 30
   - platform: midea
+    on_state:
+      logger.log: "State changed!"
     id: midea_unit
     uart_id: uart0
     name: Midea Climate


### PR DESCRIPTION
# What does this implement/fix?

Added ``on_state`` climate trigger.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1614

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
climate:
  - platform: midea
    on_state:
      logger.log: "State changed!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
