### PR TITLE
Add increment_day function to ESPTime

### DIFF
--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -131,6 +131,23 @@ void ESPTime::increment_second() {
     this->year++;
   }
 }
+void ESPTime::increment_day() {
+  this->timestamp += 86400;
+
+  // increment day
+  increment_time_value(this->day_of_week, 1, 8);
+
+  if (increment_time_value(this->day_of_month, 1, days_in_month(this->month, this->year) + 1)) {
+    // day of month roll-over, increment month
+    increment_time_value(this->month, 1, 13);
+  }
+
+  uint16_t days_in_year = (this->year % 4 == 0) ? 366 : 365;
+  if (increment_time_value(this->day_of_year, 1, days_in_year + 1)) {
+    // day of year roll-over, increment year
+    this->year++;
+  }
+}
 void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
   time_t res = 0;
 

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -90,6 +90,8 @@ struct ESPTime {
 
   /// Increment this clock instance by one second.
   void increment_second();
+  /// Increment this clock instance by one day.
+  void increment_day();
   bool operator<(ESPTime other);
   bool operator<=(ESPTime other);
   bool operator==(ESPTime other);


### PR DESCRIPTION
# What does this implement/fix? 

Adds the ability to increment an ESPTime by one day.
Update of PR https://github.com/esphome/esphome/pull/2946

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
