### PR TITLE
Enable readability-const-return-type check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,7 +69,6 @@ Checks: >-
   -mpi-*,
   -objc-*,
   -readability-braces-around-statements,
-  -readability-const-return-type,
   -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,

--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -65,7 +65,7 @@ class ClimateTraits {
   ESPDEPRECATED("This method is deprecated, use set_supported_modes() instead", "v1.20")
   void set_supports_dry_mode(bool supports_dry_mode) { set_mode_support_(CLIMATE_MODE_DRY, supports_dry_mode); }
   bool supports_mode(ClimateMode mode) const { return supported_modes_.count(mode); }
-  const std::set<ClimateMode> get_supported_modes() const { return supported_modes_; }
+  std::set<ClimateMode> get_supported_modes() const { return supported_modes_; }
 
   void set_supports_action(bool supports_action) { supports_action_ = supports_action; }
   bool get_supports_action() const { return supports_action_; }
@@ -93,7 +93,7 @@ class ClimateTraits {
   void set_supports_fan_mode_diffuse(bool supported) { set_fan_mode_support_(CLIMATE_FAN_DIFFUSE, supported); }
   bool supports_fan_mode(ClimateFanMode fan_mode) const { return supported_fan_modes_.count(fan_mode); }
   bool get_supports_fan_modes() const { return !supported_fan_modes_.empty() || !supported_custom_fan_modes_.empty(); }
-  const std::set<ClimateFanMode> get_supported_fan_modes() const { return supported_fan_modes_; }
+  std::set<ClimateFanMode> get_supported_fan_modes() const { return supported_fan_modes_; }
 
   void set_supported_custom_fan_modes(std::set<std::string> supported_custom_fan_modes) {
     supported_custom_fan_modes_ = std::move(supported_custom_fan_modes);
@@ -141,7 +141,7 @@ class ClimateTraits {
   }
   bool supports_swing_mode(ClimateSwingMode swing_mode) const { return supported_swing_modes_.count(swing_mode); }
   bool get_supports_swing_modes() const { return !supported_swing_modes_.empty(); }
-  const std::set<ClimateSwingMode> get_supported_swing_modes() { return supported_swing_modes_; }
+  std::set<ClimateSwingMode> get_supported_swing_modes() { return supported_swing_modes_; }
 
   float get_visual_min_temperature() const { return visual_min_temperature_; }
   void set_visual_min_temperature(float visual_min_temperature) { visual_min_temperature_ = visual_min_temperature; }

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -115,7 +115,7 @@ class GraphTrace {
   void set_line_type(enum LineType val) { this->line_type_ = val; }
   Color get_line_color() { return this->line_color_; }
   void set_line_color(Color val) { this->line_color_ = val; }
-  const std::string get_name() { return name_; }
+  std::string get_name() { return name_; }
   const HistoryData *get_tracedata() { return &data_; }
 
  protected:

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -27,13 +27,13 @@ std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) con
          "/" + suffix;
 }
 
-const std::string MQTTComponent::get_state_topic_() const {
+std::string MQTTComponent::get_state_topic_() const {
   if (this->custom_state_topic_.empty())
     return this->get_default_topic_for_("state");
   return this->custom_state_topic_;
 }
 
-const std::string MQTTComponent::get_command_topic_() const {
+std::string MQTTComponent::get_command_topic_() const {
   if (this->custom_command_topic_.empty())
     return this->get_default_topic_for_("command");
   return this->custom_command_topic_;

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -33,7 +33,7 @@ struct SendDiscoveryConfig {
 \
  public: \
   void set_custom_##name##_##type##_topic(const std::string &topic) { this->custom_##name##_##type##_topic_ = topic; } \
-  const std::string get_##name##_##type##_topic() const { \
+  std::string get_##name##_##type##_topic() const { \
     if (this->custom_##name##_##type##_topic_.empty()) \
       return this->get_default_topic_for_(#name "/" #type); \
     return this->custom_##name##_##type##_topic_; \
@@ -171,10 +171,10 @@ class MQTTComponent : public Component {
   virtual bool is_disabled_by_default() const;
 
   /// Get the MQTT topic that new states will be shared to.
-  const std::string get_state_topic_() const;
+  std::string get_state_topic_() const;
 
   /// Get the MQTT topic for listening to commands.
-  const std::string get_command_topic_() const;
+  std::string get_command_topic_() const;
 
   bool is_connected_() const;
 

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -38,7 +38,7 @@ class SelectCall {
 class SelectTraits {
  public:
   void set_options(std::vector<std::string> options) { this->options_ = std::move(options); }
-  const std::vector<std::string> get_options() const { return this->options_; }
+  std::vector<std::string> get_options() const { return this->options_; }
 
  protected:
   std::vector<std::string> options_;


### PR DESCRIPTION
# What does this implement/fix? 

https://releases.llvm.org/11.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-const-return-type.html

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
