### PR TITLE
Allow framework version validator to be maximum version 

### DIFF
--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -49,9 +49,9 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     _validate,
-    cv.only_with_arduino,
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 7, 4),
+        esp32_arduino=cv.Version(99, 0, 0),
         max_version=True,
         extra_message="Please see note on documentation for FastLED",
     ),

--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -50,6 +50,11 @@ CONFIG_SCHEMA = cv.All(
     ),
     _validate,
     cv.only_with_arduino,
+    cv.require_framework_version(
+        esp8266_arduino=cv.Version(2, 7, 4),
+        max_version=True,
+        extra_message="Please see note on documentation for FastLED",
+    ),
 )
 
 

--- a/esphome/components/fastled_spi/light.py
+++ b/esphome/components/fastled_spi/light.py
@@ -33,7 +33,12 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DATA_RATE): cv.frequency,
         }
     ),
-    cv.only_with_arduino,
+    cv.require_framework_version(
+        esp8266_arduino=cv.Version(2, 7, 4),
+        esp32_arduino=cv.Version(99, 0, 0),
+        max_version=True,
+        extra_message="Please see note on documentation for FastLED",
+    ),
 )
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1713,30 +1713,49 @@ def require_framework_version(
     esp_idf=None,
     esp32_arduino=None,
     esp8266_arduino=None,
+    max_version=False,
+    extra_message=None,
 ):
     def validator(value):
         core_data = CORE.data[KEY_CORE]
         framework = core_data[KEY_TARGET_FRAMEWORK]
         if framework == "esp-idf":
             if esp_idf is None:
-                raise Invalid("This feature is incompatible with esp-idf")
+                msg = "This feature is incompatible with esp-idf"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
             required = esp_idf
         elif CORE.is_esp32 and framework == "arduino":
             if esp32_arduino is None:
-                raise Invalid(
-                    "This feature is incompatible with ESP32 using arduino framework"
-                )
+                msg = "This feature is incompatible with ESP32 using arduino framework"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
             required = esp32_arduino
         elif CORE.is_esp8266 and framework == "arduino":
             if esp8266_arduino is None:
-                raise Invalid("This feature is incompatible with ESP8266")
+                msg = "This feature is incompatible with ESP8266"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
             required = esp8266_arduino
         else:
             raise NotImplementedError
+
+        if max_version:
+            if core_data[KEY_FRAMEWORK_VERSION] > required:
+                msg = f"This feature requires framework version {required} or lower"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
+            return value
+
         if core_data[KEY_FRAMEWORK_VERSION] < required:
-            raise Invalid(
-                f"This feature requires at least framework version {required}"
-            )
+            msg = f"This feature requires at least framework version {required}"
+            if extra_message:
+                msg += f". {extra_message}"
+            raise Invalid(msg)
         return value
 
     return validator


### PR DESCRIPTION
# What does this implement/fix? 

FastLED seems to be incompatable with Arduino ESP8266 v3+
- https://github.com/FastLED/FastLED/issues/1322
- https://github.com/FastLED/FastLED/issues/1264

So this extension adds to the validator to allow blocking components on newer framework versions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1905

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
