### PR TITLE
Set UTF-8 encoding and version for prometheus /metrics

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -7,7 +7,7 @@ namespace esphome {
 namespace prometheus {
 
 void PrometheusHandler::handleRequest(AsyncWebServerRequest *req) {
-  AsyncResponseStream *stream = req->beginResponseStream("text/plain");
+  AsyncResponseStream *stream = req->beginResponseStream("text/plain; version=0.0.4; charset=utf-8");
 
 #ifdef USE_SENSOR
   this->sensor_type_(stream);


### PR DESCRIPTION
# What does this implement/fix? 
This adds explicit UTF-8 encoding and prometheus metrics version to fix encoding problems in browsers for values like `µg/m³`

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment
- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
web_server:
prometheus:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
         (imho does not need further tests)
