### PR TITLE
Cache virtualenv instead of pip cache between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,23 @@ jobs:
         with:
           python-version: '3.7'
 
-      - name: Cache pip modules
+      - name: Cache virtualenv
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: pip-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements*.txt') }}
+          path: .venv
+          key: venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
-            pip-${{ steps.python.outputs.python-version }}-
+            venv-${{ steps.python.outputs.python-version }}-
 
-      - name: Set up python environment
+      - name: Set up virtualenv
         run: |
-          pip3 install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
-          pip3 install -e .
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -U pip
+          pip install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
+          pip install -e .
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> $GITHUB_ENV
 
       # Use per check platformio cache because checks use different parts
       - name: Cache platformio


### PR DESCRIPTION
# What does this implement/fix? 

Even with the pip cache, installing dependencies [takes about 30 seconds](https://github.com/esphome/esphome/runs/4244835102). We can avoid this whole step by installing dependencies into a virtualenv and caching the whole virtualenv, which takes only ~10 seconds. 

Unfortunately we can't skip the completle setup step, as installing esphome itself into the venv modifies the source checkout and that isn't cached. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
