### PR TITLE
BLE_Sensor: Use as_reversed_hex_array to properly parse UUIDs after #1627

### DIFF
--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -67,7 +67,7 @@ async def to_code(config):
             var.set_service_uuid32(esp32_ble_tracker.as_hex(config[CONF_SERVICE_UUID]))
         )
     elif len(config[CONF_SERVICE_UUID]) == len(esp32_ble_tracker.bt_uuid128_format):
-        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_SERVICE_UUID])
+        uuid128 = esp32_ble_tracker.as_reversed_hex_array(config[CONF_SERVICE_UUID])
         cg.add(var.set_service_uuid128(uuid128))
 
     if len(config[CONF_CHARACTERISTIC_UUID]) == len(esp32_ble_tracker.bt_uuid16_format):
@@ -87,7 +87,9 @@ async def to_code(config):
     elif len(config[CONF_CHARACTERISTIC_UUID]) == len(
         esp32_ble_tracker.bt_uuid128_format
     ):
-        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_CHARACTERISTIC_UUID])
+        uuid128 = esp32_ble_tracker.as_reversed_hex_array(
+            config[CONF_CHARACTERISTIC_UUID]
+        )
         cg.add(var.set_char_uuid128(uuid128))
 
     if CONF_DESCRIPTOR_UUID in config:
@@ -108,7 +110,9 @@ async def to_code(config):
         elif len(config[CONF_DESCRIPTOR_UUID]) == len(
             esp32_ble_tracker.bt_uuid128_format
         ):
-            uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_DESCRIPTOR_UUID])
+            uuid128 = esp32_ble_tracker.as_reversed_hex_array(
+                config[CONF_DESCRIPTOR_UUID]
+            )
             cg.add(var.set_descr_uuid128(uuid128))
 
     if CONF_LAMBDA in config:


### PR DESCRIPTION
# What does this implement/fix? 
#1627 has been incorrectly labeled as a non-breaking change.  After this PR, the `ble_sensor` has been reversing 128-bit UUIDs.  

My yaml for the ble sensor is:
```yaml
service_uuid: "10100000-5354-4F52-5A26-4249434B454C"
characteristic_uuid: "1010000c-5354-4f52-5a26-4249434b454c"
```

but, after a compile, esphome outputs this (reversed uuids):
```
[11:25:01][C][ble_sensor:021]:   Service UUID       : 4C454B43-4942-265A-524F-545300001010
[11:25:01][C][ble_sensor:022]:   Characteristic UUID: 4C454B43-4942-265A-524F-54530C001010
```

I ran git bisect to determine this PR was the cause of my issue.  

After this fix it properly logs the correct UUIDs.  Thanks to Oxan in the ESPHome discord for the help.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
service_uuid: "10100000-5354-4F52-5A26-4249434B454C"
characteristic_uuid: "1010000c-5354-4f52-5a26-4249434b454c"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
