### PR TITLE
Fix speed of long-running addressable transitions

### DIFF
--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -12,7 +12,7 @@ void FastLEDLightOutput::setup() {
   ESP_LOGCONFIG(TAG, "Setting up FastLED light...");
   this->controller_->init();
   this->controller_->setLeds(this->leds_, this->num_leds_);
-  this->effect_data_ = new uint8_t[this->num_leds_];  // NOLINT
+  this->effect_data_ = new uint16_t[this->num_leds_];  // NOLINT
   if (!this->max_refresh_rate_.has_value()) {
     this->set_max_refresh_rate(this->controller_->getMaxRefreshRate());
   }

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -231,7 +231,7 @@ class FastLEDLightOutput : public light::AddressableLight {
 
   CLEDController *controller_{nullptr};
   CRGB *leds_{nullptr};
-  uint8_t *effect_data_{nullptr};
+  uint16_t *effect_data_{nullptr};
   int num_leds_{0};
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -116,7 +116,6 @@ class AddressableLightTransformer : public LightTransitionTransformer {
   AddressableLight &light_;
   Color target_color_{};
   float last_transition_progress_{0.0f};
-  float accumulated_alpha_{0.0f};
 };
 
 }  // namespace light

--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -9,12 +9,13 @@ namespace light {
 class AddressableLightWrapper : public light::AddressableLight {
  public:
   explicit AddressableLightWrapper(light::LightState *light_state) : light_state_(light_state) {
-    this->wrapper_state_ = new uint8_t[5];  // NOLINT(cppcoreguidelines-owning-memory)
+    this->wrapper_state_ = new uint8_t[4];          // NOLINT(cppcoreguidelines-owning-memory)
+    this->wrapper_effect_state_ = new uint16_t[1];  // NOLINT(cppcoreguidelines-owning-memory)
   }
 
   int32_t size() const override { return 1; }
 
-  void clear_effect_data() override { this->wrapper_state_[4] = 0; }
+  void clear_effect_data() override { this->wrapper_effect_state_[0] = 0; }
 
   light::LightTraits get_traits() override {
     LightTraits traits;
@@ -114,12 +115,13 @@ class AddressableLightWrapper : public light::AddressableLight {
 
  protected:
   light::ESPColorView get_view_internal(int32_t index) const override {
-    return {&this->wrapper_state_[0], &this->wrapper_state_[1], &this->wrapper_state_[2],
-            &this->wrapper_state_[3], &this->wrapper_state_[4], &this->correction_};
+    return {&this->wrapper_state_[0], &this->wrapper_state_[1],        &this->wrapper_state_[2],
+            &this->wrapper_state_[3], &this->wrapper_effect_state_[0], &this->correction_};
   }
 
   light::LightState *light_state_;
   uint8_t *wrapper_state_;
+  uint16_t *wrapper_effect_state_;
   ColorMode color_mode_{ColorMode::UNKNOWN};
 };
 

--- a/esphome/components/light/esp_color_view.h
+++ b/esphome/components/light/esp_color_view.h
@@ -14,7 +14,7 @@ class ESPColorSettable {
   virtual void set_green(uint8_t green) = 0;
   virtual void set_blue(uint8_t blue) = 0;
   virtual void set_white(uint8_t white) = 0;
-  virtual void set_effect_data(uint8_t effect_data) = 0;
+  virtual void set_effect_data(uint16_t effect_data) = 0;
   virtual void fade_to_white(uint8_t amnt) = 0;
   virtual void fade_to_black(uint8_t amnt) = 0;
   virtual void lighten(uint8_t delta) = 0;
@@ -37,7 +37,7 @@ class ESPColorSettable {
 
 class ESPColorView : public ESPColorSettable {
  public:
-  ESPColorView(uint8_t *red, uint8_t *green, uint8_t *blue, uint8_t *white, uint8_t *effect_data,
+  ESPColorView(uint8_t *red, uint8_t *green, uint8_t *blue, uint8_t *white, uint16_t *effect_data,
                const ESPColorCorrection *color_correction)
       : red_(red),
         green_(green),
@@ -62,7 +62,7 @@ class ESPColorView : public ESPColorSettable {
       return;
     *this->white_ = this->color_correction_->color_correct_white(white);
   }
-  void set_effect_data(uint8_t effect_data) override {
+  void set_effect_data(uint16_t effect_data) override {
     if (this->effect_data_ == nullptr)
       return;
     *this->effect_data_ = effect_data;
@@ -88,7 +88,7 @@ class ESPColorView : public ESPColorSettable {
       return 0;
     return *this->white_;
   }
-  uint8_t get_effect_data() const {
+  uint16_t get_effect_data() const {
     if (this->effect_data_ == nullptr)
       return 0;
     return *this->effect_data_;
@@ -102,7 +102,7 @@ class ESPColorView : public ESPColorSettable {
   uint8_t *const green_;
   uint8_t *const blue_;
   uint8_t *const white_;
-  uint8_t *const effect_data_;
+  uint16_t *const effect_data_;
   const ESPColorCorrection *color_correction_;
 };
 

--- a/esphome/components/light/esp_range_view.cpp
+++ b/esphome/components/light/esp_range_view.cpp
@@ -39,7 +39,7 @@ void ESPRangeView::set_white(uint8_t white) {
   for (auto c : *this)
     c.set_white(white);
 }
-void ESPRangeView::set_effect_data(uint8_t effect_data) {
+void ESPRangeView::set_effect_data(uint16_t effect_data) {
   for (auto c : *this)
     c.set_effect_data(effect_data);
 }

--- a/esphome/components/light/esp_range_view.h
+++ b/esphome/components/light/esp_range_view.h
@@ -31,7 +31,7 @@ class ESPRangeView : public ESPColorSettable {
   void set_green(uint8_t green) override;
   void set_blue(uint8_t blue) override;
   void set_white(uint8_t white) override;
-  void set_effect_data(uint8_t effect_data) override;
+  void set_effect_data(uint16_t effect_data) override;
 
   void fade_to_white(uint8_t amnt) override;
   void fade_to_black(uint8_t amnt) override;

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -55,9 +55,8 @@ class LightTransitionTransformer : public LightTransformer {
   }
 
  protected:
-  // This looks crazy, but it reduces to 6x^5 - 15x^4 + 10x^3 which is just a smooth sigmoid-like
-  // transition from 0 to 1 on x = [0, 1]
-  static float smoothed_progress(float x) { return x * x * x * (x * (x * 6.0f - 15.0f) + 10.0f); }
+  // This is a sigmoid-like transition from 0 to 1 on x=[0, 1] with zero derivative at x=0 and x=1.
+  static float smoothed_progress(float x) { return (-2.0f * x + 3.0f) * x * x; }
 
   bool changing_color_mode_{false};
   LightColorValues end_values_{};

--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -81,7 +81,7 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight {
       (*this)[i] = Color(0, 0, 0, 0);
     }
 
-    this->effect_data_ = new uint8_t[this->size()];  // NOLINT
+    this->effect_data_ = new uint16_t[this->size()];  // NOLINT
     this->controller_->Begin();
   }
 
@@ -106,7 +106,7 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight {
 
  protected:
   NeoPixelBus<T_COLOR_FEATURE, T_METHOD> *controller_{nullptr};
-  uint8_t *effect_data_{nullptr};
+  uint16_t *effect_data_{nullptr};
   uint8_t rgb_offsets_[4]{0, 1, 2, 3};
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

Ever since I fixed transitions for addressable lights running fast in #2124, they were starting too slow. Fix that through some complicated math.

I'm not convinced yet whether this is the best solution, or if we should just give up on avoiding copying the state for each LED. After all, the state is just 4 bytes per LED, so even with 1024 LEDs it'd only cost 3 KB of RAM over this solution (and only during transitions). Input welcome.

Furthermore, I'm fairly sure this works, but last time I touched transitions a lot of stuff broke unexpectedly, so testing welcome!

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2397 (and probably others)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
