### PR TITLE
Improve ESP8266 iram usage

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -116,7 +116,7 @@ optional<uint32_t> HOT Scheduler::next_schedule_in() {
     return 0;
   return next_time - now;
 }
-void IRAM_ATTR HOT Scheduler::call() {
+void HOT Scheduler::call() {
   const uint32_t now = this->millis_();
   this->process_to_add();
 


### PR DESCRIPTION
# What does this implement/fix? 

The `::call` function takes up ~1kb of IRAM, which is just enough to go over the limit in https://github.com/esphome/issues/issues/3050

Shouldn't really be a problem since if it's called often it will be in the cache anyways.

Fixes https://github.com/esphome/issues/issues/3050 - all other bigger IRAM symbols are from arduino framework itself, so the only option for those cases would be to change the IRAM setup as described [here](https://docs.platformio.org/en/stable/platforms/espressif8266.html#mmu-adjusting-icache-to-iram-ratio).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
