### PR TITLE
Fix ESP32C3 toolchain requires stdarg import in helpers

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -8,6 +8,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstring>
+#include <cstdarg>
 
 #if defined(USE_ESP8266)
 #include <osapi.h>


### PR DESCRIPTION
# What does this implement/fix? 

```
src/esphome/core/helpers.cpp: In function 'std::__cxx11::string esphome::str_snprintf(const char*, size_t, ...)':
src/esphome/core/helpers.cpp:140:3: error: 'va_start' was not declared in this scope
   va_start(args, len);
   ^~~~~~~~
src/esphome/core/helpers.cpp:140:3: note: suggested alternative: 'stat'
   va_start(args, len);
   ^~~~~~~~
   stat
src/esphome/core/helpers.cpp:142:3: error: 'va_end' was not declared in this scope
   va_end(args);
   ^~~~~~
src/esphome/core/helpers.cpp:142:3: note: suggested alternative: 'rand'
   va_end(args);
   ^~~~~~
   rand
src/esphome/core/helpers.cpp: In function 'std::__cxx11::string esphome::str_sprintf(const char*, ...)':
src/esphome/core/helpers.cpp:153:3: error: 'va_start' was not declared in this scope
   va_start(args, fmt);
   ^~~~~~~~
src/esphome/core/helpers.cpp:153:3: note: suggested alternative: 'stat'
   va_start(args, fmt);
```

would probably be good to check these in our CI infra as well, but not in this PR

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
