### PR TITLE
Use to_string() from STL when available

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -197,52 +197,6 @@ uint8_t reverse_bits_8(uint8_t x) {
 uint16_t reverse_bits_16(uint16_t x) {
   return uint16_t(reverse_bits_8(x & 0xFF) << 8) | uint16_t(reverse_bits_8(x >> 8));
 }
-std::string to_string(const std::string &val) { return val; }
-std::string to_string(int val) {
-  char buf[64];
-  sprintf(buf, "%d", val);
-  return buf;
-}
-std::string to_string(long val) {  // NOLINT
-  char buf[64];
-  sprintf(buf, "%ld", val);
-  return buf;
-}
-std::string to_string(long long val) {  // NOLINT
-  char buf[64];
-  sprintf(buf, "%lld", val);
-  return buf;
-}
-std::string to_string(unsigned val) {  // NOLINT
-  char buf[64];
-  sprintf(buf, "%u", val);
-  return buf;
-}
-std::string to_string(unsigned long val) {  // NOLINT
-  char buf[64];
-  sprintf(buf, "%lu", val);
-  return buf;
-}
-std::string to_string(unsigned long long val) {  // NOLINT
-  char buf[64];
-  sprintf(buf, "%llu", val);
-  return buf;
-}
-std::string to_string(float val) {
-  char buf[64];
-  sprintf(buf, "%f", val);
-  return buf;
-}
-std::string to_string(double val) {
-  char buf[64];
-  sprintf(buf, "%f", val);
-  return buf;
-}
-std::string to_string(long double val) {
-  char buf[64];
-  sprintf(buf, "%Lf", val);
-  return buf;
-}
 
 uint32_t fnv1_hash(const std::string &str) {
   uint32_t hash = 2166136261UL;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -36,17 +36,6 @@ std::string get_mac_address_pretty();
 void set_mac_address(uint8_t *mac);
 #endif
 
-std::string to_string(const std::string &val);
-std::string to_string(int val);
-std::string to_string(long val);                // NOLINT
-std::string to_string(long long val);           // NOLINT
-std::string to_string(unsigned val);            // NOLINT
-std::string to_string(unsigned long val);       // NOLINT
-std::string to_string(unsigned long long val);  // NOLINT
-std::string to_string(float val);
-std::string to_string(double val);
-std::string to_string(long double val);
-
 /// Compare string a to string b (ignoring case) and return whether they are equal.
 bool str_equals_case_insensitive(const std::string &a, const std::string &b);
 bool str_startswith(const std::string &full, const std::string &start);
@@ -281,6 +270,22 @@ template<typename T> T *new_buffer(size_t length) {
 /// @name STL backports
 ///@{
 
+// std::to_string() from C++11, available from libstdc++/g++ 8+
+// See https://github.com/espressif/esp-idf/issues/1445
+#if _GLIBCXX_RELEASE >= 8
+using std::to_string;
+#else
+inline std::string to_string(int value) { return str_snprintf("%d", 32, value); }                   // NOLINT
+inline std::string to_string(long value) { return str_snprintf("%ld", 32, value); }                 // NOLINT
+inline std::string to_string(long long value) { return str_snprintf("%lld", 32, value); }           // NOLINT
+inline std::string to_string(unsigned value) { return str_snprintf("%u", 32, value); }              // NOLINT
+inline std::string to_string(unsigned long value) { return str_snprintf("%lu", 32, value); }        // NOLINT
+inline std::string to_string(unsigned long long value) { return str_snprintf("%llu", 32, value); }  // NOLINT
+inline std::string to_string(float value) { return str_snprintf("%f", 32, value); }
+inline std::string to_string(double value) { return str_snprintf("%f", 32, value); }
+inline std::string to_string(long double value) { return str_snprintf("%Lf", 32, value); }
+#endif
+
 // std::byteswap is from C++23 and technically should be a template, but this will do for now.
 constexpr uint8_t byteswap(uint8_t n) { return n; }
 constexpr uint16_t byteswap(uint16_t n) { return __builtin_bswap16(n); }
@@ -340,6 +345,9 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> constexpr
 
 /// @name Strings
 ///@{
+
+/// Convert the value to a string (added as extra overload so that to_string() can be used on all stringifiable types).
+inline std::string to_string(const std::string &val) { return val; }
 
 /// Truncate a string to a specific length.
 std::string str_truncate(const std::string &str, size_t length);


### PR DESCRIPTION
# What does this implement/fix? 

Use the `to_string()` function from the STL when it's available, instead of rolling our own.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
