### PR TITLE
Make generating combined binary output verbose

### DIFF
--- a/esphome/components/esp32/post_build.py.script
+++ b/esphome/components/esp32/post_build.py.script
@@ -1,13 +1,16 @@
 # Source https://github.com/letscontrolit/ESPEasy/pull/3845#issuecomment-1005864664
 
 import esptool
+from SCons.Script import ARGUMENTS
 
 # pylint: disable=E0602
 Import("env")  # noqa
 
 
 def esp32_create_combined_bin(source, target, env):
-    print("Generating combined binary for serial flashing")
+    verbose = bool(int(ARGUMENTS.get("PIOVERBOSE", "0")))
+    if verbose:
+        print("Generating combined binary for serial flashing")
     app_offset = 0x10000
 
     new_file_name = env.subst("$BUILD_DIR/${PROGNAME}-factory.bin")
@@ -24,18 +27,21 @@ def esp32_create_combined_bin(source, target, env):
         "--flash_size",
         flash_size,
     ]
-    print("    Offset | File")
+    if verbose:
+        print("    Offset | File")
     for section in sections:
         sect_adr, sect_file = section.split(" ", 1)
-        print(f" -  {sect_adr} | {sect_file}")
+        if verbose:
+            print(f" -  {sect_adr} | {sect_file}")
         cmd += [sect_adr, sect_file]
 
-    print(f" - {hex(app_offset)} | {firmware_name}")
     cmd += [hex(app_offset), firmware_name]
 
-    print()
-    print(f"Using esptool.py arguments: {' '.join(cmd)}")
-    print()
+    if verbose:
+        print(f" - {hex(app_offset)} | {firmware_name}")
+        print()
+        print(f"Using esptool.py arguments: {' '.join(cmd)}")
+        print()
     esptool.main(cmd)
 
 


### PR DESCRIPTION
# What does this implement/fix? 

The output of that script is quite noisy, and doesn't concern our target user. So only make it display when `-v` is given to the esphome options

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
