### PR TITLE
Add Select for modbus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -112,6 +112,7 @@ esphome/components/modbus_controller/* @martgras
 esphome/components/modbus_controller/binary_sensor/* @martgras
 esphome/components/modbus_controller/number/* @martgras
 esphome/components/modbus_controller/output/* @martgras
+esphome/components/modbus_controller/select/* @martgras @stegm
 esphome/components/modbus_controller/sensor/* @martgras
 esphome/components/modbus_controller/switch/* @martgras
 esphome/components/modbus_controller/text_sensor/* @martgras

--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -63,6 +63,7 @@ from esphome.cpp_types import (  # noqa
     uint32,
     uint64,
     int32,
+    int64,
     const_char_ptr,
     NAN,
     esphome_ns,

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -360,8 +360,9 @@ ModbusCommandItem ModbusCommandItem::create_write_multiple_command(ModbusControl
     modbusdevice->on_write_register_response(cmd.register_type, start_address, data);
   };
   for (auto v : values) {
-    cmd.payload.push_back((v / 256) & 0xFF);
-    cmd.payload.push_back(v & 0xFF);
+    auto decoded_value = decode_value(v);
+    cmd.payload.push_back(decoded_value[0]);
+    cmd.payload.push_back(decoded_value[1]);
   }
   return cmd;
 }
@@ -416,7 +417,7 @@ ModbusCommandItem ModbusCommandItem::create_write_multiple_coils(ModbusControlle
 }
 
 ModbusCommandItem ModbusCommandItem::create_write_single_command(ModbusController *modbusdevice, uint16_t start_address,
-                                                                 int16_t value) {
+                                                                 uint16_t value) {
   ModbusCommandItem cmd;
   cmd.modbusdevice = modbusdevice;
   cmd.register_type = ModbusRegisterType::HOLDING;
@@ -427,8 +428,10 @@ ModbusCommandItem ModbusCommandItem::create_write_single_command(ModbusControlle
                                          const std::vector<uint8_t> &data) {
     modbusdevice->on_write_register_response(cmd.register_type, start_address, data);
   };
-  cmd.payload.push_back((value / 256) & 0xFF);
-  cmd.payload.push_back((value % 256) & 0xFF);
+
+  auto decoded_value = decode_value(value);
+  cmd.payload.push_back(decoded_value[0]);
+  cmd.payload.push_back(decoded_value[1]);
   return cmd;
 }
 
@@ -463,84 +466,70 @@ bool ModbusCommandItem::send() {
   return true;
 }
 
-std::vector<uint16_t> float_to_payload(float value, SensorValueType value_type) {
-  union {
-    float float_value;
-    uint32_t raw;
-  } raw_to_float;
-
-  std::vector<uint16_t> data;
-  int32_t val;
-
+void number_to_payload(std::vector<uint16_t> &data, int64_t value, SensorValueType value_type) {
   switch (value_type) {
     case SensorValueType::U_WORD:
     case SensorValueType::S_WORD:
-      // cast truncates the float do some rounding here
-      data.push_back(lroundf(value) & 0xFFFF);
+      data.push_back(value & 0xFFFF);
       break;
     case SensorValueType::U_DWORD:
     case SensorValueType::S_DWORD:
-      val = lroundf(value);
-      data.push_back((val & 0xFFFF0000) >> 16);
-      data.push_back(val & 0xFFFF);
+    case SensorValueType::FP32:
+    case SensorValueType::FP32_R:
+      data.push_back((value & 0xFFFF0000) >> 16);
+      data.push_back(value & 0xFFFF);
       break;
     case SensorValueType::U_DWORD_R:
     case SensorValueType::S_DWORD_R:
-      val = lroundf(value);
-      data.push_back(val & 0xFFFF);
-      data.push_back((val & 0xFFFF0000) >> 16);
+      data.push_back(value & 0xFFFF);
+      data.push_back((value & 0xFFFF0000) >> 16);
       break;
-    case SensorValueType::FP32:
-      raw_to_float.float_value = value;
-      data.push_back((raw_to_float.raw & 0xFFFF0000) >> 16);
-      data.push_back(raw_to_float.raw & 0xFFFF);
+    case SensorValueType::U_QWORD:
+    case SensorValueType::S_QWORD:
+      data.push_back((value & 0xFFFF000000000000) >> 48);
+      data.push_back((value & 0xFFFF00000000) >> 32);
+      data.push_back((value & 0xFFFF0000) >> 16);
+      data.push_back(value & 0xFFFF);
       break;
-    case SensorValueType::FP32_R:
-      raw_to_float.float_value = value;
-      data.push_back(raw_to_float.raw & 0xFFFF);
-      data.push_back((raw_to_float.raw & 0xFFFF0000) >> 16);
+    case SensorValueType::U_QWORD_R:
+    case SensorValueType::S_QWORD_R:
+      data.push_back(value & 0xFFFF);
+      data.push_back((value & 0xFFFF0000) >> 16);
+      data.push_back((value & 0xFFFF00000000) >> 32);
+      data.push_back((value & 0xFFFF000000000000) >> 48);
       break;
     default:
-      ESP_LOGE(TAG, "Invalid data type for modbus float to payload conversation");
+      ESP_LOGE(TAG, "Invalid data type for modbus number to payload conversation: %d",
+               static_cast<uint16_t>(value_type));
       break;
   }
-  return data;
 }
 
-float payload_to_float(const std::vector<uint8_t> &data, SensorValueType sensor_value_type, uint8_t offset,
-                       uint32_t bitmask) {
-  union {
-    float float_value;
-    uint32_t raw;
-  } raw_to_float;
-
+int64_t payload_to_number(const std::vector<uint8_t> &data, SensorValueType sensor_value_type, uint8_t offset,
+                          uint32_t bitmask) {
   int64_t value = 0;  // int64_t because it can hold signed and unsigned 32 bits
-  float result = NAN;
 
   switch (sensor_value_type) {
     case SensorValueType::U_WORD:
       value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
-      result = static_cast<float>(value);
       break;
     case SensorValueType::U_DWORD:
+    case SensorValueType::FP32:
       value = get_data<uint32_t>(data, offset);
       value = mask_and_shift_by_rightbit((uint32_t) value, bitmask);
-      result = static_cast<float>(value);
       break;
     case SensorValueType::U_DWORD_R:
+    case SensorValueType::FP32_R:
       value = get_data<uint32_t>(data, offset);
       value = static_cast<uint32_t>(value & 0xFFFF) << 16 | (value & 0xFFFF0000) >> 16;
       value = mask_and_shift_by_rightbit((uint32_t) value, bitmask);
-      result = static_cast<float>(value);
       break;
     case SensorValueType::S_WORD:
       value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset),
                                          bitmask);  // default is 0xFFFF ;
-      result = static_cast<float>(value);
       break;
     case SensorValueType::S_DWORD:
       value = mask_and_shift_by_rightbit(get_data<int32_t>(data, offset), bitmask);
-      result = static_cast<float>(value);
       break;
     case SensorValueType::S_DWORD_R: {
       value = get_data<uint32_t>(data, offset);
@@ -549,18 +538,14 @@ float payload_to_float(const std::vector<uint8_t> &data, SensorValueType sensor_
       uint32_t sign_bit = (value & 0x8000) << 16;
       value = mask_and_shift_by_rightbit(
           static_cast<int32_t>(((value & 0x7FFF) << 16 | (value & 0xFFFF0000) >> 16) | sign_bit), bitmask);
-      result = static_cast<float>(value);
     } break;
     case SensorValueType::U_QWORD:
       // Ignore bitmask for U_QWORD
       value = get_data<uint64_t>(data, offset);
-      result = static_cast<float>(value);
       break;
-
     case SensorValueType::S_QWORD:
       // Ignore bitmask for S_QWORD
       value = get_data<int64_t>(data, offset);
-      result = static_cast<float>(value);
       break;
     case SensorValueType::U_QWORD_R:
       // Ignore bitmask for U_QWORD
@@ -568,32 +553,16 @@ float payload_to_float(const std::vector<uint8_t> &data, SensorValueType sensor_
       value = static_cast<uint64_t>(value & 0xFFFF) << 48 | (value & 0xFFFF000000000000) >> 48 |
               static_cast<uint64_t>(value & 0xFFFF0000) << 32 | (value & 0x0000FFFF00000000) >> 32 |
               static_cast<uint64_t>(value & 0xFFFF00000000) << 16 | (value & 0x00000000FFFF0000) >> 16;
-      result = static_cast<float>(value);
       break;
-
     case SensorValueType::S_QWORD_R:
       // Ignore bitmask for S_QWORD
       value = get_data<int64_t>(data, offset);
-      result = static_cast<float>(value);
       break;
-    case SensorValueType::FP32:
-      raw_to_float.raw = get_data<uint32_t>(data, offset);
-      ESP_LOGD(TAG, "FP32 = 0x%08X => %f", raw_to_float.raw, raw_to_float.float_value);
-      result = raw_to_float.float_value;
-      break;
-    case SensorValueType::FP32_R: {
-      auto tmp = get_data<uint32_t>(data, offset);
-      raw_to_float.raw = static_cast<uint32_t>(tmp & 0xFFFF) << 16 | (tmp & 0xFFFF0000) >> 16;
-      ESP_LOGD(TAG, "FP32_R = 0x%08X => %f", raw_to_float.raw, raw_to_float.float_value);
-      result = raw_to_float.float_value;
-    } break;
     case SensorValueType::RAW:
-      result = NAN;
-      break;
     default:
       break;
   }
-  return result;
+  return value;
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -110,7 +110,8 @@ void ModbusController::queue_command(const ModbusCommandItem &command) {
   for (auto &item : command_queue_) {
     if (item->register_address == command.register_address && item->register_count == command.register_count &&
         item->register_type == command.register_type && item->function_code == command.function_code) {
-      ESP_LOGW(TAG, "Duplicate modbus command found");
+      ESP_LOGW(TAG, "Duplicate modbus command found: type=0x%x address=%u count=%u", command.register_type,
+               command.register_address, command.register_count);
       // update the payload of the queued command
       // replaces a previous command
       item->payload = command.payload;

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -110,8 +110,8 @@ void ModbusController::queue_command(const ModbusCommandItem &command) {
   for (auto &item : command_queue_) {
     if (item->register_address == command.register_address && item->register_count == command.register_count &&
         item->register_type == command.register_type && item->function_code == command.function_code) {
-      ESP_LOGW(TAG, "Duplicate modbus command found: type=0x%x address=%u count=%u", command.register_type,
-               command.register_address, command.register_count);
+      ESP_LOGW(TAG, "Duplicate modbus command found: type=0x%x address=%u count=%u",
+               static_cast<uint8_t>(command.register_type), command.register_address, command.register_count);
       // update the payload of the queued command
       // replaces a previous command
       item->payload = command.payload;

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -195,7 +195,7 @@ inline bool coil_from_vector(int coil, const std::vector<uint8_t> &data) {
  */
 template<typename N> N mask_and_shift_by_rightbit(N data, uint32_t mask) {
   auto result = (mask & data);
-  if (result == 0) {
+  if (result == 0 || mask == 0xFFFFFFFF) {
     return result;
   }
   for (size_t pos = 0; pos < sizeof(N) << 3; pos++) {
@@ -205,22 +205,23 @@ template<typename N> N mask_and_shift_by_rightbit(N data, uint32_t mask) {
   return 0;
 }
 
-/** convert float value to vector<uint16_t> suitable for sending
- * @param value float value to cconvert
+/** Convert float value to vector<uint16_t> suitable for sending
+ * @param data target for payload
+ * @param value float value to convert
  * @param value_type defines if 16/32 or FP32 is used
  * @return vector containing the modbus register words in correct order
  */
-std::vector<uint16_t> float_to_payload(float value, SensorValueType value_type);
+void number_to_payload(std::vector<uint16_t> &data, int64_t value, SensorValueType value_type);
 
-/** convert vector<uint8_t> response payload to float
- * @param value float value to cconvert
+/** Convert vector<uint8_t> response payload to number.
+ * @param data payload with the data to convert
  * @param sensor_value_type defines if 16/32/64 bits or FP32 is used
  * @param offset offset to the data in data
  * @param bitmask bitmask used for masking and shifting
- * @return float version of the input
+ * @return 64-bit number of the payload
  */
-float payload_to_float(const std::vector<uint8_t> &data, SensorValueType sensor_value_type, uint8_t offset,
-                       uint32_t bitmask);
+int64_t payload_to_number(const std::vector<uint8_t> &data, SensorValueType sensor_value_type, uint8_t offset,
+                          uint32_t bitmask);
 
 class ModbusController;
 
@@ -347,11 +348,11 @@ class ModbusCommandItem {
    * @param modbusdevice pointer to the device to execute the command
    * @param start_address modbus address of the first register to read
    * @param register_count number of registers to read
-   * @param values uint16_t array to be written to the registers
+   * @param value uint16_t single register value to write
    * @return ModbusCommandItem with the prepared command
    */
   static ModbusCommandItem create_write_single_command(ModbusController *modbusdevice, uint16_t start_address,
-                                                       int16_t value);
+                                                       uint16_t value);
   /** Create modbus write single registers command
    *  Function 05 (05hex) Write Single Coil
    * @param modbusdevice pointer to the device to execute the command
@@ -445,13 +446,46 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
   uint16_t command_throttle_;
 };
 
-/** convert vector<uint8_t> response payload to float
- * @param value float value to cconvert
+/** Convert vector<uint8_t> response payload to float.
+ * @param data payload with data
  * @param item SensorItem object
- * @return float version of the input
+ * @return float value of data
  */
 inline float payload_to_float(const std::vector<uint8_t> &data, const SensorItem &item) {
-  return payload_to_float(data, item.sensor_value_type, item.offset, item.bitmask);
+  int64_t number = payload_to_number(data, item.sensor_value_type, item.offset, item.bitmask);
+
+  float float_value;
+  if (item.sensor_value_type == SensorValueType::FP32 || item.sensor_value_type == SensorValueType::FP32_R) {
+    union {
+      float float_value;
+      uint32_t raw;
+    } raw_to_float;
+    raw_to_float.raw = number;
+    float_value = raw_to_float.float_value;
+  } else {
+    float_value = static_cast<float>(number);
+  }
+
+  return float_value;
+}
+
+inline std::vector<uint16_t> float_to_payload(float value, SensorValueType value_type) {
+  int64_t val;
+
+  if (value_type == SensorValueType::FP32 || value_type == SensorValueType::FP32_R) {
+    union {
+      float float_value;
+      uint32_t raw;
+    } raw_to_float;
+    raw_to_float.float_value = value;
+    val = raw_to_float.raw;
+  } else {
+    val = llroundf(value);
+  }
+
+  std::vector<uint16_t> data;
+  number_to_payload(data, val, value_type);
+  return data;
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -456,12 +456,7 @@ inline float payload_to_float(const std::vector<uint8_t> &data, const SensorItem
 
   float float_value;
   if (item.sensor_value_type == SensorValueType::FP32 || item.sensor_value_type == SensorValueType::FP32_R) {
-    union {
-      float float_value;
-      uint32_t raw;
-    } raw_to_float;
-    raw_to_float.raw = number;
-    float_value = raw_to_float.float_value;
+    float_value = bit_cast<float>(static_cast<uint32_t>(number));
   } else {
     float_value = static_cast<float>(number);
   }
@@ -473,12 +468,7 @@ inline std::vector<uint16_t> float_to_payload(float value, SensorValueType value
   int64_t val;
 
   if (value_type == SensorValueType::FP32 || value_type == SensorValueType::FP32_R) {
-    union {
-      float float_value;
-      uint32_t raw;
-    } raw_to_float;
-    raw_to_float.float_value = value;
-    val = raw_to_float.raw;
+    val = bit_cast<uint32_t>(value);
   } else {
     val = llroundf(value);
   }

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -137,6 +137,7 @@ async def to_code(config):
             [
                 (ModbusSelect.operator("const_ptr"), "item"),
                 (cg.std_string.operator("const").operator("ref"), "x"),
+                (cg.int64, "value"),
                 (cg.std_vector.template(cg.uint16).operator("ref"), "payload"),
             ],
             return_type=cg.optional.template(cg.int64),

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -138,7 +138,6 @@ async def to_code(config):
                 (ModbusSelect.operator("cptr"), "item"),
                 (cg.std_string.operator("const").operator("ref"), "x"),
                 (cg.std_vector.template(cg.uint16).operator("ref"), "payload"),
-                (cg.bool_.operator("ref"), "skip_update"),
             ],
             return_type=cg.optional.template(cg.int64),
         )

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -49,19 +49,16 @@ def ensure_option_map():
     return validator
 
 
-def register_count_value_type_min():
-    def validator(value):
-        reg_count = value.get(CONF_REGISTER_COUNT)
-        if reg_count is not None:
-            value_type = value[CONF_VALUE_TYPE]
-            min_register_count = TYPE_REGISTER_MAP[value_type]
-            if min_register_count > reg_count:
-                raise cv.Invalid(
-                    f"Value type {value_type} needs at least {min_register_count} registers"
-                )
-        return value
-
-    return validator
+def register_count_value_type_min(value):
+    reg_count = value.get(CONF_REGISTER_COUNT)
+    if reg_count is not None:
+        value_type = value[CONF_VALUE_TYPE]
+        min_register_count = TYPE_REGISTER_MAP[value_type]
+        if min_register_count > reg_count:
+            raise cv.Invalid(
+                f"Value type {value_type} needs at least {min_register_count} registers"
+            )
+    return value
 
 
 INTEGER_SENSOR_VALUE_TYPE = {
@@ -86,7 +83,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
         },
     ),
-    register_count_value_type_min(),
+    register_count_value_type_min,
 )
 
 

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -13,7 +13,7 @@ from ..const import (
 )
 
 DEPENDENCIES = ["modbus_controller"]
-CODEOWNERS = ["@stegm"]
+CODEOWNERS = ["@martgras", "@stegm"]
 CONF_OPTIONSMAP = "optionsmap"
 
 ModbusSelect = modbus_controller_ns.class_(

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -120,7 +120,7 @@ async def to_code(config):
         template_ = await cg.process_lambda(
             config[CONF_LAMBDA],
             [
-                (ModbusSelect.operator("ptr"), "item"),
+                (ModbusSelect.operator("cptr"), "item"),
                 (cg.int64, "x"),
                 (
                     cg.std_vector.template(cg.uint8).operator("const").operator("ref"),
@@ -135,8 +135,8 @@ async def to_code(config):
         template_ = await cg.process_lambda(
             config[CONF_WRITE_LAMBDA],
             [
-                (ModbusSelect.operator("ptr"), "item"),
-                (cg.std_string, "x"),
+                (ModbusSelect.operator("cptr"), "item"),
+                (cg.std_string.operator("const").operator("ref"), "x"),
                 (cg.std_vector.template(cg.uint16).operator("ref"), "payload"),
                 (cg.bool_.operator("ref"), "skip_update"),
             ],

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -1,0 +1,75 @@
+from esphome.components import select
+import esphome.config_validation as cv
+import esphome.codegen as cg
+
+
+from esphome.const import CONF_ADDRESS, CONF_ID
+from .. import (
+    add_modbus_base_properties,
+    modbus_controller_ns,
+    modbus_calc_properties,
+    validate_modbus_register,
+    ModbusItemBaseSchema,
+    SensorItem,
+    MODBUS_REGISTER_TYPE,
+    SENSOR_VALUE_TYPE,
+)
+from ..const import (
+    CONF_BITMASK,
+    CONF_FORCE_NEW_RANGE,
+    CONF_MODBUS_CONTROLLER_ID,
+    CONF_REGISTER_COUNT,
+    CONF_RESPONSE_SIZE,
+    CONF_SKIP_UPDATES,
+    CONF_REGISTER_TYPE,
+    CONF_VALUE_TYPE,
+)
+
+DEPENDENCIES = ["modbus_controller"]
+CODEOWNERS = ["@stegm"]
+
+
+ModbusSelect = modbus_controller_ns.class_(
+    "ModbusSelect", cg.Component, select.Select, SensorItem
+)
+
+
+CONFIG_SCHEMA = cv.All(
+    select.SELECT_SCHEMA.extend(cv.COMPONENT_SCHEMA)
+    .extend(ModbusItemBaseSchema)
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(ModbusSelect),
+            cv.Optional(CONF_REGISTER_TYPE): cv.enum(MODBUS_REGISTER_TYPE),
+            cv.Optional(CONF_REGISTER_COUNT, default=0): cv.positive_int,
+            cv.Optional(CONF_RESPONSE_SIZE, default=2): cv.positive_int,
+            cv.Optional(CONF_VALUE_TYPE, default="U_WORD"): cv.enum(SENSOR_VALUE_TYPE),
+        }
+    ),
+    validate_modbus_register,
+)
+
+
+async def to_code(config):
+    byte_offset, reg_count = modbus_calc_properties(config)
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        config[CONF_REGISTER_TYPE],
+        config[CONF_ADDRESS],
+        byte_offset,
+        config[CONF_BITMASK],
+        config[CONF_VALUE_TYPE],
+        reg_count,
+        config[CONF_RESPONSE_SIZE],
+        config[CONF_SKIP_UPDATES],
+        config[CONF_FORCE_NEW_RANGE],
+    )
+
+    await cg.register_component(var, config)
+    await select.register_select(var, config, options=[])  # TODO
+
+    paren = await cg.get_variable(config[CONF_MODBUS_CONTROLLER_ID])
+    cg.add(paren.add_sensor_item(var))
+    await add_modbus_base_properties(
+        var, config, ModbusSelect, cg.std_string, cg.std_string
+    )

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -120,7 +120,7 @@ async def to_code(config):
         template_ = await cg.process_lambda(
             config[CONF_LAMBDA],
             [
-                (ModbusSelect.operator("cptr"), "item"),
+                (ModbusSelect.operator("const_ptr"), "item"),
                 (cg.int64, "x"),
                 (
                     cg.std_vector.template(cg.uint8).operator("const").operator("ref"),
@@ -135,7 +135,7 @@ async def to_code(config):
         template_ = await cg.process_lambda(
             config[CONF_WRITE_LAMBDA],
             [
-                (ModbusSelect.operator("cptr"), "item"),
+                (ModbusSelect.operator("const_ptr"), "item"),
                 (cg.std_string.operator("const").operator("ref"), "x"),
                 (cg.std_vector.template(cg.uint16).operator("ref"), "payload"),
             ],

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -1,15 +1,10 @@
-from esphome.components import select
-import esphome.config_validation as cv
 import esphome.codegen as cg
-
-
+import esphome.config_validation as cv
+from esphome.components import select
 from esphome.const import CONF_ADDRESS, CONF_ID
 from esphome.jsonschema import jschema_composite
-from .. import (
-    modbus_controller_ns,
-    ModbusController,
-    SensorItem,
-)
+
+from .. import ModbusController, SensorItem, modbus_controller_ns
 from ..const import (
     CONF_FORCE_NEW_RANGE,
     CONF_MODBUS_CONTROLLER_ID,
@@ -44,7 +39,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(ModbusSelect),
             cv.GenerateID(CONF_MODBUS_CONTROLLER_ID): cv.use_id(ModbusController),
             cv.Required(CONF_ADDRESS): cv.positive_int,
-            cv.Optional(CONF_REGISTER_COUNT, default=1): cv.int_range(1, 8),
+            cv.Optional(CONF_REGISTER_COUNT, default=1): cv.int_range(1, 4),
             cv.Optional(CONF_SKIP_UPDATES, default=0): cv.positive_int,
             cv.Optional(CONF_FORCE_NEW_RANGE, default=False): cv.boolean,
             cv.Required(CONF_OPTIONSMAP): ensure_option_map(),

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -33,6 +33,17 @@ def ensure_option_map():
     return validator
 
 
+def unique_mapping():
+    def validator(value):
+        all_values = list(value.values())
+        unique_values = set(value.values())
+        if len(all_values) != len(unique_values):
+            raise cv.Invalid("Mapping values must be unique.")
+        return value
+
+    return validator
+
+
 CONFIG_SCHEMA = cv.All(
     select.SELECT_SCHEMA.extend(cv.COMPONENT_SCHEMA).extend(
         {
@@ -42,7 +53,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_REGISTER_COUNT, default=1): cv.int_range(1, 4),
             cv.Optional(CONF_SKIP_UPDATES, default=0): cv.positive_int,
             cv.Optional(CONF_FORCE_NEW_RANGE, default=False): cv.boolean,
-            cv.Required(CONF_OPTIONSMAP): ensure_option_map(),
+            cv.Required(CONF_OPTIONSMAP): cv.All(ensure_option_map(), unique_mapping()),
         }
     ),
 )
@@ -50,6 +61,7 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     options_map = config[CONF_OPTIONSMAP]
+
     var = cg.new_Pvariable(
         config[CONF_ID],
         config[CONF_ADDRESS],

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -10,6 +10,7 @@ from ..const import (
     CONF_MODBUS_CONTROLLER_ID,
     CONF_REGISTER_COUNT,
     CONF_SKIP_UPDATES,
+    CONF_USE_WRITE_MULTIPLE,
 )
 
 DEPENDENCIES = ["modbus_controller"]
@@ -54,6 +55,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SKIP_UPDATES, default=0): cv.positive_int,
             cv.Optional(CONF_FORCE_NEW_RANGE, default=False): cv.boolean,
             cv.Required(CONF_OPTIONSMAP): cv.All(ensure_option_map(), unique_mapping()),
+            cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
         }
     ),
 )
@@ -77,3 +79,4 @@ async def to_code(config):
     parent = await cg.get_variable(config[CONF_MODBUS_CONTROLLER_ID])
     cg.add(parent.add_sensor_item(var))
     cg.add(var.set_parent(parent))
+    cg.add(var.set_use_write_mutiple(config[CONF_USE_WRITE_MULTIPLE]))

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -77,12 +77,12 @@ void ModbusSelect::control(const std::string &value) {
     return;
   }
 
+  const uint16_t write_address = this->start_address + this->offset / 2;
   ModbusCommandItem write_cmd;
   if ((this->register_count == 1) && (!this->use_write_multiple_)) {
-    write_cmd = ModbusCommandItem::create_write_single_command(parent_, this->write_address_, data[0]);
+    write_cmd = ModbusCommandItem::create_write_single_command(parent_, write_address, data[0]);
   } else {
-    write_cmd =
-        ModbusCommandItem::create_write_multiple_command(parent_, this->write_address_, this->register_count, data);
+    write_cmd = ModbusCommandItem::create_write_multiple_command(parent_, write_address, this->register_count, data);
   }
 
   parent_->queue_command(write_cmd);

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -42,7 +42,7 @@ void ModbusSelect::control(const std::string &value) {
     ESP_LOGV(TAG, "Set selection to %llu", mapping);
 
     ModbusCommandItem write_cmd;
-    if (this->register_count == 1) {
+    if ((this->register_count == 1) && (!this->use_write_multiple_)) {
       write_cmd =
           ModbusCommandItem::create_write_single_command(parent_, this->write_address, static_cast<uint16_t>(mapping));
     } else {

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -65,7 +65,10 @@ void ModbusSelect::control(const std::string &value) {
     }
 
 #pragma GCC diagnostic push
+#if !defined(__clang__)
+// ignores false-positive warning on mapval variable
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     number_to_payload(data, *mapval, this->sensor_value_type);
 #pragma GCC diagnostic pop
   } else {

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -21,44 +21,71 @@ void ModbusSelect::parse_and_publish(const std::vector<uint8_t> &data) {
 
   ESP_LOGV(TAG, "New select value %llu", value);
 
-  auto map_it = std::find(this->mapping.cbegin(), this->mapping.cend(), value);
+  optional<std::string> new_state;
 
-  if (map_it != this->mapping.cend()) {
-    size_t idx = std::distance(this->mapping.cbegin(), map_it);
-    std::string option = this->traits.get_options()[idx];
-    this->publish_state(option);
-  } else {
-    ESP_LOGE(TAG, "No option found for mapping %llu", value);
+  if (this->transform_func_.has_value()) {
+    auto val = (*this->transform_func_)(this, value, data);
+    if (val.has_value()) {
+      new_state = val.value();
+    }
+  }
+
+  if (!new_state.has_value()) {
+    auto map_it = std::find(this->mapping.cbegin(), this->mapping.cend(), value);
+
+    if (map_it != this->mapping.cend()) {
+      size_t idx = std::distance(this->mapping.cbegin(), map_it);
+      new_state = this->traits.get_options()[idx];
+    } else {
+      ESP_LOGE(TAG, "No option found for mapping %llu", value);
+    }
+  }
+
+  if (new_state.has_value()) {
+    this->publish_state(new_state.value());
   }
 }
 
 void ModbusSelect::control(const std::string &value) {
-  auto options = this->traits.get_options();
-  auto opt_it = std::find(options.cbegin(), options.cend(), value);
-  if (opt_it != options.cend()) {
-    size_t idx = std::distance(options.cbegin(), opt_it);
-    uint64_t mapping = this->mapping[idx];
+  optional<uint64_t> mapval;
+  std::vector<uint16_t> data;
 
-    ESP_LOGV(TAG, "Set selection to %llu", mapping);
-
-    ModbusCommandItem write_cmd;
-    if ((this->register_count == 1) && (!this->use_write_multiple_)) {
-      write_cmd =
-          ModbusCommandItem::create_write_single_command(parent_, this->write_address, static_cast<uint16_t>(mapping));
-    } else {
-      std::vector<uint16_t> data;
-      auto it = data.begin();
-      for (uint8_t i = 0; i < this->get_register_size(); i++) {
-        it = data.insert(it, static_cast<uint16_t>(mapping & 0xFFFF));
-        mapping >>= 16;
-      }
-      write_cmd =
-          ModbusCommandItem::create_write_multiple_command(parent_, this->write_address, this->register_count, data);
+  if (this->write_transform_func_.has_value()) {
+    auto val = (*this->write_transform_func_)(this, value, data);
+    if (val.has_value()) {
+      mapval = val.value();
     }
-    parent_->queue_command(write_cmd);
-  } else {
-    ESP_LOGE(TAG, "No mapping found for option %s", value.c_str());
   }
+
+  if (data.empty()) {
+    if (!mapval.has_value()) {
+      auto options = this->traits.get_options();
+      auto opt_it = std::find(options.cbegin(), options.cend(), value);
+      size_t idx = std::distance(options.cbegin(), opt_it);
+      mapval = this->mapping[idx];
+    }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    auto it = data.begin();
+    uint64_t remaining = mapval.value();
+    ESP_LOGD(TAG, "Create payload for %llu", remaining);
+    for (uint8_t i = 0; i < this->register_count; i++) {
+      it = data.insert(it, static_cast<uint16_t>(remaining & 0xFFFF));
+      remaining >>= 16;
+    }
+#pragma GCC diagnostic pop
+  }
+
+  ModbusCommandItem write_cmd;
+  if ((this->register_count == 1) && (!this->use_write_multiple_)) {
+    write_cmd = ModbusCommandItem::create_write_single_command(parent_, this->write_address, data[0]);
+  } else {
+    write_cmd =
+        ModbusCommandItem::create_write_multiple_command(parent_, this->write_address, this->register_count, data);
+  }
+
+  parent_->queue_command(write_cmd);
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -1,0 +1,69 @@
+#include "modbus_select.h"
+
+#include "esphome/core/log.h"
+
+#include <sstream>
+
+namespace esphome {
+namespace modbus_controller {
+
+static const char *const TAG = "modbus_controller.sensor";
+
+void ModbusSelect::dump_config() { LOG_SELECT(TAG, "Modbus Controller Select", this); }
+
+void ModbusSelect::parse_and_publish(const std::vector<uint8_t> &data) {
+  uint64_t value = 0;
+  auto it = data.cbegin();
+  it + this->offset;
+  size_t count = this->get_register_size();
+  while ((it != data.cend()) && (count > 0)) {
+    value <<= 8;
+    value |= *it;
+    --count;
+    ++it;
+  }
+
+  ESP_LOGV(TAG, "New select value %llu", value);
+
+  auto map_it = std::find(this->mapping.cbegin(), this->mapping.cend(), value);
+
+  if (map_it != this->mapping.cend()) {
+    size_t idx = std::distance(this->mapping.cbegin(), map_it);
+    std::string option = this->traits.get_options()[idx];
+    this->publish_state(option);
+  } else {
+    ESP_LOGE(TAG, "No option found for mapping %llu", value);
+  }
+}
+
+void ModbusSelect::control(const std::string &value) {
+  auto options = this->traits.get_options();
+  auto opt_it = std::find(options.cbegin(), options.cend(), value);
+  if (opt_it != options.cend()) {
+    size_t idx = std::distance(options.cbegin(), opt_it);
+    uint64_t mapping = this->mapping[idx];
+
+    ESP_LOGV(TAG, "Set selection to %llu", mapping);
+
+    ModbusCommandItem write_cmd;
+    if (this->register_count == 1) {
+      write_cmd =
+          ModbusCommandItem::create_write_single_command(parent_, this->write_address, static_cast<uint16_t>(mapping));
+    } else {
+      std::vector<uint16_t> data;
+      auto it = data.begin();
+      for (uint8_t i = 0; i < this->get_register_size(); i++) {
+        it = data.insert(it, static_cast<uint16_t>(mapping & 0xFFFF));
+        mapping >>= 16;
+      }
+      write_cmd =
+          ModbusCommandItem::create_write_multiple_command(parent_, this->write_address, this->register_count, data);
+    }
+    parent_->queue_command(write_cmd);
+  } else {
+    ESP_LOGE(TAG, "No mapping found for option %s", value.c_str());
+  }
+}
+
+}  // namespace modbus_controller
+}  // namespace esphome

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -45,16 +45,13 @@ void ModbusSelect::control(const std::string &value) {
   std::vector<uint16_t> data;
 
   if (this->write_transform_func_.has_value()) {
-    bool skip_update = false;
-    auto val = (*this->write_transform_func_)(this, value, data, skip_update);
-    if (skip_update) {
-      ESP_LOGD(TAG, "write lambda forces to skip update.");
-      return;
-    }
-
+    auto val = (*this->write_transform_func_)(this, value, data);
     if (val.has_value()) {
       mapval = *val;
-      ESP_LOGV(TAG, "write lambda returned mapping value %lld", *mapval);
+      ESP_LOGV(TAG, "write_lambda returned mapping value %lld", *mapval);
+    } else {
+      ESP_LOGD(TAG, "Communication handled by write_lambda - exiting control");
+      return;
     }
   }
 

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -1,8 +1,5 @@
 #include "modbus_select.h"
-
 #include "esphome/core/log.h"
-
-#include <sstream>
 
 namespace esphome {
 namespace modbus_controller {
@@ -13,8 +10,7 @@ void ModbusSelect::dump_config() { LOG_SELECT(TAG, "Modbus Controller Select", t
 
 void ModbusSelect::parse_and_publish(const std::vector<uint8_t> &data) {
   uint64_t value = 0;
-  auto it = data.cbegin();
-  it + this->offset;
+  auto it = data.cbegin() + this->offset;
   size_t count = this->get_register_size();
   while ((it != data.cend()) && (count > 0)) {
     value <<= 8;

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -65,8 +65,6 @@ void ModbusSelect::control(const std::string &value) {
       mapval = this->mapping_[idx];
     }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     auto it = data.begin();
     uint64_t remaining = mapval.value();
     ESP_LOGD(TAG, "Create payload for %llu", remaining);
@@ -74,7 +72,6 @@ void ModbusSelect::control(const std::string &value) {
       it = data.insert(it, static_cast<uint16_t>(remaining & 0xFFFF));
       remaining >>= 16;
     }
-#pragma GCC diagnostic pop
   }
 
   ModbusCommandItem write_cmd;

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -31,10 +31,10 @@ void ModbusSelect::parse_and_publish(const std::vector<uint8_t> &data) {
   }
 
   if (!new_state.has_value()) {
-    auto map_it = std::find(this->mapping.cbegin(), this->mapping.cend(), value);
+    auto map_it = std::find(this->mapping_.cbegin(), this->mapping_.cend(), value);
 
-    if (map_it != this->mapping.cend()) {
-      size_t idx = std::distance(this->mapping.cbegin(), map_it);
+    if (map_it != this->mapping_.cend()) {
+      size_t idx = std::distance(this->mapping_.cbegin(), map_it);
       new_state = this->traits.get_options()[idx];
     } else {
       ESP_LOGE(TAG, "No option found for mapping %llu", value);
@@ -62,7 +62,7 @@ void ModbusSelect::control(const std::string &value) {
       auto options = this->traits.get_options();
       auto opt_it = std::find(options.cbegin(), options.cend(), value);
       size_t idx = std::distance(options.cbegin(), opt_it);
-      mapval = this->mapping[idx];
+      mapval = this->mapping_[idx];
     }
 
 #pragma GCC diagnostic push
@@ -79,10 +79,10 @@ void ModbusSelect::control(const std::string &value) {
 
   ModbusCommandItem write_cmd;
   if ((this->register_count == 1) && (!this->use_write_multiple_)) {
-    write_cmd = ModbusCommandItem::create_write_single_command(parent_, this->write_address, data[0]);
+    write_cmd = ModbusCommandItem::create_write_single_command(parent_, this->write_address_, data[0]);
   } else {
     write_cmd =
-        ModbusCommandItem::create_write_multiple_command(parent_, this->write_address, this->register_count, data);
+        ModbusCommandItem::create_write_multiple_command(parent_, this->write_address_, this->register_count, data);
   }
 
   parent_->queue_command(write_cmd);

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -64,7 +64,10 @@ void ModbusSelect::control(const std::string &value) {
       ESP_LOGV(TAG, "Found value %lld for option '%s'", *mapval, value.c_str());
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     number_to_payload(data, *mapval, this->sensor_value_type);
+#pragma GCC diagnostic pop
   } else {
     ESP_LOGV(TAG, "Using payload from write lambda");
   }

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -11,14 +11,14 @@ namespace modbus_controller {
 
 class ModbusSelect : public Component, public select::Select, public SensorItem {
  public:
-  ModbusSelect(uint16_t start_address, uint8_t register_count, uint8_t skip_updates, bool force_new_range,
-               std::vector<uint64_t> mapping)
+  ModbusSelect(SensorValueType sensor_value_type, uint16_t start_address, uint8_t register_count, uint8_t skip_updates,
+               bool force_new_range, std::vector<int64_t> mapping)
       : Component(), select::Select(), write_address_(start_address) {
     this->register_type = ModbusRegisterType::HOLDING;  // not configurable
+    this->sensor_value_type = sensor_value_type;
     this->start_address = start_address;
-    this->offset = 0;                                // not configurable
-    this->bitmask = 0xFFFFFFFF;                      // not configurable
-    this->sensor_value_type = SensorValueType::RAW;  // not configurable
+    this->offset = 0;            // not configurable
+    this->bitmask = 0xFFFFFFFF;  // not configurable
     this->register_count = register_count;
     this->response_bytes = 0;  // not configurable
     this->skip_updates = skip_updates;
@@ -26,9 +26,9 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
     this->mapping_ = std::move(mapping);
   }
 
-  using transform_func_t = std::function<optional<std::string>(ModbusSelect *, uint64_t, const std::vector<uint8_t> &)>;
+  using transform_func_t = std::function<optional<std::string>(ModbusSelect *, int64_t, const std::vector<uint8_t> &)>;
   using write_transform_func_t =
-      std::function<optional<uint64_t>(ModbusSelect *, std::string, std::vector<uint16_t> &)>;
+      std::function<optional<int64_t>(ModbusSelect *, std::string, std::vector<uint16_t> &, bool &)>;
 
   void set_parent(ModbusController *const parent) { this->parent_ = parent; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
@@ -41,7 +41,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
 
  protected:
   const uint16_t write_address_;
-  std::vector<uint64_t> mapping_;
+  std::vector<int64_t> mapping_;
   ModbusController *parent_;
   bool use_write_multiple_{false};
   optional<transform_func_t> transform_func_;

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -24,8 +24,14 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
     this->mapping = mapping;
   }
 
+  using transform_func_t = std::function<optional<std::string>(ModbusSelect *, uint64_t, const std::vector<uint8_t> &)>;
+  using write_transform_func_t =
+      std::function<optional<uint64_t>(ModbusSelect *, std::string, std::vector<uint16_t> &)>;
+
   void set_parent(ModbusController *const parent) { this->parent_ = parent; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
+  void set_template(transform_func_t &&f) { this->transform_func_ = f; }
+  void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
 
   void dump_config() override;
   void parse_and_publish(const std::vector<uint8_t> &data) override;
@@ -36,6 +42,8 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   std::vector<uint64_t> mapping;
   ModbusController *parent_;
   bool use_write_multiple_{false};
+  optional<transform_func_t> transform_func_;
+  optional<write_transform_func_t> write_transform_func_;
 };
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -13,7 +13,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
  public:
   ModbusSelect(SensorValueType sensor_value_type, uint16_t start_address, uint8_t register_count, uint8_t skip_updates,
                bool force_new_range, std::vector<int64_t> mapping)
-      : Component(), select::Select(), write_address_(start_address) {
+      : Component(), select::Select() {
     this->register_type = ModbusRegisterType::HOLDING;  // not configurable
     this->sensor_value_type = sensor_value_type;
     this->start_address = start_address;
@@ -40,7 +40,6 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   void control(const std::string &value) override;
 
  protected:
-  const uint16_t write_address_;
   std::vector<int64_t> mapping_;
   ModbusController *parent_;
   bool use_write_multiple_{false};

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/components/modbus_controller/modbus_controller.h"
+#include "esphome/components/select/select.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace modbus_controller {
+
+class ModbusSelect : public Component, public select::Select, public SensorItem {
+ public:
+  ModbusSelect(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
+               SensorValueType value_type, uint8_t register_count, uint16_t response_bytes, uint8_t skip_updates, bool force_new_range)
+      : Component(), select::Select() {
+    this->register_type = register_type;
+    this->start_address = start_address;
+    this->offset = offset;
+    this->bitmask = bitmask;
+    this->sensor_value_type = value_type;
+    this->register_count = register_count;
+    this->response_bytes = response_bytes;
+    this->skip_updates = skip_updates;
+    this->force_new_range = force_new_range;
+  }
+
+  void parse_and_publish(const std::vector<uint8_t> &data) override {}
+  void control(const std::string &value) override {}
+};
+
+}  // namespace modbus_controller
+}  // namespace esphome

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -12,13 +12,13 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   ModbusSelect(uint16_t start_address, uint8_t register_count, uint8_t skip_updates, bool force_new_range,
                std::vector<uint64_t> mapping)
       : Component(), select::Select(), write_address(start_address) {
-    this->register_type = ModbusRegisterType::HOLDING;
+    this->register_type = ModbusRegisterType::HOLDING; // not configurable
     this->start_address = start_address;
-    this->offset = 0;
-    this->bitmask = 0xFFFFFFFF;
-    this->sensor_value_type = SensorValueType::RAW;
+    this->offset = 0; // not configurable
+    this->bitmask = 0xFFFFFFFF; // not configurable
+    this->sensor_value_type = SensorValueType::RAW; // not configurable
     this->register_count = register_count;
-    this->response_bytes = 0;
+    this->response_bytes = 0; // not configurable
     this->skip_updates = skip_updates;
     this->force_new_range = force_new_range;
     this->mapping = mapping;

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -9,22 +9,30 @@ namespace modbus_controller {
 
 class ModbusSelect : public Component, public select::Select, public SensorItem {
  public:
-  ModbusSelect(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
-               SensorValueType value_type, uint8_t register_count, uint16_t response_bytes, uint8_t skip_updates, bool force_new_range)
-      : Component(), select::Select() {
-    this->register_type = register_type;
+  ModbusSelect(uint16_t start_address, uint8_t register_count, uint8_t skip_updates, bool force_new_range,
+               std::vector<uint64_t> mapping)
+      : Component(), select::Select(), write_address(start_address) {
+    this->register_type = ModbusRegisterType::HOLDING;
     this->start_address = start_address;
-    this->offset = offset;
-    this->bitmask = bitmask;
-    this->sensor_value_type = value_type;
+    this->offset = 0;
+    this->bitmask = 0xFFFFFFFF;
+    this->sensor_value_type = SensorValueType::RAW;
     this->register_count = register_count;
-    this->response_bytes = response_bytes;
+    this->response_bytes = 0;
     this->skip_updates = skip_updates;
     this->force_new_range = force_new_range;
+    this->mapping = mapping;
   }
 
-  void parse_and_publish(const std::vector<uint8_t> &data) override {}
-  void control(const std::string &value) override {}
+  void dump_config() override;
+  void set_parent(ModbusController *const parent) { this->parent_ = parent; }
+  void parse_and_publish(const std::vector<uint8_t> &data) override;
+  void control(const std::string &value) override;
+
+ protected:
+  const uint16_t write_address;
+  std::vector<uint64_t> mapping;
+  ModbusController *parent_;
 };
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "esphome/components/modbus_controller/modbus_controller.h"
 #include "esphome/components/select/select.h"
 #include "esphome/core/component.h"
@@ -11,7 +13,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
  public:
   ModbusSelect(uint16_t start_address, uint8_t register_count, uint8_t skip_updates, bool force_new_range,
                std::vector<uint64_t> mapping)
-      : Component(), select::Select(), write_address(start_address) {
+      : Component(), select::Select(), write_address_(start_address) {
     this->register_type = ModbusRegisterType::HOLDING;  // not configurable
     this->start_address = start_address;
     this->offset = 0;                                // not configurable
@@ -21,7 +23,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
     this->response_bytes = 0;  // not configurable
     this->skip_updates = skip_updates;
     this->force_new_range = force_new_range;
-    this->mapping = mapping;
+    this->mapping_ = std::move(mapping);
   }
 
   using transform_func_t = std::function<optional<std::string>(ModbusSelect *, uint64_t, const std::vector<uint8_t> &)>;
@@ -38,8 +40,8 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   void control(const std::string &value) override;
 
  protected:
-  const uint16_t write_address;
-  std::vector<uint64_t> mapping;
+  const uint16_t write_address_;
+  std::vector<uint64_t> mapping_;
   ModbusController *parent_;
   bool use_write_multiple_{false};
   optional<transform_func_t> transform_func_;

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -27,8 +27,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   }
 
   using transform_func_t = std::function<optional<std::string>(ModbusSelect *, int64_t, const std::vector<uint8_t> &)>;
-  using write_transform_func_t =
-      std::function<optional<int64_t>(ModbusSelect *, std::string, std::vector<uint16_t> &, bool &)>;
+  using write_transform_func_t = std::function<optional<int64_t>(ModbusSelect *, std::string, std::vector<uint16_t> &)>;
 
   void set_parent(ModbusController *const parent) { this->parent_ = parent; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -24,8 +24,10 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
     this->mapping = mapping;
   }
 
-  void dump_config() override;
   void set_parent(ModbusController *const parent) { this->parent_ = parent; }
+  void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
+
+  void dump_config() override;
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   void control(const std::string &value) override;
 
@@ -33,6 +35,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   const uint16_t write_address;
   std::vector<uint64_t> mapping;
   ModbusController *parent_;
+  bool use_write_multiple_{false};
 };
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -12,8 +12,7 @@ namespace modbus_controller {
 class ModbusSelect : public Component, public select::Select, public SensorItem {
  public:
   ModbusSelect(SensorValueType sensor_value_type, uint16_t start_address, uint8_t register_count, uint8_t skip_updates,
-               bool force_new_range, std::vector<int64_t> mapping)
-      : Component(), select::Select() {
+               bool force_new_range, std::vector<int64_t> mapping) {
     this->register_type = ModbusRegisterType::HOLDING;  // not configurable
     this->sensor_value_type = sensor_value_type;
     this->start_address = start_address;

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -25,8 +25,10 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
     this->mapping_ = std::move(mapping);
   }
 
-  using transform_func_t = std::function<optional<std::string>(ModbusSelect *, int64_t, const std::vector<uint8_t> &)>;
-  using write_transform_func_t = std::function<optional<int64_t>(ModbusSelect *, std::string, std::vector<uint16_t> &)>;
+  using transform_func_t =
+      std::function<optional<std::string>(ModbusSelect *const, int64_t, const std::vector<uint8_t> &)>;
+  using write_transform_func_t =
+      std::function<optional<int64_t>(ModbusSelect *const, const std::string &, int64_t, std::vector<uint16_t> &)>;
 
   void set_parent(ModbusController *const parent) { this->parent_ = parent; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -12,13 +12,13 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   ModbusSelect(uint16_t start_address, uint8_t register_count, uint8_t skip_updates, bool force_new_range,
                std::vector<uint64_t> mapping)
       : Component(), select::Select(), write_address(start_address) {
-    this->register_type = ModbusRegisterType::HOLDING; // not configurable
+    this->register_type = ModbusRegisterType::HOLDING;  // not configurable
     this->start_address = start_address;
-    this->offset = 0; // not configurable
-    this->bitmask = 0xFFFFFFFF; // not configurable
-    this->sensor_value_type = SensorValueType::RAW; // not configurable
+    this->offset = 0;                                // not configurable
+    this->bitmask = 0xFFFFFFFF;                      // not configurable
+    this->sensor_value_type = SensorValueType::RAW;  // not configurable
     this->register_count = register_count;
-    this->response_bytes = 0; // not configurable
+    this->response_bytes = 0;  // not configurable
     this->skip_updates = skip_updates;
     this->force_new_range = force_new_range;
     this->mapping = mapping;

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -773,7 +773,7 @@ class MockObj(Expression):
             return MockObj(f"{self.base} &", "")
         if name == "ptr":
             return MockObj(f"{self.base} *", "")
-        if name == "cptr":
+        if name == "const_ptr":
             return MockObj(f"{self.base} *const", "")
         if name == "const":
             return MockObj(f"const {self.base}", "")

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -773,9 +773,11 @@ class MockObj(Expression):
             return MockObj(f"{self.base} &", "")
         if name == "ptr":
             return MockObj(f"{self.base} *", "")
+        if name == "cptr":
+            return MockObj(f"{self.base} *const", "")
         if name == "const":
             return MockObj(f"const {self.base}", "")
-        raise ValueError("Expected one of ref, ptr, const.")
+        raise ValueError("Expected one of ref, ptr, cptr, const.")
 
     @property
     def using(self) -> "MockObj":

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -777,7 +777,7 @@ class MockObj(Expression):
             return MockObj(f"{self.base} *const", "")
         if name == "const":
             return MockObj(f"const {self.base}", "")
-        raise ValueError("Expected one of ref, ptr, cptr, const.")
+        raise ValueError("Expected one of ref, ptr, const_ptr, const.")
 
     @property
     def using(self) -> "MockObj":

--- a/esphome/cpp_types.py
+++ b/esphome/cpp_types.py
@@ -15,6 +15,7 @@ uint16 = global_ns.namespace("uint16_t")
 uint32 = global_ns.namespace("uint32_t")
 uint64 = global_ns.namespace("uint64_t")
 int32 = global_ns.namespace("int32_t")
+int64 = global_ns.namespace("int64_t")
 const_char_ptr = global_ns.namespace("const char *")
 NAN = global_ns.namespace("NAN")
 esphome_ns = global_ns  # using namespace esphome;


### PR DESCRIPTION
# What does this implement/fix? 

Add Select for modbus controller

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1827

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:
  id: uart_modbus
  baud_rate: 9600
  rx_pin: GPIO16
  tx_pin: GPIO17

modbus:
  id: modbus1

modbus_controller:
  - id: modbus_device
    modbus_id: modbus1
    address: 0x01
    update_interval: 5s
    setup_priority: -10

select:
  - platform: modbus_controller
    modbus_controller_id: modbus_device
    id: reg_1002_text
    address: 1002
    name: Register 1002 (Text)
    optionsmap:
      "ready": 1
      "EV is present": 2
      "charging": 3
      "charging with ventilation": 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
