### PR TITLE
Disable platformio ldf for build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -44,12 +44,15 @@ src_filter =
     +<./>
     +<../tests/dummy_main.cpp>
     +<../.temp/all-include.cpp>
+lib_ldf_mode = off
 
 ; This are common settings for all Arduino-framework based environments.
 [common:arduino]
 extends = common
 lib_deps =
     ${common.lib_deps}
+    SPI                                                   ; spi (Arduino built-in)
+    Wire                                                  ; i2c (Arduino built-int)
     ottowinter/AsyncMqttClient-esphome@0.8.6              ; mqtt
     esphome/ESPAsyncWebServer-esphome@2.1.0               ; web_server_base
     fastled/FastLED@3.3.2                                 ; fastled_base
@@ -85,6 +88,9 @@ lib_deps =
     ESP8266WiFi                           ; wifi (Arduino built-in)
     Update                                ; ota (Arduino built-in)
     ottowinter/ESPAsyncTCP-esphome@1.2.3  ; async_tcp
+    ESP8266HTTPClient                     ; http_request (Arduino built-in)
+    ESP8266mDNS                           ; mdns (Arduino built-in)
+    DNSServer                             ; captive_portal (Arduino built-in)
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP8266
@@ -101,8 +107,17 @@ platform_packages =
 framework = arduino
 board = nodemcu-32s
 lib_deps =
+    ; order matters with lib-deps; some of the libs in common:arduino.lib_deps
+    ; don't declare built-in libraries as dependencies, so they have to be declared first
+    FS                              ; web_server_base (Arduino built-in)
+    WiFi                            ; wifi,web_server_base,ethernet (Arduino built-in)
+    Update                          ; ota,web_server_base (Arduino built-in)
     ${common:arduino.lib_deps}
     esphome/AsyncTCP-esphome@1.2.2  ; async_tcp
+    WiFiClientSecure                ; http_request,nextion (Arduino built-in)
+    HTTPClient                      ; http_request,nextion (Arduino built-in)
+    ESPmDNS                         ; mdns (Arduino built-in)
+    DNSServer                       ; captive_portal (Arduino built-in)
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP32


### PR DESCRIPTION
# What does this implement/fix? 

The library dependency finder (ldf) in platformio automatically looks for dependencies in the header files, and adds them to the lib_deps. This is a) slow and b) can result in libraries being included even if we didn't mean to.

For generated platformio setups this is already disabled:
- https://github.com/esphome/esphome/blob/511c8de6f39e0afcda27682da89aa94d49339665/esphome/components/esp8266/__init__.py#L156
- https://github.com/esphome/esphome/blob/cdda648360d2e7a86c3d7677155c3f2707596740/esphome/components/esp32/__init__.py#L294

Disable it in the "fake" build platformio.ini used for clang-tidy/intellisense as well. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
