### PR TITLE
Fix regression caused by TSL2591 auto gain

### DIFF
--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -79,7 +79,7 @@ void TSL2591Component::setup() {
     this->mark_failed();
     return;
   }
-  
+
   this->set_integration_time_and_gain(this->integration_time_, this->gain_);
   this->disable_if_power_saving_();
 }

--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -43,16 +43,34 @@ void TSL2591Component::disable_if_power_saving_() {
 }
 
 void TSL2591Component::setup() {
-  if (this->component_gain_ == TSL2591_CGAIN_AUTO)
-    this->gain_ = TSL2591_GAIN_MED;
+  switch (this->component_gain_) {
+    case TSL2591_CGAIN_LOW:
+      this->gain_ = TSL2591_GAIN_LOW;
+      break;
+    case TSL2591_CGAIN_MED:
+      this->gain_ = TSL2591_GAIN_MED;
+      break;
+    case TSL2591_CGAIN_HIGH:
+      this->gain_ = TSL2591_GAIN_HIGH;
+      break;
+    case TSL2591_CGAIN_MAX:
+      this->gain_ = TSL2591_GAIN_MAX;
+      break;
+    case TSL2591_CGAIN_AUTO:
+      this->gain_ = TSL2591_GAIN_MED;
+      break;
+  }
+
   uint8_t address = this->address_;
   ESP_LOGI(TAG, "Setting up TSL2591 sensor at I2C address 0x%02X", address);
+
   uint8_t id;
   if (!this->read_byte(TSL2591_COMMAND_BIT | TSL2591_REGISTER_DEVICE_ID, &id)) {
     ESP_LOGE(TAG, "Failed I2C read during setup()");
     this->mark_failed();
     return;
   }
+
   if (id != 0x50) {
     ESP_LOGE(TAG,
              "Could not find the TSL2591 sensor. The ID register of the device at address 0x%02X reported 0x%02X "
@@ -61,6 +79,7 @@ void TSL2591Component::setup() {
     this->mark_failed();
     return;
   }
+  
   this->set_integration_time_and_gain(this->integration_time_, this->gain_);
   this->disable_if_power_saving_();
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes issue where manual gain settings would be ignored in TSL2591

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [Gain for TSL2591 ignored unless set to 'auto'](https://github.com/esphome/issues/issues/3068)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
