### PR TITLE
add get_level() function to float output

### DIFF
--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -34,7 +34,7 @@ void FloatOutput::set_level(float state) {
 
   if (!(state == 0.0f && this->zero_means_zero_))  // regardless of min_power_, 0.0 means off
     state = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
-  
+
   state_ = state;  // remember state to read out later
 
   if (this->is_inverted())

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -38,7 +38,7 @@ void FloatOutput::set_level(float state) {
   if (this->is_inverted())
     state = 1.0f - state;
 
-  state_ = state; // remember state to read out later
+  state_ = state;  // remember state to read out later
   this->write_state(state);
 }
 

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -42,7 +42,6 @@ void FloatOutput::set_level(float state) {
   this->write_state(state);
 }
 
-
 float FloatOutput::get_level() const { return this->state_; }
 
 void FloatOutput::write_state(bool state) { this->set_level(state != this->inverted_ ? 1.0f : 0.0f); }

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -37,8 +37,13 @@ void FloatOutput::set_level(float state) {
 
   if (this->is_inverted())
     state = 1.0f - state;
+
+  state_ = state; // remember state to read out later
   this->write_state(state);
 }
+
+
+float FloatOutput::get_level() const { return this->state_; }
 
 void FloatOutput::write_state(bool state) { this->set_level(state != this->inverted_ ? 1.0f : 0.0f); }
 

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -34,11 +34,12 @@ void FloatOutput::set_level(float state) {
 
   if (!(state == 0.0f && this->zero_means_zero_))  // regardless of min_power_, 0.0 means off
     state = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
+  
+  state_ = state;  // remember state to read out later
 
   if (this->is_inverted())
     state = 1.0f - state;
 
-  state_ = state;  // remember state to read out later
   this->write_state(state);
 }
 

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -69,6 +69,9 @@ class FloatOutput : public BinaryOutput {
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
 
+  /// Get the actual level of this float output
+  float get_level() const;
+
   /// Get the maximum power output.
   float get_max_power() const;
 
@@ -82,6 +85,7 @@ class FloatOutput : public BinaryOutput {
 
   float max_power_{1.0f};
   float min_power_{0.0f};
+  float state_;
   bool zero_means_zero_;
 };
 


### PR DESCRIPTION
# What does this implement/fix? 

Float output entities have a set_level() function naturally. A light component would set output level to get light. 
Now it is almost impossible to know at what exact level the float output actually is. There are gamma conversions, effects and what so ever going on changing the float output.
I would like to maeasure as accurate as possible the power consumption. I know how much power the full on light needs, now I need to know the PWM dimming value. And this can not be calculated reasonably on light control values. This get_level() functions solves the problem.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: ...
    id: my_output_id

sensor:
  - platform: template
    name: "GetLevel Sensor"
    lambda: |-
      return id(my_output_id).get_level();;
   

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
