### PR TITLE
Add support for Waveshare 7.5in-bv2

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -44,6 +44,9 @@ WaveshareEPaper7P5In = waveshare_epaper_ns.class_(
 WaveshareEPaper7P5InBC = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InBC", WaveshareEPaper
 )
+WaveshareEPaper7P5InBV2 = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P5InBV2", WaveshareEPaper
+)
 WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2", WaveshareEPaper
 )
@@ -70,6 +73,7 @@ MODELS = {
     "4.20in-bv2": ("b", WaveshareEPaper4P2InBV2),
     "5.83in": ("b", WaveshareEPaper5P8In),
     "7.50in": ("b", WaveshareEPaper7P5In),
+    "7.50in-bv2": ("b", WaveshareEPaper7P5InBV2),
     "7.50in-bc": ("b", WaveshareEPaper7P5InBC),
     "7.50inv2": ("b", WaveshareEPaper7P5InV2),
     "2.13in-ttgo-dke": ("c", WaveshareEPaper2P13InDKE),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -937,6 +937,74 @@ void WaveshareEPaper5P8In::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
+void WaveshareEPaper7P5InBV2::initialize() {
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x07);
+  this->data(0x07); // VGH=20V,VGL=-20V
+  this->data(0x3f); // VDH=15V
+  this->data(0x3f); // VDL=-15V
+  // COMMAND POWER ON
+  this->command(0x04);
+  delay(100);
+  this->wait_until_idle_();
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0F); // KW3f, KWR-2F, BWROTP 0f, BWOTP 1f
+  this->command(0x61); // tres
+  this->data(0x03); // 800px
+  this->data(0x20);
+  this->data(0x01); // 400px
+  this->data(0xE0);
+  this->command(0x15);
+  this->data(0x00);
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x11);
+  this->data(0x07);
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+  // COMMAND RESOLUTION SETTING
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00); // 800*480
+  this->data(0x00);
+  this->data(0x00);
+}
+void HOT WaveshareEPaper7P5InBV2::display() {
+  // COMMAND DATA START TRANSMISSION 1 (B/W data)
+  this->command(0x10);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2 (RED data)
+  this->command(0x13);
+  delay(2);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0x00);
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+}
+int WaveshareEPaper7P5InBV2::get_width_internal() { return 800; }
+int WaveshareEPaper7P5InBV2::get_height_internal() { return 480; }
+void WaveshareEPaper7P5InBV2::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-bv2");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
 void WaveshareEPaper7P5In::initialize() {
   // COMMAND POWER SETTING
   this->command(0x01);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -941,20 +941,20 @@ void WaveshareEPaper7P5InBV2::initialize() {
   // COMMAND POWER SETTING
   this->command(0x01);
   this->data(0x07);
-  this->data(0x07); // VGH=20V,VGL=-20V
-  this->data(0x3f); // VDH=15V
-  this->data(0x3f); // VDL=-15V
+  this->data(0x07);  // VGH=20V,VGL=-20V
+  this->data(0x3f);  // VDH=15V
+  this->data(0x3f);  // VDL=-15V
   // COMMAND POWER ON
   this->command(0x04);
-  delay(100);
+  delay(100); // NOLINT
   this->wait_until_idle_();
   // COMMAND PANEL SETTING
   this->command(0x00);
-  this->data(0x0F); // KW3f, KWR-2F, BWROTP 0f, BWOTP 1f
-  this->command(0x61); // tres
-  this->data(0x03); // 800px
+  this->data(0x0F);     // KW3f, KWR-2F, BWROTP 0f, BWOTP 1f
+  this->command(0x61);  // tres
+  this->data(0x03);     // 800px
   this->data(0x20);
-  this->data(0x01); // 400px
+  this->data(0x01);  // 400px
   this->data(0xE0);
   this->command(0x15);
   this->data(0x00);
@@ -968,7 +968,7 @@ void WaveshareEPaper7P5InBV2::initialize() {
   // COMMAND RESOLUTION SETTING
   this->command(0x65);
   this->data(0x00);
-  this->data(0x00); // 800*480
+  this->data(0x00);  // 800*480
   this->data(0x00);
   this->data(0x00);
 }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -946,7 +946,7 @@ void WaveshareEPaper7P5InBV2::initialize() {
   this->data(0x3f);  // VDL=-15V
   // COMMAND POWER ON
   this->command(0x04);
-  delay(100); // NOLINT
+  delay(100);  // NOLINT
   this->wait_until_idle_();
   // COMMAND PANEL SETTING
   this->command(0x00);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -121,6 +121,7 @@ enum WaveshareEPaperTypeBModel {
   WAVESHARE_EPAPER_4_2_IN_B_V2,
   WAVESHARE_EPAPER_7_5_IN,
   WAVESHARE_EPAPER_7_5_INV2,
+  WAVESHARE_EPAPER_7_5_IN_B_V2,
 };
 
 class WaveshareEPaper2P7In : public WaveshareEPaper {
@@ -272,6 +273,29 @@ class WaveshareEPaper7P5In : public WaveshareEPaper {
     // COMMAND DEEP SLEEP
     this->command(0x07);
     this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class WaveshareEPaper7P5InBV2 : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07); // deep sleep
+    this->data(0xA5);    // check byte
   }
 
  protected:

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -294,8 +294,8 @@ class WaveshareEPaper7P5InBV2 : public WaveshareEPaper {
     this->command(0x02);
     this->wait_until_idle_();
     // COMMAND DEEP SLEEP
-    this->command(0x07); // deep sleep
-    this->data(0xA5);    // check byte
+    this->command(0x07);  // deep sleep
+    this->data(0xA5);     // check byte
   }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix? 

Adds support for Waveshare 7.5in-bv2 (and v3) displays. These differ from the 7.5in and 7.5in-b displays. Only black and white are supported right now, but setup is there to add red color support.

Product: https://www.waveshare.com/7.5inch-e-paper-b.htm

Datasheet: https://www.waveshare.com/wiki/File:7.5inch_e-paper-b-Specification.pdf
v2 spec: https://www.waveshare.com/w/upload/4/44/7.5inch_e-Paper_B_V2_Specification.pdf
v3 spec: https://www.waveshare.com/w/upload/8/8c/7.5inch-e-paper-b-v3-specification.pdf

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1859

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: epaper
  platform: ESP32
  board: nodemcu-32s

font:
  - file: "segoeui.ttf"
    id: segoe
    size: 64

spi:
  clk_pin: 13
  mosi_pin: 14

display:
  - platform: waveshare_epaper
    id: disp
    cs_pin: 15
    dc_pin: 27
    busy_pin: 25
    reset_pin: 26
    model: 7.50in-BV2
    update_interval: 30s
    reset_duration: 2ms
    lambda: |-
      it.fill(COLOR_OFF);
      it.print(0,0,id(segoe), "Hello, World!");

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
