### PR TITLE
Fix zeroconf time comparisons

### DIFF
--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -14,8 +14,8 @@ from zeroconf import (
     Zeroconf,
     ServiceBrowser,
 )
-from zeroconf._services import ServiceStateChange
-from zeroconf._utils.time import current_time_millis
+from zeroconf import ServiceStateChange
+from zeroconf import current_time_millis
 
 _CLASS_IN = 1
 _FLAGS_QR_QUERY = 0x0000  # query

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -88,7 +88,7 @@ class DashboardStatus(threading.Thread):
         entries = self.zc.cache.entries_with_name(key)
         if not entries:
             return False
-        now = time.time() * 1000
+        now = time.monotonic() * 1000
 
         return any(
             (entry.created + DashboardStatus.OFFLINE_AFTER) >= now for entry in entries
@@ -99,7 +99,7 @@ class DashboardStatus(threading.Thread):
             self.on_update(
                 {key: self.host_status(host) for key, host in self.key_to_host.items()}
             )
-            now = time.time() * 1000
+            now = time.monotonic() * 1000
             for host in self.query_hosts:
                 entries = self.zc.cache.entries_with_name(host)
                 if not entries or all(

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -13,9 +13,9 @@ from zeroconf import (
     RecordUpdateListener,
     Zeroconf,
     ServiceBrowser,
+    ServiceStateChange,
+    current_time_millis,
 )
-from zeroconf import ServiceStateChange
-from zeroconf import current_time_millis
 
 _CLASS_IN = 1
 _FLAGS_QR_QUERY = 0x0000  # query

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -15,6 +15,7 @@ from zeroconf import (
     ServiceBrowser,
 )
 from zeroconf._services import ServiceStateChange
+from zeroconf._utils.time import current_time_millis
 
 _CLASS_IN = 1
 _FLAGS_QR_QUERY = 0x0000  # query
@@ -88,7 +89,7 @@ class DashboardStatus(threading.Thread):
         entries = self.zc.cache.entries_with_name(key)
         if not entries:
             return False
-        now = time.monotonic() * 1000
+        now = current_time_millis()
 
         return any(
             (entry.created + DashboardStatus.OFFLINE_AFTER) >= now for entry in entries
@@ -99,7 +100,7 @@ class DashboardStatus(threading.Thread):
             self.on_update(
                 {key: self.host_status(host) for key, host in self.key_to_host.items()}
             )
-            now = time.monotonic() * 1000
+            now = current_time_millis()
             for host in self.query_hosts:
                 entries = self.zc.cache.entries_with_name(host)
                 if not entries or all(


### PR DESCRIPTION
# What does this implement/fix? 

The changes in https://github.com/jstasiak/python-zeroconf/pull/1006 meant that the time returned from `.created` on the DNSEntry was now different and we were comparing that to `time.time() * 1000`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
