### PR TITLE
Add device class support to Switch

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -525,6 +525,7 @@ message ListEntitiesSwitchResponse {
   bool assumed_state = 6;
   bool disabled_by_default = 7;
   EntityCategory entity_category = 8;
+  string device_class = 9;
 }
 message SwitchStateResponse {
   option (id) = 26;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -461,6 +461,7 @@ bool APIConnection::send_switch_info(switch_::Switch *a_switch) {
   msg.assumed_state = a_switch->assumed_state();
   msg.disabled_by_default = a_switch->is_disabled_by_default();
   msg.entity_category = static_cast<enums::EntityCategory>(a_switch->get_entity_category());
+  msg.device_class = sensor->get_device_class();
   return this->send_list_entities_switch_response(msg);
 }
 void APIConnection::switch_command(const SwitchCommandRequest &msg) {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -461,7 +461,7 @@ bool APIConnection::send_switch_info(switch_::Switch *a_switch) {
   msg.assumed_state = a_switch->assumed_state();
   msg.disabled_by_default = a_switch->is_disabled_by_default();
   msg.entity_category = static_cast<enums::EntityCategory>(a_switch->get_entity_category());
-  msg.device_class = sensor->get_device_class();
+  msg.device_class = a_switch->get_device_class();
   return this->send_list_entities_switch_response(msg);
 }
 void APIConnection::switch_command(const SwitchCommandRequest &msg) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2138,6 +2138,10 @@ bool ListEntitiesSwitchResponse::decode_length(uint32_t field_id, ProtoLengthDel
       this->icon = value.as_string();
       return true;
     }
+    case 9: {
+      this->device_class = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -2161,6 +2165,7 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(6, this->assumed_state);
   buffer.encode_bool(7, this->disabled_by_default);
   buffer.encode_enum<enums::EntityCategory>(8, this->entity_category);
+  buffer.encode_string(9, this->device_class);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
@@ -2197,6 +2202,10 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
 
   out.append("  entity_category: ");
   out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
   out.append("\n");
   out.append("}");
 }
@@ -4239,7 +4248,7 @@ void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesButtonResponse::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesButtonResponse {\n");
   out.append("  object_id: ");
   out.append("'").append(this->object_id).append("'");
@@ -4289,7 +4298,7 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->key); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ButtonCommandRequest::dump_to(std::string &out) const {
-  char buffer[64];
+  __attribute__((unused)) char buffer[64];
   out.append("ButtonCommandRequest {\n");
   out.append("  key: ");
   sprintf(buffer, "%u", this->key);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -566,6 +566,7 @@ class ListEntitiesSwitchResponse : public ProtoMessage {
   bool assumed_state{false};
   bool disabled_by_default{false};
   enums::EntityCategory entity_category{};
+  std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -4,18 +4,27 @@ from esphome import automation
 from esphome.automation import Condition, maybe_simple_id
 from esphome.components import mqtt
 from esphome.const import (
+    CONF_DEVICE_CLASS,
     CONF_ID,
     CONF_INVERTED,
+    CONF_MQTT_ID,
     CONF_ON_TURN_OFF,
     CONF_ON_TURN_ON,
     CONF_TRIGGER_ID,
-    CONF_MQTT_ID,
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_OUTLET,
+    DEVICE_CLASS_SWITCH,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.cpp_helpers import setup_entity
 
 CODEOWNERS = ["@esphome/core"]
 IS_PLATFORM_COMPONENT = True
+DEVICE_CLASSES = [
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_OUTLET,
+    DEVICE_CLASS_SWITCH,
+]
 
 switch_ns = cg.esphome_ns.namespace("switch_")
 Switch = switch_ns.class_("Switch", cg.EntityBase)
@@ -51,6 +60,7 @@ SWITCH_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).e
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SwitchTurnOffTrigger),
             }
         ),
+        cv.Optional(CONF_DEVICE_CLASS): cv.one_of(*DEVICE_CLASSES, lower=True),
     }
 )
 
@@ -70,6 +80,9 @@ async def setup_switch_core_(var, config):
     if CONF_MQTT_ID in config:
         mqtt_ = cg.new_Pvariable(config[CONF_MQTT_ID], var)
         await mqtt.register_mqtt_component(mqtt_, config)
+
+    if CONF_DEVICE_CLASS in config:
+        cg.add(var.set_device_class(config[CONF_DEVICE_CLASS]))
 
 
 async def register_switch(var, config):

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -46,5 +46,13 @@ void Switch::set_inverted(bool inverted) { this->inverted_ = inverted; }
 uint32_t Switch::hash_base() { return 3129890955UL; }
 bool Switch::is_inverted() const { return this->inverted_; }
 
+std::string Switch::get_device_class() {
+  if (this->device_class_.has_value())
+    return *this->device_class_;
+  return this->device_class();
+}
+void Switch::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
+std::string Switch::device_class() { return ""; }
+
 }  // namespace switch_
 }  // namespace esphome

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -49,10 +49,9 @@ bool Switch::is_inverted() const { return this->inverted_; }
 std::string Switch::get_device_class() {
   if (this->device_class_.has_value())
     return *this->device_class_;
-  return this->device_class();
+  return "";
 }
 void Switch::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
-std::string Switch::device_class() { return ""; }
 
 }  // namespace switch_
 }  // namespace esphome

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -20,6 +20,9 @@ namespace switch_ {
     if ((obj)->is_inverted()) { \
       ESP_LOGCONFIG(TAG, "%s  Inverted: YES", prefix); \
     } \
+    if (!(obj)->get_device_class().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
+    } \
   }
 
 /** Base class for all switches.
@@ -88,6 +91,11 @@ class Switch : public EntityBase {
 
   bool is_inverted() const;
 
+  /// Get the device class, using the manual override if set.
+  std::string get_device_class();
+  /// Manually set the device class.
+  void set_device_class(const std::string &device_class);
+
  protected:
   /** Write the given state to hardware. You should implement this
    * abstract method if you want to create your own switch.
@@ -99,12 +107,16 @@ class Switch : public EntityBase {
    */
   virtual void write_state(bool state) = 0;
 
+  /// Override this to set the default device class.
+  virtual std::string device_class();  // NOLINT
+
   uint32_t hash_base() override;
 
   CallbackManager<void(bool)> state_callback_{};
   bool inverted_{false};
   Deduplicator<bool> publish_dedup_;
   ESPPreferenceObject rtc_;
+  optional<std::string> device_class_;
 };
 
 }  // namespace switch_

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -107,9 +107,6 @@ class Switch : public EntityBase {
    */
   virtual void write_state(bool state) = 0;
 
-  /// Override this to set the default device class.
-  virtual std::string device_class();  // NOLINT
-
   uint32_t hash_base() override;
 
   CallbackManager<void(bool)> state_callback_{};

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -91,9 +91,9 @@ class Switch : public EntityBase {
 
   bool is_inverted() const;
 
-  /// Get the device class, using the manual override if set.
+  /// Get the device class for this switch.
   std::string get_device_class();
-  /// Manually set the device class.
+  /// Set the Home Assistant device class for this switch.
   void set_device_class(const std::string &device_class);
 
  protected:

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -905,6 +905,9 @@ DEVICE_CLASS_VOLTAGE = "voltage"
 DEVICE_CLASS_UPDATE = "update"
 # device classes of button component
 DEVICE_CLASS_RESTART = "restart"
+# device classes of switch component
+DEVICE_CLASS_OUTLET = "outlet"
+DEVICE_CLASS_SWITCH = "switch"
 
 
 # state classes

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2022,6 +2022,10 @@ switch:
   - platform: template
     id: ble1_status
     optimistic: true
+  - platform: template
+    id: outlet_switch
+    optimistic: true
+    device_class: outlet
 
 fan:
   - platform: binary


### PR DESCRIPTION
# What does this implement/fix? 

Add support for setting device classes on Switches.

Currently, a rough draft.

Needs:
- [x] Release of `aioesphomeapi`, to include <https://github.com/esphome/aioesphomeapi/pull/157>
- [x] Bump of `aioesphomeapi` in this PR
- [x] Home Assistant PR: https://github.com/home-assistant/core/pull/64919
- [x] Documentation: https://github.com/esphome/esphome-docs/pull/1853
- [x] Actual testing...

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** closes esphome/feature-requests#1572

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
switch:
  - platform: template
    id: outlet_switch
    optimistic: true
    device_class: outlet
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
