### PR TITLE
Set correct include_dir in platformio.ini 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,8 +5,13 @@
 
 [platformio]
 default_envs = esp8266, esp32, esp32-idf
+; Ideally, we want src_dir to be the root directory of the repository, to mimic the runtime build
+; environment as best as possible. Unfortunately, the ESP-IDF toolchain really doesn't like this
+; being the root directory. Instead, set esphome/ as the source directory, all our sources are in
+; there anyway. Set the root directory as the include_dir, so that the esphome/ directory is on the
+; include path.
 src_dir = esphome
-include_dir =
+include_dir = .
 
 [runtime]
 ; This are the flags as set by the runtime.

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -58,10 +58,14 @@ def clang_options(idedata):
     # defines
     cmd.extend(f'-D{define}' for define in idedata['defines'])
 
-    # add include directories, using -isystem for dependencies to suppress their errors
+    # add toolchain include directories using -isystem
+    # idedata contains include directories for all toolchains of this platform, only use those from the one in use
+    toolchain_dir = os.path.normpath(f"{idedata['cxx_path']}/../../")
     for directory in idedata['includes']['toolchain']:
-        if 'xtensa-esp32s2-elf' not in directory:
+        if directory.startswith(toolchain_dir):
             cmd.extend(['-isystem', directory])
+
+    # add include directories, using -isystem for dependencies to suppress their errors
     for directory in sorted(set(idedata['includes']['build'])):
         dependency = "framework-arduino" in directory or "/libdeps/" in directory
         cmd.extend(['-isystem' if dependency else '-I', directory])

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from helpers import print_error_for_file, get_output, filter_grep, \
-    build_all_include, temp_header_file, git_ls_files, filter_changed, load_idedata, basepath
+    build_all_include, temp_header_file, git_ls_files, filter_changed, load_idedata, root_path, basepath
 import argparse
 import click
 import colorama
@@ -58,17 +58,21 @@ def clang_options(idedata):
     # defines
     cmd.extend(f'-D{define}' for define in idedata['defines'])
 
-    # add toolchain include directories using -isystem
+    # add toolchain include directories using -isystem to suppress their errors
     # idedata contains include directories for all toolchains of this platform, only use those from the one in use
     toolchain_dir = os.path.normpath(f"{idedata['cxx_path']}/../../")
     for directory in idedata['includes']['toolchain']:
         if directory.startswith(toolchain_dir):
             cmd.extend(['-isystem', directory])
 
-    # add include directories, using -isystem for dependencies to suppress their errors
+    # add library include directories using -isystem to suppress their errors
     for directory in sorted(set(idedata['includes']['build'])):
-        dependency = "framework-arduino" in directory or "/libdeps/" in directory
-        cmd.extend(['-isystem' if dependency else '-I', directory])
+        # skip our own directories, we add those later
+        if not directory.startswith(f"{root_path}/") or directory.startswith(f"{root_path}/.pio/"):
+            cmd.extend(['-isystem', directory])
+
+    # add the esphome include directory using -I
+    cmd.extend(['-I', root_path])
 
     return cmd
 


### PR DESCRIPTION
# What does this implement/fix? 

Based upon #2998, also fixes the problems with updating PlatformIO to 5.2.4 (#2919, see https://github.com/esphome/esphome/pull/2666#issuecomment-979463555) and thus zeroconf (#2951, #2796).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
