### PR TITLE
Fix parsing numbers in Anova

### DIFF
--- a/esphome/components/anova/anova_base.cpp
+++ b/esphome/components/anova/anova_base.cpp
@@ -104,21 +104,21 @@ void AnovaCodec::decode(const uint8_t *data, uint16_t length) {
       break;
     }
     case READ_TARGET_TEMPERATURE: {
-      this->target_temp_ = parse_number<float>(buf, sizeof(buf)).value_or(0.0f);
+      this->target_temp_ = parse_number<float>(str_until(buf, '\r')).value_or(0.0f);
       if (this->fahrenheit_)
         this->target_temp_ = ftoc(this->target_temp_);
       this->has_target_temp_ = true;
       break;
     }
     case SET_TARGET_TEMPERATURE: {
-      this->target_temp_ = parse_number<float>(buf, sizeof(buf)).value_or(0.0f);
+      this->target_temp_ = parse_number<float>(str_until(buf, '\r')).value_or(0.0f);
       if (this->fahrenheit_)
         this->target_temp_ = ftoc(this->target_temp_);
       this->has_target_temp_ = true;
       break;
     }
     case READ_CURRENT_TEMPERATURE: {
-      this->current_temp_ = parse_number<float>(buf, sizeof(buf)).value_or(0.0f);
+      this->current_temp_ = parse_number<float>(str_until(buf, '\r')).value_or(0.0f);
       if (this->fahrenheit_)
         this->current_temp_ = ftoc(this->current_temp_);
       this->has_current_temp_ = true;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -449,12 +449,10 @@ std::string str_truncate(const std::string &str, size_t length) {
   return str.length() > length ? str.substr(0, length) : str;
 }
 std::string str_until(const char *str, char ch) {
-  char* pos = strchr(str, ch);
+  char *pos = strchr(str, ch);
   return pos == nullptr ? std::string(str) : std::string(str, pos - str);
 }
-std::string str_until(const std::string &str, char ch) {
-  return str.substr(0, str.find(ch));
-}
+std::string str_until(const std::string &str, char ch) { return str.substr(0, str.find(ch)); }
 std::string str_snake_case(const std::string &str) {
   std::string result;
   result.resize(str.length());

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -448,6 +448,13 @@ IRAM_ATTR InterruptLock::~InterruptLock() { portENABLE_INTERRUPTS(); }
 std::string str_truncate(const std::string &str, size_t length) {
   return str.length() > length ? str.substr(0, length) : str;
 }
+std::string str_until(const char *str, char ch) {
+  char* pos = strchr(str, ch);
+  return pos == nullptr ? std::string(str) : std::string(str, pos - str);
+}
+std::string str_until(const std::string &str, char ch) {
+  return str.substr(0, str.find(ch));
+}
 std::string str_snake_case(const std::string &str) {
   std::string result;
   result.resize(str.length());

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -353,6 +353,12 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> constexpr
 /// Truncate a string to a specific length.
 std::string str_truncate(const std::string &str, size_t length);
 
+/// Extract the part of the string until either the first occurence of the specified character, or the end (requires str
+/// to be null-terminated).
+std::string str_until(const char *str, char ch);
+/// Extract the part of the string until either the first occurence of the specified character, or the end.
+std::string str_until(const std::string &str, char ch);
+
 /// Convert the string to snake case (lowercase with underscores).
 std::string str_snake_case(const std::string &str);
 


### PR DESCRIPTION
# What does this implement/fix? 

#2659 broke parsing in Anova, as the value from the sensor had a carriage return appended to it. Strip that before parsing it.

Introduce the `str_until` helper to extract the part of a string from the start until a specified character or the end, as this can be useful more generally, e.g. it could also have been used for #2814. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2757

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
