### PR TITLE
Fix heatpumpir codegen min/max temperatures

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -109,8 +109,8 @@ def to_code(config):
     cg.add(var.set_protocol(config[CONF_PROTOCOL]))
     cg.add(var.set_horizontal_default(config[CONF_HORIZONTAL_DEFAULT]))
     cg.add(var.set_vertical_default(config[CONF_VERTICAL_DEFAULT]))
-    cg.add(var.set_max_temperature(config[CONF_MIN_TEMPERATURE]))
-    cg.add(var.set_min_temperature(config[CONF_MAX_TEMPERATURE]))
+    cg.add(var.set_max_temperature(config[CONF_MAX_TEMPERATURE]))
+    cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
 
     # PIO isn't updating releases, so referencing the release tag directly. See:
     # https://github.com/ToniA/arduino-heatpumpir/commit/0948c619d86407a4e50e8db2f3c193e0576c86fd


### PR DESCRIPTION
# What does this implement/fix? 

For min and max temps for heatpumpir the code generated in `main.cpp` the values are around the wrong way, this causes the `clamp` function to never return the target temp and pass this to the arduino heatpumpir library

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
