### PR TITLE
[debug] Refactor debug sensors to use the normal sensor model.

### DIFF
--- a/esphome/components/debug/__init__.py
+++ b/esphome/components/debug/__init__.py
@@ -2,6 +2,11 @@ import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
     CONF_ID,
+    CONF_DEVICE,
+    CONF_FREE,
+    CONF_FRAGMENTATION,
+    CONF_BLOCK,
+    CONF_LOOP_TIME,
 )
 
 CODEOWNERS = ["@OttoWinter"]
@@ -15,6 +20,21 @@ DebugComponent = debug_ns.class_("DebugComponent", cg.PollingComponent)
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DebugComponent),
+        cv.Optional(CONF_DEVICE): cv.invalid(
+            "The 'device' option has been moved to the 'debug' text_sensor component"
+        ),
+        cv.Optional(CONF_FREE): cv.invalid(
+            "The 'free' option has been moved to the 'debug' sensor component"
+        ),
+        cv.Optional(CONF_BLOCK): cv.invalid(
+            "The 'block' option has been moved to the 'debug' sensor component"
+        ),
+        cv.Optional(CONF_FRAGMENTATION): cv.invalid(
+            "The 'fragmentation' option has been moved to the 'debug' sensor component"
+        ),
+        cv.Optional(CONF_LOOP_TIME): cv.invalid(
+            "The 'loop_time' option has been moved to the 'debug' sensor component"
+        ),
     }
 ).extend(cv.polling_component_schema("60s"))
 

--- a/esphome/components/debug/__init__.py
+++ b/esphome/components/debug/__init__.py
@@ -1,23 +1,13 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.components import sensor, text_sensor
 from esphome.const import (
     CONF_ID,
-    CONF_DEVICE,
-    CONF_FREE,
-    CONF_FRAGMENTATION,
-    CONF_BLOCK,
-    CONF_LOOP_TIME,
-    UNIT_MILLISECOND,
-    UNIT_PERCENT,
-    UNIT_BYTES,
-    ICON_COUNTER,
-    ICON_TIMER,
 )
 
 CODEOWNERS = ["@OttoWinter"]
 DEPENDENCIES = ["logger"]
 
+CONF_DEBUG_ID = "debug_id"
 debug_ns = cg.esphome_ns.namespace("debug")
 DebugComponent = debug_ns.class_("DebugComponent", cg.PollingComponent)
 
@@ -25,19 +15,6 @@ DebugComponent = debug_ns.class_("DebugComponent", cg.PollingComponent)
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DebugComponent),
-        cv.Optional(CONF_DEVICE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {cv.GenerateID(): cv.declare_id(text_sensor.TextSensor)}
-        ),
-        cv.Optional(CONF_FREE): sensor.sensor_schema(UNIT_BYTES, ICON_COUNTER, 0),
-        cv.Optional(CONF_BLOCK): sensor.sensor_schema(UNIT_BYTES, ICON_COUNTER, 0),
-        cv.Optional(CONF_FRAGMENTATION): cv.All(
-            cv.only_on_esp8266,
-            cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
-            sensor.sensor_schema(UNIT_PERCENT, ICON_COUNTER, 1),
-        ),
-        cv.Optional(CONF_LOOP_TIME): sensor.sensor_schema(
-            UNIT_MILLISECOND, ICON_TIMER, 1
-        ),
     }
 ).extend(cv.polling_component_schema("60s"))
 
@@ -45,24 +22,3 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-
-    if CONF_DEVICE in config:
-        sens = cg.new_Pvariable(config[CONF_DEVICE][CONF_ID])
-        await text_sensor.register_text_sensor(sens, config[CONF_DEVICE])
-        cg.add(var.set_device_info_sensor(sens))
-
-    if CONF_FREE in config:
-        sens = await sensor.new_sensor(config[CONF_FREE])
-        cg.add(var.set_free_sensor(sens))
-
-    if CONF_BLOCK in config:
-        sens = await sensor.new_sensor(config[CONF_BLOCK])
-        cg.add(var.set_block_sensor(sens))
-
-    if CONF_FRAGMENTATION in config:
-        sens = await sensor.new_sensor(config[CONF_FRAGMENTATION])
-        cg.add(var.set_fragmentation_sensor(sens))
-
-    if CONF_LOOP_TIME in config:
-        sens = await sensor.new_sensor(config[CONF_LOOP_TIME])
-        cg.add(var.set_loop_time_sensor(sens))

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -23,6 +23,13 @@
 #include <Esp.h>
 #endif
 
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+
 namespace esphome {
 namespace debug {
 
@@ -47,12 +54,16 @@ void DebugComponent::dump_config() {
 #endif
 
   ESP_LOGCONFIG(TAG, "Debug component:");
+#ifdef USE_TEXT_SENSOR
   LOG_TEXT_SENSOR("  ", "Device info", this->device_info_);
+#endif  // USE_TEXT_SENSOR
+#ifdef USE_SENSOR
   LOG_SENSOR("  ", "Free space on heap", this->free_sensor_);
   LOG_SENSOR("  ", "Largest free heap block", this->block_sensor_);
 #if defined(USE_ESP8266) && ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
   LOG_SENSOR("  ", "Heap fragmentation", this->fragmentation_sensor_);
-#endif
+#endif  // defined(USE_ESP8266) && ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
+#endif  // USE_SENSOR
 
   ESP_LOGD(TAG, "ESPHome version %s", ESPHOME_VERSION);
   device_info += ESPHOME_VERSION;
@@ -268,11 +279,13 @@ void DebugComponent::dump_config() {
   device_info += ESP.getResetInfo().c_str();
 #endif
 
+#ifdef USE_TEXT_SENSOR
   if (this->device_info_ != nullptr) {
     if (device_info.length() > 255)
       device_info.resize(255);
     this->device_info_->publish_state(device_info);
   }
+#endif  // USE_TEXT_SENSOR
 }
 
 void DebugComponent::loop() {
@@ -284,6 +297,7 @@ void DebugComponent::loop() {
     this->status_momentary_warning("heap", 1000);
   }
 
+#ifdef USE_SENSOR
   // calculate loop time - from last call to this one
   if (this->loop_time_sensor_ != nullptr) {
     uint32_t now = millis();
@@ -291,9 +305,11 @@ void DebugComponent::loop() {
     this->max_loop_time_ = std::max(this->max_loop_time_, loop_time);
     this->last_loop_timetag_ = now;
   }
+#endif  // USE_SENSOR
 }
 
 void DebugComponent::update() {
+#ifdef USE_SENSOR
   if (this->free_sensor_ != nullptr) {
     this->free_sensor_->publish_state(get_free_heap());
   }
@@ -318,6 +334,7 @@ void DebugComponent::update() {
     this->loop_time_sensor_->publish_state(this->max_loop_time_);
     this->max_loop_time_ = 0;
   }
+#endif  // USE_SENSOR
 }
 
 float DebugComponent::get_setup_priority() const { return setup_priority::LATE; }

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -23,13 +23,6 @@
 #include <Esp.h>
 #endif
 
-#ifdef USE_TEXT_SENSOR
-#include "esphome/components/text_sensor/text_sensor.h"
-#endif
-#ifdef USE_SENSOR
-#include "esphome/components/sensor/sensor.h"
-#endif
-
 namespace esphome {
 namespace debug {
 

--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -1,12 +1,18 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/macros.h"
 #include "esphome/core/helpers.h"
-#include "esphome/components/text_sensor/text_sensor.h"
-#include "esphome/components/sensor/sensor.h"
 
 namespace esphome {
+namespace text_sensor {
+class TextSensor;
+}
+namespace sensor {
+class Sensor;
+}
+
 namespace debug {
 
 class DebugComponent : public PollingComponent {
@@ -16,27 +22,35 @@ class DebugComponent : public PollingComponent {
   float get_setup_priority() const override;
   void dump_config() override;
 
+#ifdef USE_TEXT_SENSOR
   void set_device_info_sensor(text_sensor::TextSensor *device_info) { device_info_ = device_info; }
+#endif  // USE_TEXT_SENSOR
+#ifdef USE_SENSOR
   void set_free_sensor(sensor::Sensor *free_sensor) { free_sensor_ = free_sensor; }
   void set_block_sensor(sensor::Sensor *block_sensor) { block_sensor_ = block_sensor; }
 #if defined(USE_ESP8266) && ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
   void set_fragmentation_sensor(sensor::Sensor *fragmentation_sensor) { fragmentation_sensor_ = fragmentation_sensor; }
 #endif
   void set_loop_time_sensor(sensor::Sensor *loop_time_sensor) { loop_time_sensor_ = loop_time_sensor; }
-
+#endif  // USE_SENSOR
  protected:
   uint32_t free_heap_{};
 
+#ifdef USE_SENSOR
   uint32_t last_loop_timetag_{0};
   uint32_t max_loop_time_{0};
 
-  text_sensor::TextSensor *device_info_{nullptr};
   sensor::Sensor *free_sensor_{nullptr};
   sensor::Sensor *block_sensor_{nullptr};
 #if defined(USE_ESP8266) && ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
   sensor::Sensor *fragmentation_sensor_{nullptr};
 #endif
   sensor::Sensor *loop_time_sensor_{nullptr};
+#endif  // USE_SENSOR
+
+#ifdef USE_TEXT_SENSOR
+  text_sensor::TextSensor *device_info_{nullptr};
+#endif  // USE_TEXT_SENSOR
 };
 
 }  // namespace debug

--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -5,14 +5,14 @@
 #include "esphome/core/macros.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace text_sensor {
-class TextSensor;
-}
-namespace sensor {
-class Sensor;
-}
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
 
+namespace esphome {
 namespace debug {
 
 class DebugComponent : public PollingComponent {

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -1,0 +1,49 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    CONF_FREE,
+    CONF_FRAGMENTATION,
+    CONF_BLOCK,
+    CONF_LOOP_TIME,
+    UNIT_MILLISECOND,
+    UNIT_PERCENT,
+    UNIT_BYTES,
+    ICON_COUNTER,
+    ICON_TIMER,
+)
+from . import CONF_DEBUG_ID, DebugComponent
+
+DEPENDENCIES = ["debug"]
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_DEBUG_ID): cv.use_id(DebugComponent),
+    cv.Optional(CONF_FREE): sensor.sensor_schema(UNIT_BYTES, ICON_COUNTER, 0),
+    cv.Optional(CONF_BLOCK): sensor.sensor_schema(UNIT_BYTES, ICON_COUNTER, 0),
+    cv.Optional(CONF_FRAGMENTATION): cv.All(
+        cv.only_on_esp8266,
+        cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
+        sensor.sensor_schema(UNIT_PERCENT, ICON_COUNTER, 1),
+    ),
+    cv.Optional(CONF_LOOP_TIME): sensor.sensor_schema(UNIT_MILLISECOND, ICON_TIMER, 0),
+}
+
+
+async def to_code(config):
+    debug_component = await cg.get_variable(config[CONF_DEBUG_ID])
+
+    if CONF_FREE in config:
+        sens = await sensor.new_sensor(config[CONF_FREE])
+        cg.add(debug_component.set_free_sensor(sens))
+
+    if CONF_BLOCK in config:
+        sens = await sensor.new_sensor(config[CONF_BLOCK])
+        cg.add(debug_component.set_block_sensor(sens))
+
+    if CONF_FRAGMENTATION in config:
+        sens = await sensor.new_sensor(config[CONF_FRAGMENTATION])
+        cg.add(debug_component.set_fragmentation_sensor(sens))
+
+    if CONF_LOOP_TIME in config:
+        sens = await sensor.new_sensor(config[CONF_LOOP_TIME])
+        cg.add(debug_component.set_loop_time_sensor(sens))

--- a/esphome/components/debug/text_sensor.py
+++ b/esphome/components/debug/text_sensor.py
@@ -1,0 +1,29 @@
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import (
+    CONF_ID,
+    CONF_DEVICE,
+)
+from . import CONF_DEBUG_ID, DebugComponent
+
+DEPENDENCIES = ["debug"]
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_DEBUG_ID): cv.use_id(DebugComponent),
+        cv.Optional(CONF_DEVICE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+            {cv.GenerateID(): cv.declare_id(text_sensor.TextSensor)}
+        ),
+    }
+)
+
+
+async def to_code(config):
+    debug_component = await cg.get_variable(config[CONF_DEBUG_ID])
+
+    if CONF_DEVICE in config:
+        sens = cg.new_Pvariable(config[CONF_DEVICE][CONF_ID])
+        await text_sensor.register_text_sensor(sens, config[CONF_DEVICE])
+        cg.add(debug_component.set_device_info_sensor(sens))


### PR DESCRIPTION
Fixes debug component compile when no text sensors are enabled.

# What does this implement/fix?
With #1578 the debug component doesn't compile anymore without a "text_sensor:" entry in the config.
This MR refactors the component to use the normal sensor and text_sensor model and excludes the sensor and text sensor components if they aren't loaded.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1879

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml

debug:

text_sensor:
  - platform: debug
    device:
      name: "Device Info"

sensor:
  - platform: debug
    free:
      name: "Heap Free"
    block:
      name: "Heap Max Block"
    loop_time:
      name: "Loop Time"
```

## Checklist:
  - [x] The code change is tested and works locally.
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
