### PR TITLE
Fix tm1637 bootloop

### DIFF
--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -176,7 +176,7 @@ void TM1637Display::display() {
 
   // Write the data bytes
   if (this->inverted_) {
-    for (uint8_t i = this->length_ - 1; i >= 0; i--) {
+    for (int8_t i = this->length_ - 1; i >= 0; i--) {
       this->send_byte_(this->buffer_[i]);
     }
   } else {


### PR DESCRIPTION
# What does this implement/fix? 
A PR remark of #2878 (to avoid an infinite loop...) introduced a bootloop (unsigned integer overflowed to 255 instead of -1, causing an infinite loop)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  platform: tm1637
  id: tm1637_display
  clk_pin: GPIO16
  dio_pin: GPIO17
  inverted: true
  length: 4
  lambda: |-
    it.print("0234");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
