### PR TITLE
Upgrade to latest zeroconf release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ esptool==3.2
 click==8.0.3
 esphome-dashboard==20211021.1
 aioesphomeapi==10.2.0
-zeroconf==0.36.13
+zeroconf==0.37.0
 
 # esp-idf requires this, but doesn't bundle it by default
 # https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24


### PR DESCRIPTION
# What does this implement/fix? 

Update to latest upstream release 0.37.0

Change log: https://github.com/jstasiak/python-zeroconf/releases/tag/0.37.0

Platform.io requires it [already](https://github.com/platformio/platformio-core/blob/develop/setup.py#L42) (not released yet).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
