### PR TITLE
Add ENS210 Humidity & Temperature sensor component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -58,6 +58,7 @@ esphome/components/dht/* @OttoWinter
 esphome/components/ds1307/* @badbadc0ffee
 esphome/components/dsmr/* @glmnet @zuidwijk
 esphome/components/ektf2232/* @jesserockz
+esphome/components/ens210/* @itn3rd77
 esphome/components/esp32/* @esphome/core
 esphome/components/esp32_ble/* @jesserockz
 esphome/components/esp32_ble_server/* @jesserockz

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -163,7 +163,7 @@ esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz
 esphome/components/rgbct/* @jesserockz
 esphome/components/rtttl/* @glmnet
-esphome/components/safe_mode/* @paulmonigatti
+esphome/components/safe_mode/* @jsuanet @paulmonigatti
 esphome/components/scd4x/* @sjtrny
 esphome/components/script/* @esphome/core
 esphome/components/sdm_meter/* @jesserockz @polyfaces
@@ -173,7 +173,7 @@ esphome/components/select/* @esphome/core
 esphome/components/sensor/* @esphome/core
 esphome/components/sgp40/* @SenexCrenshaw
 esphome/components/sht4x/* @sjtrny
-esphome/components/shutdown/* @esphome/core
+esphome/components/shutdown/* @esphome/core @jsuanet
 esphome/components/sim800l/* @glmnet
 esphome/components/sm2135/* @BoukeHaarsma23
 esphome/components/socket/* @esphome/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -163,7 +163,7 @@ esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz
 esphome/components/rgbct/* @jesserockz
 esphome/components/rtttl/* @glmnet
-esphome/components/safe_mode/* @jsuanet @paulmonigatti
+esphome/components/safe_mode/* @paulmonigatti
 esphome/components/scd4x/* @sjtrny
 esphome/components/script/* @esphome/core
 esphome/components/sdm_meter/* @jesserockz @polyfaces
@@ -173,7 +173,7 @@ esphome/components/select/* @esphome/core
 esphome/components/sensor/* @esphome/core
 esphome/components/sgp40/* @SenexCrenshaw
 esphome/components/sht4x/* @sjtrny
-esphome/components/shutdown/* @esphome/core @jsuanet
+esphome/components/shutdown/* @esphome/core
 esphome/components/sim800l/* @glmnet
 esphome/components/sm2135/* @BoukeHaarsma23
 esphome/components/socket/* @esphome/core

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -129,7 +129,9 @@ void ENS210Component::setup() {
 void ENS210Component::dump_config() {
   ESP_LOGCONFIG(TAG, "ENS210:");
   LOG_I2C_DEVICE(this);
-  ESP_LOGE(TAG, "%s", LOG_STR_ARG(ens210_status_to_human(this->error_code_)));
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "%s", LOG_STR_ARG(ens210_status_to_human(this->error_code_)));
+  }
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
@@ -151,7 +153,7 @@ void ENS210Component::update() {
     return;
   }
   // Wait for measurement to complete
-  this->set_timeout("data", uint32_t(ENS210_BOOTING_MS), [this]() {
+  this->set_timeout("data", uint32_t(ENS210_SINGLE_MEASURMENT_CONVERSION_TIME_MS), [this]() {
     int temperature_data, temperature_status, humidity_data, humidity_status;
     uint8_t data[6];
     uint32_t h_val_data, t_val_data;
@@ -159,7 +161,6 @@ void ENS210Component::update() {
     temperature_status = ENS210_STATUS_I2C_ERROR;
     humidity_status = ENS210_STATUS_I2C_ERROR;
 
-    delay(ENS210_SINGLE_MEASURMENT_CONVERSION_TIME_MS);
     // Read T_VAL and H_VAL
     if (!this->read_bytes(ENS210_REGISTER_T_VAL, data, 6)) {
       ESP_LOGE(TAG, "Communication with ENS210 failed!");

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -129,7 +129,7 @@ void ENS210Component::setup() {
 void ENS210Component::dump_config() {
   ESP_LOGCONFIG(TAG, "ENS210:");
   LOG_I2C_DEVICE(this);
-  ESP_LOGE(TAG, LOG_STR_ARG(ens210_status_to_human(this->error_code_)));
+  ESP_LOGE(TAG, "%s", LOG_STR_ARG(ens210_status_to_human(this->error_code_)));
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -165,7 +165,7 @@ void ENS210Component::update() {
     float humidity = (humidity_data & 0xFFFF) / 512.0;
     this->humidity_sensor_->publish_state(humidity);
   } else {
-    ESP_LOGW(TAG, "Humidity status failure: %s", status_str(humidity_status));
+    ESP_LOGW(TAG, "Humidity status failure: %s", status_str_(humidity_status));
     this->status_set_warning();
     return;
   }
@@ -179,7 +179,7 @@ void ENS210Component::update() {
     float temperature = (temperature_data & 0xFFFF) / 64.0 - 27315L / 100.0;
     this->temperature_sensor_->publish_state(temperature);
   } else {
-    ESP_LOGW(TAG, "Temperature status failure: %s", status_str(temperature_status));
+    ESP_LOGW(TAG, "Temperature status failure: %s", status_str_(temperature_status));
   }
 }
 

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -173,8 +173,10 @@ void ENS210Component::update() {
     extract_measurement_(h_val_data, &humidity_data, &humidity_status);
 
     if (humidity_status == ENS210_STATUS_OK) {
-      float humidity = (humidity_data & 0xFFFF) / 512.0;
-      this->humidity_sensor_->publish_state(humidity);
+      if (this->humidity_sensor_ != nullptr) {
+        float humidity = (humidity_data & 0xFFFF) / 512.0;
+        this->humidity_sensor_->publish_state(humidity);
+      }
     } else {
       ESP_LOGW(TAG, "Humidity status failure: %s", LOG_STR_ARG(ens210_status_to_human(humidity_status)));
       this->status_set_warning();
@@ -186,9 +188,11 @@ void ENS210Component::update() {
     extract_measurement_(t_val_data, &temperature_data, &temperature_status);
 
     if (temperature_status == ENS210_STATUS_OK) {
-      // Temperature in Celsius
-      float temperature = (temperature_data & 0xFFFF) / 64.0 - 27315L / 100.0;
-      this->temperature_sensor_->publish_state(temperature);
+      if (this->temperature_sensor_ != nullptr) {
+        // Temperature in Celsius
+        float temperature = (temperature_data & 0xFFFF) / 64.0 - 27315L / 100.0;
+        this->temperature_sensor_->publish_state(temperature);
+      }
     } else {
       ESP_LOGW(TAG, "Temperature status failure: %s", LOG_STR_ARG(ens210_status_to_human(temperature_status)));
     }

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -167,7 +167,7 @@ void ENS210Component::update() {
     float humidity = (humidity_data & 0xFFFF) / 512.0;
     this->humidity_sensor_->publish_state(humidity);
   } else {
-    ESP_LOGW(TAG, "Humidity status failure: %s", status_str_(humidity_status));
+    ESP_LOGW(TAG, "Humidity status failure: %s", status_str(humidity_status));
     this->status_set_warning();
     return;
   }
@@ -181,7 +181,7 @@ void ENS210Component::update() {
     float temperature = (temperature_data & 0xFFFF) / 64.0 - 27315L / 100.0;
     this->temperature_sensor_->publish_state(temperature);
   } else {
-    ESP_LOGW(TAG, "Temperature status failure: %s", status_str_(temperature_status));
+    ESP_LOGW(TAG, "Temperature status failure: %s", status_str(temperature_status));
   }
 }
 

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -16,31 +16,32 @@ namespace ens210 {
 static const char *const TAG = "ens210";
 
 // ENS210 chip constants
-static const uint8_t  ENS210_BOOTING_MS                           = 2;       // Booting time in ms (also after reset, or going to high power)
-static const uint8_t  ENS210_SINGLE_MEASURMENT_CONVERSION_TIME_MS = 130;     // Conversion time in ms for single shot T/H measurement
-static const uint16_t ENS210_PART_ID                              = 0x0210;  // The expected part id of the ENS210
+static const uint8_t ENS210_BOOTING_MS = 2;  // Booting time in ms (also after reset, or going to high power)
+static const uint8_t ENS210_SINGLE_MEASURMENT_CONVERSION_TIME_MS =
+    130;                                        // Conversion time in ms for single shot T/H measurement
+static const uint16_t ENS210_PART_ID = 0x0210;  // The expected part id of the ENS210
 
 // Addresses of the ENS210 registers
-static const uint8_t  ENS210_REGISTER_PART_ID    = 0x00;
-static const uint8_t  ENS210_REGISTER_UID        = 0x04;
-static const uint8_t  ENS210_REGISTER_SYS_CTRL   = 0x10;
-static const uint8_t  ENS210_REGISTER_SYS_STAT   = 0x11;
-static const uint8_t  ENS210_REGISTER_SENS_RUN   = 0x21;
-static const uint8_t  ENS210_REGISTER_SENS_START = 0x22;
-static const uint8_t  ENS210_REGISTER_SENS_STOP  = 0x23;
-static const uint8_t  ENS210_REGISTER_SENS_STAT  = 0x24;
-static const uint8_t  ENS210_REGISTER_T_VAL      = 0x30;
-static const uint8_t  ENS210_REGISTER_H_VAL      = 0x33;
+static const uint8_t ENS210_REGISTER_PART_ID = 0x00;
+static const uint8_t ENS210_REGISTER_UID = 0x04;
+static const uint8_t ENS210_REGISTER_SYS_CTRL = 0x10;
+static const uint8_t ENS210_REGISTER_SYS_STAT = 0x11;
+static const uint8_t ENS210_REGISTER_SENS_RUN = 0x21;
+static const uint8_t ENS210_REGISTER_SENS_START = 0x22;
+static const uint8_t ENS210_REGISTER_SENS_STOP = 0x23;
+static const uint8_t ENS210_REGISTER_SENS_STAT = 0x24;
+static const uint8_t ENS210_REGISTER_T_VAL = 0x30;
+static const uint8_t ENS210_REGISTER_H_VAL = 0x33;
 
 // CRC-7 constants
-static const uint8_t  CRC7_WIDTH = 7;     // A 7 bits CRC has polynomial of 7th order, which has 8 terms
-static const uint8_t  CRC7_POLY  = 0x89;  // The 8 coefficients of the polynomial
-static const uint8_t  CRC7_IVEC  = 0x7F;  // Initial vector has all 7 bits high
+static const uint8_t CRC7_WIDTH = 7;    // A 7 bits CRC has polynomial of 7th order, which has 8 terms
+static const uint8_t CRC7_POLY = 0x89;  // The 8 coefficients of the polynomial
+static const uint8_t CRC7_IVEC = 0x7F;  // Initial vector has all 7 bits high
 
 // Payload data constants
-static const uint8_t  DATA7_WIDTH = 17;
-static const uint32_t DATA7_MASK  = ((1UL<<DATA7_WIDTH)-1);  // 0b 0 1111 1111 1111 1111
-static const uint32_t DATA7_MSB   = (1UL<<(DATA7_WIDTH-1));  // 0b 1 0000 0000 0000 0000
+static const uint8_t DATA7_WIDTH = 17;
+static const uint32_t DATA7_MASK = ((1UL << DATA7_WIDTH) - 1);  // 0b 0 1111 1111 1111 1111
+static const uint32_t DATA7_MSB = (1UL << (DATA7_WIDTH - 1));   // 0b 1 0000 0000 0000 0000
 
 // Compute the CRC-7 of 'value' (should only have 17 bits)
 // https://en.wikipedia.org/wiki/Cyclic_redundancy_check#Computation
@@ -48,7 +49,7 @@ static uint32_t crc7(uint32_t value) {
   // Setup polynomial
   uint32_t polynomial = CRC7_POLY;
   // Align polynomial with data
-  polynomial = polynomial << (DATA7_WIDTH - CRC7_WIDTH -1);
+  polynomial = polynomial << (DATA7_WIDTH - CRC7_WIDTH - 1);
   // Loop variable (indicates which bit to test, start with highest)
   uint32_t bit = DATA7_MSB;
   // Make room for CRC value
@@ -58,10 +59,11 @@ static uint32_t crc7(uint32_t value) {
   // Insert initial vector
   value |= CRC7_IVEC;
   // Apply division until all bits done
-  while( bit & (DATA7_MASK<<CRC7_WIDTH) ) {
-      if( bit & value ) value ^= polynomial;
-      bit >>= 1;
-      polynomial >>= 1;
+  while (bit & (DATA7_MASK << CRC7_WIDTH)) {
+    if (bit & value)
+      value ^= polynomial;
+    bit >>= 1;
+    polynomial >>= 1;
   }
   return value;
 }
@@ -96,7 +98,7 @@ void ENS210Component::setup() {
     return;
   }
   // Pack bytes into partid
-  part_id= data[1]*256U + data[0]*1U;
+  part_id = data[1] * 256U + data[0] * 1U;
   // Check expected part id of the ENS210
   if (part_id != ENS210_PART_ID) {
     this->error_code_ = ENS210_WRONG_CHIP_ID;
@@ -134,8 +136,8 @@ void ENS210Component::update() {
   uint8_t data[6];
   uint32_t h_val_data, t_val_data;
   // Set default status for early bail out
-  temperature_status= ENS210_STATUS_I2C_ERROR;
-  humidity_status= ENS210_STATUS_I2C_ERROR;
+  temperature_status = ENS210_STATUS_I2C_ERROR;
+  humidity_status = ENS210_STATUS_I2C_ERROR;
   // Execute a single measurement
   if (!this->write_byte(ENS210_REGISTER_SENS_RUN, 0x00)) {
     ESP_LOGE(TAG, "Starting single measurement failed!");
@@ -143,7 +145,7 @@ void ENS210Component::update() {
     return;
   }
   // Trigger measurement
-   if (!this->write_byte(ENS210_REGISTER_SENS_START, 0x03)) {
+  if (!this->write_byte(ENS210_REGISTER_SENS_START, 0x03)) {
     ESP_LOGE(TAG, "Trigger of measurement failed!");
     this->status_set_warning();
     return;
@@ -157,44 +159,44 @@ void ENS210Component::update() {
     return;
   }
   // Pack bytes for humidity
-  h_val_data= (uint32_t)((uint32_t)data[5]<<16 | (uint32_t)data[4]<<8 | (uint32_t)data[3]);
+  h_val_data = (uint32_t)((uint32_t) data[5] << 16 | (uint32_t) data[4] << 8 | (uint32_t) data[3]);
   // Extract humidity data and update the status
   extract_measurement_(h_val_data, &humidity_data, &humidity_status);
 
-  if(humidity_status == ENS210_STATUS_OK) {
+  if (humidity_status == ENS210_STATUS_OK) {
     float humidity = (humidity_data & 0xFFFF) / 512.0;
     this->humidity_sensor_->publish_state(humidity);
   } else {
-    ESP_LOGW(TAG, "Humidity status failure: %s", status_str_(humidity_status));
+    ESP_LOGW(TAG, "Humidity status failure: %s", status_str(humidity_status));
     this->status_set_warning();
     return;
   }
   // Pack bytes for temperature
-  t_val_data= (uint32_t)((uint32_t)data[2]<<16 | (uint32_t)data[1]<<8 | (uint32_t)data[0]);
+  t_val_data = (uint32_t)((uint32_t) data[2] << 16 | (uint32_t) data[1] << 8 | (uint32_t) data[0]);
   // Extract temperature data and update the status
   extract_measurement_(t_val_data, &temperature_data, &temperature_status);
 
-  if(temperature_status == ENS210_STATUS_OK) {
+  if (temperature_status == ENS210_STATUS_OK) {
     // Temperature in Celsius
     float temperature = (temperature_data & 0xFFFF) / 64.0 - 27315L / 100.0;
     this->temperature_sensor_->publish_state(temperature);
   } else {
-    ESP_LOGW(TAG, "Temperature status failure: %s", status_str_(temperature_status));
+    ESP_LOGW(TAG, "Temperature status failure: %s", status_str(temperature_status));
   }
 }
 
 // Extracts measurement 'data' and 'status' from a 'val' obtained from measurment.
 void ENS210Component::extract_measurement_(uint32_t val, int *data, int *status) {
-  *data            = (val>>0 ) & 0xffff;
-  int valid        = (val>>16) & 0x1;
-  uint32_t crc     = (val>>17) & 0x7f;
-  uint32_t payload = (val>>0 ) & 0x1ffff;
+  *data = (val >> 0) & 0xffff;
+  int valid = (val >> 16) & 0x1;
+  uint32_t crc = (val >> 17) & 0x7f;
+  uint32_t payload = (val >> 0) & 0x1ffff;
   // Check CRC
   uint8_t crc_ok = crc7(payload) == crc;
 
   if (!crc_ok) {
     *status = ENS210_STATUS_CRC_ERROR;
-  } else if(!valid) {
+  } else if (!valid) {
     *status = ENS210_STATUS_INVALID;
   } else {
     *status = ENS210_STATUS_OK;
@@ -202,15 +204,15 @@ void ENS210Component::extract_measurement_(uint32_t val, int *data, int *status)
 }
 
 // Converts a status to a human readable string.
-const char * ENS210Component::status_str_( int status ) {
-  switch( status ) {
+const char *ENS210Component::status_str_(int status) {
+  switch (status) {
     case ENS210_STATUS_I2C_ERROR:
       return "I2C error";
     case ENS210_STATUS_CRC_ERROR:
       return "CRC error";
     case ENS210_STATUS_INVALID:
       return "Invalid data";
-    case ENS210_STATUS_OK :
+    case ENS210_STATUS_OK:
       return "Status OK";
     default:
       return "Unknown status";
@@ -219,7 +221,7 @@ const char * ENS210Component::status_str_( int status ) {
 
 // Sets ENS210 to low (true) or high (false) power. Returns false on I2C problems.
 bool ENS210Component::set_low_power_(bool enable) {
-  uint8_t low_power_cmd = enable ? 0x01: 0x00;
+  uint8_t low_power_cmd = enable ? 0x01 : 0x00;
   ESP_LOGD(TAG, "Enable low power: %s", enable ? "true" : "false");
   bool result = this->write_byte(ENS210_REGISTER_SYS_CTRL, low_power_cmd);
   delay(ENS210_BOOTING_MS);

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -1,0 +1,230 @@
+// ENS210 relative humidity and temperature sensor with I2C interface from ScioSense
+//
+// Datasheet: https://www.sciosense.com/wp-content/uploads/2021/01/ENS210.pdf
+//
+// Implementation based on:
+//   https://github.com/maarten-pennings/ENS210
+//   https://github.com/sciosense/ENS210_driver
+
+#include "ens210.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace ens210 {
+
+static const char *const TAG = "ens210";
+
+// ENS210 chip constants
+static const uint8_t  ENS210_BOOTING_MS                           = 2;       // Booting time in ms (also after reset, or going to high power)
+static const uint8_t  ENS210_SINGLE_MEASURMENT_CONVERSION_TIME_MS = 130;     // Conversion time in ms for single shot T/H measurement
+static const uint16_t ENS210_PART_ID                              = 0x0210;  // The expected part id of the ENS210
+
+// Addresses of the ENS210 registers
+static const uint8_t  ENS210_REGISTER_PART_ID    = 0x00;
+static const uint8_t  ENS210_REGISTER_UID        = 0x04;
+static const uint8_t  ENS210_REGISTER_SYS_CTRL   = 0x10;
+static const uint8_t  ENS210_REGISTER_SYS_STAT   = 0x11;
+static const uint8_t  ENS210_REGISTER_SENS_RUN   = 0x21;
+static const uint8_t  ENS210_REGISTER_SENS_START = 0x22;
+static const uint8_t  ENS210_REGISTER_SENS_STOP  = 0x23;
+static const uint8_t  ENS210_REGISTER_SENS_STAT  = 0x24;
+static const uint8_t  ENS210_REGISTER_T_VAL      = 0x30;
+static const uint8_t  ENS210_REGISTER_H_VAL      = 0x33;
+
+// CRC-7 constants
+static const uint8_t  CRC7_WIDTH = 7;     // A 7 bits CRC has polynomial of 7th order, which has 8 terms
+static const uint8_t  CRC7_POLY  = 0x89;  // The 8 coefficients of the polynomial
+static const uint8_t  CRC7_IVEC  = 0x7F;  // Initial vector has all 7 bits high
+
+// Payload data constants
+static const uint8_t  DATA7_WIDTH = 17;
+static const uint32_t DATA7_MASK  = ((1UL<<DATA7_WIDTH)-1);  // 0b 0 1111 1111 1111 1111
+static const uint32_t DATA7_MSB   = (1UL<<(DATA7_WIDTH-1));  // 0b 1 0000 0000 0000 0000
+
+// Compute the CRC-7 of 'value' (should only have 17 bits)
+// https://en.wikipedia.org/wiki/Cyclic_redundancy_check#Computation
+static uint32_t crc7(uint32_t value) {
+  // Setup polynomial
+  uint32_t polynomial = CRC7_POLY;
+  // Align polynomial with data
+  polynomial = polynomial << (DATA7_WIDTH - CRC7_WIDTH -1);
+  // Loop variable (indicates which bit to test, start with highest)
+  uint32_t bit = DATA7_MSB;
+  // Make room for CRC value
+  value = value << CRC7_WIDTH;
+  bit = bit << CRC7_WIDTH;
+  polynomial = polynomial << CRC7_WIDTH;
+  // Insert initial vector
+  value |= CRC7_IVEC;
+  // Apply division until all bits done
+  while( bit & (DATA7_MASK<<CRC7_WIDTH) ) {
+      if( bit & value ) value ^= polynomial;
+      bit >>= 1;
+      polynomial >>= 1;
+  }
+  return value;
+}
+
+void ENS210Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ENS210...");
+  uint8_t data[2];
+  uint16_t part_id = 0;
+  // Reset
+  if (!this->write_byte(ENS210_REGISTER_SYS_CTRL, 0x80)) {
+    this->write_byte(ENS210_REGISTER_SYS_CTRL, 0x80);
+    this->error_code_ = ENS210_STATUS_I2C_ERROR;
+    this->mark_failed();
+    return;
+  }
+  // Wait to boot after reset
+  delay(ENS210_BOOTING_MS);
+  // Must disable low power to read PART_ID
+  if (!set_low_power_(false)) {
+    // Try to go back to default mode (low power enabled)
+    set_low_power_(true);
+    this->error_code_ = ENS210_STATUS_I2C_ERROR;
+    this->mark_failed();
+    return;
+  }
+  // Read the PART_ID
+  if (!this->read_bytes(ENS210_REGISTER_PART_ID, data, 2)) {
+    // Try to go back to default mode (low power enabled)
+    set_low_power_(true);
+    this->error_code_ = ENS210_STATUS_I2C_ERROR;
+    this->mark_failed();
+    return;
+  }
+  // Pack bytes into partid
+  part_id= data[1]*256U + data[0]*1U;
+  // Check expected part id of the ENS210
+  if (part_id != ENS210_PART_ID) {
+    this->error_code_ = ENS210_WRONG_CHIP_ID;
+    this->mark_failed();
+  }
+  // Set default power mode (low power enabled)
+  set_low_power_(true);
+}
+
+void ENS210Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "ENS210:");
+  LOG_I2C_DEVICE(this);
+  switch (this->error_code_) {
+    case ENS210_STATUS_I2C_ERROR:
+      ESP_LOGE(TAG, "I2C error - communication with ENS210 failed!");
+      break;
+    case ENS210_WRONG_CHIP_ID:
+      ESP_LOGE(TAG, "ENS210 has wrong chip ID! Is it a ENS210?");
+      break;
+    case ENS210_STATUS_OK:
+    default:
+      break;
+  }
+
+  LOG_UPDATE_INTERVAL(this);
+
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
+}
+
+float ENS210Component::get_setup_priority() const { return setup_priority::DATA; }
+
+void ENS210Component::update() {
+  int temperature_data, temperature_status, humidity_data, humidity_status;
+  uint8_t data[6];
+  uint32_t h_val_data, t_val_data;
+  // Set default status for early bail out
+  temperature_status= ENS210_STATUS_I2C_ERROR;
+  humidity_status= ENS210_STATUS_I2C_ERROR;
+  // Execute a single measurement
+  if (!this->write_byte(ENS210_REGISTER_SENS_RUN, 0x00)) {
+    ESP_LOGE(TAG, "Starting single measurement failed!");
+    this->status_set_warning();
+    return;
+  }
+  // Trigger measurement
+   if (!this->write_byte(ENS210_REGISTER_SENS_START, 0x03)) {
+    ESP_LOGE(TAG, "Trigger of measurement failed!");
+    this->status_set_warning();
+    return;
+  }
+  // Wait for measurement to complete
+  delay(ENS210_SINGLE_MEASURMENT_CONVERSION_TIME_MS);
+  // Read T_VAL and H_VAL
+  if (!this->read_bytes(ENS210_REGISTER_T_VAL, data, 6)) {
+    ESP_LOGE(TAG, "Communication with ENS210 failed!");
+    this->status_set_warning();
+    return;
+  }
+  // Pack bytes for humidity
+  h_val_data= (uint32_t)((uint32_t)data[5]<<16 | (uint32_t)data[4]<<8 | (uint32_t)data[3]);
+  // Extract humidity data and update the status
+  extract_measurement_(h_val_data, &humidity_data, &humidity_status);
+
+  if(humidity_status == ENS210_STATUS_OK) {
+    float humidity = (humidity_data & 0xFFFF) / 512.0;
+    this->humidity_sensor_->publish_state(humidity);
+  } else {
+    ESP_LOGW(TAG, "Humidity status failure: %s", status_str(humidity_status));
+    this->status_set_warning();
+    return;
+  }
+  // Pack bytes for temperature
+  t_val_data= (uint32_t)((uint32_t)data[2]<<16 | (uint32_t)data[1]<<8 | (uint32_t)data[0]);
+  // Extract temperature data and update the status
+  extract_measurement_(t_val_data, &temperature_data, &temperature_status);
+
+  if(temperature_status == ENS210_STATUS_OK) {
+    // Temperature in Celsius
+    float temperature = (temperature_data & 0xFFFF) / 64.0 - 27315L / 100.0;
+    this->temperature_sensor_->publish_state(temperature);
+  } else {
+    ESP_LOGW(TAG, "Temperature status failure: %s", status_str(temperature_status));
+  }
+}
+
+// Extracts measurement 'data' and 'status' from a 'val' obtained from measurment.
+void ENS210Component::extract_measurement_(uint32_t val, int *data, int *status) {
+  *data            = (val>>0 ) & 0xffff;
+  int valid        = (val>>16) & 0x1;
+  uint32_t crc     = (val>>17) & 0x7f;
+  uint32_t payload = (val>>0 ) & 0x1ffff;
+  // Check CRC
+  uint8_t crc_ok = crc7(payload) == crc;
+
+  if (!crc_ok) {
+    *status = ENS210_STATUS_CRC_ERROR;
+  } else if(!valid) {
+    *status = ENS210_STATUS_INVALID;
+  } else {
+    *status = ENS210_STATUS_OK;
+  }
+}
+
+// Converts a status to a human readable string.
+const char * ENS210Component::status_str_( int status ) {
+  switch( status ) {
+    case ENS210_STATUS_I2C_ERROR:
+      return "I2C error";
+    case ENS210_STATUS_CRC_ERROR:
+      return "CRC error";
+    case ENS210_STATUS_INVALID:
+      return "Invalid data";
+    case ENS210_STATUS_OK :
+      return "Status OK";
+    default:
+      return "Unknown status";
+  }
+}
+
+// Sets ENS210 to low (true) or high (false) power. Returns false on I2C problems.
+bool ENS210Component::set_low_power_(bool enable) {
+  uint8_t low_power_cmd = enable ? 0x01: 0x00;
+  ESP_LOGD(TAG, "Enable low power: %s", enable ? "true" : "false");
+  bool result = this->write_byte(ENS210_REGISTER_SYS_CTRL, low_power_cmd);
+  delay(ENS210_BOOTING_MS);
+  return result;
+}
+
+}  // namespace ens210
+}  // namespace esphome

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -167,7 +167,7 @@ void ENS210Component::update() {
     float humidity = (humidity_data & 0xFFFF) / 512.0;
     this->humidity_sensor_->publish_state(humidity);
   } else {
-    ESP_LOGW(TAG, "Humidity status failure: %s", status_str(humidity_status));
+    ESP_LOGW(TAG, "Humidity status failure: %s", status_str_(humidity_status));
     this->status_set_warning();
     return;
   }
@@ -181,7 +181,7 @@ void ENS210Component::update() {
     float temperature = (temperature_data & 0xFFFF) / 64.0 - 27315L / 100.0;
     this->temperature_sensor_->publish_state(temperature);
   } else {
-    ESP_LOGW(TAG, "Temperature status failure: %s", status_str(temperature_status));
+    ESP_LOGW(TAG, "Temperature status failure: %s", status_str_(temperature_status));
   }
 }
 

--- a/esphome/components/ens210/ens210.h
+++ b/esphome/components/ens210/ens210.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace ens210 {
+
+/// This class implements support for the ENS210 relative humidity and temperature i2c sensor.
+class ENS210Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  float get_setup_priority() const override;
+  void dump_config() override;
+  void setup() override;
+  void update() override;
+
+  void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+
+ protected:
+  bool set_low_power_(bool enable);
+  const char * status_str_( int status );
+  void extract_measurement_(uint32_t val, int *data, int *status);
+
+  sensor::Sensor *temperature_sensor_;
+  sensor::Sensor *humidity_sensor_;
+
+  enum ErrorCode {
+    ENS210_STATUS_OK = 0,           // The value was read, the CRC matches, and data is valid
+    ENS210_STATUS_INVALID,          // The value was read, the CRC matches, but the data is invalid (e.g. the measurement was not yet finished)
+    ENS210_STATUS_CRC_ERROR,        // The value was read, but the CRC over the payload (valid and data) does not match
+    ENS210_STATUS_I2C_ERROR,        // There was an I2C communication error
+    ENS210_WRONG_CHIP_ID            // The read PART_ID is not the expected part id of the ENS210
+  } error_code_{ENS210_STATUS_OK};
+};
+
+}  // namespace ens210
+}  // namespace esphome

--- a/esphome/components/ens210/ens210.h
+++ b/esphome/components/ens210/ens210.h
@@ -18,14 +18,6 @@ class ENS210Component : public PollingComponent, public i2c::I2CDevice {
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
 
- protected:
-  bool set_low_power_(bool enable);
-  const char *status_str_(int status);
-  void extract_measurement_(uint32_t val, int *data, int *status);
-
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *humidity_sensor_;
-
   enum ErrorCode {
     ENS210_STATUS_OK = 0,     // The value was read, the CRC matches, and data is valid
     ENS210_STATUS_INVALID,    // The value was read, the CRC matches, but the data is invalid (e.g. the measurement was
@@ -34,6 +26,13 @@ class ENS210Component : public PollingComponent, public i2c::I2CDevice {
     ENS210_STATUS_I2C_ERROR,  // There was an I2C communication error
     ENS210_WRONG_CHIP_ID      // The read PART_ID is not the expected part id of the ENS210
   } error_code_{ENS210_STATUS_OK};
+
+ protected:
+  bool set_low_power_(bool enable);
+  void extract_measurement_(uint32_t val, int *data, int *status);
+
+  sensor::Sensor *temperature_sensor_;
+  sensor::Sensor *humidity_sensor_;
 };
 
 }  // namespace ens210

--- a/esphome/components/ens210/ens210.h
+++ b/esphome/components/ens210/ens210.h
@@ -20,18 +20,19 @@ class ENS210Component : public PollingComponent, public i2c::I2CDevice {
 
  protected:
   bool set_low_power_(bool enable);
-  const char * status_str_( int status );
+  const char *status_str_(int status);
   void extract_measurement_(uint32_t val, int *data, int *status);
 
   sensor::Sensor *temperature_sensor_;
   sensor::Sensor *humidity_sensor_;
 
   enum ErrorCode {
-    ENS210_STATUS_OK = 0,           // The value was read, the CRC matches, and data is valid
-    ENS210_STATUS_INVALID,          // The value was read, the CRC matches, but the data is invalid (e.g. the measurement was not yet finished)
-    ENS210_STATUS_CRC_ERROR,        // The value was read, but the CRC over the payload (valid and data) does not match
-    ENS210_STATUS_I2C_ERROR,        // There was an I2C communication error
-    ENS210_WRONG_CHIP_ID            // The read PART_ID is not the expected part id of the ENS210
+    ENS210_STATUS_OK = 0,     // The value was read, the CRC matches, and data is valid
+    ENS210_STATUS_INVALID,    // The value was read, the CRC matches, but the data is invalid (e.g. the measurement was
+                              // not yet finished)
+    ENS210_STATUS_CRC_ERROR,  // The value was read, but the CRC over the payload (valid and data) does not match
+    ENS210_STATUS_I2C_ERROR,  // There was an I2C communication error
+    ENS210_WRONG_CHIP_ID      // The read PART_ID is not the expected part id of the ENS210
   } error_code_{ENS210_STATUS_OK};
 };
 

--- a/esphome/components/ens210/sensor.py
+++ b/esphome/components/ens210/sensor.py
@@ -12,6 +12,7 @@ from esphome.const import (
     UNIT_PERCENT,
 )
 
+CODEOWNERS = ["@itn3rd77"]
 DEPENDENCIES = ["i2c"]
 
 ens210_ns = cg.esphome_ns.namespace("ens210")

--- a/esphome/components/ens210/sensor.py
+++ b/esphome/components/ens210/sensor.py
@@ -1,0 +1,57 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_HUMIDITY,
+    CONF_ID,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_PERCENT,
+)
+
+DEPENDENCIES = ["i2c"]
+
+ens210_ns = cg.esphome_ns.namespace("ens210")
+
+ENS210Component = ens210_ns.class_(
+    "ENS210Component", cg.PollingComponent, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ENS210Component),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_HUMIDITY,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x43))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature_sensor(sens))
+
+    if CONF_HUMIDITY in config:
+        sens = await sensor.new_sensor(config[CONF_HUMIDITY])
+        cg.add(var.set_humidity_sensor(sens))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -556,8 +556,7 @@ sensor:
     temperature:
       name: 'Living Room Temperature 6'
     humidity:
-      name: 'Living Room Pressure 6'
-      name: "Living Room Pressure 5"
+      name: 'Living Room Humidity 5'
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: hlw8012

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -545,10 +545,18 @@ sensor:
   - platform: esp32_hall
     name: "ESP32 Hall Sensor"
     update_interval: 15s
-  - platform: hdc1080
+  - platform: ens210
     temperature:
       name: "Living Room Temperature 5"
     humidity:
+      name: 'Living Room Humidity 5'
+    update_interval: 15s
+    i2c_id: i2c_bus
+  - platform: hdc1080
+    temperature:
+      name: 'Living Room Temperature 6'
+    humidity:
+      name: 'Living Room Pressure 6'
       name: "Living Room Pressure 5"
     update_interval: 15s
     i2c_id: i2c_bus


### PR DESCRIPTION
# What does this implement/fix? 

Add initial implementation for the ENS210 relative humidity and temperature i2c sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1745

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration entry
sensor:
  - platform: ens210
    temperature:
      name: "Living Room Temperature"
    humidity:
      name: "Living Room Humidity"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
