### PR TITLE
Add light.on_state trigger

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -14,6 +14,7 @@ from esphome.const import (
     CONF_RESTORE_MODE,
     CONF_ON_TURN_OFF,
     CONF_ON_TURN_ON,
+    CONF_ON_STATE,
     CONF_TRIGGER_ID,
     CONF_COLD_WHITE_COLOR_TEMPERATURE,
     CONF_WARM_WHITE_COLOR_TEMPERATURE,
@@ -37,6 +38,7 @@ from .types import (  # noqa
     AddressableLight,
     LightTurnOnTrigger,
     LightTurnOffTrigger,
+    LightStateTrigger,
 )
 
 CODEOWNERS = ["@esphome/core"]
@@ -67,6 +69,11 @@ LIGHT_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).ex
         cv.Optional(CONF_ON_TURN_OFF): auto.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(LightTurnOffTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_STATE): auto.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(LightStateTrigger),
             }
         ),
     }

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -158,6 +158,9 @@ async def setup_light_core_(light_var, output_var, config):
     for conf in config.get(CONF_ON_TURN_OFF, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], light_var)
         await auto.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_STATE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], light_var)
+        await auto.build_automation(trigger, [], conf)
 
     if CONF_COLOR_CORRECT in config:
         cg.add(output_var.set_correction(*config[CONF_COLOR_CORRECT]))

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -141,6 +141,15 @@ class LightTurnOffTrigger : public Trigger<> {
   }
 };
 
+class LightStateTrigger : public Trigger<> {
+ public:
+  LightStateTrigger(LightState *a_light) {
+    a_light->add_new_remote_values_callback([this, a_light]() {
+      this->trigger();
+    });
+  }
+};
+
 // This is slightly ugly, but we can't log in headers, and can't make this a static method on AddressableSet
 // due to the template. It's just a temporary warning anyway.
 void addressableset_warn_about_scale(const char *field);

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -144,9 +144,7 @@ class LightTurnOffTrigger : public Trigger<> {
 class LightStateTrigger : public Trigger<> {
  public:
   LightStateTrigger(LightState *a_light) {
-    a_light->add_new_remote_values_callback([this, a_light]() {
-      this->trigger();
-    });
+    a_light->add_new_remote_values_callback([this]() { this->trigger(); });
   }
 };
 

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -41,9 +41,7 @@ LightTurnOnTrigger = light_ns.class_(
 LightTurnOffTrigger = light_ns.class_(
     "LightTurnOffTrigger", automation.Trigger.template()
 )
-LightStateTrigger = light_ns.class_(
-    "LightStateTrigger", automation.Trigger.template()
-)
+LightStateTrigger = light_ns.class_("LightStateTrigger", automation.Trigger.template())
 
 # Effects
 LightEffect = light_ns.class_("LightEffect")

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -41,6 +41,9 @@ LightTurnOnTrigger = light_ns.class_(
 LightTurnOffTrigger = light_ns.class_(
     "LightTurnOffTrigger", automation.Trigger.template()
 )
+LightStateTrigger = light_ns.class_(
+    "LightStateTrigger", automation.Trigger.template()
+)
 
 # Effects
 LightEffect = light_ns.class_("LightEffect")


### PR DESCRIPTION
# What does this implement/fix? 

Adds an `on_state` trigger to light core for any `remote_values` change. This allows automation based on any commanded light state change rather than only when the light is commanded to be on from off or when the light becomes off. For example, project I am working on requires an action when the light is commanded to be off, not when it achieves off. So, the current automation was insufficient.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1700

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
    light:
      - platform: binary # or any other platform
        # ...
        on_turn_on:
        - logger.log: "Light Turned On!"
        on_turn_off:
        - logger.log: "Light Turned Off!"
        on_state:
        - logger.log: "Light State Changed!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
