### PR TITLE
AF4991 I2C Rotary Encoder board support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,8 +12,10 @@ esphome/core/* @esphome/core
 
 # Integrations
 esphome/components/ac_dimmer/* @glmnet
+esphome/components/adafruit_seesaw/* @MrEditor97
 esphome/components/adc/* @esphome/core
 esphome/components/addressable_light/* @justfalter
+esphome/components/af4991/* @MrEditor97
 esphome/components/airthings_ble/* @jeromelaban
 esphome/components/airthings_wave_mini/* @ncareau
 esphome/components/airthings_wave_plus/* @jeromelaban

--- a/esphome/components/adafruit_seesaw/__init__.py
+++ b/esphome/components/adafruit_seesaw/__init__.py
@@ -1,0 +1,9 @@
+# Dummy integration to allow relying on Ardafruit Seesaw API
+import esphome.config_validation as cv
+
+DEPENDENCIES = ["i2c"]
+CODEOWNERS = ["@MrEditor97"]
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema({}),
+)

--- a/esphome/components/adafruit_seesaw/adafruit_seesaw.cpp
+++ b/esphome/components/adafruit_seesaw/adafruit_seesaw.cpp
@@ -1,0 +1,257 @@
+#include "adafruit_seesaw.h"
+#include "esphome/core/log.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace adafruit_seesaw {
+
+static const char *const TAG = "adafruit_seesaw";
+
+/**
+ * @brief Set the mode of a GPIO Pin
+ *
+ * @param pin the pin number - the pin number on the SAMD09 breakout, they correspond to the number on the
+ * silkscreen.
+ * @param mode the mode to set the pin up with. INPUT, OUTPUT, INPUT_PULLUP, INPUT_PULLDOWN
+ */
+void AdafruitSeesaw::pin_mode(uint8_t pin, uint8_t mode) {
+  if (pin >= 32) {
+    pin_mode_bulk(0, 1ul << (pin - 32), mode);
+  } else {
+    pin_mode_bulk(1ul << pin, mode);
+  }
+}
+
+/**
+ * @brief Sets the mode of multiple GPIO Pins
+ *
+ * @param pins a group of pins - the pins that match up on the SAMD09 breakout, they correspond to the number on the
+ * silkscreen
+ * @param mode the mode to set the pin up with. INPUT, OUTPUT, INPUT_PULLUP, INPUT_PULLDOWN
+ */
+void AdafruitSeesaw::pin_mode_bulk(uint32_t pins, uint8_t mode) {
+  switch (mode) {
+    case OUTPUT:
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRSET_BULK, pins);
+      break;
+    case INPUT:
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRCLR_BULK, pins);
+      break;
+    case INPUT_PULLUP:
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRCLR_BULK, pins);
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_PULLENSET, pins);
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_BULK_SET, pins);
+      break;
+    case INPUT_PULLDOWN:
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRCLR_BULK, pins);
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_PULLENSET, pins);
+      this->write_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_BULK_CLR, pins);
+      break;
+  }
+}
+
+/**
+ * @brief Sets the mode of multiple GPIO Pins. This method supports pins in A and B groups
+ *
+ * @param pins_a bitmask of the pins to write on Port A
+ * @param pins_b bitmask of the pins to write on Port B
+ * @param mode mode to set the pin up with. INPUT, OUTPUT, INPUT_PULLUP, INPUT_PULLDOWN
+ */
+void AdafruitSeesaw::pin_mode_bulk(uint32_t pins_a, uint32_t pins_b, uint8_t mode) {
+  uint64_t pins = (uint64_t) pins_a << 32 | (uint64_t) pins_b;
+
+  switch (mode) {
+    case OUTPUT:
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRSET_BULK, pins);
+      break;
+    case INPUT:
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRCLR_BULK, pins);
+      break;
+    case INPUT_PULLUP:
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRCLR_BULK, pins);
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_PULLENSET, pins);
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_BULK_SET, pins);
+      break;
+    case INPUT_PULLDOWN:
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_DIRCLR_BULK, pins);
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_PULLENSET, pins);
+      this->write_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_BULK_CLR, pins);
+      break;
+  }
+}
+
+/**
+ * @brief Read the current status of a GPIO Pin
+ *
+ * @param pin the pin number - the pin number on the SAMD09 breakout, they correspond to the number on the
+ * silkscreen.
+ * @return the status of the pin - HIGH or LOW (1 or 0)
+ */
+bool AdafruitSeesaw::digital_read(uint8_t pin) {
+  if (pin >= 32) {
+    return digital_read_bulk_b((1ul << (pin - 32))) != 0;
+  } else {
+    return this->digital_read_bulk((1ul << pin)) != 0;
+  }
+}
+
+/**
+ * @brief Read the status of multiple pins on Port B
+ *
+ * @param pins a bitmask of the pins to read - on the SAMD09 breakout, they correspond to the number on the
+ * silkscreen.
+ * @return the status of the passed pins.
+ */
+uint32_t AdafruitSeesaw::digital_read_bulk_b(uint32_t pins) {
+  uint64_t buffer = 0;
+  this->read_64((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_BULK, &buffer);
+
+  uint32_t result =
+      ((uint32_t) buffer << 24 | ((uint32_t) buffer << 16) | ((uint32_t) buffer << 8) | ((uint32_t) buffer));
+
+  return buffer & pins;
+}
+
+/**
+ * @brief Read the status of multiple pins on Port A
+ *
+ * @param pins a bitmask of the pins to read - on the SAMD09 breakout, they correspond to the number on the
+ * silkscreen.
+ * @return the status of the passed pins.
+ */
+uint32_t AdafruitSeesaw::digital_read_bulk(uint32_t pins) {
+  uint32_t buffer = 0;
+  this->read_32((uint16_t) SEESAW_GPIO_BASE << 8 | SEESAW_GPIO_BULK, &buffer);
+
+  return buffer & pins;
+}
+
+/**
+ * @brief Writes a 8 bit value to the connected device
+ *
+ * @param reg a bitmask of the base register and secondary register
+ * @param value data to write to register
+ * @return i2c::ErrorCode
+ */
+i2c::ErrorCode AdafruitSeesaw::write_8(uint16_t reg, uint8_t value) {
+  std::vector<uint8_t> data;
+  data.push_back(reg >> 8);
+  data.push_back(reg >> 0);
+  data.push_back(value);
+  return this->write(data.data(), data.size());
+}
+
+/**
+ * @brief Writes a 16 bit value to the connected device
+ *
+ * @param reg a bitmask of the base register and secondary register
+ * @param value data to write to register
+ * @return i2c::ErrorCode
+ */
+i2c::ErrorCode AdafruitSeesaw::write_16(uint16_t reg, uint16_t value) {
+  std::vector<uint8_t> data;
+  data.push_back(reg >> 8);
+  data.push_back(reg >> 0);
+  data.push_back(value >> 8);
+  data.push_back(value >> 0);
+  return this->write(data.data(), data.size());
+}
+
+/**
+ * @brief Writes a 32 bit value to the connected device
+ *
+ * @param reg a bitmask of the base register and secondary register
+ * @param value data to write to register
+ * @return i2c::ErrorCode
+ */
+i2c::ErrorCode AdafruitSeesaw::write_32(uint16_t reg, uint32_t value) {
+  std::vector<uint8_t> data;
+  data.push_back(reg >> 8);
+  data.push_back(reg >> 0);
+  data.push_back(value >> 24);
+  data.push_back(value >> 16);
+  data.push_back(value >> 8);
+  data.push_back(value >> 0);
+  return this->write(data.data(), data.size());
+}
+
+/**
+ * @brief Writes a 64 bit value to the connected device
+ *
+ * @param reg a bitmask of the base register and secondary register
+ * @param value data to write to register
+ * @return i2c::ErrorCode
+ */
+i2c::ErrorCode AdafruitSeesaw::write_64(uint16_t reg, uint64_t value) {
+  std::vector<uint8_t> data;
+  data.push_back(reg >> 8);
+  data.push_back(reg >> 0);
+  data.push_back(value >> 56);
+  data.push_back(value >> 48);
+  data.push_back(value >> 40);
+  data.push_back(value >> 32);
+  data.push_back(value >> 24);
+  data.push_back(value >> 16);
+  data.push_back(value >> 8);
+  data.push_back(value >> 0);
+  return this->write(data.data(), data.size());
+}
+
+/**
+ * @brief Reads a 32 bit value from the connected device
+ *
+ * @param reg a bitmask of the base register and secondary register
+ * @param value data to push the return value into
+ * @return i2c::ErrorCode
+ */
+i2c::ErrorCode AdafruitSeesaw::read_32(uint16_t reg, uint32_t *value) {
+  uint8_t reg_data[2];
+  reg_data[0] = reg >> 8;
+  reg_data[1] = reg >> 0;
+  i2c::ErrorCode err = this->write(reg_data, 2);
+  if (err != i2c::ERROR_OK)
+    return err;
+  uint8_t recv[4];
+  err = this->read(recv, 4);
+  if (err != i2c::ERROR_OK)
+    return err;
+  *value = 0;
+  *value |= ((uint32_t) recv[0]) << 24;
+  *value |= ((uint32_t) recv[1]) << 16;
+  *value |= ((uint32_t) recv[2]) << 8;
+  *value |= ((uint32_t) recv[3]);
+  return i2c::ERROR_OK;
+}
+
+/**
+ * @brief Reads a 64 bit value from the connected device
+ *
+ * @param reg a bitmask of the base register and secondary register
+ * @param value data to push the return value into
+ * @return i2c::ErrorCode
+ */
+i2c::ErrorCode AdafruitSeesaw::read_64(uint16_t reg, uint64_t *value) {
+  uint8_t reg_data[2];
+  reg_data[0] = reg >> 8;
+  reg_data[1] = reg >> 0;
+  i2c::ErrorCode err = this->write(reg_data, 2);
+  if (err != i2c::ERROR_OK)
+    return err;
+  uint8_t recv[8];
+  err = this->read(recv, 8);
+  if (err != i2c::ERROR_OK)
+    return err;
+  *value = 0;
+  *value |= ((uint64_t) recv[0]) << 56;
+  *value |= ((uint64_t) recv[1]) << 48;
+  *value |= ((uint64_t) recv[2]) << 40;
+  *value |= ((uint64_t) recv[3]) << 32;
+  *value |= ((uint64_t) recv[4]) << 24;
+  *value |= ((uint64_t) recv[5]) << 16;
+  *value |= ((uint64_t) recv[6]) << 8;
+  *value |= ((uint64_t) recv[7]);
+  return i2c::ERROR_OK;
+}
+
+}  // namespace adafruit_seesaw
+}  // namespace esphome

--- a/esphome/components/adafruit_seesaw/adafruit_seesaw.cpp
+++ b/esphome/components/adafruit_seesaw/adafruit_seesaw.cpp
@@ -109,7 +109,7 @@ uint32_t AdafruitSeesaw::digital_read_bulk_b(uint32_t pins) {
   uint32_t result =
       ((uint32_t) buffer << 24 | ((uint32_t) buffer << 16) | ((uint32_t) buffer << 8) | ((uint32_t) buffer));
 
-  return buffer & pins;
+  return result & pins;
 }
 
 /**

--- a/esphome/components/adafruit_seesaw/adafruit_seesaw.h
+++ b/esphome/components/adafruit_seesaw/adafruit_seesaw.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+
+/**
+ * @brief Built to be able to be used with Adafruit Seesaw compatibile devices.
+ * These devices use the SAMD09 chip, and are fully customizable. This will eventually support
+ * direct control of the SAMD09 chip.
+ *
+ * Currently this supports:
+ *  - Adafruit I2C QT Rotary Encoder board (except the onboard Neopixel)
+ *
+ * More to come in future when I get my hands on the boards!
+ */
+namespace adafruit_seesaw {
+
+enum {
+  SEESAW_STATUS_BASE = 0x00,
+  SEESAW_GPIO_BASE = 0x01,
+  SEESAW_SERCOM0_BASE = 0x02,
+
+  SEESAW_TIMER_BASE = 0x08,
+  SEESAW_ADC_BASE = 0x09,
+  SEESAW_DAC_BASE = 0x0A,
+  SEESAW_INTERRUPT_BASE = 0x0B,
+  SEESAW_DAP_BASE = 0x0C,
+  SEESAW_EEPROM_BASE = 0x0D,
+  SEESAW_NEOPIXEL_BASE = 0x0E,
+  SEESAW_TOUCH_BASE = 0x0F,
+  SEESAW_KEYPAD_BASE = 0x10,
+  SEESAW_ENCODER_BASE = 0x11,
+};
+
+enum {
+  SEESAW_GPIO_DIRSET_BULK = 0x02,
+  SEESAW_GPIO_DIRCLR_BULK = 0x03,
+  SEESAW_GPIO_BULK = 0x04,
+  SEESAW_GPIO_BULK_SET = 0x05,
+  SEESAW_GPIO_BULK_CLR = 0x06,
+  SEESAW_GPIO_BULK_TOGGLE = 0x07,
+  SEESAW_GPIO_INTENSET = 0x08,
+  SEESAW_GPIO_INTENCLR = 0x09,
+  SEESAW_GPIO_INTFLAG = 0x0A,
+  SEESAW_GPIO_PULLENSET = 0x0B,
+  SEESAW_GPIO_PULLENCLR = 0x0C,
+};
+
+enum {
+  SEESAW_STATUS_HW_ID = 0x01,
+  SEESAW_STATUS_VERSION = 0x02,
+  SEESAW_STATUS_OPTIONS = 0x03,
+  SEESAW_STATUS_TEMP = 0x04,
+  SEESAW_STATUS_SWRST = 0x7F,
+};
+
+enum {
+  SEESAW_TIMER_STATUS = 0x00,
+  SEESAW_TIMER_PWM = 0x01,
+  SEESAW_TIMER_FREQ = 0x02,
+};
+
+enum {
+  SEESAW_ADC_STATUS = 0x00,
+  SEESAW_ADC_INTEN = 0x02,
+  SEESAW_ADC_INTENCLR = 0x03,
+  SEESAW_ADC_WINMODE = 0x04,
+  SEESAW_ADC_WINTHRESH = 0x05,
+  SEESAW_ADC_CHANNEL_OFFSET = 0x07,
+};
+
+enum {
+  SEESAW_SERCOM_STATUS = 0x00,
+  SEESAW_SERCOM_INTEN = 0x02,
+  SEESAW_SERCOM_INTENCLR = 0x03,
+  SEESAW_SERCOM_BAUD = 0x04,
+  SEESAW_SERCOM_DATA = 0x05,
+};
+
+enum {
+  SEESAW_NEOPIXEL_STATUS = 0x00,
+  SEESAW_NEOPIXEL_PIN = 0x01,
+  SEESAW_NEOPIXEL_SPEED = 0x02,
+  SEESAW_NEOPIXEL_BUF_LENGTH = 0x03,
+  SEESAW_NEOPIXEL_BUF = 0x04,
+  SEESAW_NEOPIXEL_SHOW = 0x05,
+};
+
+enum {
+  SEESAW_TOUCH_CHANNEL_OFFSET = 0x10,
+};
+
+enum {
+  SEESAW_KEYPAD_STATUS = 0x00,
+  SEESAW_KEYPAD_EVENT = 0x01,
+  SEESAW_KEYPAD_INTENSET = 0x02,
+  SEESAW_KEYPAD_INTENCLR = 0x03,
+  SEESAW_KEYPAD_COUNT = 0x04,
+  SEESAW_KEYPAD_FIFO = 0x10,
+};
+
+enum {
+  SEESAW_KEYPAD_EDGE_HIGH = 0,
+  SEESAW_KEYPAD_EDGE_LOW,
+  SEESAW_KEYPAD_EDGE_FALLING,
+  SEESAW_KEYPAD_EDGE_RISING,
+};
+
+enum {
+  SEESAW_ENCODER_STATUS = 0x00,
+  SEESAW_ENCODER_INTENSET = 0x10,
+  INTENCLR = 0x20,
+  SEESAW_ENCODER_POSITION = 0x30,
+  SEESAW_ENCODER_DELTA = 0x40,
+};
+
+enum { INPUT, OUTPUT, INPUT_PULLUP, INPUT_PULLDOWN };
+
+class AdafruitSeesaw : public i2c::I2CDevice {
+ public:
+  void pin_mode(uint8_t pin, uint8_t mode);
+  void pin_mode_bulk(uint32_t pins, uint8_t mode);
+  void pin_mode_bulk(uint32_t pins_a, uint32_t pins_b, uint8_t mode);
+
+  bool digital_read(uint8_t pin);
+  uint32_t digital_read_bulk(uint32_t pins);
+  uint32_t digital_read_bulk_b(uint32_t pins);
+
+  i2c::ErrorCode write_8(uint16_t reg, uint8_t value);
+  i2c::ErrorCode write_16(uint16_t reg, uint16_t value);
+  i2c::ErrorCode write_32(uint16_t reg, uint32_t value);
+  i2c::ErrorCode write_64(uint16_t reg, uint64_t value);
+  i2c::ErrorCode read_32(uint16_t reg, uint32_t *value);
+  i2c::ErrorCode read_64(uint16_t reg, uint64_t *value);
+};
+
+}  // namespace adafruit_seesaw
+}  // namespace esphome

--- a/esphome/components/af4991/__init__.py
+++ b/esphome/components/af4991/__init__.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["i2c"]
+CODEOWNERS = ["@MrEditor97"]
+AUTO_LOAD = ["adafruit_seesaw"]
+
+af4991_ns = cg.esphome_ns.namespace("af4991")
+AF4991 = af4991_ns.class_("AF4991", cg.Component, i2c.I2CDevice)
+
+CONF_AF4991_ID = "af4991_id"
+
+MULTI_CONF = True
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(AF4991),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x36))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/af4991/af4991.cpp
+++ b/esphome/components/af4991/af4991.cpp
@@ -1,0 +1,47 @@
+#include "af4991.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace af4991 {
+
+static const char *const TAG = "af4991";
+
+void AF4991::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up AF4991...");
+
+  // Software Reset the device
+  this->write_8((uint16_t) adafruit_seesaw::SEESAW_STATUS_BASE << 8 | adafruit_seesaw::SEESAW_STATUS_SWRST,
+                (uint8_t) 0xFF);
+
+  delay(100);  // NO LINT
+
+  // Check connected device matches the expected device
+  this->read_32((uint16_t) adafruit_seesaw::SEESAW_STATUS_BASE << 8 | adafruit_seesaw::SEESAW_STATUS_VERSION,
+                &product_version_);
+  product_version_ = (product_version_ >> 16 & 0xFFFF);
+
+  if (product_version_ != 4991) {
+    this->error_code_ = this->INCORRECT_FIRMWARE_DETECTED;
+    this->mark_failed();
+    return;
+  }
+}
+
+void AF4991::dump_config() {
+  ESP_LOGCONFIG(TAG, "AF4991");
+  LOG_I2C_DEVICE(this);
+  ESP_LOGCONFIG(TAG, "  Product ID: %d", product_version_);
+
+  switch (this->error_code_) {
+    case this->INCORRECT_FIRMWARE_DETECTED:
+      ESP_LOGE(TAG, "The expected firmware for the Adafruit 4991 I2C Encoder board is: 4991, but got: %d",
+               product_version_);
+    case this->NONE:
+    default:
+      break;
+  }
+}
+
+}  // namespace af4991
+}  // namespace esphome

--- a/esphome/components/af4991/af4991.cpp
+++ b/esphome/components/af4991/af4991.cpp
@@ -22,7 +22,7 @@ void AF4991::setup() {
   product_version_ = (product_version_ >> 16 & 0xFFFF);
 
   if (product_version_ != 4991) {
-    this->error_code_ = this->INCORRECT_FIRMWARE_DETECTED;
+    this->error_code_ = INCORRECT_FIRMWARE_DETECTED;
     this->mark_failed();
     return;
   }
@@ -34,10 +34,10 @@ void AF4991::dump_config() {
   ESP_LOGCONFIG(TAG, "  Product ID: %d", product_version_);
 
   switch (this->error_code_) {
-    case this->INCORRECT_FIRMWARE_DETECTED:
+    case INCORRECT_FIRMWARE_DETECTED:
       ESP_LOGE(TAG, "The expected firmware for the Adafruit 4991 I2C Encoder board is: 4991, but got: %d",
                product_version_);
-    case this->NONE:
+    case NONE:
     default:
       break;
   }

--- a/esphome/components/af4991/af4991.cpp
+++ b/esphome/components/af4991/af4991.cpp
@@ -14,7 +14,7 @@ void AF4991::setup() {
   this->write_8((uint16_t) adafruit_seesaw::SEESAW_STATUS_BASE << 8 | adafruit_seesaw::SEESAW_STATUS_SWRST,
                 (uint8_t) 0xFF);
 
-  delay(100);  // NO LINT
+  delay(100);  // NOLINT
 
   // Check connected device matches the expected device
   this->read_32((uint16_t) adafruit_seesaw::SEESAW_STATUS_BASE << 8 | adafruit_seesaw::SEESAW_STATUS_VERSION,

--- a/esphome/components/af4991/af4991.h
+++ b/esphome/components/af4991/af4991.h
@@ -11,7 +11,9 @@ class AF4991 : public Component, public adafruit_seesaw::AdafruitSeesaw {
  public:
   void setup() override;
   void dump_config() override;
-
+  
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  
  protected:
   uint32_t product_version_ = 0;
   enum ErrorCode {

--- a/esphome/components/af4991/af4991.h
+++ b/esphome/components/af4991/af4991.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/core/hal.h"
+#include "esphome/core/component.h"
+#include "esphome/components/adafruit_seesaw/adafruit_seesaw.h"
+
+namespace esphome {
+namespace af4991 {
+
+class AF4991 : public Component, public adafruit_seesaw::AdafruitSeesaw {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  uint32_t product_version_ = 0;
+  enum ErrorCode {
+    NONE = 0,
+    INCORRECT_FIRMWARE_DETECTED,
+  } error_code_{NONE};
+};
+
+}  // namespace af4991
+}  // namespace esphome

--- a/esphome/components/af4991/af4991.h
+++ b/esphome/components/af4991/af4991.h
@@ -11,9 +11,9 @@ class AF4991 : public Component, public adafruit_seesaw::AdafruitSeesaw {
  public:
   void setup() override;
   void dump_config() override;
-  
+
   float get_setup_priority() const override { return setup_priority::DATA; }
-  
+
  protected:
   uint32_t product_version_ = 0;
   enum ErrorCode {

--- a/esphome/components/af4991/binary_sensor/__init__.py
+++ b/esphome/components/af4991/binary_sensor/__init__.py
@@ -1,0 +1,36 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import CONF_ID, CONF_PIN
+from .. import CONF_AF4991_ID, af4991_ns, AF4991
+
+DEPENDENCIES = ["af4991"]
+
+AF4991BinarySensor = af4991_ns.class_(
+    "AF4991BinarySensor", cg.Component, binary_sensor.BinarySensor
+)
+
+CONFIG_SCHEMA = cv.All(
+    binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(AF4991BinarySensor),
+            cv.Required(CONF_AF4991_ID): cv.use_id(AF4991),
+            cv.Optional(
+                CONF_PIN
+            ): cv.int_,  # The pin that is being used on the connected I2C Board
+        }
+    ).extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await binary_sensor.register_binary_sensor(var, config)
+
+    parent = await cg.get_variable(config[CONF_AF4991_ID])
+    cg.add(var.set_parent(parent))
+
+    if CONF_PIN in config:
+        cg.add(var.set_pin(config[CONF_PIN]))

--- a/esphome/components/af4991/binary_sensor/af4991_binary_sensor.cpp
+++ b/esphome/components/af4991/binary_sensor/af4991_binary_sensor.cpp
@@ -1,0 +1,28 @@
+#include "af4991_binary_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace af4991 {
+
+static const char *const TAG = "af4991.binary_sensor";
+
+void AF4991BinarySensor::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up AF4991 Encoder Switch...");
+  this->parent_->pin_mode(this->switch_pin_, adafruit_seesaw::INPUT_PULLUP);
+}
+
+void AF4991BinarySensor::dump_config() {
+  LOG_BINARY_SENSOR("", "AF4991 Switch", this);
+  ESP_LOGCONFIG(TAG, "  Pin: %i", this->switch_pin_);
+}
+
+void AF4991BinarySensor::loop() {
+  if (!this->parent_->digital_read(this->switch_pin_)) {
+    this->publish_state(true);
+  } else {
+    this->publish_state(false);
+  }
+}
+
+}  // namespace af4991
+}  // namespace esphome

--- a/esphome/components/af4991/binary_sensor/af4991_binary_sensor.h
+++ b/esphome/components/af4991/binary_sensor/af4991_binary_sensor.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/af4991/af4991.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+
+namespace esphome {
+namespace af4991 {
+
+class AF4991BinarySensor : public Component, public binary_sensor::BinarySensor {
+ public:
+  // Set parent value of the switch
+  void set_parent(AF4991 *parent) { this->parent_ = parent; }
+
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+
+ protected:
+  AF4991 *parent_{nullptr};
+
+  uint8_t switch_pin_{24};  // Built in through the I2C Boards firmware
+};
+
+}  // namespace af4991
+}  // namespace esphome

--- a/esphome/components/af4991/sensor/__init__.py
+++ b/esphome/components/af4991/sensor/__init__.py
@@ -1,0 +1,145 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.components import sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_INVERT,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_TRIGGER_ID,
+    CONF_VALUE,
+    ICON_ROTATE_RIGHT,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_STEPS,
+)
+from .. import CONF_AF4991_ID, af4991_ns, AF4991
+
+DEPENDENCIES = ["af4991"]
+
+AF4991Sensor = af4991_ns.class_("AF4991Sensor", cg.Component, sensor.Sensor)
+AF4991SensorSetValueAction = af4991_ns.class_(
+    "AF4991SensorSetValueAction", automation.Action
+)
+AF4991SensorClockwiseTrigger = af4991_ns.class_(
+    "AF4991SensorClockwiseTrigger", automation.Trigger
+)
+AF4991SensorAnticlockwiseTrigger = af4991_ns.class_(
+    "AF4991SensorAnticlockwiseTrigger", automation.Trigger
+)
+
+CONF_ON_CLOCKWISE = "on_clockwise"
+CONF_ON_ANTICLOCKWISE = "on_anticlockwise"
+CONF_CLOCKWISE_STEPS_BEFORE_TRIGGER = "clockwise_steps_before_trigger"
+CONF_ANTICLOCKWISE_STEPS_BEFORE_TRIGGER = "anticlockwise_steps_before_trigger"
+
+CONF_PUBLISH_INITIAL_VALUE = "publish_initial_value"
+
+
+def validate_min_max_value(config):
+    if CONF_MIN_VALUE in config and CONF_MAX_VALUE in config:
+        min_value = config[CONF_MIN_VALUE]
+        max_value = config[CONF_MAX_VALUE]
+
+        if min_value >= max_value:
+            raise cv.Invalid(
+                f"Max value {max_value} must be smaller than min value {min_value}"
+            )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    sensor.sensor_schema(
+        unit_of_measurement=UNIT_STEPS,
+        accuracy_decimals=0,
+        icon=ICON_ROTATE_RIGHT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(AF4991Sensor),
+            cv.Required(CONF_AF4991_ID): cv.use_id(AF4991),
+            cv.Optional(CONF_INVERT, default=False): cv.boolean,
+            cv.Optional(CONF_MIN_VALUE): cv.int_,
+            cv.Optional(CONF_MAX_VALUE): cv.int_,
+            cv.Optional(CONF_PUBLISH_INITIAL_VALUE, default=False): cv.boolean,
+            cv.Optional(
+                CONF_CLOCKWISE_STEPS_BEFORE_TRIGGER, default=1
+            ): cv.positive_int,
+            cv.Optional(
+                CONF_ANTICLOCKWISE_STEPS_BEFORE_TRIGGER, default=1
+            ): cv.positive_int,
+            cv.Optional(CONF_ON_CLOCKWISE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        AF4991SensorClockwiseTrigger
+                    )
+                }
+            ),
+            cv.Optional(CONF_ON_ANTICLOCKWISE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        AF4991SensorAnticlockwiseTrigger
+                    )
+                }
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA),
+    validate_min_max_value,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)
+
+    parent = await cg.get_variable(config[CONF_AF4991_ID])
+    cg.add(var.set_parent(parent))
+
+    cg.add(var.set_sensor_invert(config[CONF_INVERT]))
+    cg.add(var.set_publish_initial_value(config[CONF_PUBLISH_INITIAL_VALUE]))
+
+    if CONF_MIN_VALUE in config:
+        cg.add(var.set_min_value(config[CONF_MIN_VALUE]))
+    if CONF_MAX_VALUE in config:
+        cg.add(var.set_max_value(config[CONF_MAX_VALUE]))
+
+    cg.add(
+        var.set_clockwise_steps_before_trigger(
+            config[CONF_CLOCKWISE_STEPS_BEFORE_TRIGGER]
+        )
+    )
+    cg.add(
+        var.set_anticlockwise_steps_before_trigger(
+            config[CONF_ANTICLOCKWISE_STEPS_BEFORE_TRIGGER]
+        )
+    )
+
+    for conf in config.get(CONF_ON_CLOCKWISE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_ANTICLOCKWISE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+
+
+@automation.register_action(
+    "sensor.af4991.set_value",
+    AF4991SensorSetValueAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(AF4991),
+            cv.Required(CONF_VALUE): cv.templatable(cv.int_),
+        }
+    ),
+)
+async def sensor_template_publish_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    template_ = await cg.templatable(config[CONF_VALUE], args, int)
+    cg.add(var.set_value(template_))
+
+    return var

--- a/esphome/components/af4991/sensor/af4991_sensor.cpp
+++ b/esphome/components/af4991/sensor/af4991_sensor.cpp
@@ -1,0 +1,100 @@
+#include "af4991_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace af4991 {
+
+static const char *const TAG = "af4991.sensor";
+
+void AF4991Sensor::setup() { ESP_LOGCONFIG(TAG, "Setting up AF4991 Encoder Sensor..."); }
+
+void AF4991Sensor::dump_config() {
+  LOG_SENSOR("", "AF4991 Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Invert: %s", this->invert_ ? "true" : "false");
+  ESP_LOGCONFIG(TAG, "  Clockwise Rotation before Trigger: %isteps", this->clockwise_steps_before_trigger_);
+  ESP_LOGCONFIG(TAG, "  Anticlockwise Rotation before Trigger: %isteps", this->anticlockwise_steps_before_trigger_);
+}
+
+/**
+ * @brief Checks to ensure the read sensor value is within the limits set by the user
+ *
+ * @param position position to reference from
+ * @return int32_t
+ */
+int32_t AF4991Sensor::check_position_within_limit_(int32_t position) {
+  if (position > this->max_value_) {
+    this->set_sensor_value(this->invert_ ? ~this->max_value_ + 1 : this->max_value_);
+    position = this->max_value_;
+
+    return position;
+  }
+
+  if (position < this->min_value_) {
+    this->set_sensor_value(this->invert_ ? ~this->min_value_ + 1 : this->min_value_);
+    position = this->min_value_;
+
+    return position;
+  }
+
+  return position;
+}
+
+void AF4991Sensor::loop() {
+  uint32_t unsigned_new_position = 0;
+  int32_t new_position = 0;
+  int32_t unchecked_new_position = 0;
+
+  // Retrieve encoder position
+  i2c::ErrorCode error = this->parent_->read_32(
+      (uint16_t) adafruit_seesaw::SEESAW_ENCODER_BASE << 8 | adafruit_seesaw::SEESAW_ENCODER_POSITION,
+      &unsigned_new_position);
+
+  // Convert to int32_t
+  new_position = check_position_within_limit_(this->invert_ ? (int32_t) ~unsigned_new_position + 1
+                                                            : (int32_t) unsigned_new_position);
+  unchecked_new_position = this->invert_ ? (int32_t) ~unsigned_new_position + 1 : (int32_t) unsigned_new_position;
+
+  // Check to see if there was a error
+  if (error != i2c::ERROR_OK) {
+    return;
+  }
+
+  // Calculate encoder rotation direction
+  // Clockwise Directional Movements
+  if (unchecked_new_position > this->position_) {
+    this->clockwise_move_ += 1;
+    this->anticlockwise_move_ = 0;
+
+    // Check to see if made movement is enough to trigger the automation trigger
+    if (this->clockwise_move_ >= this->clockwise_steps_before_trigger_) {
+      this->clockwise_move_ = 0;
+
+      this->on_clockwise_callback_.call();
+    }
+
+    // Anticlockwise Directional Movements
+  } else if (unchecked_new_position < this->position_) {
+    this->anticlockwise_move_ += 1;
+    this->clockwise_move_ = 0;
+
+    // Check to see if made movement is enough to trigger the automation trigger
+    if (this->anticlockwise_move_ >= this->anticlockwise_steps_before_trigger_) {
+      this->anticlockwise_move_ = 0;
+
+      this->on_anticlockwise_callback_.call();
+    }
+  }
+
+  // Check to see if positional value has changed
+  if (this->position_ != new_position || this->publish_initial_value_) {
+    // Publish new state
+    this->publish_state(new_position);
+
+    // Updates stored position
+    this->position_ = new_position;
+    this->publish_initial_value_ = false;
+  }
+}
+
+}  // namespace af4991
+}  // namespace esphome

--- a/esphome/components/af4991/sensor/af4991_sensor.h
+++ b/esphome/components/af4991/sensor/af4991_sensor.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/af4991/af4991.h"
+
+namespace esphome {
+namespace af4991 {
+
+class AF4991Sensor : public Component, public sensor::Sensor {
+ public:
+  // Set parent value of the sensor
+  void set_parent(AF4991 *parent) { this->parent_ = parent; }
+
+  // Set the sensor value
+  void set_sensor_value(int32_t value) {
+    this->parent_->write_32(
+        (uint16_t) adafruit_seesaw::SEESAW_ENCODER_BASE << 8 | adafruit_seesaw::SEESAW_ENCODER_POSITION,
+        (uint32_t) value);
+  }
+
+  // Invert sensor value
+  void set_sensor_invert(bool invert) { this->invert_ = invert; }
+
+  // Publish initial value
+  void set_publish_initial_value(bool publish_initial_value) { this->publish_initial_value_ = publish_initial_value; }
+
+  // Set min and max values
+  void set_min_value(int32_t min_value) { this->min_value_ = min_value; }
+  void set_max_value(int32_t max_value) { this->max_value_ = max_value; }
+
+  // Callbacks trigger after x number of steps
+  void set_clockwise_steps_before_trigger(int32_t value) { this->clockwise_steps_before_trigger_ = value; }
+  void set_anticlockwise_steps_before_trigger(int32_t value) { this->anticlockwise_steps_before_trigger_ = value; }
+
+  // Directional callbacks
+  void add_on_clockwise_callback(std::function<void()> callback) {
+    this->on_clockwise_callback_.add(std::move(callback));
+  }
+  void add_on_anticlockwise_callback(std::function<void()> callback) {
+    this->on_anticlockwise_callback_.add(std::move(callback));
+  }
+
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+
+ protected:
+  int32_t check_position_within_limit_(int32_t position);
+
+  AF4991 *parent_{nullptr};
+
+  bool invert_ = false;
+  bool publish_initial_value_ = false;
+
+  int32_t min_value_{INT32_MIN};
+  int32_t max_value_{INT32_MAX};
+
+  volatile int32_t position_{this->min_value_ > 0 ? this->min_value_ : 0};
+  int32_t clockwise_steps_before_trigger_{1};
+  int32_t anticlockwise_steps_before_trigger_{1};
+  int32_t clockwise_move_{0};
+  int32_t anticlockwise_move_{0};
+
+  CallbackManager<void()> on_clockwise_callback_;
+  CallbackManager<void()> on_anticlockwise_callback_;
+};
+
+template<typename... Ts> class AF4991SensorSetValueAction : public Action<Ts...> {
+ public:
+  AF4991SensorSetValueAction(AF4991Sensor *encoder) : encoder_(encoder) {}
+  TEMPLATABLE_VALUE(int32_t, value)
+
+  void play(Ts... x) override { this->encoder_->set_sensor_value((int32_t) this->value_.value(x...)); }
+
+ protected:
+  AF4991Sensor *encoder_;
+};
+
+class AF4991SensorClockwiseTrigger : public Trigger<> {
+ public:
+  explicit AF4991SensorClockwiseTrigger(AF4991Sensor *parent) {
+    parent->add_on_clockwise_callback([this]() { this->trigger(); });
+  }
+};
+
+class AF4991SensorAnticlockwiseTrigger : public Trigger<> {
+ public:
+  explicit AF4991SensorAnticlockwiseTrigger(AF4991Sensor *parent) {
+    parent->add_on_anticlockwise_callback([this]() { this->trigger(); });
+  }
+};
+
+}  // namespace af4991
+}  // namespace esphome

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -298,6 +298,9 @@ sensor:
       name: "Wave Mini Pressure"
     tvoc:
       name: "Wave Mini VOC"
+  - platform: af4991
+    af4991_id: af4991_component
+    name: Rotary Encoder
 
 time:
   - platform: homeassistant
@@ -371,7 +374,10 @@ binary_sensor:
       name: 'CGPR1 Idle Time'
     illuminance:
       name: 'CGPR1 Illuminance'
-
+  - platform: af4991
+    af4991_id: af4991_component
+    name: Encoder Switch
+    
 esp32_ble_tracker:
   on_ble_advertise:
     - mac_address: AC:37:43:77:5F:4C
@@ -510,3 +516,7 @@ cap1188:
   touch_threshold: 0x20
   allow_multiple_touches: true
   reset_pin: 14
+
+af4991:
+  id: af4991_component
+  address: 0x36


### PR DESCRIPTION
# What does this implement/fix? 

Adds the ability to use Adafruit I2C QT Rotary Encoder breakout boards.
I have added a little bit of a multi-use section within the pull request which contains some of the methods of communication with Adafruit's Seesaw based boards with the intention of adding support for the SAMD09 extension board in the future, which should use the same read and write methods that I have used for the encoder board.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1623

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

i2c:
  sda: 21
  scl: 22
  scan: true

af4991:
  id: af4991_component
  address: 0x36

sensor:
  - platform: af4991
    af4991_id: af4991_component
    name: Rotary Encoder

# Only required if the encoder has a button built into it
binary_sensor:
  - platform: af4991
    af4991_id: af4991_component
    name: Rotary Encoder Switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
