### PR TITLE
Add retry handler

### DIFF
--- a/esphome/components/template/sensor/template_sensor.cpp
+++ b/esphome/components/template/sensor/template_sensor.cpp
@@ -1,6 +1,5 @@
 #include "template_sensor.h"
 #include "esphome/core/log.h"
-#include "esphome/core/hal.h"
 #include <cmath>
 
 namespace esphome {
@@ -22,21 +21,6 @@ float TemplateSensor::get_setup_priority() const { return setup_priority::HARDWA
 void TemplateSensor::set_template(std::function<optional<float>()> &&f) { this->f_ = f; }
 void TemplateSensor::dump_config() {
   LOG_SENSOR("", "Template Sensor", this);
-  this->set_retry(
-      500, 10,
-      []() {
-        static auto last = millis();
-        static int counter = 1;
-        ESP_LOGI("RETRY DEMO", "RETRY Count=%u last invocation = %u ms", counter++, millis() - last);
-        last = millis();
-        if (counter < 6)
-          return RETRY;
-        else {
-          ESP_LOGI("RETRY DEMO", "retry stopped by lambda");
-          return DONE;
-        }
-      },
-      2.5f);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/template/sensor/template_sensor.cpp
+++ b/esphome/components/template/sensor/template_sensor.cpp
@@ -1,5 +1,6 @@
 #include "template_sensor.h"
 #include "esphome/core/log.h"
+#include "esphome/core/hal.h"
 #include <cmath>
 
 namespace esphome {
@@ -21,6 +22,21 @@ float TemplateSensor::get_setup_priority() const { return setup_priority::HARDWA
 void TemplateSensor::set_template(std::function<optional<float>()> &&f) { this->f_ = f; }
 void TemplateSensor::dump_config() {
   LOG_SENSOR("", "Template Sensor", this);
+  this->set_retry(
+      500, 10,
+      []() {
+        static auto last = millis();
+        static int counter = 1;
+        ESP_LOGI("RETRY DEMO", "RETRY Count=%u last invocation = %u ms", counter++, millis() - last);
+        last = millis();
+        if (counter < 6)
+          return RETRY;
+        else {
+          ESP_LOGI("RETRY DEMO", "retry stopped by lambda");
+          return DONE;
+        }
+      },
+      2.5f);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -61,7 +61,7 @@ void Component::set_retry(const std::string &name, uint32_t initial_wait_time, u
 }
 
 bool Component::cancel_retry(const std::string &name) {  // NOLINT
-  return App.scheduler.cancel_interval(this, name);
+  return App.scheduler.cancel_retry(this, name);
 }
 
 void Component::set_timeout(const std::string &name, uint32_t timeout, std::function<void()> &&f) {  // NOLINT

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -55,9 +55,9 @@ bool Component::cancel_interval(const std::string &name) {  // NOLINT
   return App.scheduler.cancel_interval(this, name);
 }
 
-void Component::set_retry(const std::string &name, uint32_t inital_wait_time, uint8_t max_retries,
+void Component::set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,
                           std::function<RetryResult()> &&f, float backoff_increase_factor) {  // NOLINT
-  App.scheduler.set_retry(this, name, inital_wait_time, max_retries, std::move(f), backoff_increase_factor);
+  App.scheduler.set_retry(this, name, initial_wait_time, max_retries, std::move(f), backoff_increase_factor);
 }
 
 bool Component::cancel_retry(const std::string &name) {  // NOLINT
@@ -129,9 +129,9 @@ void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // N
 void Component::set_interval(uint32_t interval, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_interval(this, "", interval, std::move(f));
 }
-void Component::set_retry(uint32_t inital_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
+void Component::set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
                           float backoff_increase_factor) {  // NOLINT
-  App.scheduler.set_retry(this, "", inital_wait_time, max_retries, std::move(f), backoff_increase_factor);
+  App.scheduler.set_retry(this, "", initial_wait_time, max_retries, std::move(f), backoff_increase_factor);
 }
 bool Component::is_failed() { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED; }
 bool Component::can_proceed() { return true; }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -55,9 +55,9 @@ bool Component::cancel_interval(const std::string &name) {  // NOLINT
   return App.scheduler.cancel_interval(this, name);
 }
 
-void Component::set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,
+void Component::set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
                           std::function<RetryResult()> &&f, float backoff_increase_factor) {  // NOLINT
-  App.scheduler.set_retry(this, name, initial_wait_time, max_retries, std::move(f), backoff_increase_factor);
+  App.scheduler.set_retry(this, name, initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
 }
 
 bool Component::cancel_retry(const std::string &name) {  // NOLINT
@@ -129,9 +129,9 @@ void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // N
 void Component::set_interval(uint32_t interval, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_interval(this, "", interval, std::move(f));
 }
-void Component::set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
+void Component::set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult()> &&f,
                           float backoff_increase_factor) {  // NOLINT
-  App.scheduler.set_retry(this, "", initial_wait_time, max_retries, std::move(f), backoff_increase_factor);
+  App.scheduler.set_retry(this, "", initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
 }
 bool Component::is_failed() { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED; }
 bool Component::can_proceed() { return true; }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -55,6 +55,15 @@ bool Component::cancel_interval(const std::string &name) {  // NOLINT
   return App.scheduler.cancel_interval(this, name);
 }
 
+void Component::set_retry(const std::string &name, uint32_t inital_wait_time, uint8_t max_retries,
+                          std::function<RetryResult()> &&f, float backoff_increase_factor) {  // NOLINT
+  App.scheduler.set_retry(this, name, inital_wait_time, max_retries, std::move(f), backoff_increase_factor);
+}
+
+bool Component::cancel_retry(const std::string &name) {  // NOLINT
+  return App.scheduler.cancel_interval(this, name);
+}
+
 void Component::set_timeout(const std::string &name, uint32_t timeout, std::function<void()> &&f) {  // NOLINT
   return App.scheduler.set_timeout(this, name, timeout, std::move(f));
 }
@@ -119,6 +128,10 @@ void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // N
 }
 void Component::set_interval(uint32_t interval, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_interval(this, "", interval, std::move(f));
+}
+void Component::set_retry(uint32_t inital_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
+                          float backoff_increase_factor) {  // NOLINT
+  App.scheduler.set_retry(this, "", inital_wait_time, max_retries, std::move(f), backoff_increase_factor);
 }
 bool Component::is_failed() { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED; }
 bool Component::can_proceed() { return true; }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -149,6 +149,13 @@ class Component {
    */
   const char *get_component_source() const;
 
+ protected:
+  friend class Application;
+
+  virtual void call_loop();
+  virtual void call_setup();
+  virtual void call_dump_config();
+
   /** Set an interval function with a unique name. Empty name means no cancelling possible.
    *
    * This will call f every interval ms. Can be cancelled via CancelInterval().
@@ -229,13 +236,6 @@ class Component {
    * @return Whether a timeout functions was deleted.
    */
   bool cancel_timeout(const std::string &name);  // NOLINT
-
- protected:
-  friend class Application;
-
-  virtual void call_loop();
-  virtual void call_setup();
-  virtual void call_dump_config();
 
   /** Defer a callback to the next loop() call.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -178,12 +178,12 @@ class Component {
   /** Set an retry function with a unique name. Empty name means no cancelling possible.
    *
    * This will call f. If f returns RetryResult::RETRY f is called again after inital_wait_time ms.
-   * f should return RetryResult::DONE if no repeat is required. The inial wait time will be increased
+   * f should return RetryResult::DONE if no repeat is required. The initial wait time will be increased
    * by backoff_increase_factor for each iteration. Default is doubling the time between iterations
    * Can be cancelled via cancel_retry().
    *
    * IMPORTANT: Do not rely on this having correct timing. This is only called from
-   * loop() and therefore can be significantly delay.
+   * loop() and therefore can be significantly delayed.
    *
    * @param name The identifier for this retry function.
    * @param inital_wait_time The time in ms before f is called again
@@ -201,7 +201,7 @@ class Component {
   /** Cancel a retry function.
    *
    * @param name The identifier for this retry function.
-   * @return Whether an retry functions was deleted.
+   * @return Whether a retry function was deleted.
    */
   bool cancel_retry(const std::string &name);  // NOLINT
 

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -61,7 +61,7 @@ extern const uint32_t STATUS_LED_OK;
 extern const uint32_t STATUS_LED_WARNING;
 extern const uint32_t STATUS_LED_ERROR;
 
-enum  RetryResult { DONE, RETRY };
+enum RetryResult { DONE, RETRY };
 
 class Component {
  public:

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -199,11 +199,11 @@ class Component {
    * @param backoff_increase_factor time between retries is increased by this factor on every retry
    * @see cancel_retry()
    */
-  void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,
-                 std::function<RetryResult()> &&f, float backoff_increase_factor = 2.0f);  // NOLINT
+  void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,  // NOLINT
+                 std::function<RetryResult()> &&f, float backoff_increase_factor = 2.0f);   // NOLINT
 
-  void set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
-                 float backoff_increase_factor = 2.0f);  // NOLINT
+  void set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,  // NOLINT
+                 float backoff_increase_factor = 2.0f);                                              // NOLINT
 
   /** Cancel a retry function.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -200,10 +200,10 @@ class Component {
    * @see cancel_retry()
    */
   void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,  // NOLINT
-                 std::function<RetryResult()> &&f, float backoff_increase_factor = 2.0f);   // NOLINT
+                 std::function<RetryResult()> &&f, float backoff_increase_factor = 1.0f);   // NOLINT
 
   void set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,  // NOLINT
-                 float backoff_increase_factor = 2.0f);                                              // NOLINT
+                 float backoff_increase_factor = 1.0f);                                              // NOLINT
 
   /** Cancel a retry function.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -177,7 +177,7 @@ class Component {
 
   /** Set an retry function with a unique name. Empty name means no cancelling possible.
    *
-   * This will call f. If f returns RetryResult::RETRY f is called again after inital_wait_time ms.
+   * This will call f. If f returns RetryResult::RETRY f is called again after initial_wait_time ms.
    * f should return RetryResult::DONE if no repeat is required. The initial wait time will be increased
    * by backoff_increase_factor for each iteration. Default is doubling the time between iterations
    * Can be cancelled via cancel_retry().
@@ -186,16 +186,16 @@ class Component {
    * loop() and therefore can be significantly delayed.
    *
    * @param name The identifier for this retry function.
-   * @param inital_wait_time The time in ms before f is called again
+   * @param initial_wait_time The time in ms before f is called again
    * @param max_retries The maximum number of retries
    * @param f The function (or lambda) that should be called
    * @param backoff_increase_factor time between retries is increased by this factor on every retry
    * @see cancel_retry()
    */
-  void set_retry(const std::string &name, uint32_t inital_wait_time, uint8_t max_retries,
+  void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,
                  std::function<RetryResult()> &&f, float backoff_increase_factor = 2.0f);  // NOLINT
 
-  void set_retry(uint32_t inital_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
+  void set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
                  float backoff_increase_factor = 2.0f);  // NOLINT
 
   /** Cancel a retry function.

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -194,16 +194,16 @@ class Component {
    *
    * @param name The identifier for this retry function.
    * @param initial_wait_time The time in ms before f is called again
-   * @param max_retries The maximum number of retries
+   * @param max_attempts The maximum number of retries
    * @param f The function (or lambda) that should be called
    * @param backoff_increase_factor time between retries is increased by this factor on every retry
    * @see cancel_retry()
    */
-  void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,  // NOLINT
-                 std::function<RetryResult()> &&f, float backoff_increase_factor = 1.0f);   // NOLINT
+  void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,  // NOLINT
+                 std::function<RetryResult()> &&f, float backoff_increase_factor = 1.0f);    // NOLINT
 
-  void set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,  // NOLINT
-                 float backoff_increase_factor = 1.0f);                                              // NOLINT
+  void set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult()> &&f,  // NOLINT
+                 float backoff_increase_factor = 1.0f);                                               // NOLINT
 
   /** Cancel a retry function.
    *

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -128,9 +128,9 @@ void IRAM_ATTR HOT Scheduler::call() {
     ESP_LOGVV(TAG, "Items: count=%u, now=%u", this->items_.size(), now);
     while (!this->empty_()) {
       auto item = std::move(this->items_[0]);
-      ESP_LOGVV(TAG, "  %s '%s' interval=%u last_execution=%u (%u) next=%u (%u)", item->get_type_str(), item->name.c_str(),
-                item->interval, item->last_execution, item->last_execution_major, item->next_execution(),
-                item->next_execution_major());
+      ESP_LOGVV(TAG, "  %s '%s' interval=%u last_execution=%u (%u) next=%u (%u)", item->get_type_str(),
+                item->name.c_str(), item->interval, item->last_execution, item->last_execution_major,
+                item->next_execution(), item->next_execution_major());
 
       this->pop_raw_();
       old_items.push_back(std::move(item));

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -211,7 +211,8 @@ void IRAM_ATTR HOT Scheduler::call() {
         continue;
       }
 
-      if (item->type == SchedulerItem::INTERVAL || item->type == SchedulerItem::RETRY) {
+      if (item->type == SchedulerItem::INTERVAL ||
+          (item->type == SchedulerItem::RETRY && (--item->retry_countdown > 0 && retry_result != RetryResult::DONE))) {
         if (item->interval != 0) {
           const uint32_t before = item->last_execution;
           const uint32_t amount = (now - item->last_execution) / item->interval;
@@ -222,8 +223,7 @@ void IRAM_ATTR HOT Scheduler::call() {
             item->interval *= item->backoff_multiplier;
         }
       }
-      if (item->type == SchedulerItem::INTERVAL || (--item->retry_countdown > 0 && retry_result != RetryResult::DONE))
-        this->push_(std::move(item));
+      this->push_(std::move(item));
     }
   }
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -222,8 +222,8 @@ void IRAM_ATTR HOT Scheduler::call() {
           if (item->type == SchedulerItem::RETRY)
             item->interval *= item->backoff_multiplier;
         }
+        this->push_(std::move(item));
       }
-      this->push_(std::move(item));
     }
   }
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -78,7 +78,7 @@ void HOT Scheduler::set_retry(Component *component, const std::string &name, uin
   const uint32_t now = this->millis_();
 
   if (!name.empty())
-    this->cancel_interval(component, name);
+    this->cancel_retry(component, name);
 
   if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
@@ -248,8 +248,7 @@ void IRAM_ATTR HOT Scheduler::call() {
             item->last_execution_major++;
         }
         this->push_(std::move(item));
-      } else {
-        if (item->type == SchedulerItem::RETRY)
+      } else if (item->type == SchedulerItem::RETRY) {
           if (--item->retry_countdown > 0 && item->retry_result != RetryResult::DONE) {
             if (item->interval != 0) {
               const uint32_t before = item->last_execution;

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -73,33 +73,33 @@ bool HOT Scheduler::cancel_interval(Component *component, const std::string &nam
   return this->cancel_item_(component, name, SchedulerItem::INTERVAL);
 }
 
-void HOT Scheduler::set_retry(Component *component, const std::string &name, uint32_t inital_wait_time,
+void HOT Scheduler::set_retry(Component *component, const std::string &name, uint32_t initial_wait_time,
                               uint8_t max_retries, std::function<RetryResult()> &&func, float backoff_increase_factor) {
   const uint32_t now = this->millis_();
 
   if (!name.empty())
     this->cancel_interval(component, name);
 
-  if (inital_wait_time == SCHEDULER_DONT_RUN)
+  if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
 
   // only put offset in lower half
   uint32_t offset = 0;
-  if (inital_wait_time != 0)
-    offset = (random_uint32() % inital_wait_time) / 2;
+  if (initial_wait_time != 0)
+    offset = (random_uint32() % initial_wait_time) / 2;
 
-  ESP_LOGVV(TAG, "set_retry(name='%s', inital_wait_time=%u,max_retries=%u, backoff_factor=%0.1f offset=%u)",
-            name.c_str(), inital_wait_time, max_retries, backoff_increase_factor, offset);
+  ESP_LOGVV(TAG, "set_retry(name='%s', initial_wait_time=%u,max_retries=%u, backoff_factor=%0.1f offset=%u)",
+            name.c_str(), initial_wait_time, max_retries, backoff_increase_factor, offset);
 
   auto item = make_unique<SchedulerItem>();
   item->component = component;
   item->name = name;
   item->type = SchedulerItem::RETRY;
-  item->interval = inital_wait_time;
+  item->interval = initial_wait_time;
   item->retry_countdown = max_retries;
   item->backoff_multiplier = backoff_increase_factor;
   item->retry_result = RetryResult::RETRY;
-  item->last_execution = now - offset - inital_wait_time;
+  item->last_execution = now - offset - initial_wait_time;
   item->last_execution_major = this->millis_major_;
   if (item->last_execution > now)
     item->last_execution_major--;

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -16,7 +16,7 @@ class Scheduler {
   bool cancel_interval(Component *component, const std::string &name);
 
   void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,
-                 std::function<RetryResult()> &&func, float backoff_increase_factor = 2.0f);
+                 std::function<RetryResult()> &&func, float backoff_increase_factor = 1.0f);
   bool cancel_retry(Component *component, const std::string &name);
 
   optional<uint32_t> next_schedule_in();

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -35,10 +35,12 @@ class Scheduler {
       uint32_t timeout;
     };
     uint32_t last_execution;
-    std::function<void()> f;
-    std::function<RetryResult()> retry_f;
-    void retry_wrapper();
-    RetryResult retry_result{};
+    // Ideally this should be a union or std::variant
+    // but unions don't work with object like std::function
+    //  union CallBack_{
+    std::function<void()> void_callback;
+    std::function<RetryResult()> retry_callback;
+    //  };
     uint8_t retry_countdown{3};
     float backoff_multiplier{1.0f};
     bool remove;
@@ -54,6 +56,18 @@ class Scheduler {
     }
 
     static bool cmp(const std::unique_ptr<SchedulerItem> &a, const std::unique_ptr<SchedulerItem> &b);
+    const char *get_type_str() {
+      switch (this->type) {
+        case SchedulerItem::INTERVAL:
+          return "interval";
+        case SchedulerItem::RETRY:
+          return "retry";
+        case SchedulerItem::TIMEOUT:
+          return "timeout";
+        default:
+          return "INVALID TYPE!";
+      }
+    }
   };
 
   uint32_t millis_();

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -15,7 +15,7 @@ class Scheduler {
   void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> &&func);
   bool cancel_interval(Component *component, const std::string &name);
 
-  void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,
+  void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
                  std::function<RetryResult()> &&func, float backoff_increase_factor = 1.0f);
   bool cancel_retry(Component *component, const std::string &name);
 
@@ -65,7 +65,7 @@ class Scheduler {
         case SchedulerItem::TIMEOUT:
           return "timeout";
         default:
-          return "INVALID TYPE!";
+          return "";
       }
     }
   };

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -15,7 +15,7 @@ class Scheduler {
   void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> &&func);
   bool cancel_interval(Component *component, const std::string &name);
 
-  void set_retry(Component *component, const std::string &name, uint32_t inital_wait_time, uint8_t max_retries,
+  void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_retries,
                  std::function<RetryResult()> &&func, float backoff_increase_factor = 2.0f);
   bool cancel_retry(Component *component, const std::string &name);
 


### PR DESCRIPTION
# What does this implement/fix? 

adds a retry handler to Component similar to set_timeout and set_interval.   Retrying a operation from a component without using `delay()` is currently quite tedious. This function makes retries easier and allows exponential backoff

**Signature**:
`  void set_retry(uint32_t initial_wait_time, uint8_t max_retries, std::function<RetryResult()> &&f,
                 float backoff_increase_factor = 1.0f); `

`initial_wait_time` is the delay for the first retry. 
`max_retries` how often to retry 
`f` the function to retry.   If `f` returns `RETRY`  then it will be called again. `DONE` stops the retries
`backoff_increase_factor` defines how the time between the retries changes (initial_wait_time is multiplied with it) 

Usage from a component
```c++
          this->set_retry(500,10, []() {
            static auto last = millis();
            static int counter = 1 ; 
            ESP_LOGI("RETRY DEMO", "RETRY Count=%u last invocation = %u ms",counter++, millis()-last);
            last = millis();
            if (counter < 6)
              return RETRY;
            else {
              ESP_LOGI("RETRY DEMO","retry stopped by lambda");
              return DONE;
            }
          },2.5f);
```

The existing implementation for Scheduler::SchedulerItem uses `std::function<void>()` for the callbacks. 
To avoid breaking exiting code set_retry wraps the `std::function<RetryResult>()` callback in a void function. 
Not sure if there is an easier approach here.  All 'more elegant' version I tested crashed :)

Feedback about different function signatures or any improvement is welcome :) 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
