### PR TITLE
Add delay to improve stability

### DIFF
--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -163,7 +163,7 @@ void SCD30Component::update() {
     this->status_set_warning();
     return;
   }
-
+  delay(4);
   this->set_timeout(50, [this]() {
     uint16_t raw_data[6];
     if (!this->read_data_(raw_data, 6)) {
@@ -200,6 +200,7 @@ bool SCD30Component::is_data_ready_() {
   if (!this->write_command_(SCD30_CMD_GET_DATA_READY_STATUS)) {
     return false;
   }
+  delay(4);
   uint16_t is_data_ready;
   if (!this->read_data_(&is_data_ready, 1)) {
     return false;

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -163,7 +163,7 @@ void SCD30Component::update() {
     this->status_set_warning();
     return;
   }
-  delay(4);
+
   this->set_timeout(50, [this]() {
     uint16_t raw_data[6];
     if (!this->read_data_(raw_data, 6)) {


### PR DESCRIPTION
According to Sensirion's SCD30 interface description:
Section 1.4.4 "Get data ready status" & Section 1.4.5 "Read measurement"
Quote:
> Note that the read header should be send with a delay of > 3ms following the write sequence

https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.5_CO2/Sensirion_CO2_Sensors_SCD30_Interface_Description.pdf

# What does this implement/fix? 

Fixes randomly occurring unusually high CO2 values (spikes) when reading from the sensor.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes NONE

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> NONE

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: scd30
    co2:
      name: "Workshop CO2"
      accuracy_decimals: 1
    temperature:
      name: "Workshop Temperature"
      accuracy_decimals: 2
    humidity:
      name: "Workshop Humidity"
      accuracy_decimals: 1
    temperature_offset: 1.5 °C
    address: 0x61
    update_interval: 5s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
