### PR TITLE
Allow wizard to specify secrets

### DIFF
--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -87,19 +87,10 @@ def wizard_file(**kwargs):
 
     if "ssid" in kwargs:
         if kwargs["ssid"].startswith("!secret"):
-            # pylint: disable=consider-using-f-string
-            config += """  ssid: {ssid}
-    password: {psk}
-    """.format(
-                **kwargs
-            )
+            template = "  ssid: {ssid}\n  password: {psk}\n"
         else:
-            # pylint: disable=consider-using-f-string
-            config += """  ssid: "{ssid}"
-    password: "{psk}"
-    """.format(
-                **kwargs
-            )
+            template = """  ssid: "{ssid}"\n  password: "{psk}"\n"""
+        config += template.format(**kwargs)
     else:
         config += """  # ssid: "My SSID"
   # password: "mypassword"

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -86,7 +86,7 @@ def wizard_file(**kwargs):
     config += "\n\nwifi:\n"
 
     if "ssid" in kwargs:
-        if kwargs["ssid"].startsWith("!secret"):
+        if kwargs["ssid"].startswith("!secret"):
             # pylint: disable=consider-using-f-string
             config += """  ssid: {ssid}
     password: {psk}

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -86,7 +86,7 @@ def wizard_file(**kwargs):
     config += "\n\nwifi:\n"
 
     if "ssid" in kwargs:
-        if "!secret" in kwargs["ssid"]:
+        if kwargs["ssid"].startsWith("!secret"):
             # pylint: disable=consider-using-f-string
             config += """  ssid: {ssid}
     password: {psk}

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -86,12 +86,20 @@ def wizard_file(**kwargs):
     config += "\n\nwifi:\n"
 
     if "ssid" in kwargs:
-        # pylint: disable=consider-using-f-string
-        config += """  ssid: "{ssid}"
-  password: "{psk}"
-""".format(
-            **kwargs
-        )
+        if "!secret" in kwargs["ssid"]:
+            # pylint: disable=consider-using-f-string
+            config += """  ssid: {ssid}
+    password: {psk}
+    """.format(
+                **kwargs
+            )
+        else:
+            # pylint: disable=consider-using-f-string
+            config += """  ssid: "{ssid}"
+    password: "{psk}"
+    """.format(
+                **kwargs
+            )
     else:
         config += """  # ssid: "My SSID"
   # password: "mypassword"


### PR DESCRIPTION
# What does this implement/fix? 

Allow wizard to specify secrets.

Currently the ssid value is always wrapped in quotes, which doesnt work for secrets, so this is a simple check to not wrap it in this case.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
