### PR TITLE
Add map filter for text sensors

### DIFF
--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -88,16 +88,13 @@ def validate_mapping(value):
         a, b = value.split("->", 1)
         value = {CONF_FROM: a.strip(), CONF_TO: b.strip()}
 
-    return cv.Schema({
-        cv.Required(CONF_FROM): cv.string,
-        cv.Required(CONF_TO): cv.string
-    })(value)
+    return cv.Schema(
+        {cv.Required(CONF_FROM): cv.string, cv.Required(CONF_TO): cv.string}
+    )(value)
 
 
 @FILTER_REGISTRY.register(
-    "substitute",
-    SubstituteFilter,
-    cv.ensure_list(validate_mapping)
+    "substitute", SubstituteFilter, cv.ensure_list(validate_mapping)
 )
 async def substitute_filter_to_code(config, filter_id):
     from_strings = [conf[CONF_FROM] for conf in config]
@@ -105,14 +102,12 @@ async def substitute_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id, from_strings, to_strings)
 
 
-@FILTER_REGISTRY.register(
-    "map",
-    MapFilter,
-    cv.ensure_list(validate_mapping)
-)
+@FILTER_REGISTRY.register("map", MapFilter, cv.ensure_list(validate_mapping))
 async def map_filter_to_code(config, filter_id):
     map_ = cg.std_ns.class_("map").template(cg.std_string, cg.std_string)
-    return cg.new_Pvariable(filter_id, map_([(item[CONF_FROM], item[CONF_TO]) for item in config]))
+    return cg.new_Pvariable(
+        filter_id, map_([(item[CONF_FROM], item[CONF_TO]) for item in config])
+    )
 
 
 icon = cv.icon

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -70,5 +70,11 @@ optional<std::string> SubstituteFilter::new_value(std::string value) {
   return value;
 }
 
+// Map
+optional<std::string> MapFilter::new_value(std::string value) {
+  auto item = mappings_.find(value);
+  return item == mappings_.end() ? value : item->first;
+}
+
 }  // namespace text_sensor
 }  // namespace esphome

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -73,7 +73,7 @@ optional<std::string> SubstituteFilter::new_value(std::string value) {
 // Map
 optional<std::string> MapFilter::new_value(std::string value) {
   auto item = mappings_.find(value);
-  return item == mappings_.end() ? value : item->first;
+  return item == mappings_.end() ? value : item->second;
 }
 
 }  // namespace text_sensor

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -4,6 +4,7 @@
 #include "esphome/core/helpers.h"
 #include <queue>
 #include <utility>
+#include <map>
 
 namespace esphome {
 namespace text_sensor {
@@ -106,6 +107,17 @@ class SubstituteFilter : public Filter {
  protected:
   std::vector<std::string> from_strings_;
   std::vector<std::string> to_strings_;
+};
+
+/// A filter that maps values from one set to another
+class MapFilter : public Filter {
+ public:
+  MapFilter(std::map<std::string, std::string> mappings)
+    : mappings_(std::move(mappings)) {}
+  optional<std::string> new_value(std::string value) override;
+
+ protected:
+  std::map<std::string, std::string> mappings_;
 };
 
 }  // namespace text_sensor

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -112,8 +112,7 @@ class SubstituteFilter : public Filter {
 /// A filter that maps values from one set to another
 class MapFilter : public Filter {
  public:
-  MapFilter(std::map<std::string, std::string> mappings)
-    : mappings_(std::move(mappings)) {}
+  MapFilter(std::map<std::string, std::string> mappings) : mappings_(std::move(mappings)) {}
   optional<std::string> new_value(std::string value) override;
 
  protected:

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -461,7 +461,7 @@ text_sensor:
           - Hello -> Goodbye
       - map:
           - red -> green
-      - lambda: return "1234";
+      - lambda: return {"1234"};
   - platform: homeassistant
     entity_id: sensor.hello_world2
     id: ha_hello_world2

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -452,6 +452,16 @@ text_sensor:
     name: 'Template Text Sensor'
     lambda: |-
       return {"Hello World"};
+    filters:
+      - to_upper:
+      - to_lower:
+      - append: "xyz"
+      - prepend: "abcd"
+      - substitute:
+          - Hello -> Goodbye
+      - map:
+          - red -> green
+      - lambda: return "1234";
   - platform: homeassistant
     entity_id: sensor.hello_world2
     id: ha_hello_world2


### PR DESCRIPTION
# What does this implement/fix? 

Add map filter for text sensors, that allows mapping between values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1632

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
text_sensor:
  - platform: template
    name: "Test"
    lambda: return {"Hello"};
    filters:
      - map:
        - Hello -> Goodbye
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
