### PR TITLE
tlc59208f : fix compilation error

### DIFF
--- a/esphome/components/tlc59208f/tlc59208f_output.cpp
+++ b/esphome/components/tlc59208f/tlc59208f_output.cpp
@@ -1,6 +1,7 @@
 #include "tlc59208f_output.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/hal.h"
 
 namespace esphome {
 namespace tlc59208f {


### PR DESCRIPTION
add esphome/core/hal.h include to fix  compilation error 

```
src/esphome/components/tlc59208f/tlc59208f_output.cpp: In member function 'virtual void esphome::tlc59208f::TLC59208FOutput::setup()':
src/esphome/components/tlc59208f/tlc59208f_output.cpp:107:24: error: 'delayMicroseconds' was not declared in this scope
   delayMicroseconds(500);
                        ^
```

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2785

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
