### PR TITLE
Fix compile warning in Tuya automations

### DIFF
--- a/esphome/components/tuya/automation.cpp
+++ b/esphome/components/tuya/automation.cpp
@@ -9,7 +9,7 @@ namespace tuya {
 
 void check_expected_datapoint(const TuyaDatapoint &dp, TuyaDatapointType expected) {
   if (dp.type != expected) {
-    ESP_LOGW(TAG, "Tuya sensor %u expected datapoint type %#02hhX but got %#02hhX", dp.id, 
+    ESP_LOGW(TAG, "Tuya sensor %u expected datapoint type %#02hhX but got %#02hhX", dp.id,
              static_cast<uint8_t>(expected), static_cast<uint8_t>(dp.type));
   }
 }

--- a/esphome/components/tuya/automation.cpp
+++ b/esphome/components/tuya/automation.cpp
@@ -9,7 +9,8 @@ namespace tuya {
 
 void check_expected_datapoint(const TuyaDatapoint &dp, TuyaDatapointType expected) {
   if (dp.type != expected) {
-    ESP_LOGW(TAG, "Tuya sensor %u expected datapoint type %#02hhX but got %#02hhX", dp.id, expected, dp.type);
+    ESP_LOGW(TAG, "Tuya sensor %u expected datapoint type %#02hhX but got %#02hhX", dp.id, 
+             static_cast<uint8_t>(expected), static_cast<uint8_t>(dp.type));
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix? 

#1812 introduced a compiler warning, fix it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
