### PR TITLE
Fix indentation of write_lambda for modbus_controller number

### DIFF
--- a/esphome/components/modbus_controller/number/__init__.py
+++ b/esphome/components/modbus_controller/number/__init__.py
@@ -129,14 +129,14 @@ async def to_code(config):
             return_type=cg.optional.template(float),
         )
         cg.add(var.set_template(template_))
-        if CONF_WRITE_LAMBDA in config:
-            template_ = await cg.process_lambda(
-                config[CONF_WRITE_LAMBDA],
-                [
-                    (ModbusNumber.operator("ptr"), "item"),
-                    (cg.float_, "x"),
-                    (cg.std_vector.template(cg.uint16).operator("ref"), "payload"),
-                ],
-                return_type=cg.optional.template(float),
-            )
-            cg.add(var.set_write_template(template_))
+    if CONF_WRITE_LAMBDA in config:
+        template_ = await cg.process_lambda(
+            config[CONF_WRITE_LAMBDA],
+            [
+                (ModbusNumber.operator("ptr"), "item"),
+                (cg.float_, "x"),
+                (cg.std_vector.template(cg.uint16).operator("ref"), "payload"),
+            ],
+            return_type=cg.optional.template(float),
+        )
+        cg.add(var.set_write_template(template_))


### PR DESCRIPTION
# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2694

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
