### PR TITLE
Fix path to extra_scripts in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -89,7 +89,7 @@ build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP8266
     -DUSE_ESP8266_FRAMEWORK_ARDUINO
-extra_scripts = post:esphome/components/esp8266/post_build.py
+extra_scripts = post:esphome/components/esp8266/post_build.py.script
 
 ; This are common settings for the ESP32 (all variants) using Arduino.
 [common:esp32-arduino]
@@ -108,7 +108,7 @@ build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP32
     -DUSE_ESP32_FRAMEWORK_ARDUINO
-extra_scripts = post:esphome/components/esp32/post_build.py
+extra_scripts = post:esphome/components/esp32/post_build.py.script
 
 ; This are common settings for the ESP32 (all variants) using IDF.
 [common:esp32-idf]
@@ -127,7 +127,7 @@ build_flags =
     -Wno-nonnull-compare
     -DUSE_ESP32
     -DUSE_ESP32_FRAMEWORK_ESP_IDF
-extra_scripts = post:esphome/components/esp32/post_build.py
+extra_scripts = post:esphome/components/esp32/post_build.py.script
 
 ; All the actual environments are defined below.
 [env:esp8266-arduino]


### PR DESCRIPTION
# What does this implement/fix? 

Fixes a warning in the `clang-tidy` script.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
