### PR TITLE
Ignore already stopped dhcp for ethernet

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -184,7 +184,7 @@ void EthernetComponent::start_connect_() {
   }
 
   err = tcpip_adapter_dhcpc_stop(TCPIP_ADAPTER_IF_ETH);
-  if (! (this->manual_ip_.has_value() && err == ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED )) {
+  if (err != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED)) {
     ESPHL_ERROR_CHECK(err, "DHCPC stop error");
   }
   err = tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_ETH, &info);

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -184,7 +184,9 @@ void EthernetComponent::start_connect_() {
   }
 
   err = tcpip_adapter_dhcpc_stop(TCPIP_ADAPTER_IF_ETH);
-  ESPHL_ERROR_CHECK(err, "DHCPC stop error");
+  if (! (this->manual_ip_.has_value() && err == ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED )) {
+    ESPHL_ERROR_CHECK(err, "DHCPC stop error");
+  }
   err = tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_ETH, &info);
   ESPHL_ERROR_CHECK(err, "DHCPC set IP info error");
 

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -184,7 +184,7 @@ void EthernetComponent::start_connect_() {
   }
 
   err = tcpip_adapter_dhcpc_stop(TCPIP_ADAPTER_IF_ETH);
-  if (err != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED)) {
+  if (err != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) {
     ESPHL_ERROR_CHECK(err, "DHCPC stop error");
   }
   err = tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_ETH, &info);


### PR DESCRIPTION
# What does this implement/fix? 
This PR tries to fix https://github.com/esphome/issues/issues/2783

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2783

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: wt32
  platform: ESP32
  board: nodemcu-32s

logger:

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO0_IN
  phy_addr: 1
  power_pin: GPIO16

  manual_ip:
    static_ip: 192.168.3.82
    subnet: 255.255.255.0
    gateway: 192.168.3.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
