### PR TITLE
Modbus: add binary output

### DIFF
--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -47,11 +47,16 @@ MODBUS_FUNCTION_CODE = {
 
 ModbusRegisterType_ns = modbus_controller_ns.namespace("ModbusRegisterType")
 ModbusRegisterType = ModbusRegisterType_ns.enum("ModbusRegisterType")
-MODBUS_REGISTER_TYPE = {
+
+MODBUS_WRITE_REGISTER_TYPE = {
     "custom": ModbusRegisterType.CUSTOM,
     "coil": ModbusRegisterType.COIL,
-    "discrete_input": ModbusRegisterType.DISCRETE_INPUT,
     "holding": ModbusRegisterType.HOLDING,
+}
+
+MODBUS_REGISTER_TYPE = {
+    **MODBUS_WRITE_REGISTER_TYPE,
+    "discrete_input": ModbusRegisterType.DISCRETE_INPUT,
     "read": ModbusRegisterType.READ,
 }
 

--- a/esphome/components/modbus_controller/output/__init__.py
+++ b/esphome/components/modbus_controller/output/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import output
-
 from esphome.const import (
     CONF_ADDRESS,
     CONF_ID,
@@ -11,13 +10,14 @@ from esphome.const import (
 from .. import (
     modbus_controller_ns,
     modbus_calc_properties,
-    validate_modbus_register,
     ModbusItemBaseSchema,
     SensorItem,
+    SENSOR_VALUE_TYPE,
 )
 
 from ..const import (
     CONF_MODBUS_CONTROLLER_ID,
+    CONF_REGISTER_TYPE,
     CONF_USE_WRITE_MULTIPLE,
     CONF_VALUE_TYPE,
     CONF_WRITE_LAMBDA,
@@ -26,46 +26,83 @@ from ..const import (
 DEPENDENCIES = ["modbus_controller"]
 CODEOWNERS = ["@martgras"]
 
+CONF_FLOAT = "float"
 
-ModbusOutput = modbus_controller_ns.class_(
-    "ModbusOutput", cg.Component, output.FloatOutput, SensorItem
+ModbusFloatOutput = modbus_controller_ns.class_(
+    "ModbusFloatOutput", cg.Component, output.FloatOutput, SensorItem
+)
+ModbusBinaryOutput = modbus_controller_ns.class_(
+    "ModbusBinaryOutput", cg.Component, output.FloatOutput, SensorItem
 )
 
-CONFIG_SCHEMA = cv.All(
-    output.FLOAT_OUTPUT_SCHEMA.extend(ModbusItemBaseSchema).extend(
-        {
-            cv.GenerateID(): cv.declare_id(ModbusOutput),
-            cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
-            cv.Optional(CONF_MULTIPLY, default=1.0): cv.float_,
-            cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
-        }
-    ),
-    validate_modbus_register,
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "coil": output.BINARY_OUTPUT_SCHEMA.extend(ModbusItemBaseSchema).extend(
+            {
+                cv.GenerateID(): cv.declare_id(ModbusBinaryOutput),
+                cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
+                cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
+            }
+        ),
+        "holding": output.FLOAT_OUTPUT_SCHEMA.extend(ModbusItemBaseSchema).extend(
+            {
+                cv.GenerateID(): cv.declare_id(ModbusFloatOutput),
+                cv.Optional(CONF_VALUE_TYPE, default="U_WORD"): cv.enum(
+                    SENSOR_VALUE_TYPE
+                ),
+                cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
+                cv.Optional(CONF_MULTIPLY, default=1.0): cv.float_,
+                cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
+            }
+        ),
+    },
+    lower=True,
+    key=CONF_REGISTER_TYPE,
+    default_type="holding",
 )
 
 
 async def to_code(config):
     byte_offset, reg_count = modbus_calc_properties(config)
-    var = cg.new_Pvariable(
-        config[CONF_ID],
-        config[CONF_ADDRESS],
-        byte_offset,
-        config[CONF_VALUE_TYPE],
-        reg_count,
-    )
-    await output.register_output(var, config)
-    cg.add(var.set_write_multiply(config[CONF_MULTIPLY]))
-    parent = await cg.get_variable(config[CONF_MODBUS_CONTROLLER_ID])
-    cg.add(var.set_use_write_mutiple(config[CONF_USE_WRITE_MULTIPLE]))
-    cg.add(var.set_parent(parent))
-    if CONF_WRITE_LAMBDA in config:
+    # Binary Output
+    if config[CONF_REGISTER_TYPE] == "coil":
+        var = cg.new_Pvariable(
+            config[CONF_ID],
+            config[CONF_ADDRESS],
+            byte_offset,
+        )
         template_ = await cg.process_lambda(
             config[CONF_WRITE_LAMBDA],
             [
-                (ModbusOutput.operator("ptr"), "item"),
+                (ModbusBinaryOutput.operator("ptr"), "item"),
+                (cg.bool_, "x"),
+                (cg.std_vector.template(cg.uint8).operator("ref"), "payload"),
+            ],
+            return_type=cg.optional.template(bool),
+        )
+    # Float Output
+    else:
+        var = cg.new_Pvariable(
+            config[CONF_ID],
+            config[CONF_ADDRESS],
+            byte_offset,
+            config[CONF_VALUE_TYPE],
+            reg_count,
+        )
+        cg.add(var.set_write_multiply(config[CONF_MULTIPLY]))
+        template_ = await cg.process_lambda(
+            config[CONF_WRITE_LAMBDA],
+            [
+                (ModbusFloatOutput.operator("ptr"), "item"),
                 (cg.float_, "x"),
                 (cg.std_vector.template(cg.uint16).operator("ref"), "payload"),
             ],
             return_type=cg.optional.template(float),
         )
+    await output.register_output(var, config)
+    parent = await cg.get_variable(config[CONF_MODBUS_CONTROLLER_ID])
+    cg.add(var.set_use_write_mutiple(config[CONF_USE_WRITE_MULTIPLE]))
+    cg.add(var.set_parent(parent))
+    if CONF_WRITE_LAMBDA in config:
         cg.add(var.set_write_template(template_))

--- a/esphome/components/modbus_controller/output/__init__.py
+++ b/esphome/components/modbus_controller/output/__init__.py
@@ -32,7 +32,7 @@ ModbusFloatOutput = modbus_controller_ns.class_(
     "ModbusFloatOutput", cg.Component, output.FloatOutput, SensorItem
 )
 ModbusBinaryOutput = modbus_controller_ns.class_(
-    "ModbusBinaryOutput", cg.Component, output.FloatOutput, SensorItem
+    "ModbusBinaryOutput", cg.Component, output.BinaryOutput, SensorItem
 )
 
 

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -54,7 +54,7 @@ void ModbusFloatOutput::dump_config() {
   LOG_FLOAT_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Value type=%hhu", static_cast<int>(this->sensor_value_type));
 }
 
 // ModbusBinaryOutput
@@ -62,6 +62,7 @@ void ModbusBinaryOutput::write_state(bool state) {
   // This will be called every time the user requests a state change.
   ModbusCommandItem cmd;
   std::vector<uint8_t> data;
+
   // Is there are lambda configured?
   if (this->write_transform_func_.has_value()) {
     // data is passed by reference
@@ -103,7 +104,7 @@ void ModbusBinaryOutput::dump_config() {
   LOG_BINARY_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Value type=%hhu", static_cast<int>(this->sensor_value_type));
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -53,7 +53,7 @@ void ModbusFloatOutput::dump_config() {
   LOG_FLOAT_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Value type=0x%d", this->sensor_value_type);
 }
 
 // ModbusBinaryOutput
@@ -102,7 +102,7 @@ void ModbusBinaryOutput::dump_config() {
   LOG_BINARY_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Value type=0x%d", this->sensor_value_type);
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -6,13 +6,13 @@ namespace esphome {
 namespace modbus_controller {
 
 static const char *const TAG = "modbus_controller.output";
-
-void ModbusOutput::setup() {}
+static const char *const FLOAT_TAG = "modbus_controller.float_output";
+static const char *const BINARY_TAG = "modbus_controller.binary_output";
 
 /** Write a value to the device
  *
  */
-void ModbusOutput::write_state(float value) {
+void ModbusFloatOutput::write_state(float value) {
   std::vector<uint16_t> data;
   auto original_value = value;
   // Is there are lambda configured?
@@ -22,10 +22,10 @@ void ModbusOutput::write_state(float value) {
     // in that case the return value is ignored
     auto val = (*this->write_transform_func_)(this, value, data);
     if (val.has_value()) {
-      ESP_LOGV(TAG, "Value overwritten by lambda");
+      ESP_LOGV(FLOAT_TAG, "Value overwritten by lambda");
       value = val.value();
     } else {
-      ESP_LOGV(TAG, "Communication handled by lambda - exiting control");
+      ESP_LOGV(FLOAT_TAG, "Communication handled by lambda - exiting control");
       return;
     }
   } else {
@@ -36,10 +36,9 @@ void ModbusOutput::write_state(float value) {
     data = float_to_payload(value, this->sensor_value_type);
   }
 
-  ESP_LOGD(TAG, "Updating register: start address=0x%X register count=%d new value=%.02f (val=%.02f)",
+  ESP_LOGD(FLOAT_TAG, "Updating register: start address=0x%X register count=%d new value=%.02f (val=%.02f)",
            this->start_address, this->register_count, value, original_value);
 
-  // Create and send the write command
   // Create and send the write command
   ModbusCommandItem write_cmd;
   if (this->register_count == 1 && !this->use_write_multiple_) {
@@ -51,10 +50,58 @@ void ModbusOutput::write_state(float value) {
   parent_->queue_command(write_cmd);
 }
 
-void ModbusOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "Modbus Float Output:");
+void ModbusFloatOutput::dump_config() {
+  ESP_LOGCONFIG(FLOAT_TAG, "Modbus Float Output:");
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "Modbus device start address=0x%X register count=%d value type=%hhu", this->start_address,
+  ESP_LOGCONFIG(FLOAT_TAG, "Modbus device start address=0x%X register count=%d value type=%hhu", this->start_address,
+                this->register_count, this->sensor_value_type);
+}
+
+// ModbusBinaryOutput
+void ModbusBinaryOutput::write_state(bool state) {
+  // This will be called every time the user requests a state change.
+  ModbusCommandItem cmd;
+  std::vector<uint8_t> data;
+  // Is there are lambda configured?
+  if (this->write_transform_func_.has_value()) {
+    // data is passed by reference
+    // the lambda can fill the empty vector directly
+    // in that case the return value is ignored
+    auto val = (*this->write_transform_func_)(this, state, data);
+    if (val.has_value()) {
+      ESP_LOGV(BINARY_TAG, "Value overwritten by lambda");
+      state = val.value();
+    } else {
+      ESP_LOGV(BINARY_TAG, "Communication handled by lambda - exiting control");
+      return;
+    }
+  }
+  if (!data.empty()) {
+    ESP_LOGV(BINARY_TAG, "Modbus binary output write raw: %s", format_hex_pretty(data).c_str());
+    cmd = ModbusCommandItem::create_custom_command(
+        this->parent_, data,
+        [this, cmd](ModbusRegisterType register_type, uint16_t start_address, const std::vector<uint8_t> &data) {
+          this->parent_->on_write_register_response(cmd.register_type, this->start_address, data);
+        });
+  } else {
+    ESP_LOGV(BINARY_TAG, "write_state new value = %s type = %d address = %X offset = %x", ONOFF(state),
+             (int) this->register_type, this->start_address, this->offset);
+
+    // offset for coil and discrete inputs is the coil/register number not bytes
+    if (this->use_write_multiple_) {
+      std::vector<bool> states{state};
+      cmd = ModbusCommandItem::create_write_multiple_coils(parent_, this->start_address + this->offset, states);
+    } else {
+      cmd = ModbusCommandItem::create_write_single_coil(parent_, this->start_address + this->offset, state);
+    }
+  }
+  this->parent_->queue_command(cmd);
+}
+
+void ModbusBinaryOutput::dump_config() {
+  ESP_LOGCONFIG(BINARY_TAG, "Modbus Binary Output:");
+  LOG_BINARY_OUTPUT(this);
+  ESP_LOGCONFIG(BINARY_TAG, "Modbus device start address=0x%X  register count=%d value type=%hhu", this->start_address,
                 this->register_count, this->sensor_value_type);
 }
 

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -6,8 +6,6 @@ namespace esphome {
 namespace modbus_controller {
 
 static const char *const TAG = "modbus_controller.output";
-static const char *const FLOAT_TAG = "modbus_controller.float_output";
-static const char *const BINARY_TAG = "modbus_controller.binary_output";
 
 /** Write a value to the device
  *
@@ -22,10 +20,10 @@ void ModbusFloatOutput::write_state(float value) {
     // in that case the return value is ignored
     auto val = (*this->write_transform_func_)(this, value, data);
     if (val.has_value()) {
-      ESP_LOGV(FLOAT_TAG, "Value overwritten by lambda");
+      ESP_LOGV(TAG, "Value overwritten by lambda");
       value = val.value();
     } else {
-      ESP_LOGV(FLOAT_TAG, "Communication handled by lambda - exiting control");
+      ESP_LOGV(TAG, "Communication handled by lambda - exiting control");
       return;
     }
   } else {
@@ -36,7 +34,7 @@ void ModbusFloatOutput::write_state(float value) {
     data = float_to_payload(value, this->sensor_value_type);
   }
 
-  ESP_LOGD(FLOAT_TAG, "Updating register: start address=0x%X register count=%d new value=%.02f (val=%.02f)",
+  ESP_LOGD(TAG, "Updating register: start address=0x%X register count=%d new value=%.02f (val=%.02f)",
            this->start_address, this->register_count, value, original_value);
 
   // Create and send the write command
@@ -51,10 +49,12 @@ void ModbusFloatOutput::write_state(float value) {
 }
 
 void ModbusFloatOutput::dump_config() {
-  ESP_LOGCONFIG(FLOAT_TAG, "Modbus Float Output:");
+  ESP_LOGCONFIG(TAG, "Modbus Float Output:");
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGCONFIG(FLOAT_TAG, "Modbus device start address=0x%X register count=%d value type=%hhu", this->start_address,
-                this->register_count, this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", , this->start_address, this->register_count,
+                this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
 }
 
 // ModbusBinaryOutput
@@ -69,22 +69,22 @@ void ModbusBinaryOutput::write_state(bool state) {
     // in that case the return value is ignored
     auto val = (*this->write_transform_func_)(this, state, data);
     if (val.has_value()) {
-      ESP_LOGV(BINARY_TAG, "Value overwritten by lambda");
+      ESP_LOGV(TAG, "Value overwritten by lambda");
       state = val.value();
     } else {
-      ESP_LOGV(BINARY_TAG, "Communication handled by lambda - exiting control");
+      ESP_LOGV(TAG, "Communication handled by lambda - exiting control");
       return;
     }
   }
   if (!data.empty()) {
-    ESP_LOGV(BINARY_TAG, "Modbus binary output write raw: %s", format_hex_pretty(data).c_str());
+    ESP_LOGV(TAG, "Modbus binary output write raw: %s", format_hex_pretty(data).c_str());
     cmd = ModbusCommandItem::create_custom_command(
         this->parent_, data,
         [this, cmd](ModbusRegisterType register_type, uint16_t start_address, const std::vector<uint8_t> &data) {
           this->parent_->on_write_register_response(cmd.register_type, this->start_address, data);
         });
   } else {
-    ESP_LOGV(BINARY_TAG, "write_state new value = %s type = %d address = %X offset = %x", ONOFF(state),
+    ESP_LOGV(TAG, "Write new state: value is %s, type is %d address = %X, offset = %x", ONOFF(state),
              (int) this->register_type, this->start_address, this->offset);
 
     // offset for coil and discrete inputs is the coil/register number not bytes
@@ -99,9 +99,9 @@ void ModbusBinaryOutput::write_state(bool state) {
 }
 
 void ModbusBinaryOutput::dump_config() {
-  ESP_LOGCONFIG(BINARY_TAG, "Modbus Binary Output:");
+  ESP_LOGCONFIG(TAG, "Modbus Binary Output:");
   LOG_BINARY_OUTPUT(this);
-  ESP_LOGCONFIG(BINARY_TAG, "Modbus device start address=0x%X  register count=%d value type=%hhu", this->start_address,
+  ESP_LOGCONFIG(TAG, "Modbus device start address=0x%X  register count=%d value type=%hhu", this->start_address,
                 this->register_count, this->sensor_value_type);
 }
 

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -53,7 +53,7 @@ void ModbusFloatOutput::dump_config() {
   LOG_FLOAT_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=0x%d", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
 }
 
 // ModbusBinaryOutput
@@ -102,7 +102,7 @@ void ModbusBinaryOutput::dump_config() {
   LOG_BINARY_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=0x%d", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -52,9 +52,9 @@ void ModbusFloatOutput::write_state(float value) {
 void ModbusFloatOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Float Output:");
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
-  ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=0x%d", static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
+  ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
+  ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));
 }
 
 // ModbusBinaryOutput
@@ -102,9 +102,9 @@ void ModbusBinaryOutput::write_state(bool state) {
 void ModbusBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Binary Output:");
   LOG_BINARY_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
-  ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=0x%d", static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
+  ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
+  ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include "modbus_output.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace modbus_controller {

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -54,7 +54,7 @@ void ModbusFloatOutput::dump_config() {
   LOG_FLOAT_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=%hhu", static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG, "  Value type=0x%d", static_cast<int>(this->sensor_value_type));
 }
 
 // ModbusBinaryOutput
@@ -104,7 +104,7 @@ void ModbusBinaryOutput::dump_config() {
   LOG_BINARY_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type=%hhu", static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG, "  Value type=0x%d", static_cast<int>(this->sensor_value_type));
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -51,9 +51,8 @@ void ModbusFloatOutput::write_state(float value) {
 void ModbusFloatOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Float Output:");
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", , this->start_address, this->register_count,
-                this->sensor_value_type);
-  ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", , this->start_address);
+  ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
   ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
 }
 

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -51,7 +51,7 @@ void ModbusFloatOutput::write_state(float value) {
 void ModbusFloatOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Float Output:");
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", , this->start_address);
+  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
   ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
 }

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -100,8 +100,9 @@ void ModbusBinaryOutput::write_state(bool state) {
 void ModbusBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Binary Output:");
   LOG_BINARY_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "Modbus device start address=0x%X  register count=%d value type=%hhu", this->start_address,
-                this->register_count, this->sensor_value_type);
+  ESP_LOGCONFIG(TAG, "  Device start address=0x%X", this->start_address);
+  ESP_LOGCONFIG(TAG, "  Register count=0x%d", this->register_count);
+  ESP_LOGCONFIG(TAG, "  Value type=%hhu", this->sensor_value_type);
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -21,7 +21,6 @@ class ModbusFloatOutput : public output::FloatOutput, public Component, public S
     this->start_address += offset;
     this->offset = 0;
   }
-  void setup() override{};
   void dump_config() override;
 
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
@@ -54,7 +53,6 @@ class ModbusBinaryOutput : public output::BinaryOutput, public Component, public
     this->start_address += offset;
     this->offset = 0;
   }
-  void setup() override{};
   void dump_config() override;
 
   void set_parent(ModbusController *parent) { this->parent_ = parent; }

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -7,11 +7,9 @@
 namespace esphome {
 namespace modbus_controller {
 
-using value_to_data_t = std::function<float>(float);
-
-class ModbusOutput : public output::FloatOutput, public Component, public SensorItem {
+class ModbusFloatOutput : public output::FloatOutput, public Component, public SensorItem {
  public:
-  ModbusOutput(uint16_t start_address, uint8_t offset, SensorValueType value_type, int register_count)
+  ModbusFloatOutput(uint16_t start_address, uint8_t offset, SensorValueType value_type, int register_count)
       : output::FloatOutput(), Component() {
     this->register_type = ModbusRegisterType::HOLDING;
     this->start_address = start_address;
@@ -23,7 +21,7 @@ class ModbusOutput : public output::FloatOutput, public Component, public Sensor
     this->start_address += offset;
     this->offset = 0;
   }
-  void setup() override;
+  void setup() override{};
   void dump_config() override;
 
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
@@ -31,7 +29,7 @@ class ModbusOutput : public output::FloatOutput, public Component, public Sensor
   // Do nothing
   void parse_and_publish(const std::vector<uint8_t> &data) override{};
 
-  using write_transform_func_t = std::function<optional<float>(ModbusOutput *, float, std::vector<uint16_t> &)>;
+  using write_transform_func_t = std::function<optional<float>(ModbusFloatOutput *, float, std::vector<uint16_t> &)>;
   void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
 
@@ -41,6 +39,37 @@ class ModbusOutput : public output::FloatOutput, public Component, public Sensor
 
   ModbusController *parent_;
   float multiply_by_{1.0};
+  bool use_write_multiple_;
+};
+
+class ModbusBinaryOutput : public output::BinaryOutput, public Component, public SensorItem {
+ public:
+  ModbusBinaryOutput(uint16_t start_address, uint8_t offset) : output::BinaryOutput(), Component() {
+    this->register_type = ModbusRegisterType::COIL;
+    this->start_address = start_address;
+    this->bitmask = bitmask;
+    this->sensor_value_type = SensorValueType::BIT;
+    this->skip_updates = 0;
+    this->register_count = 1;
+    this->start_address += offset;
+    this->offset = 0;
+  }
+  void setup() override{};
+  void dump_config() override;
+
+  void set_parent(ModbusController *parent) { this->parent_ = parent; }
+  // Do nothing
+  void parse_and_publish(const std::vector<uint8_t> &data) override{};
+
+  using write_transform_func_t = std::function<optional<bool>(ModbusBinaryOutput *, bool, std::vector<uint8_t> &)>;
+  void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
+  void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
+
+ protected:
+  void write_state(bool state) override;
+  optional<write_transform_func_t> write_transform_func_{nullopt};
+
+  ModbusController *parent_;
   bool use_write_multiple_;
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

Add binary output to modbus output. If `register_type` is `holding` a float output is created. For `coil` a binary output is created

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1746

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
output:
  - platform: modbus_controller
    modbus_controller_id: epever
    id: battery_capacity_number
    address: 0x9001
    #register_type: holding
    value_type: U_WORD
    use_write_multiple: true
    response_size: 1
    #offset: 0 
    byte_offset: 0
    write_lambda: |-
      ESP_LOGD("main","Modbus Number incoming value = %f",x);
      uint16_t b_capacity = x ;
      payload.push_back(b_capacity);
      return x * 1.0 ;

  - platform: modbus_controller
    modbus_controller_id: epever
    id: test_coil
    address: 0x1
    register_type: coil
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
