### PR TITLE
Enable readability-qualified-auto check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -78,7 +78,6 @@ Checks: >-
   -readability-magic-numbers,
   -readability-make-member-function-const,
   -readability-named-parameter,
-  -readability-qualified-auto,
   -readability-redundant-access-specifiers,
   -readability-redundant-member-init,
   -readability-redundant-string-init,
@@ -160,3 +159,5 @@ CheckOptions:
     value:           'lower_case'
   - key:             readability-identifier-naming.VirtualMethodSuffix
     value:           ''
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           0

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
@@ -24,7 +24,7 @@ void AirthingsWaveMini::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
 
     case ESP_GATTC_SEARCH_CMPL_EVT: {
       this->handle_ = 0;
-      auto chr = this->parent()->get_characteristic(service_uuid_, sensors_data_characteristic_uuid_);
+      auto *chr = this->parent()->get_characteristic(service_uuid_, sensors_data_characteristic_uuid_);
       if (chr == nullptr) {
         ESP_LOGW(TAG, "No sensor characteristic found at service %s char %s", service_uuid_.to_string().c_str(),
                  sensors_data_characteristic_uuid_.to_string().c_str());
@@ -56,7 +56,7 @@ void AirthingsWaveMini::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
 }
 
 void AirthingsWaveMini::read_sensors_(uint8_t *raw_value, uint16_t value_len) {
-  auto value = (WaveMiniReadings *) raw_value;
+  auto *value = (WaveMiniReadings *) raw_value;
 
   if (sizeof(WaveMiniReadings) <= value_len) {
     this->humidity_sensor_->publish_state(value->humidity / 100.0f);

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -24,7 +24,7 @@ void AirthingsWavePlus::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
 
     case ESP_GATTC_SEARCH_CMPL_EVT: {
       this->handle_ = 0;
-      auto chr = this->parent()->get_characteristic(service_uuid_, sensors_data_characteristic_uuid_);
+      auto *chr = this->parent()->get_characteristic(service_uuid_, sensors_data_characteristic_uuid_);
       if (chr == nullptr) {
         ESP_LOGW(TAG, "No sensor characteristic found at service %s char %s", service_uuid_.to_string().c_str(),
                  sensors_data_characteristic_uuid_.to_string().c_str());
@@ -56,7 +56,7 @@ void AirthingsWavePlus::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
 }
 
 void AirthingsWavePlus::read_sensors_(uint8_t *raw_value, uint16_t value_len) {
-  auto value = (WavePlusReadings *) raw_value;
+  auto *value = (WavePlusReadings *) raw_value;
 
   if (sizeof(WavePlusReadings) <= value_len) {
     ESP_LOGD(TAG, "version = %d", value->version);

--- a/esphome/components/am43/am43.cpp
+++ b/esphome/components/am43/am43.cpp
@@ -39,7 +39,7 @@ void Am43::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_i
       break;
     }
     case ESP_GATTC_SEARCH_CMPL_EVT: {
-      auto chr = this->parent_->get_characteristic(AM43_SERVICE_UUID, AM43_CHARACTERISTIC_UUID);
+      auto *chr = this->parent_->get_characteristic(AM43_SERVICE_UUID, AM43_CHARACTERISTIC_UUID);
       if (chr == nullptr) {
         if (this->parent_->get_characteristic(AM43_TUYA_SERVICE_UUID, AM43_TUYA_CHARACTERISTIC_UUID) != nullptr) {
           ESP_LOGE(TAG, "[%s] Detected a Tuya AM43 which is not supported, sorry.",
@@ -75,7 +75,7 @@ void Am43::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_i
 
       if (this->current_sensor_ > 0) {
         if (this->illuminance_ != nullptr) {
-          auto packet = this->encoder_->get_light_level_request();
+          auto *packet = this->encoder_->get_light_level_request();
           auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,
                                                  packet->length, packet->data, ESP_GATT_WRITE_TYPE_NO_RSP,
                                                  ESP_GATT_AUTH_REQ_NONE);
@@ -99,7 +99,7 @@ void Am43::update() {
   }
   if (this->current_sensor_ == 0) {
     if (this->battery_ != nullptr) {
-      auto packet = this->encoder_->get_battery_level_request();
+      auto *packet = this->encoder_->get_battery_level_request();
       auto status =
           esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_, packet->length,
                                    packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -25,7 +25,7 @@ void Am43Component::setup() {
 
 void Am43Component::loop() {
   if (this->node_state == espbt::ClientState::ESTABLISHED && !this->logged_in_) {
-    auto packet = this->encoder_->get_send_pin_request(this->pin_);
+    auto *packet = this->encoder_->get_send_pin_request(this->pin_);
     auto status =
         esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_, packet->length,
                                  packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
@@ -51,7 +51,7 @@ void Am43Component::control(const CoverCall &call) {
     return;
   }
   if (call.get_stop()) {
-    auto packet = this->encoder_->get_stop_request();
+    auto *packet = this->encoder_->get_stop_request();
     auto status =
         esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_, packet->length,
                                  packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
@@ -63,7 +63,7 @@ void Am43Component::control(const CoverCall &call) {
 
     if (this->invert_position_)
       pos = 1 - pos;
-    auto packet = this->encoder_->get_set_position_request(100 - (uint8_t)(pos * 100));
+    auto *packet = this->encoder_->get_set_position_request(100 - (uint8_t)(pos * 100));
     auto status =
         esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_, packet->length,
                                  packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
@@ -80,7 +80,7 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       break;
     }
     case ESP_GATTC_SEARCH_CMPL_EVT: {
-      auto chr = this->parent_->get_characteristic(AM43_SERVICE_UUID, AM43_CHARACTERISTIC_UUID);
+      auto *chr = this->parent_->get_characteristic(AM43_SERVICE_UUID, AM43_CHARACTERISTIC_UUID);
       if (chr == nullptr) {
         if (this->parent_->get_characteristic(AM43_TUYA_SERVICE_UUID, AM43_TUYA_CHARACTERISTIC_UUID) != nullptr) {
           ESP_LOGE(TAG, "[%s] Detected a Tuya AM43 which is not supported, sorry.", this->get_name().c_str());
@@ -120,7 +120,7 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (this->decoder_->has_pin_response()) {
         if (this->decoder_->pin_ok_) {
           ESP_LOGI(TAG, "[%s] AM43 pin accepted.", this->get_name().c_str());
-          auto packet = this->encoder_->get_position_request();
+          auto *packet = this->encoder_->get_position_request();
           auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,
                                                  packet->length, packet->data, ESP_GATT_WRITE_TYPE_NO_RSP,
                                                  ESP_GATT_AUTH_REQ_NONE);

--- a/esphome/components/anova/anova.cpp
+++ b/esphome/components/anova/anova.cpp
@@ -40,7 +40,7 @@ void Anova::control(const ClimateCall &call) {
       ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
   }
   if (call.get_target_temperature().has_value()) {
-    auto pkt = this->codec_->get_set_target_temp_request(*call.get_target_temperature());
+    auto *pkt = this->codec_->get_set_target_temp_request(*call.get_target_temperature());
     auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,
                                            pkt->length, pkt->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
     if (status)
@@ -57,7 +57,7 @@ void Anova::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_
       break;
     }
     case ESP_GATTC_SEARCH_CMPL_EVT: {
-      auto chr = this->parent_->get_characteristic(ANOVA_SERVICE_UUID, ANOVA_CHARACTERISTIC_UUID);
+      auto *chr = this->parent_->get_characteristic(ANOVA_SERVICE_UUID, ANOVA_CHARACTERISTIC_UUID);
       if (chr == nullptr) {
         ESP_LOGW(TAG, "[%s] No control service found at device, not an Anova..?", this->get_name().c_str());
         ESP_LOGW(TAG, "[%s] Note, this component does not currently support Anova Nano.", this->get_name().c_str());
@@ -133,7 +133,7 @@ void Anova::update() {
     return;
 
   if (this->current_request_ < 2) {
-    auto pkt = this->codec_->get_read_device_status_request();
+    auto *pkt = this->codec_->get_read_device_status_request();
     if (this->current_request_ == 0)
       this->codec_->get_set_unit_request(this->fahrenheit_ ? 'f' : 'c');
     auto status = esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_,

--- a/esphome/components/ballu/ballu.cpp
+++ b/esphome/components/ballu/ballu.cpp
@@ -97,7 +97,7 @@ void BalluClimate::transmit_state() {
 
   // Send code
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   data->set_carrier_frequency(38000);
 

--- a/esphome/components/bl0940/bl0940.cpp
+++ b/esphome/components/bl0940/bl0940.cpp
@@ -65,7 +65,7 @@ void BL0940::update() {
 }
 
 void BL0940::setup() {
-  for (auto i : BL0940_INIT) {
+  for (auto *i : BL0940_INIT) {
     this->write_array(i, 6);
     delay(1);
   }

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -167,7 +167,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      auto descr = this->get_config_descriptor(param->reg_for_notify.handle);
+      auto *descr = this->get_config_descriptor(param->reg_for_notify.handle);
       if (descr == nullptr) {
         ESP_LOGW(TAG, "No descriptor found for notify of handle 0x%x", param->reg_for_notify.handle);
         break;
@@ -252,7 +252,7 @@ float BLEClient::parse_char_value(uint8_t *value, uint16_t length) {
 }
 
 BLEService *BLEClient::get_service(espbt::ESPBTUUID uuid) {
-  for (auto svc : this->services_)
+  for (auto *svc : this->services_)
     if (svc->uuid == uuid)
       return svc;
   return nullptr;
@@ -261,7 +261,7 @@ BLEService *BLEClient::get_service(espbt::ESPBTUUID uuid) {
 BLEService *BLEClient::get_service(uint16_t uuid) { return this->get_service(espbt::ESPBTUUID::from_uint16(uuid)); }
 
 BLECharacteristic *BLEClient::get_characteristic(espbt::ESPBTUUID service, espbt::ESPBTUUID chr) {
-  auto svc = this->get_service(service);
+  auto *svc = this->get_service(service);
   if (svc == nullptr)
     return nullptr;
   return svc->get_characteristic(chr);
@@ -293,10 +293,10 @@ BLECharacteristic *BLEService::get_characteristic(uint16_t uuid) {
 }
 
 BLEDescriptor *BLEClient::get_descriptor(espbt::ESPBTUUID service, espbt::ESPBTUUID chr, espbt::ESPBTUUID descr) {
-  auto svc = this->get_service(service);
+  auto *svc = this->get_service(service);
   if (svc == nullptr)
     return nullptr;
-  auto ch = svc->get_characteristic(chr);
+  auto *ch = svc->get_characteristic(chr);
   if (ch == nullptr)
     return nullptr;
   return ch->get_descriptor(descr);
@@ -389,7 +389,7 @@ BLEDescriptor *BLECharacteristic::get_descriptor(uint16_t uuid) {
 }
 
 void BLECharacteristic::write_value(uint8_t *new_val, int16_t new_val_size) {
-  auto client = this->service->client;
+  auto *client = this->service->client;
   auto status = esp_ble_gattc_write_char(client->gattc_if, client->conn_id, this->handle, new_val_size, new_val,
                                          ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (status) {

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -32,7 +32,7 @@ void BLEBinaryOutput::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
         break;
       }
 
-      auto chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
+      auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
       if (chr == nullptr) {
         ESP_LOGW(TAG, "[%s] Characteristic not found.", this->char_uuid_.to_string().c_str());
         break;
@@ -54,7 +54,7 @@ void BLEBinaryOutput::write_state(bool state) {
     return;
   }
 
-  auto chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
+  auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
   if (chr == nullptr) {
     ESP_LOGW(TAG, "[%s] Characteristic not found.  State update can not be written.",
              this->char_uuid_.to_string().c_str());

--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -43,7 +43,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
     }
     case ESP_GATTC_SEARCH_CMPL_EVT: {
       this->handle = 0;
-      auto chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
+      auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
       if (chr == nullptr) {
         this->status_set_warning();
         this->publish_state(NAN);
@@ -53,7 +53,7 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
       }
       this->handle = chr->handle;
       if (this->descr_uuid_.get_uuid().len > 0) {
-        auto descr = chr->get_descriptor(this->descr_uuid_);
+        auto *descr = chr->get_descriptor(this->descr_uuid_);
         if (descr == nullptr) {
           this->status_set_warning();
           this->publish_state(NAN);

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -75,7 +75,7 @@ void Canbus::loop() {
     }
 
     // fire all triggers
-    for (auto trigger : this->triggers_) {
+    for (auto *trigger : this->triggers_) {
       if ((trigger->can_id_ == can_message.can_id) && (trigger->use_extended_id_ == can_message.use_extended_id)) {
         trigger->trigger(data);
       }

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -175,7 +175,7 @@ void LgIrClimate::transmit_(uint32_t value) {
   ESP_LOGD(TAG, "Sending climate_lg_ir code: 0x%02X", value);
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   data->set_carrier_frequency(38000);
   data->reserve(2 + BITS * 2u);

--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -104,7 +104,7 @@ void CoolixClimate::transmit_state() {
   ESP_LOGV(TAG, "Sending coolix code: 0x%06X", remote_state);
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
   remote_base::CoolixProtocol().encode(data, remote_state);
   transmit.perform();
 }

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -23,7 +23,7 @@ void DaikinClimate::transmit_state() {
   }
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
   data->set_carrier_frequency(DAIKIN_IR_FREQUENCY);
 
   data->mark(DAIKIN_HEADER_MARK);

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -52,7 +52,7 @@ void DallasComponent::setup() {
     this->found_sensors_.push_back(address);
   }
 
-  for (auto sensor : this->sensors_) {
+  for (auto *sensor : this->sensors_) {
     if (sensor->get_index().has_value()) {
       if (*sensor->get_index() >= this->found_sensors_.size()) {
         this->status_set_error();

--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -97,7 +97,7 @@ bool E131Component::process_(int universe, const E131Packet &packet) {
 
   ESP_LOGV(TAG, "Received E1.31 packet for %d universe, with %d bytes", universe, packet.count);
 
-  for (auto light_effect : light_effects_) {
+  for (auto *light_effect : light_effects_) {
     handled = light_effect->process_(universe, packet) || handled;
   }
 

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -47,7 +47,7 @@ void E131AddressableLightEffect::apply(light::AddressableLight &it, const Color 
 }
 
 bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet) {
-  auto it = get_addressable_();
+  auto *it = get_addressable_();
 
   // check if this is our universe and data are valid
   if (universe < first_universe_ || universe > get_last_universe())
@@ -57,7 +57,7 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
   // limit amount of lights per universe and received
   int output_end =
       std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + packet.count - 1));
-  auto input_data = packet.values + 1;
+  auto *input_data = packet.values + 1;
 
   ESP_LOGV(TAG, "Applying data for '%s' on %d universe, for %d-%d.", get_name().c_str(), universe, output_offset,
            output_end);

--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -116,7 +116,7 @@ bool E131Component::packet_(const std::vector<uint8_t> &data, int &universe, E13
   if (data.size() < E131_MIN_PACKET_SIZE)
     return false;
 
-  auto sbuff = reinterpret_cast<const E131RawPacket *>(&data[0]);
+  auto *sbuff = reinterpret_cast<const E131RawPacket *>(&data[0]);
 
   if (memcmp(sbuff->acn_id, ACN_ID, sizeof(sbuff->acn_id)) != 0)
     return false;

--- a/esphome/components/fujitsu_general/fujitsu_general.cpp
+++ b/esphome/components/fujitsu_general/fujitsu_general.cpp
@@ -207,7 +207,7 @@ void FujitsuGeneralClimate::transmit_(uint8_t const *message, uint8_t length) {
   ESP_LOGV(TAG, "Transmit message length %d", length);
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   data->set_carrier_frequency(FUJITSU_GENERAL_CARRIER_FREQUENCY);
 

--- a/esphome/components/heatpumpir/ir_sender_esphome.cpp
+++ b/esphome/components/heatpumpir/ir_sender_esphome.cpp
@@ -6,20 +6,20 @@ namespace esphome {
 namespace heatpumpir {
 
 void IRSenderESPHome::setFrequency(int frequency) {  // NOLINT(readability-identifier-naming)
-  auto data = transmit_.get_data();
+  auto *data = transmit_.get_data();
   data->set_carrier_frequency(1000 * frequency);
 }
 
 // Send an IR 'mark' symbol, i.e. transmitter ON
 void IRSenderESPHome::mark(int mark_length) {
-  auto data = transmit_.get_data();
+  auto *data = transmit_.get_data();
   data->mark(mark_length);
 }
 
 // Send an IR 'space' symbol, i.e. transmitter OFF
 void IRSenderESPHome::space(int space_length) {
   if (space_length) {
-    auto data = transmit_.get_data();
+    auto *data = transmit_.get_data();
     data->space(space_length);
   } else {
     transmit_.perform();

--- a/esphome/components/hitachi_ac344/hitachi_ac344.cpp
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.cpp
@@ -211,7 +211,7 @@ void HitachiClimate::transmit_state() {
   invert_byte_pairs(remote_state_ + 3, HITACHI_AC344_STATE_LENGTH - 3);
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
   data->set_carrier_frequency(HITACHI_AC344_FREQ);
 
   uint8_t repeat = 0;

--- a/esphome/components/hitachi_ac424/hitachi_ac424.cpp
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.cpp
@@ -212,7 +212,7 @@ void HitachiClimate::transmit_state() {
   invert_byte_pairs(remote_state_ + 3, HITACHI_AC424_STATE_LENGTH - 3);
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
   data->set_carrier_frequency(HITACHI_AC424_FREQ);
 
   uint8_t repeat = 0;

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -20,11 +20,11 @@ void MDNSComponent::setup() {
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
-    auto proto = service.proto.c_str();
+    auto *proto = service.proto.c_str();
     while (*proto == '_') {
       proto++;
     }
-    auto service_type = service.service_type.c_str();
+    auto *service_type = service.service_type.c_str();
     while (*service_type == '_') {
       service_type++;
     }

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -54,7 +54,7 @@ void MitsubishiClimate::transmit_state() {
   }
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   data->set_carrier_frequency(38000);
   // repeat twice

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -99,7 +99,7 @@ void ModbusController::on_register_data(ModbusRegisterType register_type, uint16
 
   // loop through all sensors with the same start address
   auto sensors = find_sensors_(register_type, start_address);
-  for (auto sensor : sensors) {
+  for (auto *sensor : sensors) {
     sensor->parse_and_publish(data);
   }
 }

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -688,7 +688,7 @@ void Nextion::process_nextion_commands_() {
         int index = 0;
         int found = -1;
         for (auto &nb : this->nextion_queue_) {
-          auto component = nb->component;
+          auto *component = nb->component;
           if (component->get_queue_type() == NextionQueueType::WAVEFORM_SENSOR) {
             size_t buffer_to_send = component->get_wave_buffer().size() < 255 ? component->get_wave_buffer().size()
                                                                               : 255;  // ADDT command can only send 255

--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -104,7 +104,7 @@ void IRAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensorStore 
   }
 
   if (rotation_dir != 0) {
-    auto first_zero = std::find(arg->rotation_events.begin(), arg->rotation_events.end(), 0);  // find first zero
+    auto *first_zero = std::find(arg->rotation_events.begin(), arg->rotation_events.end(), 0);  // find first zero
     if (first_zero == arg->rotation_events.begin()  // are we at the start (first event this loop iteration)
         || std::signbit(*std::prev(first_zero)) !=
                std::signbit(rotation_dir)  // or is the last stored event the wrong direction

--- a/esphome/components/tcl112/tcl112.cpp
+++ b/esphome/components/tcl112/tcl112.cpp
@@ -120,7 +120,7 @@ void Tcl112Climate::transmit_state() {
            remote_state[13]);
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   data->set_carrier_frequency(38000);
 

--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -179,7 +179,7 @@ void TeleInfo::loop() {
   }
 }
 void TeleInfo::publish_value_(const std::string &tag, const std::string &val) {
-  for (auto element : teleinfo_listeners_) {
+  for (auto *element : teleinfo_listeners_) {
     if (tag != element->tag)
       continue;
     element->publish_val(val);

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -197,7 +197,7 @@ void ToshibaClimate::transmit_generic_() {
 
   // Transmit
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   encode_(data, message, message_length, 1);
 
@@ -210,7 +210,7 @@ void ToshibaClimate::transmit_rac_pt1411hwru_() {
       clamp<float>(this->target_temperature, TOSHIBA_RAC_PT1411HWRU_TEMP_C_MIN, TOSHIBA_RAC_PT1411HWRU_TEMP_C_MAX);
   float temp_adjd = temperature - TOSHIBA_RAC_PT1411HWRU_TEMP_C_MIN;
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   // Byte 0:  Header upper (0xB2)
   message[0] = RAC_PT1411HWRU_MESSAGE_HEADER0;
@@ -357,7 +357,7 @@ void ToshibaClimate::transmit_rac_pt1411hwru_temp_(const bool cs_state, const bo
     uint8_t message[RAC_PT1411HWRU_MESSAGE_LENGTH] = {0};
     float temperature = clamp<float>(this->current_temperature, 0.0, TOSHIBA_RAC_PT1411HWRU_TEMP_C_MAX + 1);
     auto transmit = this->transmitter_->transmit();
-    auto data = transmit.get_data();
+    auto *data = transmit.get_data();
     // "Comfort Sense" feature notes
     // IR Code: 0xBA45 xxXX yyYY
     // xx: Temperature in °C

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -208,7 +208,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
 #ifdef USE_TIME
       if (this->time_id_.has_value()) {
         this->send_local_time_();
-        auto time_id = *this->time_id_;
+        auto *time_id = *this->time_id_;
         time_id->add_on_time_sync_callback([this] { this->send_local_time_(); });
       } else {
         ESP_LOGW(TAG, "LOCAL_TIME_QUERY is not handled because time is not configured");
@@ -414,7 +414,7 @@ void Tuya::send_wifi_status_() {
 #ifdef USE_TIME
 void Tuya::send_local_time_() {
   std::vector<uint8_t> payload;
-  auto time_id = *this->time_id_;
+  auto *time_id = *this->time_id_;
   time::ESPTime now = time_id->now();
   if (now.is_valid()) {
     uint8_t year = now.year - 2000;

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -120,7 +120,7 @@ void WhirlpoolClimate::transmit_state() {
 
   // Send code
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   data->set_carrier_frequency(38000);
 

--- a/esphome/components/yashima/yashima.cpp
+++ b/esphome/components/yashima/yashima.cpp
@@ -171,7 +171,7 @@ void YashimaClimate::transmit_state_() {
   remote_state[1] |= YASHIMA_TEMP_MAP_BYTE1[safecelsius - YASHIMA_TEMP_MIN];
 
   auto transmit = this->transmitter_->transmit();
-  auto data = transmit.get_data();
+  auto *data = transmit.get_data();
 
   data->set_carrier_frequency(YASHIMA_CARRIER_FREQUENCY);
 


### PR DESCRIPTION
# What does this implement/fix? 

https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-qualified-auto.html

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
