### PR TITLE
Allow for subsecond sampling of hmc5883l

### DIFF
--- a/esphome/components/hmc5883l/sensor.py
+++ b/esphome/components/hmc5883l/sensor.py
@@ -114,8 +114,8 @@ CONFIG_SCHEMA = (
 
 
 def auto_data_rate(config):
-    interval_sec = config[CONF_UPDATE_INTERVAL].seconds
-    interval_hz = 1.0 / interval_sec
+    interval_msec = config[CONF_UPDATE_INTERVAL].total_milliseconds
+    interval_hz = 1000.0 / interval_msec
     for datarate in sorted(HMC5883LDatarates.keys()):
         if float(datarate) >= interval_hz:
             return HMC5883LDatarates[datarate]


### PR DESCRIPTION
# What does this implement/fix? 

The HMC5883L magnetic field sensor only accepted update intervals >= 1 second. But the device can handle more frequent updates (up to 75Hz I believe). Use total_milliseconds instead of seconds to allow for update intervals specified in milliseconds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: hmc5883l
    update_interval: 25ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
