### PR TITLE
Feed watchdog while setting up OTA

### DIFF
--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -360,7 +360,6 @@ error:
 }
 
 bool OTAComponent::readall_(uint8_t *buf, size_t len) {
-  App.feed_wdt();
   uint32_t start = millis();
   uint32_t at = 0;
   while (len - at > 0) {
@@ -373,6 +372,7 @@ bool OTAComponent::readall_(uint8_t *buf, size_t len) {
     ssize_t read = this->client_->read(buf + at, len - at);
     if (read == -1) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        App.feed_wdt();
         delay(1);
         continue;
       }
@@ -384,13 +384,13 @@ bool OTAComponent::readall_(uint8_t *buf, size_t len) {
     } else {
       at += read;
     }
+    App.feed_wdt();
     delay(1);
   }
 
   return true;
 }
 bool OTAComponent::writeall_(const uint8_t *buf, size_t len) {
-  App.feed_wdt();
   uint32_t start = millis();
   uint32_t at = 0;
   while (len - at > 0) {
@@ -403,6 +403,7 @@ bool OTAComponent::writeall_(const uint8_t *buf, size_t len) {
     ssize_t written = this->client_->write(buf + at, len - at);
     if (written == -1) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        App.feed_wdt();
         delay(1);
         continue;
       }
@@ -411,6 +412,7 @@ bool OTAComponent::writeall_(const uint8_t *buf, size_t len) {
     } else {
       at += written;
     }
+    App.feed_wdt();
     delay(1);
   }
   return true;

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -360,6 +360,7 @@ error:
 }
 
 bool OTAComponent::readall_(uint8_t *buf, size_t len) {
+  App.feed_wdt();
   uint32_t start = millis();
   uint32_t at = 0;
   while (len - at > 0) {
@@ -389,6 +390,7 @@ bool OTAComponent::readall_(uint8_t *buf, size_t len) {
   return true;
 }
 bool OTAComponent::writeall_(const uint8_t *buf, size_t len) {
+  App.feed_wdt();
   uint32_t start = millis();
   uint32_t at = 0;
   while (len - at > 0) {


### PR DESCRIPTION
# What does this implement/fix? 

Slow connections can cause a watchdog trigger during the setup process for the OTA update (see logs in comment below).
This PR feeds the wdt in the blocking read/write commands.

(Before https://github.com/esphome/esphome/pull/2846 the watchdog was being reset at the delays)

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
