### PR TITLE
Remove redundant name from binary_sensor constructor

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -22,7 +22,6 @@ from esphome.const import (
     CONF_STATE,
     CONF_TIMING,
     CONF_TRIGGER_ID,
-    CONF_NAME,
     CONF_MQTT_ID,
     DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_BATTERY,
@@ -443,7 +442,7 @@ async def register_binary_sensor(var, config):
 
 
 async def new_binary_sensor(config):
-    var = cg.new_Pvariable(config[CONF_ID], config[CONF_NAME])
+    var = cg.new_Pvariable(config[CONF_ID])
     await register_binary_sensor(var, config)
     return var
 

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -42,8 +42,7 @@ void BinarySensor::send_state_internal(bool state, bool is_initial) {
   }
 }
 std::string BinarySensor::device_class() { return ""; }
-BinarySensor::BinarySensor(const std::string &name) : EntityBase(name), state(false) {}
-BinarySensor::BinarySensor() : BinarySensor("") {}
+BinarySensor::BinarySensor() : state(false) {}
 void BinarySensor::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
 std::string BinarySensor::get_device_class() {
   if (this->device_class_.has_value())

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -26,11 +26,6 @@ namespace binary_sensor {
 class BinarySensor : public EntityBase {
  public:
   explicit BinarySensor();
-  /** Construct a binary sensor with the specified name
-   *
-   * @param name Name of this binary sensor.
-   */
-  explicit BinarySensor(const std::string &name);
 
   /** Add a callback to be notified of state changes.
    *


### PR DESCRIPTION
# What does this implement/fix? 

`name` is set in the `setup_entity` common function for all EntityBase classes, so having a name in a constructor is completely redundant as it will be set in codegen again later.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
