### PR TITLE
Update aht10.cpp

### DIFF
--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -54,6 +54,7 @@ void AHT10Component::update() {
     this->status_set_warning();
     return;
   }
+  delayMicroseconds(40);
   uint8_t data[6];
   uint8_t delay = AHT10_DEFAULT_DELAY;
   if (this->humidity_sensor_ != nullptr)


### PR DESCRIPTION
Adds the required delay between polls.

# What does this implement/fix? 
Fix for esp8266. Creates the required delay between polls.

Quick description and explanation of changes

On esp8266(esp8285) without this delay, the aht10 sensor is not updated! Data is read only once at power up.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [+] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

https://github.com/esphome/issues/issues/1635

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [+] ESP32
- [ ] ESP32 IDF
- [+] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [+] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
 
It was:
![esphome_aht10_err](https://user-images.githubusercontent.com/48506975/142199782-496e74ee-988d-4728-9a86-c35779e9c46d.jpg)

Has become:
![esphome_aht10_ok](https://user-images.githubusercontent.com/48506975/142199835-c759a2a2-274c-4829-9af2-83c5b2f8e42b.jpg)

