### PR TITLE
Move i2c scan to setup

### DIFF
--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace esphome {
 namespace i2c {
@@ -40,6 +42,20 @@ class I2CBus {
     return writev(address, &buf, 1);
   }
   virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt) = 0;
+
+ protected:
+  void i2c_scan_() {
+    for (uint8_t address = 8; address < 120; address++) {
+      auto err = writev(address, nullptr, 0);
+      if (err == ERROR_OK) {
+        scan_results_.emplace_back(true, address);
+      } else if (err == ERROR_UNKNOWN) {
+        scan_results_.emplace_back(false, address);
+      }
+    }
+  }
+  std::vector<std::pair<bool, int>> scan_results_;
+  bool scan_{false};
 };
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -48,13 +48,13 @@ class I2CBus {
     for (uint8_t address = 8; address < 120; address++) {
       auto err = writev(address, nullptr, 0);
       if (err == ERROR_OK) {
-        scan_results_.emplace_back(true, address);
+        scan_results_.emplace_back(address, true);
       } else if (err == ERROR_UNKNOWN) {
-        scan_results_.emplace_back(false, address);
+        scan_results_.emplace_back(address, false);
       }
     }
   }
-  std::vector<std::pair<bool, int>> scan_results_;
+  std::vector<std::pair<uint8_t, bool>> scan_results_;
   bool scan_{false};
 };
 

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -2,6 +2,7 @@
 
 #include "i2c_bus_arduino.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 #include <Arduino.h>
 #include <cstring>
 
@@ -27,6 +28,23 @@ void ArduinoI2CBus::setup() {
   wire_->begin(sda_pin_, scl_pin_);
   wire_->setClock(frequency_);
   initialized_ = true;
+  if (this->scan_) {
+    ESP_LOGV(TAG, "Scanning i2c bus for active devices...");
+    uint8_t found = 0;
+    for (uint8_t address = 8; address < 120; address++) {
+      auto err = writev(address, nullptr, 0);
+      if (err == ERROR_OK) {
+        ESP_LOGV(TAG, "Found i2c device at address 0x%02X", address);
+        scan_results_.push_back(str_sprintf("Found i2c device at address 0x%02X", address));
+        found++;
+      } else if (err == ERROR_UNKNOWN) {
+        ESP_LOGV(TAG, "Unknown error at address 0x%02X", address);
+        scan_results_.push_back(str_sprintf("Unknown error at address 0x%02X", address));
+      }
+    }
+    if (found == 0)
+      ESP_LOGI(TAG, "Found no i2c devices!");
+  }
 }
 void ArduinoI2CBus::dump_config() {
   ESP_LOGCONFIG(TAG, "I2C Bus:");
@@ -45,20 +63,13 @@ void ArduinoI2CBus::dump_config() {
       break;
   }
   if (this->scan_) {
-    ESP_LOGI(TAG, "Scanning i2c bus for active devices...");
-    uint8_t found = 0;
-    for (uint8_t address = 8; address < 120; address++) {
-      auto err = writev(address, nullptr, 0);
-      if (err == ERROR_OK) {
-        ESP_LOGI(TAG, "Found i2c device at address 0x%02X", address);
-        found++;
-      } else if (err == ERROR_UNKNOWN) {
-        ESP_LOGI(TAG, "Unknown error at address 0x%02X", address);
-      }
-    }
-    if (found == 0) {
+    ESP_LOGI(TAG, "i2c bus scan results...");
+    for (const auto &s : scan_results_)
+      ESP_LOGI(TAG, "%s", s.c_str());
+    if (scan_results_.empty())
       ESP_LOGI(TAG, "Found no i2c devices!");
-    }
+    // release memory
+    scan_results_ = std::vector<std::string>();
   }
 }
 ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -50,7 +50,7 @@ void ArduinoI2CBus::dump_config() {
       break;
   }
   if (this->scan_) {
-    ESP_LOGI(TAG, "i2c bus scan results...");
+    ESP_LOGI(TAG, "Results from i2c bus scan:");
     if (scan_results_.empty()) {
       ESP_LOGI(TAG, "Found no i2c devices!");
     } else {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -55,10 +55,10 @@ void ArduinoI2CBus::dump_config() {
       ESP_LOGI(TAG, "Found no i2c devices!");
     } else {
       for (const auto &s : scan_results_) {
-        if (s.first)
-          ESP_LOGI(TAG, "Found i2c device at address 0x%02X", s.second);
+        if (s.second)
+          ESP_LOGI(TAG, "Found i2c device at address 0x%02X", s.first);
         else
-          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.second);
+          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.first);
       }
     }
   }

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -30,20 +30,7 @@ void ArduinoI2CBus::setup() {
   initialized_ = true;
   if (this->scan_) {
     ESP_LOGV(TAG, "Scanning i2c bus for active devices...");
-    uint8_t found = 0;
-    for (uint8_t address = 8; address < 120; address++) {
-      auto err = writev(address, nullptr, 0);
-      if (err == ERROR_OK) {
-        ESP_LOGV(TAG, "Found i2c device at address 0x%02X", address);
-        scan_results_.push_back(str_sprintf("Found i2c device at address 0x%02X", address));
-        found++;
-      } else if (err == ERROR_UNKNOWN) {
-        ESP_LOGV(TAG, "Unknown error at address 0x%02X", address);
-        scan_results_.push_back(str_sprintf("Unknown error at address 0x%02X", address));
-      }
-    }
-    if (found == 0)
-      ESP_LOGI(TAG, "Found no i2c devices!");
+    this->i2c_scan_();
   }
 }
 void ArduinoI2CBus::dump_config() {
@@ -64,12 +51,19 @@ void ArduinoI2CBus::dump_config() {
   }
   if (this->scan_) {
     ESP_LOGI(TAG, "i2c bus scan results...");
-    for (const auto &s : scan_results_)
-      ESP_LOGI(TAG, "%s", s.c_str());
-    if (scan_results_.empty())
+    if (scan_results_.empty()) {
       ESP_LOGI(TAG, "Found no i2c devices!");
+    } else {
+      for (const auto &s : scan_results_) {
+        if (s.first)
+          ESP_LOGI(TAG, "Found i2c device at address 0x%02X", s.second);
+        else
+          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.second);
+      }
+    }
   }
 }
+
 ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -68,8 +68,6 @@ void ArduinoI2CBus::dump_config() {
       ESP_LOGI(TAG, "%s", s.c_str());
     if (scan_results_.empty())
       ESP_LOGI(TAG, "Found no i2c devices!");
-    // release memory
-    scan_results_ = std::vector<std::string>();
   }
 }
 ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifdef USE_ARDUINO
+
 #include "i2c_bus.h"
 #include "esphome/core/component.h"
 #include <Wire.h>

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifdef USE_ARDUINO
-
+#include <vector>
 #include "i2c_bus.h"
 #include "esphome/core/component.h"
 #include <Wire.h>
@@ -39,6 +39,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   uint8_t scl_pin_;
   uint32_t frequency_;
   bool initialized_ = false;
+  std::vector<std::string> scan_results_;
 };
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #ifdef USE_ARDUINO
-#include <vector>
 #include "i2c_bus.h"
 #include "esphome/core/component.h"
 #include <Wire.h>
@@ -34,12 +33,10 @@ class ArduinoI2CBus : public I2CBus, public Component {
 
  protected:
   TwoWire *wire_;
-  bool scan_;
   uint8_t sda_pin_;
   uint8_t scl_pin_;
   uint32_t frequency_;
   bool initialized_ = false;
-  std::vector<std::string> scan_results_;
 };
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -60,7 +60,7 @@ void IDFI2CBus::dump_config() {
       break;
   }
   if (this->scan_) {
-    ESP_LOGI(TAG, "i2c bus scan results...");
+    ESP_LOGI(TAG, "Results from i2c bus scan:");
     if (scan_results_.empty()) {
       ESP_LOGI(TAG, "Found no i2c devices!");
     } else {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -78,8 +78,6 @@ void IDFI2CBus::dump_config() {
       ESP_LOGI(TAG, "%s", s.c_str());
     if (scan_results_.empty())
       ESP_LOGI(TAG, "Found no i2c devices!");
-    // release memory
-    scan_results_ = std::vector<std::string>();
   }
 }
 ErrorCode IDFI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -37,24 +37,11 @@ void IDFI2CBus::setup() {
     this->mark_failed();
     return;
   }
+  initialized_ = true;
   if (this->scan_) {
     ESP_LOGV(TAG, "Scanning i2c bus for active devices...");
-    uint8_t found = 0;
-    for (uint8_t address = 8; address < 120; address++) {
-      auto err = writev(address, nullptr, 0);
-      if (err == ERROR_OK) {
-        ESP_LOGV(TAG, "Found i2c device at address 0x%02X", address);
-        scan_results_.push_back(str_sprintf("Found i2c device at address 0x%02X", address));
-        found++;
-      } else if (err == ERROR_UNKNOWN) {
-        scan_results_.push_back(str_sprintf("Unknown error at address 0x%02X", address));
-        ESP_LOGV(TAG, "Unknown error at address 0x%02X", address);
-      }
-    }
-    if (found == 0)
-      ESP_LOGD(TAG, "Found no i2c devices!");
+    this->i2c_scan_();
   }
-  initialized_ = true;
 }
 void IDFI2CBus::dump_config() {
   ESP_LOGCONFIG(TAG, "I2C Bus:");
@@ -74,12 +61,19 @@ void IDFI2CBus::dump_config() {
   }
   if (this->scan_) {
     ESP_LOGI(TAG, "i2c bus scan results...");
-    for (const auto &s : scan_results_)
-      ESP_LOGI(TAG, "%s", s.c_str());
-    if (scan_results_.empty())
+    if (scan_results_.empty()) {
       ESP_LOGI(TAG, "Found no i2c devices!");
+    } else {
+      for (const auto &s : scan_results_) {
+        if (s.first)
+          ESP_LOGI(TAG, "Found i2c device at address 0x%02X", s.second);
+        else
+          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.second);
+      }
+    }
   }
 }
+
 ErrorCode IDFI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -3,6 +3,7 @@
 #include "i2c_bus_esp_idf.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 #include <cstring>
 
 namespace esphome {
@@ -36,6 +37,23 @@ void IDFI2CBus::setup() {
     this->mark_failed();
     return;
   }
+  if (this->scan_) {
+    ESP_LOGV(TAG, "Scanning i2c bus for active devices...");
+    uint8_t found = 0;
+    for (uint8_t address = 8; address < 120; address++) {
+      auto err = writev(address, nullptr, 0);
+      if (err == ERROR_OK) {
+        ESP_LOGV(TAG, "Found i2c device at address 0x%02X", address);
+        scan_results_.push_back(str_sprintf("Found i2c device at address 0x%02X", address));
+        found++;
+      } else if (err == ERROR_UNKNOWN) {
+        scan_results_.push_back(str_sprintf("Unknown error at address 0x%02X", address));
+        ESP_LOGV(TAG, "Unknown error at address 0x%02X", address);
+      }
+    }
+    if (found == 0)
+      ESP_LOGD(TAG, "Found no i2c devices!");
+  }
   initialized_ = true;
 }
 void IDFI2CBus::dump_config() {
@@ -55,21 +73,13 @@ void IDFI2CBus::dump_config() {
       break;
   }
   if (this->scan_) {
-    ESP_LOGI(TAG, "Scanning i2c bus for active devices...");
-    uint8_t found = 0;
-    for (uint8_t address = 8; address < 120; address++) {
-      auto err = writev(address, nullptr, 0);
-
-      if (err == ERROR_OK) {
-        ESP_LOGI(TAG, "Found i2c device at address 0x%02X", address);
-        found++;
-      } else if (err == ERROR_UNKNOWN) {
-        ESP_LOGI(TAG, "Unknown error at address 0x%02X", address);
-      }
-    }
-    if (found == 0) {
+    ESP_LOGI(TAG, "i2c bus scan results...");
+    for (const auto &s : scan_results_)
+      ESP_LOGI(TAG, "%s", s.c_str());
+    if (scan_results_.empty())
       ESP_LOGI(TAG, "Found no i2c devices!");
-    }
+    // release memory
+    scan_results_ = std::vector<std::string>();
   }
 }
 ErrorCode IDFI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -65,10 +65,10 @@ void IDFI2CBus::dump_config() {
       ESP_LOGI(TAG, "Found no i2c devices!");
     } else {
       for (const auto &s : scan_results_) {
-        if (s.first)
-          ESP_LOGI(TAG, "Found i2c device at address 0x%02X", s.second);
+        if (s.second)
+          ESP_LOGI(TAG, "Found i2c device at address 0x%02X", s.first);
         else
-          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.second);
+          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.first);
       }
     }
   }

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -5,6 +5,7 @@
 #include "i2c_bus.h"
 #include "esphome/core/component.h"
 #include <driver/i2c.h>
+#include <vector>
 
 namespace esphome {
 namespace i2c {
@@ -33,6 +34,7 @@ class IDFI2CBus : public I2CBus, public Component {
  private:
   void recover_();
   RecoveryCode recovery_result_;
+  std::vector<std::string> scan_results_;
 
  protected:
   i2c_port_t port_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -5,7 +5,6 @@
 #include "i2c_bus.h"
 #include "esphome/core/component.h"
 #include <driver/i2c.h>
-#include <vector>
 
 namespace esphome {
 namespace i2c {
@@ -34,11 +33,9 @@ class IDFI2CBus : public I2CBus, public Component {
  private:
   void recover_();
   RecoveryCode recovery_result_;
-  std::vector<std::string> scan_results_;
 
  protected:
   i2c_port_t port_;
-  bool scan_;
   uint8_t sda_pin_;
   bool sda_pullup_enabled_;
   uint8_t scl_pin_;


### PR DESCRIPTION
# What does this implement/fix? 

move i2c scan from dump_config to setup.

Intermittently SPS30 fails to initialize.
In https://github.com/esphome/issues/issues/2735#issuecomment-979188757   the log shows that the i2c scan happens in between two ic2 operations of SPS 30 causing setup of the component to fail. 
IMHO the i2c scan should be completed before  running setup for i2c components


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2735

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
