### PR TITLE
Support inverted tm1637 display

### DIFF
--- a/esphome/components/tm1637/display.py
+++ b/esphome/components/tm1637/display.py
@@ -8,6 +8,8 @@ from esphome.const import (
     CONF_ID,
     CONF_LAMBDA,
     CONF_INTENSITY,
+    CONF_INVERTED,
+    CONF_LENGTH,
 )
 
 CODEOWNERS = ["@glmnet"]
@@ -22,6 +24,8 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
         cv.Optional(CONF_INTENSITY, default=7): cv.All(
             cv.uint8_t, cv.Range(min=0, max=7)
         ),
+        cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+        cv.Optional(CONF_LENGTH, default=6): cv.All(cv.uint8_t, cv.Range(min=1, max=6)),
         cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_DIO_PIN): pins.gpio_output_pin_schema,
     }
@@ -39,6 +43,8 @@ async def to_code(config):
     cg.add(var.set_dio_pin(dio))
 
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
+    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    cg.add(var.set_length(config[CONF_LENGTH]))
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -131,6 +131,8 @@ void TM1637Display::setup() {
 void TM1637Display::dump_config() {
   ESP_LOGCONFIG(TAG, "TM1637:");
   ESP_LOGCONFIG(TAG, "  INTENSITY: %d", this->intensity_);
+  ESP_LOGCONFIG(TAG, "  INVERTED: %d", this->inverted_);
+  ESP_LOGCONFIG(TAG, "  LENGTH: %d", this->length_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
   LOG_UPDATE_INTERVAL(this);
@@ -173,8 +175,14 @@ void TM1637Display::display() {
   this->send_byte_(TM1637_I2C_COMM2);
 
   // Write the data bytes
-  for (auto b : this->buffer_) {
-    this->send_byte_(b);
+  if (this->inverted_) {
+    for (auto i = this->length_ - 1; i >= 0; i--) {
+      this->send_byte_(this->buffer_[i]);
+    }
+  } else {
+    for (auto b : this->buffer_) {
+      this->send_byte_(b);
+    }
   }
 
   this->stop_();
@@ -241,14 +249,27 @@ uint8_t TM1637Display::print(uint8_t start_pos, const char *str) {
     }
     // Remap segments, for compatibility with MAX7219 segment definition which is
     // XABCDEFG, but TM1637 is // XGFEDCBA
-    data = ((data & 0x80) ? 0x80 : 0) |  // no move X
-           ((data & 0x40) ? 0x1 : 0) |   // A
-           ((data & 0x20) ? 0x2 : 0) |   // B
-           ((data & 0x10) ? 0x4 : 0) |   // C
-           ((data & 0x8) ? 0x8 : 0) |    // D
-           ((data & 0x4) ? 0x10 : 0) |   // E
-           ((data & 0x2) ? 0x20 : 0) |   // F
-           ((data & 0x1) ? 0x40 : 0);    // G
+    if (this->inverted_) {
+      // XABCDEFG > XGCBAFED
+      data = ((data & 0x80) ? 0x80 : 0) |  // no move X
+             ((data & 0x40) ? 0x8 : 0) |   // A
+             ((data & 0x20) ? 0x10 : 0) |  // B
+             ((data & 0x10) ? 0x20 : 0) |  // C
+             ((data & 0x8) ? 0x1 : 0) |    // D
+             ((data & 0x4) ? 0x2 : 0) |    // E
+             ((data & 0x2) ? 0x4 : 0) |    // F
+             ((data & 0x1) ? 0x40 : 0);    // G
+    } else {
+      // XABCDEFG > XGFEDCBA
+      data = ((data & 0x80) ? 0x80 : 0) |  // no move X
+             ((data & 0x40) ? 0x1 : 0) |   // A
+             ((data & 0x20) ? 0x2 : 0) |   // B
+             ((data & 0x10) ? 0x4 : 0) |   // C
+             ((data & 0x8) ? 0x8 : 0) |    // D
+             ((data & 0x4) ? 0x10 : 0) |   // E
+             ((data & 0x2) ? 0x20 : 0) |   // F
+             ((data & 0x1) ? 0x40 : 0);    // G
+    }
     if (*str == '.') {
       if (pos != start_pos)
         pos--;

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -176,7 +176,7 @@ void TM1637Display::display() {
 
   // Write the data bytes
   if (this->inverted_) {
-    for (auto i = this->length_ - 1; i >= 0; i--) {
+    for (uint8_t i = this->length_ - 1; i >= 0; i--) {
       this->send_byte_(this->buffer_[i]);
     }
   } else {

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -130,9 +130,9 @@ void TM1637Display::setup() {
 }
 void TM1637Display::dump_config() {
   ESP_LOGCONFIG(TAG, "TM1637:");
-  ESP_LOGCONFIG(TAG, "  INTENSITY: %d", this->intensity_);
-  ESP_LOGCONFIG(TAG, "  INVERTED: %d", this->inverted_);
-  ESP_LOGCONFIG(TAG, "  LENGTH: %d", this->length_);
+  ESP_LOGCONFIG(TAG, "  Intensity: %d", this->intensity_);
+  ESP_LOGCONFIG(TAG, "  Inverted: %d", this->inverted_);
+  ESP_LOGCONFIG(TAG, "  Length: %d", this->length_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/tm1637/tm1637.h
+++ b/esphome/components/tm1637/tm1637.h
@@ -41,6 +41,8 @@ class TM1637Display : public PollingComponent {
   uint8_t print(const char *str);
 
   void set_intensity(uint8_t intensity) { this->intensity_ = intensity; }
+  void set_inverted(bool inverted) { this->inverted_ = inverted; }
+  void set_length(uint8_t length) { this->length_ = length; }
 
   void display();
 
@@ -62,6 +64,8 @@ class TM1637Display : public PollingComponent {
   GPIOPin *dio_pin_;
   GPIOPin *clk_pin_;
   uint8_t intensity_;
+  uint8_t length_;
+  bool inverted_;
   optional<tm1637_writer_t> writer_{};
   uint8_t buffer_[6] = {0};
 };

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2119,6 +2119,8 @@ display:
       mcp23xxx: mcp23017_hub
       number: 2
     intensity: 3
+    inverted: true
+    length: 4
     lambda: |-
       it.print("1234");
   - platform: pcd8544


### PR DESCRIPTION
# What does this implement/fix? 
Support inverting the tm1637 display


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1703

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  platform: tm1637
  id: tm1637_display
  clk_pin: GPIO16
  dio_pin: GPIO17
  inverted: true
  length: 4
  lambda: |-
    it.print("0234");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
