### PR TITLE
serialize modbus requests using a queue

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -21,9 +21,13 @@ void Modbus::loop() {
   }
   // stop blocking new send commands after send_wait_time_ ms regardless if a response has been received since then
   if (now - this->last_send_ > send_wait_time_) {
-    waiting_for_response = 0;
+    waiting_for_response = false;
   }
-
+  if (!waiting_for_response && !request_queue_.empty()) {
+    auto &request = request_queue_.front();
+    this->send_raw(request, true);
+    request_queue_.pop();
+  }
   while (this->available()) {
     uint8_t byte;
     this->read_byte(&byte);
@@ -52,6 +56,16 @@ uint16_t crc16(const uint8_t *data, uint8_t len) {
 }
 
 bool Modbus::parse_modbus_byte_(uint8_t byte) {
+// give an option to disable for backward compability
+#ifndef MODBUS_DONT_DROP_WHEN_IDLE
+  // Dump stray bytes from uart
+  // Since modbus devices don't send data without a request
+  // this shouldn't happen in theory but helps remove sproadic transmission errors
+  if (!waiting_for_response) {
+    ESP_LOGW(TAG, "Modbus received unexpected Byte %d (0X%x) discarding it", byte, byte);
+    return false;
+  }
+#endif
   size_t at = this->rx_buffer_.size();
   this->rx_buffer_.push_back(byte);
   const uint8_t *raw = &this->rx_buffer_[0];
@@ -97,30 +111,12 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     return false;
   }
   std::vector<uint8_t> data(this->rx_buffer_.begin() + data_offset, this->rx_buffer_.begin() + data_offset + data_len);
-  bool found = false;
-  for (auto *device : this->devices_) {
-    if (device->address_ == address) {
-      // Is it an error response?
-      if ((function_code & 0x80) == 0x80) {
-        ESP_LOGD(TAG, "Modbus error function code: 0x%X exception: %d", function_code, raw[2]);
-        if (waiting_for_response != 0) {
-          device->on_modbus_error(function_code & 0x7F, raw[2]);
-        } else {
-          // Ignore modbus exception not related to a pending command
-          ESP_LOGD(TAG, "Ignoring Modbus error - not expecting a response");
-        }
-      } else {
-        device->on_modbus_data(data);
-      }
-      found = true;
-    }
-  }
-  waiting_for_response = 0;
-
+  // If no direct callback was provided fallback scanning for a matching device
+  bool found = this->dispatch_to_device_(address, function_code, raw[2], data);
+  waiting_for_response = false;
   if (!found) {
     ESP_LOGW(TAG, "Got Modbus frame from unknown address 0x%02X! ", address);
   }
-
   // return false to reset buffer
   return false;
 }
@@ -135,8 +131,17 @@ float Modbus::get_setup_priority() const {
   return setup_priority::BUS - 1.0f;
 }
 
+// modbus requests must be serialized.
+// no request can be sent while waiting for a response.
+// this becomes a concern if multiple modbus devices are connected and the components
+// don't (and can't) synchronize their requests.
+// if a component sends a request while another component is waiting for a response it's not possible to identify to
+// which request  the bytes read from uart belong to. Using a queue allows enforcing the serialization at the
+// modbus level without breaking existing components building on modbus or forcing them to check the state of modbus
+// (idle / waiting for response) the queue is checked in loop() and queued requests are send when no other request is
+// pending
 void Modbus::send(uint8_t address, uint8_t function_code, uint16_t start_address, uint16_t number_of_entities,
-                  uint8_t payload_len, const uint8_t *payload) {
+                  uint8_t payload_len, const uint8_t *payload, bool force_send) {
   static const size_t MAX_VALUES = 128;
 
   // Only check max number of registers for standard function codes
@@ -166,31 +171,46 @@ void Modbus::send(uint8_t address, uint8_t function_code, uint16_t start_address
       data.push_back(payload[i]);
     }
   }
+  ESP_LOGVV(TAG, "Modbus enqueue: %s", format_hex_pretty(data).c_str());
+  if (!force_send) {
+    // move the payload (without CRC to outgoing queue)
+    request_queue_.push(std::move(data));
+  } else {
+    auto crc = crc16(data.data(), data.size());
+    data.push_back(crc >> 0);
+    data.push_back(crc >> 8);
 
-  auto crc = crc16(data.data(), data.size());
-  data.push_back(crc >> 0);
-  data.push_back(crc >> 8);
+    if (this->flow_control_pin_ != nullptr)
+      this->flow_control_pin_->digital_write(true);
 
-  if (this->flow_control_pin_ != nullptr)
-    this->flow_control_pin_->digital_write(true);
+    this->write_array(data);
+    this->flush();
 
-  this->write_array(data);
-  this->flush();
-
-  if (this->flow_control_pin_ != nullptr)
-    this->flow_control_pin_->digital_write(false);
-  waiting_for_response = address;
-  last_send_ = millis();
-  ESP_LOGV(TAG, "Modbus write: %s", format_hex_pretty(data).c_str());
+    if (this->flow_control_pin_ != nullptr)
+      this->flow_control_pin_->digital_write(false);
+    waiting_for_response = true;
+    last_send_ = millis();
+    ESP_LOGV(TAG, "Modbus write: %s", format_hex_pretty(data).c_str());
+  }
 }
 
-// Helper function for lambdas
+// send modbus request directly without enqueuing.
+// not recommened anymore but provided for compatibility issues with the new queueing api
+// make sure not using the api from multiple components (more than 1 device attached)
+void Modbus::send_direct(uint8_t address, uint8_t function_code, uint16_t start_address, uint16_t number_of_entities,
+                         uint8_t payload_len, const uint8_t *payload) {
+  send(address, function_code, start_address, number_of_entities, payload_len, payload, true);
+}
+
 // Send raw command. Except CRC everything must be contained in payload
-void Modbus::send_raw(const std::vector<uint8_t> &payload) {
+void Modbus::send_raw(const std::vector<uint8_t> &payload, bool force_send) {
   if (payload.empty()) {
     return;
   }
-
+  if (!force_send) {
+    request_queue_.push(payload);
+    return;
+  }
   if (this->flow_control_pin_ != nullptr)
     this->flow_control_pin_->digital_write(true);
 
@@ -201,10 +221,32 @@ void Modbus::send_raw(const std::vector<uint8_t> &payload) {
   this->flush();
   if (this->flow_control_pin_ != nullptr)
     this->flow_control_pin_->digital_write(false);
-  waiting_for_response = payload[0];
+  waiting_for_response = true;
   ESP_LOGV(TAG, "Modbus write raw: %s", format_hex_pretty(payload).c_str());
   last_send_ = millis();
 }
 
+bool Modbus::dispatch_to_device_(uint8_t address, uint8_t function_code, uint8_t exception_code,
+                                 const std::vector<uint8_t> &data) {
+  bool found = false;
+  for (auto *device : this->devices_) {
+    if (device->address_ == address) {
+      // Is it an error response?
+      if ((function_code & 0x80) == 0x80) {
+        ESP_LOGD(TAG, "Modbus error function code: 0x%X exception: %d", function_code, exception_code);
+        if (waiting_for_response) {
+          device->on_modbus_error(function_code & 0x7F, exception_code);
+        } else {
+          // Ignore modbus exception not related to a pending command
+          ESP_LOGD(TAG, "Ignoring Modbus error - not expecting a response");
+        }
+      } else {
+        device->on_modbus_data(data);
+      }
+      found = true;
+    }
+  }
+  return found;
+}
 }  // namespace modbus
 }  // namespace esphome

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -8,9 +8,6 @@ namespace modbus {
 
 class ModbusDevice;
 
-using on_modbus_data_callback_t = std::function<void(uint8_t address, uint8_t function_code, uint8_t exception_code,
-                                                     const std::vector<uint8_t> &data)>;
-
 class Modbus : public uart::UARTDevice, public Component {
  public:
   Modbus() = default;
@@ -31,10 +28,12 @@ class Modbus : public uart::UARTDevice, public Component {
             uint8_t payload_len = 0, const uint8_t *payload = nullptr, bool force_send = false);
   void send_raw(const std::vector<uint8_t> &payload, bool force_send = false);
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
-  bool waiting_for_response{false};
   void set_send_wait_time(uint16_t time_in_ms) { send_wait_time_ = time_in_ms; }
+  bool waiting_for_response() { return waiting_for_response_; }
 
  protected:
+  bool waiting_for_response_{false};
+
   bool dispatch_to_device_(uint8_t address, uint8_t function_code, uint8_t exception_code,
                            const std::vector<uint8_t> &data);
   bool parse_modbus_byte_(uint8_t byte);
@@ -68,7 +67,7 @@ class ModbusDevice {
   }
   void send_raw(const std::vector<uint8_t> &payload) { this->parent_->send_raw(payload, use_send_direct_); }
   // If more than one device is connected sending a new command before a response is received should be blocked
-  bool waiting_for_response() { return parent_->waiting_for_response; }
+  bool waiting_for_response() { return parent_->waiting_for_response(); }
 
  protected:
   friend Modbus;

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <queue>
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
@@ -7,6 +7,9 @@ namespace esphome {
 namespace modbus {
 
 class ModbusDevice;
+
+using on_modbus_data_callback_t = std::function<void(uint8_t address, uint8_t function_code, uint8_t exception_code,
+                                                     const std::vector<uint8_t> &data)>;
 
 class Modbus : public uart::UARTDevice, public Component {
  public:
@@ -22,19 +25,24 @@ class Modbus : public uart::UARTDevice, public Component {
 
   float get_setup_priority() const override;
 
+  void send_direct(uint8_t address, uint8_t function_code, uint16_t start_address, uint16_t number_of_entities,
+                   uint8_t payload_len = 0, const uint8_t *payload = nullptr);
   void send(uint8_t address, uint8_t function_code, uint16_t start_address, uint16_t number_of_entities,
-            uint8_t payload_len = 0, const uint8_t *payload = nullptr);
-  void send_raw(const std::vector<uint8_t> &payload);
+            uint8_t payload_len = 0, const uint8_t *payload = nullptr, bool force_send = false);
+  void send_raw(const std::vector<uint8_t> &payload, bool force_send = false);
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
-  uint8_t waiting_for_response{0};
+  bool waiting_for_response{false};
   void set_send_wait_time(uint16_t time_in_ms) { send_wait_time_ = time_in_ms; }
 
  protected:
-  GPIOPin *flow_control_pin_{nullptr};
-
+  bool dispatch_to_device_(uint8_t address, uint8_t function_code, uint8_t exception_code,
+                           const std::vector<uint8_t> &data);
   bool parse_modbus_byte_(uint8_t byte);
+
+  GPIOPin *flow_control_pin_{nullptr};
   uint16_t send_wait_time_{250};
   std::vector<uint8_t> rx_buffer_;
+  std::queue<std::vector<uint8_t>> request_queue_;
   uint32_t last_modbus_byte_{0};
   uint32_t last_send_{0};
   std::vector<ModbusDevice *> devices_;
@@ -46,21 +54,28 @@ class ModbusDevice {
  public:
   void set_parent(Modbus *parent) { parent_ = parent; }
   void set_address(uint8_t address) { address_ = address; }
+  void set_use_send_direct(bool use_send_direct) { use_send_direct_ = use_send_direct; }
   virtual void on_modbus_data(const std::vector<uint8_t> &data) = 0;
   virtual void on_modbus_error(uint8_t function_code, uint8_t exception_code) {}
   void send(uint8_t function, uint16_t start_address, uint16_t number_of_entities, uint8_t payload_len = 0,
             const uint8_t *payload = nullptr) {
-    this->parent_->send(this->address_, function, start_address, number_of_entities, payload_len, payload);
+    this->parent_->send(this->address_, function, start_address, number_of_entities, payload_len, payload,
+                        use_send_direct_);
   }
-  void send_raw(const std::vector<uint8_t> &payload) { this->parent_->send_raw(payload); }
-  // If more than one device is connected block sending a new command before a response is received
-  bool waiting_for_response() { return parent_->waiting_for_response != 0; }
+  void send_direct(uint8_t function, uint16_t start_address, uint16_t number_of_entities, uint8_t payload_len = 0,
+                   const uint8_t *payload = nullptr) {
+    this->parent_->send(this->address_, function, start_address, number_of_entities, payload_len, payload, true);
+  }
+  void send_raw(const std::vector<uint8_t> &payload) { this->parent_->send_raw(payload, use_send_direct_); }
+  // If more than one device is connected sending a new command before a response is received should be blocked
+  bool waiting_for_response() { return parent_->waiting_for_response; }
 
  protected:
   friend Modbus;
 
   Modbus *parent_;
   uint8_t address_;
+  bool use_send_direct_{false};
 };
 
 }  // namespace modbus


### PR DESCRIPTION
# What does this implement/fix? 

Refactor modbus for better multi device reliability

modbus requests must be serialized.
no request must be sent while waiting for a response.
this becomes a concern if multiple modbus devices are connected and the components don't (and can't) synchronize their requests.
if a component sends a request while another component is waiting for a response it's not possible to identify to which request  the bytes read from uart belong to.
Introducing a queue allows enforcing the serialization at the modbus level without breaking existing components building on modbus or forcing them to check the state of modbus (idle / waiting for response)  the queue is checked in loop() and queued requests are send when no other request is pending.

Sinnce I can't test all components building on `modbus`  these 2 options can be used to restore the "old" behavior: 
(Ideally the options are never required and can be removed if no problems are reported. )

- **use_send_direct** (*Optional*, boolean): the modbus component serializes requests to ensure no other request is sent while another device is waiting for a response. 
    This option disables the serialization and forces the modbus component to send a request directly when received. This option can be used for backward compatibility if the serialization causes incorreect behavoir.

- **dont_drop_when_idle** (*Optional*, boolean): The modbus component is polling the connected UART for new data. Modbus devices should never send anything unless they received a command. Therefore anything received from UART without a previous command is dropped. 
    This option disables dropping unexpected bytes read from UART for backward compatibility. 

 
I'm running this PR for a couple of days now without noticing a problem. 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1790

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
