### PR TITLE
Bump improv library version

### DIFF
--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -56,7 +56,7 @@ async def to_code(config):
     cg.add(ble_server.register_service_component(var))
 
     cg.add_define("USE_IMPROV")
-    cg.add_library("esphome/Improv", "1.0.0")
+    cg.add_library("esphome/Improv", "1.1.0")
 
     cg.add(var.set_identify_duration(config[CONF_IDENTIFY_DURATION]))
     cg.add(var.set_authorized_duration(config[CONF_AUTHORIZED_DURATION]))

--- a/esphome/components/improv_serial/__init__.py
+++ b/esphome/components/improv_serial/__init__.py
@@ -30,4 +30,4 @@ FINAL_VALIDATE_SCHEMA = validate_logger_baud_rate
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    cg.add_library("esphome/Improv", "1.0.0")
+    cg.add_library("esphome/Improv", "1.1.0")

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -111,58 +111,15 @@ std::vector<uint8_t> ImprovSerialComponent::build_version_info_() {
 bool ImprovSerialComponent::parse_improv_serial_byte_(uint8_t byte) {
   size_t at = this->rx_buffer_.size();
   this->rx_buffer_.push_back(byte);
-  ESP_LOGD(TAG, "Improv Serial byte: 0x%02X", byte);
+  ESP_LOGV(TAG, "Improv Serial byte: 0x%02X", byte);
   const uint8_t *raw = &this->rx_buffer_[0];
-  if (at == 0)
-    return byte == 'I';
-  if (at == 1)
-    return byte == 'M';
-  if (at == 2)
-    return byte == 'P';
-  if (at == 3)
-    return byte == 'R';
-  if (at == 4)
-    return byte == 'O';
-  if (at == 5)
-    return byte == 'V';
 
-  if (at == 6)
-    return byte == IMPROV_SERIAL_VERSION;
-
-  if (at == 7)
-    return true;
-  uint8_t type = raw[7];
-
-  if (at == 8)
-    return true;
-  uint8_t data_len = raw[8];
-
-  if (at < 8 + data_len)
-    return true;
-
-  if (at == 8 + data_len)
-    return true;
-
-  if (at == 8 + data_len + 1) {
-    uint8_t checksum = 0x00;
-    for (size_t i = 0; i < at; i++)
-      checksum += raw[i];
-
-    if (checksum != byte) {
-      ESP_LOGW(TAG, "Error decoding Improv payload");
-      this->set_error_(improv::ERROR_INVALID_RPC);
-      return false;
-    }
-
-    if (type == TYPE_RPC) {
-      this->set_error_(improv::ERROR_NONE);
-      auto command = improv::parse_improv_data(&raw[9], data_len, false);
-      return this->parse_improv_payload_(command);
-    }
-  }
-
-  // If we got here then the command coming is is improv, but not an RPC command
-  return false;
+  return improv::parse_improv_serial_byte(
+      at, byte, raw, [this](improv::ImprovCommand command) -> bool { return this->parse_improv_payload_(command); },
+      [this](improv::Error error) -> void {
+        ESP_LOGW(TAG, "Error decoding Improv payload");
+        this->set_error_(error);
+      });
 }
 
 bool ImprovSerialComponent::parse_improv_payload_(improv::ImprovCommand &command) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ build_flags =
 lib_deps =
     esphome/noise-c@0.1.4         ; api
     makuna/NeoPixelBus@2.6.9      ; neopixelbus
-    esphome/Improv@1.0.0          ; improv_serial / esp32_improv
+    esphome/Improv@1.1.0          ; improv_serial / esp32_improv
     bblanchon/ArduinoJson@6.18.5  ; json
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix? 

Bumps Improv libary to move serial byte parsing there.

https://github.com/improv-wifi/sdk-cpp/releases/tag/v1.1.0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
