### PR TITLE
Fix register ranges in modbus controller

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -99,8 +99,8 @@ void ModbusController::on_register_data(ModbusRegisterType register_type, uint16
 
   // loop through all sensors with the same start address
   auto sensors = find_sensors_(register_type, start_address);
-  for (auto sensor_it = sensors.cbegin(); sensor_it != sensors.cend(); sensor_it++) {
-    (*sensor_it)->parse_and_publish(data);
+  for (auto sensor : sensors) {
+    sensor->parse_and_publish(data);
   }
 }
 

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -269,7 +269,7 @@ void ModbusController::dump_config() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   ESP_LOGCONFIG(TAG, "sensormap");
   for (auto &it : sensormap_) {
-    ESP_LOGCONFIG("TAG", "  Sensor 0x%llX start=0x%X count=%d size=%d", it.second->getkey(), it.second->start_address,
+    ESP_LOGCONFIG(TAG, "  Sensor 0x%llX start=0x%X count=%d size=%d", it.second->getkey(), it.second->start_address,
                   it.second->register_count, it.second->get_register_size());
   }
 #endif

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -179,15 +179,13 @@ size_t ModbusController::create_register_ranges_() {
   uint8_t buffer_offset = ix->second->offset;
   uint8_t skip_updates = ix->second->skip_updates;
   auto first_sensorkey = ix->second->getkey();
-  total_register_count = 0;
   while (ix != sensormap_.end()) {
     ESP_LOGV(TAG, "Register: 0x%X %d %d  0x%llx (%d) buffer_offset = %d (0x%X) skip=%u", ix->second->start_address,
              ix->second->register_count, ix->second->offset, ix->second->getkey(), total_register_count, buffer_offset,
              buffer_offset, ix->second->skip_updates);
     // if this is a sequential address based on number of registers and address of previous sensor
     // convert to an offset to the previous sensor (address 0x101 becomes address 0x100 offset 2 bytes)
-    if (!ix->second->force_new_range && total_register_count >= 0 &&
-        prev->second->register_type == ix->second->register_type &&
+    if (!ix->second->force_new_range && prev->second->register_type == ix->second->register_type &&
         prev->second->start_address + total_register_count == ix->second->start_address &&
         prev->second->start_address < ix->second->start_address) {
       ix->second->start_address = prev->second->start_address;

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -280,6 +280,11 @@ void ModbusController::dump_config() {
     ESP_LOGCONFIG(TAG, "  Sensor start=0x%X count=%d size=%d", it->start_address, it->register_count,
                   it->get_register_size());
   }
+  ESP_LOGCONFIG(TAG, "ranges");
+  for (auto &it : register_ranges_) {
+    ESP_LOGCONFIG(TAG, "  Range type=%d start=0x%X count=%d skip_updates=%d", (uint8_t) it.register_type,
+                  it.start_address, it.register_count, it.skip_updates);
+  }
 #endif
 }
 

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -6,7 +6,7 @@
 #include "esphome/components/modbus/modbus.h"
 
 #include <list>
-#include <map>
+#include <set>
 #include <queue>
 #include <vector>
 
@@ -62,12 +62,14 @@ enum class SensorValueType : uint8_t {
   FP32_R = 0xD
 };
 
+class SensorItem;
+
 struct RegisterRange {
   uint16_t start_address;
   ModbusRegisterType register_type;
   uint8_t register_count;
   uint8_t skip_updates;  // the config value
-  uint64_t first_sensorkey;
+  SensorItem *first_sensor;
   uint8_t skip_updates_counter;  // the running value
 } __attribute__((packed));
 
@@ -107,18 +109,6 @@ inline ModbusFunctionCode modbus_register_write_function(ModbusRegisterType reg_
       break;
   }
 }
-
-/** All sensors are stored in a map
- * to enable binary sensors for values encoded as bits in the same register the key of each sensor
- * the key is a 64 bit integer that combines the register properties
- * sensormap_ is sorted by this key. The key ensures the correct order when creating consequtive ranges
- * Format:  function_code (8 bit) | start address (16 bit)| offset (8bit)| bitmask (32 bit)
- */
-inline uint64_t calc_key(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset = 0,
-                         uint32_t bitmask = 0) {
-  return uint64_t((uint16_t(register_type) << 24) + (uint32_t(start_address) << 8) + (offset & 0xFF)) << 32 | bitmask;
-}
-inline uint16_t register_from_key(uint64_t key) { return (key >> 40) & 0xFFFF; }
 
 inline uint8_t c_to_hex(char c) { return (c >= 'A') ? (c >= 'a') ? (c - 'a' + 10) : (c - 'A' + 10) : (c - '0'); }
 
@@ -250,7 +240,6 @@ class SensorItem {
   virtual void parse_and_publish(const std::vector<uint8_t> &data) = 0;
 
   void set_custom_data(const std::vector<uint8_t> &data) { custom_data = data; }
-  uint64_t getkey() const { return calc_key(register_type, start_address, offset, bitmask); }
   size_t virtual get_register_size() const {
     if (register_type == ModbusRegisterType::COIL || register_type == ModbusRegisterType::DISCRETE_INPUT)
       return 1;
@@ -269,6 +258,33 @@ class SensorItem {
   uint8_t skip_updates;
   std::vector<uint8_t> custom_data{};
   bool force_new_range{false};
+};
+
+// ModbusController::create_register_ranges_ tries to optimize register range
+// for this the sensors should be order of its start_address separated by the
+// register type.
+class SensorItemsComparator {
+ public:
+  bool operator()(const SensorItem *lhs, const SensorItem *rhs) {
+    // first sort according to register type
+    if (lhs->register_type < rhs->register_type) {
+      return true;
+    }
+
+    // ensure that sensor with force_new_range set are before the others
+    if (lhs->force_new_range && !rhs->force_new_range) {
+      return true;
+    }
+
+    // sort by start address
+    if (lhs->start_address < rhs->start_address) {
+      return true;
+    }
+
+    // The pointer to the sensor are added at last to ensure that
+    // multiple sensors with the save values can be added with a stable sort order.
+    return lhs < rhs;
+  }
 };
 
 class ModbusCommandItem {
@@ -382,7 +398,7 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
   /// queues a modbus command in the send queue
   void queue_command(const ModbusCommandItem &command);
   /// Registers a sensor with the controller. Called by esphomes code generator
-  void add_sensor_item(SensorItem *item) { sensormap_[item->getkey()] = item; }
+  void add_sensor_item(SensorItem *item) { sensorset_.insert(item); }
   /// called when a modbus response was prased without errors
   void on_modbus_data(const std::vector<uint8_t> &data) override;
   /// called when a modbus error response was received
@@ -400,7 +416,7 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
   /// parse sensormap_ and create range of sequential addresses
   size_t create_register_ranges_();
   // find register in sensormap. Returns iterator with all registers having the same start address
-  std::map<uint64_t, SensorItem *>::iterator find_register_(ModbusRegisterType register_type, uint16_t start_address);
+  std::set<SensorItem *>::iterator find_register_(ModbusRegisterType register_type, uint16_t start_address);
   /// submit the read command for the address range to the send queue
   void update_range_(RegisterRange &r);
   /// parse incoming modbus data
@@ -410,10 +426,10 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
   /// get the number of queued modbus commands (should be mostly empty)
   size_t get_command_queue_length_() { return command_queue_.size(); }
   /// dump the parsed sensormap for diagnostics
-  void dump_sensormap_();
+  void dump_sensors_();
   /// Collection of all sensors for this component
   /// see calc_key how the key is contructed
-  std::map<uint64_t, SensorItem *> sensormap_;
+  std::set<SensorItem *, SensorItemsComparator> sensorset_;
   /// Continous range of modbus registers
   std::vector<RegisterRange> register_ranges_;
   /// Hold the pending requests to be sent

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -267,18 +267,18 @@ class SensorItemsComparator {
  public:
   bool operator()(const SensorItem *lhs, const SensorItem *rhs) {
     // first sort according to register type
-    if (lhs->register_type < rhs->register_type) {
-      return true;
+    if (lhs->register_type != rhs->register_type) {
+      return lhs->register_type < rhs->register_type;
     }
 
     // ensure that sensor with force_new_range set are before the others
-    if (lhs->force_new_range && !rhs->force_new_range) {
-      return true;
+    if (lhs->force_new_range != rhs->force_new_range) {
+      return lhs->force_new_range > rhs->force_new_range;
     }
 
     // sort by start address
-    if (lhs->start_address < rhs->start_address) {
-      return true;
+    if (lhs->start_address != rhs->start_address) {
+      return lhs->start_address < rhs->start_address;
     }
 
     // The pointer to the sensor are added at last to ensure that

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -37,7 +37,7 @@ enum class ModbusFunctionCode {
   READ_FIFO_QUEUE = 0x18,                // not implemented
 };
 
-enum class ModbusRegisterType : int {
+enum class ModbusRegisterType : uint8_t {
   CUSTOM = 0x0,
   COIL = 0x01,
   DISCRETE_INPUT = 0x02,

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -250,11 +250,10 @@ class SensorItem {
 };
 
 // ModbusController::create_register_ranges_ tries to optimize register range
-// for this the sensors should be order of its start_address separated by the
-// register type.
+// for this the sensors must be ordered by register_type, start_address and bitmask
 class SensorItemsComparator {
  public:
-  bool operator()(const SensorItem *lhs, const SensorItem *rhs) {
+  bool operator()(const SensorItem *lhs, const SensorItem *rhs) const {
     // first sort according to register type
     if (lhs->register_type != rhs->register_type) {
       return lhs->register_type < rhs->register_type;
@@ -275,8 +274,8 @@ class SensorItemsComparator {
       return lhs->offset < rhs->offset;
     }
 
-    // The pointer to the sensor are added at last to ensure that
-    // multiple sensors with the save values can be added with a stable sort order.
+    // The pointer to the sensor is used last to ensure that
+    // multiple sensors with the same values can be added with a stable sort order.
     return lhs < rhs;
   }
 };
@@ -404,7 +403,7 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
   void queue_command(const ModbusCommandItem &command);
   /// Registers a sensor with the controller. Called by esphomes code generator
   void add_sensor_item(SensorItem *item) { sensorset_.insert(item); }
-  /// called when a modbus response was prased without errors
+  /// called when a modbus response was parsed without errors
   void on_modbus_data(const std::vector<uint8_t> &data) override;
   /// called when a modbus error response was received
   void on_modbus_error(uint8_t function_code, uint8_t exception_code) override;


### PR DESCRIPTION
# What does this implement/fix? 

This PR fixes/optimizes the creation of register ranges from the configured sensors. The current code has two problems:
1. If a register is used twice e.g. as number and sensor one of them are not updated (lost because of duplicated key) (see also https://github.com/esphome/issues/issues/2845)
2. If a (holding or input) register is mapped to multiple switches, multiple requests are generated instead of re-using the previous fetched data.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Example config with the following features:
* Register 12 is used twice, once as sensor and once as number
* Register 11 has three switches with different bitmasks

The current code generated three ranges, the code from the PR only two.

Current:
* Range : A Size: 2 (3) skip: 0
* Range : B Size: 2 (3) skip: 0

PR:
* Range : A Size: 3 (3) skip: 0

```yaml
uart:
  id: uart_modbus
  baud_rate: 9600
  rx_pin: GPIO16
  tx_pin: GPIO17

modbus:
  id: modbus1

modbus_controller:
  - id: modbus_device
    modbus_id: modbus1
    address: 0x01
    update_interval: 5s
    setup_priority: -10

sensor:
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: reg_10
    register_type: holding
    address: 10
    value_type: U_WORD
    name: Register 10
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: reg_12
    register_type: holding
    address: 12
    value_type: U_WORD
    name: Register 12 (Sensor)

switch:
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: switch_bit_0
    name: Bit 0
    register_type: holding
    address: 11
    bitmask: 1
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: switch_bit_1
    name: Bit 1
    register_type: holding
    address: 11
    bitmask: 2
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: switch_bit_2
    name: Bit 2
    register_type: holding
    address: 11
    bitmask: 3

number:
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: reg_12_number
    address: 12
    value_type: U_WORD
    name: Register 12 (Number)
    min_value: 0
    max_value: 42
    step: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
