### PR TITLE
Support inkplate10

### DIFF
--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_FULL_UPDATE_EVERY,
     CONF_ID,
     CONF_LAMBDA,
+    CONF_MODEL,
     CONF_PAGES,
     CONF_WAKEUP_PIN,
 )
@@ -40,6 +41,13 @@ Inkplate6 = inkplate6_ns.class_(
     "Inkplate6", cg.PollingComponent, i2c.I2CDevice, display.DisplayBuffer
 )
 
+InkplateModel = inkplate6_ns.enum("InkplateModel")
+
+MODELS = {
+    "inkplate_6": InkplateModel.INKPLATE_6,
+    "inkplate_10": InkplateModel.INKPLATE_10,
+}
+
 CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(
         {
@@ -47,6 +55,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
             cv.Optional(CONF_PARTIAL_UPDATING, default=True): cv.boolean,
             cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
+            cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(
+                MODELS, lower=True, space="_"
+            ),
             # Control pins
             cv.Required(CONF_CKV_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_GMOD_PIN): pins.gpio_output_pin_schema,
@@ -109,6 +120,8 @@ async def to_code(config):
     cg.add(var.set_greyscale(config[CONF_GREYSCALE]))
     cg.add(var.set_partial_updating(config[CONF_PARTIAL_UPDATING]))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
+
+    cg.add(var.set_model(config[CONF_MODEL]))
 
     ckv = await cg.gpio_pin_expression(config[CONF_CKV_PIN])
     cg.add(var.set_ckv_pin(ckv))

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -113,6 +113,7 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
       return 800;
     else if (this->model_ == INKPLATE_10)
       return 1200;
+    return 0;
   }
 
   int get_height_internal() override {
@@ -120,6 +121,7 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
       return 600;
     else if (this->model_ == INKPLATE_10)
       return 825;
+    return 0;
   }
 
   size_t get_buffer_length_();

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -10,6 +10,11 @@
 namespace esphome {
 namespace inkplate6 {
 
+enum InkplateModel : uint8_t {
+  INKPLATE_6 = 0,
+  INKPLATE_10 = 1,
+};
+
 class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public i2c::I2CDevice {
  public:
   const uint8_t LUT2[16] = {0b10101010, 0b10101001, 0b10100110, 0b10100101, 0b10011010, 0b10011001,
@@ -42,6 +47,8 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
   }
   void set_partial_updating(bool partial_updating) { this->partial_updating_ = partial_updating; }
   void set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
+
+  void set_model(InkplateModel model) { this->model_ = model; }
 
   void set_display_data_0_pin(InternalGPIOPin *data) { this->display_data_0_pin_ = data; }
   void set_display_data_1_pin(InternalGPIOPin *data) { this->display_data_1_pin_ = data; }
@@ -101,9 +108,19 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
   void pins_z_state_();
   void pins_as_outputs_();
 
-  int get_width_internal() override { return 800; }
+  int get_width_internal() override {
+    if (this->model_ == INKPLATE_6)
+      return 800;
+    else if (this->model_ == INKPLATE_10)
+      return 1200;
+  }
 
-  int get_height_internal() override { return 600; }
+  int get_height_internal() override {
+    if (this->model_ == INKPLATE_6)
+      return 600;
+    else if (this->model_ == INKPLATE_10)
+      return 825;
+  }
 
   size_t get_buffer_length_();
 
@@ -132,6 +149,8 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
   bool block_partial_;
   bool greyscale_;
   bool partial_updating_;
+
+  InkplateModel model_;
 
   InternalGPIOPin *display_data_0_pin_;
   InternalGPIOPin *display_data_1_pin_;


### PR DESCRIPTION
# What does this implement/fix? 

The only difference between inkplate6 and 10 seems to be the resolution, so a simple enum and config option to change that.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1743

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
