### PR TITLE
Fix compile error for idf projects with ArduinoJson 6

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -4,6 +4,9 @@
 #ifdef USE_ESP8266
 #include <Esp.h>
 #endif
+#ifdef USE_ESP_IDF
+#include <esp_heap_caps.h>
+#endif
 
 namespace esphome {
 namespace json {

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -4,7 +4,7 @@
 #ifdef USE_ESP8266
 #include <Esp.h>
 #endif
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 #include <esp_heap_caps.h>
 #endif
 


### PR DESCRIPTION
**Quick description and explanation of changes**

trying to compile for idf with https://github.com/esphome/esphome/pull/2844 fails with:
```
src/esphome/components/json/json_util.cpp: In function 'std::__cxx11::string esphome::json::build_json(const json_build_t&)':
src/esphome/components/json/json_util.cpp:24:61: error: 'MALLOC_CAP_DEFAULT' was not declared in this scope
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT) - 2048;
                                                             ^~~~~~~~~~~~~~~~~~
src/esphome/components/json/json_util.cpp:24:61: note: suggested alternative: 'MALLOC_ALIGNMENT'
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT) - 2048;
                                                             ^~~~~~~~~~~~~~~~~~
                                                             MALLOC_ALIGNMENT
src/esphome/components/json/json_util.cpp:24:28: error: 'heap_caps_get_largest_free_block' was not declared in this scope
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT) - 2048;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
the reason is the missing include of esp_heap_caps.h



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

Used for testing mqtt idf (https://github.com/esphome/esphome/pull/2930)

```yaml
external_components:
  - source: github://pr#2930
    components: ["mqtt"]
esphome:
  name: testing

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:
  level: VERBOSE

wifi:
  ssid: !secret wifi_sid
  password: !secret wifi_password


mqtt:
  broker: 192.168.0.114
  port: 1883
  discovery: true
  discovery_prefix: homeassistant
  on_message:
    topic: testing/sensor/uptime_sensor/state
    qos: 0
    then:
      - lambda: |-
          ESP_LOGD("Mqtt Test","testing/sensor/uptime_sensor/state=[%s]",x.c_str());

sensor:
  - platform: uptime
    name: Uptime Sensor
    id: uptime_sensor
    update_interval: 10s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
