### PR TITLE
Support clang-tidy for ESP32 variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,26 +51,26 @@ jobs:
             name: Run script/clang-format
           - id: clang-tidy
             name: Run script/clang-tidy for ESP8266
-            options: --environment esp8266-tidy --grep USE_ESP8266
+            options: --environment esp8266-arduino-tidy --grep USE_ESP8266
             pio_cache_key: tidyesp8266
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 1/4
-            options: --environment esp32-tidy --split-num 4 --split-at 1
+            name: Run script/clang-tidy for ESP32 Arduino 1/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
             pio_cache_key: tidyesp32
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 2/4
-            options: --environment esp32-tidy --split-num 4 --split-at 2
+            name: Run script/clang-tidy for ESP32 Arduino 2/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
             pio_cache_key: tidyesp32
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 3/4
-            options: --environment esp32-tidy --split-num 4 --split-at 3
+            name: Run script/clang-tidy for ESP32 Arduino 3/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
             pio_cache_key: tidyesp32
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 4/4
-            options: --environment esp32-tidy --split-num 4 --split-at 4
+            name: Run script/clang-tidy for ESP32 Arduino 4/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
             pio_cache_key: tidyesp32
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 esp-idf
+            name: Run script/clang-tidy for ESP32 IDF
             options: --environment esp32-idf-tidy --grep USE_ESP_IDF
             pio_cache_key: tidyesp32-idf
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,14 +13,14 @@ default_envs = esp8266-arduino, esp32-arduino, esp32-idf
 src_dir = esphome
 include_dir = .
 
-[runtime]
-; This are the flags as set by the runtime.
+; This are just the build flags as set by the runtime.
+[flags:runtime]
 build_flags =
     -Wno-unused-but-set-variable
     -Wno-sign-compare
 
-[clangtidy]
-; This are the flags for clang-tidy.
+; This are just the build flags for clang-tidy.
+[flags:clangtidy]
 build_flags =
     -Wall
     -Wextra
@@ -30,6 +30,7 @@ build_flags =
     -Wshadow-field-in-constructor
     -Wshadow-uncaptured-local
 
+; This are common settings for all environments.
 [common]
 lib_deps =
     esphome/noise-c@0.1.4         ; api
@@ -43,6 +44,7 @@ src_filter =
     +<../tests/dummy_main.cpp>
     +<../.temp/all-include.cpp>
 
+; This are common settings for all Arduino-framework based environments.
 [common:arduino]
 extends = common
 lib_deps =
@@ -62,12 +64,14 @@ build_flags =
     ${common.build_flags}
     -DUSE_ARDUINO
 
+; This are common settings for all IDF-framework based environments.
 [common:idf]
 extends = common
 build_flags =
     ${common.build_flags}
     -DUSE_ESP_IDF
 
+; This are common settings for the ESP8266 using Arduino.
 [common:esp8266-arduino]
 extends = common:arduino
 ; when changing this also copy it to esphome-docker-base images
@@ -76,7 +80,6 @@ platform_packages =
     platformio/framework-arduinoespressif8266 @ ~3.30002.0
 
 framework = arduino
-board = nodemcuv2
 lib_deps =
     ${common:arduino.lib_deps}
     ESP8266WiFi                           ; wifi (Arduino built-in)
@@ -87,6 +90,7 @@ build_flags =
     -DUSE_ESP8266
     -DUSE_ESP8266_FRAMEWORK_ARDUINO
 
+; This are common settings for the ESP32 (all variants) using Arduino.
 [common:esp32-arduino]
 extends = common:arduino
 ; when changing this also copy it to esphome-docker-base images
@@ -104,6 +108,7 @@ build_flags =
     -DUSE_ESP32
     -DUSE_ESP32_FRAMEWORK_ARDUINO
 
+; This are common settings for the ESP32 (all variants) using IDF.
 [common:esp32-idf]
 extends = common:idf
 ; when changing this also copy it to esphome-docker-base images
@@ -112,7 +117,6 @@ platform_packages =
     platformio/framework-espidf @ ~3.40300.0
 
 framework = espidf
-board = nodemcu-32s
 lib_deps =
     ${common:idf.lib_deps}
     espressif/esp32-camera@1.0.0  ; esp32_camera
@@ -122,40 +126,79 @@ build_flags =
     -DUSE_ESP32
     -DUSE_ESP32_FRAMEWORK_ESP_IDF
 
+; All the actual environments are defined below.
 [env:esp8266-arduino]
 extends = common:esp8266-arduino
+board = nodemcuv2
 build_flags =
     ${common:esp8266-arduino.build_flags}
-    ${runtime.build_flags}
+    ${flags:runtime.build_flags}
 
 [env:esp8266-arduino-tidy]
 extends = common:esp8266-arduino
+board = nodemcuv2
 build_flags =
     ${common:esp8266-arduino.build_flags}
-    ${clangtidy.build_flags}
+    ${flags:clangtidy.build_flags}
 
 [env:esp32-arduino]
 extends = common:esp32-arduino
+board = esp32dev
 build_flags =
     ${common:esp32-arduino.build_flags}
-    ${runtime.build_flags}
+    ${flags:runtime.build_flags}
 
 [env:esp32-arduino-tidy]
 extends = common:esp32-arduino
+board = esp32dev
 build_flags =
     ${common:esp32-arduino.build_flags}
-    ${clangtidy.build_flags}
+    ${flags:clangtidy.build_flags}
 
 [env:esp32-idf]
 extends = common:esp32-idf
+board = esp32dev
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf
 build_flags =
     ${common:esp32-idf.build_flags}
-    ${runtime.build_flags}
+    ${flags:runtime.build_flags}
 
 [env:esp32-idf-tidy]
 extends = common:esp32-idf
+board = esp32dev
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf-tidy
 build_flags =
     ${common:esp32-idf.build_flags}
-    ${clangtidy.build_flags}
+    ${flags:clangtidy.build_flags}
+
+[env:esp32c3-idf]
+extends = common:esp32-idf
+board = esp32-c3-devkitm-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32c3-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:runtime.build_flags}
+
+[env:esp32c3-idf-tidy]
+extends = common:esp32-idf
+board = esp32-c3-devkitm-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32c3-idf-tidy
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:clangtidy.build_flags}
+
+[env:esp32s2-idf]
+extends = common:esp32-idf
+board = esp32-s2-kaluga-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32s2-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:runtime.build_flags}
+
+[env:esp32s2-idf-tidy]
+extends = common:esp32-idf
+board = esp32-s2-kaluga-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32s2-idf-tidy
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:clangtidy.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@
 ; It's *not* used during runtime.
 
 [platformio]
-default_envs = esp8266, esp32, esp32-idf
+default_envs = esp8266-arduino, esp32-arduino, esp32-idf
 ; Ideally, we want src_dir to be the root directory of the repository, to mimic the runtime build
 ; environment as best as possible. Unfortunately, the ESP-IDF toolchain really doesn't like this
 ; being the root directory. Instead, set esphome/ as the source directory, all our sources are in
@@ -68,7 +68,7 @@ build_flags =
     ${common.build_flags}
     -DUSE_ESP_IDF
 
-[common:esp8266]
+[common:esp8266-arduino]
 extends = common:arduino
 ; when changing this also copy it to esphome-docker-base images
 platform = platformio/espressif8266 @ 3.2.0
@@ -122,25 +122,25 @@ build_flags =
     -DUSE_ESP32
     -DUSE_ESP32_FRAMEWORK_ESP_IDF
 
-[env:esp8266]
-extends = common:esp8266
+[env:esp8266-arduino]
+extends = common:esp8266-arduino
 build_flags =
-    ${common:esp8266.build_flags}
+    ${common:esp8266-arduino.build_flags}
     ${runtime.build_flags}
 
-[env:esp8266-tidy]
-extends = common:esp8266
+[env:esp8266-arduino-tidy]
+extends = common:esp8266-arduino
 build_flags =
-    ${common:esp8266.build_flags}
+    ${common:esp8266-arduino.build_flags}
     ${clangtidy.build_flags}
 
-[env:esp32]
+[env:esp32-arduino]
 extends = common:esp32-arduino
 build_flags =
     ${common:esp32-arduino.build_flags}
     ${runtime.build_flags}
 
-[env:esp32-tidy]
+[env:esp32-arduino-tidy]
 extends = common:esp32-arduino
 build_flags =
     ${common:esp32-arduino.build_flags}

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -126,8 +126,8 @@ def main():
     parser.add_argument('-j', '--jobs', type=int,
                         default=multiprocessing.cpu_count(),
                         help='number of tidy instances to be run in parallel.')
-    parser.add_argument('-e', '--environment', default='esp32-tidy',
-                        help='the PlatformIO environment to run against (esp8266-tidy or esp32-tidy)')
+    parser.add_argument('-e', '--environment', default='esp32-arduino-tidy',
+                        help='the PlatformIO environment to run against (esp8266-arduino-tidy or esp32-arduino-tidy)')
     parser.add_argument('files', nargs='*', default=[],
                         help='files to be processed (regex on path)')
     parser.add_argument('--fix', action='store_true', help='apply fix-its')

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -135,7 +135,7 @@ def main():
                         default=multiprocessing.cpu_count(),
                         help='number of tidy instances to be run in parallel.')
     parser.add_argument('-e', '--environment', default='esp32-arduino-tidy',
-                        help='the PlatformIO environment to run against (esp8266-arduino-tidy or esp32-arduino-tidy)')
+                        help='the PlatformIO environment to use (as defined in platformio.ini)')
     parser.add_argument('files', nargs='*', default=[],
                         help='files to be processed (regex on path)')
     parser.add_argument('--fix', action='store_true', help='apply fix-its')

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -17,9 +17,19 @@ import threading
 
 
 def clang_options(idedata):
-    cmd = [
-        # target 32-bit arch (this prevents size mismatch errors on a 64-bit host)
-        '-m32',
+    cmd = []
+
+    # extract target architecture from triplet in g++ filename
+    triplet = os.path.basename(idedata['cxx_path'])[:-4]
+    if triplet.startswith("xtensa-"):
+        # clang doesn't support Xtensa (yet?), so compile in 32-bit mode and pretend we're the Xtensa compiler
+        cmd.append('-m32')
+        cmd.append('-D__XTENSA__')
+    else:
+        cmd.append(f'--target={triplet}')
+
+    # set flags
+    cmd.extend([
         # disable built-in include directories from the host
         '-nostdinc',
         '-nostdinc++',
@@ -39,15 +49,13 @@ def clang_options(idedata):
         # suppress warning about attribute cannot be applied to type
         # https://github.com/esp8266/Arduino/pull/8258
         '-Ddeprecated(x)=',
-        # pretend we're an Xtensa compiler, which gates some features in the headers
-        '-D__XTENSA__',
         # allow to condition code on the presence of clang-tidy
         '-DCLANG_TIDY',
         # (esp-idf) Disable this header because they use asm with registers clang-tidy doesn't know
         '-D__XTENSA_API_H__',
         # (esp-idf) Fix __once_callable in some libstdc++ headers
         '-D_GLIBCXX_HAVE_TLS',
-    ]
+    ])
 
     # copy compiler flags, except those clang doesn't understand.
     cmd.extend(flag for flag in idedata['cxx_flags'].split(' ')


### PR DESCRIPTION
# What does this implement/fix? 

Support running clang-tidy for the ESP32 variants (S2, C3). Not added to CI since they don't succeed yet (and I'm not sure whether we want to make CI even heavier...)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
