### PR TITLE
Convert clamp() helper to backport of std::clamp()

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -230,17 +230,6 @@ void HighFrequencyLoopRequester::stop() {
 }
 bool HighFrequencyLoopRequester::is_high_frequency() { return high_freq_num_requests > 0; }
 
-template<typename T> T clamp(const T val, const T min, const T max) {
-  if (val < min)
-    return min;
-  if (val > max)
-    return max;
-  return val;
-}
-template uint8_t clamp(uint8_t, uint8_t, uint8_t);
-template float clamp(float, float, float);
-template int clamp(int, int, int);
-
 float lerp(float completion, float start, float end) { return start + (end - start) * completion; }
 
 bool str_startswith(const std::string &full, const std::string &start) { return full.rfind(start, 0) == 0; }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -58,15 +58,6 @@ class HighFrequencyLoopRequester {
   bool started_{false};
 };
 
-/** Clamp the value between min and max.
- *
- * @param val The value.
- * @param min The minimum value.
- * @param max The maximum value.
- * @return val clamped in between min and max.
- */
-template<typename T> T clamp(T val, T min, T max);
-
 /** Linearly interpolate between end start and end by completion.
  *
  * @tparam T The input/output typename.
@@ -279,6 +270,18 @@ using std::is_trivially_copyable;
 // other variants that use a newer compiler anyway.
 // NOLINTNEXTLINE(readability-identifier-naming)
 template<typename T> struct is_trivially_copyable : public std::integral_constant<bool, true> {};
+#endif
+
+// std::clamp from C++17
+#if __cpp_lib_clamp >= 201603
+using std::clamp;
+#else
+template<typename T, typename Compare> constexpr const T &clamp(const T &v, const T &lo, const T &hi, Compare comp) {
+  return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
+}
+template<typename T> constexpr const T &clamp(const T &v, const T &lo, const T &hi) {
+  return clamp(v, lo, hi, std::less<T>{});
+}
 #endif
 
 // std::bit_cast from C++20


### PR DESCRIPTION
# What does this implement/fix? 

Now also available for other types than float, int and uint8_t.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
