### PR TITLE
logger: add option to include relative timestamp

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -28,6 +28,7 @@ from esphome.util import (
     safe_print,
     list_yaml_files,
     get_serial_ports,
+    format_time,
 )
 from esphome.log import color, setup_log, Fore
 
@@ -127,7 +128,7 @@ def run_miniterm(config, port):
                 .replace(b"\n", b"")
                 .decode("utf8", "backslashreplace")
             )
-            time = datetime.now().time().strftime("[%H:%M:%S]")
+            time = format_time(datetime.now().time())
             message = time + line
             safe_print(message)
 

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -7,7 +7,7 @@ from aioesphomeapi import APIClient, ReconnectLogic, APIConnectionError, LogLeve
 import zeroconf
 
 from esphome.const import CONF_KEY, CONF_PORT, CONF_PASSWORD, __version__
-from esphome.util import safe_print
+from esphome.util import safe_print, format_time
 from . import CONF_ENCRYPTION
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ async def async_run_logs(config, address):
     first_connect = True
 
     def on_log(msg):
-        time_ = datetime.now().time().strftime("[%H:%M:%S]")
+        time_ = format_time(datetime.now().time())
         text = msg.message.decode("utf8", "backslashreplace")
         safe_print(time_ + text)
 

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -23,7 +23,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, EsphomeError
 from esphome.log import color, Fore
-from esphome.util import safe_print
+from esphome.util import safe_print, format_time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None):
     _LOGGER.info("Starting log output from %s", topic)
 
     def on_message(client, userdata, msg):
-        time_ = datetime.now().time().strftime("[%H:%M:%S]")
+        time_ = format_time(datetime.now().time())
         payload = msg.payload.decode(errors="backslashreplace")
         message = time_ + payload
         safe_print(message)

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from datetime import time
+
 from esphome import const
 
 _LOGGER = logging.getLogger(__name__)
@@ -306,3 +308,9 @@ def get_serial_ports() -> List[SerialPort]:
 
     result.sort(key=lambda x: x.path)
     return result
+
+
+def format_time(timestamp: time):
+    return timestamp.strftime("[%H:%M:%S.{ms:03d}]").format(
+        ms=timestamp.microsecond // 1000
+    )


### PR DESCRIPTION
# What does this implement/fix? 

Add an option to logger component to include a timestamp into every log message.
The timestamp is number of milliseconds since start of ESP execution, and overflows approximately every 49 days and 17 hours. Useful when debugging performance issues, or optimizing battery-powered setups utilizing deep sleep.

Example in which I debug latencies in my battery powered ESP eInk display that received data over BLE (excerpt with parts omitted for brevity):
```
[22:19:36.231][I][app:029]: Running through setup()...
[22:19:36.232][D][main:010]: (T871) Woke up
[22:19:36.874][D][esp32_ble_tracker:214]: Starting scan...
...
[22:19:37.259][D][myhomeiot_ble_client:069]: [3C:61:05:10:D7:6E] Found device
...
[22:19:37.303][I][myhomeiot_ble_client:032]: [3C:61:05:10:D7:6E] Connecting
...
[22:19:37.428][I][myhomeiot_ble_client:087]: [3C:61:05:10:D7:6E] Connected successfully, app_id (1)
...
[22:19:38.487][D][main:059]: Sensor data received, JSON parsing result: Ok
...
[22:19:38.625][D][main:094]: Starting eInk update
...
[22:19:44.090][D][main:096]: Screen update complete
...
[22:19:44.102][I][deep_sleep:103]: Beginning Deep Sleep
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
