### PR TITLE
Support simple transparent pngs for display

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -213,7 +213,6 @@ void DisplayBuffer::vprintf_(int x, int y, Font *font, Color color, TextAlign al
 void DisplayBuffer::image(int x, int y, Image *image, Color color_on, Color color_off) {
   switch (image->get_type()) {
     case IMAGE_TYPE_BINARY:
-    case IMAGE_TYPE_TRANSPARENT_BINARY:
       for (int img_x = 0; img_x < image->get_width(); img_x++) {
         for (int img_y = 0; img_y < image->get_height(); img_y++) {
           this->draw_pixel_at(x + img_x, y + img_y, image->get_pixel(img_x, img_y) ? color_on : color_off);
@@ -231,6 +230,14 @@ void DisplayBuffer::image(int x, int y, Image *image, Color color_on, Color colo
       for (int img_x = 0; img_x < image->get_width(); img_x++) {
         for (int img_y = 0; img_y < image->get_height(); img_y++) {
           this->draw_pixel_at(x + img_x, y + img_y, image->get_color_pixel(img_x, img_y));
+        }
+      }
+      break;
+    case IMAGE_TYPE_TRANSPARENT_BINARY:
+      for (int img_x = 0; img_x < image->get_width(); img_x++) {
+        for (int img_y = 0; img_y < image->get_height(); img_y++) {
+          if (image->get_pixel(img_x, img_y))
+            this->draw_pixel_at(x + img_x, y + img_y, color_on);
         }
       }
       break;

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -213,6 +213,7 @@ void DisplayBuffer::vprintf_(int x, int y, Font *font, Color color, TextAlign al
 void DisplayBuffer::image(int x, int y, Image *image, Color color_on, Color color_off) {
   switch (image->get_type()) {
     case IMAGE_TYPE_BINARY:
+    case IMAGE_TYPE_TRANSPARENT_BINARY:
       for (int img_x = 0; img_x < image->get_width(); img_x++) {
         for (int img_y = 0; img_y < image->get_height(); img_y++) {
           this->draw_pixel_at(x + img_x, y + img_y, image->get_pixel(img_x, img_y) ? color_on : color_off);

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -73,7 +73,12 @@ extern const Color COLOR_OFF;
 /// Turn the pixel ON.
 extern const Color COLOR_ON;
 
-enum ImageType { IMAGE_TYPE_BINARY = 0, IMAGE_TYPE_GRAYSCALE = 1, IMAGE_TYPE_RGB24 = 2 };
+enum ImageType {
+  IMAGE_TYPE_BINARY = 0,
+  IMAGE_TYPE_GRAYSCALE = 1,
+  IMAGE_TYPE_RGB24 = 2,
+  IMAGE_TYPE_TRANSPARENT_BINARY = 3,
+};
 
 enum DisplayRotation {
   DISPLAY_ROTATION_0_DEGREES = 0,

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -24,6 +24,7 @@ IMAGE_TYPE = {
     "BINARY": ImageType.IMAGE_TYPE_BINARY,
     "GRAYSCALE": ImageType.IMAGE_TYPE_GRAYSCALE,
     "RGB24": ImageType.IMAGE_TYPE_RGB24,
+    "TRANSPARENT_BINARY": ImageType.IMAGE_TYPE_TRANSPARENT_BINARY,
 }
 
 Image_ = display.display_ns.class_("Image")
@@ -95,6 +96,17 @@ async def to_code(config):
         for y in range(height):
             for x in range(width):
                 if image.getpixel((x, y)):
+                    continue
+                pos = x + y * width8
+                data[pos // 8] |= 0x80 >> (pos % 8)
+
+    elif config[CONF_TYPE] == "TRANSPARENT_BINARY":
+        image = image.convert("RGBA")
+        width8 = ((width + 7) // 8) * 8
+        data = [0 for _ in range(height * width8 // 8)]
+        for y in range(height):
+            for x in range(width):
+                if not image.getpixel((x, y))[3]:
                     continue
                 pos = x + y * width8
                 data[pos // 8] |= 0x80 >> (pos % 8)


### PR DESCRIPTION
# What does this implement/fix? 

This allows you to supply a transparent png and any pixels that are not fully transparent will become a solid color on pixel.

This only looks at the alpha part of the pixel and does not care for the actual color.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1796

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
