### PR TITLE
Add logging for some Nextion errors that didn't have any

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -329,6 +329,7 @@ void Nextion::process_nextion_commands_() {
 
         break;
       case 0x02:  // invalid Component ID or name was used
+        ESP_LOGW(TAG, "Nextion reported component ID or name invalid!");
         this->remove_from_q_();
         break;
       case 0x03:  // invalid Page ID or name was used
@@ -387,6 +388,7 @@ void Nextion::process_nextion_commands_() {
         }
         break;
       case 0x1A:  // variable name invalid
+        ESP_LOGW(TAG, "Nextion reported variable name invalid!");
         this->remove_from_q_();
 
         break;


### PR DESCRIPTION
I found this helpful to understand what was failing, and it seems to
make sense to handle all of these cases the same way.

# What does this implement/fix? 

Trivial addition of similar logging as the other error codes already had.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
