### PR TITLE
Respect ESPHOME_USE_SUBPROCESS in esp32 post_build script

### DIFF
--- a/esphome/components/esp32/post_build.py.script
+++ b/esphome/components/esp32/post_build.py.script
@@ -1,6 +1,10 @@
 # Source https://github.com/letscontrolit/ESPEasy/pull/3845#issuecomment-1005864664
 
-import esptool
+import os
+if os.environ.get("ESPHOME_USE_SUBPROCESS") is None:
+    import esptool
+else:
+    import subprocess
 from SCons.Script import ARGUMENTS
 
 # pylint: disable=E0602
@@ -42,8 +46,11 @@ def esp32_create_combined_bin(source, target, env):
         print()
         print(f"Using esptool.py arguments: {' '.join(cmd)}")
         print()
-    esptool.main(cmd)
 
+    if os.environ.get("ESPHOME_USE_SUBPROCESS") is None:
+        esptool.main(cmd)
+    else:
+        subprocess.run(["esptool.py", *cmd])
 
 # pylint: disable=E0602
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)  # noqa


### PR DESCRIPTION

# What does this implement/fix?

This makes esp32 builds work again, when esptool is in the PATH, but not
in the PYTHONPATH.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/NixOS/nixpkgs/issues/161114

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 
n/a

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
