### PR TITLE
Honor user set values for col/row start for INITR_MINI_160X80.

### DIFF
--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -265,8 +265,8 @@ void ST7735::setup() {
     height_ == 0 ? height_ = ST7735_TFTHEIGHT_160 : height_;
     width_ == 0 ? width_ = ST7735_TFTWIDTH_80 : width_;
     display_init_(RCMD2GREEN160X80);
-    colstart_ = 24;
-    rowstart_ = 0;  // For default rotation 0
+    colstart_ == 0 ? colstart_ = 24 : colstart_;
+    rowstart_ == 0 ? rowstart_ = 0 : rowstart_;
   } else {
     // colstart, rowstart left at default '0' values
     display_init_(RCMD2RED);


### PR DESCRIPTION
If the caller sets a value for colstart and/or rowstart when using the INITR_MINI_160X80 model, use those values instead of the default 24 and 0.

After this patch devices with a 160x80 TFT like the m5stick C can set row/col start (1, 26 for m5stick) and avoid garbage lines showing in the display.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
- platform: st7735
  model: INITR_MINI160X80  # Garbage on the sides, overrides row/col start settings below
  row_start: 1
  col_start: 26
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
