### PR TITLE
Remove Content-Length header from camera snapshot response

### DIFF
--- a/esphome/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.cpp
@@ -233,7 +233,7 @@ esp_err_t CameraWebServer::snapshot_handler_(struct httpd_req *req) {
 
   httpd_resp_set_hdr(req, "Content-Disposition", "inline; filename=capture.jpg");
 
-  //if (res == ESP_OK) {
+  // if (res == ESP_OK) {
   //  res = httpd_resp_set_hdr(req, CONTENT_LENGTH, esphome::to_string(image->get_data_length()).c_str());
   //}
   if (res == ESP_OK) {

--- a/esphome/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.cpp
@@ -233,9 +233,6 @@ esp_err_t CameraWebServer::snapshot_handler_(struct httpd_req *req) {
 
   httpd_resp_set_hdr(req, "Content-Disposition", "inline; filename=capture.jpg");
 
-  // if (res == ESP_OK) {
-  //  res = httpd_resp_set_hdr(req, CONTENT_LENGTH, esphome::to_string(image->get_data_length()).c_str());
-  //}
   if (res == ESP_OK) {
     res = httpd_resp_send(req, (const char *) image->get_data_buffer(), image->get_data_length());
   }

--- a/esphome/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.cpp
@@ -233,9 +233,9 @@ esp_err_t CameraWebServer::snapshot_handler_(struct httpd_req *req) {
 
   httpd_resp_set_hdr(req, "Content-Disposition", "inline; filename=capture.jpg");
 
-  if (res == ESP_OK) {
-    res = httpd_resp_set_hdr(req, CONTENT_LENGTH, esphome::to_string(image->get_data_length()).c_str());
-  }
+  //if (res == ESP_OK) {
+  //  res = httpd_resp_set_hdr(req, CONTENT_LENGTH, esphome::to_string(image->get_data_length()).c_str());
+  //}
   if (res == ESP_OK) {
     res = httpd_resp_send(req, (const char *) image->get_data_buffer(), image->get_data_length());
   }


### PR DESCRIPTION
# What does this implement/fix? 

The camera snapshot was pushing CONTENT_LENGTH headers which was causing problems.

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esp32_camera:
   external_clock:
     pin: GPIO0
     frequency: 20MHz
   i2c_pins:
     sda: GPIO26
     scl: GPIO27
   data_pins: [GPIO5, GPIO18, GPIO19, GPIO21, GPIO36, GPIO39, GPIO34, GPIO35]
   vsync_pin: GPIO25
   href_pin: GPIO23
   pixel_clock_pin: GPIO22
   power_down_pin: GPIO32
   name: ${devicename} cam
   resolution: 1024X768

esp32_camera_web_server:
  - port: 8080
    mode: stream
  - port: 8081
    mode: snapshot
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
