### PR TITLE
Relax the icon validator to allow non-mdi icons

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -296,9 +296,9 @@ def icon(value):
     value = string_strict(value)
     if not value:
         return value
-    if value.startswith("mdi:"):
+    if re.match("^[\\w\\-]+:[\\w\\-]+$", value):
         return value
-    raise Invalid('Icons should start with prefix "mdi:"')
+    raise Invalid('Icons must match the format "[icon pack]:[icon]", e.g. "mdi:home-assistant"')
 
 
 def boolean(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -298,7 +298,9 @@ def icon(value):
         return value
     if re.match("^[\\w\\-]+:[\\w\\-]+$", value):
         return value
-    raise Invalid('Icons must match the format "[icon pack]:[icon]", e.g. "mdi:home-assistant"')
+    raise Invalid(
+        'Icons must match the format "[icon pack]:[icon]", e.g. "mdi:home-assistant"'
+    )
 
 
 def boolean(value):

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -66,7 +66,7 @@ def test_string_string__invalid(value):
         config_validation.string_strict(value)
 
 
-@given(builds(lambda v: "mdi:" + v, text()))
+@given(builds(lambda v: "mdi:" + v, text(alphabet=string.ascii_letters + string.digits + "-_", min_size=1, max_size=20)))
 @example("")
 def test_icon__valid(value):
     actual = config_validation.icon(value)
@@ -75,7 +75,7 @@ def test_icon__valid(value):
 
 
 def test_icon__invalid():
-    with pytest.raises(Invalid, match="Icons should start with prefix"):
+    with pytest.raises(Invalid, match="Icons must match the format "):
         config_validation.icon("foo")
 
 


### PR DESCRIPTION
# What does this implement/fix? 

Allow icons from icon packs other than `mdi:`, for example `fas:mobile-alt`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/feature-requests#1164

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
