### PR TITLE
Correct constant for dynamic I2S bus in NeoPixelBus

### DIFF
--- a/esphome/components/neopixelbus/_methods.py
+++ b/esphome/components/neopixelbus/_methods.py
@@ -88,8 +88,8 @@ def _esp32_i2s_default_bus():
 
 
 def _validate_esp32_i2s_bus(value):
-    if isinstance(value, str) and value.lower() == CHANNEL_DYNAMIC:
-        value = CHANNEL_DYNAMIC
+    if isinstance(value, str) and value.lower() == BUS_DYNAMIC:
+        value = BUS_DYNAMIC
     else:
         value = cv.int_(value)
     variant_buses = {


### PR DESCRIPTION
# What does this implement/fix? 

Correct constant for dynamic I2S bus in NeoPixelBus

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
