### PR TITLE
Workaround installing as editable package not working

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN \
 
 # Copy esphome and install
 COPY . /esphome
-RUN pip3 install --no-cache-dir -e /esphome
+RUN pip3 install --no-cache-dir /esphome
 
 # Settings for dashboard
 ENV USERNAME="" PASSWORD=""


### PR DESCRIPTION
# What does this implement/fix? 

No idea why this suddenly changed from 21st December 2021, but the package link started to be installed inside the docker image into `/usr/lib/` instead of `/usr/local/lib` like all previous builds. You can see this below in the `container-diff`

This is not because of a code change as if I rebuild the 2021.12.1 image or a few other previous ones it is broken.

<details>
<summary>

`container-diff diff esphome/esphome-amd64:2021.12.1 esphome/esphome-amd64:2021.12.2 --type=file`
</summary>

```
-----File-----

These entries have been added to esphome/esphome-amd64:2021.12.1:
FILE                                                                                            SIZE
/root/.cache/pip/http/c/e                                                                       931.3K
/root/.cache/pip/http/c/e/e                                                                     931.3K
/root/.cache/pip/http/c/e/e/9                                                                   931.3K
/root/.cache/pip/http/c/e/e/9/4                                                                 931.3K
/root/.cache/pip/http/c/e/e/9/4/cee947084c37811e4caea491bdb7cd7ba16b29a230a80a13d8b2d00a        931.3K
/usr/bin/esphome                                                                                937B
/usr/lib/python3.9/site-packages                                                                19B
/usr/lib/python3.9/site-packages/easy-install.pth                                               9B
/usr/lib/python3.9/site-packages/esphome.egg-link                                               10B

These entries have been deleted from esphome/esphome-amd64:2021.12.1:
FILE                                                                                            SIZE
/root/.cache/pip/http/f                                                                         931.1K
/root/.cache/pip/http/f/6                                                                       931.1K
/root/.cache/pip/http/f/6/7                                                                     931.1K
/root/.cache/pip/http/f/6/7/3                                                                   931.1K
/root/.cache/pip/http/f/6/7/3/a                                                                 931.1K
/root/.cache/pip/http/f/6/7/3/a/f673a8f2e0039b01907fd360076e6fa9b5500c8c1472ae1639b0f891        931.1K
/usr/local/bin/esphome                                                                          937B
/usr/local/lib/python3.9/dist-packages/easy-install.pth                                         9B
/usr/local/lib/python3.9/dist-packages/esphome.egg-link                                         10B

These entries have been changed between esphome/esphome-amd64:2021.12.1 and esphome/esphome-amd64:2021.12.2:
FILE                                                                                            SIZE1         SIZE2
/root/.cache/pip/http/0/4/1/8/c/0418c83b80f7f7bfaec2738bfbbee53d2c1562196c0781702f6eddc8        103.3K        104.1K
/root/.cache/pip/http/c/9/1/5/1/c915186bed19af5c2add5f38006cbecca9fd97011a234853622f3103        35.1K         35.2K
/esphome/esphome/__pycache__/const.cpython-39.pyc                                               35K           35K
/esphome/esphome/const.py                                                                       29.6K         29.6K
/root/.cache/pip/http/4/d/2/7/2/4d272e6453941ce8b0a37a02cdb1685fc612c33441fa74691fb40656        11K           11.1K
/esphome/esphome/components/esp32/core.cpp                                                      2.3K          2.4K
/esphome/esphome.egg-info/PKG-INFO                                                              1.6K          1.6K
/esphome/esphome/components/mqtt/mqtt_button.cpp                                                1.3K          1.3K
/esphome/esphome/__pycache__/__init__.cpython-39.pyc                                            119B          119B
```
</details>


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2856

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
