### PR TITLE
Add restore_mode to fan component

### DIFF
--- a/esphome/components/fan/fan_state.cpp
+++ b/esphome/components/fan/fan_state.cpp
@@ -37,8 +37,7 @@ void FanState::setup() {
     case FAN_RESTORE_INVERTED_DEFAULT_ON:
       this->rtc_ = global_preferences->make_preference<FanStateRTCState>(this->get_object_id_hash());
       if (!this->rtc_.load(&recovered)) {
-        if (this->restore_mode_ == FAN_RESTORE_DEFAULT_ON ||
-            this->restore_mode_ == FAN_RESTORE_INVERTED_DEFAULT_ON) {
+        if (this->restore_mode_ == FAN_RESTORE_DEFAULT_ON || this->restore_mode_ == FAN_RESTORE_INVERTED_DEFAULT_ON) {
           call.set_state(true);
         } else {
           call.set_state(false);

--- a/esphome/components/fan/fan_state.h
+++ b/esphome/components/fan/fan_state.h
@@ -20,6 +20,15 @@ enum ESPDEPRECATED("FanSpeed is deprecated.", "2021.9") FanSpeed {
 /// Simple enum to represent the direction of a fan
 enum FanDirection { FAN_DIRECTION_FORWARD = 0, FAN_DIRECTION_REVERSE = 1 };
 
+enum FanRestoreMode {
+  FAN_RESTORE_DEFAULT_OFF,
+  FAN_RESTORE_DEFAULT_ON,
+  FAN_ALWAYS_OFF,
+  FAN_ALWAYS_ON,
+  FAN_RESTORE_INVERTED_DEFAULT_OFF,
+  FAN_RESTORE_INVERTED_DEFAULT_ON,
+};
+
 class FanState;
 
 class FanStateCall {
@@ -81,6 +90,9 @@ class FanState : public EntityBase, public Component {
   /// Set the traits of this fan (i.e. what features it supports).
   void set_traits(const FanTraits &traits);
 
+  /// Set the restore mode of this fan
+  void set_restore_mode(FanRestoreMode restore_mode) { this->restore_mode_ = restore_mode; }
+
   /// The current ON/OFF state of the fan.
   bool state{false};
   /// The current oscillation state of the fan.
@@ -106,6 +118,9 @@ class FanState : public EntityBase, public Component {
   FanTraits traits_{};
   CallbackManager<void()> state_callback_{};
   ESPPreferenceObject rtc_;
+
+  /// Restore mode of the fan.
+  FanRestoreMode restore_mode_;
 };
 
 }  // namespace fan


### PR DESCRIPTION
# What does this implement/fix? 

Add `restore_mode` to the `fan` component, similar to the `light` and `switch` components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2925

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1802

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
fan:
  - platform: 'binary'
    output: 'output1'
    name: 'Test'
    restore_mode: 'RESTORE_DEFAULT_OFF'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).