### PR TITLE
[modbus_controller] add missing skip_updates

### DIFF
--- a/esphome/components/modbus_controller/switch/__init__.py
+++ b/esphome/components/modbus_controller/switch/__init__.py
@@ -18,6 +18,7 @@ from ..const import (
     CONF_FORCE_NEW_RANGE,
     CONF_MODBUS_CONTROLLER_ID,
     CONF_REGISTER_TYPE,
+    CONF_SKIP_UPDATES,
     CONF_USE_WRITE_MULTIPLE,
     CONF_WRITE_LAMBDA,
 )
@@ -53,6 +54,7 @@ async def to_code(config):
         config[CONF_ADDRESS],
         byte_offset,
         config[CONF_BITMASK],
+        config[CONF_SKIP_UPDATES],
         config[CONF_FORCE_NEW_RANGE],
     )
     await cg.register_component(var, config)

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -10,14 +10,14 @@ namespace modbus_controller {
 class ModbusSwitch : public Component, public switch_::Switch, public SensorItem {
  public:
   ModbusSwitch(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
-               bool force_new_range)
+               uint8_t skip_updates, bool force_new_range)
       : Component(), switch_::Switch() {
     this->register_type = register_type;
     this->start_address = start_address;
     this->offset = offset;
     this->bitmask = bitmask;
     this->sensor_value_type = SensorValueType::BIT;
-    this->skip_updates = 0;
+    this->skip_updates = skip_updates;
     this->register_count = 1;
     if (register_type == ModbusRegisterType::HOLDING || register_type == ModbusRegisterType::COIL) {
       this->start_address += offset;


### PR DESCRIPTION
# What does this implement/fix? 

The property `skip_updates' is ignored for modbus switch

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2951

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
