### PR TITLE
Add --mqtt-ca-cert option as an extra mqtt option.

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -286,7 +286,8 @@ def show_logs(config, args, port):
         from esphome import mqtt
 
         return mqtt.show_logs(
-            config, args.topic, args.username, args.password, args.client_id
+            config, args.topic, args.username, args.password, args.client_id,
+            mqtt_ca_cert(args.mqtt_ca_cert)
         )
 
     raise EsphomeError("No remote or local logging method configured (api/mqtt/logger)")
@@ -296,8 +297,14 @@ def clean_mqtt(config, args):
     from esphome import mqtt
 
     return mqtt.clear_topic(
-        config, args.topic, args.username, args.password, args.client_id
+        config, args.topic, args.username, args.password, args.client_id,
+        mqtt_ca_cert(args.mqtt_ca_cert)
     )
+
+def mqtt_ca_cert(ca_cert_path):
+    import os
+
+    return None if ca_cert_path is None else os.path.abspath(ca_cert_path)
 
 
 def command_wizard(args):
@@ -531,6 +538,8 @@ def parse_args(argv):
     mqtt_options.add_argument("--username", help="Manually set the MQTT username.")
     mqtt_options.add_argument("--password", help="Manually set the MQTT password.")
     mqtt_options.add_argument("--client-id", help="Manually set the MQTT client id.")
+    mqtt_options.add_argument("--mqtt-ca-cert",
+        help="Self signed certificate path when TLS is used.")
 
     subparsers = parser.add_subparsers(
         help="Command to run:", dest="command", metavar="command"

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -286,8 +286,12 @@ def show_logs(config, args, port):
         from esphome import mqtt
 
         return mqtt.show_logs(
-            config, args.topic, args.username, args.password, args.client_id,
-            mqtt_ca_cert(args.mqtt_ca_cert)
+            config,
+            args.topic,
+            args.username,
+            args.password,
+            args.client_id,
+            mqtt_ca_cert(args.mqtt_ca_cert),
         )
 
     raise EsphomeError("No remote or local logging method configured (api/mqtt/logger)")
@@ -297,13 +301,16 @@ def clean_mqtt(config, args):
     from esphome import mqtt
 
     return mqtt.clear_topic(
-        config, args.topic, args.username, args.password, args.client_id,
-        mqtt_ca_cert(args.mqtt_ca_cert)
+        config,
+        args.topic,
+        args.username,
+        args.password,
+        args.client_id,
+        mqtt_ca_cert(args.mqtt_ca_cert),
     )
 
-def mqtt_ca_cert(ca_cert_path):
-    import os
 
+def mqtt_ca_cert(ca_cert_path):
     return None if ca_cert_path is None else os.path.abspath(ca_cert_path)
 
 
@@ -538,8 +545,9 @@ def parse_args(argv):
     mqtt_options.add_argument("--username", help="Manually set the MQTT username.")
     mqtt_options.add_argument("--password", help="Manually set the MQTT password.")
     mqtt_options.add_argument("--client-id", help="Manually set the MQTT client id.")
-    mqtt_options.add_argument("--mqtt-ca-cert",
-        help="Self signed certificate path when TLS is used.")
+    mqtt_options.add_argument(
+        "--mqtt-ca-cert", help="Self signed certificate path when TLS is used."
+    )
 
     subparsers = parser.add_subparsers(
         help="Command to run:", dest="command", metavar="command"

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -28,7 +28,8 @@ from esphome.util import safe_print
 _LOGGER = logging.getLogger(__name__)
 
 
-def initialize(config, subscriptions, on_message, username, password, client_id):
+def initialize(config, subscriptions, on_message, username, password, client_id,
+        ca_certs=None):
     def on_connect(client, userdata, flags, return_code):
         _LOGGER.info("Connected to MQTT broker!")
         for topic in subscriptions:
@@ -74,7 +75,7 @@ def initialize(config, subscriptions, on_message, username, password, client_id)
         else:
             tls_version = ssl.PROTOCOL_SSLv23
         client.tls_set(
-            ca_certs=None,
+            ca_certs=ca_certs,
             certfile=None,
             keyfile=None,
             cert_reqs=ssl.CERT_REQUIRED,
@@ -96,7 +97,8 @@ def initialize(config, subscriptions, on_message, username, password, client_id)
     return 0
 
 
-def show_logs(config, topic=None, username=None, password=None, client_id=None):
+def show_logs(config, topic=None, username=None, password=None, client_id=None,
+        ca_certs=None):
     if topic is not None:
         pass  # already have topic
     elif CONF_MQTT in config:
@@ -118,10 +120,12 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None):
         message = time_ + payload
         safe_print(message)
 
-    return initialize(config, [topic], on_message, username, password, client_id)
+    return initialize(config, [topic], on_message, username, password,
+            client_id, ca_certs)
 
 
-def clear_topic(config, topic, username=None, password=None, client_id=None):
+def clear_topic(config, topic, username=None, password=None, client_id=None,
+        ca_certs=None):
     if topic is None:
         discovery_prefix = config[CONF_MQTT].get(CONF_DISCOVERY_PREFIX, "homeassistant")
         name = config[CONF_ESPHOME][CONF_NAME]
@@ -142,7 +146,8 @@ def clear_topic(config, topic, username=None, password=None, client_id=None):
             return
         client.publish(msg.topic, None, retain=True)
 
-    return initialize(config, [topic], on_message, username, password, client_id)
+    return initialize(config, [topic], on_message, username, password,
+            client_id, ca_certs)
 
 
 # From marvinroger/async-mqtt-client -> scripts/get-fingerprint/get-fingerprint.py

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -28,8 +28,9 @@ from esphome.util import safe_print
 _LOGGER = logging.getLogger(__name__)
 
 
-def initialize(config, subscriptions, on_message, username, password, client_id,
-        ca_certs=None):
+def initialize(
+    config, subscriptions, on_message, username, password, client_id, ca_certs=None
+):
     def on_connect(client, userdata, flags, return_code):
         _LOGGER.info("Connected to MQTT broker!")
         for topic in subscriptions:
@@ -97,8 +98,9 @@ def initialize(config, subscriptions, on_message, username, password, client_id,
     return 0
 
 
-def show_logs(config, topic=None, username=None, password=None, client_id=None,
-        ca_certs=None):
+def show_logs(
+    config, topic=None, username=None, password=None, client_id=None, ca_certs=None
+):
     if topic is not None:
         pass  # already have topic
     elif CONF_MQTT in config:
@@ -120,12 +122,14 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None,
         message = time_ + payload
         safe_print(message)
 
-    return initialize(config, [topic], on_message, username, password,
-            client_id, ca_certs)
+    return initialize(
+        config, [topic], on_message, username, password, client_id, ca_certs
+    )
 
 
-def clear_topic(config, topic, username=None, password=None, client_id=None,
-        ca_certs=None):
+def clear_topic(
+    config, topic, username=None, password=None, client_id=None, ca_certs=None
+):
     if topic is None:
         discovery_prefix = config[CONF_MQTT].get(CONF_DISCOVERY_PREFIX, "homeassistant")
         name = config[CONF_ESPHOME][CONF_NAME]
@@ -146,8 +150,9 @@ def clear_topic(config, topic, username=None, password=None, client_id=None,
             return
         client.publish(msg.topic, None, retain=True)
 
-    return initialize(config, [topic], on_message, username, password,
-            client_id, ca_certs)
+    return initialize(
+        config, [topic], on_message, username, password, client_id, ca_certs
+    )
 
 
 # From marvinroger/async-mqtt-client -> scripts/get-fingerprint/get-fingerprint.py


### PR DESCRIPTION
This feature allows easy integration when self signed certificate are
used in MQTT servers.

# What does this implement/fix? 

Adds new command line argument to specify a custom MQTT ca-cert used when TLS is enabled and uses self signed certificates.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  