### PR TITLE
SGP40 - Reduce delay in measurement

### DIFF
--- a/esphome/components/sgp40/sgp40.cpp
+++ b/esphome/components/sgp40/sgp40.cpp
@@ -211,7 +211,7 @@ uint16_t SGP40Component::measure_raw_() {
     ESP_LOGD(TAG, "write error");
     return UINT16_MAX;
   }
-  delay(250);  // NOLINT
+  delay(30);
   uint16_t raw_data[1];
 
   if (!this->read_data_(raw_data, 1)) {


### PR DESCRIPTION
# What does this implement/fix? 

SGP40Component::measure_raw_is called with a 1 Hz frequency and delays for 250ms.
According to the datasheet a raw measurement takes max 30 ms.
Ref: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9_Gas_Sensors/Datasheets/Sensirion_Gas_Sensors_Datasheet_SGP40.pdf 

In my tests 30 ms works reliably 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
