### PR TITLE
CAN bus: support remote transmission request flag for canbus.send

### DIFF
--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -9,6 +9,7 @@ IS_PLATFORM_COMPONENT = True
 
 CONF_CAN_ID = "can_id"
 CONF_USE_EXTENDED_ID = "use_extended_id"
+CONF_REMOTE_TRANSMISSION_REQUEST = "remote_transmission_request"
 CONF_CANBUS_ID = "canbus_id"
 CONF_BIT_RATE = "bit_rate"
 CONF_ON_FRAME = "on_frame"
@@ -113,6 +114,7 @@ async def register_canbus(var, config):
             cv.GenerateID(CONF_CANBUS_ID): cv.use_id(CanbusComponent),
             cv.Optional(CONF_CAN_ID): cv.int_range(min=0, max=0x1FFFFFFF),
             cv.Optional(CONF_USE_EXTENDED_ID, default=False): cv.boolean,
+            cv.Optional(CONF_REMOTE_TRANSMISSION_REQUEST, default=False): cv.boolean,
             cv.Required(CONF_DATA): cv.templatable(validate_raw_data),
         },
         validate_id,
@@ -131,6 +133,11 @@ async def canbus_action_to_code(config, action_id, template_arg, args):
         config[CONF_USE_EXTENDED_ID], args, cg.uint32
     )
     cg.add(var.set_use_extended_id(use_extended_id))
+
+    remote_transmission_request = await cg.templatable(
+        config[CONF_REMOTE_TRANSMISSION_REQUEST], args, cg.uint32
+    )
+    cg.add(var.set_remote_transmission_request(remote_transmission_request))
 
     data = config[CONF_DATA]
     if isinstance(data, bytes):

--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -135,7 +135,7 @@ async def canbus_action_to_code(config, action_id, template_arg, args):
     cg.add(var.set_use_extended_id(use_extended_id))
 
     remote_transmission_request = await cg.templatable(
-        config[CONF_REMOTE_TRANSMISSION_REQUEST], args, cg.uint32
+        config[CONF_REMOTE_TRANSMISSION_REQUEST], args, bool
     )
     cg.add(var.set_remote_transmission_request(remote_transmission_request))
 

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -28,9 +28,9 @@ void Canbus::send_data(uint32_t can_id, bool use_extended_id, bool remote_transm
 
   uint8_t size = static_cast<uint8_t>(data.size());
   if (use_extended_id) {
-    ESP_LOGD(TAG, "send extended id=0x%08x rtr=%d size=%d", can_id, remote_transmission_request, size);
+    ESP_LOGD(TAG, "send extended id=0x%08x rtr=%s size=%d", can_id, TRUEFALSE(remote_transmission_request), size);
   } else {
-    ESP_LOGD(TAG, "send extended id=0x%03x rtr=%d size=%d", can_id, remote_transmission_request, size);
+    ESP_LOGD(TAG, "send extended id=0x%03x rtr=%s size=%d", can_id, TRUEFALSE(remote_transmission_request), size);
   }
   if (size > CAN_MAX_DATA_LENGTH)
     size = CAN_MAX_DATA_LENGTH;

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -22,7 +22,8 @@ void Canbus::dump_config() {
   }
 }
 
-void Canbus::send_data(uint32_t can_id, bool use_extended_id, bool remote_transmission_request, const std::vector<uint8_t> &data) {
+void Canbus::send_data(uint32_t can_id, bool use_extended_id, bool remote_transmission_request,
+                       const std::vector<uint8_t> &data) {
   struct CanFrame can_message;
 
   uint8_t size = static_cast<uint8_t>(data.size());

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -22,20 +22,21 @@ void Canbus::dump_config() {
   }
 }
 
-void Canbus::send_data(uint32_t can_id, bool use_extended_id, const std::vector<uint8_t> &data) {
+void Canbus::send_data(uint32_t can_id, bool use_extended_id, bool remote_transmission_request, const std::vector<uint8_t> &data) {
   struct CanFrame can_message;
 
   uint8_t size = static_cast<uint8_t>(data.size());
   if (use_extended_id) {
-    ESP_LOGD(TAG, "send extended id=0x%08x size=%d", can_id, size);
+    ESP_LOGD(TAG, "send extended id=0x%08x rtr=%d size=%d", can_id, remote_transmission_request, size);
   } else {
-    ESP_LOGD(TAG, "send extended id=0x%03x size=%d", can_id, size);
+    ESP_LOGD(TAG, "send extended id=0x%03x rtr=%d size=%d", can_id, remote_transmission_request, size);
   }
   if (size > CAN_MAX_DATA_LENGTH)
     size = CAN_MAX_DATA_LENGTH;
   can_message.can_data_length_code = size;
   can_message.can_id = can_id;
   can_message.use_extended_id = use_extended_id;
+  can_message.remote_transmission_request = remote_transmission_request;
 
   for (int i = 0; i < size; i++) {
     can_message.data[i] = data[i];

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -62,7 +62,7 @@ class Canbus : public Component {
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void loop() override;
 
-  void send_data(uint32_t can_id, bool use_extended_id, const std::vector<uint8_t> &data);
+  void send_data(uint32_t can_id, bool use_extended_id, bool remote_transmission_request, const std::vector<uint8_t> &data);
   void set_can_id(uint32_t can_id) { this->can_id_ = can_id; }
   void set_use_extended_id(bool use_extended_id) { this->use_extended_id_ = use_extended_id; }
   void set_bitrate(CanSpeed bit_rate) { this->bit_rate_ = bit_rate; }
@@ -96,21 +96,24 @@ template<typename... Ts> class CanbusSendAction : public Action<Ts...>, public P
 
   void set_use_extended_id(bool use_extended_id) { this->use_extended_id_ = use_extended_id; }
 
+  void set_remote_transmission_request(bool remote_transmission_request) { this->remote_transmission_request_ = remote_transmission_request; }
+
   void play(Ts... x) override {
     auto can_id = this->can_id_.has_value() ? *this->can_id_ : this->parent_->can_id_;
     auto use_extended_id =
         this->use_extended_id_.has_value() ? *this->use_extended_id_ : this->parent_->use_extended_id_;
     if (this->static_) {
-      this->parent_->send_data(can_id, use_extended_id, this->data_static_);
+      this->parent_->send_data(can_id, use_extended_id, this->remote_transmission_request_, this->data_static_);
     } else {
       auto val = this->data_func_(x...);
-      this->parent_->send_data(can_id, use_extended_id, val);
+      this->parent_->send_data(can_id, use_extended_id, this->remote_transmission_request_, val);
     }
   }
 
  protected:
   optional<uint32_t> can_id_{};
   optional<bool> use_extended_id_{};
+  bool remote_transmission_request_{false};
   bool static_{false};
   std::function<std::vector<uint8_t>(Ts...)> data_func_{};
   std::vector<uint8_t> data_static_{};

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -62,7 +62,8 @@ class Canbus : public Component {
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void loop() override;
 
-  void send_data(uint32_t can_id, bool use_extended_id, bool remote_transmission_request, const std::vector<uint8_t> &data);
+  void send_data(uint32_t can_id, bool use_extended_id, bool remote_transmission_request,
+                 const std::vector<uint8_t> &data);
   void set_can_id(uint32_t can_id) { this->can_id_ = can_id; }
   void set_use_extended_id(bool use_extended_id) { this->use_extended_id_ = use_extended_id; }
   void set_bitrate(CanSpeed bit_rate) { this->bit_rate_ = bit_rate; }
@@ -96,7 +97,9 @@ template<typename... Ts> class CanbusSendAction : public Action<Ts...>, public P
 
   void set_use_extended_id(bool use_extended_id) { this->use_extended_id_ = use_extended_id; }
 
-  void set_remote_transmission_request(bool remote_transmission_request) { this->remote_transmission_request_ = remote_transmission_request; }
+  void set_remote_transmission_request(bool remote_transmission_request) {
+    this->remote_transmission_request_ = remote_transmission_request;
+  }
 
   void play(Ts... x) override {
     auto can_id = this->can_id_.has_value() ? *this->can_id_ : this->parent_->can_id_;

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -64,6 +64,10 @@ class Canbus : public Component {
 
   void send_data(uint32_t can_id, bool use_extended_id, bool remote_transmission_request,
                  const std::vector<uint8_t> &data);
+  void send_data(uint32_t can_id, bool use_extended_id, const std::vector<uint8_t> &data) {
+    // for backwards compatibility only
+    this->send_data(can_id, use_extended_id, false, data);
+  }
   void set_can_id(uint32_t can_id) { this->can_id_ = can_id; }
   void set_use_extended_id(bool use_extended_id) { this->use_extended_id_ = use_extended_id; }
   void set_bitrate(CanSpeed bit_rate) { this->bit_rate_ = bit_rate; }

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2499,6 +2499,16 @@ text_sensor:
           canbus_id: esp32_internal_can
           can_id: 23
           data: [0x10, 0x20, 0x30]
+      - canbus.send:
+          canbus_id: mcp2515_can
+          can_id: 24
+          remote_transmission_request: true
+          data: []
+      - canbus.send:
+          canbus_id: esp32_internal_can
+          can_id: 24
+          remote_transmission_request: true
+          data: []
   - platform: template
     name: Template Text Sensor
     id: ${textname}_text


### PR DESCRIPTION
# What does this implement/fix? 

Support remote transmission request flag for sending CAN bus messages. The CAN bus component already supports the flag in its internal structures but it has not been available for use from outside yet.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1948

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
on_...:
  - canbus.send:
      can_id: 24
      remote_transmission_request: true
      data: []
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
