### PR TITLE
Enable mDNS during OTA safe mode

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -1,7 +1,7 @@
 from esphome.const import CONF_ID
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.core import CORE
+from esphome.core import CORE, coroutine_with_priority
 
 CODEOWNERS = ["@esphome/core"]
 DEPENDENCIES = ["network"]
@@ -29,6 +29,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
+@coroutine_with_priority(55.0)
 async def to_code(config):
     if CORE.using_arduino:
         if CORE.is_esp32:


### PR DESCRIPTION
# What does this implement/fix? 

Without this, OTA gets initialized added to the config before `mdns` is, and so when `ota` safe mode is triggered the mdns component registration code isn't even reached. Fix by setting a high priority on the mDNS to_code task (higher than OTA)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
