### PR TITLE
Make CallbackManager invocable

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -176,6 +176,9 @@ template<typename... Ts> class CallbackManager<void(Ts...)> {
       cb(args...);
   }
 
+  /// Call all callbacks in this manager.
+  void operator()(Ts... args) { call(args...); }
+
  protected:
   std::vector<std::function<void(Ts...)>> callbacks_;
 };


### PR DESCRIPTION
# What does this implement/fix? 

Make `CallbackManager` directly invocable, instead of having to use the `call()` member function.

Not necessary at all, but I unconsciously tried to use it like this three times now, so let's make my brain happy :)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
