### PR TITLE
Add LONG LONG flag for arduinojson

### DIFF
--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -4,8 +4,9 @@
 
 #include "esphome/core/helpers.h"
 
-#undef ARDUINOJSON_ENABLE_STD_STRING
 #define ARDUINOJSON_ENABLE_STD_STRING 1  // NOLINT
+
+#define ARDUINOJSON_USE_LONG_LONG 1  // NOLINT
 
 #include <ArduinoJson.h>
 


### PR DESCRIPTION
# What does this implement/fix? 

As reported on Discord, putting a timestamp into json on Arduino 3+ for ESP8266 no longer works as I believe that `time_t` has changed to be 64-bit size with the underlying toolchain update.

This flag adds 64 bytes to the binary of ESP8266, and 40 bytes to the binary of ESP32.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
