### PR TITLE
Enable readability-named-parameter check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -77,7 +77,6 @@ Checks: >-
   -readability-isolate-declaration,
   -readability-magic-numbers,
   -readability-make-member-function-const,
-  -readability-named-parameter,
   -readability-qualified-auto,
   -readability-redundant-access-specifiers,
   -readability-redundant-member-init,

--- a/esphome/components/anova/anova.h
+++ b/esphome/components/anova/anova.h
@@ -36,7 +36,7 @@ class Anova : public climate::Climate, public esphome::ble_client::BLEClientNode
     traits.set_visual_temperature_step(0.1);
     return traits;
   }
-  void set_unit_of_measurement(const char *);
+  void set_unit_of_measurement(const char *unit);
 
  protected:
   std::unique_ptr<AnovaCodec> codec_;

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -52,7 +52,7 @@ template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
 
  protected:
   virtual void execute(Ts... x) = 0;
-  template<int... S> void execute_(std::vector<ExecuteServiceArgument> args, seq<S...>) {
+  template<int... S> void execute_(std::vector<ExecuteServiceArgument> args, seq<S...> type) {
     this->execute((get_execute_arg_value<Ts>(args[S]))...);
   }
 

--- a/esphome/components/hm3301/hm3301.h
+++ b/esphome/components/hm3301/hm3301.h
@@ -44,8 +44,8 @@ class HM3301Component : public PollingComponent, public i2c::I2CDevice {
   AQICalculatorType aqi_calc_type_;
   AQICalculatorFactory aqi_calculator_factory_ = AQICalculatorFactory();
 
-  bool validate_checksum_(const uint8_t *);
-  uint16_t get_sensor_value_(const uint8_t *, uint8_t);
+  bool validate_checksum_(const uint8_t *data);
+  uint16_t get_sensor_value_(const uint8_t *data, uint8_t i);
 };
 
 }  // namespace hm3301

--- a/esphome/components/kalman_combinator/kalman_combinator.cpp
+++ b/esphome/components/kalman_combinator/kalman_combinator.cpp
@@ -28,7 +28,7 @@ void KalmanCombinatorComponent::add_source(Sensor *sensor, std::function<float(f
 }
 
 void KalmanCombinatorComponent::add_source(Sensor *sensor, float stddev) {
-  this->add_source(sensor, std::function<float(float)>{[stddev](float) -> float { return stddev; }});
+  this->add_source(sensor, std::function<float(float)>{[stddev](float x) -> float { return stddev; }});
 }
 
 void KalmanCombinatorComponent::update_variance_() {

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -440,7 +440,7 @@ ModbusCommandItem ModbusCommandItem::create_custom_command(
   cmd.modbusdevice = modbusdevice;
   cmd.function_code = ModbusFunctionCode::CUSTOM;
   if (handler == nullptr) {
-    cmd.on_data_func = [](ModbusRegisterType, uint16_t, const std::vector<uint8_t> &data) {
+    cmd.on_data_func = [](ModbusRegisterType register_type, uint16_t start_address, const std::vector<uint8_t> &data) {
       ESP_LOGI(TAG, "Custom Command sent");
     };
   } else {

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -27,7 +27,6 @@ class ModbusNumber : public number::Number, public Component, public SensorItem 
   void dump_config() override;
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
-  void set_update_interval(int) {}
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
   void set_write_multiply(float factor) { multiply_by_ = factor; }
 

--- a/esphome/components/sim800l/sim800l.h
+++ b/esphome/components/sim800l/sim800l.h
@@ -49,8 +49,8 @@ class Sim800LComponent : public uart::UARTDevice, public PollingComponent {
   void dial(const std::string &recipient);
 
  protected:
-  void send_cmd_(const std::string &);
-  void parse_cmd_(std::string);
+  void send_cmd_(const std::string &message);
+  void parse_cmd_(std::string message);
 
   std::string sender_;
   char read_buffer_[SIM800L_READ_BUFFER_LENGTH];

--- a/esphome/components/tm1651/tm1651.h
+++ b/esphome/components/tm1651/tm1651.h
@@ -21,9 +21,9 @@ class TM1651Display : public Component {
   void setup() override;
   void dump_config() override;
 
-  void set_level_percent(uint8_t);
-  void set_level(uint8_t);
-  void set_brightness(uint8_t);
+  void set_level_percent(uint8_t new_level);
+  void set_level(uint8_t new_level);
+  void set_brightness(uint8_t new_brightness);
 
   void turn_on();
   void turn_off();
@@ -39,8 +39,8 @@ class TM1651Display : public Component {
 
   void repaint_();
 
-  uint8_t calculate_level_(uint8_t);
-  uint8_t calculate_brightness_(uint8_t);
+  uint8_t calculate_level_(uint8_t new_level);
+  uint8_t calculate_brightness_(uint8_t new_brightness);
 };
 
 template<typename... Ts> class SetLevelPercentAction : public Action<Ts...>, public Parented<TM1651Display> {

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -299,7 +299,7 @@ class WiFiComponent : public Component {
   void wifi_scan_done_callback_();
 #endif
 #ifdef USE_ESP_IDF
-  void wifi_process_event_(IDFWiFiEvent *);
+  void wifi_process_event_(IDFWiFiEvent *data);
 #endif
 
   std::string use_address_;


### PR DESCRIPTION
# What does this implement/fix? 

https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-named-parameter.html

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
