### PR TITLE
Attempt to load states of light from preferences, else fall back to d…

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -54,14 +54,14 @@ void LightState::setup() {
       this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
       // Attempted to load states of light from preferences, else fall back to default values
       if (!this->rtc_.load(&recovered)) {
-          recovered.state = false;
+        recovered.state = false;
       }
       break;
     case LIGHT_RESTORE_DEFAULT_ON:
       this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
       // Attempted to load states of light from preferences, else fall back to default values
       if (!this->rtc_.load(&recovered)) {
-          recovered.state = true;
+        recovered.state = true;
       }
       break;
     case LIGHT_RESTORE_INVERTED_DEFAULT_OFF:

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -52,15 +52,17 @@ void LightState::setup() {
   switch (this->restore_mode_) {
     case LIGHT_RESTORE_DEFAULT_OFF:
       this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
-        if (!this->rtc_.load(&recovered)) {
+      // Attempted to load states of light from preferences, else fall back to default values
+      if (!this->rtc_.load(&recovered)) {
           recovered.state = false;
-        }
+      }
       break;
     case LIGHT_RESTORE_DEFAULT_ON:
-        this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
-        if (!this->rtc_.load(&recovered)) {
+      this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
+      // Attempted to load states of light from preferences, else fall back to default values
+      if (!this->rtc_.load(&recovered)) {
           recovered.state = true;
-        }
+      }
       break;
     case LIGHT_RESTORE_INVERTED_DEFAULT_OFF:
     case LIGHT_RESTORE_INVERTED_DEFAULT_ON:

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -51,7 +51,17 @@ void LightState::setup() {
   LightStateRTCState recovered{};
   switch (this->restore_mode_) {
     case LIGHT_RESTORE_DEFAULT_OFF:
+      this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
+        if (!this->rtc_.load(&recovered)) {
+          recovered.state = false;
+        }
+      break;
     case LIGHT_RESTORE_DEFAULT_ON:
+        this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
+        if (!this->rtc_.load(&recovered)) {
+          recovered.state = true;
+        }
+      break;
     case LIGHT_RESTORE_INVERTED_DEFAULT_OFF:
     case LIGHT_RESTORE_INVERTED_DEFAULT_ON:
       this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());


### PR DESCRIPTION
…efault values

# What does this implement/fix? 

Attempted to load states of light from preferences, else fall back to default values

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
