### PR TITLE
Fix SlowPWM output switch at the end of period

### DIFF
--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -15,7 +15,7 @@ void SlowPWMOutput::loop() {
   uint32_t now = millis();
   float scaled_state = this->state_ * this->period_;
 
-  if (now - this->period_start_time_ > this->period_) {
+  if (now - this->period_start_time_ >= this->period_) {
     ESP_LOGVV(TAG, "End of period. State: %f, Scaled state: %f", this->state_, scaled_state);
     this->period_start_time_ += this->period_;
   }


### PR DESCRIPTION
# What does this implement/fix? 

In rare occasions when `now` equals to `this->period_start_time_ + this->period_` (happens to me every couple of minutes in average on Sonoff 4CH with state=1.0 and period=10s) the output is set to false instead of being always true. Noticed that because my relay was clicking unexpectedly :)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
