### PR TITLE
Allow setting command_topic at component level

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1580,6 +1580,7 @@ MQTT_COMPONENT_SCHEMA = Schema(
         Optional(CONF_RETAIN): All(requires_component("mqtt"), boolean),
         Optional(CONF_DISCOVERY): All(requires_component("mqtt"), boolean),
         Optional(CONF_STATE_TOPIC): All(requires_component("mqtt"), publish_topic),
+        Optional(CONF_COMMAND_TOPIC): All(requires_component("mqtt"), publish_topic),
         Optional(CONF_AVAILABILITY): All(
             requires_component("mqtt"), Any(None, MQTT_COMPONENT_AVAILABILITY_SCHEMA)
         ),

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -460,6 +460,7 @@ sensor:
     retain: False
     availability:
     state_topic: livingroom/custom_state_topic
+    command_topic: livingroom/custom_command_topic
     measurement_duration: 31
     i2c_id: i2c_bus
   - platform: bme280


### PR DESCRIPTION
# What does this implement/fix? 

It is not possible to set arbitrary `command_topic` at mqtt component level, because it is rejected by the validation.
The solution is to add missing `command_topic` option in `MQTT_COMPONENT_SCHEMA`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
  - platform: template
    state_topic: ${mqtt_topic_prefix}/cover/1/state
    command_topic: ${mqtt_topic_prefix}/cover/1/command 

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
