### PR TITLE
Enable readability-redundant-access-specifiers check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -79,7 +79,6 @@ Checks: >-
   -readability-make-member-function-const,
   -readability-named-parameter,
   -readability-qualified-auto,
-  -readability-redundant-access-specifiers,
   -readability-redundant-member-init,
   -readability-redundant-string-init,
   -readability-uppercase-literal-suffix,

--- a/esphome/components/adalight/adalight_light_effect.h
+++ b/esphome/components/adalight/adalight_light_effect.h
@@ -13,7 +13,6 @@ class AdalightLightEffect : public light::AddressableLightEffect, public uart::U
  public:
   AdalightLightEffect(const std::string &name);
 
- public:
   void start() override;
   void stop() override;
   void apply(light::AddressableLight &it, const Color &current_color) override;
@@ -30,7 +29,6 @@ class AdalightLightEffect : public light::AddressableLightEffect, public uart::U
   void blank_all_leds_(light::AddressableLight &it);
   Frame parse_frame_(light::AddressableLight &it);
 
- protected:
   uint32_t last_ack_{0};
   uint32_t last_byte_{0};
   uint32_t last_reset_{0};

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -33,11 +33,9 @@ class E131Component : public esphome::Component {
   void loop() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
- public:
   void add_effect(E131AddressableLightEffect *light_effect);
   void remove_effect(E131AddressableLightEffect *light_effect);
 
- public:
   void set_method(E131ListenMethod listen_method) { this->listen_method_ = listen_method; }
 
  protected:
@@ -47,7 +45,6 @@ class E131Component : public esphome::Component {
   void join_(int universe);
   void leave_(int universe);
 
- protected:
   E131ListenMethod listen_method_{E131_MULTICAST};
   std::unique_ptr<UDP> udp_;
   std::set<E131AddressableLightEffect *> light_effects_;

--- a/esphome/components/e131/e131_addressable_light_effect.h
+++ b/esphome/components/e131/e131_addressable_light_effect.h
@@ -17,19 +17,16 @@ class E131AddressableLightEffect : public light::AddressableLightEffect {
  public:
   E131AddressableLightEffect(const std::string &name);
 
- public:
   void start() override;
   void stop() override;
   void apply(light::AddressableLight &it, const Color &current_color) override;
 
- public:
   int get_data_per_universe() const;
   int get_lights_per_universe() const;
   int get_first_universe() const;
   int get_last_universe() const;
   int get_universe_count() const;
 
- public:
   void set_first_universe(int universe) { this->first_universe_ = universe; }
   void set_channels(E131LightChannels channels) { this->channels_ = channels; }
   void set_e131(E131Component *e131) { this->e131_ = e131; }
@@ -37,7 +34,6 @@ class E131AddressableLightEffect : public light::AddressableLightEffect {
  protected:
   bool process_(int universe, const E131Packet &packet);
 
- protected:
   int first_universe_{0};
   int last_universe_{0};
   E131LightChannels channels_{E131_RGB};

--- a/esphome/components/esp32_camera_web_server/camera_web_server.h
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.h
@@ -36,7 +36,6 @@ class CameraWebServer : public Component {
   esp_err_t streaming_handler_(struct httpd_req *req);
   esp_err_t snapshot_handler_(struct httpd_req *req);
 
- protected:
   uint16_t port_{0};
   void *httpd_{nullptr};
   SemaphoreHandle_t semaphore_;

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -36,7 +36,6 @@ class ModbusTextSensor : public Component, public text_sensor::TextSensor, publi
  protected:
   optional<transform_func_t> transform_func_{nullopt};
 
- protected:
   RawEncoding encode_;
 };
 

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -186,7 +186,6 @@ class MQTTComponent : public Component {
   /// Generate the Home Assistant MQTT discovery object id by automatically transforming the friendly name.
   std::string get_default_object_id_() const;
 
- protected:
   std::string custom_state_topic_{};
   std::string custom_command_topic_{};
   bool retain_{true};

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -17,7 +17,6 @@ class WLEDLightEffect : public light::AddressableLightEffect {
  public:
   WLEDLightEffect(const std::string &name);
 
- public:
   void start() override;
   void stop() override;
   void apply(light::AddressableLight &it, const Color &current_color) override;
@@ -32,7 +31,6 @@ class WLEDLightEffect : public light::AddressableLightEffect {
   bool parse_drgbw_frame_(light::AddressableLight &it, const uint8_t *payload, uint16_t size);
   bool parse_dnrgb_frame_(light::AddressableLight &it, const uint8_t *payload, uint16_t size);
 
- protected:
   uint16_t port_{0};
   std::unique_ptr<UDP> udp_;
   uint32_t blank_at_{0};


### PR DESCRIPTION
# What does this implement/fix? 

https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-redundant-access-specifiers.html

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
