### PR TITLE
Fix too-broad matcher for custom CI script

### DIFF
--- a/.github/workflows/matchers/ci-custom.json
+++ b/.github/workflows/matchers/ci-custom.json
@@ -4,7 +4,7 @@
             "owner": "ci-custom",
             "pattern": [
                 {
-                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(.*)$",
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+lint:\\s+(.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -659,7 +659,9 @@ for fname in files:
 run_checks(LINT_POST_CHECKS, "POST")
 
 for f, errs in sorted(errors.items()):
-    err_str = (f"{styled(colorama.Style.BRIGHT, f'{f}:{lineno}:{col}:')} {msg}\n" for lineno, col, msg in errs)
+    bold = functools.partial(styled, colorama.Style.BRIGHT)
+    bold_red = functools.partial(styled, (colorama.Style.BRIGHT, colorama.Fore.RED))
+    err_str = (f"{bold(f'{f}:{lineno}:{col}:')} {bold_red('lint:')} {msg}\n" for lineno, col, msg in errs)
     print_error_for_file(f, "\n".join(err_str))
 
 if args.print_slowest:


### PR DESCRIPTION
# What does this implement/fix? 

The change in the matcher for `ci-custom` in #2762 caused it to also match notes from clang-tidy (see e.g. [this run](https://github.com/esphome/esphome/runs/4345839152?check_suite_focus=true)), clobbering the diff view in PRs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
