### PR TITLE
Add support for additional colors on GROW R503

### DIFF
--- a/esphome/components/fingerprint_grow/__init__.py
+++ b/esphome/components/fingerprint_grow/__init__.py
@@ -80,6 +80,10 @@ AURA_LED_COLORS = {
     "RED": AuraLEDColor.RED,
     "BLUE": AuraLEDColor.BLUE,
     "PURPLE": AuraLEDColor.PURPLE,
+    "GREEN": AuraLEDColor.GREEN,
+    "YELLOW": AuraLEDColor.YELLOW,
+    "CYAN": AuraLEDColor.CYAN,
+    "WHITE": AuraLEDColor.WHITE,
 }
 validate_aura_led_colors = cv.enum(AURA_LED_COLORS, upper=True)
 

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -76,6 +76,10 @@ enum GrowAuraLEDColor {
   RED = 0x01,
   BLUE = 0x02,
   PURPLE = 0x03,
+  GREEN = 0x04,
+  YELLOW = 0x05,
+  CYAN = 0x06,
+  WHITE = 0x07,
 };
 
 class FingerprintGrowComponent : public PollingComponent, public uart::UARTDevice {


### PR DESCRIPTION
# What does this implement/fix? 

Adds GREEN, YELLOW, CYAN and WHITE to available colors on GROW component.

Docs: https://github.com/esphome/esphome-docs/pull/1850

