### PR TITLE
Add cv.require_esphome_version helper

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -63,7 +63,7 @@ from esphome.jsonschema import (
     jschema_registry,
     jschema_typed,
 )
-
+from esphome.util import parse_esphome_version
 from esphome.voluptuous_schema import _Schema
 from esphome.yaml_util import make_data_base
 
@@ -1736,6 +1736,19 @@ def require_framework_version(
         if core_data[KEY_FRAMEWORK_VERSION] < required:
             raise Invalid(
                 f"This feature requires at least framework version {required}"
+            )
+        return value
+
+    return validator
+
+
+def require_esphome_version(*version):
+    def validator(value):
+        esphome_version = parse_esphome_version()
+        if esphome_version < version:
+            requires_version = f"{version[0]}.{version[1]}.{version[2]}"
+            raise Invalid(
+                f"This component requires at least ESPHome version {requires_version}"
             )
         return value
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1742,11 +1742,11 @@ def require_framework_version(
     return validator
 
 
-def require_esphome_version(*version):
+def require_esphome_version(year, month, patch):
     def validator(value):
         esphome_version = parse_esphome_version()
-        if esphome_version < version:
-            requires_version = f"{version[0]}.{version[1]}.{version[2]}"
+        if esphome_version < (year, month, patch):
+            requires_version = f"{year}.{month}.{patch}"
             raise Invalid(
                 f"This component requires at least ESPHome version {requires_version}"
             )

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -1,3 +1,4 @@
+import typing
 from typing import Union, List
 
 import collections
@@ -240,6 +241,13 @@ def run_external_process(*cmd, **kwargs):
 
 def is_dev_esphome_version():
     return "dev" in const.__version__
+
+
+def parse_esphome_version() -> typing.Tuple[int, int, int]:
+    match = re.match(r"^(\d+).(\d+).(\d+)(-dev\d*|b\d*)?$", const.__version__)
+    if match is None:
+        raise ValueError(f"Failed to parse ESPHome version '{const.__version__}'")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
 
 
 # Custom OrderedDict with nicer repr method for debugging


### PR DESCRIPTION
# What does this implement/fix? 

This can be used by external components to declare the minimum ESPHome version they support in a somewhat user-friendly way.

```python
CONFIG_SCHEMA = cv.All(
  cv.require_esphome_version(2022, 2, 0),
  cv.Schema(
    #...
  )
)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
