### PR TITLE
Fix config merging with null

### DIFF
--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -39,6 +39,8 @@ def merge_config(full_old, full_new):
             if not isinstance(old, list):
                 return new
             return old + new
+        elif new is None:
+            return old
 
         return new
 


### PR DESCRIPTION
# What does this implement/fix? 

The [last change](https://github.com/esphome/esphome/pull/3062/commits/3666c6a8eb343cfa6f0dfdd5a4e618a30deec549) that I made in #3062 didn't work and I didn't test it properly. This PR modifies `esphome.config_helpers.merge_config` such that `merge_config(old, None)` returns `old` instead of `None`. If this isn't desirable then we could instead modify https://github.com/esphome/esphome/blob/dev/esphome/components/substitutions/__init__.py#L112 to only call `merge_config` if `new in item`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
---
substitutions:
  a_component: 'switch'
  a_platform: 'output'
  b_component: 'switch'
  b_platform: 'output'

packages:
  a:
    ${a_component}:
      - platform: '${a_platform}'
        output: 'output1'
        name: 'Output 1'
  b:
    ${b_component}:
      - platform: '${b_platform}'
        output: 'output2'
        name: 'Output 2'

esphome:
  name: 'test'
  platform: 'ESP8266'
  board: 'esp01_1m'

output:
  - platform: 'gpio'
    pin: 'GPIO1'
    id: 'output1'
  - platform: 'gpio'
    pin: 'GPIO2'
    id: 'output2'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
