### PR TITLE
Restore brightness when restore_mode: ALWAYS_OFF

### DIFF
--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -49,12 +49,12 @@ void LightState::setup() {
 
   auto call = this->make_call();
   LightStateRTCState recovered{};
+  this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
   switch (this->restore_mode_) {
     case LIGHT_RESTORE_DEFAULT_OFF:
     case LIGHT_RESTORE_DEFAULT_ON:
     case LIGHT_RESTORE_INVERTED_DEFAULT_OFF:
     case LIGHT_RESTORE_INVERTED_DEFAULT_ON:
-      this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_object_id_hash());
       // Attempt to load from preferences, else fall back to default values
       if (!this->rtc_.load(&recovered)) {
         recovered.state = false;
@@ -69,9 +69,11 @@ void LightState::setup() {
       }
       break;
     case LIGHT_ALWAYS_OFF:
+      this->rtc_.load(&recovered);
       recovered.state = false;
       break;
     case LIGHT_ALWAYS_ON:
+      this->rtc_.load(&recovered);
       recovered.state = true;
       break;
   }


### PR DESCRIPTION
Restore brightness when restore_mode: ALWAYS_ON || ALWAYS_OFF

# What does this implement/fix? 

Fix reset brightness at 100% after reboot/poweroff esp when restore_mode: ALWAYS_ON || ALWAYS_OFF

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
