### PR TITLE
Correct bitmask for third color (blue) scaling.

### DIFF
--- a/esphome/components/display/display_color_utils.h
+++ b/esphome/components/display/display_color_utils.h
@@ -42,7 +42,7 @@ class ColorUtil {
                        ? esp_scale(((colorcode >> third_bits) & ((1 << second_bits) - 1)), ((1 << second_bits) - 1))
                        : esp_scale(((colorcode >> 8) & 0xFF), ((1 << second_bits) - 1));
 
-    third_color = (right_bit_aligned ? esp_scale(((colorcode >> 0) & 0xFF), ((1 << third_bits) - 1))
+    third_color = (right_bit_aligned ? esp_scale(((colorcode >> 0) & ((1 << third_bits) - 1)), ((1 << third_bits) - 1))
                                      : esp_scale(((colorcode >> 0) & 0xFF), (1 << third_bits) - 1));
 
     Color color_return;


### PR DESCRIPTION
# What does this implement/fix? 
Colors represented as 8 bit 332 can be scaled to the internal Color format which is 24+8 bits (RGB+W).

But the scaling function was slightly wrong for the 3rd color.  A bitmask needs to be applied before scaling.

Example format 332 RGB representing color 0xff - the whitest value possible, r=7,g=7,b=3.  This needs to be scaled up to ideally r=255,g=255,b=255.

To scale the blue color, you need to mask 3 with 0b00000011, then scale.

But the existing code masks with 0xFF = 0b11111111, then scales.

This means that in this case, you get some of the green distorting the blue channel.  End user symptom: the white doesn't look as white as it should.

This PR fixes the bitmask by following the pattern from `first_color` & `second_color` directly above it.  The bitmask is set to `(1 << third_bits) - 1))`.  In the example case the bitmask is 0b00000011.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** #2469

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
