### PR TITLE
Add option to load docker image when building

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -32,6 +32,7 @@ parser.add_argument("--dry-run", action="store_true", help="Don't run any comman
 subparsers = parser.add_subparsers(help="Action to perform", dest="command", required=True)
 build_parser = subparsers.add_parser("build", help="Build the image")
 build_parser.add_argument("--push", help="Also push the images", action="store_true")
+build_parser.add_argument("--load", help="Load the docker image locally", action="store_true")
 manifest_parser = subparsers.add_parser("manifest", help="Create a manifest from already pushed images")
 
 
@@ -132,6 +133,8 @@ def main():
             cmd += ["--tag", img]
         if args.push:
             cmd += ["--push", "--cache-to", f"type=registry,ref={cache_img},mode=max"]
+        if args.load:
+            cmd += ["--load", "--progress=plain"]
 
         run_command(*cmd, ".")
     elif args.command == "manifest":

--- a/docker/build.py
+++ b/docker/build.py
@@ -134,7 +134,7 @@ def main():
         if args.push:
             cmd += ["--push", "--cache-to", f"type=registry,ref={cache_img},mode=max"]
         if args.load:
-            cmd += ["--load", "--progress=plain"]
+            cmd += ["--load"]
 
         run_command(*cmd, ".")
     elif args.command == "manifest":


### PR DESCRIPTION
# What does this implement/fix? 

This adds a `--load` flag to the `docker/build.py` script which is useful for local builds

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
