### PR TITLE
Prettier date time display after time sync

### DIFF
--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -71,8 +71,9 @@ void SNTPComponent::loop() {
   if (!time.is_valid())
     return;
 
-  ESP_LOGD(TAG, "Synchronized time: %d-%d-%d %d:%02d:%02d", time.year, time.month, time.day_of_month, time.hour,
-           time.minute, time.second);
+  ESP_LOGD(TAG, "Synchronized time: %04d-%02d-%02d %02d:%02d:%02d",
+           time.year, time.month, time.day_of_month,
+           time.hour, time.minute, time.second);
   this->time_sync_callback_.call();
   this->has_time_ = true;
 }

--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -71,9 +71,8 @@ void SNTPComponent::loop() {
   if (!time.is_valid())
     return;
 
-  ESP_LOGD(TAG, "Synchronized time: %04d-%02d-%02d %02d:%02d:%02d",
-           time.year, time.month, time.day_of_month,
-           time.hour, time.minute, time.second);
+  ESP_LOGD(TAG, "Synchronized time: %04d-%02d-%02d %02d:%02d:%02d", time.year, time.month, time.day_of_month, time.hour,
+           time.minute, time.second);
   this->time_sync_callback_.call();
   this->has_time_ = true;
 }

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -35,8 +35,9 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   }
 
   auto time = this->now();
-  ESP_LOGD(TAG, "Synchronized time: %d-%d-%d %d:%d:%d", time.year, time.month, time.day_of_month, time.hour,
-           time.minute, time.second);
+  ESP_LOGD(TAG, "Synchronized time: %04d-%02d-%02d %02d:%02d:%02d",
+           time.year, time.month, time.day_of_month,
+           time.hour, time.minute, time.second);
 
   this->time_sync_callback_.call();
 }

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -35,9 +35,8 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   }
 
   auto time = this->now();
-  ESP_LOGD(TAG, "Synchronized time: %04d-%02d-%02d %02d:%02d:%02d",
-           time.year, time.month, time.day_of_month,
-           time.hour, time.minute, time.second);
+  ESP_LOGD(TAG, "Synchronized time: %04d-%02d-%02d %02d:%02d:%02d", time.year, time.month, time.day_of_month, time.hour,
+           time.minute, time.second);
 
   this->time_sync_callback_.call();
 }


### PR DESCRIPTION
Make the date/time display after time sync prettier by always formatting into fixed width fields.

# What does this implement/fix? 

When a device synchronizes time to the HA instance, or gets the time via NTP, a diagnostic message is printed to the screen. In this message, the date and time was not printed as pretty as could be.

Before the change:
``Synchronized time: 2021-11-20 11:5:51``

After the change:
``Synchronized time: 2021-11-20 11:05:51``

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).