### PR TITLE
Allow empty UART debug: option, logging in hex format by default

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -3,6 +3,7 @@ from typing import Optional
 import esphome.codegen as cg
 import esphome.config_validation as cv
 import esphome.final_validate as fv
+from esphome.yaml_util import make_data_base
 from esphome import pins, automation
 from esphome.const import (
     CONF_BAUD_RATE,
@@ -24,6 +25,7 @@ from esphome.const import (
     CONF_DELIMITER,
     CONF_DUMMY_RECEIVER,
     CONF_DUMMY_RECEIVER_ID,
+    CONF_LAMBDA,
 )
 from esphome.core import CORE
 
@@ -94,7 +96,29 @@ UART_DIRECTIONS = {
     "BOTH": UARTDirection.UART_DIRECTION_BOTH,
 }
 
-AFTER_DEFAULTS = {CONF_BYTES: 256, CONF_TIMEOUT: "100ms"}
+# The reason for having CONF_BYTES at 150 by default:
+#
+# The log message buffer size is 512 bytes by default. About 35 bytes are
+# used for the log prefix. That leaves us with 477 bytes for logging data.
+# The default log output is hex, which uses 3 characters per represented
+# byte (2 hex chars + 1 separator). That means that 477 / 3 = 159 bytes
+# can be represented in a single log line. Using 150, because people love
+# round numbers.
+AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
+
+# By default, log in hex format when no specific sequence is provided.
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':');"
+DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
+
+
+def maybe_empty_debug(schema):
+    def validator(value):
+        if value is None:
+            value = {}
+        return schema(value)
+
+    return validator
+
 
 DEBUG_SCHEMA = cv.Schema(
     {
@@ -113,7 +137,9 @@ DEBUG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DELIMITER): cv.templatable(validate_raw_data),
             }
         ),
-        cv.Required(CONF_SEQUENCE): automation.validate_automation(),
+        cv.Optional(
+            CONF_SEQUENCE, default=DEFAULT_SEQUENCE
+        ): automation.validate_automation(),
         cv.Optional(CONF_DUMMY_RECEIVER, default=False): cv.boolean,
         cv.GenerateID(CONF_DUMMY_RECEIVER_ID): cv.declare_id(UARTDummyReceiver),
     }
@@ -135,7 +161,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INVERT): cv.invalid(
                 "This option has been removed. Please instead use invert in the tx/rx pin schemas."
             ),
-            cv.Optional(CONF_DEBUG): DEBUG_SCHEMA,
+            cv.Optional(CONF_DEBUG): maybe_empty_debug(DEBUG_SCHEMA),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN),

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -158,7 +158,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INVERT): cv.invalid(
                 "This option has been removed. Please instead use invert in the tx/rx pin schemas."
             ),
-            cv.Optional(CONF_DEBUG): maybe_empty_debug(DEBUG_SCHEMA),
+            cv.Optional(CONF_DEBUG): maybe_empty_debug,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN),

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -111,13 +111,10 @@ DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':');"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
-def maybe_empty_debug(schema):
-    def validator(value):
-        if value is None:
-            value = {}
-        return schema(value)
-
-    return validator
+def maybe_empty_debug(value):
+    if value is None:
+        value = {}
+    return DEBUG_SCHEMA(value)
 
 
 DEBUG_SCHEMA = cv.Schema(

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -254,6 +254,8 @@ uart:
     tx_pin: GPIO4
     rx_pin: GPIO5
     baud_rate: 38400
+    # Specifically added for testing debug with no options at all.
+    debug:
 
 modbus:
   uart_id: uart1


### PR DESCRIPTION
# What does this implement/fix? 

As requested by @jesserockz :
"Can we get a default config for uart debug so it automatically includes a simple hex logger just by having debug: in there?"

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1642

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  debug:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
