### PR TITLE
Rename WEBSERVER_PORT define to USE_WEBSERVER_PORT

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -805,7 +805,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.project_version = ESPHOME_PROJECT_VERSION;
 #endif
 #ifdef USE_WEBSERVER
-  resp.webserver_port = WEBSERVER_PORT;
+  resp.webserver_port = USE_WEBSERVER_PORT;
 #endif
   return resp;
 }

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -128,7 +128,7 @@ void ESP32ImprovComponent::loop() {
         std::vector<std::string> urls = {ESPHOME_MY_LINK};
 #ifdef USE_WEBSERVER
         auto ip = wifi::global_wifi_component->wifi_sta_ip();
-        std::string webserver_url = "http://" + ip.str() + ":" + to_string(WEBSERVER_PORT);
+        std::string webserver_url = "http://" + ip.str() + ":" + to_string(USE_WEBSERVER_PORT);
         urls.push_back(webserver_url);
 #endif
         std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, urls);

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -95,7 +95,7 @@ std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv:
   std::vector<std::string> urls;
 #ifdef USE_WEBSERVER
   auto ip = wifi::global_wifi_component->wifi_sta_ip();
-  std::string webserver_url = "http://" + ip.str() + ":" + to_string(WEBSERVER_PORT);
+  std::string webserver_url = "http://" + ip.str() + ":" + to_string(USE_WEBSERVER_PORT);
   urls.push_back(webserver_url);
 #endif
   std::vector<uint8_t> data = improv::build_rpc_response(command, urls, false);

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -16,8 +16,8 @@ namespace mdns {
 
 static const char *const TAG = "mdns";
 
-#ifndef WEBSERVER_PORT
-#define WEBSERVER_PORT 80  // NOLINT
+#ifndef USE_WEBSERVER_PORT
+#define USE_WEBSERVER_PORT 80  // NOLINT
 #endif
 
 void MDNSComponent::compile_records_() {
@@ -63,7 +63,7 @@ void MDNSComponent::compile_records_() {
     MDNSService service{};
     service.service_type = "_prometheus-http";
     service.proto = "_tcp";
-    service.port = WEBSERVER_PORT;
+    service.port = USE_WEBSERVER_PORT;
     this->services_.push_back(service);
   }
 #endif
@@ -74,7 +74,7 @@ void MDNSComponent::compile_records_() {
     MDNSService service{};
     service.service_type = "_http";
     service.proto = "_tcp";
-    service.port = WEBSERVER_PORT;
+    service.port = USE_WEBSERVER_PORT;
     service.txt_records.push_back({"version", ESPHOME_VERSION});
     this->services_.push_back(service);
   }

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -66,8 +66,8 @@ async def to_code(config):
     cg.add_define("USE_WEBSERVER")
 
     cg.add(paren.set_port(config[CONF_PORT]))
-    cg.add_define("WEBSERVER_PORT", config[CONF_PORT])
     cg.add_define("USE_WEBSERVER")
+    cg.add_define("USE_WEBSERVER_PORT", config[CONF_PORT])
     cg.add(var.set_css_url(config[CONF_CSS_URL]))
     cg.add(var.set_js_url(config[CONF_JS_URL]))
     cg.add(var.set_allow_ota(config[CONF_OTA]))

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -47,8 +47,8 @@
 #define USE_MQTT
 #define USE_PROMETHEUS
 #define USE_WEBSERVER
+#define USE_WEBSERVER_PORT 80  // NOLINT
 #define USE_WIFI_WPA2_EAP
-#define WEBSERVER_PORT 80  // NOLINT
 #endif
 
 // ESP32-specific feature flags


### PR DESCRIPTION
# What does this implement/fix? 

For consistency.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
