### PR TITLE
Remove unused obj attribute from AssignmentExpression

### DIFF
--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -62,14 +62,13 @@ class RawExpression(Expression):
 
 
 class AssignmentExpression(Expression):
-    __slots__ = ("type", "modifier", "name", "rhs", "obj")
+    __slots__ = ("type", "modifier", "name", "rhs")
 
-    def __init__(self, type_, modifier, name, rhs, obj):
+    def __init__(self, type_, modifier, name, rhs):
         self.type = type_
         self.modifier = modifier
         self.name = name
         self.rhs = safe_exp(rhs)
-        self.obj = obj
 
     def __str__(self):
         if self.type is None:
@@ -427,8 +426,8 @@ class LineComment(Statement):
 class ProgmemAssignmentExpression(AssignmentExpression):
     __slots__ = ()
 
-    def __init__(self, type_, name, rhs, obj):
-        super().__init__(type_, "", name, rhs, obj)
+    def __init__(self, type_, name, rhs):
+        super().__init__(type_, "", name, rhs)
 
     def __str__(self):
         return f"static const {self.type} {self.name}[] PROGMEM = {self.rhs}"
@@ -437,8 +436,8 @@ class ProgmemAssignmentExpression(AssignmentExpression):
 class StaticConstAssignmentExpression(AssignmentExpression):
     __slots__ = ()
 
-    def __init__(self, type_, name, rhs, obj):
-        super().__init__(type_, "", name, rhs, obj)
+    def __init__(self, type_, name, rhs):
+        super().__init__(type_, "", name, rhs)
 
     def __str__(self):
         return f"static const {self.type} {self.name}[] = {self.rhs}"
@@ -447,7 +446,7 @@ class StaticConstAssignmentExpression(AssignmentExpression):
 def progmem_array(id_, rhs) -> "MockObj":
     rhs = safe_exp(rhs)
     obj = MockObj(id_, ".")
-    assignment = ProgmemAssignmentExpression(id_.type, id_, rhs, obj)
+    assignment = ProgmemAssignmentExpression(id_.type, id_, rhs)
     CORE.add(assignment)
     CORE.register_variable(id_, obj)
     return obj
@@ -456,7 +455,7 @@ def progmem_array(id_, rhs) -> "MockObj":
 def static_const_array(id_, rhs) -> "MockObj":
     rhs = safe_exp(rhs)
     obj = MockObj(id_, ".")
-    assignment = StaticConstAssignmentExpression(id_.type, id_, rhs, obj)
+    assignment = StaticConstAssignmentExpression(id_.type, id_, rhs)
     CORE.add(assignment)
     CORE.register_variable(id_, obj)
     return obj
@@ -484,7 +483,7 @@ def variable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     obj = MockObj(id_, ".")
     if type_ is not None:
         id_.type = type_
-    assignment = AssignmentExpression(id_.type, "", id_, rhs, obj)
+    assignment = AssignmentExpression(id_.type, "", id_, rhs)
     CORE.add(assignment)
     CORE.register_variable(id_, obj)
     return obj
@@ -507,7 +506,7 @@ def new_variable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj
         id_.type = type_
     decl = VariableDeclarationExpression(id_.type, "", id_)
     CORE.add_global(decl)
-    assignment = AssignmentExpression(None, "", id_, rhs, obj)
+    assignment = AssignmentExpression(None, "", id_, rhs)
     CORE.add(assignment)
     CORE.register_variable(id_, obj)
     return obj

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -528,7 +528,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         id_.type = type_
     decl = VariableDeclarationExpression(id_.type, "*", id_)
     CORE.add_global(decl)
-    assignment = AssignmentExpression(None, None, id_, rhs, obj)
+    assignment = AssignmentExpression(None, None, id_, rhs)
     CORE.add(assignment)
     CORE.register_variable(id_, obj)
     return obj

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -13,9 +13,9 @@ class TestExpressions:
         "target, expected",
         (
             (cg.RawExpression("foo && bar"), "foo && bar"),
-            (cg.AssignmentExpression(None, None, "foo", "bar", None), 'foo = "bar"'),
-            (cg.AssignmentExpression(ct.float_, "*", "foo", 1, None), "float *foo = 1"),
-            (cg.AssignmentExpression(ct.float_, "", "foo", 1, None), "float foo = 1"),
+            (cg.AssignmentExpression(None, None, "foo", "bar"), 'foo = "bar"'),
+            (cg.AssignmentExpression(ct.float_, "*", "foo", 1), "float *foo = 1"),
+            (cg.AssignmentExpression(ct.float_, "", "foo", 1), "float foo = 1"),
             (cg.VariableDeclarationExpression(ct.int32, "*", "foo"), "int32_t *foo"),
             (cg.VariableDeclarationExpression(ct.int32, "", "foo"), "int32_t foo"),
             (cg.ParameterExpression(ct.std_string, "foo"), "std::string foo"),
@@ -274,7 +274,7 @@ class TestStatements:
                 "// Help help\n// I'm being repressed",
             ),
             (
-                cg.ProgmemAssignmentExpression(ct.uint16, "foo", "bar", None),
+                cg.ProgmemAssignmentExpression(ct.uint16, "foo", "bar"),
                 'static const uint16_t foo[] PROGMEM = "bar"',
             ),
         ),


### PR DESCRIPTION
# What does this implement/fix? 

The obj attribute isn't used anywhere, so remove it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
