### PR TITLE
Fix pm1006 polling component definition

### DIFF
--- a/esphome/components/pm1006/sensor.py
+++ b/esphome/components/pm1006/sensor.py
@@ -16,7 +16,9 @@ CODEOWNERS = ["@habbie"]
 DEPENDENCIES = ["uart"]
 
 pm1006_ns = cg.esphome_ns.namespace("pm1006")
-PM1006Component = pm1006_ns.class_("PM1006Component", uart.UARTDevice, cg.PollingComponent)
+PM1006Component = pm1006_ns.class_(
+    "PM1006Component", uart.UARTDevice, cg.PollingComponent
+)
 
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/pm1006/sensor.py
+++ b/esphome/components/pm1006/sensor.py
@@ -16,7 +16,7 @@ CODEOWNERS = ["@habbie"]
 DEPENDENCIES = ["uart"]
 
 pm1006_ns = cg.esphome_ns.namespace("pm1006")
-PM1006Component = pm1006_ns.class_("PM1006Component", uart.UARTDevice, cg.Component)
+PM1006Component = pm1006_ns.class_("PM1006Component", uart.UARTDevice, cg.PollingComponent)
 
 
 CONFIG_SCHEMA = cv.All(


### PR DESCRIPTION
# Fix pm1006 polling component definition

pm1006 is polling component (see https://github.com/esphome/esphome/blob/dev/esphome/components/pm1006/pm1006.h), this PR fix definition so we can use component.update

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  rx_pin: GPIO16
  tx_pin: GPIO17
  baud_rate: 9600

sensor:
  - platform: pm1006
    id: pm1006_sensor
    update_interval: never
    pm_2_5:
      id: pm2_5_value

interval:
  - interval: 60s
    then:
      - component.update: pm1006_sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
