### PR TITLE
Online PNG image support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -176,6 +176,7 @@ esphome/components/nextion/switch/* @senexcrenshaw
 esphome/components/nextion/text_sensor/* @senexcrenshaw
 esphome/components/nfc/* @jesserockz
 esphome/components/number/* @esphome/core
+esphome/components/online_image/* @guillempages
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core
 esphome/components/pca9554/* @hwstar

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -339,10 +339,8 @@ void DisplayBuffer::image(int x, int y, Image *image, Color color_on, Color colo
 }
 
 #ifdef USE_ONLINE_IMAGE
-void DisplayBuffer::image(int x, int y, online_image::OnlineImage * image) {
-  image->draw(x, y, this);
-}
-#endif // USE_ONLINE_IMAGE
+void DisplayBuffer::image(int x, int y, online_image::OnlineImage *image) { image->draw(x, y, this); }
+#endif  // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH
 void DisplayBuffer::graph(int x, int y, graph::Graph *graph, Color color_on) { graph->draw(this, x, y, color_on); }

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -7,6 +7,10 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 
+#ifdef USE_ONLINE_IMAGE
+#include "esphome/components/online_image/online_image.h"
+#endif
+
 namespace esphome {
 namespace display {
 
@@ -333,6 +337,12 @@ void DisplayBuffer::image(int x, int y, Image *image, Color color_on, Color colo
       break;
   }
 }
+
+#ifdef USE_ONLINE_IMAGE
+void DisplayBuffer::image(int x, int y, online_image::OnlineImage * image) {
+  image->draw(x, y, this);
+}
+#endif // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH
 void DisplayBuffer::graph(int x, int y, graph::Graph *graph, Color color_on) { graph->draw(this, x, y, color_on); }

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -339,7 +339,9 @@ void DisplayBuffer::image(int x, int y, Image *image, Color color_on, Color colo
 }
 
 #ifdef USE_ONLINE_IMAGE
-void DisplayBuffer::image(int x, int y, online_image::OnlineImage *image) { image->draw(x, y, this); }
+void DisplayBuffer::image(int x, int y, online_image::OnlineImage *image, Color color_on, Color color_off) {
+  image->draw(x, y, this, color_on, color_off);
+}
 #endif  // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -335,7 +335,8 @@ class DisplayBuffer {
    * @param y The y coordinate of the upper left corner.
    * @param image The image to draw
    */
-  void image(int x, int y, online_image::OnlineImage *image, Color color_on = Color(255, 255, 255), Color color_off = Color(0, 0, 0));
+  void image(int x, int y, online_image::OnlineImage *image, Color color_on = Color(255, 255, 255),
+             Color color_off = Color(0, 0, 0));
 #endif  // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -23,9 +23,9 @@ namespace esphome {
 
 #ifdef USE_ONLINE_IMAGE
 namespace online_image {
-  class OnlineImage;
+class OnlineImage;
 }
-#endif // USE_ONLINE_IMAGE
+#endif  // USE_ONLINE_IMAGE
 namespace display {
 
 /** TextAlign is used to tell the display class how to position a piece of text. By default
@@ -335,8 +335,8 @@ class DisplayBuffer {
    * @param y The y coordinate of the upper left corner.
    * @param image The image to draw
    */
-  void image(int x, int y, online_image::OnlineImage * image);
-#endif // USE_ONLINE_IMAGE
+  void image(int x, int y, online_image::OnlineImage *image);
+#endif  // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH
   /** Draw the `graph` with the top-left corner at [x,y] to the screen.

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -335,7 +335,7 @@ class DisplayBuffer {
    * @param y The y coordinate of the upper left corner.
    * @param image The image to draw
    */
-  void image(int x, int y, online_image::OnlineImage *image);
+  void image(int x, int y, online_image::OnlineImage *image, Color color_on = COLOR_ON, Color color_off = COLOR_OFF);
 #endif  // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -20,6 +20,12 @@
 #endif
 
 namespace esphome {
+
+#ifdef USE_ONLINE_IMAGE
+namespace online_image {
+  class OnlineImage;
+}
+#endif // USE_ONLINE_IMAGE
 namespace display {
 
 /** TextAlign is used to tell the display class how to position a piece of text. By default
@@ -321,6 +327,16 @@ class DisplayBuffer {
    * @param color_off The color to replace in binary images for the off bits.
    */
   void image(int x, int y, Image *image, Color color_on = COLOR_ON, Color color_off = COLOR_OFF);
+
+#ifdef USE_ONLINE_IMAGE
+  /** Download and draw the `image` with the top-left corner at [x,y] to the screen.
+   *
+   * @param x The x coordinate of the upper left corner.
+   * @param y The y coordinate of the upper left corner.
+   * @param image The image to draw
+   */
+  void image(int x, int y, online_image::OnlineImage * image);
+#endif // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH
   /** Draw the `graph` with the top-left corner at [x,y] to the screen.

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -335,7 +335,7 @@ class DisplayBuffer {
    * @param y The y coordinate of the upper left corner.
    * @param image The image to draw
    */
-  void image(int x, int y, online_image::OnlineImage *image, Color color_on = COLOR_ON, Color color_off = COLOR_OFF);
+  void image(int x, int y, online_image::OnlineImage *image, Color color_on = Color(255, 255, 255), Color color_off = Color(0, 0, 0));
 #endif  // USE_ONLINE_IMAGE
 
 #ifdef USE_GRAPH

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -1,19 +1,12 @@
-import logging
-
-from esphome.components import display
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
-    CONF_DITHER,
     CONF_ID,
     CONF_FORMAT,
     CONF_RAW_DATA_ID,
-    CONF_RESIZE,
-    CONF_TYPE,
     CONF_URL,
 )
-
-_LOGGER = logging.getLogger(__name__)
+from esphome.core import CORE
 
 DEPENDENCIES = ["display"]
 MULTI_CONF = True
@@ -22,7 +15,7 @@ online_image_ns = cg.esphome_ns.namespace("online_image")
 
 ImageFormat = online_image_ns.enum("ImageFormat")
 IMAGE_FORMAT = {
-#    "JPEG": ImageFormat.JPEG,
+#    "JPEG": ImageFormat.JPEG,  # Not yet supported
     "PNG": ImageFormat.PNG,
 }
 
@@ -32,7 +25,6 @@ IMAGE_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_ID): cv.declare_id(Image_),
         cv.Required(CONF_URL): cv.string,
-        cv.Optional(CONF_RESIZE): cv.dimensions,
         cv.Optional(CONF_FORMAT, default="PNG"): cv.enum(IMAGE_FORMAT, upper=True),
         cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
     }
@@ -43,11 +35,17 @@ CONFIG_SCHEMA = IMAGE_SCHEMA
 async def to_code(config):
     url = config[CONF_URL]
     width, height = 0, 0
-    if config.get(CONF_RESIZE):
-        width, height = config[CONF_RESIZE]
 
     cg.new_Pvariable(
-        config[CONF_ID], url, width, height
+        config[CONF_ID], url, width, height, config[CONF_FORMAT]
     )
     cg.add_define("USE_ONLINE_IMAGE")
-    cg.add_library("pngle", None)
+    if CORE.is_esp32:
+        cg.add_library("WiFiClientSecure", None)
+        cg.add_library("HTTPClient", None)
+    if CORE.is_esp8266:
+        cg.add_library("ESP8266HTTPClient", None)
+
+    if config[CONF_FORMAT] in ['PNG']:
+        cg.add_define("ONLINE_IMAGE_PNG_SUPPORT")
+        cg.add_library("pngle", None)

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
 from esphome.core import CORE
 
 DEPENDENCIES = ["display"]
+CODEOWNERS = ["@guillempages"]
 MULTI_CONF = True
 
 online_image_ns = cg.esphome_ns.namespace("online_image")

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -1,6 +1,7 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
+    CONF_BUFFER_SIZE,
     CONF_ESP8266_DISABLE_SSL_SUPPORT,
     CONF_ID,
     CONF_FORMAT,
@@ -25,6 +26,7 @@ IMAGE_SCHEMA = cv.Schema(
         cv.Required(CONF_ID): cv.declare_id(Image_),
         cv.Required(CONF_URL): cv.string,
         cv.Optional(CONF_FORMAT, default="PNG"): cv.enum(IMAGE_FORMAT, upper=True),
+        cv.Optional(CONF_BUFFER_SIZE, default=2048): cv.int_range(256, 65536),
         cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
     }
 )
@@ -36,7 +38,14 @@ async def to_code(config):
     url = config[CONF_URL]
     width, height = 0, 0
 
-    cg.new_Pvariable(config[CONF_ID], url, width, height, config[CONF_FORMAT])
+    cg.new_Pvariable(
+        config[CONF_ID],
+        url,
+        width,
+        height,
+        config[CONF_FORMAT],
+        config[CONF_BUFFER_SIZE],
+    )
     cg.add_define("USE_ONLINE_IMAGE")
 
     if CORE.is_esp8266 and not config[CONF_ESP8266_DISABLE_SSL_SUPPORT]:

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -1,0 +1,60 @@
+import logging
+
+from esphome.components import display
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import (
+    CONF_DITHER,
+    CONF_ID,
+    CONF_FORMAT,
+    CONF_RAW_DATA_ID,
+    CONF_RESIZE,
+    CONF_TYPE,
+    CONF_URL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ["display"]
+MULTI_CONF = True
+
+online_image_ns = cg.esphome_ns.namespace("online_image")
+
+ImageType = display.display_ns.enum("ImageType")
+IMAGE_TYPE = {
+    "BINARY": ImageType.IMAGE_TYPE_BINARY,
+    "GRAYSCALE": ImageType.IMAGE_TYPE_GRAYSCALE,
+    "RGB24": ImageType.IMAGE_TYPE_RGB24,
+    "TRANSPARENT_BINARY": ImageType.IMAGE_TYPE_TRANSPARENT_BINARY,
+}
+ImageFormat = online_image_ns.enum("ImageFormat")
+IMAGE_FORMAT = {
+    "JPEG": ImageFormat.JPEG,
+    "PNG": ImageFormat.PNG,
+}
+
+Image_ = online_image_ns.class_("OnlineImage")
+
+IMAGE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.declare_id(Image_),
+        cv.Required(CONF_URL): cv.string,
+        cv.Optional(CONF_RESIZE): cv.dimensions,
+        cv.Optional(CONF_TYPE, default="BINARY"): cv.enum(IMAGE_TYPE, upper=True),
+        cv.Optional(CONF_FORMAT, default="PNG"): cv.enum(IMAGE_FORMAT, upper=True),
+        cv.Optional(CONF_DITHER, default="NONE"): cv.one_of(
+            "NONE", "FLOYDSTEINBERG", upper=True
+        ),
+        cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
+    }
+)
+
+CONFIG_SCHEMA = IMAGE_SCHEMA
+
+async def to_code(config):
+    url = config[CONF_URL]
+    cg.new_Pvariable(
+        config[CONF_ID], url, IMAGE_TYPE[config[CONF_TYPE]]
+    )
+    cg.add_define("USE_ONLINE_IMAGE")
+    cg.add_library("pngle", None)

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -20,16 +20,9 @@ MULTI_CONF = True
 
 online_image_ns = cg.esphome_ns.namespace("online_image")
 
-ImageType = display.display_ns.enum("ImageType")
-IMAGE_TYPE = {
-    "BINARY": ImageType.IMAGE_TYPE_BINARY,
-    "GRAYSCALE": ImageType.IMAGE_TYPE_GRAYSCALE,
-    "RGB24": ImageType.IMAGE_TYPE_RGB24,
-    "TRANSPARENT_BINARY": ImageType.IMAGE_TYPE_TRANSPARENT_BINARY,
-}
 ImageFormat = online_image_ns.enum("ImageFormat")
 IMAGE_FORMAT = {
-    "JPEG": ImageFormat.JPEG,
+#    "JPEG": ImageFormat.JPEG,
     "PNG": ImageFormat.PNG,
 }
 
@@ -40,11 +33,7 @@ IMAGE_SCHEMA = cv.Schema(
         cv.Required(CONF_ID): cv.declare_id(Image_),
         cv.Required(CONF_URL): cv.string,
         cv.Optional(CONF_RESIZE): cv.dimensions,
-        cv.Optional(CONF_TYPE, default="BINARY"): cv.enum(IMAGE_TYPE, upper=True),
         cv.Optional(CONF_FORMAT, default="PNG"): cv.enum(IMAGE_FORMAT, upper=True),
-        cv.Optional(CONF_DITHER, default="NONE"): cv.one_of(
-            "NONE", "FLOYDSTEINBERG", upper=True
-        ),
         cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
     }
 )
@@ -53,8 +42,12 @@ CONFIG_SCHEMA = IMAGE_SCHEMA
 
 async def to_code(config):
     url = config[CONF_URL]
+    width, height = 0, 0
+    if config.get(CONF_RESIZE):
+        width, height = config[CONF_RESIZE]
+
     cg.new_Pvariable(
-        config[CONF_ID], url, IMAGE_TYPE[config[CONF_TYPE]]
+        config[CONF_ID], url, width, height
     )
     cg.add_define("USE_ONLINE_IMAGE")
     cg.add_library("pngle", None)

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -16,10 +16,7 @@ MULTI_CONF = True
 online_image_ns = cg.esphome_ns.namespace("online_image")
 
 ImageFormat = online_image_ns.enum("ImageFormat")
-IMAGE_FORMAT = {
-#    "JPEG": ImageFormat.JPEG,  # Not yet supported
-    "PNG": ImageFormat.PNG,
-}
+IMAGE_FORMAT = {"PNG": ImageFormat.PNG}  # Add new supported formats here
 
 Image_ = online_image_ns.class_("OnlineImage")
 
@@ -34,13 +31,12 @@ IMAGE_SCHEMA = cv.Schema(
 
 CONFIG_SCHEMA = IMAGE_SCHEMA
 
+
 async def to_code(config):
     url = config[CONF_URL]
     width, height = 0, 0
 
-    cg.new_Pvariable(
-        config[CONF_ID], url, width, height, config[CONF_FORMAT]
-    )
+    cg.new_Pvariable(config[CONF_ID], url, width, height, config[CONF_FORMAT])
     cg.add_define("USE_ONLINE_IMAGE")
 
     if CORE.is_esp8266 and not config[CONF_ESP8266_DISABLE_SSL_SUPPORT]:
@@ -52,6 +48,6 @@ async def to_code(config):
     if CORE.is_esp8266:
         cg.add_library("ESP8266HTTPClient", None)
 
-    if config[CONF_FORMAT] in ['PNG']:
+    if config[CONF_FORMAT] in ["PNG"]:
         cg.add_define("ONLINE_IMAGE_PNG_SUPPORT")
         cg.add_library("pngle", None)

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -1,6 +1,7 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
+    CONF_ESP8266_DISABLE_SSL_SUPPORT,
     CONF_ID,
     CONF_FORMAT,
     CONF_RAW_DATA_ID,
@@ -41,6 +42,10 @@ async def to_code(config):
         config[CONF_ID], url, width, height, config[CONF_FORMAT]
     )
     cg.add_define("USE_ONLINE_IMAGE")
+
+    if CORE.is_esp8266 and not config[CONF_ESP8266_DISABLE_SSL_SUPPORT]:
+        cg.add_define("USE_HTTP_REQUEST_ESP8266_HTTPS")
+
     if CORE.is_esp32:
         cg.add_library("WiFiClientSecure", None)
         cg.add_library("HTTPClient", None)

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -1,0 +1,93 @@
+#include "online_image.h"
+#include "esphome/core/color.h"
+
+#ifdef USE_ESP32
+#include <HTTPClient.h>
+#endif
+#ifdef USE_ESP8266
+#include <ESP8266HTTPClient.h>
+#ifdef USE_HTTP_REQUEST_ESP8266_HTTPS
+#include <WiFiClientSecure.h>
+#endif
+#endif
+
+#include "pngle.h"
+
+namespace esphome {
+namespace online_image {
+
+using display::DisplayBuffer;
+
+bool OnlineImage::get_pixel(int x, int y) const {
+    return false;
+}
+Color OnlineImage::get_color_pixel(int x, int y) const {
+    return Color::BLACK;
+}
+Color OnlineImage::get_grayscale_pixel(int x, int y) const {
+    return Color::BLACK;
+}
+
+void drawCallback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]) {
+    DisplayBuffer* display = (DisplayBuffer*)pngle_get_user_data(pngle);
+  Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
+  float g_scale = 1.0;
+
+  if (rgba[3]) {
+    x = ceil(x * g_scale);
+    y = ceil(y * g_scale);
+    w = ceil(w * g_scale);
+    h = ceil(h * g_scale);
+    display->filled_rectangle(x, y, w, h, color);
+  }
+}
+
+void OnlineImage::draw(int x, int y, DisplayBuffer* display) {
+  HTTPClient http;
+
+  http.begin(url);
+
+  int httpCode = http.GET();
+  if (httpCode != HTTP_CODE_OK) {
+    http.end();
+    return ;
+  }
+
+  WiFiClient *stream = http.getStreamPtr();
+
+  pngle_t *pngle = pngle_new();
+  pngle_set_user_data(pngle, display);
+  pngle_set_draw_callback(pngle, drawCallback);
+
+  uint8_t buf[2048];
+  int remain = 0;
+  while (http.connected()) {
+    size_t size = stream->available();
+    if (!size) { delay(1); continue; }
+
+    if (size > sizeof(buf) - remain) {
+      size = sizeof(buf) - remain;
+    }
+
+    int len = stream->readBytes(buf + remain, size);
+    if (len > 0) {
+      int fed = pngle_feed(pngle, buf, remain + len);
+      if (fed < 0) {
+        break;
+      }
+
+      remain = remain + len - fed;
+      if (remain > 0) memmove(buf, buf + fed, remain);
+    } else {
+      delay(1);
+    }
+  }
+
+  pngle_destroy(pngle);
+
+  http.end();
+
+}
+
+} // namespace online_image
+} // namespace esphome

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -65,7 +65,8 @@ void OnlineImage::draw(int x, int y, DisplayBuffer *display, Color color_on, Col
 
   decoder->prepare(stream);
   ESP_LOGD(TAG, "Downloading image from %s", url_);
-  size_t size = decoder->decode(http, stream);
+  std::vector<uint8_t> buffer(this->buffer_size_);
+  size_t size = decoder->decode(http, stream, buffer);
   ESP_LOGD(TAG, "Decoded %d bytes", size);
 
   http.end();

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -55,6 +55,7 @@ void OnlineImage::draw(int x, int y, DisplayBuffer *display) {
   decoder->set_offset(x, y);
 
   decoder->prepare(stream);
+  ESP_LOGD(TAG, "Downloading image from %s", url_);
   size_t size = decoder->decode(http, stream);
   ESP_LOGD(TAG, "Decoded %d bytes", size);
 

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -27,7 +27,7 @@ namespace online_image {
 
 using display::DisplayBuffer;
 
-void OnlineImage::draw(int x, int y, DisplayBuffer *display) {
+void OnlineImage::draw(int x, int y, DisplayBuffer *display, Color color_on, Color color_off) {
   HTTPClient http;
 
   std::unique_ptr<ImageDecoder> decoder;
@@ -42,6 +42,8 @@ void OnlineImage::draw(int x, int y, DisplayBuffer *display) {
     ESP_LOGE(TAG, "Could not instantiate decoder. Image format unsupported.");
     return;
   }
+
+  decoder->set_monochrome_colors(color_on, color_off);
 
   http.begin(url_);
 

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -1,6 +1,7 @@
 #ifdef USE_ARDUINO
 
 #include "online_image.h"
+#include "esphome/core/application.h"
 #include "esphome/core/color.h"
 #include "esphome/core/log.h"
 
@@ -45,10 +46,16 @@ void OnlineImage::draw(int x, int y, DisplayBuffer *display, Color color_on, Col
 
   decoder->set_monochrome_colors(color_on, color_off);
 
-  http.begin(url_);
+  int begin_status = http.begin(url_);
+  if (!begin_status) {
+    ESP_LOGE(TAG, "Could not download image from %s. Connection failed: %i", url_, begin_status);
+    return;
+  }
 
   int http_code = http.GET();
   if (http_code != HTTP_CODE_OK) {
+    App.feed_wdt();
+    ESP_LOGE(TAG, "Could not download image from %s. Error code: %i", url_, http_code);
     http.end();
     return;
   }

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -1,3 +1,5 @@
+#ifdef USE_ARDUINO
+
 #include "online_image.h"
 #include "esphome/core/color.h"
 #include "esphome/core/log.h"
@@ -25,41 +27,41 @@ namespace online_image {
 
 using display::DisplayBuffer;
 
-
-void OnlineImage::draw(int x, int y, DisplayBuffer* display) {
+void OnlineImage::draw(int x, int y, DisplayBuffer *display) {
   HTTPClient http;
-
 
   std::unique_ptr<ImageDecoder> decoder;
 
-  #ifdef ONLINE_IMAGE_PNG_SUPPORT
-  if (format == ImageFormat::PNG) {
+#ifdef ONLINE_IMAGE_PNG_SUPPORT
+  if (format_ == ImageFormat::PNG) {
     decoder = esphome::make_unique<PngDecoder>(display);
   }
-  #endif // ONLINE_IMAGE_PNG_SUPPORT
+#endif  // ONLINE_IMAGE_PNG_SUPPORT
 
   if (!decoder) {
     ESP_LOGE(TAG, "Could not instantiate decoder. Image format unsupported.");
     return;
   }
 
-  http.begin(url);
+  http.begin(url_);
 
-  int httpCode = http.GET();
-  if (httpCode != HTTP_CODE_OK) {
+  int http_code = http.GET();
+  if (http_code != HTTP_CODE_OK) {
     http.end();
     return;
   }
   WiFiClient *stream = http.getStreamPtr();
 
-  decoder->setOffset(x, y);
+  decoder->set_offset(x, y);
 
   decoder->prepare(stream);
-  int size = decoder->decode(http, stream);
-
+  size_t size = decoder->decode(http, stream);
+  ESP_LOGD(TAG, "Decoded %d bytes", size);
 
   http.end();
 }
 
-} // namespace online_image
-} // namespace esphome
+}  // namespace online_image
+}  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -1,5 +1,6 @@
 #include "online_image.h"
 #include "esphome/core/color.h"
+#include "esphome/core/log.h"
 
 #ifdef USE_ESP32
 #include <HTTPClient.h>
@@ -11,91 +12,53 @@
 #endif
 #endif
 
-#include "pngle.h"
+#include <memory>
+
+static const char *const TAG = "online_image";
+
+#ifdef ONLINE_IMAGE_PNG_SUPPORT
+#include "png_image.h"
+#endif
 
 namespace esphome {
 namespace online_image {
 
 using display::DisplayBuffer;
 
-struct Context {
-  int x;
-  int y;
-  uint16_t w;
-  uint16_t h;
-  DisplayBuffer* display;
-};
-
-void drawCallback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]) {
-    Context* context = (Context*)pngle_get_user_data(pngle);
-  Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
-
-  float scale_x = 1;
-  float scale_y = 1;
-  uint32_t width = pngle_get_width(pngle);
-  uint32_t height = pngle_get_height(pngle);
-  if (width && width <= context->w) {
-    scale_x = context->w / width;
-  }
-  if (height && height <= context->h) {
-    scale_y = context->h / height;
-  }
-
-  if (rgba[3]) {
-    x = context->x + ceil(x * scale_x);
-    y = context->y + ceil(y * scale_y);
-    w = ceil(w * scale_x);
-    h = ceil(h * scale_y);
-    context->display->filled_rectangle(x, y, w, h, color);
-  }
-}
 
 void OnlineImage::draw(int x, int y, DisplayBuffer* display) {
   HTTPClient http;
+
+
+  std::unique_ptr<ImageDecoder> decoder;
+
+  #ifdef ONLINE_IMAGE_PNG_SUPPORT
+  if (format == ImageFormat::PNG) {
+    decoder = esphome::make_unique<PngDecoder>(display);
+  }
+  #endif // ONLINE_IMAGE_PNG_SUPPORT
+
+  if (!decoder) {
+    ESP_LOGE(TAG, "Could not instantiate decoder. Image format unsupported.");
+    return;
+  }
 
   http.begin(url);
 
   int httpCode = http.GET();
   if (httpCode != HTTP_CODE_OK) {
     http.end();
-    return ;
+    return;
   }
-
   WiFiClient *stream = http.getStreamPtr();
 
-  pngle_t *pngle = pngle_new();
-  Context context_data {.x=x, .y=y, .w=width, .h=height, .display=display};
-  pngle_set_user_data(pngle, &context_data);
-  pngle_set_draw_callback(pngle, drawCallback);
+  decoder->setOffset(x, y);
 
-  uint8_t buf[2048];
-  int remain = 0;
-  while (http.connected()) {
-    size_t size = stream->available();
-    if (!size) { delay(1); continue; }
+  decoder->prepare(stream);
+  int size = decoder->decode(http, stream);
 
-    if (size > sizeof(buf) - remain) {
-      size = sizeof(buf) - remain;
-    }
-
-    int len = stream->readBytes(buf + remain, size);
-    if (len > 0) {
-      int fed = pngle_feed(pngle, buf, remain + len);
-      if (fed < 0) {
-        break;
-      }
-
-      remain = remain + len - fed;
-      if (remain > 0) memmove(buf, buf + fed, remain);
-    } else {
-      delay(1);
-    }
-  }
-
-  pngle_destroy(pngle);
 
   http.end();
-
 }
 
 } // namespace online_image

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifdef USE_ARDUINO
+
 #include "esphome/components/display/display_buffer.h"
 
 #ifdef USE_ESP32
@@ -24,8 +26,6 @@ enum ImageFormat {
   PNG,
 };
 
-void debug_log(const char * format, ...);
-
 /**
  * @brief Image that will be downloaded and decoded in runtime.
  */
@@ -39,7 +39,8 @@ class OnlineImage {
    * @param height Desired height of the target image area.
    * @param format Format that the image is encoded in (@see ImageFormat).
    */
-  OnlineImage(const char* url, uint16_t width, uint16_t height, ImageFormat format): url(url), width(width), height(height), format(format) {};
+  OnlineImage(const char *url, uint16_t width, uint16_t height, ImageFormat format)
+      : url_(url), width_(width), height_(height), format_(format){};
 
   /**
    * @brief Draw the image on the display.
@@ -48,67 +49,71 @@ class OnlineImage {
    * @param y Y coordinate to draw the image on.
    * @param display the display to draw to.
    */
-  void draw(int x, int y, display::DisplayBuffer* display);
+  void draw(int x, int y, display::DisplayBuffer *display);
 
  protected:
-  const char* url;
-  const uint16_t width;
-  const uint16_t height;
-  const ImageFormat format;
-
+  const char *url_;
+  const uint16_t width_;
+  const uint16_t height_;
+  const ImageFormat format_;
 };
 
 /**
  * @brief Class to abstract decoding different image formats.
  */
 class ImageDecoder {
-  public:
-    /**
-     * @brief Construct a new Image Decoder object
-     *
-     * @param display The display to draw the decoded image to.
-     */
-    ImageDecoder(display::DisplayBuffer * display): display_(display) {};
-    virtual ~ImageDecoder() = default;
+ public:
+  /**
+   * @brief Construct a new Image Decoder object
+   *
+   * @param display The display to draw the decoded image to.
+   */
+  ImageDecoder(display::DisplayBuffer *display) : display_(display){};
+  virtual ~ImageDecoder() = default;
 
-    /**
-     * @brief Set the offset where the image should be drawn to.
-     *
-     * @param x leftmost coordinate.
-     * @param y topmost coordinate.
-     */
-    virtual void setOffset(int x, int y) {offset_x = x; offset_y = y;};
+  /**
+   * @brief Set the offset where the image should be drawn to.
+   *
+   * @param x leftmost coordinate.
+   * @param y topmost coordinate.
+   */
+  virtual void set_offset(int x, int y) {
+    offset_x_ = x;
+    offset_y_ = y;
+  };
 
-    /**
-     * @brief Initialize the decoder.
-     *
-     * @param stream WiFiClient to read the data from, in case the decoder needs initial data to auto-configure itself.
-     */
-    virtual void prepare(WiFiClient* stream) {};
+  /**
+   * @brief Initialize the decoder.
+   *
+   * @param stream WiFiClient to read the data from, in case the decoder needs initial data to auto-configure itself.
+   */
+  virtual void prepare(WiFiClient *stream){};
 
-    /**
-     * @brief Decode the image and draw it to the display.
-     *
-     * @param http HTTPClient object, to detect when the image has been fully downloaded.
-     * @param stream The WiFiClient stream to read the image from.
-     * @return int the total number of bytes received over HTTP.
-     */
-    virtual int decode(HTTPClient& http, WiFiClient* stream) {return 0;};
+  /**
+   * @brief Decode the image and draw it to the display.
+   *
+   * @param http HTTPClient object, to detect when the image has been fully downloaded.
+   * @param stream The WiFiClient stream to read the image from.
+   * @return int the total number of bytes received over HTTP.
+   */
+  virtual size_t decode(HTTPClient &http, WiFiClient *stream) { return 0; };
 
-    /**
-     * @return the leftmost coordinate.
-     */
-    int x0() {return offset_x;}
-    /**
-     * @return the topmost coordinate.
-     */
-    int y0() {return offset_y;}
+  /**
+   * @return the leftmost coordinate.
+   */
+  int x0() { return offset_x_; }
+  /**
+   * @return the topmost coordinate.
+   */
+  int y0() { return offset_y_; }
 
-  protected:
-    display::DisplayBuffer* display_;
-    int offset_x = 0;
-    int offset_y = 0;
+ protected:
+  display::DisplayBuffer *display_;
+  int offset_x_ = 0;
+  int offset_y_ = 0;
 };
 
-} // namespace online_image
-} // namespace esphome
+}  // namespace online_image
+}  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -123,11 +123,32 @@ class ImageDecoder {
   /**
    * @return the color for on pixels.
    */
-  Color color_on() { return color_on_; }
+  const Color &color_on() { return color_on_; }
   /**
    * @return the color for off pixels.
    */
-  Color color_off() { return color_off_; }
+  const Color &color_off() { return color_off_; }
+
+  /**
+   * @brief Draw a rectangle on the display_buffer using the defined color.
+   * Will check the given coordinates for out-of-bounds, and clip the rectangle accordingly.
+   * In case of binary displays, the color will be converted to binary as well.
+   *
+   * @param x The left-most coordinate of the rectangle.
+   * @param y The top-most coordinate of the rectangle.
+   * @param w The width of the rectangle.
+   * @param h The height of the rectangle.
+   * @param color The color to draw the rectangle with.
+   */
+  void draw(uint32_t x, uint32_t y, uint32_t w, uint32_t h, Color color);
+
+  /**
+   * @brief Converts an RGB color (ignoring alpha) to a 1-bit grayscale color.
+   *
+   * @param color The color to convert from; the alpha channel will be ignored.
+   * @return Whether the 8-bit grayscale equivalent color is brighter than average (i.e. brighter than 0x7F).
+   */
+  bool is_color_on(const Color &color);
 
  protected:
   display::DisplayBuffer *display_;

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -1,25 +1,113 @@
 #pragma once
 #include "esphome/components/display/display_buffer.h"
 
+#ifdef USE_ESP32
+#include <HTTPClient.h>
+#endif
+#ifdef USE_ESP8266
+#include <ESP8266HTTPClient.h>
+#ifdef USE_HTTP_REQUEST_ESP8266_HTTPS
+#include <WiFiClientSecure.h>
+#endif
+#endif
+
 namespace esphome {
 namespace online_image {
 
+/**
+ * @brief Format that the image is encoded with.
+ */
 enum ImageFormat {
+  /** JPEG format. Not supported yet. */
   JPEG,
+  /** PNG format. */
   PNG,
 };
 
+void debug_log(const char * format, ...);
+
+/**
+ * @brief Image that will be downloaded and decoded in runtime.
+ */
 class OnlineImage {
  public:
-  OnlineImage(const char* url, uint16_t width, uint16_t height): url(url), width(width), height(height) {};
+  /**
+   * @brief Construct a new Online Image object.
+   *
+   * @param url URL to download the image from.
+   * @param width Desired widh of the target image area.
+   * @param height Desired height of the target image area.
+   * @param format Format that the image is encoded in (@see ImageFormat).
+   */
+  OnlineImage(const char* url, uint16_t width, uint16_t height, ImageFormat format): url(url), width(width), height(height), format(format) {};
 
+  /**
+   * @brief Draw the image on the display.
+   *
+   * @param x X coordinate to draw the image on.
+   * @param y Y coordinate to draw the image on.
+   * @param display the display to draw to.
+   */
   void draw(int x, int y, display::DisplayBuffer* display);
 
  protected:
   const char* url;
   const uint16_t width;
   const uint16_t height;
+  const ImageFormat format;
 
+};
+
+/**
+ * @brief Class to abstract decoding different image formats.
+ */
+class ImageDecoder {
+  public:
+    /**
+     * @brief Construct a new Image Decoder object
+     *
+     * @param display The display to draw the decoded image to.
+     */
+    ImageDecoder(display::DisplayBuffer * display): display_(display) {};
+    virtual ~ImageDecoder() = default;
+
+    /**
+     * @brief Set the offset where the image should be drawn to.
+     *
+     * @param x leftmost coordinate.
+     * @param y topmost coordinate.
+     */
+    virtual void setOffset(int x, int y) {offset_x = x; offset_y = y;};
+
+    /**
+     * @brief Initialize the decoder.
+     *
+     * @param stream WiFiClient to read the data from, in case the decoder needs initial data to auto-configure itself.
+     */
+    virtual void prepare(WiFiClient* stream) {};
+
+    /**
+     * @brief Decode the image and draw it to the display.
+     *
+     * @param http HTTPClient object, to detect when the image has been fully downloaded.
+     * @param stream The WiFiClient stream to read the image from.
+     * @return int the total number of bytes received over HTTP.
+     */
+    virtual int decode(HTTPClient& http, WiFiClient* stream) {return 0;};
+
+    /**
+     * @return the leftmost coordinate.
+     */
+    int x0() {return offset_x;}
+    /**
+     * @return the topmost coordinate.
+     */
+    int y0() {return offset_y;}
+
+  protected:
+    display::DisplayBuffer* display_;
+    int offset_x = 0;
+    int offset_y = 0;
 };
 
 } // namespace online_image

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -49,7 +49,7 @@ class OnlineImage {
    * @param y Y coordinate to draw the image on.
    * @param display the display to draw to.
    */
-  void draw(int x, int y, display::DisplayBuffer *display);
+  void draw(int x, int y, display::DisplayBuffer *display, Color color_on, Color color_off);
 
  protected:
   const char *url_;
@@ -83,6 +83,17 @@ class ImageDecoder {
   };
 
   /**
+   * @brief Set the on and off colors for monochrome images.
+   *
+   * @param color_on The color to use when the original pixel is not black.
+   * @param color_off The color to use when the original pixel is black.
+   */
+  void set_monochrome_colors(Color color_on, Color color_off) {
+    color_on_ = color_on;
+    color_off_ = color_off;
+  }
+
+  /**
    * @brief Initialize the decoder.
    *
    * @param stream WiFiClient to read the data from, in case the decoder needs initial data to auto-configure itself.
@@ -106,11 +117,21 @@ class ImageDecoder {
    * @return the topmost coordinate.
    */
   int y0() { return offset_y_; }
+  /**
+   * @return the color for on pixels.
+   */
+  Color color_on() { return color_on_; }
+  /**
+   * @return the color for off pixels.
+   */
+  Color color_off() { return color_off_; }
 
  protected:
   display::DisplayBuffer *display_;
   int offset_x_ = 0;
   int offset_y_ = 0;
+  Color color_on_ = display::COLOR_ON;
+  Color color_off_ = display::COLOR_OFF;
 };
 
 }  // namespace online_image

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "esphome/components/display/display_buffer.h"
+
+namespace esphome {
+namespace online_image {
+
+enum ImageFormat {
+  JPEG,
+  PNG,
+};
+
+class OnlineImage: public esphome::display::Image {
+ public:
+  OnlineImage(const char* url, display::ImageType type): Image(nullptr, 0, 0, type), url(url) {};
+  bool get_pixel(int x, int y) const override;
+  Color get_color_pixel(int x, int y) const override;
+  Color get_grayscale_pixel(int x, int y) const override;
+
+  void draw(int x, int y, display::DisplayBuffer* display);
+
+ protected:
+  const char* url;
+
+};
+
+} // namespace online_image
+} // namespace esphome

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -39,8 +39,8 @@ class OnlineImage {
    * @param height Desired height of the target image area.
    * @param format Format that the image is encoded in (@see ImageFormat).
    */
-  OnlineImage(const char *url, uint16_t width, uint16_t height, ImageFormat format)
-      : url_(url), width_(width), height_(height), format_(format){};
+  OnlineImage(const char *url, uint16_t width, uint16_t height, ImageFormat format, uint32_t buffer_size)
+      : url_(url), width_(width), height_(height), buffer_size_(buffer_size), format_(format){};
 
   /**
    * @brief Draw the image on the display.
@@ -55,6 +55,7 @@ class OnlineImage {
   const char *url_;
   const uint16_t width_;
   const uint16_t height_;
+  const uint32_t buffer_size_;
   const ImageFormat format_;
 };
 
@@ -105,9 +106,11 @@ class ImageDecoder {
    *
    * @param http HTTPClient object, to detect when the image has been fully downloaded.
    * @param stream The WiFiClient stream to read the image from.
+   * @param buffer The buffer to use for downloading the image chunks.
+   *
    * @return int the total number of bytes received over HTTP.
    */
-  virtual size_t decode(HTTPClient &http, WiFiClient *stream) { return 0; };
+  virtual size_t decode(HTTPClient &http, WiFiClient *stream, std::vector<uint8_t> &buffer) { return 0; };
 
   /**
    * @return the leftmost coordinate.

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -9,17 +9,16 @@ enum ImageFormat {
   PNG,
 };
 
-class OnlineImage: public esphome::display::Image {
+class OnlineImage {
  public:
-  OnlineImage(const char* url, display::ImageType type): Image(nullptr, 0, 0, type), url(url) {};
-  bool get_pixel(int x, int y) const override;
-  Color get_color_pixel(int x, int y) const override;
-  Color get_grayscale_pixel(int x, int y) const override;
+  OnlineImage(const char* url, uint16_t width, uint16_t height): url(url), width(width), height(height) {};
 
   void draw(int x, int y, display::DisplayBuffer* display);
 
  protected:
   const char* url;
+  const uint16_t width;
+  const uint16_t height;
 
 };
 

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -2,6 +2,8 @@
 
 #include "png_image.h"
 #include "esphome/components/display/display_buffer.h"
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
 
 #ifdef ONLINE_IMAGE_PNG_SUPPORT
 namespace esphome {
@@ -38,11 +40,12 @@ void PngDecoder::prepare(WiFiClient *stream) {
   pngle_set_draw_callback(pngle, drawCallback);
 }
 
-size_t PngDecoder::decode(HTTPClient &http, WiFiClient *stream) {
+size_t HOT PngDecoder::decode(HTTPClient &http, WiFiClient *stream) {
   uint8_t buf[2048];
   int remain = 0;
   int total = 0;
   while (http.connected()) {
+    App.feed_wdt();
     size_t size = stream->available();
     if (!size) {
       delay(1);
@@ -69,6 +72,7 @@ size_t PngDecoder::decode(HTTPClient &http, WiFiClient *stream) {
       delay(1);
     }
   }
+  App.feed_wdt();
   return total;
 }
 

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -1,0 +1,76 @@
+
+#include "png_image.h"
+#include "esphome/components/display/display_buffer.h"
+
+#ifdef ONLINE_IMAGE_PNG_SUPPORT
+namespace esphome {
+namespace online_image {
+
+/**
+ * @brief Callback method that will be called by the PNGLE engine when a chunk
+ * of the image is decoded.
+ *
+ * @param pngle The PNGLE object, including the context data.
+ * @param x The X coordinate to draw the rectangle on.
+ * @param y The Y coordinate to draw the rectangle on.
+ * @param w The width of the rectangle to draw.
+ * @param h The height of the rectangle to draw.
+ * @param rgba The color to paint the rectangle in.
+ */
+void drawCallback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]) {
+  PngDecoder* decoder = (PngDecoder*)pngle_get_user_data(pngle);
+  Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
+
+  if (rgba[3]) {
+    x += decoder->x0();
+    y += decoder->y0();
+    decoder->display()->filled_rectangle(x, y, w, h, color);
+  }
+}
+
+PngDecoder::PngDecoder(display::DisplayBuffer * display): ImageDecoder(display), pngle(pngle_new()) {
+
+}
+
+PngDecoder::~PngDecoder() {
+    pngle_destroy(pngle);
+}
+
+void PngDecoder::prepare(WiFiClient * stream) {
+  pngle_set_user_data(pngle, this);
+  pngle_set_draw_callback(pngle, drawCallback);
+}
+
+int PngDecoder::decode(HTTPClient& http, WiFiClient* stream) {
+  uint8_t buf[2048];
+  int remain = 0;
+  int total = 0;
+  while (http.connected()) {
+    size_t size = stream->available();
+    if (!size) { delay(1); continue; }
+
+    if (size > sizeof(buf) - remain) {
+      size = sizeof(buf) - remain;
+    }
+
+    int len = stream->readBytes(buf + remain, size);
+    total += len;
+    if (len > 0) {
+      int fed = pngle_feed(pngle, buf, remain + len);
+      if (fed < 0) {
+        break;
+      }
+
+      remain = remain + len - fed;
+      if (remain > 0) memmove(buf, buf + fed, remain);
+    } else {
+      delay(1);
+    }
+  }
+  return total;
+}
+
+} // namespace online_image
+} // namespace esphome
+
+#endif // ONLINE_IMAGE_PNG_SUPPORT

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -6,6 +6,9 @@
 #include "esphome/core/helpers.h"
 
 #ifdef ONLINE_IMAGE_PNG_SUPPORT
+
+static const char *const TAG = "online_image.png";
+
 namespace esphome {
 namespace online_image {
 
@@ -79,6 +82,7 @@ size_t HOT PngDecoder::decode(HTTPClient &http, WiFiClient *stream) {
     if (len > 0) {
       int fed = pngle_feed(pngle, buf, remain + len);
       if (fed < 0) {
+        ESP_LOGE(TAG, "Error decoding image: %s", pngle_error(pngle));
         break;
       }
 

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_ARDUINO
 
 #include "png_image.h"
 #include "esphome/components/display/display_buffer.h"
@@ -18,7 +19,7 @@ namespace online_image {
  * @param rgba The color to paint the rectangle in.
  */
 void drawCallback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]) {
-  PngDecoder* decoder = (PngDecoder*)pngle_get_user_data(pngle);
+  PngDecoder *decoder = (PngDecoder *) pngle_get_user_data(pngle);
   Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
 
   if (rgba[3]) {
@@ -28,26 +29,25 @@ void drawCallback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h
   }
 }
 
-PngDecoder::PngDecoder(display::DisplayBuffer * display): ImageDecoder(display), pngle(pngle_new()) {
+PngDecoder::PngDecoder(display::DisplayBuffer *display) : ImageDecoder(display), pngle(pngle_new()) {}
 
-}
+PngDecoder::~PngDecoder() { pngle_destroy(pngle); }
 
-PngDecoder::~PngDecoder() {
-    pngle_destroy(pngle);
-}
-
-void PngDecoder::prepare(WiFiClient * stream) {
+void PngDecoder::prepare(WiFiClient *stream) {
   pngle_set_user_data(pngle, this);
   pngle_set_draw_callback(pngle, drawCallback);
 }
 
-int PngDecoder::decode(HTTPClient& http, WiFiClient* stream) {
+size_t PngDecoder::decode(HTTPClient &http, WiFiClient *stream) {
   uint8_t buf[2048];
   int remain = 0;
   int total = 0;
   while (http.connected()) {
     size_t size = stream->available();
-    if (!size) { delay(1); continue; }
+    if (!size) {
+      delay(1);
+      continue;
+    }
 
     if (size > sizeof(buf) - remain) {
       size = sizeof(buf) - remain;
@@ -62,7 +62,9 @@ int PngDecoder::decode(HTTPClient& http, WiFiClient* stream) {
       }
 
       remain = remain + len - fed;
-      if (remain > 0) memmove(buf, buf + fed, remain);
+      if (remain > 0) {
+        memmove(buf, buf + fed, remain);
+      }
     } else {
       delay(1);
     }
@@ -70,7 +72,9 @@ int PngDecoder::decode(HTTPClient& http, WiFiClient* stream) {
   return total;
 }
 
-} // namespace online_image
-} // namespace esphome
+}  // namespace online_image
+}  // namespace esphome
 
-#endif // ONLINE_IMAGE_PNG_SUPPORT
+#endif  // ONLINE_IMAGE_PNG_SUPPORT
+
+#endif  // USE_ARDUINO

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -10,6 +10,21 @@ namespace esphome {
 namespace online_image {
 
 /**
+ * @brief Converts an RGB color (ignoring alpha) to a 1-bit grayscale color.
+ *
+ * @param color The color to convert from; the alpha channel will be ignored.
+ * @return Whether the 8-bit grayscale equivalent color is brighter than average (i.e. brighter than 0x7F).
+ */
+static bool isColorOn(Color color) {
+  // This produces the most accurate monochrome conversion, but is slightly slower.
+  //  return (0.2125 * color.r + 0.7154 * color.g + 0.0721 * color.b) > 127;
+
+  // Approximation using fast integer computations; produces acceptable results
+  // Would be equivalent to 0.25 * R + 0.5 * G + 0.25 * B
+  return ((color.r >> 2) + (color.g >> 1) + (color.b >> 2)) & 0x80;
+}
+
+/**
  * @brief Callback method that will be called by the PNGLE engine when a chunk
  * of the image is decoded.
  *
@@ -20,9 +35,12 @@ namespace online_image {
  * @param h The height of the rectangle to draw.
  * @param rgba The color to paint the rectangle in.
  */
-void drawCallback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]) {
+static void drawCallback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]) {
   PngDecoder *decoder = (PngDecoder *) pngle_get_user_data(pngle);
   Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
+  if (decoder->display()->get_display_type() == display::DisplayType::DISPLAY_TYPE_BINARY) {
+    color = isColorOn(color) ? decoder->color_on() : decoder->color_off();
+  }
 
   if (rgba[3]) {
     x += decoder->x0();

--- a/esphome/components/online_image/png_image.h
+++ b/esphome/components/online_image/png_image.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifdef USE_ARDUINO
+
 #include "online_image.h"
 #ifdef ONLINE_IMAGE_PNG_SUPPORT
 
@@ -10,28 +12,31 @@ namespace online_image {
 /**
  * @brief Image decoder specialization for PNG images.
  */
-class PngDecoder: public ImageDecoder {
-  public:
-    /**
-     * @brief Construct a new PNG Decoder object.
-     *
-     * @param display The display to draw the decoded image to.
-     */
-    PngDecoder(display::DisplayBuffer * display);
-    virtual ~PngDecoder();
+class PngDecoder : public ImageDecoder {
+ public:
+  /**
+   * @brief Construct a new PNG Decoder object.
+   *
+   * @param display The display to draw the decoded image to.
+   */
+  PngDecoder(display::DisplayBuffer *display);
+  virtual ~PngDecoder();
 
-    void prepare(WiFiClient* stream) override;
-    int decode(HTTPClient& http, WiFiClient* stream) override;
+  void prepare(WiFiClient *stream) override;
+  size_t decode(HTTPClient &http, WiFiClient *stream) override;
 
-    /**
-     * @return The display to draw to. Needed by the callback function.
-     */
-    display::DisplayBuffer* display() {return display_;}
-  private:
-    pngle_t* pngle;
+  /**
+   * @return The display to draw to. Needed by the callback function.
+   */
+  display::DisplayBuffer *display() { return display_; }
+
+ private:
+  pngle_t *pngle;
 };
 
-} // namespace online_image
-} // namespace esphome
+}  // namespace online_image
+}  // namespace esphome
 
-#endif // ONLINE_IMAGE_PNG_SUPPORT
+#endif  // ONLINE_IMAGE_PNG_SUPPORT
+
+#endif  // USE_ARDUINO

--- a/esphome/components/online_image/png_image.h
+++ b/esphome/components/online_image/png_image.h
@@ -23,7 +23,7 @@ class PngDecoder : public ImageDecoder {
   virtual ~PngDecoder();
 
   void prepare(WiFiClient *stream) override;
-  size_t decode(HTTPClient &http, WiFiClient *stream) override;
+  size_t decode(HTTPClient &http, WiFiClient *stream, std::vector<uint8_t> &buffer) override;
 
   /**
    * @return The display to draw to. Needed by the callback function.

--- a/esphome/components/online_image/png_image.h
+++ b/esphome/components/online_image/png_image.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "online_image.h"
+#ifdef ONLINE_IMAGE_PNG_SUPPORT
+
+#include <pngle.h>
+
+namespace esphome {
+namespace online_image {
+
+/**
+ * @brief Image decoder specialization for PNG images.
+ */
+class PngDecoder: public ImageDecoder {
+  public:
+    /**
+     * @brief Construct a new PNG Decoder object.
+     *
+     * @param display The display to draw the decoded image to.
+     */
+    PngDecoder(display::DisplayBuffer * display);
+    virtual ~PngDecoder();
+
+    void prepare(WiFiClient* stream) override;
+    int decode(HTTPClient& http, WiFiClient* stream) override;
+
+    /**
+     * @return The display to draw to. Needed by the callback function.
+     */
+    display::DisplayBuffer* display() {return display_;}
+  private:
+    pngle_t* pngle;
+};
+
+} // namespace online_image
+} // namespace esphome
+
+#endif // ONLINE_IMAGE_PNG_SUPPORT

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -435,6 +435,11 @@ cover:
     source_id: tuya_cover
     name: Tuya Cover copy
 
+online_image:
+  - url: "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
+    id: png_image
+    format: PNG
+
 display:
   - platform: addressable_light
     id: led_matrix_32x8_display
@@ -500,6 +505,8 @@ display:
     powerup_pin: GPIO1
     wakeup_pin: GPIO1
     vcom_pin: GPIO1
+    lambda: |-
+      it.image(0, 0, id(png_image));
 
 number:
   - platform: tuya


### PR DESCRIPTION
# What does this implement/fix?

This PR implements the possibility of downloading PNG images at runtime and showing them in a compatible display.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** relates to https://github.com/esphome/feature-requests/issues/1463

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2076

## Test Environment

- [x] ESP32 (Inkplate10)
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml
# Example config.yaml
online_image:
  - url: "https://www.example.org/image.png"
    id: example_image
    format: PNG

display:
  # ...
  lambda: |-
    it.image(0, 0, id(example_image));

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
