### PR TITLE
Docker move deps install into base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,11 @@
 # One of "docker", "hassio"
 ARG BASEIMGTYPE=docker
 
+# https://github.com/hassio-addons/addon-debian-base/releases
 FROM ghcr.io/hassio-addons/debian-base/amd64:5.2.3 AS base-hassio-amd64
 FROM ghcr.io/hassio-addons/debian-base/aarch64:5.2.3 AS base-hassio-arm64
 FROM ghcr.io/hassio-addons/debian-base/armv7:5.2.3 AS base-hassio-armv7
+# https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye
 FROM debian:bullseye-20220125-slim AS base-docker-amd64
 FROM debian:bullseye-20220125-slim AS base-docker-arm64
 FROM debian:bullseye-20220125-slim AS base-docker-armv7
@@ -52,15 +54,15 @@ RUN \
     && mkdir -p /piolibs
 
 
-
-# ======================= docker-type image =======================
-FROM base AS docker
-
 # First install requirements to leverage caching when requirements don't change
 COPY requirements.txt requirements_optional.txt docker/platformio_install_deps.py platformio.ini /
 RUN \
     pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
     && /platformio_install_deps.py /platformio.ini
+
+
+# ======================= docker-type image =======================
+FROM base AS docker
 
 # Copy esphome and install
 COPY . /esphome
@@ -104,12 +106,6 @@ ARG BUILD_VERSION=dev
 # Copy root filesystem
 COPY docker/ha-addon-rootfs/ /
 
-# First install requirements to leverage caching when requirements don't change
-COPY requirements.txt requirements_optional.txt docker/platformio_install_deps.py platformio.ini /
-RUN \
-    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
-    && /platformio_install_deps.py /platformio.ini
-
 # Copy esphome and install
 COPY . /esphome
 RUN pip3 install --no-cache-dir --no-use-pep517 -e /esphome
@@ -147,10 +143,8 @@ RUN \
         /var/{cache,log}/* \
         /var/lib/apt/lists/*
 
-COPY requirements.txt requirements_optional.txt requirements_test.txt docker/platformio_install_deps.py platformio.ini /
-RUN \
-    pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt -r /requirements_test.txt \
-    && /platformio_install_deps.py /platformio.ini
+COPY requirements_test.txt /
+RUN pip3 install --no-cache-dir -r /requirements_test.txt
 
 VOLUME ["/esphome"]
 WORKDIR /esphome


### PR DESCRIPTION
# What does this implement/fix? 

Looking at the past publish release workflows it seems that the `pip3 install` and `/platformio_install_deps.py` layers aren't cached. I'm assuming this is because those are in substages of the multistage dockerfile.

Move those steps to the base file to get better caching.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
