### PR TITLE
Fix calibration parameter for bme680 humidity calculation

### DIFF
--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -95,7 +95,7 @@ void BME680Component::setup() {
   this->calibration_.t3 = cal1[3];
 
   this->calibration_.h1 = cal2[2] << 4 | (cal2[1] & 0x0F);
-  this->calibration_.h2 = cal2[0] << 4 | cal2[1];
+  this->calibration_.h2 = cal2[0] << 4 | cal2[1] >> 4;
   this->calibration_.h3 = cal2[3];
   this->calibration_.h4 = cal2[4];
   this->calibration_.h5 = cal2[5];


### PR DESCRIPTION
# What does this implement/fix? 

This fixes the humidity calculation for me, before it was about 10% too
high when comparing to both another humidity sensor, and also the same
sensor connected to a raspberry pi using the bme680-python library
It also seems more consistent with what is done here: https://github.com/pimoroni/bme680-python/blob/7afe2ef78259d89c83cacc9cbf2d55abff8c8e68/library/bme680/constants.py#L335

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** I believe it fixes https://github.com/esphome/issues/issues/2217 as the issue seems consistent with what I observed.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
