### PR TITLE
Don't use pyproject.toml for esphome build

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -5,6 +5,6 @@ set -e
 
 cd "$(dirname "$0")/.."
 pip3 install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
-pip3 install -e .
+pip3 install --no-use-pep517 -e .
 
 pre-commit install


### PR DESCRIPTION
# What does this implement/fix? 

This makes editable installation work again.

It seems that the mere existence of a pyproject.toml changes behavior of
pip install such that editable mode doesn't work anymore.

The main purpose of `pyproject.toml` in the ESPHome project seems to
set configuration options for black. Passing `--no-use-pep517` to pip
explicitly disables use of `pyproject.toml`.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2888

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
