### PR TITLE
CHG: [MQTT] Allow asynchronous payloads

### DIFF
--- a/esphome/components/mqtt/custom_mqtt_device.h
+++ b/esphome/components/mqtt/custom_mqtt_device.h
@@ -61,9 +61,9 @@ class CustomMQTTDevice {
   template<typename T> void subscribe(const std::string &topic, void (T::*callback)(), uint8_t qos = 0);
 
   template<typename T>
-  void subscribe_raw(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total),
-                 uint8_t qos = 0);
-
+  void subscribe_raw(const std::string &topic,
+                     void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total),
+                     uint8_t qos = 0);
 
   /** Subscribe to an MQTT topic and call the callback if the payload can be decoded
    * as JSON with the given Quality of Service.
@@ -100,8 +100,7 @@ class CustomMQTTDevice {
   template<typename T>
   void subscribe_json(const std::string &topic, void (T::*callback)(const std::string &, JsonObject), uint8_t qos = 0);
 
-  template<typename T>
-  void subscribe_json(const std::string &topic, void (T::*callback)(JsonObject), uint8_t qos = 0);
+  template<typename T> void subscribe_json(const std::string &topic, void (T::*callback)(JsonObject), uint8_t qos = 0);
 
   /** Publish an MQTT message with the given payload and QoS and retain settings.
    *
@@ -209,8 +208,12 @@ template<typename T> void CustomMQTTDevice::subscribe(const std::string &topic, 
   global_mqtt_client->subscribe(topic, f, qos);
 }
 template<typename T>
-void CustomMQTTDevice::subscribe_raw(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total), uint8_t qos) {
-  auto f = std::bind(callback, (T *) this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5);
+void CustomMQTTDevice::subscribe_raw(const std::string &topic,
+                                     void (T::*callback)(const std::string &, char *payload, size_t len, size_t index,
+                                                         size_t total),
+                                     uint8_t qos) {
+  auto f = std::bind(callback, (T *) this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+                     std::placeholders::_4, std::placeholders::_5);
   global_mqtt_client->subscribe_raw(topic, f, qos);
 }
 template<typename T>

--- a/esphome/components/mqtt/custom_mqtt_device.h
+++ b/esphome/components/mqtt/custom_mqtt_device.h
@@ -52,6 +52,10 @@ class CustomMQTTDevice {
    * @param qos The Quality of Service to subscribe with. Defaults to 0.
    */
   template<typename T>
+  void subscribe(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total),
+                 uint8_t qos = 0);
+
+  template<typename T>
   void subscribe(const std::string &topic, void (T::*callback)(const std::string &, const std::string &),
                  uint8_t qos = 0);
 
@@ -95,7 +99,8 @@ class CustomMQTTDevice {
   template<typename T>
   void subscribe_json(const std::string &topic, void (T::*callback)(const std::string &, JsonObject), uint8_t qos = 0);
 
-  template<typename T> void subscribe_json(const std::string &topic, void (T::*callback)(JsonObject), uint8_t qos = 0);
+  template<typename T>
+  void subscribe_json(const std::string &topic, void (T::*callback)(JsonObject), uint8_t qos = 0);
 
   /** Publish an MQTT message with the given payload and QoS and retain settings.
    *
@@ -187,6 +192,11 @@ class CustomMQTTDevice {
   bool is_connected();
 };
 
+template<typename T>
+void CustomMQTTDevice::subscribe(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total), uint8_t qos) {
+  auto f = std::bind(callback, (T *) this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5);
+  global_mqtt_client->subscribe(topic, f, qos);
+}
 template<typename T>
 void CustomMQTTDevice::subscribe(const std::string &topic,
                                  void (T::*callback)(const std::string &, const std::string &), uint8_t qos) {

--- a/esphome/components/mqtt/custom_mqtt_device.h
+++ b/esphome/components/mqtt/custom_mqtt_device.h
@@ -52,10 +52,6 @@ class CustomMQTTDevice {
    * @param qos The Quality of Service to subscribe with. Defaults to 0.
    */
   template<typename T>
-  void subscribe(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total),
-                 uint8_t qos = 0);
-
-  template<typename T>
   void subscribe(const std::string &topic, void (T::*callback)(const std::string &, const std::string &),
                  uint8_t qos = 0);
 
@@ -63,6 +59,11 @@ class CustomMQTTDevice {
   void subscribe(const std::string &topic, void (T::*callback)(const std::string &), uint8_t qos = 0);
 
   template<typename T> void subscribe(const std::string &topic, void (T::*callback)(), uint8_t qos = 0);
+
+  template<typename T>
+  void subscribe_raw(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total),
+                 uint8_t qos = 0);
+
 
   /** Subscribe to an MQTT topic and call the callback if the payload can be decoded
    * as JSON with the given Quality of Service.
@@ -193,11 +194,6 @@ class CustomMQTTDevice {
 };
 
 template<typename T>
-void CustomMQTTDevice::subscribe(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total), uint8_t qos) {
-  auto f = std::bind(callback, (T *) this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5);
-  global_mqtt_client->subscribe(topic, f, qos);
-}
-template<typename T>
 void CustomMQTTDevice::subscribe(const std::string &topic,
                                  void (T::*callback)(const std::string &, const std::string &), uint8_t qos) {
   auto f = std::bind(callback, (T *) this, std::placeholders::_1, std::placeholders::_2);
@@ -211,6 +207,11 @@ void CustomMQTTDevice::subscribe(const std::string &topic, void (T::*callback)(c
 template<typename T> void CustomMQTTDevice::subscribe(const std::string &topic, void (T::*callback)(), uint8_t qos) {
   auto f = std::bind(callback, (T *) this);
   global_mqtt_client->subscribe(topic, f, qos);
+}
+template<typename T>
+void CustomMQTTDevice::subscribe_raw(const std::string &topic, void (T::*callback)(const std::string &, char *payload, size_t len, size_t index, size_t total), uint8_t qos) {
+  auto f = std::bind(callback, (T *) this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5);
+  global_mqtt_client->subscribe_raw(topic, f, qos);
 }
 template<typename T>
 void CustomMQTTDevice::subscribe_json(const std::string &topic, void (T::*callback)(const std::string &, JsonObject),

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -322,7 +322,7 @@ void MQTTClientComponent::resubscribe_subscriptions_() {
   }
 }
 
-void MQTTClientComponent::subscribe(const std::string &topic, const mqtt_callback_t callback, uint8_t qos) {
+void MQTTClientComponent::subscribe(const std::string &topic, const mqtt_callback_t& callback, uint8_t qos) {
   auto f = [callback, this](const std::string &topic, char *payload, size_t len, size_t index, size_t total) {
     if (index == 0)
       this->payload_buffer_.reserve(total);

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -324,18 +324,6 @@ void MQTTClientComponent::resubscribe_subscriptions_() {
 }
 
 void MQTTClientComponent::subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos) {
-  MQTTSubscription subscription{
-      .topic = topic,
-      .qos = qos,
-      .callback = std::move(callback),
-      .subscribed = false,
-      .resubscribe_timeout = 0,
-  };
-  this->resubscribe_subscription_(&subscription);
-  this->subscriptions_.push_back(subscription);
-}
-
-void MQTTClientComponent::subscribe(const std::string &topic, mqtt_string_callback_t callback, uint8_t qos) {
   auto f = [callback, this](const std::string &topic, char *payload, size_t len, size_t index, size_t total) {
     if (index == 0)
       this->payload_buffer_.reserve(total);
@@ -353,6 +341,18 @@ void MQTTClientComponent::subscribe(const std::string &topic, mqtt_string_callba
       .topic = topic,
       .qos = qos,
       .callback = f,
+      .subscribed = false,
+      .resubscribe_timeout = 0,
+  };
+  this->resubscribe_subscription_(&subscription);
+  this->subscriptions_.push_back(subscription);
+}
+
+void MQTTClientComponent::subscribe_raw(const std::string &topic, mqtt_raw_callback_t callback, uint8_t qos) {
+  MQTTSubscription subscription{
+      .topic = topic,
+      .qos = qos,
+      .callback = std::move(callback),
       .subscribed = false,
       .resubscribe_timeout = 0,
   };

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -322,7 +322,7 @@ void MQTTClientComponent::resubscribe_subscriptions_() {
   }
 }
 
-void MQTTClientComponent::subscribe(const std::string &topic, const mqtt_callback_t& callback, uint8_t qos) {
+void MQTTClientComponent::subscribe(const std::string &topic, const mqtt_callback_t &callback, uint8_t qos) {
   auto f = [callback, this](const std::string &topic, char *payload, size_t len, size_t index, size_t total) {
     if (index == 0)
       this->payload_buffer_.reserve(total);

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -29,9 +29,8 @@ MQTTClientComponent::MQTTClientComponent() {
 void MQTTClientComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MQTT...");
   this->mqtt_client_.onMessage([this](char const *topic, char *payload, AsyncMqttClientMessageProperties properties,
-                                      size_t len, size_t index, size_t total) {
-    this->on_message(topic, payload, len, index, total);
-  });
+                                      size_t len, size_t index,
+                                      size_t total) { this->on_message(topic, payload, len, index, total); });
   this->mqtt_client_.onDisconnect([this](AsyncMqttClientDisconnectReason reason) {
     this->state_ = MQTT_CLIENT_DISCONNECTED;
     this->disconnect_reason_ = reason;

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -322,7 +322,7 @@ void MQTTClientComponent::resubscribe_subscriptions_() {
   }
 }
 
-void MQTTClientComponent::subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos) {
+void MQTTClientComponent::subscribe(const std::string &topic, const mqtt_callback_t callback, uint8_t qos) {
   auto f = [callback, this](const std::string &topic, char *payload, size_t len, size_t index, size_t total) {
     if (index == 0)
       this->payload_buffer_.reserve(total);

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -19,8 +19,8 @@ namespace mqtt {
  *
  * First parameter is the topic, the second one is the payload.
  */
-using mqtt_callback_t = std::function<void(const std::string &, char *payload, size_t len, size_t index, size_t total)>;
-using mqtt_string_callback_t = std::function<void(const std::string &, const std::string &)>;
+using mqtt_callback_t = std::function<void(const std::string &, const std::string &)>;
+using mqtt_raw_callback_t = std::function<void(const std::string &, char *payload, size_t len, size_t index, size_t total)>;
 using mqtt_json_callback_t = std::function<void(const std::string &, JsonObject)>;
 
 /// internal struct for MQTT messages.
@@ -35,7 +35,7 @@ struct MQTTMessage {
 struct MQTTSubscription {
   std::string topic;
   uint8_t qos;
-  mqtt_callback_t callback;
+  mqtt_raw_callback_t callback;
   bool subscribed;
   uint32_t resubscribe_timeout;
 };
@@ -154,7 +154,7 @@ class MQTTClientComponent : public Component {
   void disable_log_message();
   bool is_log_message_enabled() const;
 
-  /** Subscribe to an MQTT topic and call callback when a partial message is received.
+  /** Subscribe to an MQTT topic and call callback when a complete message is received.
    *
    * @param topic The topic. Wildcards are currently not supported.
    * @param callback The callback function.
@@ -162,13 +162,13 @@ class MQTTClientComponent : public Component {
    */
   void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos = 0);
 
-  /** Subscribe to an MQTT topic and call callback when a complete message is received.
+  /** Subscribe to an MQTT topic and call callback when a partial message is received.
    *
    * @param topic The topic. Wildcards are currently not supported.
    * @param callback The callback function.
    * @param qos The QoS of this subscription.
    */
-  void subscribe(const std::string &topic, mqtt_string_callback_t callback, uint8_t qos = 0);
+  void subscribe_raw(const std::string &topic, mqtt_raw_callback_t callback, uint8_t qos = 0);
 
   /** Subscribe to a MQTT topic and automatically parse JSON payload.
    *

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -20,7 +20,8 @@ namespace mqtt {
  * First parameter is the topic, the second one is the payload.
  */
 using mqtt_callback_t = std::function<void(const std::string &, const std::string &)>;
-using mqtt_raw_callback_t = std::function<void(const std::string &, char *payload, size_t len, size_t index, size_t total)>;
+using mqtt_raw_callback_t =
+    std::function<void(const std::string &, char *payload, size_t len, size_t index, size_t total)>;
 using mqtt_json_callback_t = std::function<void(const std::string &, JsonObject)>;
 
 /// internal struct for MQTT messages.

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -161,7 +161,7 @@ class MQTTClientComponent : public Component {
    * @param callback The callback function.
    * @param qos The QoS of this subscription.
    */
-  void subscribe(const std::string &topic, const mqtt_callback_t callback, uint8_t qos = 0);
+  void subscribe(const std::string &topic, const mqtt_callback_t& callback, uint8_t qos = 0);
 
   /** Subscribe to an MQTT topic and call callback when a partial message is received.
    *

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -161,7 +161,7 @@ class MQTTClientComponent : public Component {
    * @param callback The callback function.
    * @param qos The QoS of this subscription.
    */
-  void subscribe(const std::string &topic, const mqtt_callback_t& callback, uint8_t qos = 0);
+  void subscribe(const std::string &topic, const mqtt_callback_t &callback, uint8_t qos = 0);
 
   /** Subscribe to an MQTT topic and call callback when a partial message is received.
    *

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -19,7 +19,8 @@ namespace mqtt {
  *
  * First parameter is the topic, the second one is the payload.
  */
-using mqtt_callback_t = std::function<void(const std::string &, const std::string &)>;
+using mqtt_callback_t = std::function<void(const std::string &, char *payload, size_t len, size_t index, size_t total)>;
+using mqtt_string_callback_t = std::function<void(const std::string &, const std::string &)>;
 using mqtt_json_callback_t = std::function<void(const std::string &, JsonObject)>;
 
 /// internal struct for MQTT messages.
@@ -153,13 +154,21 @@ class MQTTClientComponent : public Component {
   void disable_log_message();
   bool is_log_message_enabled() const;
 
-  /** Subscribe to an MQTT topic and call callback when a message is received.
+  /** Subscribe to an MQTT topic and call callback when a partial message is received.
    *
    * @param topic The topic. Wildcards are currently not supported.
    * @param callback The callback function.
    * @param qos The QoS of this subscription.
    */
   void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos = 0);
+
+  /** Subscribe to an MQTT topic and call callback when a complete message is received.
+   *
+   * @param topic The topic. Wildcards are currently not supported.
+   * @param callback The callback function.
+   * @param qos The QoS of this subscription.
+   */
+  void subscribe(const std::string &topic, mqtt_string_callback_t callback, uint8_t qos = 0);
 
   /** Subscribe to a MQTT topic and automatically parse JSON payload.
    *
@@ -214,7 +223,7 @@ class MQTTClientComponent : public Component {
   /// MQTT client setup priority
   float get_setup_priority() const override;
 
-  void on_message(const std::string &topic, const std::string &payload);
+  void on_message(const std::string &topic, char *payload, size_t len, size_t index, size_t total);
 
   bool can_proceed() override;
 

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -161,7 +161,7 @@ class MQTTClientComponent : public Component {
    * @param callback The callback function.
    * @param qos The QoS of this subscription.
    */
-  void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos = 0);
+  void subscribe(const std::string &topic, const mqtt_callback_t callback, uint8_t qos = 0);
 
   /** Subscribe to an MQTT topic and call callback when a partial message is received.
    *

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -149,7 +149,7 @@ std::string MQTTComponent::get_default_object_id_() const {
   return str_sanitize(str_snake_case(this->friendly_name()));
 }
 
-void MQTTComponent::subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos) {
+void MQTTComponent::subscribe(const std::string &topic, const mqtt_callback_t &callback, uint8_t qos) {
   global_mqtt_client->subscribe(topic, std::move(callback), qos);
 }
 

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -150,7 +150,7 @@ std::string MQTTComponent::get_default_object_id_() const {
 }
 
 void MQTTComponent::subscribe(const std::string &topic, const mqtt_callback_t &callback, uint8_t qos) {
-  global_mqtt_client->subscribe(topic, std::move(callback), qos);
+  global_mqtt_client->subscribe(topic, callback, qos);
 }
 
 void MQTTComponent::subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos) {

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -127,7 +127,7 @@ class MQTTComponent : public Component {
    * @param callback The callback that will be called when a message with matching topic is received.
    * @param qos The MQTT quality of service. Defaults to 0.
    */
-  void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos = 0);
+  void subscribe(const std::string &topic, const mqtt_callback_t &callback, uint8_t qos = 0);
 
   /** Subscribe to a MQTT topic and automatically parse JSON payload.
    *


### PR DESCRIPTION
# What does this implement/fix? 

I have a custom component that implement the Rasspy Hermes protocol. That protocol uses MQTT to transfer WAV files (strange, I know, but well...)
The component actually integrates https://github.com/Romkabouter/ESP32-Rhasspy-Satellite into esphome.

The current way of working of esphome systematically put the full payload of received message in RAM, which crashes with large MQTT payloads as in this case.

This PR allows to handle payloads in chunks via an additional `subscribe` function.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

Example custom component:

```c++
      subscribe("hermes/audioServer/" SITE_ID "/playBytes/+", &RHASSPY::on_playBytes, 2);
[...]
    void RHASSPY::on_playBytes(const std::string &topic, char *payload, size_t len, size_t index, size_t total)
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
