### PR TITLE
Created "update_filter" config var in pzemac component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -124,6 +124,7 @@ esphome/components/power_supply/* @esphome/core
 esphome/components/preferences/* @esphome/core
 esphome/components/pulse_meter/* @stevebaxter
 esphome/components/pvvx_mithermometer/* @pasiz
+esphome/components/pzemac/* @leofig-rj
 esphome/components/rc522/* @glmnet
 esphome/components/rc522_i2c/* @glmnet
 esphome/components/rc522_spi/* @glmnet

--- a/esphome/components/pzemac/__init__.py
+++ b/esphome/components/pzemac/__init__.py
@@ -1,0 +1,3 @@
+CONF_UPDATE_FILTER = "update_filter"
+
+CODEOWNERS = ["@leofig-rj"]

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -48,8 +48,8 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   float power_factor = raw_power_factor / 100.0f;
 
   if (this->update_ok_count_down_ == 0) {
-    ESP_LOGD(TAG, "PZEM AC: V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, F=%.1f Hz, PF=%.2f", voltage, current, active_power,
-             active_energy, frequency, power_factor);
+    ESP_LOGD(TAG, "PZEM AC: V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, F=%.1f Hz, PF=%.2f", voltage, current,
+             active_power, active_energy, frequency, power_factor);
     if (this->voltage_sensor_ != nullptr)
       this->voltage_sensor_->publish_state(voltage);
     if (this->current_sensor_ != nullptr)

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -77,8 +77,8 @@ void PZEMAC::update() {
       this->update_not_ok_count_down_--;
     } else {
       if (this->update_filter_ > 0) {
-        ESP_LOGW(TAG, "PZEM AC: V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, F=%.1f Hz, PF=%.2f", 0.0, 0.0, 0.0,
-                 0.0, 0.0, 0.0);
+        ESP_LOGW(TAG, "PZEM AC: V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, F=%.1f Hz, PF=%.2f", 0.0, 0.0, 0.0, 0.0, 0.0,
+                 0.0);
         if (this->voltage_sensor_ != nullptr)
           this->voltage_sensor_->publish_state(0.0);
         if (this->current_sensor_ != nullptr)

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -70,7 +70,8 @@ void PZEMAC::update() {
   if (this->modbus_has_data_) {
     this->modbus_has_data_ = false;
     this->update_not_ok_count_down_ = this->update_filter_;
-    if (this->update_ok_count_down_ > 0) this->update_ok_count_down_--;
+    if (this->update_ok_count_down_ > 0)
+      this->update_ok_count_down_--;
   } else {
     this->update_ok_count_down_ = this->update_filter_;
     if (this->update_not_ok_count_down_ > 0) {

--- a/esphome/components/pzemac/pzemac.h
+++ b/esphome/components/pzemac/pzemac.h
@@ -16,6 +16,12 @@ class PZEMAC : public PollingComponent, public modbus::ModbusDevice {
   void set_frequency_sensor(sensor::Sensor *frequency_sensor) { frequency_sensor_ = frequency_sensor; }
   void set_power_factor_sensor(sensor::Sensor *power_factor_sensor) { power_factor_sensor_ = power_factor_sensor; }
 
+  void set_update_filter(uint8_t update_filter) {
+    update_filter_ = update_filter;
+    update_ok_count_down_ = update_filter;
+    update_not_ok_count_down_ = update_filter;
+  }
+
   void update() override;
 
   void on_modbus_data(const std::vector<uint8_t> &data) override;
@@ -29,6 +35,10 @@ class PZEMAC : public PollingComponent, public modbus::ModbusDevice {
   sensor::Sensor *energy_sensor_;
   sensor::Sensor *frequency_sensor_;
   sensor::Sensor *power_factor_sensor_;
+  bool modbus_has_data_{false};
+  uint8_t update_filter_{0};
+  uint8_t update_ok_count_down_{0};
+  uint8_t update_not_ok_count_down_{0};
 };
 
 }  // namespace pzemac

--- a/esphome/components/pzemac/sensor.py
+++ b/esphome/components/pzemac/sensor.py
@@ -23,6 +23,7 @@ from esphome.const import (
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
+from . import CONF_UPDATE_FILTER
 
 AUTO_LOAD = ["modbus"]
 
@@ -68,6 +69,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_POWER_FACTOR,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_UPDATE_FILTER, default=0): cv.int_range(min=0, max=255),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -104,3 +106,5 @@ async def to_code(config):
         conf = config[CONF_POWER_FACTOR]
         sens = await sensor.new_sensor(conf)
         cg.add(var.set_power_factor_sensor(sens))
+    if CONF_UPDATE_FILTER in config:
+        cg.add(var.set_update_filter(config[CONF_UPDATE_FILTER]))


### PR DESCRIPTION
# What does this implement/fix? 

The current version of the pzemac sensor platform had two behaviors that could be unwanted:
Sometimes, when the PZEM was energized, there is spurious data with very high values.
When the PZEM lacked power and the ESP8266 was still energized, the last values were kept.
To circumvent these behaviors, a logic was created to filter (or rather, disregard the first measurements at power-up) and to reset the values when the PZEM is de-energized. The configuration variable update_filter was created to handle this.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1639

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  rx_pin: D1
  tx_pin: D2
  baud_rate: 9600

modbus:

sensor:
  - platform: pzemac
    current:
      name: "PZEM-004T V3 Current"
    voltage:
      name: "PZEM-004T V3 Voltage"
    energy:
      name: "PZEM-004T V3 Energy"
    power:
      name: "PZEM-004T V3 Power"
    frequency:
      name: "PZEM-004T V3 Frequency"
    power_factor:
      name: "PZEM-004T V3 Power Factor"
    update_interval: 1s
    address: 1
    update_filter: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
