### PR TITLE
Fix parsing of multiple values in EZO sensor

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -74,6 +74,11 @@ void EZOSensor::loop() {
   if (buf[0] != 1)
     return;
 
+  // some sensors return multiple comma-separated values, terminate string after first one
+  for (int i = 1; i < sizeof(buf) - 1; i++)
+    if (buf[i] == ',')
+      buf[i] = '\0';
+
   float val = parse_number<float>((char *) &buf[1], sizeof(buf) - 2).value_or(0);
   this->publish_state(val);
 }


### PR DESCRIPTION
# What does this implement/fix? 

Fix parsing of multiple values in EZO sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2759

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
