### PR TITLE
Add number setting to web_server/rest_api

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -238,15 +238,15 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
     if (this->include_internal_ || !obj->is_internal())
       write_row(stream, obj, "number", "", [](AsyncResponseStream &stream, EntityBase *obj) {
         number::Number *number = (number::Number *) obj;
-        stream.print("<input type=\"number\" min=\"");
+        stream.print(R"(<input type="number" min=")");
         stream.print(number->traits.get_min_value());
-        stream.print("\" max=\"");
+        stream.print(R"(" max=")");
         stream.print(number->traits.get_max_value());
-        stream.print("\" step=\"");
+        stream.print(R"(" step=")");
         stream.print(number->traits.get_step());
-        stream.print("\" value=\"");
+        stream.print(R"(" value=")");
         stream.print(number->state);
-        stream.print("\"/>");
+        stream.print(R"("/>)");
       });
 #endif
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -236,7 +236,18 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #ifdef USE_NUMBER
   for (auto *obj : App.get_numbers())
     if (this->include_internal_ || !obj->is_internal())
-      write_row(stream, obj, "number", "");
+      write_row(stream, obj, "number", "", [](AsyncResponseStream &stream, EntityBase *obj) {
+        number::Number *number = (number::Number *) obj;
+        stream.print("<input type=\"number\" min=\"");
+        stream.print(number->traits.get_min_value());
+        stream.print("\" max=\"");
+        stream.print(number->traits.get_max_value());
+        stream.print("\" step=\"");
+        stream.print(number->traits.get_step());
+        stream.print("\" value=\"");
+        stream.print(number->state);
+        stream.print("\"/>");
+      });
 #endif
 
 #ifdef USE_SELECT
@@ -652,8 +663,29 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
   for (auto *obj : App.get_numbers()) {
     if (obj->get_object_id() != match.id)
       continue;
-    std::string data = this->number_json(obj, obj->state);
-    request->send(200, "text/json", data.c_str());
+
+    if (request->method() == HTTP_GET) {
+      std::string data = this->number_json(obj, obj->state);
+      request->send(200, "text/json", data.c_str());
+      return;
+    }
+
+    if (match.method != "set") {
+      request->send(404);
+      return;
+    }
+
+    auto call = obj->make_call();
+
+    if (request->hasParam("value")) {
+      String value = request->getParam("value")->value();
+      optional<float> value_f = parse_number<float>(value.c_str());
+      if (value_f.has_value())
+        call.set_value(*value_f);
+    }
+
+    this->defer([call]() mutable { call.perform(); });
+    request->send(200);
     return;
   }
   request->send(404);
@@ -661,9 +693,8 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
 std::string WebServer::number_json(number::Number *obj, float value) {
   return json::build_json([obj, value](JsonObject root) {
     root["id"] = "number-" + obj->get_object_id();
-    char buffer[64];
-    snprintf(buffer, sizeof(buffer), "%f", value);
-    root["state"] = buffer;
+    std::string state = str_sprintf("%f", value);
+    root["state"] = state;
     root["value"] = value;
   });
 }
@@ -769,7 +800,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 #endif
 
 #ifdef USE_NUMBER
-  if (request->method() == HTTP_GET && match.domain == "number")
+  if ((request->method() == HTTP_POST || request->method() == HTTP_GET) && match.domain == "number")
     return true;
 #endif
 


### PR DESCRIPTION
# What does this implement/fix? 

Missed adding `number` setting to the REST api in the past, so adding it here and also an input box to the webserver for easy setting.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1804

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
