### PR TITLE
Fix clang-tidy with multiple ESP32 toolchains installed

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -58,10 +58,14 @@ def clang_options(idedata):
     # defines
     cmd.extend(f'-D{define}' for define in idedata['defines'])
 
-    # add include directories, using -isystem for dependencies to suppress their errors
+    # add toolchain include directories using -isystem
+    # idedata contains include directories for all toolchains of this platform, only use those from the one in use
+    toolchain_dir = os.path.normpath(f"{idedata['cxx_path']}/../../")
     for directory in idedata['includes']['toolchain']:
-        if 'xtensa-esp32s2-elf' not in directory:
+        if directory.startswith(toolchain_dir):
             cmd.extend(['-isystem', directory])
+
+    # add include directories, using -isystem for dependencies to suppress their errors
     for directory in sorted(set(idedata['includes']['build'])):
         dependency = "framework-arduino" in directory or "/libdeps/" in directory
         cmd.extend(['-isystem' if dependency else '-I', directory])


### PR DESCRIPTION
# What does this implement/fix? 

The clang-tidy script failed when multiple ESP32 toolchains were installed, usually for different variants, because it added the include directories from all of them. Only use the toolchain for the device we're targeting.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
