### PR TITLE
[TCS34725] remove duplicated endian conversion

### DIFF
--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -97,7 +97,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
    *
    * (a) As light becomes brighter, the clear channel will tend to
    *     saturate first since R+G+B is approximately equal to C.
-   * (b) The TTCS34725 accumulates 1024 counts per 2.4ms of integration
+   * (b) The TCS34725 accumulates 1024 counts per 2.4ms of integration
    *     time, up to a maximum values of 65535. This means analog
    *     saturation can occur up to an integration time of 153.6ms
    *     (64*2.4ms=153.6ms).

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -180,12 +180,6 @@ void TCS34725Component::update() {
     return;
   }
 
-  // May need to fix endianness as the data read over I2C is big-endian, but most ESP platforms are little-endian
-  raw_c = i2c::i2ctohs(raw_c);
-  raw_r = i2c::i2ctohs(raw_r);
-  raw_g = i2c::i2ctohs(raw_g);
-  raw_b = i2c::i2ctohs(raw_b);
-
   const float channel_c = raw_c / 655.35f;
   const float channel_r = raw_r / 655.35f;
   const float channel_g = raw_g / 655.35f;

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -25,18 +25,18 @@ void TCS34725Component::setup() {
     this->mark_failed();
     return;
   }
-  if (this->write_config_register(TCS34725_REGISTER_ATIME, this->integration_reg_) != i2c::ERROR_OK ||
-      this->write_config_register(TCS34725_REGISTER_CONTROL, this->gain_reg_) != i2c::ERROR_OK) {
+  if (this->write_config_register_(TCS34725_REGISTER_ATIME, this->integration_reg_) != i2c::ERROR_OK ||
+      this->write_config_register_(TCS34725_REGISTER_CONTROL, this->gain_reg_) != i2c::ERROR_OK) {
     this->mark_failed();
     return;
   }
-  if (this->write_config_register(TCS34725_REGISTER_ENABLE, 0x01) !=
+  if (this->write_config_register_(TCS34725_REGISTER_ENABLE, 0x01) !=
       i2c::ERROR_OK) {  // Power on (internal oscillator on)
     this->mark_failed();
     return;
   }
   delay(3);
-  if (this->write_config_register(TCS34725_REGISTER_ENABLE, 0x03) !=
+  if (this->write_config_register_(TCS34725_REGISTER_ENABLE, 0x03) !=
       i2c::ERROR_OK) {  // Power on (internal oscillator on) + RGBC ADC Enable
     this->mark_failed();
     return;
@@ -173,19 +173,19 @@ void TCS34725Component::update() {
   uint16_t raw_g;
   uint16_t raw_b;
 
-  if (this->read_data_register(TCS34725_REGISTER_CDATAL, raw_c) != i2c::ERROR_OK) {
+  if (this->read_data_register_(TCS34725_REGISTER_CDATAL, raw_c) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
-  if (this->read_data_register(TCS34725_REGISTER_RDATAL, raw_r) != i2c::ERROR_OK) {
+  if (this->read_data_register_(TCS34725_REGISTER_RDATAL, raw_r) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
-  if (this->read_data_register(TCS34725_REGISTER_GDATAL, raw_g) != i2c::ERROR_OK) {
+  if (this->read_data_register_(TCS34725_REGISTER_GDATAL, raw_g) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
-  if (this->read_data_register(TCS34725_REGISTER_BDATAL, raw_b) != i2c::ERROR_OK) {
+  if (this->read_data_register_(TCS34725_REGISTER_BDATAL, raw_b) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -21,23 +21,23 @@ static const uint8_t TCS34725_REGISTER_BDATAL = TCS34725_COMMAND_BIT | 0x1A;
 void TCS34725Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TCS34725...");
   uint8_t id;
-  if (!this->read_byte(TCS34725_REGISTER_ID, &id)) {
+  if (this->read_register(TCS34725_REGISTER_ID, &id, 1) != i2c::ERROR_OK) {
     this->mark_failed();
     return;
   }
-
-  if (!this->write_byte(TCS34725_REGISTER_ATIME, this->integration_reg_) ||
-      !this->write_byte(TCS34725_REGISTER_CONTROL, this->gain_reg_)) {
+  if (this->write_config_register(TCS34725_REGISTER_ATIME, this->integration_reg_) != i2c::ERROR_OK ||
+      this->write_config_register(TCS34725_REGISTER_CONTROL, this->gain_reg_) != i2c::ERROR_OK) {
     this->mark_failed();
     return;
   }
-
-  if (!this->write_byte(TCS34725_REGISTER_ENABLE, 0x01)) {  // Power on (internal oscillator on)
+  if (this->write_config_register(TCS34725_REGISTER_ENABLE, 0x01) !=
+      i2c::ERROR_OK) {  // Power on (internal oscillator on)
     this->mark_failed();
     return;
   }
   delay(3);
-  if (!this->write_byte(TCS34725_REGISTER_ENABLE, 0x03)) {  // Power on (internal oscillator on) + RGBC ADC Enable
+  if (this->write_config_register(TCS34725_REGISTER_ENABLE, 0x03) !=
+      i2c::ERROR_OK) {  // Power on (internal oscillator on) + RGBC ADC Enable
     this->mark_failed();
     return;
   }
@@ -97,7 +97,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
    *
    * (a) As light becomes brighter, the clear channel will tend to
    *     saturate first since R+G+B is approximately equal to C.
-   * (b) The TCS34725 accumulates 1024 counts per 2.4ms of integration
+   * (b) The TTCS34725 accumulates 1024 counts per 2.4ms of integration
    *     time, up to a maximum values of 65535. This means analog
    *     saturation can occur up to an integration time of 153.6ms
    *     (64*2.4ms=153.6ms).
@@ -134,9 +134,9 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
     /* Adjust sat to 75% to avoid analog saturation if atime < 153.6ms */
     sat -= sat / 4.f;
   }
-
   /* Check for saturation and mark the sample as invalid if true */
   if (c >= sat) {
+    ESP_LOGW(TAG, "Saturation too high discarding sample = sat=.1%f clear = %d", sat, c);
     return;
   }
 
@@ -173,17 +173,40 @@ void TCS34725Component::update() {
   uint16_t raw_g;
   uint16_t raw_b;
 
-  if (!this->read_byte_16(TCS34725_REGISTER_CDATAL, &raw_c) || !this->read_byte_16(TCS34725_REGISTER_RDATAL, &raw_r) ||
-      !this->read_byte_16(TCS34725_REGISTER_GDATAL, &raw_g) || !this->read_byte_16(TCS34725_REGISTER_BDATAL, &raw_b)) {
-    ESP_LOGW(TAG, "Reading data from TCS34725 failed!");
+  if (this->read_data_register(TCS34725_REGISTER_CDATAL, raw_c) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
+  if (this->read_data_register(TCS34725_REGISTER_RDATAL, raw_r) != i2c::ERROR_OK) {
+    this->status_set_warning();
+    return;
+  }
+  if (this->read_data_register(TCS34725_REGISTER_GDATAL, raw_g) != i2c::ERROR_OK) {
+    this->status_set_warning();
+    return;
+  }
+  if (this->read_data_register(TCS34725_REGISTER_BDATAL, raw_b) != i2c::ERROR_OK) {
+    this->status_set_warning();
+    return;
+  }
+  ESP_LOGV(TAG, "Raw values clear=%x red=%x green=%x blue=%x", raw_c, raw_r, raw_g, raw_b);
 
-  const float channel_c = raw_c / 655.35f;
-  const float channel_r = raw_r / 655.35f;
-  const float channel_g = raw_g / 655.35f;
-  const float channel_b = raw_b / 655.35f;
+  float channel_c;
+  float channel_r;
+  float channel_g;
+  float channel_b;
+  // avoid division by 0 and return black if clear is 0
+  if (raw_c == 0) {
+    channel_c = channel_r = channel_g = channel_b = 0.0f;
+  } else {
+    float max_count = this->integration_time_ * 1024.0f / 2.4;
+    float sum = raw_c;
+    channel_r = raw_r / sum * 100.0f;
+    channel_g = raw_g / sum * 100.0f;
+    channel_b = raw_b / sum * 100.0f;
+    channel_c = raw_c / max_count * 100.0f;
+  }
+
   if (this->clear_sensor_ != nullptr)
     this->clear_sensor_->publish_state(channel_c);
   if (this->red_sensor_ != nullptr)
@@ -203,8 +226,8 @@ void TCS34725Component::update() {
   if (this->color_temperature_sensor_ != nullptr)
     this->color_temperature_sensor_->publish_state(this->color_temperature_);
 
-  ESP_LOGD(TAG, "Got R=%.1f%%,G=%.1f%%,B=%.1f%%,C=%.1f%% Illuminance=%.1flx Color Temperature=%.1fK", channel_r,
-           channel_g, channel_b, channel_c, this->illuminance_, this->color_temperature_);
+  ESP_LOGD(TAG, "Got Red=%.1f%%,Green=%.1f%%,Blue=%.1f%%,Clear=%.1f%% Illuminance=%.1flx Color Temperature=%.1fK",
+           channel_r, channel_g, channel_b, channel_c, this->illuminance_, this->color_temperature_);
 
   this->status_clear_warning();
 }

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -136,7 +136,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   }
   /* Check for saturation and mark the sample as invalid if true */
   if (c >= sat) {
-    ESP_LOGW(TAG, "Saturation too high discarding sample = sat=.1%f clear = %d", sat, c);
+    ESP_LOGW(TAG, "Saturation too high, discarding sample with saturation %.1f and clear %d", sat, c);
     return;
   }
 

--- a/esphome/components/tcs34725/tcs34725.h
+++ b/esphome/components/tcs34725/tcs34725.h
@@ -59,7 +59,8 @@ class TCS34725Component : public PollingComponent, public i2c::I2CDevice {
   i2c::ErrorCode read_data_register_(uint8_t a_register, uint16_t &data) {
     uint8_t buffer[2];
     auto retval = this->read_register(a_register, buffer, 2);
-    data = (uint16_t(buffer[1]) << 8) | (uint16_t(buffer[0]) & 0xFF);
+    if (retval == i2c::ERROR_OK)
+      data = (uint16_t(buffer[1]) << 8) | (uint16_t(buffer[0]) & 0xFF);
     return retval;
   }
   i2c::ErrorCode write_config_register_(uint8_t a_register, uint8_t data) {

--- a/esphome/components/tcs34725/tcs34725.h
+++ b/esphome/components/tcs34725/tcs34725.h
@@ -56,13 +56,13 @@ class TCS34725Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
 
  protected:
-  i2c::ErrorCode read_data_register(uint8_t a_register, uint16_t &data) {
+  i2c::ErrorCode read_data_register_(uint8_t a_register, uint16_t &data) {
     uint8_t buffer[2];
     auto retval = this->read_register(a_register, buffer, 2);
     data = (uint16_t(buffer[1]) << 8) | (uint16_t(buffer[0]) & 0xFF);
     return retval;
   }
-  i2c::ErrorCode write_config_register(uint8_t a_register, uint8_t data) {
+  i2c::ErrorCode write_config_register_(uint8_t a_register, uint8_t data) {
     return this->write_register(a_register, &data, 1);
   }
   sensor::Sensor *clear_sensor_{nullptr};

--- a/esphome/components/tcs34725/tcs34725.h
+++ b/esphome/components/tcs34725/tcs34725.h
@@ -56,6 +56,15 @@ class TCS34725Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
 
  protected:
+  i2c::ErrorCode read_data_register(uint8_t a_register, uint16_t &data) {
+    uint8_t buffer[2];
+    auto retval = this->read_register(a_register, buffer, 2);
+    data = (uint16_t(buffer[1]) << 8) | (uint16_t(buffer[0]) & 0xFF);
+    return retval;
+  }
+  i2c::ErrorCode write_config_register(uint8_t a_register, uint8_t data) {
+    return this->write_register(a_register, &data, 1);
+  }
   sensor::Sensor *clear_sensor_{nullptr};
   sensor::Sensor *red_sensor_{nullptr};
   sensor::Sensor *green_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix? 

The existing code uses i2c::read_byte_16 which calls i2c::i2ctohs. Since TCS34725 uses little endian the  i2c::i2ctohs has to be called again to revert the previous incorrect (for this sensor)  i2c::i2ctohs call. 
This fix uses i2c::write_register instead.
For consistency all remaining i2c calls are changed to use i2c::write/read_register only. 

To address the issue from 2930 the scaling algorithm for C,R,G and B is changed to report R,B,G as percentage of C. 
C is scaled in relation to the max value based on intergration time instead of hardcoding the max to 65535 

## Types of changes
 
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2930

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
