### PR TITLE
Support ISR based pulse counter on ESP32-C3

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -8,7 +8,7 @@ static const char *const TAG = "pulse_counter";
 
 const char *const EDGE_MODE_TO_STRING[] = {"DISABLE", "INCREMENT", "DECREMENT"};
 
-#ifdef USE_ESP8266
+#ifndef HAS_PCNT
 void IRAM_ATTR PulseCounterStorage::gpio_intr(PulseCounterStorage *arg) {
   const uint32_t now = micros();
   const bool discard = now - arg->last_pulse < arg->filter_us;
@@ -43,7 +43,7 @@ pulse_counter_t PulseCounterStorage::read_raw_value() {
 }
 #endif
 
-#ifdef USE_ESP32
+#ifdef HAS_PCNT
 bool PulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   static pcnt_unit_t next_pcnt_unit = PCNT_UNIT_0;
   this->pin = pin;
@@ -96,7 +96,7 @@ bool PulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
 
   if (this->filter_us != 0) {
-    uint16_t filter_val = std::min(this->filter_us * 80u, 1023u);
+    uint16_t filter_val = std::min(static_cast<unsigned int>(this->filter_us * 80u), 1023u);
     ESP_LOGCONFIG(TAG, "    Filter Value: %uus (val=%u)", this->filter_us, filter_val);
     error = pcnt_set_filter_value(this->pcnt_unit, filter_val);
     if (error != ESP_OK) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -4,8 +4,9 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
 
-#ifdef USE_ESP32
+#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
 #include <driver/pcnt.h>
+#define HAS_PCNT
 #endif
 
 namespace esphome {
@@ -17,10 +18,9 @@ enum PulseCounterCountMode {
   PULSE_COUNTER_DECREMENT,
 };
 
-#ifdef USE_ESP32
+#ifdef HAS_PCNT
 using pulse_counter_t = int16_t;
-#endif
-#ifdef USE_ESP8266
+#else
 using pulse_counter_t = int32_t;
 #endif
 
@@ -30,16 +30,15 @@ struct PulseCounterStorage {
 
   static void gpio_intr(PulseCounterStorage *arg);
 
-#ifdef USE_ESP8266
+#ifndef HAS_PCNT
   volatile pulse_counter_t counter{0};
   volatile uint32_t last_pulse{0};
 #endif
 
   InternalGPIOPin *pin;
-#ifdef USE_ESP32
+#ifdef HAS_PCNT
   pcnt_unit_t pcnt_unit;
-#endif
-#ifdef USE_ESP8266
+#else
   ISRInternalGPIOPin isr_pin;
 #endif
   PulseCounterCountMode rising_edge_mode{PULSE_COUNTER_INCREMENT};


### PR DESCRIPTION
# What does this implement/fix? 

The ESP32-C3 is considered ESP32 familiy (hence USE_ESP32 is set),
however it lacks the PCNT peripheral. Introduce a define in the header
file to determine if PCNT should be used or not.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32 (ESP32-C3)
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: balcony-wind-sensor
  platformio_options:
    board_build.flash_mode: dio
    platform: https://github.com/platformio/platform-espressif32#feature/arduino-idf-master
    platform_packages:
      - framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.2

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: arduino
  variant: esp32c3

sensor:
  - platform: pulse_counter
    pin: 0
    name: "Pulse Counter"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
