### PR TITLE
Set entity-category to diagnostic for debug component

### DIFF
--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_FRAGMENTATION,
     CONF_BLOCK,
     CONF_LOOP_TIME,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     UNIT_MILLISECOND,
     UNIT_PERCENT,
     UNIT_BYTES,
@@ -18,14 +19,34 @@ DEPENDENCIES = ["debug"]
 
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_DEBUG_ID): cv.use_id(DebugComponent),
-    cv.Optional(CONF_FREE): sensor.sensor_schema(UNIT_BYTES, ICON_COUNTER, 0),
-    cv.Optional(CONF_BLOCK): sensor.sensor_schema(UNIT_BYTES, ICON_COUNTER, 0),
+    cv.Optional(CONF_FREE): sensor.sensor_schema(
+        unit_of_measurement=UNIT_BYTES,
+        icon=ICON_COUNTER,
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    cv.Optional(CONF_BLOCK): sensor.sensor_schema(
+        unit_of_measurement=UNIT_BYTES,
+        icon=ICON_COUNTER,
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
     cv.Optional(CONF_FRAGMENTATION): cv.All(
         cv.only_on_esp8266,
         cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
-        sensor.sensor_schema(UNIT_PERCENT, ICON_COUNTER, 1),
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            icon=ICON_COUNTER,
+            accuracy_decimals=1,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        )
     ),
-    cv.Optional(CONF_LOOP_TIME): sensor.sensor_schema(UNIT_MILLISECOND, ICON_TIMER, 0),
+    cv.Optional(CONF_LOOP_TIME): sensor.sensor_schema(
+        unit_of_measurement=UNIT_MILLISECOND,
+        icon=ICON_TIMER,
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
 }
 
 

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = {
             icon=ICON_COUNTER,
             accuracy_decimals=1,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        )
+        ),
     ),
     cv.Optional(CONF_LOOP_TIME): sensor.sensor_schema(
         unit_of_measurement=UNIT_MILLISECOND,

--- a/esphome/components/debug/text_sensor.py
+++ b/esphome/components/debug/text_sensor.py
@@ -11,7 +11,9 @@ DEPENDENCIES = ["debug"]
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_DEBUG_ID): cv.use_id(DebugComponent),
-        cv.Optional(CONF_DEVICE): text_sensor.text_sensor_schema(entity_category=ENTITY_CATEGORY_DIAGNOSTIC),
+        cv.Optional(CONF_DEVICE): text_sensor.text_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+        ),
     }
 )
 

--- a/esphome/components/debug/text_sensor.py
+++ b/esphome/components/debug/text_sensor.py
@@ -1,7 +1,7 @@
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import CONF_DEVICE
+from esphome.const import CONF_DEVICE, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_DEBUG_ID, DebugComponent
 
@@ -11,7 +11,7 @@ DEPENDENCIES = ["debug"]
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_DEBUG_ID): cv.use_id(DebugComponent),
-        cv.Optional(CONF_DEVICE): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_DEVICE): text_sensor.text_sensor_schema(entity_category=ENTITY_CATEGORY_DIAGNOSTIC),
     }
 )
 


### PR DESCRIPTION
# What does this implement/fix? 

Adds entity-category "diagnostic" to the debug component so values appear in the right place within Home Assistant.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
