### PR TITLE
Remove arduino dependency from hm3301

### DIFF
--- a/esphome/components/hm3301/abstract_aqi_calculator.h
+++ b/esphome/components/hm3301/abstract_aqi_calculator.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef USE_ARDUINO
 #include <cstdint>
 
 namespace esphome {
@@ -13,5 +12,3 @@ class AbstractAQICalculator {
 
 }  // namespace hm3301
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/hm3301/aqi_calculator.h
+++ b/esphome/components/hm3301/aqi_calculator.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifdef USE_ARDUINO
-
 #include "abstract_aqi_calculator.h"
 
 namespace esphome {
@@ -48,5 +46,3 @@ class AQICalculator : public AbstractAQICalculator {
 
 }  // namespace hm3301
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/hm3301/aqi_calculator_factory.h
+++ b/esphome/components/hm3301/aqi_calculator_factory.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifdef USE_ARDUINO
-
 #include "caqi_calculator.h"
 #include "aqi_calculator.h"
 
@@ -29,5 +27,3 @@ class AQICalculatorFactory {
 
 }  // namespace hm3301
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/hm3301/caqi_calculator.h
+++ b/esphome/components/hm3301/caqi_calculator.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifdef USE_ARDUINO
-
 #include "esphome/core/log.h"
 #include "abstract_aqi_calculator.h"
 
@@ -52,5 +50,3 @@ class CAQICalculator : public AbstractAQICalculator {
 
 }  // namespace hm3301
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/hm3301/hm3301.h
+++ b/esphome/components/hm3301/hm3301.h
@@ -1,16 +1,14 @@
 #pragma once
 
-#ifdef USE_ARDUINO
-
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 #include "aqi_calculator_factory.h"
 
-#include <Seeed_HM330X.h>
-
 namespace esphome {
 namespace hm3301 {
+
+static const uint8_t SELECT_COMM_CMD = 0X88;
 
 class HM3301Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -29,9 +27,12 @@ class HM3301Component : public PollingComponent, public i2c::I2CDevice {
   void update() override;
 
  protected:
-  std::unique_ptr<HM330X> hm3301_;
-
-  HM330XErrorCode error_code_{NO_ERROR};
+  enum {
+    NO_ERROR = 0,
+    ERROR_PARAM = -1,
+    ERROR_COMM = -2,
+    ERROR_OTHERS = -128,
+  } error_code_{NO_ERROR};
 
   uint8_t data_buffer_[30];
 
@@ -43,12 +44,9 @@ class HM3301Component : public PollingComponent, public i2c::I2CDevice {
   AQICalculatorType aqi_calc_type_;
   AQICalculatorFactory aqi_calculator_factory_ = AQICalculatorFactory();
 
-  bool read_sensor_value_(uint8_t *);
   bool validate_checksum_(const uint8_t *);
   uint16_t get_sensor_value_(const uint8_t *, uint8_t);
 };
 
 }  // namespace hm3301
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/hm3301/sensor.py
+++ b/esphome/components/hm3301/sensor.py
@@ -84,7 +84,6 @@ CONFIG_SCHEMA = cv.All(
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x40)),
     _validate,
-    cv.only_with_arduino,
 )
 
 
@@ -109,6 +108,3 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_AQI])
         cg.add(var.set_aqi_sensor(sens))
         cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))
-
-    # https://platformio.org/lib/show/6306/Grove%20-%20Laser%20PM2.5%20Sensor%20HM3301
-    cg.add_library("seeed-studio/Grove - Laser PM2.5 Sensor HM3301", "1.0.3")

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,6 @@ lib_deps =
     fastled/FastLED@3.3.2                                 ; fastled_base
     mikalhart/TinyGPSPlus@1.0.2                           ; gps
     freekode/TM1651@1.0.1                                 ; tm1651
-    seeed-studio/Grove - Laser PM2.5 Sensor HM3301@1.0.3  ; hm3301
     glmnet/Dsmr@0.5                                       ; dsmr
     rweather/Crypto@0.2.0                                 ; dsmr
     dudanov/MideaUART@1.1.8                               ; midea


### PR DESCRIPTION
# What does this implement/fix? 
Remove the dependency on Arduino.
Enable esp-idf

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: hm-test

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:

i2c:
  sda: 21
  scl: 22

sensor:
  - platform: hm3301
    address: 0x40
    pm_1_0:
      name: "PM1.0"
    pm_2_5:
      name: "PM2.5"
    pm_10_0:
      name: "PM10.0"
    aqi:
      name: "AQI"
      calculation_type: "CAQI"
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
