### PR TITLE
Convert is_callable to a backport of std::is_invocable

### DIFF
--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -12,10 +12,10 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
  public:
   TemplatableStringValue() : TemplatableValue<std::string, X...>() {}
 
-  template<typename F, enable_if_t<!is_callable<F, X...>::value, int> = 0>
+  template<typename F, enable_if_t<!is_invocable<F, X...>::value, int> = 0>
   TemplatableStringValue(F value) : TemplatableValue<std::string, X...>(value) {}
 
-  template<typename F, enable_if_t<is_callable<F, X...>::value, int> = 0>
+  template<typename F, enable_if_t<is_invocable<F, X...>::value, int> = 0>
   TemplatableStringValue(F f)
       : TemplatableValue<std::string, X...>([f](X... x) -> std::string { return to_string(f(x...)); }) {}
 };

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -21,10 +21,10 @@ template<typename T, typename... X> class TemplatableValue {
  public:
   TemplatableValue() : type_(EMPTY) {}
 
-  template<typename F, enable_if_t<!is_callable<F, X...>::value, int> = 0>
+  template<typename F, enable_if_t<!is_invocable<F, X...>::value, int> = 0>
   TemplatableValue(F value) : type_(VALUE), value_(value) {}
 
-  template<typename F, enable_if_t<is_callable<F, X...>::value, int> = 0>
+  template<typename F, enable_if_t<is_invocable<F, X...>::value, int> = 0>
   TemplatableValue(F f) : type_(LAMBDA), f_(f) {}
 
   bool has_value() { return this->type_ != EMPTY; }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -268,7 +268,7 @@ template<typename T> constexpr const T &clamp(const T &v, const T &lo, const T &
 using std::is_invocable;
 #else
 // https://stackoverflow.com/a/37161919/8924614
-template<class T, class... Args> struct is_invocable {
+template<class T, class... Args> struct is_invocable {  // NOLINT(readability-identifier-naming)
   template<class U> static auto test(U *p) -> decltype((*p)(std::declval<Args>()...), void(), std::true_type());
   template<class U> static auto test(...) -> decltype(std::false_type());
   static constexpr auto value = decltype(test<T>(nullptr))::value;  // NOLINT

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -186,17 +186,6 @@ template<typename... Ts> class CallbackManager<void(Ts...)> {
   std::vector<std::function<void(Ts...)>> callbacks_;
 };
 
-// https://stackoverflow.com/a/37161919/8924614
-template<class T, class... Args>
-struct is_callable  // NOLINT
-{
-  template<class U> static auto test(U *p) -> decltype((*p)(std::declval<Args>()...), void(), std::true_type());
-
-  template<class U> static auto test(...) -> decltype(std::false_type());
-
-  static constexpr auto value = decltype(test<T>(nullptr))::value;  // NOLINT
-};
-
 void delay_microseconds_safe(uint32_t us);
 
 template<typename T> class Deduplicator {
@@ -272,6 +261,18 @@ template<typename T, typename Compare> constexpr const T &clamp(const T &v, cons
 template<typename T> constexpr const T &clamp(const T &v, const T &lo, const T &hi) {
   return clamp(v, lo, hi, std::less<T>{});
 }
+#endif
+
+// std::is_invocable from C++17
+#if __cpp_lib_is_invocable >= 201703
+using std::is_invocable;
+#else
+// https://stackoverflow.com/a/37161919/8924614
+template<class T, class... Args> struct is_invocable {
+  template<class U> static auto test(U *p) -> decltype((*p)(std::declval<Args>()...), void(), std::true_type());
+  template<class U> static auto test(...) -> decltype(std::false_type());
+  static constexpr auto value = decltype(test<T>(nullptr))::value;  // NOLINT
+};
 #endif
 
 // std::bit_cast from C++20


### PR DESCRIPTION
# What does this implement/fix? 

`std::is_callable` was renamed to `std::is_invocable`, so follow that rename and use the STL version where available.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
