### PR TITLE
support for waveshare 7.50in-hd-b

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -50,6 +50,9 @@ WaveshareEPaper7P5InBV2 = waveshare_epaper_ns.class_(
 WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2", WaveshareEPaper
 )
+WaveshareEPaper7P5InHDB = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P5InHDB", WaveshareEPaper
+)
 WaveshareEPaper2P13InDKE = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P13InDKE", WaveshareEPaper
 )
@@ -76,6 +79,7 @@ MODELS = {
     "7.50in-bv2": ("b", WaveshareEPaper7P5InBV2),
     "7.50in-bc": ("b", WaveshareEPaper7P5InBC),
     "7.50inv2": ("b", WaveshareEPaper7P5InV2),
+    "7.50in-hd-b": ("b", WaveshareEPaper7P5InHDB),
     "2.13in-ttgo-dke": ("c", WaveshareEPaper2P13InDKE),
 }
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1240,6 +1240,113 @@ void WaveshareEPaper7P5InBC::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
+   
+void WaveshareEPaper7P5InHDB::initialize() {
+  this->command(0x12); 		  //SWRESET
+
+  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x46);  // Auto Write RAM
+  this->data(0xF7);
+
+  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x47);  // Auto Write RAM
+  this->data(0xF7);
+
+  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x0C);  // Soft start setting
+  this->data(0xAE);
+  this->data(0xC7);
+  this->data(0xC3);
+  this->data(0xC0);
+  this->data(0x40);
+
+  this->command(0x01);  // Set MUX as 527
+  this->data(0xAF);
+  this->data(0x02);
+  this->data(0x01);
+
+  this->command(0x11);  // Data entry mode
+  this->data(0x01);
+
+  this->command(0x44);
+  this->data(0x00); // RAM x address start at 0
+  this->data(0x00);
+  this->data(0x6F); // RAM x address end at 36Fh -> 879
+  this->data(0x03);
+
+  this->command(0x45);
+  this->data(0xAF); // RAM y address start at 20Fh;
+  this->data(0x02);
+  this->data(0x00); // RAM y address end at 00h;
+  this->data(0x00);
+
+  this->command(0x3C); // VBD
+  this->data(0x01); // LUT1, for white
+
+  this->command(0x18);
+  this->data(0X80);
+
+  this->command(0x22);
+  this->data(0XB1);	//Load Temperature and waveform setting.
+
+  this->command(0x20);
+
+  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x4E);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0x4F);
+  this->data(0xAF);
+  this->data(0x02);
+}
+
+void HOT WaveshareEPaper7P5InHDB::display() {
+  this->command(0x4F);
+  this->data(0xAf);
+  this->data(0x02);
+
+  // BLACK
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // comment from Waveshare code
+  // this->wait_until_idle_();
+  // this->command(0x4F);
+  // this->data(0xAf);
+  // this->data(0x02);
+
+  // RED
+  this->command(0x26);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0x00);
+  this->end_data_();
+
+  this->command(0x22);
+  this->data(0xC7);
+  this->command(0x20);
+  delay(100);
+}
+
+int WaveshareEPaper7P5InHDB::get_width_internal() { return 880; }
+
+int WaveshareEPaper7P5InHDB::get_height_internal() { return 528; }
+
+void WaveshareEPaper7P5InHDB::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-HD-b");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
 
 static const uint8_t LUT_SIZE_TTGO_DKE_PART = 153;
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1242,59 +1242,59 @@ void WaveshareEPaper7P5InBC::dump_config() {
 }
 
 void WaveshareEPaper7P5InHDB::initialize() {
-  this->command(0x12);       //SWRESET
+  this->command(0x12);  // SWRESET
 
-  this->wait_until_idle_();  //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
 
-  this->command(0x46);       // Auto Write RAM
+  this->command(0x46);  // Auto Write RAM
   this->data(0xF7);
 
-  this->wait_until_idle_();  //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
 
-  this->command(0x47);       // Auto Write RAM
+  this->command(0x47);  // Auto Write RAM
   this->data(0xF7);
 
-  this->wait_until_idle_();  //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
 
-  this->command(0x0C);       // Soft start setting
+  this->command(0x0C);  // Soft start setting
   this->data(0xAE);
   this->data(0xC7);
   this->data(0xC3);
   this->data(0xC0);
   this->data(0x40);
 
-  this->command(0x01);       // Set MUX as 527
+  this->command(0x01);  // Set MUX as 527
   this->data(0xAF);
   this->data(0x02);
   this->data(0x01);
 
-  this->command(0x11);       // Data entry mode
+  this->command(0x11);  // Data entry mode
   this->data(0x01);
 
   this->command(0x44);
-  this->data(0x00);          // RAM x address start at 0
+  this->data(0x00);  // RAM x address start at 0
   this->data(0x00);
-  this->data(0x6F);          // RAM x address end at 36Fh -> 879
+  this->data(0x6F);  // RAM x address end at 36Fh -> 879
   this->data(0x03);
 
   this->command(0x45);
-  this->data(0xAF);         // RAM y address start at 20Fh;
+  this->data(0xAF);  // RAM y address start at 20Fh;
   this->data(0x02);
-  this->data(0x00);         // RAM y address end at 00h;
+  this->data(0x00);  // RAM y address end at 00h;
   this->data(0x00);
 
-  this->command(0x3C);      // VBD
-  this->data(0x01);         // LUT1, for white
+  this->command(0x3C);  // VBD
+  this->data(0x01);     // LUT1, for white
 
   this->command(0x18);
   this->data(0X80);
 
   this->command(0x22);
-  this->data(0XB1);         //Load Temperature and waveform setting.
+  this->data(0XB1);  // Load Temperature and waveform setting.
 
   this->command(0x20);
 
-  this->wait_until_idle_(); //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
 
   this->command(0x4E);
   this->data(0x00);
@@ -1332,7 +1332,7 @@ void HOT WaveshareEPaper7P5InHDB::display() {
   this->command(0x22);
   this->data(0xC7);
   this->command(0x20);
-  delay(100); // NOLINT
+  delay(100);  // NOLINT
 }
 
 int WaveshareEPaper7P5InHDB::get_width_internal() { return 880; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1316,12 +1316,6 @@ void HOT WaveshareEPaper7P5InHDB::display() {
   this->write_array(this->buffer_, this->get_buffer_length_());
   this->end_data_();
 
-  // comment from Waveshare code
-  // this->wait_until_idle_();
-  // this->command(0x4F);
-  // this->data(0xAf);
-  // this->data(0x02);
-
   // RED
   this->command(0x26);
   this->start_data_();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1240,61 +1240,61 @@ void WaveshareEPaper7P5InBC::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
-   
+
 void WaveshareEPaper7P5InHDB::initialize() {
-  this->command(0x12); 		  //SWRESET
+  this->command(0x12);       //SWRESET
 
-  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_();  //waiting for the electronic paper IC to release the idle signal
 
-  this->command(0x46);  // Auto Write RAM
+  this->command(0x46);       // Auto Write RAM
   this->data(0xF7);
 
-  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_();  //waiting for the electronic paper IC to release the idle signal
 
-  this->command(0x47);  // Auto Write RAM
+  this->command(0x47);       // Auto Write RAM
   this->data(0xF7);
 
-  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_();  //waiting for the electronic paper IC to release the idle signal
 
-  this->command(0x0C);  // Soft start setting
+  this->command(0x0C);       // Soft start setting
   this->data(0xAE);
   this->data(0xC7);
   this->data(0xC3);
   this->data(0xC0);
   this->data(0x40);
 
-  this->command(0x01);  // Set MUX as 527
+  this->command(0x01);       // Set MUX as 527
   this->data(0xAF);
   this->data(0x02);
   this->data(0x01);
 
-  this->command(0x11);  // Data entry mode
+  this->command(0x11);       // Data entry mode
   this->data(0x01);
 
   this->command(0x44);
-  this->data(0x00); // RAM x address start at 0
+  this->data(0x00);          // RAM x address start at 0
   this->data(0x00);
-  this->data(0x6F); // RAM x address end at 36Fh -> 879
+  this->data(0x6F);          // RAM x address end at 36Fh -> 879
   this->data(0x03);
 
   this->command(0x45);
-  this->data(0xAF); // RAM y address start at 20Fh;
+  this->data(0xAF);         // RAM y address start at 20Fh;
   this->data(0x02);
-  this->data(0x00); // RAM y address end at 00h;
+  this->data(0x00);         // RAM y address end at 00h;
   this->data(0x00);
 
-  this->command(0x3C); // VBD
-  this->data(0x01); // LUT1, for white
+  this->command(0x3C);      // VBD
+  this->data(0x01);         // LUT1, for white
 
   this->command(0x18);
   this->data(0X80);
 
   this->command(0x22);
-  this->data(0XB1);	//Load Temperature and waveform setting.
+  this->data(0XB1);         //Load Temperature and waveform setting.
 
   this->command(0x20);
 
-  this->wait_until_idle_();        //waiting for the electronic paper IC to release the idle signal
+  this->wait_until_idle_(); //waiting for the electronic paper IC to release the idle signal
 
   this->command(0x4E);
   this->data(0x00);
@@ -1332,7 +1332,7 @@ void HOT WaveshareEPaper7P5InHDB::display() {
   this->command(0x22);
   this->data(0xC7);
   this->command(0x20);
-  delay(100);
+  delay(100); // NOLINT
 }
 
 int WaveshareEPaper7P5InHDB::get_width_internal() { return 880; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -350,6 +350,26 @@ class WaveshareEPaper7P5InV2 : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
+class WaveshareEPaper7P5InHDB : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    //deep sleep
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
 class WaveshareEPaper2P13InDKE : public WaveshareEPaper {
  public:
   void initialize() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -359,7 +359,7 @@ class WaveshareEPaper7P5InHDB : public WaveshareEPaper {
   void dump_config() override;
 
   void deep_sleep() override {
-    //deep sleep
+    // deep sleep
     this->command(0x10);
     this->data(0x01);
   }


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the HD (880x528) variant of the 7.50 inch three color e-ink screen ([here](https://www.waveshare.com/7.5inch-hd-e-paper-hat-b.htm)).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1926

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
spi:
  clk_pin: 13
  mosi_pin: 14

display:
  - platform: waveshare_epaper
    cs_pin: 15
    dc_pin: 27
    busy_pin: 25
    reset_pin: 26
    model: 7.50in-hd-b
    update_interval: 60s
    lambda: |
      it.line(0, 0, 200, 200);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
