### PR TITLE
Explicitly use overloaded begin() for I2C master initialization

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -25,7 +25,7 @@ void ArduinoI2CBus::setup() {
   wire_ = &Wire;  // NOLINT(cppcoreguidelines-prefer-member-initializer)
 #endif
 
-  wire_->begin(sda_pin_, scl_pin_);
+  wire_->begin((int) sda_pin_, (int) scl_pin_);
   wire_->setClock(frequency_);
   initialized_ = true;
   if (this->scan_) {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -25,7 +25,7 @@ void ArduinoI2CBus::setup() {
   wire_ = &Wire;  // NOLINT(cppcoreguidelines-prefer-member-initializer)
 #endif
 
-  wire_->begin((int) sda_pin_, (int) scl_pin_);
+  wire_->begin(static_cast<int>(sda_pin_), static_cast<int>(scl_pin_));
   wire_->setClock(frequency_);
   initialized_ = true;
   if (this->scan_) {


### PR DESCRIPTION
Arduino 2.0.1 and newer support I2C slave and master mode. The two modes
have a begin() method with different signature:

```cpp
// Slave Begin
bool TwoWire::begin(uint8_t addr, int sdaPin, int sclPin, uint32_t frequency);

// Master Begin
bool TwoWire::begin(int sdaPin, int sclPin, uint32_t frequency);
```

Use type casting to make sure that overloaded method for master mode
is used.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2839

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32 (ESP32-C3)
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: esp32c3-test
  platformio_options:
    board_build.flash_mode: dio
    platform: https://github.com/platformio/platform-espressif32#feature/arduino-idf-master
    platform_packages:
      - framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.2

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: arduino
  variant: esp32c3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
