### PR TITLE
Allow Git credentials to be loaded from secrets

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -104,7 +104,7 @@ def _process_git_config(config: dict, refresh) -> str:
         refresh=refresh,
         domain=DOMAIN,
         username=config.get(CONF_USERNAME),
-        password=config.get(CONF_PASSWORD)
+        password=config.get(CONF_PASSWORD),
     )
 
     if (repo_dir / "esphome" / "components").is_dir():

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -12,6 +12,8 @@ from esphome.const import (
     CONF_TYPE,
     CONF_EXTERNAL_COMPONENTS,
     CONF_PATH,
+    CONF_USERNAME,
+    CONF_PASSWORD,
 )
 from esphome.core import CORE
 from esphome import git, loader
@@ -27,6 +29,8 @@ TYPE_LOCAL = "local"
 GIT_SCHEMA = {
     cv.Required(CONF_URL): cv.url,
     cv.Optional(CONF_REF): cv.git_ref,
+    cv.Optional(CONF_USERNAME): cv.string,
+    cv.Optional(CONF_PASSWORD): cv.string,
 }
 LOCAL_SCHEMA = {
     cv.Required(CONF_PATH): cv.directory,
@@ -99,6 +103,8 @@ def _process_git_config(config: dict, refresh) -> str:
         ref=config.get(CONF_REF),
         refresh=refresh,
         domain=DOMAIN,
+        username=config.get(CONF_USERNAME),
+        password=config.get(CONF_PASSWORD)
     )
 
     if (repo_dir / "esphome" / "components").is_dir():

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -10,6 +10,8 @@ from esphome.const import (
     CONF_REF,
     CONF_REFRESH,
     CONF_URL,
+    CONF_USERNAME,
+    CONF_PASSWORD,
 )
 import esphome.config_validation as cv
 
@@ -93,6 +95,8 @@ BASE_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Required(CONF_URL): cv.url,
+            cv.Optional(CONF_USERNAME): cv.string,
+            cv.Optional(CONF_PASSWORD): cv.string,
             cv.Exclusive(CONF_FILE, "files"): validate_yaml_filename,
             cv.Exclusive(CONF_FILES, "files"): cv.All(
                 cv.ensure_list(validate_yaml_filename),
@@ -124,6 +128,8 @@ def _process_base_package(config: dict) -> dict:
         ref=config.get(CONF_REF),
         refresh=config[CONF_REFRESH],
         domain=DOMAIN,
+        username=config.get(CONF_USERNAME),
+        password=config.get(CONF_PASSWORD),
     )
     files: str = config[CONF_FILES]
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import subprocess
 import hashlib
 import logging
+import urllib.parse
 
 from datetime import datetime
 
@@ -36,9 +37,13 @@ def _compute_destination_path(key: str, domain: str) -> Path:
 
 
 def clone_or_update(
-    *, url: str, ref: str = None, refresh: TimePeriodSeconds, domain: str
+    *, url: str, ref: str = None, refresh: TimePeriodSeconds, domain: str, username: str = None, password: str = None
 ) -> Path:
     key = f"{url}@{ref}"
+
+    if username is not None and password is not None:
+        url = url.replace("://", f"://{urllib.parse.quote(username)}:{urllib.parse.quote(password)}@")
+
     repo_dir = _compute_destination_path(key, domain)
     fetch_pr_branch = ref is not None and ref.startswith("pull/")
     if not repo_dir.is_dir():

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -37,12 +37,20 @@ def _compute_destination_path(key: str, domain: str) -> Path:
 
 
 def clone_or_update(
-    *, url: str, ref: str = None, refresh: TimePeriodSeconds, domain: str, username: str = None, password: str = None
+    *,
+    url: str,
+    ref: str = None,
+    refresh: TimePeriodSeconds,
+    domain: str,
+    username: str = None,
+    password: str = None,
 ) -> Path:
     key = f"{url}@{ref}"
 
     if username is not None and password is not None:
-        url = url.replace("://", f"://{urllib.parse.quote(username)}:{urllib.parse.quote(password)}@")
+        url = url.replace(
+            "://", f"://{urllib.parse.quote(username)}:{urllib.parse.quote(password)}@"
+        )
 
     repo_dir = _compute_destination_path(key, domain)
     fetch_pr_branch = ref is not None and ref.startswith("pull/")


### PR DESCRIPTION
# What does this implement/fix? 

I self-host a git server with a password-protected repo of ESPHome components. The only way to supply the username and password currently is by putting them in the `url` config key of `external_components.source`, but this is displayed in clear-text in logs and during config validation.

This PR adds specific `username` and `password` config keys to supply Git credentials, which support the `!secret` feature. This allows credentials to be managed securely in a centralised location, and without them being leaked in clear-text inadvertently.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1683

## Test Environment

- [x] ESP32
- ESP32 IDF
- ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

external_components:
  - source:
      type: git
      url: "https://gogs.my-domain.com/org/esphome-components"
      username: !secret gogs_username
      password: !secret gogs_password
    components: [ my_cool_component ]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs)
