### PR TITLE
Button device class

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -960,6 +960,7 @@ message ListEntitiesButtonResponse {
   string icon = 5;
   bool disabled_by_default = 6;
   EntityCategory entity_category = 7;
+  string device_class = 8;
 }
 message ButtonCommandRequest {
   option (id) = 62;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -684,6 +684,7 @@ bool APIConnection::send_button_info(button::Button *button) {
   msg.icon = button->get_icon();
   msg.disabled_by_default = button->is_disabled_by_default();
   msg.entity_category = static_cast<enums::EntityCategory>(button->get_entity_category());
+  msg.device_class = button->get_device_class();
   return this->send_list_entities_button_response(msg);
 }
 void APIConnection::button_command(const ButtonCommandRequest &msg) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -4179,6 +4179,10 @@ bool ListEntitiesButtonResponse::decode_length(uint32_t field_id, ProtoLengthDel
       this->icon = value.as_string();
       return true;
     }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -4201,6 +4205,7 @@ void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_string(8, this->device_class);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesButtonResponse::dump_to(std::string &out) const {
@@ -4233,6 +4238,10 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
 
   out.append("  entity_category: ");
   out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1050,6 +1050,7 @@ class ListEntitiesButtonResponse : public ProtoMessage {
   std::string icon{};
   bool disabled_by_default{false};
   enums::EntityCategory entity_category{};
+  std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -17,5 +17,13 @@ void Button::press() {
 void Button::add_on_press_callback(std::function<void()> &&callback) { this->press_callback_.add(std::move(callback)); }
 uint32_t Button::hash_base() { return 1495763804UL; }
 
+void Button::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
+std::string Button::get_device_class() {
+  if (this->device_class_.has_value())
+    return *this->device_class_;
+  else
+    return "";
+}
+
 }  // namespace button
 }  // namespace esphome

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -21,8 +21,7 @@ void Button::set_device_class(const std::string &device_class) { this->device_cl
 std::string Button::get_device_class() {
   if (this->device_class_.has_value())
     return *this->device_class_;
-  else
-    return "";
+  return "";
 }
 
 }  // namespace button

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -36,6 +36,12 @@ class Button : public EntityBase {
    */
   void add_on_press_callback(std::function<void()> &&callback);
 
+  /// Set the Home Assistant device class (see button::device_class).
+  void set_device_class(const std::string &device_class);
+
+  /// Get the device class for this button.
+  std::string get_device_class();
+
  protected:
   /** You should implement this virtual method if you want to create your own button.
    */
@@ -44,6 +50,7 @@ class Button : public EntityBase {
   uint32_t hash_base() override;
 
   CallbackManager<void()> press_callback_{};
+  optional<std::string> device_class_{};
 };
 
 }  // namespace button

--- a/esphome/components/mqtt/mqtt_button.cpp
+++ b/esphome/components/mqtt/mqtt_button.cpp
@@ -30,6 +30,11 @@ void MQTTButtonComponent::dump_config() {
   LOG_MQTT_COMPONENT(true, true);
 }
 
+void MQTTButtonComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) {
+  if (!this->button_->get_device_class().empty())
+    root[MQTT_DEVICE_CLASS] = this->button_->get_device_class();
+}
+
 std::string MQTTButtonComponent::component_type() const { return "button"; }
 const EntityBase *MQTTButtonComponent::get_entity() const { return this->button_; }
 

--- a/esphome/components/mqtt/mqtt_button.h
+++ b/esphome/components/mqtt/mqtt_button.h
@@ -23,7 +23,7 @@ class MQTTButtonComponent : public mqtt::MQTTComponent {
   /// Buttons do not send a state so just return true.
   bool send_initial_state() override { return true; }
 
-  void send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) override {}
+  void send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) override;
 
  protected:
   /// "button" component type.

--- a/esphome/components/restart/button/__init__.py
+++ b/esphome/components/restart/button/__init__.py
@@ -3,15 +3,17 @@ import esphome.config_validation as cv
 from esphome.components import button
 from esphome.const import (
     CONF_ID,
+    DEVICE_CLASS_RESTART,
     ENTITY_CATEGORY_CONFIG,
-    ICON_RESTART,
 )
 
 restart_ns = cg.esphome_ns.namespace("restart")
 RestartButton = restart_ns.class_("RestartButton", button.Button, cg.Component)
 
 CONFIG_SCHEMA = (
-    button.button_schema(icon=ICON_RESTART, entity_category=ENTITY_CATEGORY_CONFIG)
+    button.button_schema(
+        device_class=DEVICE_CLASS_RESTART, entity_category=ENTITY_CATEGORY_CONFIG
+    )
     .extend({cv.GenerateID(): cv.declare_id(RestartButton)})
     .extend(cv.COMPONENT_SCHEMA)
 )

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -865,7 +865,6 @@ DEVICE_CLASS_SAFETY = "safety"
 DEVICE_CLASS_SMOKE = "smoke"
 DEVICE_CLASS_SOUND = "sound"
 DEVICE_CLASS_TAMPER = "tamper"
-DEVICE_CLASS_UPDATE = "update"
 DEVICE_CLASS_VIBRATION = "vibration"
 DEVICE_CLASS_WINDOW = "window"
 # device classes of both binary_sensor and sensor component
@@ -897,6 +896,11 @@ DEVICE_CLASS_TEMPERATURE = "temperature"
 DEVICE_CLASS_TIMESTAMP = "timestamp"
 DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS = "volatile_organic_compounds"
 DEVICE_CLASS_VOLTAGE = "voltage"
+# device classes of both binary_sensor and button component
+DEVICE_CLASS_UPDATE = "update"
+# device classes of button component
+DEVICE_CLASS_RESTART = "restart"
+
 
 # state classes
 STATE_CLASS_NONE = ""


### PR DESCRIPTION
# What does this implement/fix? 

Adds device class support to buttons.

Also sets the restart button to restart device class.

- https://github.com/home-assistant/core/pull/60560
- https://github.com/home-assistant/developers.home-assistant/pull/1145

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1685

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
