### PR TITLE
Introduce big- and little-endian integer types

### DIFF
--- a/esphome/core/datatypes.h
+++ b/esphome/core/datatypes.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+
+namespace internal {
+
+/// Wrapper class for memory using big endian data layout, transparently converting it to native order.
+template<typename T> class BigEndianLayout {
+ public:
+  constexpr14 operator T() { return convert_big_endian(val_); }
+
+ private:
+  T val_;
+} __attribute__((packed));
+
+/// Wrapper class for memory using big endian data layout, transparently converting it to native order.
+template<typename T> class LittleEndianLayout {
+ public:
+  constexpr14 operator T() { return convert_little_endian(val_); }
+
+ private:
+  T val_;
+} __attribute__((packed));
+
+}  // namespace internal
+
+/// 24-bit unsigned integer type, transparently converting to 32-bit.
+struct uint24_t {  // NOLINT(readability-identifier-naming)
+  operator uint32_t() { return val; }
+  uint32_t val : 24;
+} __attribute__((packed));
+
+/// 24-bit signed integer type, transparently converting to 32-bit.
+struct int24_t {  // NOLINT(readability-identifier-naming)
+  operator int32_t() { return val; }
+  int32_t val : 24;
+} __attribute__((packed));
+
+// Integer types in big or little endian data layout.
+using uint64_be_t = internal::BigEndianLayout<uint64_t>;
+using uint32_be_t = internal::BigEndianLayout<uint32_t>;
+using uint24_be_t = internal::BigEndianLayout<uint24_t>;
+using uint16_be_t = internal::BigEndianLayout<uint16_t>;
+using int64_be_t = internal::BigEndianLayout<int64_t>;
+using int32_be_t = internal::BigEndianLayout<int32_t>;
+using int24_be_t = internal::BigEndianLayout<int24_t>;
+using int16_be_t = internal::BigEndianLayout<int16_t>;
+using uint64_le_t = internal::LittleEndianLayout<uint64_t>;
+using uint32_le_t = internal::LittleEndianLayout<uint32_t>;
+using uint24_le_t = internal::LittleEndianLayout<uint24_t>;
+using uint16_le_t = internal::LittleEndianLayout<uint16_t>;
+using int64_le_t = internal::LittleEndianLayout<int64_t>;
+using int32_le_t = internal::LittleEndianLayout<int32_t>;
+using int24_le_t = internal::LittleEndianLayout<int24_t>;
+using int16_le_t = internal::LittleEndianLayout<int16_t>;
+
+}  // namespace esphome

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -305,11 +305,21 @@ To bit_cast(const From &src) {
 }
 #endif
 
-// std::byteswap is from C++23 and technically should be a template, but this will do for now.
-constexpr uint8_t byteswap(uint8_t n) { return n; }
-constexpr uint16_t byteswap(uint16_t n) { return __builtin_bswap16(n); }
-constexpr uint32_t byteswap(uint32_t n) { return __builtin_bswap32(n); }
-constexpr uint64_t byteswap(uint64_t n) { return __builtin_bswap64(n); }
+// std::byteswap from C++23
+template<typename T> constexpr14 T byteswap(T n) {
+  T m;
+  for (size_t i = 0; i < sizeof(T); i++)
+    reinterpret_cast<uint8_t *>(&m)[i] = reinterpret_cast<uint8_t *>(&n)[sizeof(T) - 1 - i];
+  return m;
+}
+template<> constexpr14 uint8_t byteswap(uint8_t n) { return n; }
+template<> constexpr14 uint16_t byteswap(uint16_t n) { return __builtin_bswap16(n); }
+template<> constexpr14 uint32_t byteswap(uint32_t n) { return __builtin_bswap32(n); }
+template<> constexpr14 uint64_t byteswap(uint64_t n) { return __builtin_bswap64(n); }
+template<> constexpr14 int8_t byteswap(int8_t n) { return n; }
+template<> constexpr14 int16_t byteswap(int16_t n) { return __builtin_bswap16(n); }
+template<> constexpr14 int32_t byteswap(int32_t n) { return __builtin_bswap32(n); }
+template<> constexpr14 int64_t byteswap(int64_t n) { return __builtin_bswap64(n); }
 
 ///@}
 
@@ -327,7 +337,8 @@ constexpr uint32_t encode_uint32(uint8_t byte1, uint8_t byte2, uint8_t byte3, ui
 }
 
 /// Encode a value from its constituent bytes (from most to least significant) in an array with length sizeof(T).
-template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> constexpr14 T encode_value(const uint8_t *bytes) {
+template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0>
+constexpr14 T encode_value(const uint8_t *bytes) {
   T val = 0;
   for (size_t i = 0; i < sizeof(T); i++) {
     val <<= 8;
@@ -352,11 +363,20 @@ constexpr14 std::array<uint8_t, sizeof(T)> decode_value(T val) {
 }
 
 /// Convert a value between host byte order and big endian (most significant byte first) order.
-template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> constexpr T convert_big_endian(T val) {
+template<typename T> constexpr14 T convert_big_endian(T val) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return byteswap(val);
 #else
   return val;
+#endif
+}
+
+/// Convert a value between host byte order and little endian (least significant byte first) order.
+template<typename T> constexpr14 T convert_little_endian(T val) {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return val;
+#else
+  return byteswap(val);
 #endif
 }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -20,6 +20,14 @@
 #define ALWAYS_INLINE __attribute__((always_inline))
 #define PACKED __attribute__((packed))
 
+// Various functions can be constexpr in C++14, but not in C++11 (because their body isn't just a return statement).
+// Define a substitute constexpr keyword for those functions, until we can drop C++11 support.
+#if __cplusplus >= 201402L
+#define constexpr14 constexpr
+#else
+#define constexpr14 inline  // constexpr implies inline
+#endif
+
 namespace esphome {
 
 /// Get the device MAC address as raw bytes, written into the provided byte array (6 bytes).
@@ -319,7 +327,7 @@ constexpr uint32_t encode_uint32(uint8_t byte1, uint8_t byte2, uint8_t byte3, ui
 }
 
 /// Encode a value from its constituent bytes (from most to least significant) in an array with length sizeof(T).
-template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> inline T encode_value(const uint8_t *bytes) {
+template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> constexpr14 T encode_value(const uint8_t *bytes) {
   T val = 0;
   for (size_t i = 0; i < sizeof(T); i++) {
     val <<= 8;
@@ -329,12 +337,12 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> inline T 
 }
 /// Encode a value from its constituent bytes (from most to least significant) in an std::array with length sizeof(T).
 template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0>
-inline T encode_value(const std::array<uint8_t, sizeof(T)> bytes) {
+constexpr14 T encode_value(const std::array<uint8_t, sizeof(T)> bytes) {
   return encode_value<T>(bytes.data());
 }
 /// Decode a value into its constituent bytes (from most to least significant).
 template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0>
-inline std::array<uint8_t, sizeof(T)> decode_value(T val) {
+constexpr14 std::array<uint8_t, sizeof(T)> decode_value(T val) {
   std::array<uint8_t, sizeof(T)> ret{};
   for (size_t i = sizeof(T); i > 0; i--) {
     ret[i - 1] = val & 0xFF;
@@ -499,7 +507,7 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> std::stri
 ///@{
 
 /// Remap a number from one range to another.
-template<typename T, typename U> T remap(U value, U min, U max, T min_out, T max_out) {
+template<typename T, typename U> constexpr T remap(U value, U min, U max, T min_out, T max_out) {
   return (value - min) * (max_out - min_out) / (max - min) + min_out;
 }
 


### PR DESCRIPTION
# What does this implement/fix? 

Currently, many components do some kind of bit fiddling to extract values from the connected device (sample adapted from BME280):
```cpp
uint8_t data[8];
if (!this->read_bytes(BME280_REGISTER_MEASUREMENTS, data, 8))
  return; // there should be error handling here
int32_t adc_temp = ((data[3] & 0xFF) << 16) | ((data[4] & 0xFF) << 8) | (data[5] & 0xFF);
int32_t adc_pressure = ((data[0] & 0xFF) << 16) | ((data[1] & 0xFF) << 8) | (data[2] & 0xFF);
uint16_t adc_humidity = ((data[6] & 0xFF) << 8) | (data[7] & 0xFF);
this->temperature->publish_state(some_conversion_function(adc_temp)); // etc
```
This is painful code to write, painful to read and review, and it's very error-prone because the precedence of bitwise operators is unintuitive and it's very easy to use the wrong byte. This sample is actually a good example of this, as the `& 0xFF` everywhere is totally superfluous.

Instead, I want to start encouraging to do this through the type system:
```cpp
struct measurements_register {
  int24_be_t adc_pressure;
  int24_be_t adc_temp;
  uint16_be_t adc_humidity;
} __attribute__((packed));

struct measurements_register data;
if (!this->read(BME280_REGISTER_MEASUREMENTS, &data))
  return; // there should be error handling here
this->temperature->publish_state(some_conversion_function(data.adc_temp)); // etc
```

At the moment, one big obstacle to do it like this is that I2C devices usually uses big endian byte order (most significant byte first), while ESP's natively use little endian byte order. Thus, just using `int32_t` in a struct causes the values to be messed up. To fix that, introduce little endian and big endian integer types that implicitly convert to native integer types and swap the byte order when necessary. These types are distinguished by a `_be_t`/`_le_t` suffix.

Furthermore, there are quite some devices that use 24-bit integers, so introduce 24-bit integer types as well. These widen implicitly to 32-bit integers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
