### PR TITLE
Drop len parameter from parse_number()

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -79,7 +79,7 @@ void EZOSensor::loop() {
     if (buf[i] == ',')
       buf[i] = '\0';
 
-  float val = parse_number<float>((char *) &buf[1], sizeof(buf) - 2).value_or(0);
+  float val = parse_number<float>((char *) &buf[1]).value_or(0);
   this->publish_state(val);
 }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -399,8 +399,7 @@ optional<T> parse_number(const std::string &str) {
   return parse_number<T>(str.c_str());
 }
 /// Parse a decimal floating-point number from a null-terminated string.
-template<typename T, enable_if_t<(std::is_same<T, float>::value), int> = 0>
-optional<T> parse_number(const char *str) {
+template<typename T, enable_if_t<(std::is_same<T, float>::value), int> = 0> optional<T> parse_number(const char *str) {
   char *end = nullptr;
   float value = ::strtof(str, &end);
   if (end == str || *end != '\0' || value == HUGE_VALF)

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -370,9 +370,9 @@ std::string str_sanitize(const std::string &str);
 /// @name Parsing & formatting
 ///@{
 
-/// Parse an unsigned decimal number (requires null-terminated string).
+/// Parse an unsigned decimal number from a null-terminated string.
 template<typename T, enable_if_t<(std::is_integral<T>::value && std::is_unsigned<T>::value), int> = 0>
-optional<T> parse_number(const char *str, size_t len) {
+optional<T> parse_number(const char *str) {
   char *end = nullptr;
   unsigned long value = ::strtoul(str, &end, 10);  // NOLINT(google-runtime-int)
   if (end == str || *end != '\0' || value > std::numeric_limits<T>::max())
@@ -382,11 +382,11 @@ optional<T> parse_number(const char *str, size_t len) {
 /// Parse an unsigned decimal number.
 template<typename T, enable_if_t<(std::is_integral<T>::value && std::is_unsigned<T>::value), int> = 0>
 optional<T> parse_number(const std::string &str) {
-  return parse_number<T>(str.c_str(), str.length() + 1);
+  return parse_number<T>(str.c_str());
 }
-/// Parse a signed decimal number (requires null-terminated string).
+/// Parse a signed decimal number from a null-terminated string.
 template<typename T, enable_if_t<(std::is_integral<T>::value && std::is_signed<T>::value), int> = 0>
-optional<T> parse_number(const char *str, size_t len) {
+optional<T> parse_number(const char *str) {
   char *end = nullptr;
   signed long value = ::strtol(str, &end, 10);  // NOLINT(google-runtime-int)
   if (end == str || *end != '\0' || value < std::numeric_limits<T>::min() || value > std::numeric_limits<T>::max())
@@ -396,11 +396,11 @@ optional<T> parse_number(const char *str, size_t len) {
 /// Parse a signed decimal number.
 template<typename T, enable_if_t<(std::is_integral<T>::value && std::is_signed<T>::value), int> = 0>
 optional<T> parse_number(const std::string &str) {
-  return parse_number<T>(str.c_str(), str.length() + 1);
+  return parse_number<T>(str.c_str());
 }
-/// Parse a decimal floating-point number (requires null-terminated string).
+/// Parse a decimal floating-point number from a null-terminated string.
 template<typename T, enable_if_t<(std::is_same<T, float>::value), int> = 0>
-optional<T> parse_number(const char *str, size_t len) {
+optional<T> parse_number(const char *str) {
   char *end = nullptr;
   float value = ::strtof(str, &end);
   if (end == str || *end != '\0' || value == HUGE_VALF)
@@ -410,7 +410,7 @@ optional<T> parse_number(const char *str, size_t len) {
 /// Parse a decimal floating-point number.
 template<typename T, enable_if_t<(std::is_same<T, float>::value), int> = 0>
 optional<T> parse_number(const std::string &str) {
-  return parse_number<T>(str.c_str(), str.length() + 1);
+  return parse_number<T>(str.c_str());
 }
 
 ///@}


### PR DESCRIPTION
# What does this implement/fix? 

Drop the `len` parameter from `parse_number()`, as it's unnecessary since the functions require the user to supply null-terminated strings. The parameter wasn't used anyway.

(This was a leftover from another direction I initially took with these functions, but that turned out to be a bad idea. It's also more consistent with the C and C++ standard libraries, which also don't require a length for functions that read from null-terminated strings).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
