### PR TITLE
fix multi-line comment warning/error

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -145,8 +145,7 @@ def wrap_to_code(name, comp):
         if comp.config_schema is not None:
             conf_str = yaml_util.dump(conf)
             conf_str = conf_str.replace("//", "")
-            conf_str = conf_str.replace("\\n", "")
-            conf_str = conf_str.replace("\\", "")
+            conf_str = conf_str.replace("\\n\\", "")
             cg.add(cg.LineComment(indent(conf_str)))
         await coro(conf)
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -145,7 +145,8 @@ def wrap_to_code(name, comp):
         if comp.config_schema is not None:
             conf_str = yaml_util.dump(conf)
             conf_str = conf_str.replace("//", "")
-            conf_str = conf_str.replace("\\n\\", "")
+            # remove tailing \ to avoid multi-line comment warning
+            conf_str = conf_str.replace("\\\n", "\n")
             cg.add(cg.LineComment(indent(conf_str)))
         await coro(conf)
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -145,6 +145,8 @@ def wrap_to_code(name, comp):
         if comp.config_schema is not None:
             conf_str = yaml_util.dump(conf)
             conf_str = conf_str.replace("//", "")
+            conf_str = conf_str.replace("\\n", "")
+            conf_str = conf_str.replace("\\", "")
             cg.add(cg.LineComment(indent(conf_str)))
         await coro(conf)
 


### PR DESCRIPTION
# What does this implement/fix? 

lambdas can trigger multiline comment warnings.
If esp-idf is used the warning is treated as an error 

`src/main.cpp:404:3: error: multi-line comment [-Werror=comment]`

Root cause is the format returned by `yaml.dump` 
Every line is framed in `\` lamba content `\n\`
The trailing `\` is triggering the warning

Example:
```
lambda: !lambda "auto kyo32 = new Bentel_Kyo32(id(uart_bus));\nApp.register_component(kyo32);\n\
  return {\n  kyo32->zona_1,\n  kyo32->zona_2,\n  kyo32->zona_3,\n  kyo32->zona_4,\n\
  \  kyo32->zona_5,\n  kyo32->zona_6,\n  kyo32->zona_7,\n  kyo32->zona_8,\n  kyo32->zona_9,\n\
  \  kyo32->zona_10,\n  kyo32->zona_11,\n  kyo32->zona_12,\n  kyo32->zona_13,\n  kyo32->zona_14,\n\
  \  kyo32->zona_15,\n  kyo32->zona_16,\n  kyo32->zona_17,\n  kyo32->zona_18,\n  kyo32->zona_19,\n\
  \  kyo32->zona_20,\n  kyo32->zona_21,\n  kyo32->zona_22,\n  kyo32->zona_23,\n  kyo32->zona_24,\n\
  \  kyo32->zona_25,\n  kyo32->zona_26,\n  kyo32->zona_27,\n  kyo32->zona_28,\n  kyo32->zona_29,\n\
  \  kyo32->zona_30,\n  kyo32->zona_31,\n  kyo32->zona_32,\n  kyo32->zona_sabotaggio_1,\n\
  \  kyo32->zona_sabotaggio_2,\n  kyo32->zona_sabotaggio_3,\n  kyo32->zona_sabotaggio_4,\n\
  \  kyo32->zona_sabotaggio_5,\n  kyo32->zona_sabotaggio_6,\n  kyo32->zona_sabotaggio_7,\n\
```

this fix removes the `\` content `\n\` framing

Repro YAML
```yaml
esphome:
  name: testing

esp32:
  board: esp32dev
  framework:
    type: esp-idf

select:
  - platform: template
    name: "Template select"
    optimistic: true
    options:
      - slow
      - medium
      - high
    disabled_by_default: false
    id: template__templateselect
    update_interval: 60s
    initial_option: slow
    set_action:
      - lambda: |-
          int dummy1 = 0 ; 
          for (int i = 0 ; i < 2 ; i++) {
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
            ESP_LOGD("TEST", "Test");
          }

```



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
