### PR TITLE
ESP32-C3 deep sleep fix

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -14,10 +14,10 @@ from esphome.const import (
 
 def validate_pin_number(value):
     if CORE.is_esp32:
-		valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
+        valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
     if CORE.is_esp32c3:
-		valid_pins = [0, 1, 2, 3, 4, 5]
-	if value[CONF_NUMBER] not in valid_pins:
+        valid_pins = [0, 1, 2, 3, 4, 5]
+    if value[CONF_NUMBER] not in valid_pins:
         raise cv.Invalid(
             f"Only pins {', '.join(str(x) for x in valid_pins)} support wakeup"
         )

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
+from esphome.core import CORE, coroutine_with_priority
 from esphome.const import (
     CONF_ID,
     CONF_MODE,

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
 from esphome.const import (
-    CONF_ATTENUATION,
     CONF_RAW,
     CONF_ID,
     CONF_MODE,
@@ -13,7 +12,6 @@ from esphome.const import (
     CONF_WAKEUP_PIN,
 )
 
-from esphome.core import CORE
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
@@ -21,9 +19,29 @@ from esphome.components.esp32.const import (
 )
 
 WAKEUP_PINS = {
-    VARIANT_ESP32: [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39],
-    VARIANT_ESP32C3: [0, 1, 2, 3, 4, 5]
+    VARIANT_ESP32: [
+        0,
+        2,
+        4,
+        12,
+        13,
+        14,
+        15,
+        25,
+        26,
+        27,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+    ],
+    VARIANT_ESP32C3: [0, 1, 2, 3, 4, 5],
 }
+
 
 def validate_pin_number(value):
     valid_pins = WAKEUP_PINS.get(get_esp32_variant(), VARIANT_ESP32)
@@ -36,14 +54,14 @@ def validate_pin_number(value):
 
 def validate_config(config):
     if (
-        config[CONF_RAW] 
-        and get_esp32_variant() == VARIANT_ESP32C3 
+        config[CONF_RAW]
+        and get_esp32_variant() == VARIANT_ESP32C3
         and config.get(CONF_ESP32_EXT1_WAKEUP, None) is not None
     ):
         raise cv.Invalid("ESP32-C3 does not support wakeup from touch.")
     if (
-        config[CONF_RAW] 
-        and get_esp32_variant() == VARIANT_ESP32C3 
+        config[CONF_RAW]
+        and get_esp32_variant() == VARIANT_ESP32C3
         and config.get(CONF_TOUCH_WAKEUP, None) is not None
     ):
         raise cv.Invalid("ESP32-C3 does not support wakeup from ext1")

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
-from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
     CONF_MODE,
@@ -12,23 +11,13 @@ from esphome.const import (
     CONF_WAKEUP_PIN,
 )
 
-from .const import (  # noqa
-    KEY_ESP32,
-    KEY_VARIANT,
-    VARIANT_ESP32C3,
-)
-
-def get_esp32_variant():
-    return CORE.data[KEY_ESP32][KEY_VARIANT]
-
-
-def is_esp32c3():
-    return get_esp32_variant() == VARIANT_ESP32C3
+from esphome.core import CORE
+from esphome.components.esp32 import is_esp32c3
 
 def validate_pin_number(value):
     if CORE.is_esp32:
         valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
-    if CORE.is_esp32c3:
+    if is_esp32c3:
         valid_pins = [0, 1, 2, 3, 4, 5]
     if value[CONF_NUMBER] not in valid_pins:
         raise cv.Invalid(

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -38,13 +38,13 @@ def validate_config(config):
     if (
         config[CONF_RAW] 
         and get_esp32_variant() == VARIANT_ESP32C3 
-        and config.get(CONF_ESP32_EXT1_WAKEUP, None) != None
+        and config.get(CONF_ESP32_EXT1_WAKEUP, None) is not None
     ):
         raise cv.Invalid("ESP32-C3 does not support wakeup from touch.")
     if (
         config[CONF_RAW] 
         and get_esp32_variant() == VARIANT_ESP32C3 
-        and config.get(CONF_TOUCH_WAKEUP, None) != None
+        and config.get(CONF_TOUCH_WAKEUP, None) is not None
     ):
         raise cv.Invalid("ESP32-C3 does not support wakeup from ext1")
     return config

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -14,9 +14,29 @@ from esphome.const import (
 from esphome.core import CORE
 from esphome.components.esp32 import is_esp32c3
 
+
 def validate_pin_number(value):
     if CORE.is_esp32:
-        valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
+        valid_pins = [
+            0,
+            2,
+            4,
+            12,
+            13,
+            14,
+            15,
+            25,
+            26,
+            27,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+        ]
     if is_esp32c3():
         valid_pins = [0, 1, 2, 3, 4, 5]
     if value[CONF_NUMBER] not in valid_pins:

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -15,7 +15,7 @@ from esphome.const import (
 
 from esphome.core import CORE
 from esphome.components.esp32 import get_esp32_variant
-from esphome.components.esp32 import (
+from esphome.components.esp32.const import (
     VARIANT_ESP32,
     VARIANT_ESP32C3,
 )

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -17,7 +17,7 @@ from esphome.components.esp32 import is_esp32c3
 def validate_pin_number(value):
     if CORE.is_esp32:
         valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
-    if is_esp32c3:
+    if is_esp32c3():
         valid_pins = [0, 1, 2, 3, 4, 5]
     if value[CONF_NUMBER] not in valid_pins:
         raise cv.Invalid(

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -13,8 +13,11 @@ from esphome.const import (
 
 
 def validate_pin_number(value):
-    valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
-    if value[CONF_NUMBER] not in valid_pins:
+    if CORE.is_esp32:
+		valid_pins = [0, 2, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33, 34, 35, 36, 37, 38, 39]
+    if CORE.is_esp32c3:
+		valid_pins = [0, 1, 2, 3, 4, 5]
+	if value[CONF_NUMBER] not in valid_pins:
         raise cv.Invalid(
             f"Only pins {', '.join(str(x) for x in valid_pins)} support wakeup"
         )

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
-from esphome.core import CORE, coroutine_with_priority
+from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
     CONF_MODE,
@@ -12,6 +12,18 @@ from esphome.const import (
     CONF_WAKEUP_PIN,
 )
 
+from .const import (  # noqa
+    KEY_ESP32,
+    KEY_VARIANT,
+    VARIANT_ESP32C3,
+)
+
+def get_esp32_variant():
+    return CORE.data[KEY_ESP32][KEY_VARIANT]
+
+
+def is_esp32c3():
+    return get_esp32_variant() == VARIANT_ESP32C3
 
 def validate_pin_number(value):
     if CORE.is_esp32:

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
 from esphome.const import (
-    CONF_RAW,
     CONF_ID,
     CONF_MODE,
     CONF_NUMBER,

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -44,7 +44,7 @@ WAKEUP_PINS = {
 
 
 def validate_pin_number(value):
-    valid_pins = WAKEUP_PINS.get(get_esp32_variant(), VARIANT_ESP32)
+    valid_pins = WAKEUP_PINS.get(get_esp32_variant(), WAKEUP_PINS[VARIANT_ESP32])
     if value[CONF_NUMBER] not in valid_pins:
         raise cv.Invalid(
             f"Only pins {', '.join(str(x) for x in valid_pins)} support wakeup"
@@ -53,17 +53,9 @@ def validate_pin_number(value):
 
 
 def validate_config(config):
-    if (
-        config[CONF_RAW]
-        and get_esp32_variant() == VARIANT_ESP32C3
-        and config.get(CONF_ESP32_EXT1_WAKEUP, None) is not None
-    ):
+    if get_esp32_variant() == VARIANT_ESP32C3 and CONF_ESP32_EXT1_WAKEUP in config:
         raise cv.Invalid("ESP32-C3 does not support wakeup from touch.")
-    if (
-        config[CONF_RAW]
-        and get_esp32_variant() == VARIANT_ESP32C3
-        and config.get(CONF_TOUCH_WAKEUP, None) is not None
-    ):
+    if get_esp32_variant() == VARIANT_ESP32C3 and CONF_TOUCH_WAKEUP in config:
         raise cv.Invalid("ESP32-C3 does not support wakeup from ext1")
     return config
 

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -104,7 +104,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 
   App.run_safe_shutdown_hooks();
 
-#ifdef USE_ESP32
+#if defefined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
@@ -124,6 +124,18 @@ void DeepSleepComponent::begin_sleep(bool manual) {
   }
 
   esp_deep_sleep_start();
+#endif
+
+#ifdef USE_ESP32_VARIANT_ESP32C3
+  if (this->sleep_duration_.has_value())
+    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+  if (this->wakeup_pin_ != nullptr) {
+    bool level = !this->wakeup_pin_->is_inverted();
+    if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
+      level = !level;
+    }
+    esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), level);
+  }
 #endif
 
 #ifdef USE_ESP8266

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -104,7 +104,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 
   App.run_safe_shutdown_hooks();
 
-#if defefined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
+#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -57,7 +57,7 @@ class DeepSleepComponent : public Component {
  public:
   /// Set the duration in ms the component should sleep once it's in deep sleep mode.
   void set_sleep_duration(uint32_t time_ms);
-#if defined(USE_ESP32) 
+#if defined(USE_ESP32)
   /** Set the pin to wake up to on the ESP32 once it's in deep sleep mode.
    * Use the inverted property to set the wakeup level.
    */

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -57,13 +57,16 @@ class DeepSleepComponent : public Component {
  public:
   /// Set the duration in ms the component should sleep once it's in deep sleep mode.
   void set_sleep_duration(uint32_t time_ms);
-#ifdef USE_ESP32
+#if defined(USE_ESP32) 
   /** Set the pin to wake up to on the ESP32 once it's in deep sleep mode.
    * Use the inverted property to set the wakeup level.
    */
   void set_wakeup_pin(InternalGPIOPin *pin) { this->wakeup_pin_ = pin; }
 
   void set_wakeup_pin_mode(WakeupPinMode wakeup_pin_mode);
+#endif
+
+#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
 
   void set_ext1_wakeup(Ext1Wakeup ext1_wakeup);
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -262,7 +262,7 @@ power_supply:
 deep_sleep:
   run_duration: 20s
   sleep_duration: 50s
-  wakeup_pin: GPIO39
+  wakeup_pin: GPIO2
   wakeup_pin_mode: INVERT_WAKEUP
 
 ads1115:

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -60,7 +60,7 @@ deep_sleep:
     gpio_wakeup_reason: 10s
     touch_wakeup_reason: 15s
   sleep_duration: 50s
-  wakeup_pin: GPIO39
+  wakeup_pin: GPIO2
   wakeup_pin_mode: INVERT_WAKEUP
 
 as3935_i2c:


### PR DESCRIPTION
# What does this implement/fix? 

Wakeup pin validation fixed to allow RTC pins as listed in ESP32-C3 technical reference manual.

Deepsleep pin enable function has changed from esp_sleep_enable_ext0_wakeup to esp_deep_sleep_enable_gpio_wakeup

C3 variant is not capable of wakeup from ext1 or touch when in deepsleep.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [https://github.com/esphome/issues/issues/2298](url)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1810

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
