### PR TITLE
Adopt using wifi secrets that should exist at this point

### DIFF
--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -29,12 +29,11 @@ CONFIG_SCHEMA = cv.Schema(
     }
 )
 
-WIFI_MESSAGE = """
+WIFI_CONFIG = """
 
-# Do not forget to add your own wifi configuration before installing this configuration
-# wifi:
-#   ssid: !secret wifi_ssid
-#   password: !secret wifi_password
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
 """
 
 
@@ -55,6 +54,6 @@ def import_config(path: str, name: str, project_name: str, import_url: str) -> N
         "esphome": {"name_add_mac_suffix": False},
     }
     p.write_text(
-        dump(config) + WIFI_MESSAGE,
+        dump(config) + WIFI_CONFIG,
         encoding="utf8",
     )


### PR DESCRIPTION
# What does this implement/fix? 

Adopt using wifi secrets that should exist at this point after esphome/dashboard#153
The dashboard frontend will prompt the user to enter the credentials and they will be saved to secrets. If they already exist then all is well.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
