### PR TITLE
Introduce bit_cast() backport

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -254,7 +254,7 @@ uint32_t fnv1_hash(const std::string &str);
 
 /// @name STL backports
 ///@{
-  
+
 // std::to_string() from C++11, available from libstdc++/g++ 8
 // See https://github.com/espressif/esp-idf/issues/1445
 #if _GLIBCXX_RELEASE >= 8

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -291,6 +291,22 @@ using std::is_trivially_copyable;
 template<typename T> struct is_trivially_copyable : public std::integral_constant<bool, true> {};
 #endif
 
+// std::bit_cast from C++20
+#if __cpp_lib_bit_cast >= 201806
+using std::bit_cast;
+#else
+/// Convert data between types, without aliasing issues or undefined behaviour.
+template<
+    typename To, typename From,
+    enable_if_t<sizeof(To) == sizeof(From) && is_trivially_copyable<From>::value && is_trivially_copyable<To>::value,
+                int> = 0>
+To bit_cast(const From &src) {
+  To dst;
+  memcpy(&dst, &src, sizeof(To));
+  return dst;
+}
+#endif
+
 // std::byteswap is from C++23 and technically should be a template, but this will do for now.
 constexpr uint8_t byteswap(uint8_t n) { return n; }
 constexpr uint16_t byteswap(uint16_t n) { return __builtin_bswap16(n); }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -281,6 +281,16 @@ template<typename T> T *new_buffer(size_t length) {
 /// @name STL backports
 ///@{
 
+// std::is_trivially_copyable from C++11, implemented in libstdc++/g++ 5.1 (but minor releases can't be detected)
+#if _GLIBCXX_RELEASE >= 6
+using std::is_trivially_copyable;
+#else
+// Implementing this is impossible without compiler intrinsics, so don't bother. Invalid usage will be detected on
+// other variants that use a newer compiler anyway.
+// NOLINTNEXTLINE(readability-identifier-naming)
+template<typename T> struct is_trivially_copyable : public std::integral_constant<bool, true> {};
+#endif
+
 // std::byteswap is from C++23 and technically should be a template, but this will do for now.
 constexpr uint8_t byteswap(uint8_t n) { return n; }
 constexpr uint16_t byteswap(uint16_t n) { return __builtin_bswap16(n); }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -295,6 +295,7 @@ To bit_cast(const From &src) {
   memcpy(&dst, &src, sizeof(To));
   return dst;
 }
+#endif
 
 // std::byteswap is from C++23 and technically should be a template, but this will do for now.
 constexpr uint8_t byteswap(uint8_t n) { return n; }

--- a/esphome/core/preferences.h
+++ b/esphome/core/preferences.h
@@ -2,7 +2,8 @@
 
 #include <cstring>
 #include <cstdint>
-#include <type_traits>
+
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 
@@ -45,20 +46,12 @@ class ESPPreferences {
    */
   virtual bool sync() = 0;
 
-#ifndef USE_ESP8266
-  template<typename T, typename std::enable_if<std::is_trivially_copyable<T>::value, bool>::type = true>
-#else
-  // esp8266 toolchain doesn't have is_trivially_copyable
-  template<typename T>
-#endif
+  template<typename T, enable_if_t<is_trivially_copyable<T>::value, bool> = true>
   ESPPreferenceObject make_preference(uint32_t type, bool in_flash) {
     return this->make_preference(sizeof(T), type, in_flash);
   }
-#ifndef USE_ESP8266
-  template<typename T, typename std::enable_if<std::is_trivially_copyable<T>::value, bool>::type = true>
-#else
-  template<typename T>
-#endif
+
+  template<typename T, enable_if_t<is_trivially_copyable<T>::value, bool> = true>
   ESPPreferenceObject make_preference(uint32_t type) {
     return this->make_preference(sizeof(T), type);
   }


### PR DESCRIPTION
# What does this implement/fix? 

From C++20 onwards, `std::bit_cast()` is the prefered method for type punning as it doesn't suffer from strict aliasing violations or undefined behaviour. Introduce a backport (based on `memcpy`, which the compiler can usually optimize away), so that we can properly type pun, as that's often useful to convert a `uint8_t[]` (read from I2C/UART/etc) to a proper structure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
