### PR TITLE
Fix backwards string case helpers

### DIFF
--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -235,7 +235,7 @@ float DallasTemperatureSensor::get_temp_c() {
 
   return temp / 128.0f;
 }
-std::string DallasTemperatureSensor::unique_id() { return "dallas-" + str_upper_case(format_hex(this->address_)); }
+std::string DallasTemperatureSensor::unique_id() { return "dallas-" + str_lower_case(format_hex(this->address_)); }
 
 }  // namespace dallas
 }  // namespace esphome

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -116,8 +116,8 @@ template<int (*fn)(int)> std::string str_ctype_transform(const std::string &str)
   std::transform(str.begin(), str.end(), result.begin(), [](unsigned char ch) { return fn(ch); });
   return result;
 }
-std::string str_lower_case(const std::string &str) { return str_ctype_transform<std::toupper>(str); }
-std::string str_upper_case(const std::string &str) { return str_ctype_transform<std::tolower>(str); }
+std::string str_lower_case(const std::string &str) { return str_ctype_transform<std::tolower>(str); }
+std::string str_upper_case(const std::string &str) { return str_ctype_transform<std::toupper>(str); }
 std::string str_snake_case(const std::string &str) {
   std::string result;
   result.resize(str.length());


### PR DESCRIPTION
# What does this implement/fix? 

Fix backwards string case helpers

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
