### PR TITLE
set adc width to 13 bits for esp32-s2

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -17,7 +17,9 @@ namespace adc {
 static const char *const TAG = "adc";
 // 13 bits for S3 / 12 bit for all other esp32 variants
 // create a const to avoid the repated cast to enum
-static const adc_bits_width_t ADC_WIDTH_MAX_SOC_BITS = static_cast<adc_bits_width_t>(ADC_WIDTH_BIT_DEFAULT);
+#ifdef USE_ESP32
+static const adc_bits_width_t ADC_WIDTH_MAX_SOC_BITS = static_cast<adc_bits_width_t>(ADC_WIDTH_MAX - 1);
+#endif
 
 void ADCSensor::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ADC '%s'...", this->get_name().c_str());

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -15,6 +15,9 @@ namespace esphome {
 namespace adc {
 
 static const char *const TAG = "adc";
+// 13 bits for S3 / 12 bit for all other esp32 variants
+// create a const to avoid the repated cast to enum
+static const adc_bits_width_t ADC_WIDTH_MAX_SOC_BITS = static_cast<adc_bits_width_t>(ADC_WIDTH_BIT_DEFAULT);
 
 void ADCSensor::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ADC '%s'...", this->get_name().c_str());
@@ -23,14 +26,14 @@ void ADCSensor::setup() {
 #endif
 
 #ifdef USE_ESP32
-  adc1_config_width(ADC_WIDTH_BIT_12);
+  adc1_config_width(ADC_WIDTH_MAX_SOC_BITS);
   if (!autorange_) {
     adc1_config_channel_atten(channel_, attenuation_);
   }
 
   // load characteristics for each attenuation
   for (int i = 0; i < (int) ADC_ATTEN_MAX; i++) {
-    auto cal_value = esp_adc_cal_characterize(ADC_UNIT_1, (adc_atten_t) i, ADC_WIDTH_BIT_12,
+    auto cal_value = esp_adc_cal_characterize(ADC_UNIT_1, (adc_atten_t) i, ADC_WIDTH_MAX_SOC_BITS,
                                               1100,  // default vref
                                               &cal_characteristics_[i]);
     switch (cal_value) {


### PR DESCRIPTION
# What does this implement/fix? 

Fix adc compilation error for esp32-s2 and adc resolution to 13 bit

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2982

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: esp32s2-01

esp32:
  board: esp32-s2-saola-1
  variant: esp32s2
  framework:
    type: esp-idf

sensor:
  - platform: adc
    pin: GPIO3
    name: "esp32s2 adc"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
