### PR TITLE
Implement send_first_at for exponential_moving_average

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -408,18 +408,30 @@ async def sliding_window_moving_average_filter_to_code(config, filter_id):
     )
 
 
-@FILTER_REGISTRY.register(
-    "exponential_moving_average",
-    ExponentialMovingAverageFilter,
+EXPONENTIAL_AVERAGE_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_ALPHA, default=0.1): cv.positive_float,
             cv.Optional(CONF_SEND_EVERY, default=15): cv.positive_not_null_int,
+            cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.positive_not_null_int,
         }
     ),
+    validate_send_first_at,
+)
+
+
+@FILTER_REGISTRY.register(
+    "exponential_moving_average",
+    ExponentialMovingAverageFilter,
+    EXPONENTIAL_AVERAGE_SCHEMA,
 )
 async def exponential_moving_average_filter_to_code(config, filter_id):
-    return cg.new_Pvariable(filter_id, config[CONF_ALPHA], config[CONF_SEND_EVERY])
+    return cg.new_Pvariable(
+        filter_id,
+        config[CONF_ALPHA],
+        config[CONF_SEND_EVERY],
+        config[CONF_SEND_FIRST_AT],
+    )
 
 
 @FILTER_REGISTRY.register(

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -200,8 +200,8 @@ optional<float> SlidingWindowMovingAverageFilter::new_value(float value) {
 }
 
 // ExponentialMovingAverageFilter
-ExponentialMovingAverageFilter::ExponentialMovingAverageFilter(float alpha, size_t send_every)
-    : send_every_(send_every), send_at_(send_every - 1), alpha_(alpha) {}
+ExponentialMovingAverageFilter::ExponentialMovingAverageFilter(float alpha, size_t send_every, size_t send_first_at)
+    : send_every_(send_every), send_at_(send_every - send_first_at), alpha_(alpha) {}
 optional<float> ExponentialMovingAverageFilter::new_value(float value) {
   if (!std::isnan(value)) {
     if (this->first_value_) {

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -194,7 +194,7 @@ class SlidingWindowMovingAverageFilter : public Filter {
  */
 class ExponentialMovingAverageFilter : public Filter {
  public:
-  ExponentialMovingAverageFilter(float alpha, size_t send_every);
+  ExponentialMovingAverageFilter(float alpha, size_t send_every, size_t send_first_at);
 
   optional<float> new_value(float value) override;
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -358,6 +358,7 @@ sensor:
       - exponential_moving_average:
           alpha: 0.1
           send_every: 15
+          send_first_at: 15
       - throttle_average: 60s
       - throttle: 1s
       - heartbeat: 5s


### PR DESCRIPTION
# What does this implement/fix?

Implement `send_first_at` configuration for the `exponential_moving_average` sensor filter

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1928

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

sensor:
  - platform: dht
    pin: D6
    model: DHT22
    update_interval: 10s
    temperature:
      name: "Temperature"
      accuracy_decimals: 2
      filters:
        - exponential_moving_average:
            send_every: 12
            send_first_at: 12
    humidity:
      name: "Humidity"
      accuracy_decimals: 1
      filters:
        - exponential_moving_average:
            send_every: 12
            send_first_at: 12
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
