### PR TITLE
Modbus: fix response parsing error for coil write

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -69,7 +69,7 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
   uint8_t data_len = raw[2];
   uint8_t data_offset = 3;
   // the response for write command mirrors the requests and data startes at offset 2 instead of 3 for read commands
-  if (function_code == 0x5 || function_code == 0x06 || function_code == 0x10) {
+  if (function_code == 0x5 || function_code == 0x06 || function_code == 0xF || function_code == 0x10) {
     data_offset = 2;
     data_len = 4;
   }


### PR DESCRIPTION


# What does this implement/fix? 
The response to the `Force Multiple Coils (function code 0xF)` command is not parsed correctly and causes CRC errors

Quick description and explanation of changes
correct response length calculation for function code 0xF

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
