### PR TITLE
Fix display picture for nextion display

### DIFF
--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -171,7 +171,7 @@ void Nextion::set_component_coordinates(const char *component, int x, int y) {
 
 // Drawing
 void Nextion::display_picture(int picture_id, int x_start, int y_start) {
-  this->add_no_result_to_queue_with_printf_("display_picture", "pic %d %d %d", x_start, y_start, picture_id);
+  this->add_no_result_to_queue_with_printf_("display_picture", "pic %d, %d, %d", x_start, y_start, picture_id);
 }
 
 void Nextion::fill_area(int x1, int y1, int width, int height, const char *color) {


### PR DESCRIPTION
# What does this implement/fix? 

When using `display_picture` I get 
```
[09:16:10][W][nextion:405]: Nextion reported parameter quantity invalid!
```

Looking at the code it invokes:
```
  this->add_no_result_to_queue_with_printf_("display_picture", "pic %d %d %d", x_start, y_start, picture_id);
```

According to Nextion Instruction set reference: [Nextion instruction set]( https://nextion.tech/instruction-set/ ) values should be comma separated:
`usage: pic <x>,<y>,<picid>`


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: nextion
    id: dsp_nxt
    uart_id: uart_nxt
    lambda: |-
      it.display_picture(10, 10, 0);

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
