### PR TITLE
Send button presses to Home Assistant

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -976,4 +976,14 @@ message ButtonCommandRequest {
   option (no_delay) = true;
 
   fixed32 key = 1;
+  string state = 2;
+}
+message ButtonStateResponse {
+  option (id) = 63;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BUTTON";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  string state = 2;
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -677,6 +677,15 @@ void APIConnection::select_command(const SelectCommandRequest &msg) {
 #endif
 
 #ifdef USE_BUTTON
+bool APIConnection::send_button_state(button::Button *button, std::string state) {
+  if (!this->state_subscription_)
+    return false;
+
+  ButtonStateResponse resp{};
+  resp.key = button->get_object_id_hash();
+  resp.state = std::move(state);
+  return this->send_button_state_response(resp);
+}
 bool APIConnection::send_button_info(button::Button *button) {
   ListEntitiesButtonResponse msg;
   msg.key = button->get_object_id_hash();
@@ -694,7 +703,7 @@ void APIConnection::button_command(const ButtonCommandRequest &msg) {
   if (button == nullptr)
     return;
 
-  button->press();
+  button->set_state(msg.state);
 }
 #endif
 

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -75,6 +75,7 @@ class APIConnection : public APIServerConnection {
   void select_command(const SelectCommandRequest &msg) override;
 #endif
 #ifdef USE_BUTTON
+  bool send_button_state(button::Button *button, std::string state);
   bool send_button_info(button::Button *button);
   void button_command(const ButtonCommandRequest &msg) override;
 #endif

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -4276,6 +4276,16 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+bool ButtonCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
 bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -4286,7 +4296,10 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->key); }
+void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->state);
+}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ButtonCommandRequest::dump_to(std::string &out) const {
   char buffer[64];
@@ -4294,6 +4307,49 @@ void ButtonCommandRequest::dump_to(std::string &out) const {
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);
   out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ButtonStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ButtonStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ButtonStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ButtonStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ButtonStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%u", this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1071,6 +1071,7 @@ class ListEntitiesButtonResponse : public ProtoMessage {
 class ButtonCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
+  std::string state{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1078,6 +1079,20 @@ class ButtonCommandRequest : public ProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class ButtonStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string state{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 
 }  // namespace api

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -292,6 +292,14 @@ bool APIServerConnectionBase::send_list_entities_button_response(const ListEntit
 #endif
 #ifdef USE_BUTTON
 #endif
+#ifdef USE_BUTTON
+bool APIServerConnectionBase::send_button_state_response(const ButtonStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_button_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ButtonStateResponse>(msg, 63);
+}
+#endif
 bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
   switch (msg_type) {
     case 1: {

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -136,6 +136,9 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_BUTTON
   virtual void on_button_command_request(const ButtonCommandRequest &value){};
 #endif
+#ifdef USE_BUTTON
+  bool send_button_state_response(const ButtonStateResponse &msg);
+#endif
  protected:
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
 };

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -223,6 +223,17 @@ void APIServer::on_switch_update(switch_::Switch *obj, bool state) {
 }
 #endif
 
+#ifdef USE_BUTTON
+void APIServer::on_button_update(button::Button *obj, const std::string &state) {
+  ESP_LOGW(TAG, "on_button_update-1");
+  if (obj->is_internal())
+    return;
+  ESP_LOGW(TAG, "on_button_update-1");
+  for (auto &c : this->clients_)
+    c->send_button_state(obj, state);
+}
+#endif
+
 #ifdef USE_TEXT_SENSOR
 void APIServer::on_text_sensor_update(text_sensor::TextSensor *obj, const std::string &state) {
   if (obj->is_internal())

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -55,6 +55,9 @@ class APIServer : public Component, public Controller {
 #ifdef USE_SWITCH
   void on_switch_update(switch_::Switch *obj, bool state) override;
 #endif
+#ifdef USE_BUTTON
+  void on_button_update(button::Button *obj, const std::string &state) override;
+#endif
 #ifdef USE_TEXT_SENSOR
   void on_text_sensor_update(text_sensor::TextSensor *obj, const std::string &state) override;
 #endif

--- a/esphome/components/api/subscribe_state.cpp
+++ b/esphome/components/api/subscribe_state.cpp
@@ -29,6 +29,11 @@ bool InitialStateIterator::on_switch(switch_::Switch *a_switch) {
   return this->client_->send_switch_state(a_switch, a_switch->state);
 }
 #endif
+#ifdef USE_BUTTON
+bool InitialStateIterator::on_button(button::Button *button) {
+  return this->client_->send_button_state(button, button->state);
+}
+#endif
 #ifdef USE_TEXT_SENSOR
 bool InitialStateIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
   return this->client_->send_text_sensor_state(text_sensor, text_sensor->state);

--- a/esphome/components/api/subscribe_state.h
+++ b/esphome/components/api/subscribe_state.h
@@ -32,7 +32,7 @@ class InitialStateIterator : public ComponentIterator {
   bool on_switch(switch_::Switch *a_switch) override;
 #endif
 #ifdef USE_BUTTON
-  bool on_button(button::Button *button) override { return true; };
+  bool on_button(button::Button *button) override;
 #endif
 #ifdef USE_TEXT_SENSOR
   bool on_text_sensor(text_sensor::TextSensor *text_sensor) override;

--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -2,13 +2,14 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.automation import maybe_simple_id
-from esphome.components import mqtt
+from esphome.components import mqtt, time
 from esphome.const import (
     CONF_DEVICE_CLASS,
     CONF_ENTITY_CATEGORY,
     CONF_ICON,
     CONF_ID,
     CONF_ON_PRESS,
+    CONF_TIME_ID,
     CONF_TRIGGER_ID,
     CONF_MQTT_ID,
     DEVICE_CLASS_RESTART,
@@ -47,6 +48,7 @@ BUTTON_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).e
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ButtonPressTrigger),
             }
         ),
+        cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
     }
 )
 
@@ -104,6 +106,9 @@ async def register_button(var, config):
 
 async def new_button(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    if CONF_TIME_ID in config:
+        time_ = await cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time_id(time_))
     await register_button(var, config)
     return var
 

--- a/esphome/components/button/automation.h
+++ b/esphome/components/button/automation.h
@@ -20,7 +20,7 @@ template<typename... Ts> class PressAction : public Action<Ts...> {
 class ButtonPressTrigger : public Trigger<> {
  public:
   ButtonPressTrigger(Button *button) {
-    button->add_on_press_callback([this]() { this->trigger(); });
+    button->add_on_press_callback([this](std::string) { this->trigger(); });
   }
 };
 

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -11,10 +11,34 @@ Button::Button() : Button("") {}
 
 void Button::press() {
   ESP_LOGD(TAG, "'%s' Pressed.", this->get_name().c_str());
-  this->press_action();
-  this->press_callback_.call();
+
+  auto state = this->generate_state();
+  this->set_state(state);
 }
-void Button::add_on_press_callback(std::function<void()> &&callback) { this->press_callback_.add(std::move(callback)); }
+void Button::set_state(const std::string &state) {
+  if (state.empty()) {
+    // No state, old Home Assistant version
+    auto generated = this->generate_state();
+    this->set_state(generated);
+    return;
+  }
+
+  // Break possible endless loop when pressing the button in ESPHome changes the state
+  // in Home Assistant which in turn sends the new state to ESPHome.
+  if (this->state == state) {
+    return;
+  }
+
+  ESP_LOGD(TAG, "'%s' State: %s", this->get_name().c_str(), state.c_str());
+
+  this->state = state;
+  this->press_action();
+  this->press_callback_.call(state);
+}
+void Button::add_on_press_callback(std::function<void(std::string)> &&callback) {
+  ESP_LOGD(TAG, "add_on_press_callback");
+  this->press_callback_.add(std::move(callback));
+}
 uint32_t Button::hash_base() { return 1495763804UL; }
 
 void Button::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
@@ -22,6 +46,23 @@ std::string Button::get_device_class() {
   if (this->device_class_.has_value())
     return *this->device_class_;
   return "";
+}
+
+std::string Button::generate_state() {
+  std::string state;
+
+#ifdef USE_TIME
+  if (this->time_id_.has_value()) {
+    auto now = this->time_id_.value()->utcnow();
+    if (now.is_valid()) {
+      return now.strftime("%Y-%m-%dT%H:%M:%S");
+    } else {
+      ESP_LOGW(TAG, "Time is not valid.");
+    }
+  }
+#endif
+
+  return to_string(random_uint32());
 }
 
 }  // namespace button

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -1,8 +1,13 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
+
+#ifdef USE_TIME
+#include "esphome/components/time/real_time_clock.h"
+#endif
 
 namespace esphome {
 namespace button {
@@ -24,17 +29,22 @@ class Button : public EntityBase {
   explicit Button();
   explicit Button(const std::string &name);
 
+  /// Last time the button was pressed
+  std::string state;
+
   /** Press this button. This is called by the front-end.
    *
    * For implementing buttons, please override press_action.
    */
   void press();
 
+  void set_state(const std::string &state);
+
   /** Set callback for state changes.
    *
    * @param callback The void() callback.
    */
-  void add_on_press_callback(std::function<void()> &&callback);
+  void add_on_press_callback(std::function<void(std::string)> &&callback);
 
   /// Set the Home Assistant device class (see button::device_class).
   void set_device_class(const std::string &device_class);
@@ -42,15 +52,24 @@ class Button : public EntityBase {
   /// Get the device class for this button.
   std::string get_device_class();
 
+#ifdef USE_TIME
+  void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
+#endif
+
  protected:
   /** You should implement this virtual method if you want to create your own button.
    */
   virtual void press_action(){};
+  virtual std::string generate_state();
 
   uint32_t hash_base() override;
 
-  CallbackManager<void()> press_callback_{};
+  CallbackManager<void(std::string)> press_callback_{};
   optional<std::string> device_class_{};
+
+#ifdef USE_TIME
+  optional<time::RealTimeClock *> time_id_{};
+#endif
 };
 
 }  // namespace button

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -102,6 +102,11 @@ void WebServer::setup() {
         client->send(this->switch_json(obj, obj->state).c_str(), "state");
 #endif
 
+#ifdef USE_BUTTON
+    for (auto *obj : App.get_buttons())
+      client->send(this->button_json(obj, obj->state).c_str(), "state");
+#endif
+
 #ifdef USE_BINARY_SENSOR
     for (auto *obj : App.get_binary_sensors())
       if (this->include_internal_ || !obj->is_internal())
@@ -388,6 +393,16 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
 #endif
 
 #ifdef USE_BUTTON
+void WebServer::on_button_update(button::Button *obj, const std::string &state) {
+  this->events_.send(this->button_json(obj, state).c_str(), "state");
+}
+std::string WebServer::button_json(button::Button *obj, const std::string &value) {
+  return json::build_json([obj, value](JsonObject root) {
+    root["id"] = "button-" + obj->get_object_id();
+    root["state"] = value;
+    root["value"] = value;
+  });
+}
 void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlMatch &match) {
   for (button::Button *obj : App.get_buttons()) {
     if (obj->get_object_id() != match.id)

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -113,8 +113,13 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
 #endif
 
 #ifdef USE_BUTTON
+  void on_button_update(button::Button *obj, const std::string &state) override;
+
   /// Handle a button request under '/button/<id>/press'.
   void handle_button_request(AsyncWebServerRequest *request, const UrlMatch &match);
+
+  /// Dump the button state with its value as a JSON string.
+  std::string button_json(button::Button *obj, const std::string &value);
 #endif
 
 #ifdef USE_BINARY_SENSOR

--- a/esphome/core/controller.cpp
+++ b/esphome/core/controller.cpp
@@ -35,6 +35,12 @@ void Controller::setup_controller(bool include_internal) {
       obj->add_on_state_callback([this, obj](bool state) { this->on_switch_update(obj, state); });
   }
 #endif
+#ifdef USE_BUTTON
+  for (auto *obj : App.get_buttons()) {
+    if (include_internal || !obj->is_internal())
+      obj->add_on_press_callback([this, obj](const std::string &state) { this->on_button_update(obj, state); });
+  }
+#endif
 #ifdef USE_COVER
   for (auto *obj : App.get_covers()) {
     if (include_internal || !obj->is_internal())

--- a/esphome/core/controller.h
+++ b/esphome/core/controller.h
@@ -55,6 +55,9 @@ class Controller {
 #ifdef USE_SWITCH
   virtual void on_switch_update(switch_::Switch *obj, bool state){};
 #endif
+#ifdef USE_BUTTON
+  virtual void on_button_update(button::Button *obj, const std::string &state){};
+#endif
 #ifdef USE_COVER
   virtual void on_cover_update(cover::Cover *obj){};
 #endif


### PR DESCRIPTION
# What does this implement/fix?

With this change ESPHome button presses are send to Home Assistant. The existing behavior, that button presses in Home Assistant are send to ESPHome, is retained.

This allows me to use a Sonoff T1 touch switch and configure it's behavior in HA using automations with button presses as the trigger.
I created virtual buttons in ESPHome for single, double and long presses on the touchpad.

![image](https://user-images.githubusercontent.com/1143759/148132108-98288741-f090-43cb-af2b-85743e5db741.png)

Previously to handle double and long presses one had two possibilities:

1. Directly call a HA service to handle the press:
    ```yaml
     on_click:
       min_length: 1200ms
       max_length: 3000ms
       then:
       - homeassistant.service:
         service: homeassistant.toggle
         data:
           entity_id: '${some_homeassistant_light}'
     on_double_click:
       - homeassistant.service:
         service: homeassistant.toggle
         data:
           entity_id: '${some_other_homeassistant_light}'
    ```
   I don't like this solution as it hardcodes the entity IDs.
1. Emit an HA event with an ID specific to the deive:
   ```yaml
     on_click:
       min_length: 1200ms
       max_length: 3000ms
       then:
       - homeassistant.event:
         event: esphome.long_press
         data:
           device: '${device_name}'
     on_double_click:
       - homeassistant.event:
         event: esphome.double_press
         data:
           device: '${device_name}'
   ```
   Here the events are not really discoverable from the HA frontend.

I found both of the above solutions not optimal and with the introduction of the button entity I kinda expected this to work like implemented in this pull request. Even without this change a button added to ESPHome will appear in the device triggers. But nothing happens when one presses the button in ESPHome.

What this pull request does:

* Add an `ButtonStateResponse` to the native API and send it every time a button is pressed.
* Add a state to the `Button` component that should store the timestamp of the last press (like HA).
* Because by default an ESPHome device doesn't know the time, make it possible to specify a `time_id` for buttons.

This is more of a RFC. I'm pretty sure there are things that should be done better. It's also quite possible that I misunderstood the whole button thing and my solution is more of a hack.

To quote the [HA developer page](https://developers.home-assistant.io/docs/core/entity/button/)
> A button entity is an entity that can fire an event / trigger an action towards a device or service but remains stateless from the Home Assistant perspective.
> [...]
>  If you want to integrate a real, physical, stateless button device in Home Assistant, you can do so by firing custom events. The entity button entity isn't suitable for these cases.

So comments welcome :).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

No pull requests yet. But related branches/commits to make it work in HA.

- [aioesphomeapi](https://github.com/thoemy/aioesphomeapi/tree/button-state) 
- [home-assistant/core](https://github.com/thoemy/home-assistant-core/tree/esphome-button-state) 

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] Sonoff T1

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
globals:
   - id: switch_state
     type: bool
     restore_value: no
     initial_value: "false"

time:
  - platform: homeassistant
    id: homeassistant_time
    on_time_sync:
      then:
      - logger.log: "Synchronized system clock"

binary_sensor:
  - platform: template
    name: "Touchpad 1"
    on_click:
      - then:
        - button.press: button_1
        - if:
            condition:
              not:
                api.connected:
            then:
              # Homeassistant unavailable, toggle hardware switch
              - switch.toggle: switch_1
      - min_length: 1200ms
        max_length: 3000ms
        then:
        - button.press: button_1_long
    on_double_click:
      then:
        - button.press: button_1_double

switch:
  - platform: template
    name: "Switch 1"
    id: switch_1
    lambda: |-
      return id(switch_state);
    turn_on_action:
      - lambda: id(switch_state) = true;
      - logger.log: "Switched on"
    turn_off_action:
      - lambda: id(switch_state) = false;
      - logger.log: "Switched off"

button:
  - platform: template
    id: button_1
    name: Button 1
    time_id: homeassistant_time
  - platform: template
    id: button_1_long
    name: Button 1 long press
  - platform: template
    id: button_1_double
    name: Button 1 double press
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
