### PR TITLE
Offset bugfix in Modbus Text Sensor

### DIFF
--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -14,18 +14,18 @@ void ModbusTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Modbus Controller Te
 void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
   std::ostringstream output;
   uint8_t max_items = this->response_bytes;
+  uint8_t index = this->offset;
   char buffer[4];
-  bool add_comma = false;
-  for (auto b : data) {
+  while ((max_items != 0) && index < data.size()) {
+    uint8_t b = data[index];
     switch (this->encode_) {
       case RawEncoding::HEXBYTES:
         sprintf(buffer, "%02x", b);
         output << buffer;
         break;
       case RawEncoding::COMMA:
-        sprintf(buffer, add_comma ? ",%d" : "%d", b);
+        sprintf(buffer, index != this->offset ? ",%d" : "%d", b);
         output << buffer;
-        add_comma = true;
         break;
       // Anything else no encoding
       case RawEncoding::NONE:
@@ -33,9 +33,8 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
         output << (char) b;
         break;
     }
-    if (--max_items == 0) {
-      break;
-    }
+
+    index++;
   }
 
   auto result = output.str();


### PR DESCRIPTION
# What does this implement/fix? 

The Modbus Text Sensor has not been taken the offset into account.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

The text sensor is the third sensor in range and has the offset +4. But displayed are values from the first sensor.

```yaml
uart:
  id: uart_modbus
  baud_rate: 9600
  rx_pin: GPIO16
  tx_pin: GPIO17

modbus:
  id: modbus1

modbus_controller:
  - id: modbus_device
    modbus_id: modbus1
    address: 0x01
    update_interval: 5s
    setup_priority: -10

sensor:
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: reg_1000
    register_type: holding
    address: 1000
    value_type: U_WORD
    name: Register 1000
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: reg_1001
    register_type: holding
    address: 1001
    value_type: U_WORD
    name: Register 1001

text_sensor:
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: reg_1002_text
    register_type: holding
    address: 1002
    # raw_encode: HEXBYTES
    raw_encode: COMMA
    name: Register 1002 (Text)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
