### PR TITLE
[Modbus_controller] Fix duplicate cmd check

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -109,7 +109,7 @@ void ModbusController::queue_command(const ModbusCommandItem &command) {
   // not very effective but the queue is never really large
   for (auto &item : command_queue_) {
     if (item->register_address == command.register_address && item->register_count == command.register_count &&
-        item->register_type == command.register_type) {
+        item->register_type == command.register_type && item->function_code == command.function_code) {
       ESP_LOGW(TAG, "Duplicate modbus command found");
       // update the payload of the queued command
       // replaces a previous command


### PR DESCRIPTION
# What does this implement/fix? 

When a new command is submitted, the component checks for commands that are queued but not yet send. 
If found the payload is update in the existing command. 
The problem is that the modbus function code is  not included in this check so a read command can update a write command. 
Usually this doesn't occur because the queue is processed quite fast - but never the less it can happen (see linked issue)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2924

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
