### PR TITLE
I2C Dynamic Address/Value sizes

### DIFF
--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -15,24 +15,33 @@ bool I2CDevice::write_bytes_16(uint8_t a_register, const uint16_t *data, uint8_t
   return write_register(a_register, reinterpret_cast<const uint8_t *>(temp.get()), len * 2) == ERROR_OK;
 }
 
-I2CRegister &I2CRegister::operator=(uint8_t value) {
-  this->parent_->write_register(this->register_, &value, 1);
-  return *this;
-}
-I2CRegister &I2CRegister::operator&=(uint8_t value) {
-  value &= get();
-  this->parent_->write_register(this->register_, &value, 1);
-  return *this;
-}
-I2CRegister &I2CRegister::operator|=(uint8_t value) {
-  value |= get();
-  this->parent_->write_register(this->register_, &value, 1);
+template<typename TRegisterAddress, typename TRegisterValue>
+I2CRegister<TRegisterAddress, TRegisterValue> &I2CRegister<TRegisterAddress, TRegisterValue>::operator=(
+    TRegisterValue value) {
+  this->parent_->write_register(this->register_, &value);
   return *this;
 }
 
-uint8_t I2CRegister::get() const {
-  uint8_t value = 0x00;
-  this->parent_->read_register(this->register_, &value, 1);
+template<typename TRegisterAddress, typename TRegisterValue>
+I2CRegister<TRegisterAddress, TRegisterValue> &I2CRegister<TRegisterAddress, TRegisterValue>::operator&=(
+    TRegisterValue value) {
+  value &= get();
+  this->parent_->write_register(this->register_, &value);
+  return *this;
+}
+
+template<typename TRegisterAddress, typename TRegisterValue>
+I2CRegister<TRegisterAddress, TRegisterValue> &I2CRegister<TRegisterAddress, TRegisterValue>::operator|=(
+    TRegisterValue value) {
+  value |= get();
+  this->parent_->write_register(this->register_, &value);
+  return *this;
+}
+
+template<typename TRegisterAddress, typename TRegisterValue>
+TRegisterValue I2CRegister<TRegisterAddress, TRegisterValue>::get() const {
+  TRegisterValue value = 0x00;
+  this->parent_->read_register(this->register_, &value);
   return value;
 }
 

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -43,7 +43,7 @@ class I2CDevice {
   void set_i2c_address(uint8_t address) { address_ = address; }
   void set_i2c_bus(I2CBus *bus) { bus_ = bus; }
 
-  I2CRegister<> reg(uint8_t a_register) { return {this, a_register}; }
+  I2CRegister<uint8_t, uint8_t> reg(uint8_t a_register) { return {this, a_register}; }
 
   template<typename TRegisterValue = uint8_t, typename TRegisterAddress = uint8_t>
   I2CRegister<TRegisterAddress, TRegisterValue> reg(TRegisterAddress a_register) {

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -43,6 +43,8 @@ class I2CDevice {
   void set_i2c_address(uint8_t address) { address_ = address; }
   void set_i2c_bus(I2CBus *bus) { bus_ = bus; }
 
+  I2CRegister<> reg(uint8_t a_register) { return {this, a_register}; }
+
   template<typename TRegisterValue = uint8_t, typename TRegisterAddress = uint8_t>
   I2CRegister<TRegisterAddress, TRegisterValue> reg(TRegisterAddress a_register) {
     return {this, a_register};

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -12,23 +12,23 @@ namespace i2c {
 #define LOG_I2C_DEVICE(this) ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
 
 class I2CDevice;
-class I2CRegister {
+template<typename TRegisterAddress = uint8_t, typename TRegisterValue = uint8_t> class I2CRegister {
  public:
-  I2CRegister &operator=(uint8_t value);
-  I2CRegister &operator&=(uint8_t value);
-  I2CRegister &operator|=(uint8_t value);
+  I2CRegister<TRegisterAddress, TRegisterValue> &operator=(TRegisterValue value);
+  I2CRegister<TRegisterAddress, TRegisterValue> &operator&=(TRegisterValue value);
+  I2CRegister<TRegisterAddress, TRegisterValue> &operator|=(TRegisterValue value);
 
-  explicit operator uint8_t() const { return get(); }
+  explicit operator TRegisterValue() const { return get(); }
 
-  uint8_t get() const;
+  TRegisterValue get() const;
 
  protected:
   friend class I2CDevice;
 
-  I2CRegister(I2CDevice *parent, uint8_t a_register) : parent_(parent), register_(a_register) {}
+  I2CRegister(I2CDevice *parent, TRegisterAddress a_register) : parent_(parent), register_(a_register) {}
 
   I2CDevice *parent_;
-  uint8_t register_;
+  TRegisterAddress register_;
 };
 
 // like ntohs/htons but without including networking headers.
@@ -43,7 +43,10 @@ class I2CDevice {
   void set_i2c_address(uint8_t address) { address_ = address; }
   void set_i2c_bus(I2CBus *bus) { bus_ = bus; }
 
-  I2CRegister reg(uint8_t a_register) { return {this, a_register}; }
+  template<typename TRegisterValue = uint8_t, typename TRegisterAddress = uint8_t>
+  I2CRegister<TRegisterAddress, TRegisterValue> reg(TRegisterAddress a_register) {
+    return {this, a_register};
+  }
 
   ErrorCode read(uint8_t *data, size_t len) { return bus_->read(address_, data, len); }
   ErrorCode read_register(uint8_t a_register, uint8_t *data, size_t len) {

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -60,11 +60,11 @@ class I2CDevice {
 
   template<typename TRegisterAddress, typename TRegisterValue>
   ErrorCode read_register(TRegisterAddress a_register, TRegisterValue data) {
-    uint8_t *reg = reinterpret_cast<uint8_t *>(&a_register);
+    uint8_t *reg = reinterpret_cast<uint8_t *>(convert_big_endian(&a_register));
     ErrorCode err = this->write(reg, sizeof(reg));
     if (err != ERROR_OK)
       return err;
-    uint8_t *data2 = reinterpret_cast<uint8_t *>(&data);
+    uint8_t *data2 = reinterpret_cast<uint8_t *>(convert_big_endian(&data));
     return this->read(data2, sizeof(data2));
   }
 
@@ -81,9 +81,9 @@ class I2CDevice {
   template<typename TRegisterAddress, typename TRegisterValue>
   ErrorCode write_register(TRegisterAddress a_register, TRegisterValue data) {
     WriteBuffer buffers[2];
-    buffers[0].data = reinterpret_cast<uint8_t *>(&a_register);
+    buffers[0].data = reinterpret_cast<uint8_t *>(convert_big_endian(&a_register));
     buffers[0].len = sizeof(buffers[0].data);
-    buffers[1].data = reinterpret_cast<uint8_t *>(&data);
+    buffers[1].data = reinterpret_cast<uint8_t *>(convert_big_endian(&data));
     buffers[1].len = sizeof(buffers[1].data);
     return bus_->writev(address_, buffers, 2);
   }

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -53,6 +53,16 @@ class I2CDevice {
     return this->read(data, len);
   }
 
+  template<typename TRegisterAddress, typename TRegisterValue>
+  ErrorCode read_register(TRegisterAddress a_register, TRegisterValue data) {
+    uint8_t *reg = reinterpret_cast<uint8_t *>(&a_register);
+    ErrorCode err = this->write(reg, sizeof(reg));
+    if (err != ERROR_OK)
+      return err;
+    uint8_t *data2 = reinterpret_cast<uint8_t *>(&data);
+    return this->read(data2, sizeof(data2));
+  }
+
   ErrorCode write(const uint8_t *data, uint8_t len) { return bus_->write(address_, data, len); }
   ErrorCode write_register(uint8_t a_register, const uint8_t *data, size_t len) {
     WriteBuffer buffers[2];
@@ -60,6 +70,16 @@ class I2CDevice {
     buffers[0].len = 1;
     buffers[1].data = data;
     buffers[1].len = len;
+    return bus_->writev(address_, buffers, 2);
+  }
+
+  template<typename TRegisterAddress, typename TRegisterValue>
+  ErrorCode write_register(TRegisterAddress a_register, TRegisterValue data) {
+    WriteBuffer buffers[2];
+    buffers[0].data = reinterpret_cast<uint8_t *>(&a_register);
+    buffers[0].len = sizeof(buffers[0].data);
+    buffers[1].data = reinterpret_cast<uint8_t *>(&data);
+    buffers[1].len = sizeof(buffers[1].data);
     return bus_->writev(address_, buffers, 2);
   }
 


### PR DESCRIPTION
# What does this implement/fix? 

This allows dynamic sizes of I2C addresses & values. I'm a bit over my head here..new to C++ and I2C, but trying to push this feature forward.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
