### PR TITLE
SPS30 : fix i2c read size

### DIFF
--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -32,14 +32,11 @@ void SPS30Component::setup() {
       return;
     }
 
-    uint16_t raw_firmware_version[4];
-    if (!this->read_data_(raw_firmware_version, 4)) {
+    if (!this->read_data_(&raw_firmware_version_, 1)) {
       this->error_code_ = FIRMWARE_VERSION_READ_FAILED;
       this->mark_failed();
       return;
     }
-    ESP_LOGD(TAG, "  Firmware version v%0d.%02d", (raw_firmware_version[0] >> 8),
-             uint16_t(raw_firmware_version[0] & 0xFF));
     /// Serial number identification
     if (!this->write_command_(SPS30_CMD_GET_SERIAL_NUMBER)) {
       this->error_code_ = SERIAL_NUMBER_REQUEST_FAILED;
@@ -59,6 +56,8 @@ void SPS30Component::setup() {
       this->serial_number_[i * 2 + 1] = uint16_t(uint16_t(raw_serial_number[i] & 0xFF));
     }
     ESP_LOGD(TAG, "  Serial Number: '%s'", this->serial_number_);
+    this->status_clear_warning();
+    this->skipped_data_read_cycles_ = 0;
     this->start_continuous_measurement_();
   });
 }
@@ -93,10 +92,17 @@ void SPS30Component::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
   ESP_LOGCONFIG(TAG, "  Serial Number: '%s'", this->serial_number_);
-  LOG_SENSOR("  ", "PM1.0", this->pm_1_0_sensor_);
-  LOG_SENSOR("  ", "PM2.5", this->pm_2_5_sensor_);
-  LOG_SENSOR("  ", "PM4", this->pm_4_0_sensor_);
-  LOG_SENSOR("  ", "PM10", this->pm_10_0_sensor_);
+  ESP_LOGCONFIG(TAG, "  Firmware version v%0d.%0d", (raw_firmware_version_ >> 8),
+                uint16_t(raw_firmware_version_ & 0xFF));
+  LOG_SENSOR("  ", "PM1.0 Weight Concentration", this->pm_1_0_sensor_);
+  LOG_SENSOR("  ", "PM2.5 Weight Concentration", this->pm_2_5_sensor_);
+  LOG_SENSOR("  ", "PM4 Weight Concentration", this->pm_4_0_sensor_);
+  LOG_SENSOR("  ", "PM10 Weight Concentration", this->pm_10_0_sensor_);
+  LOG_SENSOR("  ", "PM1.0 Number Concentration", this->pmc_1_0_sensor_);
+  LOG_SENSOR("  ", "PM2.5 Number Concentration", this->pmc_2_5_sensor_);
+  LOG_SENSOR("  ", "PM4 Number Concentration", this->pmc_4_0_sensor_);
+  LOG_SENSOR("  ", "PM10 Number Concentration", this->pmc_10_0_sensor_);
+  LOG_SENSOR("  ", "PM typical size", this->pm_size_sensor_);
 }
 
 void SPS30Component::update() {
@@ -123,8 +129,8 @@ void SPS30Component::update() {
     return;
   }
 
-  uint16_t raw_read_status[1];
-  if (!this->read_data_(raw_read_status, 1) || raw_read_status[0] == 0x00) {
+  uint16_t raw_read_status;
+  if (!this->read_data_(&raw_read_status, 1) || raw_read_status == 0x00) {
     ESP_LOGD(TAG, "Sensor measurement not ready yet.");
     this->skipped_data_read_cycles_++;
     /// The following logic is required to address the cases when a sensor is quickly replaced before it's marked

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -33,6 +33,7 @@ class SPS30Component : public PollingComponent, public i2c::I2CDevice {
   bool read_data_(uint16_t *data, uint8_t len);
   uint8_t sht_crc_(uint8_t data1, uint8_t data2);
   char serial_number_[17] = {0};  /// Terminating NULL character
+  uint16_t raw_firmware_version_;
   bool start_continuous_measurement_();
   uint8_t skipped_data_read_cycles_ = 0;
 


### PR DESCRIPTION
# What does this implement/fix? 

Too many bytes requested when reading firmware version.
Removing leading 0 from fw subversion
Read firmware version in setup and show in dump_config.
Add missing sensors to dump_config

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2782

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1699

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
