### PR TITLE
Fix copy_file_if_changed src permissions copied too

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -1,4 +1,5 @@
 import codecs
+from contextlib import suppress
 
 import logging
 import os
@@ -233,8 +234,20 @@ def copy_file_if_changed(src: os.PathLike, dst: os.PathLike) -> None:
         return
     mkdir_p(os.path.dirname(dst))
     try:
-        shutil.copy(src, dst)
+        shutil.copyfile(src, dst)
     except OSError as err:
+        if isinstance(err, PermissionError):
+            # Older esphome versions copied over the src file permissions too.
+            # So when the dst file had 444 permissions, the dst file would have those
+            # too and subsequent writes would fail
+
+            # -> delete file (it would be overwritten anyway), and try again
+            # if that fails, use normal error handler
+            with suppress(OSError):
+                os.unlink(dst)
+                shutil.copyfile(src, dst)
+                return
+
         from esphome.core import EsphomeError
 
         raise EsphomeError(f"Error copying file {src} to {dst}: {err}") from err


### PR DESCRIPTION
# What does this implement/fix? 

Tried using nix today for a project, and saw nixOS applies a patch to the `copy_file_if_changed` method:

If esphome's sources are packaged in a way that src permissions are not writable by the user executing esphome, the `copy_file_if_changed` method would also copy those permissions. And so subsequent overwrites of the src file would fail because of the permissions.

Context: this patch https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/esphome/fix-src-permissions.patch

This kind of is indeed a bug on the esphome side, so let's fix it here. The patch is slightly different (didn't want to chmod in case the user has more complex setups like with setfacl; unlinking+copying should be fine afaik)

CC @mweinelt (original patch author)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
