### PR TITLE
AM43: autoload "sensor" to avoid compile errors

### DIFF
--- a/esphome/components/am43/cover/__init__.py
+++ b/esphome/components/am43/cover/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID, CONF_PIN
 
 CODEOWNERS = ["@buxtronix"]
 DEPENDENCIES = ["ble_client"]
-AUTO_LOAD = ["am43"]
+AUTO_LOAD = ["am43", "sensor"]
 
 CONF_INVERT_POSITION = "invert_position"
 


### PR DESCRIPTION


# What does this implement/fix? 

Whilst normally most people will have a `sensor` block anyway to fetch battery level, this allows the corner case where one isn't provided.
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2849

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
