### PR TITLE
Allow to set manufacturer data for BLEAdvertising

### DIFF
--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -42,6 +42,11 @@ void BLEAdvertising::remove_service_uuid(ESPBTUUID uuid) {
                                  this->advertising_uuids_.end());
 }
 
+void BLEAdvertising::set_manufacturer_data(uint8_t *data, uint16_t size) {
+  this->advertising_data_.p_manufacturer_data = data;
+  this->advertising_data_.manufacturer_len = size;
+}
+
 void BLEAdvertising::start() {
   int num_services = this->advertising_uuids_.size();
   if (num_services == 0) {

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -20,6 +20,7 @@ class BLEAdvertising {
   void remove_service_uuid(ESPBTUUID uuid);
   void set_scan_response(bool scan_response) { this->scan_response_ = scan_response; }
   void set_min_preferred_interval(uint16_t interval) { this->advertising_data_.min_interval = interval; }
+  void set_manufacturer_data(uint8_t *data, uint16_t size);
 
   void start();
   void stop();


### PR DESCRIPTION
# What does this implement/fix? 

Add `BLEAdvertising::set_manufacturer_data(uint8_t *data, uint16_t size)`.
`BLEAdvertising` is used by `esp32_ble`, namely when using `esp32_ble_server`.
With `set_manufacturer_data` it's now possible to re-use existing `BLEAdvertising` implementation to embed up to 31 bytes of data into the BLE advertisement, which is a common technique used in IoT and low-energy devices/sensors.

The most primitive example - with simplistic serialization etc - is with 2 ESP MCUs it's now possible to implement a client-server setup through a shared structure as shown below.

**structs.h**
```
#pragma once

typedef struct payload {
  time_t     timestamp;
  uint16_t  kitchen_co2;
  int8_t      kitchen_temperature;

} __attribute__((packed)) payload_t;

typedef struct manufacturer_data {
  unsigned short   company_id;
  payload_t  data;

} manufacturer_data_t;
```

**server.yaml**
```yaml
esphome:
  name: ble-advertisement-server
  includes:
  - structs.h
...
esp32_ble:
  id: ble

esp32_ble_server:
...
interval:
  - interval: 10seconds
    then:
      - lambda: |-
          static manufacturer_data_t* advertisement = new manufacturer_data_t;

          advertisement->data.timestamp = id(ntp).now().timestamp;
          advertisement->data.kitchen_co2 = (uint16_t) id(kitchen_co2).state;
          advertisement->data.kitchen_temperature   = (int8_t) id(kitchen_temperature).state;

          if (advertisement->company_id == 0) { // Execute once after boot for initial setup
              advertisement->company_id = 0xFFFF; // Require by BLE spec, FFFF is used for testing and non-commercial applications
              id(ble).get_advertising()->set_manufacturer_data((uint8_t*) advertisement, sizeof(manufacturer_data_t));
          }
          
          id(ble).get_advertising()->start();
```

**client.yaml**
```yaml
...
esphome:
  name: ble-advertisement-client
  includes:
  - structs.h
...
esp32_ble_tracker:

  scan_parameters:
    active: false

  on_ble_manufacturer_data_advertise:
    - mac_address: !secret mac_ble_advertisement_server
      manufacturer_id: FFFF # same value we put in the server
      then:
        - lambda: |-
            payload_t* message = (payload_t*) x.data();
            
            ESP_LOGD(
              "ble_advertisement", "Received: time=%ld, kitchen_co2=%hu, kitchen_temperature=%hhd",
              message->timestamp, message->kitchen_co2, message-> kitchen_temperature
            );
```

I know this change is not really in line with majority of the ESP components, but it unlocks great potential that is there in the existing code in `BLEAdvertising`. It might come handy for future components, or ad-hoc BLE-based setups as shown in the example above.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1892

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
Provided above ^

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
