### PR TITLE
HttpRequestComponent::get_string - avoid copy

### DIFF
--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -115,10 +115,10 @@ void HttpRequestComponent::close() {
 }
 
 const char *HttpRequestComponent::get_string() {
-  // The static variable is here because HTTPClient::getString() returns a String on ESP32, and we need something to
-  // to keep a buffer alive.
-  static std::string str;
-  str = this->client_.getString().c_str();
+  // The static variable is here because HTTPClient::getString() returns a String on ESP32,
+  // and we need something to keep a buffer alive.
+  static String str;
+  str = this->client_.getString();
   return str.c_str();
 }
 

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -115,9 +115,15 @@ void HttpRequestComponent::close() {
 }
 
 const char *HttpRequestComponent::get_string() {
+#if defined(ESP32)
   // The static variable is here because HTTPClient::getString() returns a String on ESP32,
   // and we need something to keep a buffer alive.
   static String str;
+#else
+  // However on ESP8266, HTTPClient::getString() returns a String& to a member variable.
+  // Leaving this the default so that any new platform either doesn't copy, or encounters a compilation error.
+  auto &
+#endif
   str = this->client_.getString();
   return str.c_str();
 }


### PR DESCRIPTION
# What does this implement/fix? 

Complemeting @martgras's fix in #2987 - using `String` data type (same as returned by `HTTPClient::getString()`) and direct assignment to allow [Move assignment](https://en.cppreference.com/w/cpp/language/move_assignment) on ESP32.

On ESP8266 `HTTPClient::getString()` returns a `String&` to a member variable - therefore using a reference to avoid any kind of assignment/copy.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2903

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
http_request:
  id: my_req

interval:
  - interval: 5s
    then:
      - http_request.get:
          url: http://worldtimeapi.org/api/timezone/Asia/Jerusalem
          on_response:
            then:
              - logger.log:
                  format: "Got %s"
                  args: ['id(my_req).get_string()']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
