### PR TITLE
CAN bus: make global can_id optional

### DIFF
--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -65,7 +65,7 @@ CAN_SPEEDS = {
 CANBUS_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(CanbusComponent),
-        cv.Required(CONF_CAN_ID): cv.int_range(min=0, max=0x1FFFFFFF),
+        cv.Optional(CONF_CAN_ID, default=0): cv.int_range(min=0, max=0x1FFFFFFF),
         cv.Optional(CONF_BIT_RATE, default="125KBPS"): cv.enum(CAN_SPEEDS, upper=True),
         cv.Optional(CONF_USE_EXTENDED_ID, default=False): cv.boolean,
         cv.Optional(CONF_ON_FRAME): automation.validate_automation(


### PR DESCRIPTION
# What does this implement/fix? 

Make CAN bus global can_id optional as it's not necessary/really helpful in case of receiving messages only or when sending with multiple different CAN ids.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1948

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). => n/a
  
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
