### PR TITLE
Remove PM2.5 as part of CAQI calculations

### DIFF
--- a/esphome/components/hm3301/aqi_calculator.h
+++ b/esphome/components/hm3301/aqi_calculator.h
@@ -9,7 +9,7 @@ class AQICalculator : public AbstractAQICalculator {
  public:
   uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
     int pm2_5_index = calculate_index_(pm2_5_value, pm2_5_calculation_grid_);
-    int pm10_0_index = calculate_index_(pm10_0_value, pm10_0_calculation_grid_);
+    int pm10_0_index = calculate_index_(pm10_0_value, pm10_0_concentration_breakpoints_);
 
     return (pm2_5_index < pm10_0_index) ? pm10_0_index : pm2_5_index;
   }
@@ -17,26 +17,30 @@ class AQICalculator : public AbstractAQICalculator {
  protected:
   static const int AMOUNT_OF_LEVELS = 6;
 
-  int index_grid_[AMOUNT_OF_LEVELS][2] = {{0, 51}, {51, 100}, {101, 150}, {151, 200}, {201, 300}, {301, 500}};
+  int aqi_index_[AMOUNT_OF_LEVELS][2] = {{0, 51}, {51, 100}, {101, 150}, {151, 200}, {201, 300}, {301, 500}};
 
   int pm2_5_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 12}, {13, 35}, {36, 55}, {56, 150}, {151, 250}, {251, 500}};
 
-  int pm10_0_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 54},    {55, 154},  {155, 254},
+  int pm10_0_concentration_breakpoints_[AMOUNT_OF_LEVELS][2] = {{0, 54},    {55, 154},  {155, 254},
                                                        {255, 354}, {355, 424}, {425, 604}};
 
-  int calculate_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
-    int grid_index = get_grid_index_(value, array);
-    int aqi_lo = index_grid_[grid_index][0];
-    int aqi_hi = index_grid_[grid_index][1];
-    int conc_lo = array[grid_index][0];
-    int conc_hi = array[grid_index][1];
+  int calculate_index_(uint16_t value, int concentration_breakpoints[AMOUNT_OF_LEVELS][2]) {
+    int breakpoint_index = get_breakpoint_index_(value, concentration_breakpoints);
+    if (breakpoint_index == -1) {
+      return -1;
+    }
+
+    int aqi_lo = aqi_index_[breakpoint_index][0];
+    int aqi_hi = aqi_index_[breakpoint_index][1];
+    int conc_lo = concentration_breakpoints[breakpoint_index][0];
+    int conc_hi = concentration_breakpoints[breakpoint_index][1];
 
     return (value - conc_lo) * (aqi_hi - aqi_lo) / (conc_hi - conc_lo) + aqi_lo;
   }
 
-  int get_grid_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
+  int get_breakpoint_index_(uint16_t value, int concentration_breakpoints[AMOUNT_OF_LEVELS][2]) {
     for (int i = 0; i < AMOUNT_OF_LEVELS; i++) {
-      if (value >= array[i][0] && value <= array[i][1]) {
+      if (value >= concentration_breakpoints[i][0] && value <= concentration_breakpoints[i][1]) {
         return i;
       }
     }

--- a/esphome/components/hm3301/aqi_calculator.h
+++ b/esphome/components/hm3301/aqi_calculator.h
@@ -22,7 +22,7 @@ class AQICalculator : public AbstractAQICalculator {
   int pm2_5_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 12}, {13, 35}, {36, 55}, {56, 150}, {151, 250}, {251, 500}};
 
   int pm10_0_concentration_breakpoints_[AMOUNT_OF_LEVELS][2] = {{0, 54},    {55, 154},  {155, 254},
-                                                       {255, 354}, {355, 424}, {425, 604}};
+                                                                {255, 354}, {355, 424}, {425, 604}};
 
   int calculate_index_(uint16_t value, int concentration_breakpoints[AMOUNT_OF_LEVELS][2]) {
     int breakpoint_index = get_breakpoint_index_(value, concentration_breakpoints);

--- a/esphome/components/hm3301/caqi_calculator.h
+++ b/esphome/components/hm3301/caqi_calculator.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "esphome/core/log.h"
 #include "abstract_aqi_calculator.h"
 
 namespace esphome {
@@ -9,38 +8,33 @@ namespace hm3301 {
 class CAQICalculator : public AbstractAQICalculator {
  public:
   uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
-    int pm2_5_index = calculate_index_(pm2_5_value, pm2_5_calculation_grid_);
-    int pm10_0_index = calculate_index_(pm10_0_value, pm10_0_calculation_grid_);
-
-    return (pm2_5_index < pm10_0_index) ? pm10_0_index : pm2_5_index;
+    return calculate_index_(pm10_0_value, pm10_0_concentration_breakpoints_);
   }
 
  protected:
   static const int AMOUNT_OF_LEVELS = 5;
 
-  int index_grid_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 75}, {76, 100}, {101, 400}};
+  int aqi_index_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 75}, {76, 100}, {101, 400}};
 
-  int pm2_5_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 15}, {16, 30}, {31, 55}, {56, 110}, {111, 400}};
+  int pm10_0_concentration_breakpoints_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 90}, {91, 180}, {181, 400}};
 
-  int pm10_0_calculation_grid_[AMOUNT_OF_LEVELS][2] = {{0, 25}, {26, 50}, {51, 90}, {91, 180}, {181, 400}};
-
-  int calculate_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
-    int grid_index = get_grid_index_(value, array);
-    if (grid_index == -1) {
+  int calculate_index_(uint16_t value, int concentration_breakpoints[AMOUNT_OF_LEVELS][2]) {
+    int breakpoint_index = get_breakpoint_index_(value, concentration_breakpoints);
+    if (breakpoint_index == -1) {
       return -1;
     }
 
-    int aqi_lo = index_grid_[grid_index][0];
-    int aqi_hi = index_grid_[grid_index][1];
-    int conc_lo = array[grid_index][0];
-    int conc_hi = array[grid_index][1];
+    int aqi_lo = aqi_index_[breakpoint_index][0];
+    int aqi_hi = aqi_index_[breakpoint_index][1];
+    int conc_lo = concentration_breakpoints[breakpoint_index][0];
+    int conc_hi = concentration_breakpoints[breakpoint_index][1];
 
     return (value - conc_lo) * (aqi_hi - aqi_lo) / (conc_hi - conc_lo) + aqi_lo;
   }
 
-  int get_grid_index_(uint16_t value, int array[AMOUNT_OF_LEVELS][2]) {
+  int get_breakpoint_index_(uint16_t value, int concentration_breakpoints[AMOUNT_OF_LEVELS][2]) {
     for (int i = 0; i < AMOUNT_OF_LEVELS; i++) {
-      if (value >= array[i][0] && value <= array[i][1]) {
+      if (value >= concentration_breakpoints[i][0] && value <= concentration_breakpoints[i][1]) {
         return i;
       }
     }


### PR DESCRIPTION
# What does this implement/fix? 

CAQI based on PM 10 particles only.
Ref [here](https://en.wikipedia.org/wiki/Air_quality_index) and [here](https://airly.org/en/air-quality-index-caqi-and-aqi-methods-of-calculation/).

Also version without fix I found such pikes of values
<img width="529" alt="Screenshot 2021-11-18 at 09 59 47" src="https://user-images.githubusercontent.com/940893/142384884-d4d2adff-9b04-44af-879b-19982e8a96be.png">
Values jumped from 39 to 51, there were no values in range of 40-50. Such behavior at these points is because that AQI index for PM2.5 and PM10 is on different level. So it's not gradually increasing\decreasing, it's just jumping.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
