### PR TITLE
Enable api transport encryption for new projects

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1,5 +1,6 @@
 # pylint: disable=wrong-import-position
 
+import base64
 import codecs
 import collections
 import functools
@@ -366,6 +367,8 @@ class WizardRequestHandler(BaseHandler):
             if k in ("name", "platform", "board", "ssid", "psk", "password")
         }
         kwargs["ota_password"] = secrets.token_hex(16)
+        noise_psk = secrets.token_bytes(32)
+        kwargs["api_encryption_key"] = base64.b64encode(noise_psk).decode()
         destination = settings.rel_path(f"{kwargs['name']}.yaml")
         wizard.wizard_write(path=destination, **kwargs)
         self.set_status(200)

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -162,7 +162,6 @@ if get_bool_env(ENV_QUICKWIZARD):
     def sleep(time):
         pass
 
-
 else:
     from time import sleep
 

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -94,6 +94,8 @@ def wizard_file(**kwargs):
     # Configure API
     if "password" in kwargs:
         config += f"  password: \"{kwargs['password']}\"\n"
+    if "api_encryption_key" in kwargs:
+        config += f"  encryption:\n    key: \"{kwargs['api_encryption_key']}\"\n"
 
     # Configure OTA
     config += "\nota:\n"
@@ -159,6 +161,7 @@ if get_bool_env(ENV_QUICKWIZARD):
 
     def sleep(time):
         pass
+
 
 else:
     from time import sleep


### PR DESCRIPTION
# What does this implement/fix? 

Some time has passed and API transport encryption via the protocol built with the noise protocol framework seems to work reliably now.

Enable api transport encryption by default for new projects by setting the key by default for new projects.

TODO:
- [ ] Better UX flow? Right now the user would have to edit the config, copy the key, and only then can they add it to HA. Maybe some button that adds it directly to HA and/or the message requesting the encryption key that HA shows in the config flow could be improved to guide the user ("open your configuration file, and copy the value under api->encryption->key" etc)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
