### PR TITLE
Bump Dsmr lib from 0.5 to 0.6

### DIFF
--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -78,7 +78,7 @@ async def to_code(config):
     cg.add_define("DSMR_GAS_MBUS_ID", config[CONF_GAS_MBUS_ID])
 
     # DSMR Parser
-    cg.add_library("glmnet/Dsmr", "0.5")
+    cg.add_library("glmnet/Dsmr", "0.6")
 
     # Crypto
     cg.add_library("rweather/Crypto", "0.2.0")

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,7 +46,7 @@ lib_deps =
     fastled/FastLED@3.3.2                                 ; fastled_base
     mikalhart/TinyGPSPlus@1.0.2                           ; gps
     freekode/TM1651@1.0.1                                 ; tm1651
-    glmnet/Dsmr@0.5                                       ; dsmr
+    glmnet/Dsmr@0.6                                       ; dsmr
     rweather/Crypto@0.2.0                                 ; dsmr
     dudanov/MideaUART@1.1.8                               ; midea
     ; PIO isn't update releases correctly, see:


### PR DESCRIPTION
# What does this implement/fix? 

Upgrade the Arduino Dsmr lib for the `dsmr` component.
This fixes an issue with meters that publish an invalid unit type (Wh instead of kWh for example).

Creating it as a draft, because first the Dsmr library needs a new release: 
https://github.com/glmnet/arduino-dsmr/pull/8

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
