### PR TITLE
Extend esp32_camera with requester to improve performance

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -705,7 +705,9 @@ void APIConnection::send_camera_state(std::shared_ptr<esp32_camera::CameraImage>
     return;
   if (this->image_reader_.available())
     return;
-  this->image_reader_.set_image(std::move(image));
+  if (image->was_requested_by(esphome::esp32_camera::API_REQUESTER) ||
+      image->was_requested_by(esphome::esp32_camera::IDLE))
+    this->image_reader_.set_image(std::move(image));
 }
 bool APIConnection::send_camera_info(esp32_camera::ESP32Camera *camera) {
   ListEntitiesCameraResponse msg;
@@ -723,12 +725,12 @@ void APIConnection::camera_image(const CameraImageRequest &msg) {
     return;
 
   if (msg.single)
-    esp32_camera::global_esp32_camera->request_image(esphome::esp32_camera::API_SINK);
+    esp32_camera::global_esp32_camera->request_image(esphome::esp32_camera::API_REQUESTER);
   if (msg.stream) {
-    esp32_camera::global_esp32_camera->start_stream(esphome::esp32_camera::API_SINK);
+    esp32_camera::global_esp32_camera->start_stream(esphome::esp32_camera::API_REQUESTER);
 
-    App.scheduler.set_timeout(this->parent_, "api_esp32_camera_stop_stream", ESP32_CAMERA_STOP_STREAM, []() { 
-      esp32_camera::global_esp32_camera->stop_stream(esphome::esp32_camera::API_SINK);
+    App.scheduler.set_timeout(this->parent_, "api_esp32_camera_stop_stream", ESP32_CAMERA_STOP_STREAM, []() {
+      esp32_camera::global_esp32_camera->stop_stream(esphome::esp32_camera::API_REQUESTER);
     });
   }
 }

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -136,6 +136,13 @@ void ESP32Camera::loop() {
     this->current_image_.reset();
   }
 
+  // request idle image every idle_update_interval
+  const uint32_t now = millis();
+  if (this->idle_update_interval_ != 0 && now - this->last_idle_request_ > this->idle_update_interval_) {
+    this->last_idle_request_ = now;
+    this->request_image(IDLE);
+  }
+
   // Check if we should fetch a new image
   if (!this->has_requested_image_())
     return;
@@ -143,7 +150,6 @@ void ESP32Camera::loop() {
     // image is still in use
     return;
   }
-  const uint32_t now = millis();
   if (now - this->last_update_ <= this->max_update_interval_)
     return;
 
@@ -160,12 +166,12 @@ void ESP32Camera::loop() {
     xQueueSend(this->framebuffer_return_queue_, &fb, portMAX_DELAY);
     return;
   }
-  this->current_image_ = std::make_shared<CameraImage>(fb);
+  this->current_image_ = std::make_shared<CameraImage>(fb, this->single_requesters_ | this->stream_requesters_);
 
   ESP_LOGD(TAG, "Got Image: len=%u", fb->len);
   this->new_image_callback_.call(this->current_image_);
   this->last_update_ = now;
-  this->single_requester_ = false;
+  this->single_requesters_ = 0;
 }
 void ESP32Camera::framebuffer_task(void *pv) {
   while (true) {
@@ -261,24 +267,10 @@ void ESP32Camera::set_brightness(int brightness) { this->brightness_ = brightnes
 void ESP32Camera::set_saturation(int saturation) { this->saturation_ = saturation; }
 float ESP32Camera::get_setup_priority() const { return setup_priority::DATA; }
 uint32_t ESP32Camera::hash_base() { return 3010542557UL; }
-void ESP32Camera::request_image() { this->single_requester_ = true; }
-void ESP32Camera::request_stream() { this->last_stream_request_ = millis(); }
-bool ESP32Camera::has_requested_image_() const {
-  if (this->single_requester_)
-    // single request
-    return true;
-
-  uint32_t now = millis();
-  if (now - this->last_stream_request_ < 5000)
-    // stream request
-    return true;
-
-  if (this->idle_update_interval_ != 0 && now - this->last_update_ > this->idle_update_interval_)
-    // idle update
-    return true;
-
-  return false;
-}
+void ESP32Camera::request_image(CameraRequester requester) { this->single_requesters_ |= 1 << requester; }
+void ESP32Camera::start_stream(CameraRequester requester) { this->stream_requesters_ |= 1 << requester; }
+void ESP32Camera::stop_stream(CameraRequester requester) { this->stream_requesters_ &= ~(1 << requester); }
+bool ESP32Camera::has_requested_image_() const { return this->single_requesters_ || this->stream_requesters_; }
 bool ESP32Camera::can_return_image_() const { return this->current_image_.use_count() == 1; }
 void ESP32Camera::set_max_update_interval(uint32_t max_update_interval) {
   this->max_update_interval_ = max_update_interval;
@@ -307,7 +299,10 @@ uint8_t *CameraImageReader::peek_data_buffer() { return this->image_->get_data_b
 camera_fb_t *CameraImage::get_raw_buffer() { return this->buffer_; }
 uint8_t *CameraImage::get_data_buffer() { return this->buffer_->buf; }
 size_t CameraImage::get_data_length() { return this->buffer_->len; }
-CameraImage::CameraImage(camera_fb_t *buffer) : buffer_(buffer) {}
+bool CameraImage::was_requested_by(CameraRequester requester) const {
+  return (this->requesters_ & (1 << requester)) != 0;
+}
+CameraImage::CameraImage(camera_fb_t *buffer, uint8_t requesters) : buffer_(buffer), requesters_(requesters) {}
 
 }  // namespace esp32_camera
 }  // namespace esphome

--- a/esphome/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.cpp
@@ -169,10 +169,11 @@ esp_err_t CameraWebServer::streaming_handler_(struct httpd_req *req) {
   uint32_t last_frame = millis();
   uint32_t frames = 0;
 
+  if (esp32_camera::global_esp32_camera != nullptr) {
+    esp32_camera::global_esp32_camera->start_stream(esphome::esp32_camera::WEB_SINK);
+  }
+
   while (res == ESP_OK && this->running_) {
-    if (esp32_camera::global_esp32_camera != nullptr) {
-      esp32_camera::global_esp32_camera->request_stream();
-    }
 
     auto image = this->wait_for_image_();
 
@@ -204,6 +205,10 @@ esp_err_t CameraWebServer::streaming_handler_(struct httpd_req *req) {
     res = httpd_send_all(req, STREAM_ERROR, strlen(STREAM_ERROR));
   }
 
+  if (esp32_camera::global_esp32_camera != nullptr) {
+    esp32_camera::global_esp32_camera->stop_stream(esphome::esp32_camera::WEB_SINK);
+  }
+
   ESP_LOGI(TAG, "STREAM: closed. Frames: %u", frames);
 
   return res;
@@ -213,7 +218,7 @@ esp_err_t CameraWebServer::snapshot_handler_(struct httpd_req *req) {
   esp_err_t res = ESP_OK;
 
   if (esp32_camera::global_esp32_camera != nullptr) {
-    esp32_camera::global_esp32_camera->request_image();
+    esp32_camera::global_esp32_camera->request_image(esphome::esp32_camera::WEB_SINK);
   }
 
   auto image = this->wait_for_image_();

--- a/esphome/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.cpp
@@ -14,7 +14,7 @@
 namespace esphome {
 namespace esp32_camera_web_server {
 
-static const int IMAGE_REQUEST_TIMEOUT = 2000;
+static const int IMAGE_REQUEST_TIMEOUT = 5000;
 static const char *const TAG = "esp32_camera_web_server";
 
 #define PART_BOUNDARY "123456789000000000000987654321"
@@ -68,7 +68,7 @@ void CameraWebServer::setup() {
   httpd_register_uri_handler(this->httpd_, &uri);
 
   esp32_camera::global_esp32_camera->add_image_callback([this](std::shared_ptr<esp32_camera::CameraImage> image) {
-    if (this->running_) {
+    if (this->running_ && image->was_requested_by(esp32_camera::WEB_REQUESTER)) {
       this->image_ = std::move(image);
       xSemaphoreGive(this->semaphore_);
     }
@@ -169,12 +169,9 @@ esp_err_t CameraWebServer::streaming_handler_(struct httpd_req *req) {
   uint32_t last_frame = millis();
   uint32_t frames = 0;
 
-  if (esp32_camera::global_esp32_camera != nullptr) {
-    esp32_camera::global_esp32_camera->start_stream(esphome::esp32_camera::WEB_SINK);
-  }
+  esp32_camera::global_esp32_camera->start_stream(esphome::esp32_camera::WEB_REQUESTER);
 
   while (res == ESP_OK && this->running_) {
-
     auto image = this->wait_for_image_();
 
     if (!image) {
@@ -205,9 +202,7 @@ esp_err_t CameraWebServer::streaming_handler_(struct httpd_req *req) {
     res = httpd_send_all(req, STREAM_ERROR, strlen(STREAM_ERROR));
   }
 
-  if (esp32_camera::global_esp32_camera != nullptr) {
-    esp32_camera::global_esp32_camera->stop_stream(esphome::esp32_camera::WEB_SINK);
-  }
+  esp32_camera::global_esp32_camera->stop_stream(esphome::esp32_camera::WEB_REQUESTER);
 
   ESP_LOGI(TAG, "STREAM: closed. Frames: %u", frames);
 
@@ -217,9 +212,7 @@ esp_err_t CameraWebServer::streaming_handler_(struct httpd_req *req) {
 esp_err_t CameraWebServer::snapshot_handler_(struct httpd_req *req) {
   esp_err_t res = ESP_OK;
 
-  if (esp32_camera::global_esp32_camera != nullptr) {
-    esp32_camera::global_esp32_camera->request_image(esphome::esp32_camera::WEB_SINK);
-  }
+  esp32_camera::global_esp32_camera->request_image(esphome::esp32_camera::WEB_REQUESTER);
 
   auto image = this->wait_for_image_();
 


### PR DESCRIPTION
# What does this implement/fix? 

The `esp32_camera` has two consumers (requesters): web and api.
This improves a situation when two are concurrently used
to avoid situation when if the `web` requests stream or frame
all data is being feed via `api`. Instead it tracks
who requested stream or frame and allows receiver to make
a decision if to consume frame.

This also changes a way how stream is handled. Namely it does
introduce `start_stream` and `stop_stream` to control boundaries
when the stream is needed. Previously the `request_stream` would
pull frames for up-to 5 seconds after stream finished (in case of Web)
increasing CPU and power-usage. The 5 second stream re-request behavior
is retained for API which depends on periodically requesting streaming.

This changes how `idle_update_interval` is done. Previously the idle
request would be triggered an defined interval after the last frame
was requested. This changes to request the `Idle` unconditionally
every specific interval regardless of other requesters. This
makes us feed to `idle` frame every interval via API.

In general this improves performance and interoperability by:

- if Web is used, the frames are not feed into API, except periodic Idle frame
- if Web finishes streaming, and there are no more requesters the streaming of frames
  is immediately stopeed

## Testing remarks

I noticed that sometimes it is impossible to access `:8080` and `:8081` camera web server. This is due to very small number of available sockets (10 by default in 1.0.6 Arduino). Given that `esp32_camera_web_server` since it uses `esp32_httpd` consumes 3 sockets (1 listening, 2 for message passing between threads) this very often results in inability to open a stream. My hypothesis is, that this is due to nb of allowed sockets. I will look at this separately to figure out how to fix this (easiest would be to bump to 2.0.0 of Arduino, or change how http server is implemented).

## Types of changes

- [x] Other: Performance improvement

## Test Environment

- [x] ESP32

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
