### PR TITLE
2021.12.0b3

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -91,7 +91,7 @@ void ADCSensor::dump_config() {
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 void ADCSensor::update() {
   float value_v = this->sample();
-  ESP_LOGD(TAG, "'%s': Got voltage=%.4fV", this->get_name().c_str(), value_v);
+  ESP_LOGV(TAG, "'%s': Got voltage=%.4fV", this->get_name().c_str(), value_v);
   this->publish_state(value_v);
 }
 

--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -29,12 +29,11 @@ CONFIG_SCHEMA = cv.Schema(
     }
 )
 
-WIFI_MESSAGE = """
+WIFI_CONFIG = """
 
-# Do not forget to add your own wifi configuration before installing this configuration
-# wifi:
-#   ssid: !secret wifi_ssid
-#   password: !secret wifi_password
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
 """
 
 
@@ -55,6 +54,6 @@ def import_config(path: str, name: str, project_name: str, import_url: str) -> N
         "esphome": {"name_add_mac_suffix": False},
     }
     p.write_text(
-        dump(config) + WIFI_MESSAGE,
+        dump(config) + WIFI_CONFIG,
         encoding="utf8",
     )

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -184,7 +184,9 @@ void EthernetComponent::start_connect_() {
   }
 
   err = tcpip_adapter_dhcpc_stop(TCPIP_ADAPTER_IF_ETH);
-  ESPHL_ERROR_CHECK(err, "DHCPC stop error");
+  if (err != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED) {
+    ESPHL_ERROR_CHECK(err, "DHCPC stop error");
+  }
   err = tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_ETH, &info);
   ESPHL_ERROR_CHECK(err, "DHCPC set IP info error");
 

--- a/esphome/components/mcp23x17_base/mcp23x17_base.cpp
+++ b/esphome/components/mcp23x17_base/mcp23x17_base.cpp
@@ -24,6 +24,7 @@ void MCP23X17Base::pin_mode(uint8_t pin, gpio::Flags flags) {
   uint8_t gppu = pin < 8 ? mcp23x17_base::MCP23X17_GPPUA : mcp23x17_base::MCP23X17_GPPUB;
   if (flags == gpio::FLAG_INPUT) {
     this->update_reg(pin, true, iodir);
+    this->update_reg(pin, false, gppu);
   } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
     this->update_reg(pin, true, iodir);
     this->update_reg(pin, true, gppu);

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -32,14 +32,11 @@ void SPS30Component::setup() {
       return;
     }
 
-    uint16_t raw_firmware_version[4];
-    if (!this->read_data_(raw_firmware_version, 4)) {
+    if (!this->read_data_(&raw_firmware_version_, 1)) {
       this->error_code_ = FIRMWARE_VERSION_READ_FAILED;
       this->mark_failed();
       return;
     }
-    ESP_LOGD(TAG, "  Firmware version v%0d.%02d", (raw_firmware_version[0] >> 8),
-             uint16_t(raw_firmware_version[0] & 0xFF));
     /// Serial number identification
     if (!this->write_command_(SPS30_CMD_GET_SERIAL_NUMBER)) {
       this->error_code_ = SERIAL_NUMBER_REQUEST_FAILED;
@@ -59,6 +56,8 @@ void SPS30Component::setup() {
       this->serial_number_[i * 2 + 1] = uint16_t(uint16_t(raw_serial_number[i] & 0xFF));
     }
     ESP_LOGD(TAG, "  Serial Number: '%s'", this->serial_number_);
+    this->status_clear_warning();
+    this->skipped_data_read_cycles_ = 0;
     this->start_continuous_measurement_();
   });
 }
@@ -93,10 +92,17 @@ void SPS30Component::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
   ESP_LOGCONFIG(TAG, "  Serial Number: '%s'", this->serial_number_);
-  LOG_SENSOR("  ", "PM1.0", this->pm_1_0_sensor_);
-  LOG_SENSOR("  ", "PM2.5", this->pm_2_5_sensor_);
-  LOG_SENSOR("  ", "PM4", this->pm_4_0_sensor_);
-  LOG_SENSOR("  ", "PM10", this->pm_10_0_sensor_);
+  ESP_LOGCONFIG(TAG, "  Firmware version v%0d.%0d", (raw_firmware_version_ >> 8),
+                uint16_t(raw_firmware_version_ & 0xFF));
+  LOG_SENSOR("  ", "PM1.0 Weight Concentration", this->pm_1_0_sensor_);
+  LOG_SENSOR("  ", "PM2.5 Weight Concentration", this->pm_2_5_sensor_);
+  LOG_SENSOR("  ", "PM4 Weight Concentration", this->pm_4_0_sensor_);
+  LOG_SENSOR("  ", "PM10 Weight Concentration", this->pm_10_0_sensor_);
+  LOG_SENSOR("  ", "PM1.0 Number Concentration", this->pmc_1_0_sensor_);
+  LOG_SENSOR("  ", "PM2.5 Number Concentration", this->pmc_2_5_sensor_);
+  LOG_SENSOR("  ", "PM4 Number Concentration", this->pmc_4_0_sensor_);
+  LOG_SENSOR("  ", "PM10 Number Concentration", this->pmc_10_0_sensor_);
+  LOG_SENSOR("  ", "PM typical size", this->pm_size_sensor_);
 }
 
 void SPS30Component::update() {
@@ -123,8 +129,8 @@ void SPS30Component::update() {
     return;
   }
 
-  uint16_t raw_read_status[1];
-  if (!this->read_data_(raw_read_status, 1) || raw_read_status[0] == 0x00) {
+  uint16_t raw_read_status;
+  if (!this->read_data_(&raw_read_status, 1) || raw_read_status == 0x00) {
     ESP_LOGD(TAG, "Sensor measurement not ready yet.");
     this->skipped_data_read_cycles_++;
     /// The following logic is required to address the cases when a sensor is quickly replaced before it's marked

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -33,6 +33,7 @@ class SPS30Component : public PollingComponent, public i2c::I2CDevice {
   bool read_data_(uint16_t *data, uint8_t len);
   uint8_t sht_crc_(uint8_t data1, uint8_t data2);
   char serial_number_[17] = {0};  /// Terminating NULL character
+  uint16_t raw_firmware_version_;
   bool start_continuous_measurement_();
   uint8_t skipped_data_read_cycles_ = 0;
 

--- a/esphome/components/tlc59208f/tlc59208f_output.cpp
+++ b/esphome/components/tlc59208f/tlc59208f_output.cpp
@@ -1,6 +1,7 @@
 #include "tlc59208f_output.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/hal.h"
 
 namespace esphome {
 namespace tlc59208f {

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2021.12.0b2"
+__version__ = "2021.12.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -37,6 +37,7 @@ void Application::setup() {
 
     component->call();
     this->scheduler.process_to_add();
+    this->feed_wdt();
     if (component->can_proceed())
       continue;
 
@@ -46,14 +47,15 @@ void Application::setup() {
     do {
       uint32_t new_app_state = STATUS_LED_WARNING;
       this->scheduler.call();
+      this->feed_wdt();
       for (uint32_t j = 0; j <= i; j++) {
         this->components_[j]->call();
         new_app_state |= this->components_[j]->get_component_state();
         this->app_state_ |= new_app_state;
+        this->feed_wdt();
       }
       this->app_state_ = new_app_state;
       yield();
-      this->feed_wdt();
     } while (!component->can_proceed());
   }
 
@@ -65,6 +67,7 @@ void Application::loop() {
   uint32_t new_app_state = 0;
 
   this->scheduler.call();
+  this->feed_wdt();
   for (Component *component : this->looping_components_) {
     {
       WarnIfComponentBlockingGuard guard{component};

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -86,12 +86,11 @@ def wizard_file(**kwargs):
     config += "\n\nwifi:\n"
 
     if "ssid" in kwargs:
-        # pylint: disable=consider-using-f-string
-        config += """  ssid: "{ssid}"
-  password: "{psk}"
-""".format(
-            **kwargs
-        )
+        if kwargs["ssid"].startswith("!secret"):
+            template = "  ssid: {ssid}\n  password: {psk}\n"
+        else:
+            template = """  ssid: "{ssid}"\n  password: "{psk}"\n"""
+        config += template.format(**kwargs)
     else:
         config += """  # ssid: "My SSID"
   # password: "mypassword"

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -329,9 +329,10 @@ ESPHomeLoader.add_constructor("!lambda", ESPHomeLoader.construct_lambda)
 ESPHomeLoader.add_constructor("!force", ESPHomeLoader.construct_force)
 
 
-def load_yaml(fname):
-    _SECRET_VALUES.clear()
-    _SECRET_CACHE.clear()
+def load_yaml(fname, clear_secrets=True):
+    if clear_secrets:
+        _SECRET_VALUES.clear()
+        _SECRET_CACHE.clear()
     return _load_yaml_internal(fname)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyserial==3.5
 platformio==5.2.2  # When updating platformio, also update Dockerfile
 esptool==3.2
 click==8.0.3
-esphome-dashboard==20211206.0
+esphome-dashboard==20211207.0
 aioesphomeapi==10.6.0
 zeroconf==0.36.13
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyserial==3.5
 platformio==5.2.2  # When updating platformio, also update Dockerfile
 esptool==3.2
 click==8.0.3
-esphome-dashboard==20211201.0
+esphome-dashboard==20211206.0
 aioesphomeapi==10.6.0
 zeroconf==0.36.13
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"We should forget about small efficiencies, say about 97% of the time: premature optimization is the root of all evil."_

~ C. A. R. Hoare
- Bump esphome-dashboard to 20211206.0 [esphome#2870](https://github.com/esphome/esphome/pull/2870)
- tlc59208f : fix compilation error [esphome#2867](https://github.com/esphome/esphome/pull/2867)
- ADC: Turn verbose the debugging "got voltage" [esphome#2863](https://github.com/esphome/esphome/pull/2863)
- SPS30 : fix i2c read size [esphome#2866](https://github.com/esphome/esphome/pull/2866)
- Fix MCP23x17 not disabling pullup after config change [esphome#2855](https://github.com/esphome/esphome/pull/2855)
- Ignore already stopped dhcp for ethernet [esphome#2862](https://github.com/esphome/esphome/pull/2862)
- Add endpoint to fetch secrets keys [esphome#2873](https://github.com/esphome/esphome/pull/2873)
- Adopt using wifi secrets that should exist at this point [esphome#2874](https://github.com/esphome/esphome/pull/2874)
- Allow wizard to specify secrets [esphome#2875](https://github.com/esphome/esphome/pull/2875)
- Feed watchdog when no component loops [esphome#2857](https://github.com/esphome/esphome/pull/2857)
- Bump esphome-dashboard to 20211207.0 [esphome#2877](https://github.com/esphome/esphome/pull/2877)
