### PR TITLE
Bump PlatformIO to 5.2.4 and zeroconf to 0.37.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --no-cache-dir \
         wheel==0.36.2 \
-        platformio==5.2.2 \
+        platformio==5.2.4 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_libraries_interval 1000000 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,12 @@ tornado==6.1
 tzlocal==4.1    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
-platformio==5.2.2  # When updating platformio, also update Dockerfile
+platformio==5.2.4  # When updating platformio, also update Dockerfile
 esptool==3.2
 click==8.0.3
 esphome-dashboard==20211211.0
 aioesphomeapi==10.6.0
-zeroconf==0.36.13
+zeroconf==0.37.0
 
 # esp-idf requires this, but doesn't bundle it by default
 # https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24


### PR DESCRIPTION
# What does this implement/fix? 

Bump PlatformIO to 5.2.4 and zeroconf to 0.37.0, as they're coupled.

Supersedes #2951, #2919, #2796.