### PR TITLE
Change log level from DEBUG to INFO for sniffing services of `rf_bridge`

### DIFF
--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -52,7 +52,7 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
       if (action == RF_CODE_LEARN_OK)
         ESP_LOGD(TAG, "Learning success");
 
-      ESP_LOGD(TAG, "Received RFBridge Code: sync=0x%04X low=0x%04X high=0x%04X code=0x%06X", data.sync, data.low,
+      ESP_LOGI(TAG, "Received RFBridge Code: sync=0x%04X low=0x%04X high=0x%04X code=0x%06X", data.sync, data.low,
                data.high, data.code);
       this->data_callback_.call(data);
       break;
@@ -73,7 +73,7 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
         data.code += next_byte;
       }
 
-      ESP_LOGD(TAG, "Received RFBridge Advanced Code: length=0x%02X protocol=0x%02X code=0x%s", data.length,
+      ESP_LOGI(TAG, "Received RFBridge Advanced Code: length=0x%02X protocol=0x%02X code=0x%s", data.length,
                data.protocol, data.code.c_str());
       this->advanced_data_callback_.call(data);
       break;
@@ -97,7 +97,7 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
           str += " ";
         }
       }
-      ESP_LOGD(TAG, "Received RFBridge Bucket: %s", str.c_str());
+      ESP_LOGI(TAG, "Received RFBridge Bucket: %s", str.c_str());
       break;
     }
     default:
@@ -186,7 +186,7 @@ void RFBridgeComponent::dump_config() {
 }
 
 void RFBridgeComponent::start_advanced_sniffing() {
-  ESP_LOGD(TAG, "Advanced Sniffing on");
+  ESP_LOGI(TAG, "Advanced Sniffing on");
   this->write(RF_CODE_START);
   this->write(RF_CODE_SNIFFING_ON);
   this->write(RF_CODE_STOP);
@@ -194,7 +194,7 @@ void RFBridgeComponent::start_advanced_sniffing() {
 }
 
 void RFBridgeComponent::stop_advanced_sniffing() {
-  ESP_LOGD(TAG, "Advanced Sniffing off");
+  ESP_LOGI(TAG, "Advanced Sniffing off");
   this->write(RF_CODE_START);
   this->write(RF_CODE_SNIFFING_OFF);
   this->write(RF_CODE_STOP);
@@ -202,7 +202,7 @@ void RFBridgeComponent::stop_advanced_sniffing() {
 }
 
 void RFBridgeComponent::start_bucket_sniffing() {
-  ESP_LOGD(TAG, "Raw Bucket Sniffing on");
+  ESP_LOGI(TAG, "Raw Bucket Sniffing on");
   this->write(RF_CODE_START);
   this->write(RF_CODE_RFIN_BUCKET);
   this->write(RF_CODE_STOP);


### PR DESCRIPTION
Sniffing for codes only happens if the user deliberately asked for it with the related service through HA - to find out the codes present in the air. The resulted data shouldn't be printed out only in debug mode, as this is information required to be known on demand for later use, not actually a debug info. Changing log level from DEBUG to INFO for sniffing services has two benefits:
- no need to run firmware with DEBUG enabled for occasional sniffing with devices in production (no need to flash back and forth with different log levels set just for this reason)
- if the user still wants DEBUG enabled, sniffed data appears in different color, it's easier to find between the lines.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
