### PR TITLE
display: make clear virtual

### DIFF
--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -111,7 +111,7 @@ class DisplayBuffer {
   /// Fill the entire screen with the given color.
   virtual void fill(Color color);
   /// Clear the entire screen by filling it with OFF pixels.
-  void clear();
+  virtual void clear();
 
   /// Get the width of the image in pixels with rotation applied.
   int get_width();

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -588,8 +588,8 @@ void Inkplate6::vscan_end_() {
   delayMicroseconds(0);
 }
 
-void Inkplate6::clean() {
-  ESP_LOGV(TAG, "Clean called");
+void Inkplate6::clear() {
+  ESP_LOGV(TAG, "Clear called");
   uint32_t start_time = millis();
 
   eink_on_();
@@ -599,7 +599,7 @@ void Inkplate6::clean() {
   clean_fast_(0, 8);   // Black to Black
   clean_fast_(2, 1);   // Black to White
   clean_fast_(1, 10);  // White to White
-  ESP_LOGV(TAG, "Clean finished (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Clear finished (%ums)", millis() - start_time);
 }
 
 void Inkplate6::clean_fast_(uint8_t c, uint8_t rep) {

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -72,7 +72,7 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
   void dump_config() override;
 
   void display();
-  void clean();
+  void clear() override;
   void fill(Color color) override;
 
   void update() override;


### PR DESCRIPTION
# What does this implement/fix? 

A scoped-down version of https://github.com/esphome/esphome/pull/3140.
Making `DisplayBuffer::clear()` virtual so that implementations can override it.
The primary use-case if for eInk (aka ePaper) displays, for which filling it with a color, and really clearing to get rid of artifacts are two different operations, and therefore `virtual void fill(Color color)` is not sufficient.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
