### PR TITLE
Fix HTTPRequestComponent::get_string return value

### DIFF
--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -115,8 +115,9 @@ void HttpRequestComponent::close() {
 }
 
 const char *HttpRequestComponent::get_string() {
-  static const String STR = this->client_.getString();
-  return STR.c_str();
+  static std::string str;
+  str = this->client_.getString().c_str();
+  return str.c_str();
 }
 
 }  // namespace http_request

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -114,7 +114,11 @@ void HttpRequestComponent::close() {
   this->client_.end();
 }
 
-const char *HttpRequestComponent::get_string() { return this->client_.getString().c_str(); }
+const char *HttpRequestComponent::get_string() {
+  static std::string str;
+  str = this->client_.getString().c_str();
+  return str.c_str();
+}
 
 }  // namespace http_request
 }  // namespace esphome

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -115,6 +115,8 @@ void HttpRequestComponent::close() {
 }
 
 const char *HttpRequestComponent::get_string() {
+  // The static variable is here because HTTPClient::getString() returns a String on ESP32, and we need something to
+  // to keep a buffer alive.
   static std::string str;
   str = this->client_.getString().c_str();
   return str.c_str();

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -114,11 +114,7 @@ void HttpRequestComponent::close() {
   this->client_.end();
 }
 
-const char *HttpRequestComponent::get_string() {
-  static std::string str;
-  str = this->client_.getString().c_str();
-  return str.c_str();
-}
+const char *HttpRequestComponent::get_string() { return this->client_.getString().c_str(); }
 
 }  // namespace http_request
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix? 

the static variable initialization happens only once therefore `http_request.get_string()` returns stale values. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2903

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: testm5       
esp32:
  board: pico32
  framework:
    type: arduino
logger:
  level: VERBOSE
wifi:
  networks:  
      ssid: !secret wifi_sid
      password: !secret wifi_password
http_request:
  useragent: esphome/device
  id: httpget
  timeout: 20s
sensor:
  - platform: uptime
    name: Uptime Sensor
    id: uptime_sensor
    update_interval: 20s
    on_value:
      then:
        - http_request.get:
            url: http://worldtimeapi.org/api/timezone/Europe/Berlin
            on_response:
              then:
                - logger.log:
                    format: "Got %s"
                    args: ['id(httpget).get_string()']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
