### PR TITLE
Allow to configure device model

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -762,7 +762,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.mac_address = get_mac_address_pretty();
   resp.esphome_version = ESPHOME_VERSION;
   resp.compilation_time = App.get_compilation_time();
-  resp.model = ESPHOME_BOARD;
+  resp.model = ESPHOME_DEVICE_MODEL;
 #ifdef USE_DEEP_SLEEP
   resp.has_deep_sleep = deep_sleep::global_has_deep_sleep;
 #endif

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -131,7 +131,7 @@ bool MQTTComponent::send_discovery_() {
         device_info[MQTT_DEVICE_IDENTIFIERS] = get_mac_address();
         device_info[MQTT_DEVICE_NAME] = node_name;
         device_info[MQTT_DEVICE_SW_VERSION] = "esphome v" ESPHOME_VERSION " " + App.get_compilation_time();
-        device_info[MQTT_DEVICE_MODEL] = ESPHOME_BOARD;
+        device_info[MQTT_DEVICE_MODEL] = ESPHOME_DEVICE_MODEL;
         device_info[MQTT_DEVICE_MANUFACTURER] = "espressif";
       },
       0, discovery_info.retain);

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -15,6 +15,7 @@ from esphome.const import (
     CONF_FRAMEWORK,
     CONF_INCLUDES,
     CONF_LIBRARIES,
+    CONF_MODEL,
     CONF_NAME,
     CONF_ON_BOOT,
     CONF_ON_LOOP,
@@ -135,6 +136,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Required(CONF_VERSION): cv.string_strict,
                 }
             ),
+            cv.Optional(CONF_MODEL): cv.string,
         }
     ),
     validate_hostname,
@@ -350,6 +352,12 @@ async def to_code(config):
     if CONF_PROJECT in config:
         cg.add_define("ESPHOME_PROJECT_NAME", config[CONF_PROJECT][CONF_NAME])
         cg.add_define("ESPHOME_PROJECT_VERSION", config[CONF_PROJECT][CONF_VERSION])
+
+    if CONF_MODEL in config:
+        cg.add_define("ESPHOME_DEVICE_MODEL", config[CONF_MODEL])
+    else:
+        platform = [key for key in TARGET_PLATFORMS if key in config][0]
+        cg.add_define("ESPHOME_DEVICE_MODEL", config[platform][CONF_BOARD])
 
     if config[CONF_PLATFORMIO_OPTIONS]:
         CORE.add_job(_add_platformio_options, config[CONF_PLATFORMIO_OPTIONS])

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -7,6 +7,7 @@
 
 // Informative flags
 #define ESPHOME_BOARD "dummy_board"
+#define ESPHOME_DEVICE_MODEL "dummy model"
 #define ESPHOME_PROJECT_NAME "dummy project"
 #define ESPHOME_PROJECT_VERSION "v2"
 #define ESPHOME_VARIANT "ESP32"


### PR DESCRIPTION
# What does this implement/fix? 


The "manufacturer" and "model" fields are exposed at first level in Home Assistant UI, but currently all ESPHome devices have a pretty useless values for these fields.
This PR allows to configure custom device model, to give a more useful meaning to classify your devices. It falls back to board to make it non-breaking.
The "manufacturer" should also be made configurable but will be a separate PR as currently it is hardcoded in different projects for the native API.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  platform: ESP8266
  board: esp01_1m
  model: My Custom Device
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
