### PR TITLE
TSL2591 automatic gain control

### DIFF
--- a/esphome/components/tsl2591/sensor.py
+++ b/esphome/components/tsl2591/sensor.py
@@ -56,18 +56,19 @@ INTEGRATION_TIMES = {
     600: TSL2591IntegrationTime.TSL2591_INTEGRATION_TIME_600MS,
 }
 
-TSL2591Gain = tsl2591_ns.enum("TSL2591Gain")
+TSL2591ComponentGain = tsl2591_ns.enum("TSL2591ComponentGain")
 GAINS = {
-    "1X": TSL2591Gain.TSL2591_GAIN_LOW,
-    "LOW": TSL2591Gain.TSL2591_GAIN_LOW,
-    "25X": TSL2591Gain.TSL2591_GAIN_MED,
-    "MED": TSL2591Gain.TSL2591_GAIN_MED,
-    "MEDIUM": TSL2591Gain.TSL2591_GAIN_MED,
-    "400X": TSL2591Gain.TSL2591_GAIN_HIGH,
-    "HIGH": TSL2591Gain.TSL2591_GAIN_HIGH,
-    "9500X": TSL2591Gain.TSL2591_GAIN_MAX,
-    "MAX": TSL2591Gain.TSL2591_GAIN_MAX,
-    "MAXIMUM": TSL2591Gain.TSL2591_GAIN_MAX,
+    "1X": TSL2591ComponentGain.TSL2591_CGAIN_LOW,
+    "LOW": TSL2591ComponentGain.TSL2591_CGAIN_LOW,
+    "25X": TSL2591ComponentGain.TSL2591_CGAIN_MED,
+    "MED": TSL2591ComponentGain.TSL2591_CGAIN_MED,
+    "MEDIUM": TSL2591ComponentGain.TSL2591_CGAIN_MED,
+    "400X": TSL2591ComponentGain.TSL2591_CGAIN_HIGH,
+    "HIGH": TSL2591ComponentGain.TSL2591_CGAIN_HIGH,
+    "9500X": TSL2591ComponentGain.TSL2591_CGAIN_MAX,
+    "MAX": TSL2591ComponentGain.TSL2591_CGAIN_MAX,
+    "MAXIMUM": TSL2591ComponentGain.TSL2591_CGAIN_MAX,
+    "AUTO": TSL2591ComponentGain.TSL2591_CGAIN_AUTO,
 }
 
 
@@ -117,7 +118,7 @@ CONFIG_SCHEMA = (
                 CONF_INTEGRATION_TIME, default="100ms"
             ): validate_integration_time,
             cv.Optional(CONF_NAME, default="TLS2591"): cv.string,
-            cv.Optional(CONF_GAIN, default="MEDIUM"): cv.enum(GAINS, upper=True),
+            cv.Optional(CONF_GAIN, default="AUTO"): cv.enum(GAINS, upper=True),
             cv.Optional(CONF_POWER_SAVE_MODE, default=True): cv.boolean,
             cv.Optional(CONF_DEVICE_FACTOR, default=53.0): cv.float_with_unit(
                 "device_factor", "", True

--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -377,44 +377,44 @@ float TSL2591Component::get_calculated_lux(uint16_t full_spectrum, uint16_t infr
 
 /** Calculates and updates the sensor gain setting, trying to keep the full spectrum counts near
  *  the middle of the range
- * 
+ *
  *  It's hard to tell how far down to turn the gain when it's at the top of the scale, so decrease
  *  the gain by up to 2 steps if it's near the top to be sure we get a good reading next time.
  *  Increase gain by max 2 steps per reading.
- * 
+ *
  *  If integration time is 100 MS, divide the upper thresholds by 2 to account for ADC saturation
- * 
+ *
  *  @param full_spectrum The ADC reading for TSL2591 channel 0.
- * 
+ *
  *  1/3 FS = 21,845
  */
 void TSL2591Component::automatic_gain_update(uint16_t full_spectrum) {
   TSL2591Gain new_gain = this->gain_;
   uint fs_divider = (this->integration_time_ == TSL2591_INTEGRATION_TIME_100MS) ? 2 : 1;
-  
+
   switch (this->gain_) {
     case TSL2591_GAIN_LOW:
-      if (full_spectrum < 54) // 1/3 FS / GAIN_HIGH
+      if (full_spectrum < 54)  // 1/3 FS / GAIN_HIGH
         new_gain = TSL2591_GAIN_HIGH;
-      else if (full_spectrum < 875) // 1/3 FS / GAIN_MED
+      else if (full_spectrum < 875)  // 1/3 FS / GAIN_MED
         new_gain = TSL2591_GAIN_MED;
       break;
     case TSL2591_GAIN_MED:
-      if (full_spectrum < 57) // 1/3 FS / (GAIN_MAX/GAIN_MED)
+      if (full_spectrum < 57)  // 1/3 FS / (GAIN_MAX/GAIN_MED)
         new_gain = TSL2591_GAIN_MAX;
-      else if (full_spectrum < 1365) // 1/3 FS / (GAIN_HIGH/GAIN_MED)
+      else if (full_spectrum < 1365)  // 1/3 FS / (GAIN_HIGH/GAIN_MED)
         new_gain = TSL2591_GAIN_HIGH;
-      else if (full_spectrum > 62000/fs_divider) // 2/3 FS / (GAIN_LOW/GAIN_MED) clipped to 95% FS
+      else if (full_spectrum > 62000/fs_divider)  // 2/3 FS / (GAIN_LOW/GAIN_MED) clipped to 95% FS
         new_gain = TSL2591_GAIN_LOW;
       break;
     case TSL2591_GAIN_HIGH:
-      if (full_spectrum < 920) // 1/3 FS / (GAIN_MAX/GAIN_HIGH)
+      if (full_spectrum < 920)  // 1/3 FS / (GAIN_MAX/GAIN_HIGH)
         new_gain = TSL2591_GAIN_MAX;
-      else if (full_spectrum > 62000/fs_divider) // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
+      else if (full_spectrum > 62000/fs_divider)  // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
         new_gain = TSL2591_GAIN_LOW;
       break;
     case TSL2591_GAIN_MAX:
-      if (full_spectrum > 62000/fs_divider) // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
+      if (full_spectrum > 62000/fs_divider)  // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
         new_gain = TSL2591_GAIN_MED;
       break;
   }
@@ -423,6 +423,7 @@ void TSL2591Component::automatic_gain_update(uint16_t full_spectrum) {
     this->gain_ = new_gain;
     this->set_integration_time_and_gain(this->integration_time_, this->gain_);
   }
+  ESP_LOGD(TAG, "Gain setting: %d", this->gain_);
 }
 
 }  // namespace tsl2591

--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -404,17 +404,17 @@ void TSL2591Component::automatic_gain_update(uint16_t full_spectrum) {
         new_gain = TSL2591_GAIN_MAX;
       else if (full_spectrum < 1365)  // 1/3 FS / (GAIN_HIGH/GAIN_MED)
         new_gain = TSL2591_GAIN_HIGH;
-      else if (full_spectrum > 62000/fs_divider)  // 2/3 FS / (GAIN_LOW/GAIN_MED) clipped to 95% FS
+      else if (full_spectrum > 62000 / fs_divider)  // 2/3 FS / (GAIN_LOW/GAIN_MED) clipped to 95% FS
         new_gain = TSL2591_GAIN_LOW;
       break;
     case TSL2591_GAIN_HIGH:
       if (full_spectrum < 920)  // 1/3 FS / (GAIN_MAX/GAIN_HIGH)
         new_gain = TSL2591_GAIN_MAX;
-      else if (full_spectrum > 62000/fs_divider)  // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
+      else if (full_spectrum > 62000 / fs_divider)  // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
         new_gain = TSL2591_GAIN_LOW;
       break;
     case TSL2591_GAIN_MAX:
-      if (full_spectrum > 62000/fs_divider)  // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
+      if (full_spectrum > 62000 / fs_divider)  // 2/3 FS / (GAIN_MED/GAIN_HIGH) clipped to 95% FS
         new_gain = TSL2591_GAIN_MED;
       break;
   }

--- a/esphome/components/tsl2591/tsl2591.h
+++ b/esphome/components/tsl2591/tsl2591.h
@@ -21,6 +21,19 @@ enum TSL2591IntegrationTime {
   TSL2591_INTEGRATION_TIME_600MS = 0b101,
 };
 
+/** Enum listing all gain settings for the TSL2591 component.
+ *
+ * Enum constants are used by the component to allow auto gain, not directly to registers
+ * Higher values are better for low light situations, but can increase noise.
+ */
+enum TSL2591ComponentGain {
+  TSL2591_CGAIN_LOW,   // 1x
+  TSL2591_CGAIN_MED,   // 25x
+  TSL2591_CGAIN_HIGH,  // 400x
+  TSL2591_CGAIN_MAX,   // 9500x
+  TSL2591_CGAIN_AUTO
+};
+
 /** Enum listing all gain settings for the TSL2591.
  *
  * Specific values of the enum constants are register values taken from the TSL2591 datasheet.
@@ -200,6 +213,13 @@ class TSL2591Component : public PollingComponent, public i2c::I2CDevice {
    */
   void disable();
 
+  /** Updates the gain setting based on the most recent full spectrum reading
+   *
+   * This gets called on update and tries to keep the ADC readings in the middle of the range
+   */
+
+  void automatic_gain_update(uint16_t full_spectrum);
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these. They're for ESPHome integration use.)
   /** Used by ESPHome framework. */
@@ -213,7 +233,7 @@ class TSL2591Component : public PollingComponent, public i2c::I2CDevice {
   /** Used by ESPHome framework. Does NOT actually set the value on the device. */
   void set_integration_time(TSL2591IntegrationTime integration_time);
   /** Used by ESPHome framework. Does NOT actually set the value on the device. */
-  void set_gain(TSL2591Gain gain);
+  void set_gain(TSL2591ComponentGain gain);
   /** Used by ESPHome framework. */
   void setup() override;
   /** Used by ESPHome framework. */
@@ -230,6 +250,7 @@ class TSL2591Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *visible_sensor_;
   sensor::Sensor *calculated_lux_sensor_;
   TSL2591IntegrationTime integration_time_;
+  TSL2591ComponentGain component_gain_;
   TSL2591Gain gain_;
   bool power_save_mode_enabled_;
   float device_factor_;


### PR DESCRIPTION
# What does this implement/fix? 

This PR implements automatic gain control for the TSL2591. On taking a reading, the full spectrum sensor is compared to a set of thresholds and the gain adjusted to bring the reading away from the ADC limits, with handling for early saturation at 100ms integration time. Looking for feedback, particularly on the gain schedule.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1843

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
i2c:

sensor:
  - platform: tsl2591
    name: "TSL2591"
    id: "my_tls2591"
    address: 0x29
    update_interval: 10s
    device_factor: 53
    gain: AUTO
    glass_attenuation_factor: 14.4
    visible:
      name: "TSL2591 visible light"
    infrared:
      name: "TSL2591 infrared light"
    full_spectrum:
      name: "TSL2591 full spectrum light"
    calculated_lux:
      id: i_lux
      name: "TSL2591 Lux"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
