### PR TITLE
Keep binary components in-sync with the underlying binary output

### DIFF
--- a/esphome/components/binary/fan/binary_fan.cpp
+++ b/esphome/components/binary/fan/binary_fan.cpp
@@ -60,5 +60,41 @@ void BinaryFan::loop() {
 // when that component sets itself up.
 float BinaryFan::get_setup_priority() const { return fan_->get_setup_priority() + 1.0f; }
 
+void BinaryFan::set_output(output::BinaryOutput *output) {
+  this->output_ = output;
+
+  this->output_->add_on_state_callback([this] (bool state) {
+    auto call = this->fan_->make_call();
+    call.set_state(state);
+    call.perform();
+
+    this->next_update_ = false;
+  });
+}
+
+void BinaryFan::set_oscillating(output::BinaryOutput *oscillating) {
+  this->oscillating_ = oscillating;
+
+  this->oscillating_->add_on_state_callback([this] (bool state) {
+    auto call = this->fan_->make_call();
+    call.set_oscillating(state);
+    call.perform();
+
+    this->next_update_ = false;
+  });
+}
+
+void BinaryFan::set_direction(output::BinaryOutput *direction) {
+  this->direction_ = direction;
+
+  this->direction_->add_on_state_callback([this] (bool state) {
+    auto call = this->fan_->make_call();
+    call.set_direction(static_cast<fan::FanDirection>(state));
+    call.perform();
+
+    this->next_update_ = false;
+  });
+}
+
 }  // namespace binary
 }  // namespace esphome

--- a/esphome/components/binary/fan/binary_fan.cpp
+++ b/esphome/components/binary/fan/binary_fan.cpp
@@ -63,7 +63,7 @@ float BinaryFan::get_setup_priority() const { return fan_->get_setup_priority() 
 void BinaryFan::set_output(output::BinaryOutput *output) {
   this->output_ = output;
 
-  this->output_->add_on_state_callback([this] (bool state) {
+  this->output_->add_on_state_callback([this](bool state) {
     auto call = this->fan_->make_call();
     call.set_state(state);
     call.perform();
@@ -75,7 +75,7 @@ void BinaryFan::set_output(output::BinaryOutput *output) {
 void BinaryFan::set_oscillating(output::BinaryOutput *oscillating) {
   this->oscillating_ = oscillating;
 
-  this->oscillating_->add_on_state_callback([this] (bool state) {
+  this->oscillating_->add_on_state_callback([this](bool state) {
     auto call = this->fan_->make_call();
     call.set_oscillating(state);
     call.perform();
@@ -87,7 +87,7 @@ void BinaryFan::set_oscillating(output::BinaryOutput *oscillating) {
 void BinaryFan::set_direction(output::BinaryOutput *direction) {
   this->direction_ = direction;
 
-  this->direction_->add_on_state_callback([this] (bool state) {
+  this->direction_->add_on_state_callback([this](bool state) {
     auto call = this->fan_->make_call();
     call.set_direction(static_cast<fan::FanDirection>(state));
     call.perform();

--- a/esphome/components/binary/fan/binary_fan.h
+++ b/esphome/components/binary/fan/binary_fan.h
@@ -10,13 +10,13 @@ namespace binary {
 class BinaryFan : public Component {
  public:
   void set_fan(fan::FanState *fan) { fan_ = fan; }
-  void set_output(output::BinaryOutput *output) { output_ = output; }
+  void set_output(output::BinaryOutput *output);
   void setup() override;
   void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  void set_oscillating(output::BinaryOutput *oscillating) { this->oscillating_ = oscillating; }
-  void set_direction(output::BinaryOutput *direction) { this->direction_ = direction; }
+  void set_oscillating(output::BinaryOutput *oscillating);
+  void set_direction(output::BinaryOutput *direction);
 
  protected:
   fan::FanState *fan_;

--- a/esphome/components/binary/light/binary_light_output.h
+++ b/esphome/components/binary/light/binary_light_output.h
@@ -9,7 +9,17 @@ namespace binary {
 
 class BinaryLightOutput : public light::LightOutput {
  public:
-  void set_output(output::BinaryOutput *output) { output_ = output; }
+  void set_output(output::BinaryOutput *output) { 
+    this->output_ = output;
+
+    this->output_->add_on_state_callback([this] (bool state) {
+      this->state_callback_.call(state);
+    });
+  }
+  void add_on_state_callback(std::function<void(bool)> &&callback) {
+    this->state_callback_.add(std::move(callback));
+  }
+
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::ON_OFF});

--- a/esphome/components/binary/light/binary_light_output.h
+++ b/esphome/components/binary/light/binary_light_output.h
@@ -9,16 +9,12 @@ namespace binary {
 
 class BinaryLightOutput : public light::LightOutput {
  public:
-  void set_output(output::BinaryOutput *output) { 
+  void set_output(output::BinaryOutput *output) {
     this->output_ = output;
 
-    this->output_->add_on_state_callback([this] (bool state) {
-      this->state_callback_.call(state);
-    });
+    this->output_->add_on_state_callback([this](bool state) { this->state_callback_.call(state); });
   }
-  void add_on_state_callback(std::function<void(bool)> &&callback) {
-    this->state_callback_.add(std::move(callback));
-  }
+  void add_on_state_callback(std::function<void(bool)> &&callback) { this->state_callback_.add(std::move(callback)); }
 
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();

--- a/esphome/components/light/light_output.h
+++ b/esphome/components/light/light_output.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 #include "light_traits.h"
 #include "light_state.h"
 #include "light_transformer.h"
@@ -27,6 +28,11 @@ class LightOutput {
   /// should write the new state to hardware. Every call to write_state() is
   /// preceded by (at least) one call to update_state().
   virtual void write_state(LightState *state) = 0;
+
+  virtual void add_on_state_callback(std::function<void(bool)> &&callback) {}
+
+ protected:
+  CallbackManager<void(bool)> state_callback_{};
 };
 
 }  // namespace light

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -9,7 +9,7 @@ namespace light {
 static const char *const TAG = "light";
 
 LightState::LightState(const std::string &name, LightOutput *output) : EntityBase(name), output_(output) {
-  this->output_->add_on_state_callback([this] (bool state) {
+  this->output_->add_on_state_callback([this](bool state) {
     auto call = this->make_call();
     call.set_state(state);
     call.perform();
@@ -18,7 +18,7 @@ LightState::LightState(const std::string &name, LightOutput *output) : EntityBas
   });
 }
 LightState::LightState(LightOutput *output) : output_(output) {
-  this->output_->add_on_state_callback([this] (bool state) {
+  this->output_->add_on_state_callback([this](bool state) {
     auto call = this->make_call();
     call.set_state(state);
     call.perform();

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -8,8 +8,24 @@ namespace light {
 
 static const char *const TAG = "light";
 
-LightState::LightState(const std::string &name, LightOutput *output) : EntityBase(name), output_(output) {}
-LightState::LightState(LightOutput *output) : output_(output) {}
+LightState::LightState(const std::string &name, LightOutput *output) : EntityBase(name), output_(output) {
+  this->output_->add_on_state_callback([this] (bool state) {
+    auto call = this->make_call();
+    call.set_state(state);
+    call.perform();
+
+    this->next_write_ = false;
+  });
+}
+LightState::LightState(LightOutput *output) : output_(output) {
+  this->output_->add_on_state_callback([this] (bool state) {
+    auto call = this->make_call();
+    call.set_state(state);
+    call.perform();
+
+    this->next_write_ = false;
+  });
+}
 
 LightTraits LightState::get_traits() { return this->output_->get_traits(); }
 LightCall LightState::turn_on() { return this->make_call().set_state(true); }

--- a/esphome/components/output/binary_output.h
+++ b/esphome/components/output/binary_output.h
@@ -49,9 +49,7 @@ class BinaryOutput {
     this->state_callback_.call(this->inverted_);
   }
 
-  void add_on_state_callback(std::function<void(bool)> &&callback) {
-    this->state_callback_.add(std::move(callback));
-  }
+  void add_on_state_callback(std::function<void(bool)> &&callback) { this->state_callback_.add(std::move(callback)); }
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/esphome/components/output/binary_output.h
+++ b/esphome/components/output/binary_output.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
 
 #ifdef USE_POWER_SUPPLY
 #include "esphome/components/power_supply/power_supply.h"
@@ -36,6 +37,7 @@ class BinaryOutput {
     this->power_.request();
 #endif
     this->write_state(!this->inverted_);
+    this->state_callback_.call(!this->inverted_);
   }
 
   /// Disable this binary output.
@@ -44,6 +46,11 @@ class BinaryOutput {
     this->power_.unrequest();
 #endif
     this->write_state(this->inverted_);
+    this->state_callback_.call(this->inverted_);
+  }
+
+  void add_on_state_callback(std::function<void(bool)> &&callback) {
+    this->state_callback_.add(std::move(callback));
   }
 
   // ========== INTERNAL METHODS ==========
@@ -58,6 +65,8 @@ class BinaryOutput {
 #ifdef USE_POWER_SUPPLY
   power_supply::PowerSupplyRequester power_{};
 #endif
+
+  CallbackManager<void(bool)> state_callback_{};
 };
 
 }  // namespace output

--- a/esphome/components/output/switch/output_switch.cpp
+++ b/esphome/components/output/switch/output_switch.cpp
@@ -30,9 +30,7 @@ void OutputSwitch::write_state(bool state) {
 void OutputSwitch::set_output(BinaryOutput *output) {
   output_ = output;
 
-  output_->add_on_state_callback([this] (bool state) {
-    this->publish_state(state);
-  });
+  output_->add_on_state_callback([this](bool state) { this->publish_state(state); });
 }
 
 }  // namespace output

--- a/esphome/components/output/switch/output_switch.cpp
+++ b/esphome/components/output/switch/output_switch.cpp
@@ -27,5 +27,13 @@ void OutputSwitch::write_state(bool state) {
   this->publish_state(state);
 }
 
+void OutputSwitch::set_output(BinaryOutput *output) {
+  output_ = output;
+
+  output_->add_on_state_callback([this] (bool state) {
+    this->publish_state(state);
+  });
+}
+
 }  // namespace output
 }  // namespace esphome

--- a/esphome/components/output/switch/output_switch.h
+++ b/esphome/components/output/switch/output_switch.h
@@ -9,7 +9,7 @@ namespace output {
 
 class OutputSwitch : public switch_::Switch, public Component {
  public:
-  void set_output(BinaryOutput *output) { output_ = output; }
+  void set_output(BinaryOutput *output);
 
   void setup() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }


### PR DESCRIPTION
# What does this implement/fix? 

Currently the state of components (e.g. lights, fans and switches) is only published to the frontend when the state is changed directly. For the `binary` platform (I'm only concerned with the `binary` platform at the moment but this likely affects other platforms too), the exposed component isn't updated when the `binary` component is updated through lower level mechanisms, such as `output.turn_on` and `output.turn_off`. This change adds callbacks so that state changes can be propagated in these scenarios.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
output:
  - platform: 'gpio'
    pin: '${output1_gpio}'
    id: 'output1'

button:
  - platform: 'template'
    name: 'On'
    on_press:
      output.turn_on: 'output1'
  - platform: 'template'
    name: 'Off'
    on_press:
      output.turn_off: 'output1'

fan:
  - platform: 'binary'
    output: 'output1'
    name: 'binary'

light:
  - platform: 'binary'
    output: 'output1'
    name: 'binary'

switch:
  - platform: 'output'
    output: 'output1'
    name: 'output'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
