### PR TITLE
Support different run duration for non-timer wakeup

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -41,15 +41,30 @@ EXT1_WAKEUP_MODES = {
     "ALL_LOW": esp_sleep_ext1_wakeup_mode_t.ESP_EXT1_WAKEUP_ALL_LOW,
     "ANY_HIGH": esp_sleep_ext1_wakeup_mode_t.ESP_EXT1_WAKEUP_ANY_HIGH,
 }
+WakeupCauseToRunDuration = deep_sleep_ns.struct("WakeupCauseToRunDuration")
 
 CONF_WAKEUP_PIN_MODE = "wakeup_pin_mode"
 CONF_ESP32_EXT1_WAKEUP = "esp32_ext1_wakeup"
 CONF_TOUCH_WAKEUP = "touch_wakeup"
+CONF_DEFAULT = "default"
+CONF_GPIO_WAKEUP_REASON = "gpio_wakeup_reason"
+CONF_TOUCH_WAKEUP_REASON = "touch_wakeup_reason"
+
+WAKEUP_CAUSES_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_DEFAULT): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_TOUCH_WAKEUP_REASON): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_GPIO_WAKEUP_REASON): cv.positive_time_period_milliseconds,
+    }
+)
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DeepSleepComponent),
-        cv.Optional(CONF_RUN_DURATION): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_RUN_DURATION): cv.Any(
+            cv.All(cv.only_on_esp32, WAKEUP_CAUSES_SCHEMA),
+            cv.positive_time_period_milliseconds,
+        ),
         cv.Optional(CONF_SLEEP_DURATION): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_WAKEUP_PIN): cv.All(
             cv.only_on_esp32, pins.internal_gpio_input_pin_schema, validate_pin_number
@@ -85,7 +100,28 @@ async def to_code(config):
     if CONF_WAKEUP_PIN_MODE in config:
         cg.add(var.set_wakeup_pin_mode(config[CONF_WAKEUP_PIN_MODE]))
     if CONF_RUN_DURATION in config:
-        cg.add(var.set_run_duration(config[CONF_RUN_DURATION]))
+        run_duration_config = config[CONF_RUN_DURATION]
+        if not isinstance(run_duration_config, dict):
+            cg.add(var.set_run_duration(config[CONF_RUN_DURATION]))
+        else:
+            default_run_duration = run_duration_config[CONF_DEFAULT]
+            wakeup_cause_to_run_duration = cg.StructInitializer(
+                WakeupCauseToRunDuration,
+                ("default_cause", default_run_duration),
+                (
+                    "touch_cause",
+                    run_duration_config.get(
+                        CONF_TOUCH_WAKEUP_REASON, default_run_duration
+                    ),
+                ),
+                (
+                    "gpio_cause",
+                    run_duration_config.get(
+                        CONF_GPIO_WAKEUP_REASON, default_run_duration
+                    ),
+                ),
+            )
+            cg.add(var.set_run_duration(wakeup_cause_to_run_duration))
 
     if CONF_ESP32_EXT1_WAKEUP in config:
         conf = config[CONF_ESP32_EXT1_WAKEUP]

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -13,12 +13,35 @@ static const char *const TAG = "deep_sleep";
 
 bool global_has_deep_sleep = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+optional<uint32_t> DeepSleepComponent::get_run_duration_() const {
+#ifdef USE_ESP32
+  if (this->wakeup_cause_to_run_duration_.has_value()) {
+    esp_sleep_wakeup_cause_t wakeup_cause = esp_sleep_get_wakeup_cause();
+    switch (wakeup_cause) {
+      case ESP_SLEEP_WAKEUP_EXT0:
+      case ESP_SLEEP_WAKEUP_EXT1:
+        return this->wakeup_cause_to_run_duration_->gpio_cause;
+      case ESP_SLEEP_WAKEUP_TOUCHPAD:
+        return this->wakeup_cause_to_run_duration_->touch_cause;
+      default:
+        return this->wakeup_cause_to_run_duration_->default_cause;
+    }
+  }
+#endif
+  return this->run_duration_;
+}
+
 void DeepSleepComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Deep Sleep...");
   global_has_deep_sleep = true;
 
-  if (this->run_duration_.has_value())
-    this->set_timeout(*this->run_duration_, [this]() { this->begin_sleep(); });
+  const optional<uint32_t> run_duration = get_run_duration_();
+  if (run_duration.has_value()) {
+    ESP_LOGI(TAG, "Scheduling Deep Sleep to start in %u ms", *run_duration);
+    this->set_timeout(*run_duration, [this]() { this->begin_sleep(); });
+  } else {
+    ESP_LOGD(TAG, "Not scheduling Deep Sleep, as no run duration is configured.");
+  }
 }
 void DeepSleepComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Setting up Deep Sleep...");
@@ -32,6 +55,11 @@ void DeepSleepComponent::dump_config() {
 #ifdef USE_ESP32
   if (wakeup_pin_ != nullptr) {
     LOG_PIN("  Wakeup Pin: ", this->wakeup_pin_);
+  }
+  if (this->wakeup_cause_to_run_duration_.has_value()) {
+    ESP_LOGCONFIG(TAG, "  Default Wakeup Run Duration: %u ms", this->wakeup_cause_to_run_duration_->default_cause);
+    ESP_LOGCONFIG(TAG, "  Touch Wakeup Run Duration: %u ms", this->wakeup_cause_to_run_duration_->touch_cause);
+    ESP_LOGCONFIG(TAG, "  GPIO Wakeup Run Duration: %u ms", this->wakeup_cause_to_run_duration_->gpio_cause);
   }
 #endif
 }
@@ -49,6 +77,9 @@ void DeepSleepComponent::set_wakeup_pin_mode(WakeupPinMode wakeup_pin_mode) {
 }
 void DeepSleepComponent::set_ext1_wakeup(Ext1Wakeup ext1_wakeup) { this->ext1_wakeup_ = ext1_wakeup; }
 void DeepSleepComponent::set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
+void DeepSleepComponent::set_run_duration(WakeupCauseToRunDuration wakeup_cause_to_run_duration) {
+  wakeup_cause_to_run_duration_ = wakeup_cause_to_run_duration;
+}
 #endif
 void DeepSleepComponent::set_run_duration(uint32_t time_ms) { this->run_duration_ = time_ms; }
 void DeepSleepComponent::begin_sleep(bool manual) {

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -32,6 +32,15 @@ struct Ext1Wakeup {
   esp_sleep_ext1_wakeup_mode_t wakeup_mode;
 };
 
+struct WakeupCauseToRunDuration {
+  // Run duration if woken up by timer or any other reason besides those below.
+  uint32_t default_cause;
+  // Run duration if woken up by touch pads.
+  uint32_t touch_cause;
+  // Run duration if woken up by GPIO pins.
+  uint32_t gpio_cause;
+};
+
 #endif
 
 template<typename... Ts> class EnterDeepSleepAction;
@@ -59,6 +68,11 @@ class DeepSleepComponent : public Component {
   void set_ext1_wakeup(Ext1Wakeup ext1_wakeup);
 
   void set_touch_wakeup(bool touch_wakeup);
+
+  // Set the duration in ms for how long the code should run before entering
+  // deep sleep mode, according to the cause the ESP32 has woken.
+  void set_run_duration(WakeupCauseToRunDuration wakeup_cause_to_run_duration);
+
 #endif
   /// Set a duration in ms for how long the code should run before entering deep sleep mode.
   void set_run_duration(uint32_t time_ms);
@@ -75,12 +89,17 @@ class DeepSleepComponent : public Component {
   void prevent_deep_sleep();
 
  protected:
+  // Returns nullopt if no run duration is set. Otherwise, returns the run
+  // duration before entering deep sleep.
+  optional<uint32_t> get_run_duration_() const;
+
   optional<uint64_t> sleep_duration_;
 #ifdef USE_ESP32
   InternalGPIOPin *wakeup_pin_;
   WakeupPinMode wakeup_pin_mode_{WAKEUP_PIN_MODE_IGNORE};
   optional<Ext1Wakeup> ext1_wakeup_;
   optional<bool> touch_wakeup_;
+  optional<WakeupCauseToRunDuration> wakeup_cause_to_run_duration_;
 #endif
   optional<uint32_t> run_duration_;
   bool next_enter_deep_sleep_{false};

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -1,0 +1,52 @@
+"""Tests for the deep sleep component."""
+
+
+def test_deep_sleep_setup(generate_main):
+    """
+    When the deep sleep is set in the yaml file, it should be registered in main
+    """
+    main_cpp = generate_main(
+        "tests/component_tests/deep_sleep/test_deep_sleep1.yaml"
+    )
+
+    assert "deepsleep = new deep_sleep::DeepSleepComponent();" in main_cpp
+    assert "App.register_component(deepsleep);" in main_cpp
+
+
+def test_deep_sleep_sleep_duration(generate_main):
+    """
+    When deep sleep is configured with sleep duration, it should be set.
+    """
+    main_cpp = generate_main(
+        "tests/component_tests/deep_sleep/test_deep_sleep1.yaml"
+    )
+
+    assert "deepsleep->set_sleep_duration(60000);" in main_cpp
+
+
+def test_deep_sleep_run_duration_simple(generate_main):
+    """
+    When deep sleep is configured with run duration, it should be set.
+    """
+    main_cpp = generate_main(
+        "tests/component_tests/deep_sleep/test_deep_sleep1.yaml"
+    )
+
+    assert "deepsleep->set_run_duration(10000);" in main_cpp
+
+
+def test_deep_sleep_run_duration_dictionary(generate_main):
+    """
+    When deep sleep is configured with dictionary run duration, it should be set.
+    """
+    main_cpp = generate_main(
+        "tests/component_tests/deep_sleep/test_deep_sleep2.yaml"
+    )
+
+    assert (
+        "deepsleep->set_run_duration(deep_sleep::WakeupCauseToRunDuration{\n"
+        "    .default_cause = 10000,\n"
+        "    .touch_cause = 10000,\n"
+        "    .gpio_cause = 30000,\n"
+        "});"
+    ) in main_cpp

--- a/tests/component_tests/deep_sleep/test_deep_sleep1.yaml
+++ b/tests/component_tests/deep_sleep/test_deep_sleep1.yaml
@@ -1,0 +1,9 @@
+esphome:
+  name: test
+  platform: ESP32
+  board: nodemcu-32s
+
+deep_sleep:
+  id: deepsleep
+  sleep_duration: 1min
+  run_duration: 10s

--- a/tests/component_tests/deep_sleep/test_deep_sleep2.yaml
+++ b/tests/component_tests/deep_sleep/test_deep_sleep2.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: test
+  platform: ESP32
+  board: nodemcu-32s
+
+deep_sleep:
+  id: deepsleep
+  sleep_duration: 1min
+  run_duration:
+    default: 10s
+    gpio_wakeup_reason: 30s

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -55,7 +55,10 @@ logger:
   level: DEBUG
 
 deep_sleep:
-  run_duration: 20s
+  run_duration:
+    default: 20s
+    gpio_wakeup_reason: 10s
+    touch_wakeup_reason: 15s
   sleep_duration: 50s
   wakeup_pin: GPIO39
   wakeup_pin_mode: INVERT_WAKEUP


### PR DESCRIPTION
# What does this implement/fix? 

In some cases, it useful to set different run durations according to
the wakeup cause, which can be found in ESP32.

For example, a sleep duration of 10 minutes to conserve power. When
waking because of timer, only run for 10 seconds. However, if waking up
due to touch or gpio, stay awake for longer (be available for action,
wait for OTA, etc.)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** will be done later

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
deep_sleep:
  run_duration:
    default: 20s
    gpio_wakeup_reason: 10s
    touch_wakeup_reason: 15s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs): esphome/esphome-docs#1705
