### PR TITLE
Allow UART debug configuration with no after: definition

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -94,17 +94,21 @@ UART_DIRECTIONS = {
     "BOTH": UARTDirection.UART_DIRECTION_BOTH,
 }
 
+AFTER_DEFAULTS = {CONF_BYTES: 256, CONF_TIMEOUT: "100ms"}
+
 DEBUG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(UARTDebugger),
         cv.Optional(CONF_DIRECTION, default="BOTH"): cv.enum(
             UART_DIRECTIONS, upper=True
         ),
-        cv.Optional(CONF_AFTER): cv.Schema(
+        cv.Optional(CONF_AFTER, default=AFTER_DEFAULTS): cv.Schema(
             {
-                cv.Optional(CONF_BYTES, default=256): cv.validate_bytes,
                 cv.Optional(
-                    CONF_TIMEOUT, default="100ms"
+                    CONF_BYTES, default=AFTER_DEFAULTS[CONF_BYTES]
+                ): cv.validate_bytes,
+                cv.Optional(
+                    CONF_TIMEOUT, default=AFTER_DEFAULTS[CONF_TIMEOUT]
                 ): cv.positive_time_period_milliseconds,
                 cv.Optional(CONF_DELIMITER): cv.templatable(validate_raw_data),
             }

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -39,6 +39,12 @@ uart:
   tx_pin: GPIO22
   rx_pin: GPIO23
   baud_rate: 115200
+  # Specifically added for testing debug with no after: definition.
+  debug:
+    dummy_receiver: false
+    direction: rx
+    sequence:
+      - lambda: UARTDebug::log_hex(direction, bytes, ':');
 
 ota:
   safe_mode: True


### PR DESCRIPTION
# What does this implement/fix? 

When no `after:` key is defined for the UART `debug:` feature, code generation fails with a KeyError.
The PR takes care of applying sane defaults for this, in case the key is missing from the config.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  rx_pin: D2
  baud_rate: 9600
  debug:
    direction: RX
    sequence:
      - lambda: UARTDebug::log_hex(direction, bytes, ':');
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
