### PR TITLE
Dont warn on nonnull comparisons

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -166,6 +166,7 @@ async def to_code(config):
     cg.add_platformio_option("framework", "arduino")
     cg.add_build_flag("-DUSE_ARDUINO")
     cg.add_build_flag("-DUSE_ESP8266_FRAMEWORK_ARDUINO")
+    cg.add_build_flag("-Wno-nonnull-compare")
     cg.add_platformio_option("platform", conf[CONF_PLATFORM_VERSION])
     cg.add_platformio_option(
         "platform_packages",

--- a/platformio.ini
+++ b/platformio.ini
@@ -87,6 +87,7 @@ lib_deps =
     ottowinter/ESPAsyncTCP-esphome@1.2.3  ; async_tcp
 build_flags =
     ${common:arduino.build_flags}
+    -Wno-nonnull-compare
     -DUSE_ESP8266
     -DUSE_ESP8266_FRAMEWORK_ARDUINO
 extra_scripts = post:esphome/components/esp8266/post_build.py.script


### PR DESCRIPTION
# What does this implement/fix? 

```
In file included from src/esphome/components/status/status_binary_sensor.h:4,
                 from src/esphome/components/status/status_binary_sensor.cpp:1:
src/esphome/components/status/status_binary_sensor.cpp: In member function 'virtual void esphome::status::StatusBinarySensor::dump_config()':
src/esphome/components/binary_sensor/binary_sensor.h:13:3: warning: 'nonnull' argument 'this' compared to NULL [-Wnonnull-compare]
   13 |   if ((obj) != nullptr) { \
      |   ^~
src/esphome/components/status/status_binary_sensor.cpp:34:42: note: in expansion of macro 'LOG_BINARY_SENSOR'
   34 | void StatusBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Status Binary Sensor", this); }
      |                                          ^~~~~~~~~~~~~~~~~
Compiling .pioenvs/alarm_panel/src/esphome/core/application.cpp.o
Compiling .pioenvs/alarm_panel/src/esphome/core/color.cpp.o
Compiling .pioenvs/alarm_panel/src/esphome/core/component.cpp.o
In file included from src/esphome/components/uptime/uptime_sensor.h:4,
                 from src/esphome/components/uptime/uptime_sensor.cpp:1:
src/esphome/components/uptime/uptime_sensor.cpp: In member function 'virtual void esphome::uptime::UptimeSensor::dump_config()':
src/esphome/components/sensor/sensor.h:13:3: warning: 'nonnull' argument 'this' compared to NULL [-Wnonnull-compare]
   13 |   if ((obj) != nullptr) { \
      |   ^~
src/esphome/components/uptime/uptime_sensor.cpp:31:36: note: in expansion of macro 'LOG_SENSOR'
   31 | void UptimeSensor::dump_config() { LOG_SENSOR("", "Uptime Sensor", this); }
      |                                    ^~~~~~~~~~
Compiling .pioenvs/alarm_panel/src/esphome/core/controller.cpp.o
Compiling .pioenvs/alarm_panel/src/esphome/core/entity_base.cpp.o
Compiling .pioenvs/alarm_panel/src/esphome/core/helpers.cpp.o
Compiling .pioenvs/alarm_panel/src/esphome/core/log.cpp.o
Compiling .pioenvs/alarm_panel/src/esphome/core/scheduler.cpp.o
Compiling .pioenvs/alarm_panel/src/esphome/core/util.cpp.o
In file included from src/esphome/components/wifi_signal/wifi_signal_sensor.h:5,
                 from src/esphome/components/wifi_signal/wifi_signal_sensor.cpp:1:
src/esphome/components/wifi_signal/wifi_signal_sensor.cpp: In member function 'virtual void esphome::wifi_signal::WiFiSignalSensor::dump_config()':
src/esphome/components/sensor/sensor.h:13:3: warning: 'nonnull' argument 'this' compared to NULL [-Wnonnull-compare]
   13 |   if ((obj) != nullptr) { \
      |   ^~
src/esphome/components/wifi_signal/wifi_signal_sensor.cpp:9:40: note: in expansion of macro 'LOG_SENSOR'
    9 | void WiFiSignalSensor::dump_config() { LOG_SENSOR("", "WiFi Signal", this); }
      |                                        ^~~~~~~~~~
Compiling .pioenvs/alarm_panel/src/main.cpp.o
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
