### PR TITLE
Use new platform component config blocks for wizard

### DIFF
--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -45,14 +45,26 @@ OTA_BIG = r"""       ____ _______
 
 BASE_CONFIG = """esphome:
   name: {name}
-  platform: {platform}
-  board: {board}
+"""
 
+LOGGER_API_CONFIG = """
 # Enable logging
 logger:
 
 # Enable Home Assistant API
 api:
+"""
+
+ESP8266_CONFIG = """
+esp8266:
+  board: {board}
+"""
+
+ESP32_CONFIG = """
+esp32:
+  board: {board}
+  framework:
+    type: arduino
 """
 
 
@@ -70,6 +82,14 @@ def wizard_file(**kwargs):
     kwargs["fallback_psk"] = "".join(random.choice(letters) for _ in range(12))
 
     config = BASE_CONFIG.format(**kwargs)
+
+    config += (
+        ESP8266_CONFIG.format(**kwargs)
+        if kwargs["platform"] == "ESP8266"
+        else ESP32_CONFIG.format(**kwargs)
+    )
+
+    config += LOGGER_API_CONFIG
 
     # Configure API
     if "password" in kwargs:

--- a/tests/unit_tests/test_wizard.py
+++ b/tests/unit_tests/test_wizard.py
@@ -11,7 +11,7 @@ def default_config():
     return {
         "name": "test-name",
         "platform": "test_platform",
-        "board": "test_board",
+        "board": "esp01_1m",
         "ssid": "test_ssid",
         "psk": "test_psk",
         "password": "",
@@ -105,6 +105,7 @@ def test_wizard_write_sets_platform(default_config, tmp_path, monkeypatch):
     If the platform is not explicitly set, use "ESP8266" if the board is one of the ESP8266 boards
     """
     # Given
+    del default_config["platform"]
     monkeypatch.setattr(wz, "write_file", MagicMock())
 
     # When
@@ -112,7 +113,7 @@ def test_wizard_write_sets_platform(default_config, tmp_path, monkeypatch):
 
     # Then
     generated_config = wz.write_file.call_args.args[1]
-    assert f"platform: {default_config['platform']}" in generated_config
+    assert "esp8266:" in generated_config
 
 
 def test_wizard_write_defaults_platform_from_board_esp8266(
@@ -132,7 +133,7 @@ def test_wizard_write_defaults_platform_from_board_esp8266(
 
     # Then
     generated_config = wz.write_file.call_args.args[1]
-    assert "platform: ESP8266" in generated_config
+    assert "esp8266:" in generated_config
 
 
 def test_wizard_write_defaults_platform_from_board_esp32(
@@ -152,7 +153,7 @@ def test_wizard_write_defaults_platform_from_board_esp32(
 
     # Then
     generated_config = wz.write_file.call_args.args[1]
-    assert "platform: ESP32" in generated_config
+    assert "esp32:" in generated_config
 
 
 def test_safe_print_step_prints_step_number_and_description(monkeypatch):


### PR DESCRIPTION
# What does this implement/fix? 

Instead of 
```yaml
esphome:
  name: ...
  platform: esp32
  board: ...
```

This now generates:
```yaml
esphome: 
  name: ...

esp32:
  board: ...
  framework:
    type: arduino
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
