### PR TITLE
Support setting manual_ip under networks option

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -226,7 +226,7 @@ def _validate(config):
             use_address = str(config[CONF_MANUAL_IP][CONF_STATIC_IP])
         elif CONF_NETWORKS in config:
             ips = set(
-                net[CONF_MANUAL_IP][CONF_STATIC_IP]
+                str(net[CONF_MANUAL_IP][CONF_STATIC_IP])
                 for net in config[CONF_NETWORKS]
                 if CONF_MANUAL_IP in net
             )
@@ -235,7 +235,7 @@ def _validate(config):
                     "Must specify use_address when using multiple static IP addresses."
                 )
             if len(ips) == 1:
-                use_address = ips[0]
+                use_address = next(iter(ips))
 
         config[CONF_USE_ADDRESS] = use_address
 

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -234,9 +234,9 @@ def _validate(config):
                 raise cv.Invalid(
                     "Must specify use_address when using multiple static IP addresses."
                 )
-            elif len(ips) == 1:
+            if len(ips) == 1:
                 use_address = ips[0]
-            
+
         config[CONF_USE_ADDRESS] = use_address
 
     return config

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -221,10 +221,22 @@ def _validate(config):
             raise cv.Invalid("Fast connect can only be used with one network!")
 
     if CONF_USE_ADDRESS not in config:
+        use_address = CORE.name + config[CONF_DOMAIN]
         if CONF_MANUAL_IP in config:
             use_address = str(config[CONF_MANUAL_IP][CONF_STATIC_IP])
-        else:
-            use_address = CORE.name + config[CONF_DOMAIN]
+        elif CONF_NETWORKS in config:
+            ips = set(
+                net[CONF_MANUAL_IP][CONF_STATIC_IP]
+                for net in config[CONF_NETWORKS]
+                if CONF_MANUAL_IP in net
+            )
+            if len(ips) > 1:
+                raise cv.Invalid(
+                    "Must specify use_address when using multiple static IP addresses."
+                )
+            elif len(ips) == 1:
+                use_address = ips[0]
+            
         config[CONF_USE_ADDRESS] = use_address
 
     return config
@@ -334,7 +346,8 @@ async def to_code(config):
     cg.add(var.set_use_address(config[CONF_USE_ADDRESS]))
 
     for network in config.get(CONF_NETWORKS, []):
-        cg.add(var.add_sta(wifi_network(network, config.get(CONF_MANUAL_IP))))
+        ip_config = network.get(CONF_MANUAL_IP, config.get(CONF_MANUAL_IP))
+        cg.add(var.add_sta(wifi_network(network, ip_config)))
 
     if CONF_AP in config:
         conf = config[CONF_AP]

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -16,6 +16,10 @@ wifi:
   networks:
     - ssid: 'MySSID'
       password: 'password1'
+      manual_ip:
+        static_ip: 192.168.1.23
+        gateway: 192.168.1.1
+        subnet: 255.255.255.0
 
 api:
 


### PR DESCRIPTION
# What does this implement/fix? 

Support setting `manual_ip` for an item under the `networks` option.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2247

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1687

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
