### PR TITLE
Allow setting custom command_topic for Select and Number components

### DIFF
--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -41,7 +41,7 @@ NumberInRangeCondition = number_ns.class_(
 
 icon = cv.icon
 
-NUMBER_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMPONENT_SCHEMA).extend(
+NUMBER_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).extend(
     {
         cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTNumberComponent),
         cv.GenerateID(): cv.declare_id(Number),

--- a/esphome/components/select/__init__.py
+++ b/esphome/components/select/__init__.py
@@ -30,7 +30,7 @@ SelectSetAction = select_ns.class_("SelectSetAction", automation.Action)
 
 icon = cv.icon
 
-SELECT_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMPONENT_SCHEMA).extend(
+SELECT_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).extend(
     {
         cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTSelectComponent),
         cv.GenerateID(): cv.declare_id(Select),

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2512,3 +2512,23 @@ teleinfo:
   uart_id: uart0
   update_interval: 60s
   historical_mode: true
+
+number:
+  - platform: template
+    id: test_number
+    state_topic: livingroom/custom_state_topic
+    command_topic: livingroom/custom_command_topic
+    min_value: 0
+    step: 1
+    max_value: 10
+    optimistic: true
+
+select:
+  - platform: template
+    id: test_select
+    state_topic: livingroom/custom_state_topic
+    command_topic: livingroom/custom_command_topic
+    options:
+      - one
+      - two
+    optimistic: true

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -86,8 +86,6 @@ number:
     name: My template number
     id: template_number_id
     optimistic: true
-    state_topic: livingroom/custom_state_topic
-    command_topic: livingroom/custom_command_topic
     on_value:
       - logger.log:
           format: "Number changed to %f"
@@ -107,8 +105,6 @@ select:
     optimistic: true
     initial_option: two
     restore_value: true
-    state_topic: livingroom/custom_state_topic
-    command_topic: livingroom/custom_command_topic
     on_value:
       - logger.log:
           format: "Select changed to %s"

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -86,6 +86,8 @@ number:
     name: My template number
     id: template_number_id
     optimistic: true
+    state_topic: livingroom/custom_state_topic
+    command_topic: livingroom/custom_command_topic
     on_value:
       - logger.log:
           format: "Number changed to %f"
@@ -105,6 +107,8 @@ select:
     optimistic: true
     initial_option: two
     restore_value: true
+    state_topic: livingroom/custom_state_topic
+    command_topic: livingroom/custom_command_topic
     on_value:
       - logger.log:
           format: "Select changed to %s"


### PR DESCRIPTION
# What does this implement/fix? 

Currently `MQTT_COMPONENT_SCHEMA` is used for Select and Number components.
This is incorrect, as it disallows `command_topic` customization.
`MQTT_COMMAND_COMPONENT_SCHEMA` should be used instead.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
select:
  - platform: template
    state_topic: ${mqtt_topic_prefix}/cover/1/state
    command_topic: ${mqtt_topic_prefix}/cover/1/command 
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
