### PR TITLE
ST7920 ESP32 fix

### DIFF
--- a/esphome/components/st7920/st7920.h
+++ b/esphome/components/st7920/st7920.h
@@ -14,7 +14,7 @@ using st7920_writer_t = std::function<void(ST7920 &)>;
 class ST7920 : public PollingComponent,
                public display::DisplayBuffer,
                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
-                                     spi::DATA_RATE_1MHZ> {
+                                     spi::DATA_RATE_200KHZ> {
  public:
   void set_writer(st7920_writer_t &&writer) { this->writer_local_ = writer; }
   void set_height(uint16_t height) { this->height_ = height; }


### PR DESCRIPTION
# What does this implement/fix? 

For ESP8266 the LCD works but when I tested on ESP32 I got artifacts because SPI data rate is too high

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
