### PR TITLE
Add optional display page for touchscreen binary sensors

### DIFF
--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -6,6 +6,8 @@ from esphome import automation
 from esphome.const import CONF_ON_TOUCH
 
 CODEOWNERS = ["@jesserockz"]
+DEPENDENCIES = ["display"]
+
 IS_PLATFORM_COMPONENT = True
 
 touchscreen_ns = cg.esphome_ns.namespace("touchscreen")

--- a/esphome/components/touchscreen/binary_sensor/__init__.py
+++ b/esphome/components/touchscreen/binary_sensor/__init__.py
@@ -1,7 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 
-from esphome.components import binary_sensor
+from esphome.components import binary_sensor, display
+from esphome.const import CONF_PAGE_ID
 
 from .. import touchscreen_ns, CONF_TOUCHSCREEN_ID, Touchscreen, TouchListener
 
@@ -41,6 +42,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_X_MAX): cv.int_range(min=0, max=2000),
             cv.Required(CONF_Y_MIN): cv.int_range(min=0, max=2000),
             cv.Required(CONF_Y_MAX): cv.int_range(min=0, max=2000),
+            cv.Optional(CONF_PAGE_ID): cv.use_id(display.DisplayPage),
         }
     )
     .extend(cv.COMPONENT_SCHEMA),
@@ -61,3 +63,7 @@ async def to_code(config):
             config[CONF_Y_MAX],
         )
     )
+
+    if CONF_PAGE_ID in config:
+        page = await cg.get_variable(config[CONF_PAGE_ID])
+        cg.add(var.set_page(page))

--- a/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.cpp
+++ b/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.cpp
@@ -6,6 +6,10 @@ namespace touchscreen {
 void TouchscreenBinarySensor::touch(TouchPoint tp) {
   bool touched = (tp.x >= this->x_min_ && tp.x <= this->x_max_ && tp.y >= this->y_min_ && tp.y <= this->y_max_);
 
+  if (this->page_ != nullptr) {
+    touched &= this->page_ == this->parent_->get_display()->get_active_page();
+  }
+
   if (touched) {
     this->publish_state(true);
   } else {

--- a/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
+++ b/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/display/display_buffer.h"
 #include "esphome/components/touchscreen/touchscreen.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
@@ -23,11 +24,14 @@ class TouchscreenBinarySensor : public binary_sensor::BinarySensor,
     this->y_max_ = y_max;
   }
 
+  void set_page(display::DisplayPage *page) { this->page_ = page; }
+
   void touch(TouchPoint tp) override;
   void release() override;
 
  protected:
   int16_t x_min_, x_max_, y_min_, y_max_;
+  display::DisplayPage *page_{nullptr};
 };
 
 }  // namespace touchscreen

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -44,7 +44,6 @@ class Touchscreen {
   void register_listener(TouchListener *listener) { this->touch_listeners_.push_back(listener); }
 
  protected:
-  void touch(TouchPoint tp);
   /// Call this function to send touch points to the `on_touch` listener and the binary_sensors.
   void send_touch_(TouchPoint tp);
 

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -37,12 +37,14 @@ class Touchscreen {
     this->display_height_ = display->get_height_internal();
     this->rotation_ = static_cast<TouchRotation>(display->get_rotation());
   }
+  display::DisplayBuffer *get_display() const { return this->display_; }
 
   Trigger<TouchPoint> *get_touch_trigger() { return &this->touch_trigger_; }
 
   void register_listener(TouchListener *listener) { this->touch_listeners_.push_back(listener); }
 
  protected:
+  void touch(TouchPoint tp);
   /// Call this function to send touch points to the `on_touch` listener and the binary_sensors.
   void send_touch_(TouchPoint tp);
 


### PR DESCRIPTION
# What does this implement/fix?

Add optional display page for touchscreen binary sensors.
This allows for defining binary_sensors for each page without worrying about extra manual logic if that page is the current one.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1936

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
