### PR TITLE
add sim800l diagnostics

### DIFF
--- a/esphome/components/sim800l/__init__.py
+++ b/esphome/components/sim800l/__init__.py
@@ -2,17 +2,10 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.const import (
-    CONF_DEVICE_CLASS,
-    CONF_ENTITY_CATEGORY,
     CONF_ID,
     CONF_TRIGGER_ID,
-    DEVICE_CLASS_CONNECTIVITY,
-    DEVICE_CLASS_SIGNAL_STRENGTH,
-    ENTITY_CATEGORY_DIAGNOSTIC,
-    STATE_CLASS_MEASUREMENT,
-    UNIT_DECIBEL_MILLIWATT,
 )
-from esphome.components import binary_sensor, sensor, uart
+from esphome.components import uart
 
 DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@glmnet"]
@@ -30,33 +23,15 @@ Sim800LReceivedMessageTrigger = sim800l_ns.class_(
 Sim800LSendSmsAction = sim800l_ns.class_("Sim800LSendSmsAction", automation.Action)
 Sim800LDialAction = sim800l_ns.class_("Sim800LDialAction", automation.Action)
 
+CONF_SIM800L_ID = "sim800l_id"
 CONF_ON_SMS_RECEIVED = "on_sms_received"
 CONF_RECIPIENT = "recipient"
-CONF_REGISTERED = "registered"
-CONF_RSSI = "rssi"
 CONF_MESSAGE = "message"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Sim800LComponent),
-            cv.Optional(CONF_REGISTERED): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
-                {
-                    cv.Optional(
-                        CONF_DEVICE_CLASS, default=DEVICE_CLASS_CONNECTIVITY
-                    ): binary_sensor.device_class,
-                    cv.Optional(
-                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
-                    ): cv.entity_category,
-                }
-            ),
-            cv.Optional(CONF_RSSI): sensor.sensor_schema(
-                unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
-                accuracy_decimals=0,
-                device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
-                state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            ),
             cv.Optional(CONF_ON_SMS_RECEIVED): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -78,16 +53,6 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-
-    if CONF_REGISTERED in config:
-        conf = config[CONF_REGISTERED]
-        sens = await binary_sensor.new_binary_sensor(conf)
-        cg.add(var.set_registered(sens))
-
-    if CONF_RSSI in config:
-        conf = config[CONF_RSSI]
-        sens = await sensor.new_sensor(conf)
-        cg.add(var.set_rssi_sensor(sens))
 
     for conf in config.get(CONF_ON_SMS_RECEIVED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/components/sim800l/binary_sensor.py
+++ b/esphome/components/sim800l/binary_sensor.py
@@ -1,0 +1,36 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import (
+    CONF_DEVICE_CLASS,
+    CONF_ENTITY_CATEGORY,
+    DEVICE_CLASS_CONNECTIVITY,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+from . import CONF_SIM800L_ID, Sim800LComponent
+
+DEPENDENCIES = ["sim800l"]
+
+CONF_REGISTERED = "registered"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_SIM800L_ID): cv.use_id(Sim800LComponent),
+    cv.Optional(CONF_REGISTERED): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+        {
+            cv.Optional(
+                CONF_DEVICE_CLASS, default=DEVICE_CLASS_CONNECTIVITY
+            ): binary_sensor.device_class,
+            cv.Optional(
+                CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
+            ): cv.entity_category,
+        }
+    ),
+}
+
+
+async def to_code(config):
+    sim800l_component = await cg.get_variable(config[CONF_SIM800L_ID])
+
+    if CONF_REGISTERED in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_REGISTERED])
+        cg.add(sim800l_component.set_registered_binary_sensor(sens))

--- a/esphome/components/sim800l/sensor.py
+++ b/esphome/components/sim800l/sensor.py
@@ -1,0 +1,33 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    DEVICE_CLASS_SIGNAL_STRENGTH,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_DECIBEL_MILLIWATT,
+)
+from . import CONF_SIM800L_ID, Sim800LComponent
+
+DEPENDENCIES = ["sim800l"]
+
+CONF_RSSI = "rssi"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_SIM800L_ID): cv.use_id(Sim800LComponent),
+    cv.Optional(CONF_RSSI): sensor.sensor_schema(
+        unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+
+async def to_code(config):
+    sim800l_component = await cg.get_variable(config[CONF_SIM800L_ID])
+
+    if CONF_RSSI in config:
+        sens = await sensor.new_sensor(config[CONF_RSSI])
+        cg.add(sim800l_component.set_rssi_sensor(sens))

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -130,11 +130,15 @@ void Sim800LComponent::parse_cmd_(std::string message) {
         if (comma != 6) {
           int rssi = parse_number<int>(message.substr(6, comma - 6)).value_or(0);
 
+#ifdef USE_SENSOR
           if (this->rssi_sensor_ != nullptr) {
             this->rssi_sensor_->publish_state(rssi);
           } else {
             ESP_LOGD(TAG, "RSSI: %d", rssi);
           }
+#else
+          ESP_LOGD(TAG, "RSSI: %d", rssi);
+#endif
         }
       }
       this->expect_ack_ = true;
@@ -282,8 +286,12 @@ void Sim800LComponent::send_sms(const std::string &recipient, const std::string 
 }
 void Sim800LComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SIM800L:");
+#ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "Registered", this->registered_binary_sensor_);
+#endif
+#ifdef USE_SENSOR
   LOG_SENSOR("  ", "Rssi", this->rssi_sensor_);
+#endif
 }
 void Sim800LComponent::dial(const std::string &recipient) {
   ESP_LOGD(TAG, "Dialing %s", recipient.c_str());
@@ -294,8 +302,10 @@ void Sim800LComponent::dial(const std::string &recipient) {
 
 void Sim800LComponent::set_registered_(bool registered) {
   this->registered_ = registered;
+#ifdef USE_BINARY_SENSOR
   if (this->registered_binary_sensor_ != nullptr)
     this->registered_binary_sensor_->publish_state(registered);
+#endif
 }
 
 }  // namespace sim800l

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -128,12 +128,13 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       if (message.compare(0, 5, "+CSQ:") == 0) {
         size_t comma = message.find(',', 6);
         if (comma != 6) {
-          int rssi_ = parse_number<int>(message.substr(6, comma - 6)).value_or(0);
+          int rssi = parse_number<int>(message.substr(6, comma - 6)).value_or(0);
 
-          if (this->rssi_sensor_ != nullptr)
-            this->rssi_sensor_->publish_state(rssi_);
-          else
-            ESP_LOGD(TAG, "RSSI: %d", rssi_);
+          if (this->rssi_sensor_ != nullptr) {
+            this->rssi_sensor_->publish_state(rssi);
+          } else {
+            ESP_LOGD(TAG, "RSSI: %d", rssi);
+          }
         }
       }
       this->expect_ack_ = true;

--- a/esphome/components/sim800l/sim800l.h
+++ b/esphome/components/sim800l/sim800l.h
@@ -2,9 +2,14 @@
 
 #include <utility>
 
+#include "esphome/core/defines.h"
 #include "esphome/core/component.h"
+#ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
+#endif
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/automation.h"
 
@@ -44,10 +49,14 @@ class Sim800LComponent : public uart::UARTDevice, public PollingComponent {
   void update() override;
   void loop() override;
   void dump_config() override;
-  void set_registered(binary_sensor::BinarySensor *registered_binary_sensor) {
+#ifdef USE_BINARY_SENSOR
+  void set_registered_binary_sensor(binary_sensor::BinarySensor *registered_binary_sensor) {
     registered_binary_sensor_ = registered_binary_sensor;
   }
+#endif
+#ifdef USE_SENSOR
   void set_rssi_sensor(sensor::Sensor *rssi_sensor) { rssi_sensor_ = rssi_sensor; }
+#endif
   void add_on_sms_received_callback(std::function<void(std::string, std::string)> callback) {
     this->callback_.add(std::move(callback));
   }
@@ -59,8 +68,13 @@ class Sim800LComponent : public uart::UARTDevice, public PollingComponent {
   void parse_cmd_(std::string message);
   void set_registered_(bool registered);
 
+#ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *registered_binary_sensor_{nullptr};
+#endif
+
+#ifdef USE_SENSOR
   sensor::Sensor *rssi_sensor_{nullptr};
+#endif
   std::string sender_;
   char read_buffer_[SIM800L_READ_BUFFER_LENGTH];
   size_t read_pos_{0};

--- a/esphome/components/sim800l/sim800l.h
+++ b/esphome/components/sim800l/sim800l.h
@@ -3,6 +3,8 @@
 #include <utility>
 
 #include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/automation.h"
 
@@ -42,6 +44,10 @@ class Sim800LComponent : public uart::UARTDevice, public PollingComponent {
   void update() override;
   void loop() override;
   void dump_config() override;
+  void set_registered(binary_sensor::BinarySensor *registered_binary_sensor) {
+    registered_binary_sensor_ = registered_binary_sensor;
+  }
+  void set_rssi_sensor(sensor::Sensor *rssi_sensor) { rssi_sensor_ = rssi_sensor; }
   void add_on_sms_received_callback(std::function<void(std::string, std::string)> callback) {
     this->callback_.add(std::move(callback));
   }
@@ -51,7 +57,10 @@ class Sim800LComponent : public uart::UARTDevice, public PollingComponent {
  protected:
   void send_cmd_(const std::string &message);
   void parse_cmd_(std::string message);
+  void set_registered_(bool registered);
 
+  binary_sensor::BinarySensor *registered_binary_sensor_{nullptr};
+  sensor::Sensor *rssi_sensor_{nullptr};
   std::string sender_;
   char read_buffer_[SIM800L_READ_BUFFER_LENGTH];
   size_t read_pos_{0};
@@ -60,7 +69,6 @@ class Sim800LComponent : public uart::UARTDevice, public PollingComponent {
   bool expect_ack_{false};
   sim800l::State state_{STATE_IDLE};
   bool registered_{false};
-  int rssi_{0};
 
   std::string recipient_;
   std::string outgoing_message_;


### PR DESCRIPTION
# What does this implement/fix? 

Simply adds diagnostics `registered` and `rssi` to `sim800l` integration.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1617

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1864

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
