### PR TITLE
Fix OTA updates on esp8266 by declaring arch_get_cpu_cycle_count IRAM_ATTR and HOT

### DIFF
--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -27,7 +27,7 @@ void IRAM_ATTR HOT arch_feed_wdt() {
 uint8_t progmem_read_byte(const uint8_t *addr) {
   return pgm_read_byte(addr);  // NOLINT
 }
-uint32_t arch_get_cpu_cycle_count() {
+uint32_t IRAM_ATTR HOT arch_get_cpu_cycle_count() {
   return ESP.getCycleCount();  // NOLINT(readability-static-accessed-through-instance)
 }
 uint32_t arch_get_cpu_freq_hz() { return F_CPU; }


### PR DESCRIPTION
# What does this implement/fix? 

This declares `arch_get_cpu_cycle_count` as IRAM_ATTR and HOT (the first of which makes it safe for use in interrupts, which seems to be happening during OTA and Web updates due to it being called from SPI code, which is how flash is written in esp8266). HOT was added as this is called in busy-loops, which to me fits that definition.

See exception stack in linked issue.
This issue only occurs when using Software Serial (at least, that is the only way it has been observed to materialize so far)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2629

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
