### PR TITLE
2022.2.0b2

### DIFF
--- a/esphome/components/esp32/post_build.py.script
+++ b/esphome/components/esp32/post_build.py.script
@@ -1,13 +1,16 @@
 # Source https://github.com/letscontrolit/ESPEasy/pull/3845#issuecomment-1005864664
 
 import esptool
+from SCons.Script import ARGUMENTS
 
 # pylint: disable=E0602
 Import("env")  # noqa
 
 
 def esp32_create_combined_bin(source, target, env):
-    print("Generating combined binary for serial flashing")
+    verbose = bool(int(ARGUMENTS.get("PIOVERBOSE", "0")))
+    if verbose:
+        print("Generating combined binary for serial flashing")
     app_offset = 0x10000
 
     new_file_name = env.subst("$BUILD_DIR/${PROGNAME}-factory.bin")
@@ -24,18 +27,21 @@ def esp32_create_combined_bin(source, target, env):
         "--flash_size",
         flash_size,
     ]
-    print("    Offset | File")
+    if verbose:
+        print("    Offset | File")
     for section in sections:
         sect_adr, sect_file = section.split(" ", 1)
-        print(f" -  {sect_adr} | {sect_file}")
+        if verbose:
+            print(f" -  {sect_adr} | {sect_file}")
         cmd += [sect_adr, sect_file]
 
-    print(f" - {hex(app_offset)} | {firmware_name}")
     cmd += [hex(app_offset), firmware_name]
 
-    print()
-    print(f"Using esptool.py arguments: {' '.join(cmd)}")
-    print()
+    if verbose:
+        print(f" - {hex(app_offset)} | {firmware_name}")
+        print()
+        print(f"Using esptool.py arguments: {' '.join(cmd)}")
+        print()
     esptool.main(cmd)
 
 

--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -49,7 +49,12 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     _validate,
-    cv.only_with_arduino,
+    cv.require_framework_version(
+        esp8266_arduino=cv.Version(2, 7, 4),
+        esp32_arduino=cv.Version(99, 0, 0),
+        max_version=True,
+        extra_message="Please see note on documentation for FastLED",
+    ),
 )
 
 

--- a/esphome/components/fastled_spi/light.py
+++ b/esphome/components/fastled_spi/light.py
@@ -33,7 +33,12 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DATA_RATE): cv.frequency,
         }
     ),
-    cv.only_with_arduino,
+    cv.require_framework_version(
+        esp8266_arduino=cv.Version(2, 7, 4),
+        esp32_arduino=cv.Version(99, 0, 0),
+        max_version=True,
+        extra_message="Please see note on documentation for FastLED",
+    ),
 )
 
 

--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -138,6 +138,8 @@ void RotaryEncoderSensor::setup() {
       initial_value = 0;
       break;
   }
+  initial_value = clamp(initial_value, this->store_.min_value, this->store_.max_value);
+
   this->store_.counter = initial_value;
   this->store_.last_read = initial_value;
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1713,30 +1713,49 @@ def require_framework_version(
     esp_idf=None,
     esp32_arduino=None,
     esp8266_arduino=None,
+    max_version=False,
+    extra_message=None,
 ):
     def validator(value):
         core_data = CORE.data[KEY_CORE]
         framework = core_data[KEY_TARGET_FRAMEWORK]
         if framework == "esp-idf":
             if esp_idf is None:
-                raise Invalid("This feature is incompatible with esp-idf")
+                msg = "This feature is incompatible with esp-idf"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
             required = esp_idf
         elif CORE.is_esp32 and framework == "arduino":
             if esp32_arduino is None:
-                raise Invalid(
-                    "This feature is incompatible with ESP32 using arduino framework"
-                )
+                msg = "This feature is incompatible with ESP32 using arduino framework"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
             required = esp32_arduino
         elif CORE.is_esp8266 and framework == "arduino":
             if esp8266_arduino is None:
-                raise Invalid("This feature is incompatible with ESP8266")
+                msg = "This feature is incompatible with ESP8266"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
             required = esp8266_arduino
         else:
             raise NotImplementedError
+
+        if max_version:
+            if core_data[KEY_FRAMEWORK_VERSION] > required:
+                msg = f"This feature requires framework version {required} or lower"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
+            return value
+
         if core_data[KEY_FRAMEWORK_VERSION] < required:
-            raise Invalid(
-                f"This feature requires at least framework version {required}"
-            )
+            msg = f"This feature requires at least framework version {required}"
+            if extra_message:
+                msg += f". {extra_message}"
+            raise Invalid(msg)
         return value
 
     return validator

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2022.2.0b1"
+__version__ = "2022.2.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ platformio==5.2.4  # When updating platformio, also update Dockerfile
 esptool==3.2
 click==8.0.3
 esphome-dashboard==20220209.0
-aioesphomeapi==10.8.1
+aioesphomeapi==10.8.2
 zeroconf==0.37.0
 
 # esp-idf requires this, but doesn't bundle it by default


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"I don’t care if it works on your machine! We are not shipping your machine!"_

~ Ovidiu Platon
- Bump aioesphomeapi from 10.8.1 to 10.8.2 [esphome#3182](https://github.com/esphome/esphome/pull/3182)
- Clamp rotary_encoder restored value to min and max [esphome#3184](https://github.com/esphome/esphome/pull/3184)
- Make generating combined binary output verbose [esphome#3127](https://github.com/esphome/esphome/pull/3127)
- Allow framework version validator to be maximum version  [esphome#3197](https://github.com/esphome/esphome/pull/3197) (breaking-change)
