### PR TITLE
Remove deprecated attribute from virtual entity methods

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -74,8 +74,10 @@ class BinarySensor : public EntityBase {
 
   // ========== OVERRIDE METHODS ==========
   // (You'll only need this when creating your own custom binary sensor)
-  /// Get the default device class for this sensor, or empty string for no default.
-  ESPDEPRECATED("device_class() is deprecated, set property during config validation instead.", "2022.01")
+  /** Override this to set the default device class.
+   *
+   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
+   */
   virtual std::string device_class();
 
  protected:

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -169,7 +169,11 @@ class Cover : public EntityBase {
   friend CoverCall;
 
   virtual void control(const CoverCall &call) = 0;
-  ESPDEPRECATED("device_class() is deprecated, set property during config validation instead.", "2022.01")
+
+  /** Override this to set the default device class.
+   *
+   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
+   */
   virtual std::string device_class();
 
   optional<CoverRestoreState> restore_state_();

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -150,20 +150,28 @@ class Sensor : public EntityBase {
   void internal_send_state_to_frontend(float state);
 
  protected:
-  /// Override this to set the default unit of measurement.
-  ESPDEPRECATED("unit_of_measurement() is deprecated, set property during config validation instead.", "2022.01")
+  /** Override this to set the default unit of measurement.
+   *
+   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
+   */
   virtual std::string unit_of_measurement();  // NOLINT
 
-  /// Override this to set the default accuracy in decimals.
-  ESPDEPRECATED("accuracy_decimals() is deprecated, set property during config validation instead.", "2022.01")
+  /** Override this to set the default accuracy in decimals.
+   *
+   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
+   */
   virtual int8_t accuracy_decimals();  // NOLINT
 
-  /// Override this to set the default device class.
-  ESPDEPRECATED("device_class() is deprecated, set property during config validation instead.", "2022.01")
+  /** Override this to set the default device class.
+   *
+   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
+   */
   virtual std::string device_class();  // NOLINT
 
-  /// Override this to set the default state class.
-  ESPDEPRECATED("state_class() is deprecated, set property during config validation instead.", "2022.01")
+  /** Override this to set the default state class.
+   *
+   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
+   */
   virtual StateClass state_class();  // NOLINT
 
   uint32_t hash_base() override;


### PR DESCRIPTION
# What does this implement/fix? 

Remove the deprecated attribute from the Sensor methods deprecated in #3021: gcc emits a warning about them on every class that inherits them, which is pretty annoying. I'm not sure why gcc emits this warning, but I can't actually reproduce it with a minimal example, so I suspect it's a compiler bug.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
