### PR TITLE
Drop uint{32,64}_to_string() helper functions

### DIFF
--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -38,10 +38,9 @@ void DallasComponent::setup() {
   raw_sensors = this->one_wire_->search_vec();
 
   for (auto &address : raw_sensors) {
-    std::string s = uint64_to_string(address);
     auto *address8 = reinterpret_cast<uint8_t *>(&address);
     if (crc8(address8, 7) != address8[7]) {
-      ESP_LOGW(TAG, "Dallas device 0x%s has invalid CRC.", s.c_str());
+      ESP_LOGW(TAG, "Dallas device 0x%s has invalid CRC.", format_hex(address).c_str());
       continue;
     }
     if (address8[0] != DALLAS_MODEL_DS18S20 && address8[0] != DALLAS_MODEL_DS1822 &&
@@ -77,8 +76,7 @@ void DallasComponent::dump_config() {
   } else {
     ESP_LOGD(TAG, "  Found sensors:");
     for (auto &address : this->found_sensors_) {
-      std::string s = uint64_to_string(address);
-      ESP_LOGD(TAG, "    0x%s", s.c_str());
+      ESP_LOGD(TAG, "    0x%s", format_hex(address).c_str());
     }
   }
 
@@ -147,7 +145,7 @@ void DallasTemperatureSensor::set_index(uint8_t index) { this->index_ = index; }
 uint8_t *DallasTemperatureSensor::get_address8() { return reinterpret_cast<uint8_t *>(&this->address_); }
 const std::string &DallasTemperatureSensor::get_address_name() {
   if (this->address_name_.empty()) {
-    this->address_name_ = std::string("0x") + uint64_to_string(this->address_);
+    this->address_name_ = std::string("0x") + format_hex(this->address_);
   }
 
   return this->address_name_;
@@ -237,7 +235,7 @@ float DallasTemperatureSensor::get_temp_c() {
 
   return temp / 128.0f;
 }
-std::string DallasTemperatureSensor::unique_id() { return "dallas-" + uint64_to_string(this->address_); }
+std::string DallasTemperatureSensor::unique_id() { return "dallas-" + str_upper_case(format_hex(this->address_)); }
 
 }  // namespace dallas
 }  // namespace esphome

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -101,7 +101,7 @@ void DebugComponent::dump_config() {
     info.features &= ~CHIP_FEATURE_BT;
   }
   if (info.features)
-    features += "Other:" + uint64_to_string(info.features);
+    features += "Other:" + format_hex(info.features);
   ESP_LOGD(TAG, "Chip: Model=%s, Features=%s Cores=%u, Revision=%u", model, features.c_str(), info.cores,
            info.revision);
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/defines.h"
 #include <cstdio>
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 
@@ -361,6 +362,16 @@ std::string str_until(const char *str, char ch) {
   return pos == nullptr ? std::string(str) : std::string(str, pos - str);
 }
 std::string str_until(const std::string &str, char ch) { return str.substr(0, str.find(ch)); }
+// wrapper around std::transform to run safely on functions from the ctype.h header
+// see https://en.cppreference.com/w/cpp/string/byte/toupper#Notes
+template<int (*fn)(int)> std::string str_ctype_transform(const std::string &str) {
+  std::string result;
+  result.resize(str.length());
+  std::transform(str.begin(), str.end(), result.begin(), [](unsigned char ch) { return fn(ch); });
+  return result;
+}
+std::string str_lower_case(const std::string &str) { return str_ctype_transform<std::toupper>(str); }
+std::string str_upper_case(const std::string &str) { return str_ctype_transform<std::tolower>(str); }
 std::string str_snake_case(const std::string &str) {
   std::string result;
   result.resize(str.length());

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -130,18 +130,6 @@ std::string value_accuracy_to_string(float value, int8_t accuracy_decimals) {
   snprintf(tmp, sizeof(tmp), "%.*f", accuracy_decimals, value);
   return std::string(tmp);
 }
-std::string uint64_to_string(uint64_t num) {
-  char buffer[17];
-  auto *address16 = reinterpret_cast<uint16_t *>(&num);
-  snprintf(buffer, sizeof(buffer), "%04X%04X%04X%04X", address16[3], address16[2], address16[1], address16[0]);
-  return std::string(buffer);
-}
-std::string uint32_to_string(uint32_t num) {
-  char buffer[9];
-  auto *address16 = reinterpret_cast<uint16_t *>(&num);
-  snprintf(buffer, sizeof(buffer), "%04X%04X", address16[1], address16[0]);
-  return std::string(buffer);
-}
 
 ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
   if (on == nullptr && strcasecmp(str, "on") == 0)

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -114,12 +114,6 @@ float gamma_uncorrect(float value, float gamma);
 /// Create a string from a value and an accuracy in decimals.
 std::string value_accuracy_to_string(float value, int8_t accuracy_decimals);
 
-/// Convert a uint64_t to a hex string
-std::string uint64_to_string(uint64_t num);
-
-/// Convert a uint32_t to a hex string
-std::string uint32_to_string(uint32_t num);
-
 uint8_t reverse_bits_8(uint8_t x);
 uint16_t reverse_bits_16(uint16_t x);
 uint32_t reverse_bits_32(uint32_t x);

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -369,6 +369,10 @@ std::string str_until(const char *str, char ch);
 /// Extract the part of the string until either the first occurence of the specified character, or the end.
 std::string str_until(const std::string &str, char ch);
 
+/// Convert the string to lower case.
+std::string str_lower_case(const std::string &str);
+/// Convert the string to upper case.
+std::string str_upper_case(const std::string &str);
 /// Convert the string to snake case (lowercase with underscores).
 std::string str_snake_case(const std::string &str);
 


### PR DESCRIPTION
# What does this implement/fix? 

Apparently I forgot these in #2882, `format_hex` should be used in their place. Includes #3008.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
