### PR TITLE
Analog threshold

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,6 +19,7 @@ esphome/components/airthings_wave_mini/* @ncareau
 esphome/components/airthings_wave_plus/* @jeromelaban
 esphome/components/am43/* @buxtronix
 esphome/components/am43/cover/* @buxtronix
+esphome/components/analog_threshold/* @ianchi
 esphome/components/animation/* @syndlex
 esphome/components/anova/* @buxtronix
 esphome/components/api/* @OttoWinter

--- a/esphome/components/analog_threshold/__init__.py
+++ b/esphome/components/analog_threshold/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@ianchi"]

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
@@ -1,0 +1,47 @@
+#include "analog_threshold_binary_sensor.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace analog_threshold {
+
+static const char *const TAG = "analog_threshold.binary_sensor";
+
+void AnalogThresholdBinarySensor::setup() {
+  this->last_change_ = millis();
+  this->last_above_ = this->sensor_->get_state() >= (this->lower_threshold_ + this->upper_threshold_) / 2.0f;
+  this->publish_initial_state(this->last_above_ != this->inverted_);
+}
+
+void AnalogThresholdBinarySensor::loop() {
+  const auto now = millis();
+
+  // check if we changed side
+  if (this->last_above_ != this->is_above_()) {
+    this->last_change_ = now;
+    this->last_above_ = !this->last_above_;
+  }
+
+  // check delay
+  if (now - this->last_change_ >= (this->last_above_ ? this->delay_high_ : this->delay_low_)) {
+    // change state
+    this->publish_state(this->last_above_ != this->inverted_);
+  }
+}
+void AnalogThresholdBinarySensor::dump_config() {
+  LOG_BINARY_SENSOR("", "Analog Threshold Binary Sensor", this);
+  LOG_SENSOR("  ", "Sensor", this->sensor_);
+  ESP_LOGCONFIG(TAG, "  Upper threshold: %.11f", this->upper_threshold_);
+  ESP_LOGCONFIG(TAG, "  Lower threshold: %.11f", this->lower_threshold_);
+
+  ESP_LOGCONFIG(TAG, "  Delay High: %.3fs", this->delay_high_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Delay Low: %.3fs", this->delay_low_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Inverted: %s", YESNO(this->inverted_));
+}
+
+bool AnalogThresholdBinarySensor::is_above_() const {
+  return this->sensor_->get_state() >= (this->last_above_ ? this->lower_threshold_ : this->upper_threshold_);
+}
+
+}  // namespace analog_threshold
+}  // namespace esphome

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
@@ -1,5 +1,4 @@
 #include "analog_threshold_binary_sensor.h"
-#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -8,39 +7,22 @@ namespace analog_threshold {
 static const char *const TAG = "analog_threshold.binary_sensor";
 
 void AnalogThresholdBinarySensor::setup() {
-  this->last_change_ = millis();
-  this->last_above_ = this->sensor_->get_state() >= (this->lower_threshold_ + this->upper_threshold_) / 2.0f;
-  this->publish_initial_state(this->last_above_ != this->inverted_);
+  this->publish_initial_state(this->sensor_->get_state() >= (this->lower_threshold_ + this->upper_threshold_) / 2.0f);
 }
 
-void AnalogThresholdBinarySensor::loop() {
-  const auto now = millis();
+void AnalogThresholdBinarySensor::set_sensor(sensor::Sensor *analog_sensor) {
+  this->sensor_ = analog_sensor;
 
-  // check if we changed side
-  if (this->last_above_ != this->is_above_()) {
-    this->last_change_ = now;
-    this->last_above_ = !this->last_above_;
-  }
-
-  // check delay
-  if (now - this->last_change_ >= (this->last_above_ ? this->delay_high_ : this->delay_low_)) {
-    // change state
-    this->publish_state(this->last_above_ != this->inverted_);
-  }
+  this->sensor_->add_on_state_callback([this](float sensor_value) {
+    this->publish_state(sensor_value >= (this->state ? this->lower_threshold_ : this->upper_threshold_));
+  });
 }
+
 void AnalogThresholdBinarySensor::dump_config() {
   LOG_BINARY_SENSOR("", "Analog Threshold Binary Sensor", this);
   LOG_SENSOR("  ", "Sensor", this->sensor_);
   ESP_LOGCONFIG(TAG, "  Upper threshold: %.11f", this->upper_threshold_);
   ESP_LOGCONFIG(TAG, "  Lower threshold: %.11f", this->lower_threshold_);
-
-  ESP_LOGCONFIG(TAG, "  Delay High: %.3fs", this->delay_high_ / 1e3f);
-  ESP_LOGCONFIG(TAG, "  Delay Low: %.3fs", this->delay_low_ / 1e3f);
-  ESP_LOGCONFIG(TAG, "  Inverted: %s", YESNO(this->inverted_));
-}
-
-bool AnalogThresholdBinarySensor::is_above_() const {
-  return this->sensor_->get_state() >= (this->last_above_ ? this->lower_threshold_ : this->upper_threshold_);
 }
 
 }  // namespace analog_threshold

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -22,10 +22,7 @@ class AnalogThresholdBinarySensor : public Component, public binary_sensor::Bina
   void set_delay_high(uint32_t delay) { this->delay_high_ = delay; }
   void set_delay_low(uint32_t delay) { this->delay_low_ = delay; }
 
-  
-
  protected:
-
   bool is_above_() const;
 
   sensor::Sensor *sensor_{nullptr};

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -12,7 +12,7 @@ class AnalogThresholdBinarySensor : public Component, public binary_sensor::Bina
   void dump_config() override;
   void setup() override;
 
-  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_sensor(sensor::Sensor *analog_sensor);
   void set_upper_threshold(float threshold) { this->upper_threshold_ = threshold; }

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -9,34 +9,20 @@ namespace analog_threshold {
 
 class AnalogThresholdBinarySensor : public Component, public binary_sensor::BinarySensor {
  public:
-  void loop() override;
   void dump_config() override;
   void setup() override;
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  void set_sensor(sensor::Sensor *analog_sensor) { this->sensor_ = analog_sensor; }
+  void set_sensor(sensor::Sensor *analog_sensor);
   void set_upper_threshold(float threshold) { this->upper_threshold_ = threshold; }
   void set_lower_threshold(float threshold) { this->lower_threshold_ = threshold; }
-  void set_inverted(bool inverted) { this->inverted_ = inverted; }
-  void set_delay_high(uint32_t delay) { this->delay_high_ = delay; }
-  void set_delay_low(uint32_t delay) { this->delay_low_ = delay; }
 
  protected:
-  bool is_above_() const;
-
   sensor::Sensor *sensor_{nullptr};
-  bool inverted_{false};
 
   float upper_threshold_;
   float lower_threshold_;
-
-  uint32_t delay_high_;
-  uint32_t delay_low_;
-
-  uint32_t last_change_{0};
-
-  bool last_above_;
 };
 
 }  // namespace analog_threshold

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome {
+namespace analog_threshold {
+
+class AnalogThresholdBinarySensor : public Component, public binary_sensor::BinarySensor {
+ public:
+  void loop() override;
+  void dump_config() override;
+  void setup() override;
+
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  void set_sensor(sensor::Sensor *analog_sensor) { this->sensor_ = analog_sensor; }
+  void set_upper_threshold(float threshold) { this->upper_threshold_ = threshold; }
+  void set_lower_threshold(float threshold) { this->lower_threshold_ = threshold; }
+  void set_inverted(bool inverted) { this->inverted_ = inverted; }
+  void set_delay_high(uint32_t delay) { this->delay_high_ = delay; }
+  void set_delay_low(uint32_t delay) { this->delay_low_ = delay; }
+
+  
+
+ protected:
+
+  bool is_above_() const;
+
+  sensor::Sensor *sensor_{nullptr};
+  bool inverted_{false};
+
+  float upper_threshold_;
+  float lower_threshold_;
+
+  uint32_t delay_high_;
+  uint32_t delay_low_;
+
+  uint32_t last_change_{0};
+
+  bool last_above_;
+};
+
+}  // namespace analog_threshold
+}  // namespace esphome

--- a/esphome/components/analog_threshold/binary_sensor.py
+++ b/esphome/components/analog_threshold/binary_sensor.py
@@ -1,15 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome import core
 from esphome.components import binary_sensor, sensor
 from esphome.const import (
-    CONF_DELAY,
-    CONF_HIGH,
     CONF_ID,
-    CONF_LOW,
     CONF_SENSOR_ID,
     CONF_THRESHOLD,
-    CONF_INVERTED,
 )
 
 analog_threshold_ns = cg.esphome_ns.namespace("analog_threshold")
@@ -31,16 +26,6 @@ CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
                 {cv.Required(CONF_UPPER): cv.float_, cv.Required(CONF_LOWER): cv.float_}
             ),
         ),
-        cv.Optional(CONF_INVERTED, False): cv.boolean,
-        cv.Optional(CONF_DELAY, "0s"): cv.Any(
-            cv.positive_time_period_milliseconds,
-            cv.Schema(
-                {
-                    cv.Required(CONF_HIGH): cv.positive_time_period_milliseconds,
-                    cv.Required(CONF_LOW): cv.positive_time_period_milliseconds,
-                }
-            ),
-        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -59,12 +44,3 @@ async def to_code(config):
     else:
         cg.add(var.set_upper_threshold(config[CONF_THRESHOLD][CONF_UPPER]))
         cg.add(var.set_lower_threshold(config[CONF_THRESHOLD][CONF_LOWER]))
-
-    cg.add(var.set_inverted(config[CONF_INVERTED]))
-
-    if isinstance(config[CONF_DELAY], core.TimePeriodMilliseconds):
-        cg.add(var.set_delay_high(config[CONF_DELAY]))
-        cg.add(var.set_delay_low(config[CONF_DELAY]))
-    else:
-        cg.add(var.set_delay_high(config[CONF_DELAY][CONF_HIGH]))
-        cg.add(var.set_delay_low(config[CONF_DELAY][CONF_LOW]))

--- a/esphome/components/analog_threshold/binary_sensor.py
+++ b/esphome/components/analog_threshold/binary_sensor.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-import esphome.core as core
+from esphome import core
 from esphome.components import binary_sensor, sensor
 from esphome.const import (
     CONF_DELAY,
@@ -53,7 +53,7 @@ async def to_code(config):
     bin = await cg.get_variable(config[CONF_SENSOR_ID])
     cg.add(var.set_sensor(bin))
 
-    if type(config[CONF_THRESHOLD]) == float:
+    if isinstance(config[CONF_THRESHOLD], float):
         cg.add(var.set_upper_threshold(config[CONF_THRESHOLD]))
         cg.add(var.set_lower_threshold(config[CONF_THRESHOLD]))
     else:

--- a/esphome/components/analog_threshold/binary_sensor.py
+++ b/esphome/components/analog_threshold/binary_sensor.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor, sensor
 from esphome.const import (
-    CONF_ID,
     CONF_SENSOR_ID,
     CONF_THRESHOLD,
 )
@@ -31,12 +30,11 @@ CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
-    await binary_sensor.register_binary_sensor(var, config)
 
-    bin = await cg.get_variable(config[CONF_SENSOR_ID])
-    cg.add(var.set_sensor(bin))
+    sens = await cg.get_variable(config[CONF_SENSOR_ID])
+    cg.add(var.set_sensor(sens))
 
     if isinstance(config[CONF_THRESHOLD], float):
         cg.add(var.set_upper_threshold(config[CONF_THRESHOLD]))

--- a/esphome/components/analog_threshold/binary_sensor.py
+++ b/esphome/components/analog_threshold/binary_sensor.py
@@ -1,0 +1,70 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+import esphome.core as core
+from esphome.components import binary_sensor, sensor
+from esphome.const import (
+    CONF_DELAY,
+    CONF_HIGH,
+    CONF_ID,
+    CONF_LOW,
+    CONF_SENSOR_ID,
+    CONF_THRESHOLD,
+    CONF_INVERTED,
+)
+
+analog_threshold_ns = cg.esphome_ns.namespace("analog_threshold")
+
+AnalogThresholdBinarySensor = analog_threshold_ns.class_(
+    "AnalogThresholdBinarySensor", binary_sensor.BinarySensor, cg.Component
+)
+
+CONF_UPPER = "upper"
+CONF_LOWER = "lower"
+
+CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(AnalogThresholdBinarySensor),
+        cv.Required(CONF_SENSOR_ID): cv.use_id(sensor.Sensor),
+        cv.Required(CONF_THRESHOLD): cv.Any(
+            cv.float_,
+            cv.Schema(
+                {cv.Required(CONF_UPPER): cv.float_, cv.Required(CONF_LOWER): cv.float_}
+            ),
+        ),
+        cv.Optional(CONF_INVERTED, False): cv.boolean,
+        cv.Optional(CONF_DELAY, "0s"): cv.Any(
+            cv.positive_time_period_milliseconds,
+            cv.Schema(
+                {
+                    cv.Required(CONF_HIGH): cv.positive_time_period_milliseconds,
+                    cv.Required(CONF_LOW): cv.positive_time_period_milliseconds,
+                }
+            ),
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await binary_sensor.register_binary_sensor(var, config)
+
+    bin = await cg.get_variable(config[CONF_SENSOR_ID])
+    cg.add(var.set_sensor(bin))
+
+    if type(config[CONF_THRESHOLD]) == float:
+        cg.add(var.set_upper_threshold(config[CONF_THRESHOLD]))
+        cg.add(var.set_lower_threshold(config[CONF_THRESHOLD]))
+    else:
+        cg.add(var.set_upper_threshold(config[CONF_THRESHOLD][CONF_UPPER]))
+        cg.add(var.set_lower_threshold(config[CONF_THRESHOLD][CONF_LOWER]))
+
+    cg.add(var.set_inverted(config[CONF_INVERTED]))
+
+    if isinstance(config[CONF_DELAY], core.TimePeriodMilliseconds):
+        cg.add(var.set_delay_high(config[CONF_DELAY]))
+        cg.add(var.set_delay_low(config[CONF_DELAY]))
+    else:
+        cg.add(var.set_delay_high(config[CONF_DELAY][CONF_HIGH]))
+        cg.add(var.set_delay_low(config[CONF_DELAY][CONF_LOW]))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1313,15 +1313,15 @@ binary_sensor:
     threshold: 
       upper: 110
       lower: 90
-    delay: 
-      high: 0s
-      low: 10s
+    filters: 
+      - delayed_on: 0s
+      - delayed_off: 10s
   - platform: analog_threshold
     name: Analog Trheshold 2
     sensor_id: template_sensor
     threshold: 100
-    delay: 10s
-    inverted: true
+    filters: 
+      - invert: 
 
 pca9685:
   frequency: 500

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1307,6 +1307,21 @@ binary_sensor:
         ]
   - platform: as3935
     name: "Storm Alert"
+  - platform: analog_threshold
+    name: Analog Trheshold 1
+    sensor_id: template_sensor
+    threshold: 
+      upper: 110
+      lower: 90
+    delay: 
+      high: 0s
+      low: 10s
+  - platform: analog_threshold
+    name: Analog Trheshold 2
+    sensor_id: template_sensor
+    threshold: 100
+    delay: 10s
+    inverted: true
 
 pca9685:
   frequency: 500


### PR DESCRIPTION
# What does this implement/fix? 

New component: `analog_threshold` binary sensor platform allows you to convert analog values (sensor readings) into boolean values, using a threshold as a reference.

It provides some options to reduce instability when the source signal is noisy: *hysteresis* (using different limits depending on the current state) and *delay* (only change after a new state has been kept a minimum time).

This allows the sensor to be translated into a tracking state for automations, as input for other components or to easily display in HA UI.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** It could help in esphome/feature-requests#953

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1901

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
    binary_sensor:
      - platform: analog_threshold
        name: "Garage Door Opening"
        sensor_id: motor_current_sensor
        threshold: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
