### PR TITLE
bang_bang: respect set cool- and heat-only modes

### DIFF
--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -80,21 +80,23 @@ void BangBangClimate::compute_state_() {
 
   climate::ClimateAction target_action;
   if (too_cold) {
-    // too cold -> enable heating if possible, else idle
-    if (this->supports_heat_)
+    // too cold -> enable heating if possible and enabled, else idle
+    if (this->supports_heat_ &&
+        (this->mode == climate::CLIMATE_MODE_HEAT_COOL || this->mode == climate::CLIMATE_MODE_HEAT))
       target_action = climate::CLIMATE_ACTION_HEATING;
     else
       target_action = climate::CLIMATE_ACTION_IDLE;
   } else if (too_hot) {
-    // too hot -> enable cooling if possible, else idle
-    if (this->supports_cool_)
+    // too hot -> enable cooling if possible and enabled, else idle
+    if (this->supports_cool_ &&
+        (this->mode == climate::CLIMATE_MODE_HEAT_COOL || this->mode == climate::CLIMATE_MODE_COOL))
       target_action = climate::CLIMATE_ACTION_COOLING;
     else
       target_action = climate::CLIMATE_ACTION_IDLE;
   } else {
     // neither too hot nor too cold -> in range
-    if (this->supports_cool_ && this->supports_heat_) {
-      // if supports both ends, go to idle action
+    if (this->supports_cool_ && this->supports_heat_ && this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
+      // if supports both ends and both cooling and heating enabled, go to idle action
       target_action = climate::CLIMATE_ACTION_IDLE;
     } else {
       // else use current mode and don't change (hysteresis)


### PR DESCRIPTION
# What does this implement/fix? 

First of all - I'm not sure whether I should call this a new feature or a bugfix, but I prefer the latter, because the current behavior of the bang bang climate controller seemed confusing to me. While I think that scenarios like this are fairly uncommon (in my case it's a fridge converted to a temperature-controlled fermentation chamber), in my opinion the correct behavior should be that the controller should respect the set mode, so if the system has both `heat_action` and `cool_action` they should not run if the "Operation" option in HA is set just to "Cool" or "Heat" respectively. This PR keeps the current behavior only in the "Heat/Cool" mode, which is actually intuitive. 

See the example here:

![image](https://user-images.githubusercontent.com/211416/146689084-f2875412-f0aa-4b90-bc20-eac9841f6514.png)

Without the patch, the system would switch to the heat action until 22.4 °C is reached, although just the cooling mode is selected. This makes little sense to me, IMHO the `heat_action` should not be executed at all in the cooling mode, and vice versa.

I don't think this change needs to be clarified in the docs, since this is actually what one would expect, but let me know if you think otherwise.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
