### PR TITLE
cse7766: add energy sensor

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -90,6 +90,7 @@ void CSE7766Component::parse_data_() {
   uint32_t power_cycle = this->get_24_bit_uint_(17);
 
   uint8_t adj = this->raw_data_[20];
+  uint32_t cf_pulses = (this->raw_data_[21] << 8) + this->raw_data_[22];
 
   bool power_ok = true;
   bool voltage_ok = true;
@@ -127,6 +128,18 @@ void CSE7766Component::parse_data_() {
     power = power_calib / float(power_cycle);
     this->power_acc_ += power;
     this->power_counts_ += 1;
+
+    uint32_t difference;
+    if (this->cf_pulses_last_ == 0)
+      this->cf_pulses_last_ = cf_pulses;
+
+    if (cf_pulses < this->cf_pulses_last_) {
+      difference = cf_pulses + (0x10000 - this->cf_pulses_last_);
+    } else {
+      difference = cf_pulses - this->cf_pulses_last_;
+    }
+    this->cf_pulses_last_ = cf_pulses;
+    this->energy_total_ += difference * float(power_calib) / 1000000.0 / 3600.0;
   }
 
   if ((adj & 0x20) == 0x20 && current_ok && voltage_ok && power != 0.0) {
@@ -152,6 +165,8 @@ void CSE7766Component::update() {
     this->current_sensor_->publish_state(current);
   if (this->power_sensor_ != nullptr)
     this->power_sensor_->publish_state(power);
+  if (this->energy_sensor_ != nullptr)
+    this->energy_sensor_->publish_state(this->energy_total_);
 
   this->voltage_acc_ = 0.0f;
   this->current_acc_ = 0.0f;
@@ -172,6 +187,7 @@ void CSE7766Component::dump_config() {
   LOG_SENSOR("  ", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("  ", "Current", this->current_sensor_);
   LOG_SENSOR("  ", "Power", this->power_sensor_);
+  LOG_SENSOR("  ", "Energy", this->energy_sensor_);
   this->check_uart_settings(4800);
 }
 

--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -12,6 +12,7 @@ class CSE7766Component : public PollingComponent, public uart::UARTDevice {
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }
   void set_power_sensor(sensor::Sensor *power_sensor) { power_sensor_ = power_sensor; }
+  void set_energy_sensor(sensor::Sensor *energy_sensor) { energy_sensor_ = energy_sensor; }
 
   void loop() override;
   float get_setup_priority() const override;
@@ -29,9 +30,12 @@ class CSE7766Component : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
   float voltage_acc_{0.0f};
   float current_acc_{0.0f};
   float power_acc_{0.0f};
+  float energy_total_{0.0f};
+  uint32_t cf_pulses_last_{0};
   uint32_t voltage_counts_{0};
   uint32_t current_counts_{0};
   uint32_t power_counts_{0};

--- a/esphome/components/cse7766/sensor.py
+++ b/esphome/components/cse7766/sensor.py
@@ -3,16 +3,20 @@ import esphome.config_validation as cv
 from esphome.components import sensor, uart
 from esphome.const import (
     CONF_CURRENT,
+    CONF_ENERGY,
     CONF_ID,
     CONF_POWER,
     CONF_VOLTAGE,
     DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_VOLT,
     UNIT_AMPERE,
     UNIT_WATT,
+    UNIT_WATT_HOURS,
 )
 
 DEPENDENCIES = ["uart"]
@@ -44,6 +48,12 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_ENERGY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT_HOURS,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -71,3 +81,7 @@ async def to_code(config):
         conf = config[CONF_POWER]
         sens = await sensor.new_sensor(conf)
         cg.add(var.set_power_sensor(sens))
+    if CONF_ENERGY in config:
+        conf = config[CONF_ENERGY]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_energy_sensor(sens))


### PR DESCRIPTION
# What does this implement/fix? 

Use cf pulse counter to measure total energy.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#1122](https://github.com/esphome/feature-requests/issues/1122)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1679
## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: cse7766
    current:
      name: Current
    voltage:
      name: Voltage
    power:
      name: Power
    energy:
      name: Energy
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
