### PR TITLE
Change HDC1080 init instruction failure from error to warning

### DIFF
--- a/esphome/components/hdc1080/hdc1080.cpp
+++ b/esphome/components/hdc1080/hdc1080.cpp
@@ -21,7 +21,9 @@ void HDC1080Component::setup() {
   };
 
   if (!this->write_bytes(HDC1080_CMD_CONFIGURATION, data, 2)) {
-    this->mark_failed();
+    // as instruction is same as powerup defaults (for now), interpret as warning if this fails
+    ESP_LOGW(TAG, "HDC1080 initial config instruction error");
+    //this->mark_failed();
     return;
   }
 }

--- a/esphome/components/hdc1080/hdc1080.cpp
+++ b/esphome/components/hdc1080/hdc1080.cpp
@@ -23,7 +23,7 @@ void HDC1080Component::setup() {
   if (!this->write_bytes(HDC1080_CMD_CONFIGURATION, data, 2)) {
     // as instruction is same as powerup defaults (for now), interpret as warning if this fails
     ESP_LOGW(TAG, "HDC1080 initial config instruction error");
-    //this->mark_failed();
+    this->status_set_warning();
     return;
   }
 }


### PR DESCRIPTION
# What does this implement/fix? 

HDC1080 init instruction fails (typical, all devices I've used), resulting in sensor not operating, due to a bug introduced in underlying i2c code somewhere (see issue report for more detail). This fix is a bit 'quick and dirty' but I think improves resilience - as the current hardcoded device config instruction mirrors the device's powerup defaults, it has no effect in practice. Failure of init instruction should not be terminal (device works fine if ignored).  This PR removes setting the device in error state when config instruction fails, and logs a warning instead. My testing shows the device works fine as is (even if the return state of this message was not ERROR_OK). Message is still attempted.

In the case the config init instruction (currently hardcoded) is changed in future, will need to review impact of failure (i.e. revert to entering error state on failure iff the device doesn't function as expected without the config message).

Noted that at some point, someone needs to fix the underlying bug (somethat's making this device fail - haven't been able to track it down myself as all my devices are currently wall mounted!

Quick description and explanation of changes

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2700

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
None - no change to user funtionality.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Note the filters are designed to correct RH for temperature offset. Feel free to steal.
```yaml
sensor:
  - platform: hdc1080
    temperature:
      name: "Living Room Temperature"
      id: tempsensor
      filters:
        - offset: -2.9
        - sliding_window_moving_average:
            window_size: 5
            send_every: 1
    humidity:
      name: "Living Room Humidity"
      id: humiditysensor
      filters:
        - lambda: |-
            float rh = x;
            float t1 = id(tempsensor).raw_state;
            float t2 = id(tempsensor).state;
            rh *= exp((17.67 * t1) / (t1 + 243.5));
            rh *= (273.15 + t2);
            rh /= exp((17.67 * t2) / (t2 + 243.5));
            rh /= (273.15 + t1);
            return rh;
        - sliding_window_moving_average:
            window_size: 5
            send_every: 1
    update_interval: 60s

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  Note - existing tests should suffice.
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
None added.