### PR TITLE
[Modbus_controller] Fix binary sensor lambda

### DIFF
--- a/esphome/components/modbus_controller/binary_sensor/__init__.py
+++ b/esphome/components/modbus_controller/binary_sensor/__init__.py
@@ -57,4 +57,4 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_MODBUS_CONTROLLER_ID])
     cg.add(paren.add_sensor_item(var))
-    await add_modbus_base_properties(var, config, ModbusBinarySensor, cg.float_, bool)
+    await add_modbus_base_properties(var, config, ModbusBinarySensor, bool, bool)

--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
@@ -31,12 +31,11 @@ class ModbusBinarySensor : public Component, public binary_sensor::BinarySensor,
 
   void dump_config() override;
 
-  using transform_func_t =
-      optional<std::function<optional<bool>(ModbusBinarySensor *, bool, const std::vector<uint8_t> &)>>;
+  using transform_func_t = std::function<optional<bool>(ModbusBinarySensor *, bool, const std::vector<uint8_t> &)>;
   void set_template(transform_func_t &&f) { this->transform_func_ = f; }
 
  protected:
-  transform_func_t transform_func_{nullopt};
+  optional<transform_func_t> transform_func_{nullopt};
 };
 
 }  // namespace modbus_controller


### PR DESCRIPTION
# What does this implement/fix? 

Fixing argument types for binary sensor lambda

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2922


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
binary_sensor:
  - platform: modbus_controller
    modbus_controller_id: relayboard1
    id: window_1
    name: "Window 1"
    device_class: window
    register_type: holding
    address: 0x82
    lambda: "return !x;"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
