### PR TITLE
Consistently format errors in CI scripts 

### DIFF
--- a/.github/workflows/matchers/ci-custom.json
+++ b/.github/workflows/matchers/ci-custom.json
@@ -4,7 +4,7 @@
             "owner": "ci-custom",
             "pattern": [
                 {
-                    "regexp": "^ERROR (.*):(\\d+):(\\d+) - (.*)$",
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/.github/workflows/matchers/lint-python.json
+++ b/.github/workflows/matchers/lint-python.json
@@ -5,7 +5,7 @@
       "severity": "error",
       "pattern": [
           {
-          "regexp": "^(.*):(\\d+) - ([EFCDNW]\\d{3}.*)$",
+          "regexp": "^(.*):(\\d+): ([EFCDNW]\\d{3}.*)$",
           "file": 1,
           "line": 2,
           "message": 3
@@ -17,7 +17,7 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "^(.*):(\\d+) - (\\[[EFCRW]\\d{4}\\(.*\\),.*\\].*)$",
+          "regexp": "^(.*):(\\d+): (\\[[EFCRW]\\d{4}\\(.*\\),.*\\].*)$",
           "file": 1,
           "line": 2,
           "message": 3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,6 @@
 pylint==2.11.1
 flake8==4.0.1
 black==21.10b0
-pexpect==4.8.0
 pre-commit
 
 # Unit tests

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 
 from helpers import styled, print_error_for_file, git_ls_files, filter_changed
+import argparse
 import codecs
 import collections
 import colorama
 import fnmatch
+import functools
 import os.path
 import re
-import subprocess
 import sys
 import time
-import functools
-import argparse
 
 sys.path.append(os.path.dirname(__file__))
 

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-from helpers import git_ls_files, filter_changed
+from helpers import styled, print_error_for_file, git_ls_files, filter_changed
 import codecs
 import collections
+import colorama
 import fnmatch
 import os.path
 import re
@@ -29,6 +30,8 @@ def find_all(a_str, sub):
             yield i, column
             column += len(sub)
 
+
+colorama.init()
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -657,10 +660,8 @@ for fname in files:
 run_checks(LINT_POST_CHECKS, "POST")
 
 for f, errs in sorted(errors.items()):
-    print(f"\033[0;32m************* File \033[1;32m{f}\033[0m")
-    for lineno, col, msg in errs:
-        print(f"ERROR {f}:{lineno}:{col} - {msg}")
-    print()
+    err_str = (f"{styled(colorama.Style.BRIGHT, f'{f}:{lineno}:{col}:')} {msg}\n" for lineno, col, msg in errs)
+    print_error_for_file(f, "\n".join(err_str))
 
 if args.print_slowest:
     lint_times = []

--- a/script/clang-format
+++ b/script/clang-format
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import colorama
 import multiprocessing
 import os
 import queue
@@ -12,7 +13,7 @@ import threading
 import click
 
 sys.path.append(os.path.dirname(__file__))
-from helpers import get_output, git_ls_files, filter_changed
+from helpers import print_error_for_file, get_output, git_ls_files, filter_changed
 
 
 def run_format(args, queue, lock, failed_files):
@@ -29,11 +30,7 @@ def run_format(args, queue, lock, failed_files):
         proc = subprocess.run(invocation, capture_output=True, encoding='utf-8')
         if proc.returncode != 0:
             with lock:
-                print()
-                print("\033[0;32m************* File \033[1;32m{}\033[0m".format(path))
-                print(proc.stdout)
-                print(proc.stderr)
-                print()
+                print_error_for_file(path, proc.stderr)
                 failed_files.append(path)
         queue.task_done()
 
@@ -43,6 +40,8 @@ def progress_bar_show(value):
 
 
 def main():
+    colorama.init()
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-j', '--jobs', type=int,
                         default=multiprocessing.cpu_count(),

--- a/script/clang-format
+++ b/script/clang-format
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+from helpers import print_error_for_file, get_output, git_ls_files, filter_changed
 import argparse
+import click
 import colorama
 import multiprocessing
 import os
@@ -9,11 +11,6 @@ import re
 import subprocess
 import sys
 import threading
-
-import click
-
-sys.path.append(os.path.dirname(__file__))
-from helpers import print_error_for_file, get_output, git_ls_files, filter_changed
 
 
 def run_format(args, queue, lock, failed_files):

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -13,7 +13,6 @@ import tempfile
 import threading
 
 import click
-import pexpect
 
 sys.path.append(os.path.dirname(__file__))
 from helpers import shlex_quote, get_output, filter_grep, \
@@ -87,22 +86,22 @@ def run_tidy(args, options, tmpdir, queue, lock, failed_files):
             invocation.append(name)
 
         if args.quiet:
-            invocation.append('-quiet')
+            invocation.append('--quiet')
 
-        invocation.append(os.path.abspath(path))
+        if sys.stdout.isatty():
+            invocation.append('--use-color')
+
         invocation.append(f"--header-filter={os.path.abspath(basepath)}/.*")
+        invocation.append(os.path.abspath(path))
         invocation.append('--')
         invocation.extend(options)
-        invocation_s = ' '.join(shlex_quote(x) for x in invocation)
 
-        # Use pexpect for a pseudy-TTY with colored output
-        output, rc = pexpect.run(invocation_s, withexitstatus=True, encoding='utf-8',
-                                 timeout=15 * 60)
-        if rc != 0:
+        proc = subprocess.run(invocation, capture_output=True)
+        if proc.returncode != 0:
             with lock:
                 print()
                 print("\033[0;32m************* File \033[1;32m{}\033[0m".format(path))
-                print(output)
+                print(proc.stdout.decode('ascii'))
                 print()
                 failed_files.append(path)
         queue.task_done()

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
+from helpers import print_error_for_file, get_output, filter_grep, \
+    build_all_include, temp_header_file, git_ls_files, filter_changed, load_idedata, basepath
 import argparse
+import click
 import colorama
-import json
 import multiprocessing
 import os
 import queue
@@ -12,12 +14,6 @@ import subprocess
 import sys
 import tempfile
 import threading
-
-import click
-
-sys.path.append(os.path.dirname(__file__))
-from helpers import print_error_for_file, get_output, filter_grep, \
-    build_all_include, temp_header_file, git_ls_files, filter_changed, load_idedata, basepath
 
 
 def clang_options(idedata):

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import colorama
 import json
 import multiprocessing
 import os
@@ -15,7 +16,7 @@ import threading
 import click
 
 sys.path.append(os.path.dirname(__file__))
-from helpers import shlex_quote, get_output, filter_grep, \
+from helpers import print_error_for_file, get_output, filter_grep, \
     build_all_include, temp_header_file, git_ls_files, filter_changed, load_idedata, basepath
 
 
@@ -96,13 +97,10 @@ def run_tidy(args, options, tmpdir, queue, lock, failed_files):
         invocation.append('--')
         invocation.extend(options)
 
-        proc = subprocess.run(invocation, capture_output=True)
+        proc = subprocess.run(invocation, capture_output=True, encoding='utf-8')
         if proc.returncode != 0:
             with lock:
-                print()
-                print("\033[0;32m************* File \033[1;32m{}\033[0m".format(path))
-                print(proc.stdout.decode('ascii'))
-                print()
+                print_error_for_file(path, proc.stdout)
                 failed_files.append(path)
         queue.task_done()
 
@@ -118,6 +116,8 @@ def split_list(a, n):
 
 
 def main():
+    colorama.init()
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-j', '--jobs', type=int,
                         default=multiprocessing.cpu_count(),

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -1,4 +1,5 @@
 import codecs
+import colorama
 import os.path
 import re
 import subprocess
@@ -18,6 +19,20 @@ def shlex_quote(s):
         return s
 
     return "'" + s.replace("'", "'\"'\"'") + "'"
+
+
+def styled(color, msg, reset=True):
+    prefix = ''.join(color) if isinstance(color, tuple) else color
+    suffix = colorama.Style.RESET_ALL if reset else ''
+    return prefix + msg + suffix
+
+
+def print_error_for_file(file, body):
+    print(styled(colorama.Fore.GREEN, "### File ") + styled((colorama.Fore.GREEN, colorama.Style.BRIGHT), file))
+    print()
+    if body is not None:
+        print(body)
+        print()
 
 
 def build_all_include():

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -1,4 +1,3 @@
-import codecs
 import colorama
 import os.path
 import re
@@ -10,15 +9,6 @@ root_path = os.path.abspath(os.path.normpath(os.path.join(__file__, "..", ".."))
 basepath = os.path.join(root_path, "esphome")
 temp_folder = os.path.join(root_path, ".temp")
 temp_header_file = os.path.join(temp_folder, "all-include.cpp")
-
-
-def shlex_quote(s):
-    if not s:
-        return "''"
-    if re.search(r"[^\w@%+=:,./-]", s) is None:
-        return s
-
-    return "'" + s.replace("'", "'\"'\"'") + "'"
 
 
 def styled(color, msg, reset=True):

--- a/script/lint-python
+++ b/script/lint-python
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 from __future__ import print_function
-from helpers import get_output, get_err, git_ls_files, filter_changed
+from helpers import styled, print_error_for_file, get_output, get_err, git_ls_files, filter_changed
 
 import argparse
+import colorama
 import os
 import re
 import sys
@@ -17,14 +18,18 @@ def print_error(file, lineno, msg):
     global curfile
 
     if curfile != file:
-        print()
-        print("\033[0;32m************* File \033[1;32m{}\033[0m".format(file))
+        print_error_for_file(file, None)
         curfile = file
 
-    print("{}:{} - {}".format(file, lineno, msg))
+    if lineno is not None:
+        print(f"{styled(colorama.Style.BRIGHT, f'{file}:{lineno}:')} {msg}")
+    else:
+        print(f"{styled(colorama.Style.BRIGHT, f'{file}:')} {msg}")
 
 
 def main():
+    colorama.init()
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "files", nargs="*", default=[], help="files to be processed (regex on path)"
@@ -56,6 +61,7 @@ def main():
 
     cmd = ["black", "--verbose", "--check"] + files
     print("Running black...")
+    print()
     log = get_err(*cmd)
     for line in log.splitlines():
         WOULD_REFORMAT = "would reformat"
@@ -65,7 +71,9 @@ def main():
             errors += 1
 
     cmd = ["flake8"] + files
+    print()
     print("Running flake8...")
+    print()
     log = get_output(*cmd)
     for line in log.splitlines():
         line = line.split(":", 4)
@@ -78,7 +86,9 @@ def main():
         errors += 1
 
     cmd = ["pylint", "-f", "parseable", "--persistent=n"] + files
+    print()
     print("Running pylint...")
+    print()
     log = get_output(*cmd)
     for line in log.splitlines():
         line = line.split(":", 3)

--- a/script/lint-python
+++ b/script/lint-python
@@ -2,14 +2,11 @@
 
 from __future__ import print_function
 from helpers import styled, print_error_for_file, get_output, get_err, git_ls_files, filter_changed
-
 import argparse
 import colorama
 import os
 import re
 import sys
-
-sys.path.append(os.path.dirname(__file__))
 
 curfile = None
 


### PR DESCRIPTION
# What does this implement/fix? 

* Use colorama for coloring output, so that colors are disabled when output is redirected.
* Use a consistent format for error messages.
* Convert clang-tidy script to use a regular subprocess instead of pexpect (slight performance improvement).
* Clean-up imports.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
