### PR TITLE
Require arduino in webserver for better validation

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -22,31 +22,38 @@ AUTO_LOAD = ["json", "web_server_base"]
 web_server_ns = cg.esphome_ns.namespace("web_server")
 WebServer = web_server_ns.class_("WebServer", cg.Component, cg.Controller)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(WebServer),
-        cv.Optional(CONF_PORT, default=80): cv.port,
-        cv.Optional(
-            CONF_CSS_URL, default="https://esphome.io/_static/webserver-v1.min.css"
-        ): cv.string,
-        cv.Optional(CONF_CSS_INCLUDE): cv.file_,
-        cv.Optional(
-            CONF_JS_URL, default="https://esphome.io/_static/webserver-v1.min.js"
-        ): cv.string,
-        cv.Optional(CONF_JS_INCLUDE): cv.file_,
-        cv.Optional(CONF_AUTH): cv.Schema(
-            {
-                cv.Required(CONF_USERNAME): cv.All(cv.string_strict, cv.Length(min=1)),
-                cv.Required(CONF_PASSWORD): cv.All(cv.string_strict, cv.Length(min=1)),
-            }
-        ),
-        cv.GenerateID(CONF_WEB_SERVER_BASE_ID): cv.use_id(
-            web_server_base.WebServerBase
-        ),
-        cv.Optional(CONF_INCLUDE_INTERNAL, default=False): cv.boolean,
-        cv.Optional(CONF_OTA, default=True): cv.boolean,
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(WebServer),
+            cv.Optional(CONF_PORT, default=80): cv.port,
+            cv.Optional(
+                CONF_CSS_URL, default="https://esphome.io/_static/webserver-v1.min.css"
+            ): cv.string,
+            cv.Optional(CONF_CSS_INCLUDE): cv.file_,
+            cv.Optional(
+                CONF_JS_URL, default="https://esphome.io/_static/webserver-v1.min.js"
+            ): cv.string,
+            cv.Optional(CONF_JS_INCLUDE): cv.file_,
+            cv.Optional(CONF_AUTH): cv.Schema(
+                {
+                    cv.Required(CONF_USERNAME): cv.All(
+                        cv.string_strict, cv.Length(min=1)
+                    ),
+                    cv.Required(CONF_PASSWORD): cv.All(
+                        cv.string_strict, cv.Length(min=1)
+                    ),
+                }
+            ),
+            cv.GenerateID(CONF_WEB_SERVER_BASE_ID): cv.use_id(
+                web_server_base.WebServerBase
+            ),
+            cv.Optional(CONF_INCLUDE_INTERNAL, default=False): cv.boolean,
+            cv.Optional(CONF_OTA, default=True): cv.boolean,
+        },
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.only_with_arduino,
+)
 
 
 @coroutine_with_priority(40.0)


### PR DESCRIPTION
# What does this implement/fix? 

A very cryptic validation error occurs when trying to use webserver with the esp-idf framework. This stops that and errors out directly on the webserver.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2866

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
