### PR TITLE
Add turn_on/off trigger to slow_pwm

### DIFF
--- a/esphome/components/slow_pwm/output.py
+++ b/esphome/components/slow_pwm/output.py
@@ -54,7 +54,6 @@ async def to_code(config):
         await automation.build_automation(
             var.get_turn_on_trigger(), [], config[CONF_TURN_ON_ACTION]
         )
-    if CONF_TURN_OFF_ACTION in config:
         await automation.build_automation(
             var.get_turn_off_trigger(), [], config[CONF_TURN_OFF_ACTION]
         )

--- a/esphome/components/slow_pwm/output.py
+++ b/esphome/components/slow_pwm/output.py
@@ -14,7 +14,7 @@ from esphome.const import (
 slow_pwm_ns = cg.esphome_ns.namespace("slow_pwm")
 SlowPWMOutput = slow_pwm_ns.class_("SlowPWMOutput", output.FloatOutput, cg.Component)
 
-CONF_TOGGLE_ACTION = "toggle_action"
+CONF_STATE_CHANGE_ACTION = "state_change_action"
 
 CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
@@ -30,7 +30,9 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
             "on_off",
             f"{CONF_TURN_ON_ACTION} and {CONF_TURN_OFF_ACTION} must both be defined",
         ): automation.validate_automation(single=True),
-        cv.Optional(CONF_TOGGLE_ACTION): automation.validate_automation(single=True),
+        cv.Optional(CONF_STATE_CHANGE_ACTION): automation.validate_automation(
+            single=True
+        ),
         cv.Required(CONF_PERIOD): cv.All(
             cv.positive_time_period_milliseconds,
             cv.Range(min=core.TimePeriod(milliseconds=100)),
@@ -46,9 +48,11 @@ async def to_code(config):
     if CONF_PIN in config:
         pin = await cg.gpio_pin_expression(config[CONF_PIN])
         cg.add(var.set_pin(pin))
-    if CONF_TOGGLE_ACTION in config:
+    if CONF_STATE_CHANGE_ACTION in config:
         await automation.build_automation(
-            var.get_toggle_trigger(), [(bool, "state")], config[CONF_TOGGLE_ACTION]
+            var.get_state_change_trigger(),
+            [(bool, "state")],
+            config[CONF_STATE_CHANGE_ACTION],
         )
     if CONF_TURN_ON_ACTION in config:
         await automation.build_automation(

--- a/esphome/components/slow_pwm/output.py
+++ b/esphome/components/slow_pwm/output.py
@@ -2,15 +2,35 @@ from esphome import pins, core
 from esphome.components import output
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import CONF_ID, CONF_PIN, CONF_PERIOD
+from esphome import automation
+from esphome.const import (
+    CONF_ID,
+    CONF_PIN,
+    CONF_PERIOD,
+    CONF_TURN_ON_ACTION,
+    CONF_TURN_OFF_ACTION,
+)
 
 slow_pwm_ns = cg.esphome_ns.namespace("slow_pwm")
 SlowPWMOutput = slow_pwm_ns.class_("SlowPWMOutput", output.FloatOutput, cg.Component)
 
+CONF_TOGGLE_ACTION = "toggle_action"
+
 CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.Required(CONF_ID): cv.declare_id(SlowPWMOutput),
-        cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_PIN): pins.gpio_output_pin_schema,
+        cv.Inclusive(
+            CONF_TURN_ON_ACTION,
+            "on_off",
+            f"{CONF_TURN_ON_ACTION} and {CONF_TURN_OFF_ACTION} must both be defined",
+        ): automation.validate_automation(single=True),
+        cv.Inclusive(
+            CONF_TURN_OFF_ACTION,
+            "on_off",
+            f"{CONF_TURN_ON_ACTION} and {CONF_TURN_OFF_ACTION} must both be defined",
+        ): automation.validate_automation(single=True),
+        cv.Optional(CONF_TOGGLE_ACTION): automation.validate_automation(single=True),
         cv.Required(CONF_PERIOD): cv.All(
             cv.positive_time_period_milliseconds,
             cv.Range(min=core.TimePeriod(milliseconds=100)),
@@ -23,7 +43,20 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await output.register_output(var, config)
+    if CONF_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_PIN])
+        cg.add(var.set_pin(pin))
+    if CONF_TOGGLE_ACTION in config:
+        await automation.build_automation(
+            var.get_toggle_trigger(), [(bool, "state")], config[CONF_TOGGLE_ACTION]
+        )
+    if CONF_TURN_ON_ACTION in config:
+        await automation.build_automation(
+            var.get_turn_on_trigger(), [], config[CONF_TURN_ON_ACTION]
+        )
+    if CONF_TURN_OFF_ACTION in config:
+        await automation.build_automation(
+            var.get_turn_off_trigger(), [], config[CONF_TURN_OFF_ACTION]
+        )
 
-    pin = await cg.gpio_pin_expression(config[CONF_PIN])
-    cg.add(var.set_pin(pin))
     cg.add(var.set_period(config[CONF_PERIOD]))

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -13,7 +13,7 @@ void SlowPWMOutput::setup() {
 }
 
 /// turn on/off the configured output
-void SlowPWMOutput::set_state_(bool new_state) {
+void SlowPWMOutput::set_output_state_(bool new_state) {
   static bool current_state = false;
   if (this->pin_) {
     this->pin_->digital_write(new_state);
@@ -43,15 +43,15 @@ void SlowPWMOutput::loop() {
   }
 
   if (scaled_state > now - this->period_start_time_) {
-    this->set_state_(true);
+    this->set_output_state_(true);
   } else {
-    this->set_state_(false);
+    this->set_output_state_(false);
   }
 }
 
 void SlowPWMOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Slow PWM Output:");
-  LOG_PIN("  Using pin: ", this->pin_);
+  LOG_PIN("  Pin: ", this->pin_);
   if (this->state_change_trigger_)
     ESP_LOGCONFIG(TAG, "  State change automation configured");
   if (this->turn_on_trigger_)

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -14,11 +14,10 @@ void SlowPWMOutput::setup() {
 
 /// turn on/off the configured output
 void SlowPWMOutput::set_output_state_(bool new_state) {
-  static bool current_state = false;
   if (this->pin_) {
     this->pin_->digital_write(new_state);
   }
-  if (new_state != current_state) {
+  if (new_state != current_state_) {
     if (this->state_change_trigger_) {
       this->state_change_trigger_->trigger(new_state);
     }
@@ -29,7 +28,7 @@ void SlowPWMOutput::set_output_state_(bool new_state) {
       if (this->turn_off_trigger_)
         this->turn_off_trigger_->trigger();
     }
-    current_state = new_state;
+    current_state_ = new_state;
   }
 }
 

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -19,8 +19,8 @@ void SlowPWMOutput::set_state_(bool new_state) {
     this->pin_->digital_write(new_state);
   }
   if (new_state != current_state) {
-    if (this->toggle_trigger_) {
-      this->toggle_trigger_->trigger(new_state);
+    if (this->state_change_trigger_) {
+      this->state_change_trigger_->trigger(new_state);
     }
     if (new_state) {
       if (this->turn_on_trigger_)
@@ -52,8 +52,8 @@ void SlowPWMOutput::loop() {
 void SlowPWMOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Slow PWM Output:");
   LOG_PIN("  Using pin: ", this->pin_);
-  if (this->toggle_trigger_)
-    ESP_LOGCONFIG(TAG, "  Toggle on automation configured");
+  if (this->state_change_trigger_)
+    ESP_LOGCONFIG(TAG, "  State change automation configured");
   if (this->turn_on_trigger_)
     ESP_LOGCONFIG(TAG, "  Turn on automation configured");
   if (this->turn_off_trigger_)

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -51,8 +51,7 @@ void SlowPWMOutput::loop() {
 
 void SlowPWMOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Slow PWM Output:");
-  if (this->pin_)
-    LOG_PIN("  Using pin: ", this->pin_);
+  LOG_PIN("  Using pin: ", this->pin_);
   if (this->toggle_trigger_)
     ESP_LOGCONFIG(TAG, "  Toggle on automation configured");
   if (this->turn_on_trigger_)

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -31,10 +31,10 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
     return turn_off_trigger_.get();
   }
 
-  Trigger<bool> *get_toggle_trigger() {
-    if (!toggle_trigger_)
-      toggle_trigger_ = make_unique<Trigger<bool>>();
-    return toggle_trigger_.get();
+  Trigger<bool> *get_state_change_trigger() {
+    if (!state_change_trigger_)
+      state_change_trigger_ = make_unique<Trigger<bool>>();
+    return state_change_trigger_.get();
   }
 
  protected:
@@ -48,7 +48,7 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
 
   std::unique_ptr<Trigger<>> turn_on_trigger_{nullptr};
   std::unique_ptr<Trigger<>> turn_off_trigger_{nullptr};
-  std::unique_ptr<Trigger<bool>> toggle_trigger_{nullptr};
+  std::unique_ptr<Trigger<bool>> state_change_trigger_{nullptr};
   float state_;
   unsigned int period_start_time_{0};
   unsigned int period_{5000};

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -19,35 +19,34 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
 
   Trigger<> *get_turn_on_trigger() {
     // Lazy create
-    if (!turn_on_trigger_)
-      turn_on_trigger_ = make_unique<Trigger<>>();
-    return turn_on_trigger_.get();
+    if (!this->turn_on_trigger_)
+      this->turn_on_trigger_ = make_unique<Trigger<>>();
+    return this->turn_on_trigger_.get();
   }
   Trigger<> *get_turn_off_trigger() {
-    if (!turn_off_trigger_)
-      turn_off_trigger_ = make_unique<Trigger<>>();
-    return turn_off_trigger_.get();
+    if (!this->turn_off_trigger_)
+      this->turn_off_trigger_ = make_unique<Trigger<>>();
+    return this->turn_off_trigger_.get();
   }
 
   Trigger<bool> *get_state_change_trigger() {
-    if (!state_change_trigger_)
-      state_change_trigger_ = make_unique<Trigger<bool>>();
-    return state_change_trigger_.get();
+    if (!this->state_change_trigger_)
+      this->state_change_trigger_ = make_unique<Trigger<bool>>();
+    return this->state_change_trigger_.get();
   }
 
  protected:
-  /// turn on/off the configured output
-  void set_state_(bool state);
   void loop() override;
+  void write_state(float state) override { state_ = state; }
+  /// turn on/off the configured output
+  void set_output_state_(bool state);
 
   GPIOPin *pin_{nullptr};
-
-  void write_state(float state) override { state_ = state; }
-
   std::unique_ptr<Trigger<>> turn_on_trigger_{nullptr};
   std::unique_ptr<Trigger<>> turn_off_trigger_{nullptr};
   std::unique_ptr<Trigger<bool>> state_change_trigger_{nullptr};
-  float state_;
+  float state_{0};
+  bool current_state_{false};
   unsigned int period_start_time_{0};
   unsigned int period_{5000};
 };

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -3,8 +3,6 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/output/float_output.h"
-#include "esphome/components/output/binary_output.h"
-#include "esphome/components/switch/switch.h"
 
 namespace esphome {
 namespace slow_pwm {

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -1,8 +1,10 @@
 #pragma once
-
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/output/float_output.h"
+#include "esphome/components/output/binary_output.h"
+#include "esphome/components/switch/switch.h"
 
 namespace esphome {
 namespace slow_pwm {
@@ -11,19 +13,43 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
  public:
   void set_pin(GPIOPin *pin) { pin_ = pin; };
   void set_period(unsigned int period) { period_ = period; };
-
   /// Initialize pin
   void setup() override;
   void dump_config() override;
   /// HARDWARE setup_priority
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
+  Trigger<> *get_turn_on_trigger() {
+    // Lazy create
+    if (!turn_on_trigger_)
+      turn_on_trigger_ = make_unique<Trigger<>>();
+    return turn_on_trigger_.get();
+  }
+  Trigger<> *get_turn_off_trigger() {
+    if (!turn_off_trigger_)
+      turn_off_trigger_ = make_unique<Trigger<>>();
+    return turn_off_trigger_.get();
+  }
+
+  Trigger<bool> *get_toggle_trigger() {
+    if (!toggle_trigger_)
+      toggle_trigger_ = make_unique<Trigger<bool>>();
+    return toggle_trigger_.get();
+  }
+
  protected:
-  void write_state(float state) override;
+  /// turn on/off the configured output
+  void set_state_(bool state);
   void loop() override;
 
-  GPIOPin *pin_;
-  float state_{0};
+  GPIOPin *pin_{nullptr};
+
+  void write_state(float state) override { state_ = state; }
+
+  std::unique_ptr<Trigger<>> turn_on_trigger_{nullptr};
+  std::unique_ptr<Trigger<>> turn_off_trigger_{nullptr};
+  std::unique_ptr<Trigger<bool>> toggle_trigger_{nullptr};
+  float state_;
   unsigned int period_start_time_{0};
   unsigned int period_{5000};
 };


### PR DESCRIPTION
# What does this implement/fix? 

Adds triggers to slow_pwm. These triggers can be used to turn on/off any other compoment and slow_pwm is not longer limited to GPIO. 

- change 'pin'  to optional.
- add  `toggle_action`, `turn_on_action` and `turn_off_action` trigger
- if pin is configured it will be executed regardless if the turn_on/off_action triggers are defined to avoid breaking existing code
-  `toggle_action` and `turn_on/off_action` can be used togther. `toggle_action` is called before `turn_on/off_action`. It's recommended to use either `toggle_action` or `turn_on/off_action` to change the state of an output. Using both automations together is only recommended for monitoring. Both variants are provided for ease of use. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1548

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1730

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: testing
  on_boot:
    priority: -100
    then:
      output.set_level:
        id: my_slow_pwm
        level: 25%
          
output:
  - platform: template
    id: output1
    type: binary
    write_action:
      - then:
          - lambda: ESP_LOGD("Template Output","set state to %d",state);

  - platform: slow_pwm
    id: my_slow_pwm
    period: 15s
    # pin: 5
    # state_change_action:
    #  - lambda: |-
    #      ESP_LOGD("SLOW PWM","toggle to state %d",state);
    #      auto *out1 = id(output1);
    #      if (state)
    #        out1->turn_on();
    #      else
    #        out1->turn_off();
    turn_on_action:
      - lambda: |-
          auto *out1 = id(output1);
          out1->turn_on();
    turn_off_action:
      - output.turn_off: output1
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
