### PR TITLE
Fix distorted gif frames when resizing

### DIFF
--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -76,8 +76,6 @@ async def to_code(config):
         pos = 0
         for frameIndex in range(frames):
             image.seek(frameIndex)
-            if CONF_RESIZE in config:
-                image.thumbnail(config[CONF_RESIZE])
             frame = image.convert("RGB")
             if CONF_RESIZE in config:
                 frame = frame.resize(config[CONF_RESIZE])

--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -44,9 +44,9 @@ async def to_code(config):
     width, height = image.size
     frames = image.n_frames
     if CONF_RESIZE in config:
-        image_copy = image.copy()
-        image_copy.thumbnail(config[CONF_RESIZE])
-        width, height = image_copy.size
+        new_width_max, new_height_max = config[CONF_RESIZE]
+        ratio = min(new_width_max / width, new_height_max / height)
+        width, height = int(width * ratio), int(height * ratio)
     else:
         if width > 500 or height > 500:
             _LOGGER.warning(
@@ -61,7 +61,7 @@ async def to_code(config):
             image.seek(frameIndex)
             frame = image.convert("L", dither=Image.NONE)
             if CONF_RESIZE in config:
-                frame = frame.resize(config[CONF_RESIZE])
+                frame = frame.resize([width, height])
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
@@ -78,7 +78,7 @@ async def to_code(config):
             image.seek(frameIndex)
             frame = image.convert("RGB")
             if CONF_RESIZE in config:
-                frame = frame.resize(config[CONF_RESIZE])
+                frame = frame.resize([width, height])
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
@@ -99,7 +99,7 @@ async def to_code(config):
             image.seek(frameIndex)
             frame = image.convert("1", dither=Image.NONE)
             if CONF_RESIZE in config:
-                frame = frame.resize(config[CONF_RESIZE])
+                frame = frame.resize([width, height])
             for y in range(height):
                 for x in range(width):
                     if frame.getpixel((x, y)):

--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -62,7 +62,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in frame {frameIndex}: {len(pixels)} != {height*width}"
+                    f"Unexpected number of pixels in frame {frameIndex}: ({len(pixels)} != {height*width}"
                 )
             for pix in pixels:
                 data[pos] = pix
@@ -79,7 +79,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in frame {frameIndex}: {len(pixels)} != {height*width}"
+                    f"Unexpected number of pixels in frame {frameIndex}: ({len(pixels)} != {height*width}"
                 )
             for pix in pixels:
                 data[pos] = pix[0]

--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -76,6 +76,8 @@ async def to_code(config):
         pos = 0
         for frameIndex in range(frames):
             image.seek(frameIndex)
+            if CONF_RESIZE in config:
+                image.thumbnail(config[CONF_RESIZE])
             frame = image.convert("RGB")
             if CONF_RESIZE in config:
                 frame = frame.resize(config[CONF_RESIZE])

--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -44,8 +44,9 @@ async def to_code(config):
     width, height = image.size
     frames = image.n_frames
     if CONF_RESIZE in config:
-        image.thumbnail(config[CONF_RESIZE])
-        width, height = image.size
+        image_copy = image.copy()
+        image_copy.thumbnail(config[CONF_RESIZE])
+        width, height = image_copy.size
     else:
         if width > 500 or height > 500:
             _LOGGER.warning(
@@ -59,6 +60,8 @@ async def to_code(config):
         for frameIndex in range(frames):
             image.seek(frameIndex)
             frame = image.convert("L", dither=Image.NONE)
+            if CONF_RESIZE in config:
+                frame = frame.resize(config[CONF_RESIZE])
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
@@ -73,9 +76,9 @@ async def to_code(config):
         pos = 0
         for frameIndex in range(frames):
             image.seek(frameIndex)
-            if CONF_RESIZE in config:
-                image.thumbnail(config[CONF_RESIZE])
             frame = image.convert("RGB")
+            if CONF_RESIZE in config:
+                frame = frame.resize(config[CONF_RESIZE])
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
@@ -95,6 +98,8 @@ async def to_code(config):
         for frameIndex in range(frames):
             image.seek(frameIndex)
             frame = image.convert("1", dither=Image.NONE)
+            if CONF_RESIZE in config:
+                frame = frame.resize(config[CONF_RESIZE])
             for y in range(height):
                 for x in range(width):
                     if frame.getpixel((x, y)):

--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -65,7 +65,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in frame {frameIndex}: ({len(pixels)} != {height*width}"
+                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height*width})"
                 )
             for pix in pixels:
                 data[pos] = pix
@@ -82,7 +82,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in frame {frameIndex}: ({len(pixels)} != {height*width}"
+                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height*width})"
                 )
             for pix in pixels:
                 data[pos] = pix[0]


### PR DESCRIPTION
# What does this implement/fix? 
Further to #2750, when scaling animated gif images using the `resize` config, anything after the first frame seemed to be corrupted, with a distorted image.

This seemed to be caused by the `image.thumbnail()`, which appeared to damage the 2nd and following frames in the pillow image object.

The proposed solution is to use arithmetic to calculate the highest ratio value that keeps the original aspect ratio within the target width,height. Then we call `resize()` on each frame just before saving it to the buffer.  This works reliably for me on `RGB24`, `BINARY`, `GRAYSCALE` image types.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** relates to #2750 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
