### PR TITLE
Set the wrapped single light in light partition to internal

### DIFF
--- a/esphome/components/partition/light.py
+++ b/esphome/components/partition/light.py
@@ -103,6 +103,7 @@ async def to_code(config):
                 await cg.get_variable(conf[CONF_SINGLE_LIGHT_ID]),
             )
             light_state = cg.new_Pvariable(conf[CONF_LIGHT_ID], "", wrapper)
+            cg.add(light_state.set_internal(True))
             await cg.register_component(light_state, conf)
             cg.add(cg.App.register_light(light_state))
             segments.append(AddressableSegment(light_state, 0, 1, False))

--- a/esphome/components/partition/light.py
+++ b/esphome/components/partition/light.py
@@ -103,9 +103,7 @@ async def to_code(config):
                 await cg.get_variable(conf[CONF_SINGLE_LIGHT_ID]),
             )
             light_state = cg.new_Pvariable(conf[CONF_LIGHT_ID], "", wrapper)
-            cg.add(light_state.set_internal(True))
             await cg.register_component(light_state, conf)
-            cg.add(cg.App.register_light(light_state))
             segments.append(AddressableSegment(light_state, 0, 1, False))
 
         else:


### PR DESCRIPTION
# What does this implement/fix? 

Using single_light_id in a light partition generates a helper wrapped light that gets exposed to the frontend with an empty string as name. This change marks that light as internal so it doesn't get exposed anymore.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
