### PR TITLE
 Clean-up random helper functions 

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -721,7 +721,7 @@ APIError APINoiseFrameHelper::shutdown(int how) {
 }
 extern "C" {
 // declare how noise generates random bytes (here with a good HWRNG based on the RF system)
-void noise_rand_bytes(void *output, size_t len) { esphome::fill_random(reinterpret_cast<uint8_t *>(output), len); }
+void noise_rand_bytes(void *output, size_t len) { esphome::random_bytes(reinterpret_cast<uint8_t *>(output), len); }
 }
 #endif  // USE_API_NOISE
 

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -331,9 +331,10 @@ class AddressableFlickerEffect : public AddressableLightEffect {
       return;
 
     this->last_update_ = now;
-    fast_random_set_seed(random_uint32());
+    uint32_t rng_state = random_uint32();
     for (auto var : it) {
-      const uint8_t flicker = fast_random_8() % intensity;
+      rng_state = (rng_state * 0x9E3779B9) + 0x9E37;
+      const uint8_t flicker = (rng_state & 0xFF) % intensity;
       // scale down by random factor
       var = var.get() * (255 - flicker);
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -87,22 +87,6 @@ void fill_random(uint8_t *data, size_t len) {
 #endif
 }
 
-static uint32_t fast_random_seed = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-void fast_random_set_seed(uint32_t seed) { fast_random_seed = seed; }
-uint32_t fast_random_32() {
-  fast_random_seed = (fast_random_seed * 2654435769ULL) + 40503ULL;
-  return fast_random_seed;
-}
-uint16_t fast_random_16() {
-  uint32_t rand32 = fast_random_32();
-  return (rand32 & 0xFFFF) + (rand32 >> 16);
-}
-uint8_t fast_random_8() {
-  uint32_t rand32 = fast_random_32();
-  return (rand32 & 0xFF) + ((rand32 >> 8) & 0xFF);
-}
-
 float gamma_correct(float value, float gamma) {
   if (value <= 0.0f)
     return 0.0f;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -286,9 +286,7 @@ uint32_t random_uint32() {
 #error "No random source available for this configuration."
 #endif
 }
-float random_float() {
-  return static_cast<float>(random_uint32()) / static_cast<float>(UINT32_MAX);
-}
+float random_float() { return static_cast<float>(random_uint32()) / static_cast<float>(UINT32_MAX); }
 void random_bytes(uint8_t *data, size_t len) {
 #ifdef USE_ESP32
   esp_fill_random(data, len);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -64,29 +64,6 @@ void set_mac_address(uint8_t *mac) { esp_base_mac_addr_set(mac); }
 
 std::string generate_hostname(const std::string &base) { return base + std::string("-") + get_mac_address(); }
 
-uint32_t random_uint32() {
-#ifdef USE_ESP32
-  return esp_random();
-#elif defined(USE_ESP8266)
-  return os_random();
-#endif
-}
-
-double random_double() { return random_uint32() / double(UINT32_MAX); }
-
-float random_float() { return float(random_double()); }
-
-void fill_random(uint8_t *data, size_t len) {
-#if defined(USE_ESP_IDF) || defined(USE_ESP32_FRAMEWORK_ARDUINO)
-  esp_fill_random(data, len);
-#elif defined(USE_ESP8266)
-  int err = os_get_random(data, len);
-  assert(err == 0);
-#else
-#error "No random source for this system config"
-#endif
-}
-
 float gamma_correct(float value, float gamma) {
   if (value <= 0.0f)
     return 0.0f;
@@ -297,6 +274,32 @@ IRAM_ATTR InterruptLock::~InterruptLock() { portENABLE_INTERRUPTS(); }
 #endif
 
 // ---------------------------------------------------------------------------------------------------------------------
+
+// Mathematics
+
+uint32_t random_uint32() {
+#ifdef USE_ESP32
+  return esp_random();
+#elif defined(USE_ESP8266)
+  return os_random();
+#else
+#error "No random source available for this configuration."
+#endif
+}
+float random_float() {
+  return static_cast<float>(random_uint32()) / static_cast<float>(UINT32_MAX);
+}
+void random_bytes(uint8_t *data, size_t len) {
+#ifdef USE_ESP32
+  esp_fill_random(data, len);
+#elif defined(USE_ESP8266)
+  if (os_get_random(data, len) != 0) {
+    ESP_LOGE(TAG, "Failed to generate random bytes!");
+  }
+#else
+#error "No random source available for this configuration."
+#endif
+}
 
 // Strings
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -78,20 +78,6 @@ template<typename T, typename... Args> std::unique_ptr<T> make_unique(Args &&...
 }
 #endif
 
-/// Return a random 32 bit unsigned integer.
-uint32_t random_uint32();
-
-/** Returns a random double between 0 and 1.
- *
- * Note: This function probably doesn't provide a truly uniform distribution.
- */
-double random_double();
-
-/// Returns a random float between 0 and 1. Essentially just casts random_double() to a float.
-float random_float();
-
-void fill_random(uint8_t *data, size_t len);
-
 /// Applies gamma correction with the provided gamma to value.
 float gamma_correct(float value, float gamma);
 /// Reverts gamma correction with the provided gamma to value.
@@ -290,6 +276,18 @@ constexpr uint8_t byteswap(uint8_t n) { return n; }
 constexpr uint16_t byteswap(uint16_t n) { return __builtin_bswap16(n); }
 constexpr uint32_t byteswap(uint32_t n) { return __builtin_bswap32(n); }
 constexpr uint64_t byteswap(uint64_t n) { return __builtin_bswap64(n); }
+
+///@}
+
+/// @name Mathematics
+///@{
+
+/// Return a random 32-bit unsigned integer.
+uint32_t random_uint32();
+/// Return a random float between 0 and 1.
+float random_float();
+/// Generate \p len number of random bytes.
+void random_bytes(uint8_t *data, size_t len);
 
 ///@}
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -92,11 +92,6 @@ float random_float();
 
 void fill_random(uint8_t *data, size_t len);
 
-void fast_random_set_seed(uint32_t seed);
-uint32_t fast_random_32();
-uint16_t fast_random_16();
-uint8_t fast_random_8();
-
 /// Applies gamma correction with the provided gamma to value.
 float gamma_correct(float value, float gamma);
 /// Reverts gamma correction with the provided gamma to value.


### PR DESCRIPTION
# What does this implement/fix? 

* Drop the fast random functions that are only used by the addressable flicker effect (where it is inlined). They don't seem very useful as the general-purpose random functions are also plenty fast, and rarely are a lot of random numbers necessary.
* Drop the (unused) random_double function.
* Rename fill_random to random_bytes for consistency, it was only used in one place.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
