### PR TITLE
Allow attenuation for `sensor.adc` to be null

### DIFF
--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -143,8 +143,9 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(ADCSensor),
             cv.Required(CONF_PIN): validate_adc_pin,
             cv.Optional(CONF_RAW, default=False): cv.boolean,
-            cv.SplitDefault(CONF_ATTENUATION, esp32="0db"): cv.All(
-                cv.only_on_esp32, cv.enum(ATTENUATION_MODES, lower=True)
+            cv.SplitDefault(CONF_ATTENUATION, esp32="0db"): cv.Any(
+                cv.null,
+                cv.All(cv.only_on_esp32, cv.enum(ATTENUATION_MODES, lower=True)),
             ),
         }
     )
@@ -167,7 +168,7 @@ async def to_code(config):
     if CONF_RAW in config:
         cg.add(var.set_output_raw(config[CONF_RAW]))
 
-    if CONF_ATTENUATION in config:
+    if config.get(CONF_ATTENUATION) is not None:
         if config[CONF_ATTENUATION] == "auto":
             cg.add(var.set_autorange(cg.global_ns.true))
         else:

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -327,6 +327,21 @@ def boolean(value):
     )
 
 
+def null(value):
+    """Validate the given config option to be null.
+
+    This option allows a bunch of different ways of expressing boolean values:
+     - null
+     - '' (empty string)
+    """
+
+    if value is None:
+        return value
+    if isinstance(value, str) and value in (""):
+        return None
+    raise Invalid(f"Expected null value, but cannot convert {value} to null")
+
+
 @jschema_composite
 def ensure_list(*validators):
     """Validate this configuration option to be a list.

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -95,6 +95,17 @@ def test_boolean__invalid(value):
         config_validation.boolean(value)
 
 
+@pytest.mark.parametrize("value", (None, ""))
+def test_null__valid(value):
+    assert config_validation.null(value) is None
+
+
+@pytest.mark.parametrize("value", (false, true))
+def test_null__invalid(value):
+    with pytest.raises(Invalid, match="Expected null value"):
+        config_validation.null(value)
+
+
 # TODO: ensure_list
 @given(integers())
 def hex_int__valid(value):


### PR DESCRIPTION
# What does this implement/fix? 

Currently it isn't possible to define an ADC sensor in a package that is intended to be used on both ESP8266 and ESP32 because there is no null value for the `attenuation` key and no way to remove the key from the configuration.

This problem isn't unique to `sensor.adc` and would benefit from a generalized solution. The best option I could think of was to filter out null values in `esphome.config.validate_config`, but that would prevent components from accepting a `null` value altogether, which may not be desirable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
---
substitutions:
  adc_attenuation: ''

sensor:
  - platform: 'adc'
    pin: 'A0'
    id: 'temperature_adc'
    attenuation: '${adc_attenuation}'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
