### PR TITLE
Fix 8266 SPI Clock Polarity Setting

### DIFF
--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -195,7 +195,14 @@ class SPIComponent : public Component {
   void enable(GPIOPin *cs) {
 #ifdef USE_SPI_ARDUINO_BACKEND
     if (this->hw_spi_ != nullptr) {
-      uint8_t data_mode = (uint8_t(CLOCK_POLARITY) << 1) | uint8_t(CLOCK_PHASE);
+      uint8_t data_mode = SPI_MODE0;
+      if (!CLOCK_POLARITY && CLOCK_PHASE) {
+        data_mode = SPI_MODE1;
+      } else if (CLOCK_POLARITY && !CLOCK_PHASE) {
+        data_mode = SPI_MODE2;
+      } else if (CLOCK_POLARITY && CLOCK_PHASE) {
+        data_mode = SPI_MODE3;
+      }
       SPISettings settings(DATA_RATE, BIT_ORDER, data_mode);
       this->hw_spi_->beginTransaction(settings);
     } else {


### PR DESCRIPTION
# What does this implement/fix? 

For ESP8266s, SPI clock polarity is not set correctly based on [this](https://github.com/esp8266/Arduino/blob/2492057b61034621c7acf84fbb22837d857cd81a/libraries/SPI/SPI.h#L38-L41). This PR corrects this incorrect behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** This was discussed on the ESPHome Discord server in the #general-support channel in a thread named #SSD1325

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). **N/A**
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). **N/A**