### PR TITLE
Perform merges when substituting dict keys

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 from esphome.core import EsphomeError
+from esphome.config_helpers import merge_config
 
 from esphome import git, yaml_util
 from esphome.const import (
@@ -16,26 +17,6 @@ from esphome.const import (
 import esphome.config_validation as cv
 
 DOMAIN = CONF_PACKAGES
-
-
-def _merge_package(full_old, full_new):
-    def merge(old, new):
-        # pylint: disable=no-else-return
-        if isinstance(new, dict):
-            if not isinstance(old, dict):
-                return new
-            res = old.copy()
-            for k, v in new.items():
-                res[k] = merge(old[k], v) if k in old else v
-            return res
-        elif isinstance(new, list):
-            if not isinstance(old, list):
-                return new
-            return old + new
-
-        return new
-
-    return merge(full_old, full_new)
 
 
 def validate_git_package(config: dict):
@@ -167,7 +148,7 @@ def do_packages_pass(config: dict):
                     package_config = _process_base_package(package_config)
                 if isinstance(package_config, dict):
                     recursive_package = do_packages_pass(package_config)
-                config = _merge_package(recursive_package, config)
+                config = merge_config(recursive_package, config)
 
         del config[CONF_PACKAGES]
     return config

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from esphome import core
 from esphome.const import CONF_SUBSTITUTIONS
 from esphome.yaml_util import ESPHomeDataBase, make_data_base
+from esphome.components.packages import _merge_package
 
 CODEOWNERS = ["@esphome/core"]
 _LOGGER = logging.getLogger(__name__)
@@ -108,7 +109,7 @@ def _substitute_item(substitutions, item, path):
             if sub is not None:
                 item[k] = sub
         for old, new in replace_keys:
-            item[new] = item[old]
+            item[new] = _merge_package(item.get(new), item.get(old))
             del item[old]
     elif isinstance(item, str):
         sub = _expand_substitutions(substitutions, item, path)

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -5,7 +5,7 @@ import esphome.config_validation as cv
 from esphome import core
 from esphome.const import CONF_SUBSTITUTIONS
 from esphome.yaml_util import ESPHomeDataBase, make_data_base
-from esphome.components.packages import _merge_package
+from esphome.config_helpers import merge_config
 
 CODEOWNERS = ["@esphome/core"]
 _LOGGER = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ def _substitute_item(substitutions, item, path):
             if sub is not None:
                 item[k] = sub
         for old, new in replace_keys:
-            item[new] = _merge_package(item.get(new), item.get(old))
+            item[new] = merge_config(item.get(new), item.get(old))
             del item[old]
     elif isinstance(item, str):
         sub = _expand_substitutions(substitutions, item, path)

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -109,7 +109,7 @@ def _substitute_item(substitutions, item, path):
             if sub is not None:
                 item[k] = sub
         for old, new in replace_keys:
-            item[new] = merge_config(item.get(new), item.get(old))
+            item[new] = merge_config(item.get(old), item.get(new))
             del item[old]
     elif isinstance(item, str):
         sub = _expand_substitutions(substitutions, item, path)

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -23,3 +23,23 @@ def read_config_file(path):
         return data["content"]
 
     return read_file(path)
+
+
+def merge_config(full_old, full_new):
+    def merge(old, new):
+        # pylint: disable=no-else-return
+        if isinstance(new, dict):
+            if not isinstance(old, dict):
+                return new
+            res = old.copy()
+            for k, v in new.items():
+                res[k] = merge(old[k], v) if k in old else v
+            return res
+        elif isinstance(new, list):
+            if not isinstance(old, list):
+                return new
+            return old + new
+
+        return new
+
+    return merge(full_old, full_new)


### PR DESCRIPTION
# What does this implement/fix? 

Substitutions are performed on `dict` keys destructively.

I have many Shelly devices and I created `output1` and `output2` packages that are included depending on which Shelly device is being used. When using substitutions in the keys of the `output1` and `output2` packages, I end up with less components than I am expecting due to this current behaviour.

I can explain my use case a bit more if it helps, but I managed to produce a minimal configuration to reproduce the problem (see below).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
---
substitutions:
  a_component: 'switch'
  a_platform: 'output'
  b_component: 'switch'
  b_platform: 'output'

packages:
  a:
    ${a_component}:
      - platform: '${a_platform}'
        output: 'output1'
        name: 'Output 1'
  b:
    ${b_component}:
      - platform: '${b_platform}'
        output: 'output2'
        name: 'Output 2'

esphome:
  name: 'test'
  platform: 'ESP8266'
  board: 'esp01_1m'

output:
  - platform: 'gpio'
    pin: 'GPIO1'
    id: 'output1'
  - platform: 'gpio'
    pin: 'GPIO2'
    id: 'output2'
```

Compiling this configuration produces only a single `switch` component:

```yaml
switch:
- platform: output
  output: output1
  name: Output 1
  disabled_by_default: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
