### PR TITLE
Generate basic config for esphome-web devices

### DIFF
--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components.packages import validate_source_shorthand
+from esphome.wizard import wizard_file
 from esphome.yaml_util import dump
 
 
@@ -36,48 +37,6 @@ wifi:
   password: !secret wifi_password
 """
 
-ESPHOME_WEB_COMMON = (
-    """# Enable logging
-logger:
-
-# Enable Home Assistant API
-api:
-
-# Allow OTA updates
-ota:"""
-    + WIFI_CONFIG
-    + """  ap: {}
-
-# In combination with the `ap` this allows the user
-# to provision wifi credentials to the device via WiFi AP.
-captive_portal:
-
-web_server:
-"""
-)
-
-ESPHOME_WEB_CONFIG_ESP32 = (
-    """
-esphome:
-  name: "${name}"
-  platform: ESP32
-  board: esp32dev
-
-"""
-    + ESPHOME_WEB_COMMON
-)
-
-ESPHOME_WEB_CONFIG_ESP8266 = (
-    """
-esphome:
-  name: "${name}"
-  platform: ESP8266
-  board: esp01_1m
-
-"""
-    + ESPHOME_WEB_COMMON
-)
-
 
 async def to_code(config):
     cg.add_define("USE_DASHBOARD_IMPORT")
@@ -92,9 +51,13 @@ def import_config(path: str, name: str, project_name: str, import_url: str) -> N
 
     if project_name == "esphome.web":
         p.write_text(
-            f"substitutions:\n  name: {name}\n" + ESPHOME_WEB_CONFIG_ESP32
-            if "esp32" in import_url
-            else ESPHOME_WEB_CONFIG_ESP8266,
+            wizard_file(
+                name=name,
+                platform="ESP32" if "esp32" in import_url else "ESP8266",
+                board="esp32dev" if "esp32" in import_url else "esp01_1m",
+                ssid="!secret wifi_ssid",
+                psk="!secret wifi_password",
+            ),
             encoding="utf8",
         )
     else:


### PR DESCRIPTION
# What does this implement/fix? 

Instead of a package based config, a minimal config for the user to build from is generated for ESPHome web adopted devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
