### PR TITLE
fixed wrong setup-usage tc9548a

### DIFF
--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -22,7 +22,7 @@ i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffer
 void TCA9548AComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TCA9548A...");
   uint8_t status = 0;
-  if (this->read_register(0x00, &status, 1) != i2c::ERROR_OK) {
+  if (this->read(&status, 1) != i2c::ERROR_OK) {
     ESP_LOGI(TAG, "TCA9548A failed");
     this->mark_failed();
     return;

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -24,6 +24,7 @@ class TCA9548AComponent : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::IO; }
   void update();
 
   i2c::ErrorCode switch_to_channel(uint8_t channel);


### PR DESCRIPTION
# What does this implement/fix? 

on setup of the tca9548a a zero-byte was send that closes all channels. 
This leads to a non-deterministic behavoir depending on setup-time relative to attached devices.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [-] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
