### PR TITLE
Show full version information for dev builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,7 +112,9 @@ RUN \
 
 # Copy esphome and install
 COPY . /esphome
-RUN pip3 install --no-cache-dir -e /esphome
+RUN \
+    sed -i "s/^__version__ = .*$/__version__ = \"${BUILD_VERSION}\"/" /esphome/esphome/const.py \
+    && pip3 install --no-cache-dir -e /esphome
 
 # Labels
 LABEL \

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -28,7 +28,7 @@ from esphome.util import (
     safe_print,
     list_yaml_files,
     get_serial_ports,
-    get_full_version
+    get_full_version,
 )
 from esphome.log import color, setup_log, Fore
 
@@ -160,7 +160,7 @@ def write_cpp(config):
 
 
 def generate_cpp_contents(config):
-    _LOGGER.info("Generating C++ source...")
+    _LOGGER.info(f"Generating C++ source from {get_full_version()}...")
 
     for name, component, conf in iter_components(CORE.config):
         if component.to_code is not None:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -160,7 +160,7 @@ def write_cpp(config):
 
 
 def generate_cpp_contents(config):
-    _LOGGER.info(f"Generating C++ source from {get_full_version()}...")
+    _LOGGER.info("Generating C++ source from %s..." % get_full_version())
 
     for name, component, conf in iter_components(CORE.config):
         if component.to_code is not None:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -28,6 +28,7 @@ from esphome.util import (
     safe_print,
     list_yaml_files,
     get_serial_ports,
+    get_full_version
 )
 from esphome.log import color, setup_log, Fore
 
@@ -402,7 +403,7 @@ def command_mqtt_fingerprint(args, config):
 
 
 def command_version(args):
-    safe_print(f"Version: {const.__version__}")
+    safe_print(f"Version: {get_full_version()}")
     return 0
 
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -160,7 +160,7 @@ def write_cpp(config):
 
 
 def generate_cpp_contents(config):
-    _LOGGER.info("Generating C++ source from %s..." % get_full_version())
+    _LOGGER.info("Generating C++ source from %s...", get_full_version())
 
     for name, component, conf in iter_components(CORE.config):
         if component.to_code is not None:

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -108,7 +108,7 @@ cookie_authenticated_yes = b"yes"
 
 
 def template_args():
-    version = const.__version__
+    version = util.get_full_version()
     if "b" in version:
         docs_link = "https://beta.esphome.io/"
     elif "dev" in version:

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -262,7 +262,7 @@ def get_full_version():
             check=False,
         )
         return f"{const.__version__}-{proc.stdout.strip()}"
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         pass
 
     # use hardcoded version if we can't find anything

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -21,6 +21,7 @@ from esphome.helpers import (
     get_bool_env,
 )
 from esphome.storage_json import StorageJSON, storage_path
+from esphome.util import get_full_version
 from esphome import loader
 
 _LOGGER = logging.getLogger(__name__)
@@ -302,7 +303,7 @@ def generate_version_h():
     if not match:
         raise EsphomeError(f"Could not parse version {__version__}.")
     return VERSION_H_FORMAT.format(
-        __version__, match.group(1), match.group(2), match.group(3)
+        get_full_version(), match.group(1), match.group(2), match.group(3)
     )
 
 


### PR DESCRIPTION
# What does this implement/fix? 

We've had _quite_ a few cases recently where it wasn't clear which dev build people were running.

* When running from source, add the git commit to the version number: `2022.1.0-dev-dcbb2f4b25b3`
* When running from the Home Assistant addon, add the date the image was build to the version number: `2022.1.0-dev20211207`
* Print the version number as a log message before compiling
* Embed the full verison number in the firmware (so it gets shown during boot/dump_config).

This is a bit bruteforce and ugly solution, input is welcome.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
