### PR TITLE
Fix published state for modbus number

### DIFF
--- a/esphome/components/modbus_controller/number/modbus_number.cpp
+++ b/esphome/components/modbus_controller/number/modbus_number.cpp
@@ -27,6 +27,7 @@ void ModbusNumber::parse_and_publish(const std::vector<uint8_t> &data) {
 
 void ModbusNumber::control(float value) {
   std::vector<uint16_t> data;
+  float write_value = value;
   // Is there are lambda configured?
   if (this->write_transform_func_.has_value()) {
     // data is passed by reference
@@ -35,23 +36,23 @@ void ModbusNumber::control(float value) {
     auto val = (*this->write_transform_func_)(this, value, data);
     if (val.has_value()) {
       ESP_LOGV(TAG, "Value overwritten by lambda");
-      value = val.value();
+      write_value = val.value();
     } else {
       ESP_LOGV(TAG, "Communication handled by lambda - exiting control");
       return;
     }
   } else {
-    value = multiply_by_ * value;
+    write_value = multiply_by_ * write_value;
   }
 
   // lambda didn't set payload
   if (data.empty()) {
-    data = float_to_payload(value, this->sensor_value_type);
+    data = float_to_payload(write_value, this->sensor_value_type);
   }
 
   ESP_LOGD(TAG,
            "Updating register: connected Sensor=%s start address=0x%X register count=%d new value=%.02f (val=%.02f)",
-           this->get_name().c_str(), this->start_address, this->register_count, value, value);
+           this->get_name().c_str(), this->start_address, this->register_count, write_value, write_value);
 
   // Create and send the write command
   auto write_cmd = ModbusCommandItem::create_write_multiple_command(parent_, this->start_address + this->offset,


### PR DESCRIPTION
# What does this implement/fix? 

After writing a value to modbus via number, it will publish the value that was modified by the `lambda` or `multiply` instead of the original user chosen value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
