### PR TITLE
modbus_controller: bugfix: enable overriding calculated register size

### DIFF
--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -182,9 +182,8 @@ async def add_modbus_base_properties(
     if CONF_CUSTOM_COMMAND in config:
         cg.add(var.set_custom_data(config[CONF_CUSTOM_COMMAND]))
 
-    if CONF_RESPONSE_SIZE in config:
-        if config[CONF_RESPONSE_SIZE] > 0:
-            cg.add(var.set_register_size(config[CONF_RESPONSE_SIZE]))
+    if config[CONF_RESPONSE_SIZE] > 0:
+        cg.add(var.set_register_size(config[CONF_RESPONSE_SIZE]))
 
     if CONF_LAMBDA in config:
         template_ = await cg.process_lambda(

--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -13,6 +13,7 @@ from .const import (
     CONF_MODBUS_CONTROLLER_ID,
     CONF_REGISTER_COUNT,
     CONF_REGISTER_TYPE,
+    CONF_RESPONSE_SIZE,
     CONF_SKIP_UPDATES,
     CONF_VALUE_TYPE,
 )
@@ -125,6 +126,7 @@ ModbusItemBaseSchema = cv.Schema(
         cv.Optional(CONF_SKIP_UPDATES, default=0): cv.positive_int,
         cv.Optional(CONF_FORCE_NEW_RANGE, default=False): cv.boolean,
         cv.Optional(CONF_LAMBDA): cv.returning_lambda,
+        cv.Optional(CONF_RESPONSE_SIZE, default=0): cv.positive_int,
     },
 )
 
@@ -179,6 +181,10 @@ async def add_modbus_base_properties(
 ):
     if CONF_CUSTOM_COMMAND in config:
         cg.add(var.set_custom_data(config[CONF_CUSTOM_COMMAND]))
+
+    if CONF_RESPONSE_SIZE in config:
+        if config[CONF_RESPONSE_SIZE] > 0:
+            cg.add(var.set_register_size(config[CONF_RESPONSE_SIZE]))
 
     if CONF_LAMBDA in config:
         template_ = await cg.process_lambda(

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -256,16 +256,18 @@ class SensorItem {
   size_t virtual get_register_size() const {
     if (register_type == ModbusRegisterType::COIL || register_type == ModbusRegisterType::DISCRETE_INPUT)
       return 1;
-    else
-      return register_count * 2;
+    else  // if CONF_RESPONSE_BYTES is used override the default
+      return response_bytes > 0 ? response_bytes : register_count * 2;
   }
-
+  // Override register size for modbus devices not using 1 register for one dword
+  void set_register_size(uint8_t register_size) { response_bytes = register_size; }
   ModbusRegisterType register_type;
   SensorValueType sensor_value_type;
   uint16_t start_address;
   uint32_t bitmask;
   uint8_t offset;
   uint8_t register_count;
+  uint8_t response_bytes{0};
   uint8_t skip_updates;
   std::vector<uint8_t> custom_data{};
   bool force_new_range{false};

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -13,7 +13,7 @@ void ModbusTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Modbus Controller Te
 
 void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
   std::ostringstream output;
-  uint8_t max_items = this->response_bytes_;
+  uint8_t max_items = this->response_bytes;
   char buffer[4];
   bool add_comma = false;
   for (auto b : data) {

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -17,7 +17,7 @@ class ModbusTextSensor : public Component, public text_sensor::TextSensor, publi
     this->register_type = register_type;
     this->start_address = start_address;
     this->offset = offset;
-    this->response_bytes_ = response_bytes;
+    this->response_bytes = response_bytes;
     this->register_count = register_count;
     this->encode_ = encode;
     this->skip_updates = skip_updates;
@@ -38,7 +38,6 @@ class ModbusTextSensor : public Component, public text_sensor::TextSensor, publi
 
  protected:
   RawEncoding encode_;
-  uint16_t response_bytes_;
 };
 
 }  // namespace modbus_controller


### PR DESCRIPTION
# What does this implement/fix? 

https://github.com/esphome/esphome/pull/2654 breaks devices that return more than 2 bytes per register. 
This fix enables overriding the response size for a register 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1691

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: modbus_controller
    modbus_controller_id: controller
    id: voltage
    address: 0
    unit_of_measurement: "V"
    register_type: "read"
    value_type: FP32
    register_count: 1
    response_size: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
