### PR TITLE
Add USB_CDC logger option for esp-idf platform.

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -54,13 +54,12 @@ LOG_LEVEL_SEVERITY = [
     "VERY_VERBOSE",
 ]
 
-ESP32_REDUCED_VARIANTS = [VARIANT_ESP32C3, VARIANT_ESP32S2]
-
-UART_SELECTION_ESP32_REDUCED = ["UART0", "UART1"]
-
-USB_CDC_ESP32_VARIANTS = [VARIANT_ESP32S2]
-
 UART_SELECTION_ESP32 = ["UART0", "UART1", "UART2"]
+
+UART_SELECTION_ESP32_VARIANTS = {
+    VARIANT_ESP32C3: ["UART0", "UART1"],
+    VARIANT_ESP32S2: ["UART0", "UART1", "USB_CDC"],
+}
 
 UART_SELECTION_ESP8266 = ["UART0", "UART0_SWAP", "UART1"]
 
@@ -84,11 +83,10 @@ is_log_level = cv.one_of(*LOG_LEVELS, upper=True)
 
 def uart_selection(value):
     if CORE.is_esp32:
-        if value.upper() == "USB_CDC":
-            return get_esp32_variant() in USB_CDC_ESP32_VARIANTS
-        if get_esp32_variant() in ESP32_REDUCED_VARIANTS:
-            return cv.one_of(*UART_SELECTION_ESP32_REDUCED, upper=True)(value)
-        return cv.one_of(*UART_SELECTION_ESP32, upper=True)(value)
+        uart_selection = UART_SELECTION_ESP32_VARIANTS.get(
+            get_esp32_variant(), UART_SELECTION_ESP32
+        )
+        return cv.one_of(*uart_selection, upper=True)(value)
     if CORE.is_esp8266:
         return cv.one_of(*UART_SELECTION_ESP8266, upper=True)(value)
     raise NotImplementedError

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -56,7 +56,9 @@ LOG_LEVEL_SEVERITY = [
 
 ESP32_REDUCED_VARIANTS = [VARIANT_ESP32C3, VARIANT_ESP32S2]
 
-UART_SELECTION_ESP32_REDUCED = ["UART0", "UART1", "USB_CDC"]
+UART_SELECTION_ESP32_REDUCED = ["UART0", "UART1"]
+
+USB_CDC_ESP32_VARIANTS = [VARIANT_ESP32S2]
 
 UART_SELECTION_ESP32 = ["UART0", "UART1", "UART2"]
 
@@ -82,6 +84,8 @@ is_log_level = cv.one_of(*LOG_LEVELS, upper=True)
 
 def uart_selection(value):
     if CORE.is_esp32:
+        if value.upper() == "USB_CDC":
+            return get_esp32_variant() in USB_CDC_ESP32_VARIANTS
         if get_esp32_variant() in ESP32_REDUCED_VARIANTS:
             return cv.one_of(*UART_SELECTION_ESP32_REDUCED, upper=True)(value)
         return cv.one_of(*UART_SELECTION_ESP32, upper=True)(value)

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -116,8 +116,12 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
     this->hw_serial_->println(msg);
 #endif  // USE_ARDUINO
 #ifdef USE_ESP_IDF
+#ifdef CONFIG_ESP_CONSOLE_USB_CDC
+    puts(msg);
+#else
     uart_write_bytes(uart_num_, msg, strlen(msg));
     uart_write_bytes(uart_num_, "\n", 1);
+#endif
 #endif
   }
 
@@ -161,6 +165,9 @@ void Logger::pre_setup() {
     }
 #endif  // USE_ARDUINO
 #ifdef USE_ESP_IDF
+#if defined(CONFIG_ESP_CONSOLE_USB_CDC)
+    uart_num_ = -1;
+#else
     uart_num_ = UART_NUM_0;
     switch (uart_) {
       case UART_SELECTION_UART0:
@@ -185,6 +192,7 @@ void Logger::pre_setup() {
     const int uart_buffer_size = tx_buffer_size_;
     // Install UART driver using an event queue here
     uart_driver_install(uart_num_, uart_buffer_size, uart_buffer_size, 10, nullptr, 0);
+#endif
 #endif
 
 #ifdef USE_ARDUINO

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -27,6 +27,9 @@ enum UARTSelection {
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32S2)
   UART_SELECTION_UART2,
 #endif
+#if defined(CONFIG_ESP_CONSOLE_USB_CDC)
+  UART_SELECTION_USB_CDC,
+#endif
 #ifdef USE_ESP8266
   UART_SELECTION_UART0_SWAP,
 #endif


### PR DESCRIPTION
# What does this implement/fix? 

ESP32S2 and ESP32C3 have a builtin USB controller that
can be used for logging.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/esphome/feature-requests/issues/1598

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: test-logger

external_components:
  - source:
      type: local
      path: esphome/esphome/components
    components: [ logger ]

esp32:
  board: featheresp32-s2
  framework:
    type: esp-idf
    version: recommended

# Enable logging
logger:
  level: VERY_VERBOSE
  hardware_uart: USB_CDC

# Enable Home Assistant API
api:
  password: ""

ota:
  password: ""

wifi:
  ssid: "TestWifi"
  password: "***"

sensor:
  - platform: uptime
    name: Uptime Sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
