### PR TITLE
slow_pwm: allow to restart a cycle on state change

### DIFF
--- a/esphome/components/slow_pwm/output.py
+++ b/esphome/components/slow_pwm/output.py
@@ -15,6 +15,7 @@ slow_pwm_ns = cg.esphome_ns.namespace("slow_pwm")
 SlowPWMOutput = slow_pwm_ns.class_("SlowPWMOutput", output.FloatOutput, cg.Component)
 
 CONF_STATE_CHANGE_ACTION = "state_change_action"
+CONF_RESTART_CYCLE_ON_STATE_CHANGE = "restart_cycle_on_state_change"
 
 CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
@@ -37,6 +38,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
             cv.positive_time_period_milliseconds,
             cv.Range(min=core.TimePeriod(milliseconds=100)),
         ),
+        cv.Optional(CONF_RESTART_CYCLE_ON_STATE_CHANGE, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -63,3 +65,8 @@ async def to_code(config):
         )
 
     cg.add(var.set_period(config[CONF_PERIOD]))
+    cg.add(
+        var.set_restart_cycle_on_state_change(
+            config[CONF_RESTART_CYCLE_ON_STATE_CHANGE]
+        )
+    )

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -18,6 +18,12 @@ void SlowPWMOutput::set_output_state_(bool new_state) {
     this->pin_->digital_write(new_state);
   }
   if (new_state != current_state_) {
+    if (this->pin_) {
+      ESP_LOGV(TAG, "Switching output pin %s to %s", this->pin_->dump_summary().c_str(), ONOFF(new_state));
+    } else {
+      ESP_LOGV(TAG, "Switching to %s", ONOFF(new_state));
+    }
+
     if (this->state_change_trigger_) {
       this->state_change_trigger_->trigger(new_state);
     }
@@ -29,10 +35,6 @@ void SlowPWMOutput::set_output_state_(bool new_state) {
         this->turn_off_trigger_->trigger();
     }
     current_state_ = new_state;
-    if (this->pin_)
-      ESP_LOGD(TAG, "Switching output pin %s to %s", this->pin_->dump_summary().c_str(), ONOFF(new_state));
-    else
-      ESP_LOGD(TAG, "Switching to %s", ONOFF(new_state));
   }
 }
 
@@ -58,7 +60,7 @@ void SlowPWMOutput::dump_config() {
   if (this->turn_off_trigger_)
     ESP_LOGCONFIG(TAG, "  Turn off automation configured");
   ESP_LOGCONFIG(TAG, "  Period: %d ms", this->period_);
-  ESP_LOGCONFIG(TAG, "  Restart a cycle on state change: %s", YESNO(this->restart_cycle_on_state_change_));
+  ESP_LOGCONFIG(TAG, "  Restart cycle on state change: %s", YESNO(this->restart_cycle_on_state_change_));
   LOG_FLOAT_OUTPUT(this);
 }
 

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -11,6 +11,10 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
  public:
   void set_pin(GPIOPin *pin) { pin_ = pin; };
   void set_period(unsigned int period) { period_ = period; };
+  void set_restart_cycle_on_state_change(bool restart_cycle_on_state_change) {
+    restart_cycle_on_state_change_ = restart_cycle_on_state_change;
+  }
+
   /// Initialize pin
   void setup() override;
   void dump_config() override;
@@ -37,7 +41,7 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
 
  protected:
   void loop() override;
-  void write_state(float state) override { state_ = state; }
+  void write_state(float state) override;
   /// turn on/off the configured output
   void set_output_state_(bool state);
 
@@ -49,6 +53,7 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
   bool current_state_{false};
   unsigned int period_start_time_{0};
   unsigned int period_;
+  bool restart_cycle_on_state_change_;
 };
 
 }  // namespace slow_pwm

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -48,7 +48,7 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
   float state_{0};
   bool current_state_{false};
   unsigned int period_start_time_{0};
-  unsigned int period_{5000};
+  unsigned int period_;
 };
 
 }  // namespace slow_pwm

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1144,6 +1144,7 @@ output:
     pin: GPIO5
     id: my_slow_pwm
     period: 15s
+    restart_cycle_on_state_change: false
   - platform: sm2135
     id: sm2135_0
     channel: 0


### PR DESCRIPTION
# What does this implement/fix? 

I'm trying to leverage slow_pwm to control my underfloor heating actuators (to periodically heat up the floor not to let it to freeze too much when cooking in the room - thermometer goes high up at that moment, for example), but because the period is long (>20 minutes), I'd like to disable the actuator for the last several minutes of those 20 minutes, not at quite random (compared to the switching time) moments of time.

So, here's the option to reset a cycle start time when a new value is written to slow_pwm :)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1774

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: slow_pwm
    pin: GPIO5
    id: my_slow_pwm
    period: 15s
    restart_cycle_on_state_change: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
