### PR TITLE
Implement IPv6 sockets for lwIP

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -178,15 +178,14 @@ class LWIPRawImpl : public Socket {
       errno = EINVAL;
       return -1;
     }
-    this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, name, addrlen);
-    return 0;
+    return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, name, addrlen);
   }
   std::string getpeername() override {
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return "";
     }
-    char buffer[50];
+    char buffer[50] = {};
     if (IP_IS_V4_VAL(pcb_->remote_ip)) {
       inet_ntoa_r(pcb_->remote_ip, buffer, sizeof(buffer));
     }
@@ -206,15 +205,14 @@ class LWIPRawImpl : public Socket {
       errno = EINVAL;
       return -1;
     }
-    this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, name, addrlen);
-    return 0;
+    return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, name, addrlen);
   }
   std::string getsockname() override {
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return "";
     }
-    char buffer[50];
+    char buffer[50] = {};
     if (IP_IS_V4_VAL(pcb_->local_ip)) {
       inet_ntoa_r(pcb_->local_ip, buffer, sizeof(buffer));
     }

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -76,7 +76,7 @@ class LWIPRawImpl : public Socket {
     auto family = name->sa_family;
 #if LWIP_IPV6
     if (family == AF_INET) {
-      if (addrlen < sizeof(sockaddr_in6)) {
+      if (addrlen < sizeof(sockaddr_in)) {
         errno = EINVAL;
         return -1;
       }
@@ -84,16 +84,17 @@ class LWIPRawImpl : public Socket {
       port = ntohs(addr4->sin_port);
       ip.type = IPADDR_TYPE_V4;
       ip.u_addr.ip4.addr = addr4->sin_addr.s_addr;
-
+      LWIP_LOG("tcp_bind(%p ip=%s port=%u)", pcb_, ip4addr_ntoa(&ip.u_addr.ip4), port);
     } else if (family == AF_INET6) {
-      if (addrlen < sizeof(sockaddr_in)) {
+      if (addrlen < sizeof(sockaddr_in6)) {
         errno = EINVAL;
         return -1;
       }
       auto *addr6 = reinterpret_cast<const sockaddr_in6 *>(name);
       port = ntohs(addr6->sin6_port);
-      ip.type = IPADDR_TYPE_V6;
+      ip.type = IPADDR_TYPE_ANY;
       memcpy(&ip.u_addr.ip6.addr, &addr6->sin6_addr.un.u8_addr, 16);
+      LWIP_LOG("tcp_bind(%p ip=%s port=%u)", pcb_, ip6addr_ntoa(&ip.u_addr.ip6), port);
     } else {
       errno = EINVAL;
       return -1;
@@ -106,8 +107,8 @@ class LWIPRawImpl : public Socket {
     auto *addr4 = reinterpret_cast<const sockaddr_in *>(name);
     port = ntohs(addr4->sin_port);
     ip.addr = addr4->sin_addr.s_addr;
-#endif
     LWIP_LOG("tcp_bind(%p ip=%u port=%u)", pcb_, ip.addr, port);
+#endif
     err_t err = tcp_bind(pcb_, &ip, port);
     if (err == ERR_USE) {
       LWIP_LOG("  -> err ERR_USE");

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -73,9 +73,9 @@ class LWIPRawImpl : public Socket {
     }
     ip_addr_t ip;
     in_port_t port;
-    auto family = name->sa_family;
+    family_ = name->sa_family;
 #if LWIP_IPV6
-    if (family == AF_INET) {
+    if (family_ == AF_INET) {
       if (addrlen < sizeof(sockaddr_in)) {
         errno = EINVAL;
         return -1;
@@ -85,7 +85,7 @@ class LWIPRawImpl : public Socket {
       ip.type = IPADDR_TYPE_V4;
       ip.u_addr.ip4.addr = addr4->sin_addr.s_addr;
       LWIP_LOG("tcp_bind(%p ip=%s port=%u)", pcb_, ip4addr_ntoa(&ip.u_addr.ip4), port);
-    } else if (family == AF_INET6) {
+    } else if (family_ == AF_INET6) {
       if (addrlen < sizeof(sockaddr_in6)) {
         errno = EINVAL;
         return -1;
@@ -100,7 +100,7 @@ class LWIPRawImpl : public Socket {
       return -1;
     }
 #else
-    if (family != AF_INET) {
+    if (family_ != AF_INET) {
       errno = EINVAL;
       return -1;
     }
@@ -183,8 +183,7 @@ class LWIPRawImpl : public Socket {
       errno = EINVAL;
       return -1;
     }
-    auto family = name->sa_family;
-    if (family == AF_INET) {
+    if (family_ == AF_INET) {
       struct sockaddr_in *addr = reinterpret_cast<struct sockaddr_in *>(name);
       addr->sin_family = AF_INET;
       *addrlen = addr->sin_len = sizeof(struct sockaddr_in);
@@ -192,7 +191,7 @@ class LWIPRawImpl : public Socket {
       inet_addr_from_ip4addr(&addr->sin_addr, ip_2_ip4(&pcb_->remote_ip));
     }
 #if LWIP_IPV6
-    else if (family == AF_INET6) {
+    else if (family_ == AF_INET6) {
       struct sockaddr_in6 *addr = reinterpret_cast<struct sockaddr_in6 *>(name);
       addr->sin6_family = AF_INET6;
       *addrlen = addr->sin6_len = sizeof(struct sockaddr_in6);
@@ -231,8 +230,7 @@ class LWIPRawImpl : public Socket {
       errno = EINVAL;
       return -1;
     }
-    auto family = name->sa_family;
-    if (family == AF_INET) {
+    if (family_ == AF_INET) {
       struct sockaddr_in *addr = reinterpret_cast<struct sockaddr_in *>(name);
       addr->sin_family = AF_INET;
       *addrlen = addr->sin_len = sizeof(struct sockaddr_in);
@@ -240,7 +238,7 @@ class LWIPRawImpl : public Socket {
       inet_addr_from_ip4addr(&addr->sin_addr, ip_2_ip4(&pcb_->local_ip));
     }
 #if LWIP_IPV6
-    else if (family == AF_INET6) {
+    else if (family_ == AF_INET6) {
       struct sockaddr_in6 *addr = reinterpret_cast<struct sockaddr_in6 *>(name);
       addr->sin6_family = AF_INET6;
       *addrlen = addr->sin6_len = sizeof(struct sockaddr_in6);
@@ -592,6 +590,7 @@ class LWIPRawImpl : public Socket {
   // don't use lwip nodelay flag, it sometimes causes reconnect
   // instead use it for determining whether to call lwip_output
   bool nodelay_ = false;
+  sa_family_t family_ = 0;
 };
 
 std::unique_ptr<Socket> socket(int domain, int type, int protocol) {


### PR DESCRIPTION
# What does this implement/fix? 
- Implements IPv6 sockets in lwip_raw_tcp_impl that is used on ESP8266. This does not enable IPv6, that would be another PR.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
