### PR TITLE
Enable readability-redundant-member-init check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -80,7 +80,6 @@ Checks: >-
   -readability-named-parameter,
   -readability-qualified-auto,
   -readability-redundant-access-specifiers,
-  -readability-redundant-member-init,
   -readability-redundant-string-init,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof,

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -162,7 +162,7 @@ void ESP32TouchComponent::on_shutdown() {
 }
 
 ESP32TouchBinarySensor::ESP32TouchBinarySensor(touch_pad_t touch_pad, uint16_t threshold, uint16_t wakeup_threshold)
-    : BinarySensor(), touch_pad_(touch_pad), threshold_(threshold), wakeup_threshold_(wakeup_threshold) {}
+    : touch_pad_(touch_pad), threshold_(threshold), wakeup_threshold_(wakeup_threshold) {}
 
 }  // namespace esp32_touch
 }  // namespace esphome

--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
@@ -10,8 +10,7 @@ namespace modbus_controller {
 class ModbusBinarySensor : public Component, public binary_sensor::BinarySensor, public SensorItem {
  public:
   ModbusBinarySensor(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
-                     uint8_t skip_updates, bool force_new_range)
-      : Component(), binary_sensor::BinarySensor() {
+                     uint8_t skip_updates, bool force_new_range) {
     this->register_type = register_type;
     this->start_address = start_address;
     this->offset = offset;

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -393,7 +393,7 @@ class ModbusCommandItem {
 
 class ModbusController : public PollingComponent, public modbus::ModbusDevice {
  public:
-  ModbusController(uint16_t throttle = 0) : modbus::ModbusDevice(), command_throttle_(throttle){};
+  ModbusController(uint16_t throttle = 0) : command_throttle_(throttle){};
   void dump_config() override;
   void loop() override;
   void setup() override;

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -12,8 +12,7 @@ using value_to_data_t = std::function<float>(float);
 class ModbusNumber : public number::Number, public Component, public SensorItem {
  public:
   ModbusNumber(uint16_t start_address, uint8_t offset, uint32_t bitmask, SensorValueType value_type, int register_count,
-               uint8_t skip_updates, bool force_new_range)
-      : number::Number(), Component(), SensorItem() {
+               uint8_t skip_updates, bool force_new_range) {
     this->register_type = ModbusRegisterType::HOLDING;
     this->start_address = start_address;
     this->offset = offset;

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -9,8 +9,7 @@ namespace modbus_controller {
 
 class ModbusFloatOutput : public output::FloatOutput, public Component, public SensorItem {
  public:
-  ModbusFloatOutput(uint16_t start_address, uint8_t offset, SensorValueType value_type, int register_count)
-      : output::FloatOutput(), Component() {
+  ModbusFloatOutput(uint16_t start_address, uint8_t offset, SensorValueType value_type, int register_count) {
     this->register_type = ModbusRegisterType::HOLDING;
     this->start_address = start_address;
     this->offset = offset;
@@ -43,7 +42,7 @@ class ModbusFloatOutput : public output::FloatOutput, public Component, public S
 
 class ModbusBinaryOutput : public output::BinaryOutput, public Component, public SensorItem {
  public:
-  ModbusBinaryOutput(uint16_t start_address, uint8_t offset) : output::BinaryOutput(), Component() {
+  ModbusBinaryOutput(uint16_t start_address, uint8_t offset) {
     this->register_type = ModbusRegisterType::COIL;
     this->start_address = start_address;
     this->bitmask = bitmask;

--- a/esphome/components/modbus_controller/sensor/modbus_sensor.h
+++ b/esphome/components/modbus_controller/sensor/modbus_sensor.h
@@ -10,8 +10,7 @@ namespace modbus_controller {
 class ModbusSensor : public Component, public sensor::Sensor, public SensorItem {
  public:
   ModbusSensor(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
-               SensorValueType value_type, int register_count, uint8_t skip_updates, bool force_new_range)
-      : Component(), sensor::Sensor() {
+               SensorValueType value_type, int register_count, uint8_t skip_updates, bool force_new_range) {
     this->register_type = register_type;
     this->start_address = start_address;
     this->offset = offset;

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -10,8 +10,7 @@ namespace modbus_controller {
 class ModbusSwitch : public Component, public switch_::Switch, public SensorItem {
  public:
   ModbusSwitch(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint32_t bitmask,
-               uint8_t skip_updates, bool force_new_range)
-      : Component(), switch_::Switch() {
+               uint8_t skip_updates, bool force_new_range) {
     this->register_type = register_type;
     this->start_address = start_address;
     this->offset = offset;

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -12,8 +12,7 @@ enum class RawEncoding { NONE = 0, HEXBYTES = 1, COMMA = 2 };
 class ModbusTextSensor : public Component, public text_sensor::TextSensor, public SensorItem {
  public:
   ModbusTextSensor(ModbusRegisterType register_type, uint16_t start_address, uint8_t offset, uint8_t register_count,
-                   uint16_t response_bytes, RawEncoding encode, uint8_t skip_updates, bool force_new_range)
-      : Component() {
+                   uint16_t response_bytes, RawEncoding encode, uint8_t skip_updates, bool force_new_range) {
     this->register_type = register_type;
     this->start_address = start_address;
     this->offset = offset;

--- a/esphome/components/mqtt/mqtt_binary_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_binary_sensor.cpp
@@ -23,7 +23,7 @@ void MQTTBinarySensorComponent::dump_config() {
   LOG_MQTT_COMPONENT(true, false)
 }
 MQTTBinarySensorComponent::MQTTBinarySensorComponent(binary_sensor::BinarySensor *binary_sensor)
-    : MQTTComponent(), binary_sensor_(binary_sensor) {
+    : binary_sensor_(binary_sensor) {
   if (this->binary_sensor_->is_status_binary_sensor()) {
     this->set_custom_state_topic(mqtt::global_mqtt_client->get_availability().topic);
   }

--- a/esphome/components/mqtt/mqtt_button.cpp
+++ b/esphome/components/mqtt/mqtt_button.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "mqtt.button";
 
 using namespace esphome::button;
 
-MQTTButtonComponent::MQTTButtonComponent(button::Button *button) : MQTTComponent(), button_(button) {}
+MQTTButtonComponent::MQTTButtonComponent(button::Button *button) : button_(button) {}
 
 void MQTTButtonComponent::setup() {
   this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {

--- a/esphome/components/mqtt/mqtt_fan.cpp
+++ b/esphome/components/mqtt/mqtt_fan.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "mqtt.fan";
 
 using namespace esphome::fan;
 
-MQTTFanComponent::MQTTFanComponent(FanState *state) : MQTTComponent(), state_(state) {}
+MQTTFanComponent::MQTTFanComponent(FanState *state) : state_(state) {}
 
 FanState *MQTTFanComponent::get_state() const { return this->state_; }
 std::string MQTTFanComponent::component_type() const { return "fan"; }

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -28,7 +28,7 @@ void MQTTJSONLightComponent::setup() {
   this->state_->add_new_remote_values_callback([this, f]() { this->defer("send", f); });
 }
 
-MQTTJSONLightComponent::MQTTJSONLightComponent(LightState *state) : MQTTComponent(), state_(state) {}
+MQTTJSONLightComponent::MQTTJSONLightComponent(LightState *state) : state_(state) {}
 
 bool MQTTJSONLightComponent::publish_state_() {
   return this->publish_json(this->get_state_topic_(),

--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "mqtt.number";
 
 using namespace esphome::number;
 
-MQTTNumberComponent::MQTTNumberComponent(Number *number) : MQTTComponent(), number_(number) {}
+MQTTNumberComponent::MQTTNumberComponent(Number *number) : number_(number) {}
 
 void MQTTNumberComponent::setup() {
   this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &state) {

--- a/esphome/components/mqtt/mqtt_select.cpp
+++ b/esphome/components/mqtt/mqtt_select.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "mqtt.select";
 
 using namespace esphome::select;
 
-MQTTSelectComponent::MQTTSelectComponent(Select *select) : MQTTComponent(), select_(select) {}
+MQTTSelectComponent::MQTTSelectComponent(Select *select) : select_(select) {}
 
 void MQTTSelectComponent::setup() {
   this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &state) {

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -17,7 +17,7 @@ static const char *const TAG = "mqtt.sensor";
 
 using namespace esphome::sensor;
 
-MQTTSensorComponent::MQTTSensorComponent(Sensor *sensor) : MQTTComponent(), sensor_(sensor) {}
+MQTTSensorComponent::MQTTSensorComponent(Sensor *sensor) : sensor_(sensor) {}
 
 void MQTTSensorComponent::setup() {
   this->sensor_->add_on_state_callback([this](float state) { this->publish_state(state); });

--- a/esphome/components/mqtt/mqtt_switch.cpp
+++ b/esphome/components/mqtt/mqtt_switch.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "mqtt.switch";
 
 using namespace esphome::switch_;
 
-MQTTSwitchComponent::MQTTSwitchComponent(switch_::Switch *a_switch) : MQTTComponent(), switch_(a_switch) {}
+MQTTSwitchComponent::MQTTSwitchComponent(switch_::Switch *a_switch) : switch_(a_switch) {}
 
 void MQTTSwitchComponent::setup() {
   this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {

--- a/esphome/components/mqtt/mqtt_text_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_text_sensor.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "mqtt.text_sensor";
 
 using namespace esphome::text_sensor;
 
-MQTTTextSensor::MQTTTextSensor(TextSensor *sensor) : MQTTComponent(), sensor_(sensor) {}
+MQTTTextSensor::MQTTTextSensor(TextSensor *sensor) : sensor_(sensor) {}
 void MQTTTextSensor::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
   config.command_topic = false;
 }

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -284,7 +284,7 @@ class RemoteReceiverBinarySensorBase : public binary_sensor::BinarySensorInitial
                                        public Component,
                                        public RemoteReceiverListener {
  public:
-  explicit RemoteReceiverBinarySensorBase() : BinarySensorInitiallyOff() {}
+  explicit RemoteReceiverBinarySensorBase() {}
   void dump_config() override;
   virtual bool matches(RemoteReceiveData src) = 0;
   bool on_receive(RemoteReceiveData src) override {

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -291,8 +291,7 @@ optional<float> FilterOutValueFilter::new_value(float value) {
 }
 
 // ThrottleFilter
-ThrottleFilter::ThrottleFilter(uint32_t min_time_between_inputs)
-    : Filter(), min_time_between_inputs_(min_time_between_inputs) {}
+ThrottleFilter::ThrottleFilter(uint32_t min_time_between_inputs) : min_time_between_inputs_(min_time_between_inputs) {}
 optional<float> ThrottleFilter::new_value(float value) {
   const uint32_t now = millis();
   if (this->last_input_ == 0 || now - this->last_input_ >= min_time_between_inputs_) {

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -35,7 +35,7 @@ std::string format_sockaddr(const struct sockaddr_storage &storage) {
 
 class BSDSocketImpl : public Socket {
  public:
-  BSDSocketImpl(int fd) : Socket(), fd_(fd) {}
+  BSDSocketImpl(int fd) : fd_(fd) {}
   ~BSDSocketImpl() override {
     if (!closed_) {
       close();  // NOLINT(clang-analyzer-optin.cplusplus.VirtualCall)

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -177,7 +177,7 @@ bool Component::has_overridden_loop() const {
   return loop_overridden || call_loop_overridden;
 }
 
-PollingComponent::PollingComponent(uint32_t update_interval) : Component(), update_interval_(update_interval) {}
+PollingComponent::PollingComponent(uint32_t update_interval) : update_interval_(update_interval) {}
 
 void PollingComponent::call_setup() {
   // Let the polling component subclass setup their HW.


### PR DESCRIPTION
# What does this implement/fix? 

https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-redundant-member-init.html

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
