### PR TITLE
Remove unused polling_component_schema from modbus number

### DIFF
--- a/esphome/components/modbus_controller/number/__init__.py
+++ b/esphome/components/modbus_controller/number/__init__.py
@@ -58,8 +58,7 @@ def validate_modbus_number(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    number.NUMBER_SCHEMA.extend(ModbusItemBaseSchema)
-    .extend(
+    number.NUMBER_SCHEMA.extend(ModbusItemBaseSchema).extend(
         {
             cv.GenerateID(): cv.declare_id(ModbusNumber),
             cv.Optional(CONF_VALUE_TYPE, default="U_WORD"): cv.enum(SENSOR_VALUE_TYPE),
@@ -72,8 +71,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MULTIPLY, default=1.0): cv.float_,
             cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
         }
-    )
-    .extend(cv.polling_component_schema("60s")),
+    ),
     validate_min_max,
     validate_modbus_number,
 )

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -26,6 +26,11 @@ class ModbusNumber : public number::Number, public Component, public SensorItem 
   void dump_config() override;
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void set_update_interval(int) {
+    // update_interval is determined by modbus_controller
+    // ignore the value passed in
+    return;
+  }
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
   void set_write_multiply(float factor) { multiply_by_ = factor; }
 

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -26,11 +26,6 @@ class ModbusNumber : public number::Number, public Component, public SensorItem 
   void dump_config() override;
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
-  void set_update_interval(int) {
-    // update_interval is determined by modbus_controller
-    // ignore the value passed in
-    return;
-  }
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
   void set_write_multiply(float factor) { multiply_by_ = factor; }
 

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -14,8 +14,8 @@ esp32:
 
 wifi:
   networks:
-    - ssid: 'MySSID'
-      password: 'password1'
+    - ssid: "MySSID"
+      password: "password1"
       manual_ip:
         static_ip: 192.168.1.23
         gateway: 192.168.1.1
@@ -39,7 +39,6 @@ uart:
 
 i2c:
 
-
 modbus:
   uart_id: uart1
   flow_control_pin: 5
@@ -50,12 +49,19 @@ modbus_controller:
     address: 0x2
     modbus_id: mod_bus1
 
-
 binary_sensor:
   - platform: gpio
     pin: GPIO0
     id: io0_button
     icon: mdi:gesture-tap-button
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_test
+    id: modbus_binsensortest
+    register_type: read
+    address: 0x3200
+    bitmask: 0x80 #(bit 8)
+    lambda: !lambda "{ return x ;}"
 
 tlc5947:
   data_pin: GPIO12
@@ -74,6 +80,14 @@ output:
 
   - platform: mcp47a1
     id: output_mcp47a1
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_test
+    id: modbus_output_test
+    lambda: |-
+      return x * 1.0 ;
+    address: 0x9001
+    value_type: U_WORD
 
 demo:
 
@@ -104,8 +118,19 @@ number:
     max_value: 100
     min_value: 0
     step: 5
-    unit_of_measurement: '%'
+    unit_of_measurement: "%"
     mode: slider
+
+  - id: modbus_numbertest
+    platform: modbus_controller
+    modbus_controller_id: modbus_controller_test
+    name: "ModbusNumber"
+    address: 0x9002
+    value_type: U_WORD
+    lambda: "return  x * 1.0; "
+    write_lambda: |-
+      return x * 1.0 ;
+    multiply: 1.0
 
 select:
   - platform: template
@@ -170,8 +195,7 @@ sensor:
       name: "SelecEM2M Maximum Demand Apparent Power"
       disabled_by_default: true
 
-  - id: battery_voltage
-    name: "Battery voltage2"
+  - id: modbus_sensortest
     platform: modbus_controller
     modbus_controller_id: modbus_controller_test
     address: 0x331A
@@ -199,6 +223,14 @@ script:
           count: 5
           then:
             - logger.log: "looping!"
+
+switch:
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller_test
+    id: modbus_switch_test
+    register_type: coil
+    address: 2
+    bitmask: 1
 
 ektf2232:
   interrupt_pin: GPIO36


### PR DESCRIPTION
# What does this implement/fix? 

PR #3098 breaks ModbusNumber because it removed the empty `set_update_interval()`  member 

Updated test5.yaml with all Modbus_controller entity types to catch these issues during CI

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
