### PR TITLE
Fix ESP8266 climate memaccess warning

### DIFF
--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -1,4 +1,5 @@
 #include "climate.h"
+#include "esphome/core/macros.h"
 
 namespace esphome {
 namespace climate {
@@ -326,14 +327,16 @@ optional<ClimateDeviceRestoreState> Climate::restore_state_() {
   return recovered;
 }
 void Climate::save_state_() {
-#if defined(USE_ESP_IDF) && !defined(CLANG_TIDY)
+#if (defined(USE_ESP_IDF) || (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0))) && !defined(CLANG_TIDY)
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
+#define TEMP_IGNORE_MEMACCESS
 #endif
   ClimateDeviceRestoreState state{};
   // initialize as zero to prevent random data on stack triggering erase
   memset(&state, 0, sizeof(ClimateDeviceRestoreState));
-#if USE_ESP_IDF && !defined(CLANG_TIDY)
+#if TEMP_IGNORE_MEMACCESS
 #pragma GCC diagnostic pop
+#unset TEMP_IGNORE_MEMACCESS
 #endif
 
   state.mode = this->mode;

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -334,7 +334,7 @@ void Climate::save_state_() {
   ClimateDeviceRestoreState state{};
   // initialize as zero to prevent random data on stack triggering erase
   memset(&state, 0, sizeof(ClimateDeviceRestoreState));
-#if TEMP_IGNORE_MEMACCESS
+#ifdef TEMP_IGNORE_MEMACCESS
 #pragma GCC diagnostic pop
 #undef TEMP_IGNORE_MEMACCESS
 #endif

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -327,7 +327,8 @@ optional<ClimateDeviceRestoreState> Climate::restore_state_() {
   return recovered;
 }
 void Climate::save_state_() {
-#if (defined(USE_ESP_IDF) || (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0))) && !defined(CLANG_TIDY)
+#if (defined(USE_ESP_IDF) || (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0))) && \
+    !defined(CLANG_TIDY)
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #define TEMP_IGNORE_MEMACCESS
 #endif

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -336,7 +336,7 @@ void Climate::save_state_() {
   memset(&state, 0, sizeof(ClimateDeviceRestoreState));
 #if TEMP_IGNORE_MEMACCESS
 #pragma GCC diagnostic pop
-#unset TEMP_IGNORE_MEMACCESS
+#undef TEMP_IGNORE_MEMACCESS
 #endif
 
   state.mode = this->mode;


### PR DESCRIPTION
# What does this implement/fix? 

Fixes https://github.com/esphome/issues/issues/3053

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
