### PR TITLE
INA260 Current and Power Sensor support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -73,6 +73,7 @@ esphome/components/homeassistant/* @OttoWinter
 esphome/components/hrxl_maxsonar_wr/* @netmikey
 esphome/components/i2c/* @esphome/core
 esphome/components/improv_serial/* @esphome/core
+esphome/components/ina260/* @MrEditor97
 esphome/components/inkbird_ibsth1_mini/* @fkirill
 esphome/components/inkplate6/* @jesserockz
 esphome/components/integration/* @OttoWinter

--- a/esphome/components/ina260/ina260.cpp
+++ b/esphome/components/ina260/ina260.cpp
@@ -1,0 +1,152 @@
+#include "ina260.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace ina260 {
+
+static const char *const TAG = "ina260";
+
+// | A0   | A1   | Address |
+// | GND  | GND  | 0x40    |
+// | GND  | V_S+ | 0x41    |
+// | GND  | SDA  | 0x42    |
+// | GND  | SCL  | 0x43    |
+// | V_S+ | GND  | 0x44    |
+// | V_S+ | V_S+ | 0x45    |
+// | V_S+ | SDA  | 0x46    |
+// | V_S+ | SCL  | 0x47    |
+// | SDA  | GND  | 0x48    |
+// | SDA  | V_S+ | 0x49    |
+// | SDA  | SDA  | 0x4A    |
+// | SDA  | SCL  | 0x4B    |
+// | SCL  | GND  | 0x4C    |
+// | SCL  | V_S+ | 0x4D    |
+// | SCL  | SDA  | 0x4E    |
+// | SCL  | SCL  | 0x4F    |
+
+enum {
+  INA260_REGISTER_CONFIG = 0x00,
+  INA260_REGISTER_CURRENT = 0x01,
+  INA260_REGISTER_BUS_VOLTAGE = 0x02,
+  INA260_REGISTER_POWER = 0x03,
+  INA260_REGISTER_MASK_ENABLE = 0x06,
+  INA260_REGISTER_ALERT_LIMIT = 0x07,
+  INA260_REGISTER_MANUFACTURE_ID = 0xFE,
+  INA260_REGISTER_DEVICE_ID = 0xFF
+};
+
+enum mode {
+  INA260_MODE_SHUTDOWN = 0x00,
+  INA260_MODE_TRIGGERED = 0x03,
+  INA260_MODE_CONTINOUS = 0x07,
+};
+
+void INA260Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up INA260...");
+
+  // Reset device on setup
+  // 0bx000000000000000 << 15 RESET Bit (1 -> trigger reset)
+  if (!this->write_byte_16(INA260_REGISTER_CONFIG, 0x8000)) {
+    this->error_code_ = DEVICE_RESET_FAILED;
+    this->mark_failed();
+    return;
+  }
+
+  delay(2);  // NOLINT
+
+  this->read_byte_16(INA260_REGISTER_MANUFACTURE_ID, &this->manufacture_id_);
+  this->read_byte_16(INA260_REGISTER_DEVICE_ID, &this->device_id_);
+
+  if (this->manufacture_id_ != (uint16_t) 0x5449 || this->device_id_ != (uint16_t) 0x2270) {
+    this->error_code_ = COMMUNICATION_FAILED;
+    this->mark_failed();
+    return;
+  }
+
+  uint16_t config = 0x0000;
+
+  // Averaging Mode AVG Bit Settings[11:9] (000 -> 1 sample, 001 -> 4 sample, 111 -> 1024 samples)
+  config |= 0b0000001000000000;
+
+  // Bus Voltage Conversion Time VBUSCT Bit Settings [8:6] (100 -> 1.1ms, 111 -> 8.244 ms)
+  config |= 0b0000000100000000;
+
+  // Mode Settings [2:0] Combinations (001 -> Continuous)
+  config |= 0b0000000000000001;
+
+  if (!this->write_byte_16(INA260_REGISTER_CONFIG, config)) {
+    this->error_code_ = FAILED_TO_UPDATE_CONFIGURATION;
+    this->mark_failed();
+    return;
+  }
+}
+
+void INA260Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "INA260:");
+  LOG_I2C_DEVICE(this);
+  LOG_UPDATE_INTERVAL(this);
+
+  ESP_LOGCONFIG(TAG, "  Manufacture ID: 0x%x", this->manufacture_id_);
+  ESP_LOGCONFIG(TAG, "  Device ID: 0x%x", this->device_id_);
+
+  LOG_SENSOR("  ", "Bus Voltage", this->bus_voltage_sensor_);
+  LOG_SENSOR("  ", "Current", this->current_sensor_);
+  LOG_SENSOR("  ", "Power", this->power_sensor_);
+
+  switch (this->error_code_) {
+    case COMMUNICATION_FAILED:
+      ESP_LOGE(TAG, "Connected device does not match a known INA260 sensor");
+      break;
+    case DEVICE_RESET_FAILED:
+      ESP_LOGE(TAG, "Device reset failed - Is the device connected?");
+      break;
+    case FAILED_TO_UPDATE_CONFIGURATION:
+      ESP_LOGE(TAG, "Failed to update device configuration");
+      break;
+    case NONE:
+      break;
+    default:
+      break;
+  }
+}
+
+void INA260Component::update() {
+  if (this->bus_voltage_sensor_ != nullptr) {
+    uint16_t raw_bus_voltage;
+    if (!this->read_byte_16(INA260_REGISTER_BUS_VOLTAGE, &raw_bus_voltage)) {
+      this->status_set_warning();
+      return;
+    }
+    float bus_voltage_v = int16_t(raw_bus_voltage) * 0.00125f;
+    this->bus_voltage_sensor_->publish_state(bus_voltage_v);
+  }
+
+  if (this->current_sensor_ != nullptr) {
+    uint16_t raw_current;
+    if (!this->read_byte_16(INA260_REGISTER_CURRENT, &raw_current)) {
+      this->status_set_warning();
+      return;
+    }
+    // float current_ma = int16_t(raw_current) * (this->calibration_lsb_ / 1000.0f);
+    // this->current_sensor_->publish_state(current_ma / 1000.0f);
+    float current_ma = int16_t(raw_current) * 0.00125f;
+    this->current_sensor_->publish_state(current_ma);
+  }
+
+  if (this->power_sensor_ != nullptr) {
+    uint16_t raw_power;
+    if (!this->read_byte_16(INA260_REGISTER_POWER, &raw_power)) {
+      this->status_set_warning();
+      return;
+    }
+    // float power_mw = int16_t(raw_power) * (this->calibration_lsb_ * 25.0f / 1000.0f);
+    float power_mw = int16_t(raw_power) * 10 * 0.00125f;
+    this->power_sensor_->publish_state(power_mw);
+  }
+
+  this->status_clear_warning();
+}
+
+}  // namespace ina260
+}  // namespace esphome

--- a/esphome/components/ina260/ina260.cpp
+++ b/esphome/components/ina260/ina260.cpp
@@ -85,7 +85,6 @@ void INA260Component::dump_config() {
       ESP_LOGE(TAG, "Failed to update device configuration");
       break;
     case NONE:
-      break;
     default:
       break;
   }

--- a/esphome/components/ina260/ina260.cpp
+++ b/esphome/components/ina260/ina260.cpp
@@ -36,12 +36,6 @@ enum {
   INA260_REGISTER_DEVICE_ID = 0xFF
 };
 
-enum mode {
-  INA260_MODE_SHUTDOWN = 0x00,
-  INA260_MODE_TRIGGERED = 0x03,
-  INA260_MODE_CONTINOUS = 0x07,
-};
-
 void INA260Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up INA260...");
 
@@ -72,8 +66,8 @@ void INA260Component::setup() {
   // Bus Voltage Conversion Time VBUSCT Bit Settings [8:6] (100 -> 1.1ms, 111 -> 8.244 ms)
   config |= 0b0000000100000000;
 
-  // Mode Settings [2:0] Combinations (001 -> Continuous)
-  config |= 0b0000000000000001;
+  // Mode Settings [2:0] Combinations (111 -> Shunt, Bus, Continuous)
+  config |= 0b0000000000000111;
 
   if (!this->write_byte_16(INA260_REGISTER_CONFIG, config)) {
     this->error_code_ = FAILED_TO_UPDATE_CONFIGURATION;
@@ -128,8 +122,6 @@ void INA260Component::update() {
       this->status_set_warning();
       return;
     }
-    // float current_ma = int16_t(raw_current) * (this->calibration_lsb_ / 1000.0f);
-    // this->current_sensor_->publish_state(current_ma / 1000.0f);
     float current_ma = int16_t(raw_current) * 0.00125f;
     this->current_sensor_->publish_state(current_ma);
   }
@@ -140,8 +132,7 @@ void INA260Component::update() {
       this->status_set_warning();
       return;
     }
-    // float power_mw = int16_t(raw_power) * (this->calibration_lsb_ * 25.0f / 1000.0f);
-    float power_mw = int16_t(raw_power) * 10 * 0.00125f;
+    float power_mw = ((int16_t(raw_power) * 10.0f) / 1000.0f);
     this->power_sensor_->publish_state(power_mw);
   }
 

--- a/esphome/components/ina260/ina260.h
+++ b/esphome/components/ina260/ina260.h
@@ -24,10 +24,7 @@ class INA260Component : public PollingComponent, public i2c::I2CDevice {
   uint16_t manufacture_id_{0};
   uint16_t device_id_{0};
 
-  // float shunt_resistance_ohm_{0.02};
-  float max_current_amp_{13};
-
-  uint32_t calibration_lsb_{0};
+  float max_current_amp_{15};
 
   sensor::Sensor *bus_voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};

--- a/esphome/components/ina260/ina260.h
+++ b/esphome/components/ina260/ina260.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace ina260 {
+
+class INA260Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_max_current_amps(float max_current_amp) { this->max_current_amp_ = max_current_amp; }
+  void set_bus_voltage_sensor(sensor::Sensor *bus_voltage_sensor) { this->bus_voltage_sensor_ = bus_voltage_sensor; }
+  void set_current_sensor(sensor::Sensor *current_sensor) { this->current_sensor_ = current_sensor; }
+  void set_power_sensor(sensor::Sensor *power_sensor) { this->power_sensor_ = power_sensor; }
+
+ protected:
+  uint16_t manufacture_id_{0};
+  uint16_t device_id_{0};
+
+  // float shunt_resistance_ohm_{0.02};
+  float max_current_amp_{13};
+
+  uint32_t calibration_lsb_{0};
+
+  sensor::Sensor *bus_voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
+  sensor::Sensor *power_sensor_{nullptr};
+
+  enum ErrorCode {
+    NONE,
+    COMMUNICATION_FAILED,
+    DEVICE_RESET_FAILED,
+    FAILED_TO_UPDATE_CONFIGURATION,
+  } error_code_{NONE};
+};
+
+}  // namespace ina260
+}  // namespace esphome

--- a/esphome/components/ina260/ina260.h
+++ b/esphome/components/ina260/ina260.h
@@ -15,7 +15,6 @@ class INA260Component : public PollingComponent, public i2c::I2CDevice {
 
   float get_setup_priority() const override { return setup_priority::DATA; }
 
-  void set_max_current_amps(float max_current_amp) { this->max_current_amp_ = max_current_amp; }
   void set_bus_voltage_sensor(sensor::Sensor *bus_voltage_sensor) { this->bus_voltage_sensor_ = bus_voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { this->current_sensor_ = current_sensor; }
   void set_power_sensor(sensor::Sensor *power_sensor) { this->power_sensor_ = power_sensor; }
@@ -23,8 +22,6 @@ class INA260Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   uint16_t manufacture_id_{0};
   uint16_t device_id_{0};
-
-  float max_current_amp_{15};
 
   sensor::Sensor *bus_voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};

--- a/esphome/components/ina260/sensor.py
+++ b/esphome/components/ina260/sensor.py
@@ -1,0 +1,81 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_BUS_VOLTAGE,
+    CONF_CURRENT,
+    CONF_MAX_CURRENT,
+    CONF_POWER,
+    CONF_SHUNT_RESISTANCE,
+    DEVICE_CLASS_VOLTAGE,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_POWER,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_VOLT,
+    UNIT_AMPERE,
+    UNIT_WATT,
+)
+
+DEPENDENCIES = ["i2c"]
+CODEOWNERS = ["@MrEditor97"]
+
+ina260_ns = cg.esphome_ns.namespace("ina260")
+INA260Component = ina260_ns.class_(
+    "INA260Component", cg.PollingComponent, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(INA260Component),
+            cv.Optional(CONF_BUS_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_SHUNT_RESISTANCE, default=0.002): cv.All(
+                cv.resistance, cv.Range(min=0.0)
+            ),
+            cv.Optional(CONF_MAX_CURRENT, default=15): cv.All(
+                cv.current, cv.Range(min=0.0)
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x40))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    cg.add(var.set_max_current_amps(config[CONF_MAX_CURRENT]))
+
+    if CONF_BUS_VOLTAGE in config:
+        sens = await sensor.new_sensor(config[CONF_BUS_VOLTAGE])
+        cg.add(var.set_bus_voltage_sensor(sens))
+
+    if CONF_CURRENT in config:
+        sens = await sensor.new_sensor(config[CONF_CURRENT])
+        cg.add(var.set_current_sensor(sens))
+
+    if CONF_POWER in config:
+        sens = await sensor.new_sensor(config[CONF_POWER])
+        cg.add(var.set_power_sensor(sens))

--- a/esphome/components/ina260/sensor.py
+++ b/esphome/components/ina260/sensor.py
@@ -5,7 +5,6 @@ from esphome.const import (
     CONF_ID,
     CONF_BUS_VOLTAGE,
     CONF_CURRENT,
-    CONF_MAX_CURRENT,
     CONF_POWER,
     DEVICE_CLASS_VOLTAGE,
     DEVICE_CLASS_CURRENT,
@@ -46,9 +45,6 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_MAX_CURRENT, default=15): cv.All(
-                cv.current, cv.Range(min=0.0)
-            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -61,8 +57,6 @@ async def to_code(config):
 
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
-
-    cg.add(var.set_max_current_amps(config[CONF_MAX_CURRENT]))
 
     if CONF_BUS_VOLTAGE in config:
         sens = await sensor.new_sensor(config[CONF_BUS_VOLTAGE])

--- a/esphome/components/ina260/sensor.py
+++ b/esphome/components/ina260/sensor.py
@@ -7,7 +7,6 @@ from esphome.const import (
     CONF_CURRENT,
     CONF_MAX_CURRENT,
     CONF_POWER,
-    CONF_SHUNT_RESISTANCE,
     DEVICE_CLASS_VOLTAGE,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_POWER,
@@ -46,9 +45,6 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=2,
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_SHUNT_RESISTANCE, default=0.002): cv.All(
-                cv.resistance, cv.Range(min=0.0)
             ),
             cv.Optional(CONF_MAX_CURRENT, default=15): cv.All(
                 cv.current, cv.Range(min=0.0)

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -304,6 +304,16 @@ sensor:
       name: "Wave Mini Pressure"
     tvoc:
       name: "Wave Mini VOC"
+  - platform: ina260
+    address: 0x40
+    current:
+      name: "INA260 Current"
+    power:
+      name: "INA260 Power"
+    bus_voltage:
+      name: "INA260 Voltage"
+    max_current: 15A
+    update_interval: 60s
 
 time:
   - platform: homeassistant

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -312,7 +312,6 @@ sensor:
       name: "INA260 Power"
     bus_voltage:
       name: "INA260 Voltage"
-    max_current: 15A
     update_interval: 60s
 
 time:


### PR DESCRIPTION
# What does this implement/fix? 

Adding of INA260 Current and Power sensor support to ESP Home.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1649

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
i2c:
  sda: 21
  scl: 22
  scan: true

sensor:
  - platform: ina260
    address: 0x40
    current:
      name: "INA260 Current"
    power:
      name: "INA260 Power"
    bus_voltage:
      name: "INA260 Voltage"
    max_current: 15A
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
