### PR TITLE
Fix restoring preferences for ESP32

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -76,6 +76,7 @@ class ESP32Preferences : public ESPPreferences {
   uint32_t current_offset = 0;
 
   void open() {
+    nvs_flash_init();
     esp_err_t err = nvs_open("esphome", NVS_READWRITE, &nvs_handle);
     if (err == 0)
       return;


### PR DESCRIPTION
# What does this implement/fix? 

Preferences are not restored after a restart (also reported by people as "preferences aren't saved").
Added a missing `nvs_flash_init()` call before `nvs_open(...)` to get things going.
Before this fix, `nvs_open(...)` returned `ESP_ERR_NVS_NOT_INITIALIZED`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2682

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
