### PR TITLE
2021.11.0b9

### DIFF
--- a/esphome/components/ble_client/sensor/__init__.py
+++ b/esphome/components/ble_client/sensor/__init__.py
@@ -67,7 +67,7 @@ async def to_code(config):
             var.set_service_uuid32(esp32_ble_tracker.as_hex(config[CONF_SERVICE_UUID]))
         )
     elif len(config[CONF_SERVICE_UUID]) == len(esp32_ble_tracker.bt_uuid128_format):
-        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_SERVICE_UUID])
+        uuid128 = esp32_ble_tracker.as_reversed_hex_array(config[CONF_SERVICE_UUID])
         cg.add(var.set_service_uuid128(uuid128))
 
     if len(config[CONF_CHARACTERISTIC_UUID]) == len(esp32_ble_tracker.bt_uuid16_format):
@@ -87,7 +87,9 @@ async def to_code(config):
     elif len(config[CONF_CHARACTERISTIC_UUID]) == len(
         esp32_ble_tracker.bt_uuid128_format
     ):
-        uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_CHARACTERISTIC_UUID])
+        uuid128 = esp32_ble_tracker.as_reversed_hex_array(
+            config[CONF_CHARACTERISTIC_UUID]
+        )
         cg.add(var.set_char_uuid128(uuid128))
 
     if CONF_DESCRIPTOR_UUID in config:
@@ -108,7 +110,9 @@ async def to_code(config):
         elif len(config[CONF_DESCRIPTOR_UUID]) == len(
             esp32_ble_tracker.bt_uuid128_format
         ):
-            uuid128 = esp32_ble_tracker.as_hex_array(config[CONF_DESCRIPTOR_UUID])
+            uuid128 = esp32_ble_tracker.as_reversed_hex_array(
+                config[CONF_DESCRIPTOR_UUID]
+            )
             cg.add(var.set_descr_uuid128(uuid128))
 
     if CONF_LAMBDA in config:

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -141,11 +141,15 @@ void SenseAirComponent::abc_get_period() {
 }
 
 bool SenseAirComponent::senseair_write_command_(const uint8_t *command, uint8_t *response, uint8_t response_length) {
+  // Verify we have somewhere to store the response
+  if (response == nullptr) {
+    return false;
+  }
+  // Write wake up byte required by some S8 sensor models
+  this->write_byte(0);
   this->flush();
+  delay(5);
   this->write_array(command, SENSEAIR_REQUEST_LENGTH);
-
-  if (response == nullptr)
-    return true;
 
   bool ret = this->read_array(response, response_length);
   this->flush();

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2021.11.0b8"
+__version__ = "2021.11.0b9"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"Some people, when confronted with a problem, think “I know, I’ll use regular expressions.” Now they have two problems."_

~ Jamie Zawinski
- BLE_Sensor: Use as_reversed_hex_array to properly parse UUIDs after #1627 [esphome#2737](https://github.com/esphome/esphome/pull/2737) (breaking-change)
- Fix senseair component uart read timeout [esphome#2658](https://github.com/esphome/esphome/pull/2658)
