### PR TITLE
Fix lilygo touchscreen rotation

### DIFF
--- a/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
+++ b/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
@@ -113,8 +113,27 @@ void LilygoT547Touchscreen::loop() {
       if (tp.state == 0x06)
         tp.state = 0x07;
 
-      tp.y = (uint16_t)((buffer[i * 5 + 1 + offset] << 4) | ((buffer[i * 5 + 3 + offset] >> 4) & 0x0F));
-      tp.x = (uint16_t)((buffer[i * 5 + 2 + offset] << 4) | (buffer[i * 5 + 3 + offset] & 0x0F));
+      uint16_t y = (uint16_t)((buffer[i * 5 + 1 + offset] << 4) | ((buffer[i * 5 + 3 + offset] >> 4) & 0x0F));
+      uint16_t x = (uint16_t)((buffer[i * 5 + 2 + offset] << 4) | (buffer[i * 5 + 3 + offset] & 0x0F));
+
+      switch (this->rotation_) {
+        case ROTATE_0_DEGREES:
+          tp.y = this->display_height_ - y;
+          tp.x = x;
+          break;
+        case ROTATE_90_DEGREES:
+          tp.x = this->display_height_ - y;
+          tp.y = this->display_width_ - x;
+          break;
+        case ROTATE_180_DEGREES:
+          tp.y = y;
+          tp.x = this->display_width_ - x;
+          break;
+        case ROTATE_270_DEGREES:
+          tp.x = y;
+          tp.y = x;
+          break;
+      }
 
       this->defer([this, tp]() { this->send_touch_(tp); });
     }
@@ -122,8 +141,28 @@ void LilygoT547Touchscreen::loop() {
     TouchPoint tp;
     tp.id = (buffer[0] >> 4) & 0x0F;
     tp.state = 0x06;
-    tp.y = (uint16_t)((buffer[0 * 5 + 1] << 4) | ((buffer[0 * 5 + 3] >> 4) & 0x0F));
-    tp.x = (uint16_t)((buffer[0 * 5 + 2] << 4) | (buffer[0 * 5 + 3] & 0x0F));
+
+    uint16_t y = (uint16_t)((buffer[0 * 5 + 1] << 4) | ((buffer[0 * 5 + 3] >> 4) & 0x0F));
+    uint16_t x = (uint16_t)((buffer[0 * 5 + 2] << 4) | (buffer[0 * 5 + 3] & 0x0F));
+
+    switch (this->rotation_) {
+      case ROTATE_0_DEGREES:
+        tp.y = this->display_height_ - y;
+        tp.x = x;
+        break;
+      case ROTATE_90_DEGREES:
+        tp.x = this->display_height_ - y;
+        tp.y = this->display_width_ - x;
+        break;
+      case ROTATE_180_DEGREES:
+        tp.y = y;
+        tp.x = this->display_width_ - x;
+        break;
+      case ROTATE_270_DEGREES:
+        tp.x = y;
+        tp.y = x;
+        break;
+    }
 
     this->defer([this, tp]() { this->send_touch_(tp); });
   }


### PR DESCRIPTION
# What does this implement/fix? 

I forgot to do the rotation part for lilygo t5 4.7 touchscreens before merging #3084 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
