### PR TITLE
Update BH1750 MTreg register on sensor update

### DIFF
--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -55,7 +55,8 @@ void BH1750Sensor::update() {
 
   uint8_t mtreg_hi = (this->measurement_duration_ >> 5) & 0b111;
   uint8_t mtreg_lo = (this->measurement_duration_ >> 0) & 0b11111;
-  if (!this->write_bytes(BH1750_COMMAND_MT_REG_HI | mtreg_hi, nullptr, 0) && !this->write_bytes(BH1750_COMMAND_MT_REG_LO | mtreg_lo, nullptr, 0)) {
+  if (!this->write_bytes(BH1750_COMMAND_MT_REG_HI | mtreg_hi, nullptr, 0) &&
+      !this->write_bytes(BH1750_COMMAND_MT_REG_LO | mtreg_lo, nullptr, 0)) {
     ESP_LOGW(TAG, "Failed to update BH1750 MTreg value!");
   }
 


### PR DESCRIPTION
# What does this implement/fix? 

This PR adds code to actually update the value of the MTreg register of a BH1750 sensor. The current code only considers it for calculations but doesn't change the register itself.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
- platform: bh1750
    name: "estacao_luz"
    address: 0x23
    measurement_duration: 69
    update_interval: 60s
    id: "sensor_luz"
    on_value:
      then:
        - if:
            condition:
              sensor.in_range:
                id: sensor_luz
                above: 10.0
            then:
              lambda: |-
                id(sensor_luz).set_measurement_duration(69);
                ESP_LOGD("main", "BH1750 measurement time changed to 69");
        - if:
            condition:
              sensor.in_range:
                id: sensor_luz
                above: 40000.00
            then:
              lambda: |-
                id(sensor_luz).set_measurement_duration(32);
                ESP_LOGD("main", "BH1750 measurement time changed to 32");
        - if:
            condition:
              sensor.in_range:
                id: sensor_luz
                below: 10.0
            then:
              lambda: |-
                id(sensor_luz).set_measurement_duration(138);
                ESP_LOGD("main", "BH1750 measurement time changed to 138");

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

I haven't had the chance to test this locally yet.
