### PR TITLE
Add gpio 12 to strapping pin list

### DIFF
--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -18,7 +18,7 @@ _ESP_SDIO_PINS = {
     11: "Flash Command",
 }
 
-_ESP32_STRAPPING_PINS = {0, 2, 4, 15}
+_ESP32_STRAPPING_PINS = {0, 2, 4, 12, 15}
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
# What does this implement/fix? 

If gpio12 is pulled high esp32 won't boot.
See https://www.esp32.com/viewtopic.php?t=597

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2791

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
