### PR TITLE
Improv serial/checksum changes

### DIFF
--- a/esphome/components/improv/improv.cpp
+++ b/esphome/components/improv/improv.cpp
@@ -11,7 +11,7 @@ ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_c
   Command command = (Command) data[0];
   uint8_t data_length = data[1];
 
-  if (data_length != length - 3) {
+  if (data_length != length - 2 - check_checksum) {
     improv_command.command = UNKNOWN;
     return improv_command;
   }

--- a/esphome/components/improv/improv.cpp
+++ b/esphome/components/improv/improv.cpp
@@ -71,7 +71,7 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::
   return out;
 }
 
-#ifdef USE_ARDUINO
+#ifdef ARDUINO
 std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum) {
   std::vector<uint8_t> out;
   uint32_t length = 0;
@@ -94,6 +94,6 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<Strin
   }
   return out;
 }
-#endif  // USE_ARDUINO
+#endif  // ARDUINO
 
 }  // namespace improv

--- a/esphome/components/improv/improv.cpp
+++ b/esphome/components/improv/improv.cpp
@@ -2,11 +2,11 @@
 
 namespace improv {
 
-ImprovCommand parse_improv_data(const std::vector<uint8_t> &data) {
-  return parse_improv_data(data.data(), data.size());
+ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_checksum) {
+  return parse_improv_data(data.data(), data.size(), check_checksum);
 }
 
-ImprovCommand parse_improv_data(const uint8_t *data, size_t length) {
+ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_checksum) {
   ImprovCommand improv_command;
   Command command = (Command) data[0];
   uint8_t data_length = data[1];
@@ -16,16 +16,18 @@ ImprovCommand parse_improv_data(const uint8_t *data, size_t length) {
     return improv_command;
   }
 
-  uint8_t checksum = data[length - 1];
+  if (check_checksum) {
+    uint8_t checksum = data[length - 1];
 
-  uint32_t calculated_checksum = 0;
-  for (uint8_t i = 0; i < length - 1; i++) {
-    calculated_checksum += data[i];
-  }
+    uint32_t calculated_checksum = 0;
+    for (uint8_t i = 0; i < length - 1; i++) {
+      calculated_checksum += data[i];
+    }
 
-  if ((uint8_t) calculated_checksum != checksum) {
-    improv_command.command = BAD_CHECKSUM;
-    return improv_command;
+    if ((uint8_t) calculated_checksum != checksum) {
+      improv_command.command = BAD_CHECKSUM;
+      return improv_command;
+    }
   }
 
   if (command == WIFI_SETTINGS) {
@@ -46,7 +48,7 @@ ImprovCommand parse_improv_data(const uint8_t *data, size_t length) {
   return improv_command;
 }
 
-std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::string> &datum) {
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::string> &datum, bool add_checksum) {
   std::vector<uint8_t> out;
   uint32_t length = 0;
   out.push_back(command);
@@ -58,17 +60,19 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::
   }
   out.insert(out.begin() + 1, length);
 
-  uint32_t calculated_checksum = 0;
+  if (add_checksum) {
+    uint32_t calculated_checksum = 0;
 
-  for (uint8_t byte : out) {
-    calculated_checksum += byte;
+    for (uint8_t byte : out) {
+      calculated_checksum += byte;
+    }
+    out.push_back(calculated_checksum);
   }
-  out.push_back(calculated_checksum);
   return out;
 }
 
 #ifdef USE_ARDUINO
-std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum) {
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum) {
   std::vector<uint8_t> out;
   uint32_t length = 0;
   out.push_back(command);
@@ -80,12 +84,14 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<Strin
   }
   out.insert(out.begin() + 1, length);
 
-  uint32_t calculated_checksum = 0;
+  if (add_checksum) {
+    uint32_t calculated_checksum = 0;
 
-  for (uint8_t byte : out) {
-    calculated_checksum += byte;
+    for (uint8_t byte : out) {
+      calculated_checksum += byte;
+    }
+    out.push_back(calculated_checksum);
   }
-  out.push_back(calculated_checksum);
   return out;
 }
 #endif  // USE_ARDUINO

--- a/esphome/components/improv/improv.h
+++ b/esphome/components/improv/improv.h
@@ -51,12 +51,13 @@ struct ImprovCommand {
   std::string password;
 };
 
-ImprovCommand parse_improv_data(const std::vector<uint8_t> &data);
-ImprovCommand parse_improv_data(const uint8_t *data, size_t length);
+ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_checksum = true);
+ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_checksum = true);
 
-std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::string> &datum);
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::string> &datum,
+                                        bool add_checksum = true);
 #ifdef ARDUINO
-std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum);
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum = true);
 #endif  // ARDUINO
 
 }  // namespace improv

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -98,13 +98,13 @@ std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv:
   std::string webserver_url = "http://" + ip.str() + ":" + to_string(WEBSERVER_PORT);
   urls.push_back(webserver_url);
 #endif
-  std::vector<uint8_t> data = improv::build_rpc_response(command, urls);
+  std::vector<uint8_t> data = improv::build_rpc_response(command, urls, false);
   return data;
 }
 
 std::vector<uint8_t> ImprovSerialComponent::build_version_info_() {
   std::vector<std::string> infos = {"ESPHome", ESPHOME_VERSION, ESPHOME_VARIANT, App.get_name()};
-  std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_DEVICE_INFO, infos);
+  std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_DEVICE_INFO, infos, false);
   return data;
 };
 
@@ -143,7 +143,7 @@ bool ImprovSerialComponent::parse_improv_serial_byte_(uint8_t byte) {
   if (at == 8 + data_len) {
     if (type == TYPE_RPC) {
       this->set_error_(improv::ERROR_NONE);
-      auto command = improv::parse_improv_data(&raw[9], data_len);
+      auto command = improv::parse_improv_data(&raw[9], data_len, false);
       return this->parse_improv_payload_(command);
     }
   }
@@ -232,6 +232,12 @@ void ImprovSerialComponent::send_response_(std::vector<uint8_t> &response) {
   data[7] = TYPE_RPC_RESPONSE;
   data[8] = response.size();
   data.insert(data.end(), response.begin(), response.end());
+
+  uint8_t checksum = 0x00;
+  for (uint8_t d : data)
+    checksum += d;
+  data.push_back(checksum);
+
   this->write_data_(data);
 }
 


### PR DESCRIPTION
# What does this implement/fix? 

`improv_serial` does not do checksums of the data portion but a checksum of the packet as a whole which is outside the shared `improv` code.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
