### PR TITLE
Docker ha-addon switch to nginx-light

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,7 +95,7 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        nginx=1.18.0-6.1 \
+        nginx-light=1.18.0-6.1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \


### PR DESCRIPTION
# What does this implement/fix? 

`nginx` means install [nginx-core](https://packages.debian.org/bullseye/nginx-core), which itself depends on a whole bunch of stuff we don't need (including libx11!!)

```
 The following additional packages will be installed:
   fontconfig-config fonts-dejavu-core iproute2 libbpf0 libelf1 libfontconfig1
   libgd3 libgeoip1 libicu67 libmnl0 libnginx-mod-http-geoip
   libnginx-mod-http-image-filter libnginx-mod-http-xslt-filter
   libnginx-mod-mail libnginx-mod-stream libnginx-mod-stream-geoip libx11-6
   libx11-data libxml2 libxpm4 libxslt1.1 libxtables12 nginx-common nginx-core
   sensible-utils ucf
```

We don't use those features, so instead use [nginx-light](https://packages.debian.org/bullseye/nginx-light)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
