### PR TITLE
total_daily_energy: allow to disable restore mode

### DIFF
--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -4,6 +4,7 @@ from esphome.components import sensor, time
 from esphome.const import (
     CONF_ICON,
     CONF_ID,
+    CONF_RESTORE,
     CONF_TIME_ID,
     DEVICE_CLASS_ENERGY,
     CONF_METHOD,
@@ -36,6 +37,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(TotalDailyEnergy),
             cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
             cv.Required(CONF_POWER_ID): cv.use_id(sensor.Sensor),
+            cv.Optional(CONF_RESTORE, default=True): cv.boolean,
             cv.Optional(
                 CONF_MIN_SAVE_INTERVAL, default="0s"
             ): cv.positive_time_period_milliseconds,
@@ -70,5 +72,6 @@ async def to_code(config):
     cg.add(var.set_parent(sens))
     time_ = await cg.get_variable(config[CONF_TIME_ID])
     cg.add(var.set_time(time_))
+    cg.add(var.set_restore(config[CONF_RESTORE]))
     cg.add(var.set_min_save_interval(config[CONF_MIN_SAVE_INTERVAL]))
     cg.add(var.set_method(config[CONF_METHOD]))

--- a/esphome/components/total_daily_energy/total_daily_energy.cpp
+++ b/esphome/components/total_daily_energy/total_daily_energy.cpp
@@ -7,14 +7,14 @@ namespace total_daily_energy {
 static const char *const TAG = "total_daily_energy";
 
 void TotalDailyEnergy::setup() {
-  this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+  float initial_value = 0;
 
-  float recovered;
-  if (this->pref_.load(&recovered)) {
-    this->publish_state_and_save(recovered);
-  } else {
-    this->publish_state_and_save(0);
+  if (this->restore_) {
+    this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+    this->pref_.load(&initial_value);
   }
+  this->publish_state_and_save(initial_value);
+
   this->last_update_ = millis();
   this->last_save_ = this->last_update_;
 

--- a/esphome/components/total_daily_energy/total_daily_energy.h
+++ b/esphome/components/total_daily_energy/total_daily_energy.h
@@ -17,6 +17,7 @@ enum TotalDailyEnergyMethod {
 
 class TotalDailyEnergy : public sensor::Sensor, public Component {
  public:
+  void set_restore(bool restore) { restore_ = restore; }
   void set_min_save_interval(uint32_t min_interval) { this->min_save_interval_ = min_interval; }
   void set_time(time::RealTimeClock *time) { time_ = time; }
   void set_parent(Sensor *parent) { parent_ = parent; }
@@ -41,6 +42,7 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   uint32_t last_update_{0};
   uint32_t last_save_{0};
   uint32_t min_save_interval_{0};
+  bool restore_;
   float total_energy_{0.0f};
   float last_power_state_{0.0f};
 };


### PR DESCRIPTION
# What does this implement/fix? 
Similarly to the *Integration* component, allow to disable the saving of intermediate results to device.
Currently you can set the save interval but not disable it.
To make it non-breaking, the default `restore` mode is `true`, which is the opposite of the default behavior of *Integration* component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1656

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:


```yaml
sensor:
  - platform: total_daily_energy
    name: "Total Daily Energy"
    power_id: my_power
    restore: false
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
