### PR TITLE
Fix template button after abstract press_action

### DIFF
--- a/esphome/components/template/button/__init__.py
+++ b/esphome/components/template/button/__init__.py
@@ -1,10 +1,13 @@
 import esphome.config_validation as cv
 from esphome.components import button
 
+from .. import template_ns
+
+TemplateButton = template_ns.class_("TemplateButton", button.Button)
 
 CONFIG_SCHEMA = button.BUTTON_SCHEMA.extend(
     {
-        cv.GenerateID(): cv.declare_id(button.Button),
+        cv.GenerateID(): cv.declare_id(TemplateButton),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/template/button/template_button.h
+++ b/esphome/components/template/button/template_button.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+
+namespace esphome {
+namespace template_ {
+
+class TemplateButton : public button::Button {
+ public:
+  // Implements the abstract `press_action` but the `on_press` trigger already handles the press.
+  void press_action() override{};
+};
+
+}  // namespace template_
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Related to - https://github.com/esphome/esphome/pull/3242

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
