### PR TITLE
Implement output button

### DIFF
--- a/esphome/components/output/button/__init__.py
+++ b/esphome/components/output/button/__init__.py
@@ -1,0 +1,26 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import button, output
+from esphome.const import CONF_ID, CONF_OUTPUT, CONF_DURATION
+from .. import output_ns
+
+OutputButton = output_ns.class_("OutputButton", button.Button, cg.Component)
+
+CONFIG_SCHEMA = button.BUTTON_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(OutputButton),
+        cv.Required(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
+        cv.Required(CONF_DURATION): cv.positive_time_period_milliseconds,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_duration(config[CONF_DURATION]))
+
+    output_ = await cg.get_variable(config[CONF_OUTPUT])
+    cg.add(var.set_output(output_))
+
+    await cg.register_component(var, config)
+    await button.register_button(var, config)

--- a/esphome/components/output/button/output_button.cpp
+++ b/esphome/components/output/button/output_button.cpp
@@ -1,0 +1,23 @@
+#include "output_button.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace output {
+
+static const char *const TAG = "output.button";
+
+void OutputButton::dump_config() {
+  LOG_BUTTON("", "Output Button", this);
+  ESP_LOGCONFIG(TAG, "  Duration: %.1fs", this->duration_ / 1e3f);
+}
+void OutputButton::press_action() {
+  this->output_->turn_on();
+
+  // Use a named timeout so that it's automatically cancelled if button is pressed again before it's reset
+  this->set_timeout("reset", this->duration_, [this]() {
+    this->output_->turn_off();
+  });
+}
+
+}  // namespace output
+}  // namespace esphome

--- a/esphome/components/output/button/output_button.cpp
+++ b/esphome/components/output/button/output_button.cpp
@@ -14,9 +14,7 @@ void OutputButton::press_action() {
   this->output_->turn_on();
 
   // Use a named timeout so that it's automatically cancelled if button is pressed again before it's reset
-  this->set_timeout("reset", this->duration_, [this]() {
-    this->output_->turn_off();
-  });
+  this->set_timeout("reset", this->duration_, [this]() { this->output_->turn_off(); });
 }
 
 }  // namespace output

--- a/esphome/components/output/button/output_button.h
+++ b/esphome/components/output/button/output_button.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/button/button.h"
+#include "esphome/components/output/binary_output.h"
+
+namespace esphome {
+namespace output {
+
+class OutputButton : public button::Button, public Component {
+ public:
+  void dump_config() override;
+
+  void set_output(BinaryOutput *output) { output_ = output; }
+  void set_duration(uint32_t duration) { duration_ = duration; }
+
+ protected:
+  void press_action() override;
+
+  output::BinaryOutput *output_;
+  uint32_t duration_;
+};
+
+}  // namespace output
+}  // namespace esphome

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1352,6 +1352,10 @@ daly_bms:
   uart_id: uart1
 
 button:
+  - platform: output
+    id: output_button
+    output: out
+    duration: 100ms
   - platform: wake_on_lan
     target_mac_address: 12:34:56:78:90:ab
     name: wol_test_1


### PR DESCRIPTION
# What does this implement/fix? 

Implement a button that momentarily drives an output high.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1846

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
output:
  - platform: template
    id: out
    type: binary
    write_action:
      - lambda: >-
            ESP_LOGI("output", "set: %d", state);

button:
  - platform: output
    name: Generic Output
    output: out
    duration: 100ms
```
(yes, I was too lazy to grab my multimeter and use a GPIO output).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
