### PR TITLE
[modbus_controller] fix incorrect start address for number write

### DIFF
--- a/esphome/components/modbus_controller/number/modbus_number.cpp
+++ b/esphome/components/modbus_controller/number/modbus_number.cpp
@@ -57,9 +57,11 @@ void ModbusNumber::control(float value) {
   // Create and send the write command
   ModbusCommandItem write_cmd;
   if (this->register_count == 1 && !this->use_write_multiple_) {
-    write_cmd = ModbusCommandItem::create_write_single_command(parent_, this->start_address + this->offset, data[0]);
+    // since offset is in bytes and a register is 16 bits we get the start by adding offset/2
+    write_cmd =
+        ModbusCommandItem::create_write_single_command(parent_, this->start_address + this->offset / 2, data[0]);
   } else {
-    write_cmd = ModbusCommandItem::create_write_multiple_command(parent_, this->start_address + this->offset,
+    write_cmd = ModbusCommandItem::create_write_multiple_command(parent_, this->start_address + this->offset / 2,
                                                                  this->register_count, data);
   }
   // publish new value


### PR DESCRIPTION
# What does this implement/fix? 
Modbus number uses an incorrect start address for writing.   start_address is twice  the expected value. 
The code has this issue for some time but was hidden by the fact that offset was always 0. https://github.com/esphome/esphome/pull/2981 optimized how the ranges are organized and surfaced this bug. 



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2957

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
