### PR TITLE
Tcs34725 automatic sampling settings for improved dynamics and accuracy

### DIFF
--- a/esphome/components/tcs34725/sensor.py
+++ b/esphome/components/tcs34725/sensor.py
@@ -31,6 +31,7 @@ TCS34725Component = tcs34725_ns.class_(
 
 TCS34725IntegrationTime = tcs34725_ns.enum("TCS34725IntegrationTime")
 TCS34725_INTEGRATION_TIMES = {
+    "auto": TCS34725IntegrationTime.TCS34725_INTEGRATION_TIME_AUTO,
     "2.4ms": TCS34725IntegrationTime.TCS34725_INTEGRATION_TIME_2_4MS,
     "24ms": TCS34725IntegrationTime.TCS34725_INTEGRATION_TIME_24MS,
     "50ms": TCS34725IntegrationTime.TCS34725_INTEGRATION_TIME_50MS,
@@ -88,7 +89,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_CLEAR_CHANNEL): color_channel_schema,
             cv.Optional(CONF_ILLUMINANCE): illuminance_schema,
             cv.Optional(CONF_COLOR_TEMPERATURE): color_temperature_schema,
-            cv.Optional(CONF_INTEGRATION_TIME, default="2.4ms"): cv.enum(
+            cv.Optional(CONF_INTEGRATION_TIME, default="auto"): cv.enum(
                 TCS34725_INTEGRATION_TIMES, lower=True
             ),
             cv.Optional(CONF_GAIN, default="1X"): cv.enum(TCS34725_GAINS, upper=True),

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -310,7 +310,7 @@ void TCS34725Component::set_integration_time(TCS34725IntegrationTime integration
   // if an integration time is 0x100, this is auto start with 154ms as this gives best starting point
   TCS34725IntegrationTime my_integration_time_regval;
 
-  if (integration_time == 0x100) {
+  if (integration_time == TCS34725_INTEGRATION_TIME_AUTO) {
     this->integration_time_auto_ = true;
     this->integration_reg_ = TCS34725_INTEGRATION_TIME_154MS;
     my_integration_time_regval = TCS34725_INTEGRATION_TIME_154MS;

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -307,7 +307,7 @@ void TCS34725Component::set_integration_time(TCS34725IntegrationTime integration
   } else {
     this->integration_reg_ = integration_time;
     my_integration_time_regval = integration_time;
-    integration_time_auto_ = false;
+    this->integration_time_auto_ = false;
   }
   this->integration_time_ = (256.f - my_integration_time_regval) * 2.4f;
   ESP_LOGI(TAG, "TCS34725I Integration time set to: %.1fms", this->integration_time_);

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -136,11 +136,11 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   }
   /* Check for saturation and mark the sample as invalid if true */
   if (c >= sat) {
-    if (this->integration_time_auto_){
+    if (this->integration_time_auto_) {
       ESP_LOGI(TAG,
              "Saturation too high, sample discarded, autogain ongoing",
              sat, c);
-    }else{      
+    } else {
       ESP_LOGW(TAG,
              "Saturation too high, sample with saturation %.1f and clear %d treat values carefully or use grey filter",
              sat, c);
@@ -160,7 +160,8 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   if (r2 == 0) {
     // legacy code
     if (!this->integration_time_auto_) {
-      ESP_LOGW(TAG, "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
+      ESP_LOGW(TAG, 
+               "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
       return;
     }
   }
@@ -237,8 +238,7 @@ void TCS34725Component::update() {
   // - not auto mode
   // - clear not oversaturated
   // - clear oversaturated but gain and timing cannot go lower
-  if (!this->integration_time_auto_ || raw_c < 65530 || 
-       (this->gain_reg_ == 0 && this->integration_time_ < 200) ){
+  if (!this->integration_time_auto_ || raw_c < 65530 || (this->gain_reg_ == 0 && this->integration_time_ < 200)) {
 
     if (this->illuminance_sensor_ != nullptr)
       this->illuminance_sensor_->publish_state(this->illuminance_);
@@ -250,8 +250,7 @@ void TCS34725Component::update() {
   ESP_LOGD(TAG,
            "Got Red=%.1f%%,Green=%.1f%%,Blue=%.1f%%,Clear=%.1f%% Illuminance=%.1flx Color "
            "Temperature=%.1fK",
-           channel_r, channel_g, channel_b, channel_c, this->illuminance_,
-           this->color_temperature_);
+           channel_r, channel_g, channel_b, channel_c, this->illuminance_, this->color_temperature_);
 
   if (this->integration_time_auto_) {
     // change integration time an gain to achieve maximum resolution an dynamic range
@@ -291,13 +290,14 @@ void TCS34725Component::update() {
 
     // calculate register value from timing
     uint8_t regval_atime = (uint8_t)(256.f - integration_time_next / 2.4f);
-    ESP_LOGD(TAG, "Integration time: %.1fms, ideal: %.1fms regval_new %d Gain: %.f Clear channel raw: %d  gain reg: %d", 
+    ESP_LOGD(TAG, 
+             "Integration time: %.1fms, ideal: %.1fms regval_new %d Gain: %.f Clear channel raw: %d  gain reg: %d",
              this->integration_time_, integration_time_next, regval_atime, this->gain_, raw_c, this->gain_reg_);
 
     if (this->integration_reg_ != regval_atime || gain_reg_val_new != this->gain_reg_) {
       this->integration_reg_ = regval_atime;
       this->gain_reg_ = gain_reg_val_new;
-      set_gain((TCS34725Gain)gain_reg_val_new);
+      set_gain((TCS34725Gain) gain_reg_val_new);
       if (this->write_config_register_(TCS34725_REGISTER_ATIME, this->integration_reg_) != i2c::ERROR_OK ||
           this->write_config_register_(TCS34725_REGISTER_CONTROL, this->gain_reg_) != i2c::ERROR_OK) {
         this->mark_failed();

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -154,7 +154,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   if (r2 == 0) {
     ESP_LOGW(TAG, "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
     // legacy code
-    if (!integration_time_auto_) {
+    if (!this->integration_time_auto_) {
       return;
     }
   }
@@ -238,7 +238,7 @@ void TCS34725Component::update() {
            this->integration_time_, channel_r, channel_g, channel_b, channel_c, this->illuminance_,
            this->color_temperature_);
 
-  if (integration_time_auto_) {
+  if (this->integration_time_auto_) {
     // change integration time an gain to achieve maximum resolution an dynamic range
     // calculate optimal integration time to achieve 70% satuaration
     float integration_time_ideal;

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -301,7 +301,7 @@ void TCS34725Component::set_integration_time(TCS34725IntegrationTime integration
   TCS34725IntegrationTime my_integration_time_regval;
 
   if (integration_time == 0x100) {
-    integration_time_auto_ = true;
+    this->integration_time_auto_ = true;
     this->integration_reg_ = TCS34725_INTEGRATION_TIME_154MS;
     my_integration_time_regval = TCS34725_INTEGRATION_TIME_154MS;
   } else {

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -192,7 +192,7 @@ void TCS34725Component::update() {
     this->status_set_warning();
     return;
   }
-  ESP_LOGD(TAG, "Raw values clear=%d red=%d green=%d blue=%d", raw_c, raw_r, raw_g, raw_b);
+  ESP_LOGV(TAG, "Raw values clear=%d red=%d green=%d blue=%d", raw_c, raw_r, raw_g, raw_b);
 
   float channel_c;
   float channel_r;
@@ -238,8 +238,6 @@ void TCS34725Component::update() {
     float integration_time_ideal;
     integration_time_ideal = 60 / ((float) raw_c /655.35) * this->integration_time_;
 
-    ESP_LOGD(TAG, "integration_time_ideal %.1f", integration_time_ideal);
-
     uint8_t gainRegVal = this->gain_reg_; 
     // increase gain if less than 20% of white channel used and high integration time
     // increase only if not already maximum
@@ -250,7 +248,7 @@ void TCS34725Component::update() {
         gainRegVal= this->gain_reg_ +1;
         // update integration time to new situation
         integration_time_ideal = integration_time_ideal /4;
-        ESP_LOGD(TAG, "TCS34725I Gain increase to %d", 2^gainRegVal);
+        //ESP_LOGD(TAG, "TCS34725I Gain increase to %d", 2^gainRegVal);
       }
     }
 
@@ -261,7 +259,7 @@ void TCS34725Component::update() {
         gainRegVal = this->gain_reg_ - 1;
         // update integration time to new situation
         integration_time_ideal = integration_time_ideal *4;
-        ESP_LOGD(TAG, "TCS34725I Gain adjust to %d", 2^gainRegVal);
+        //ESP_LOGD(TAG, "TCS34725I Gain adjust to %d", 2^gainRegVal);
       }
     }    
 

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -138,8 +138,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   if (c >= sat) {
     if (this->integration_time_auto_) {
       ESP_LOGI(TAG,
-             "Saturation too high, sample discarded, autogain ongoing",
-             sat, c);
+             "Saturation too high, sample discarded, autogain ongoing",);
     } else {
       ESP_LOGW(TAG,
              "Saturation too high, sample with saturation %.1f and clear %d treat values carefully or use grey filter",

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -139,9 +139,10 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
     if (this->integration_time_auto_) {
       ESP_LOGI(TAG, "Saturation too high, sample discarded, autogain ongoing");
     } else {
-      ESP_LOGW(TAG,
-             "Saturation too high, sample with saturation %.1f and clear %d treat values carefully or use grey filter",
-             sat, c);
+      ESP_LOGW(
+          TAG,
+          "Saturation too high, sample with saturation %.1f and clear %d treat values carefully or use grey filter",
+          sat, c);
     }
   }
 
@@ -158,7 +159,8 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   if (r2 == 0) {
     // legacy code
     if (!this->integration_time_auto_) {
-      ESP_LOGW(TAG, "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
+      ESP_LOGW(TAG, 
+               "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
       return;
     }
   }

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -244,26 +244,26 @@ void TCS34725Component::update() {
     float integration_time_ideal;
     integration_time_ideal = 60 / ((float) raw_c / 655.35) * this->integration_time_;
 
-    uint8_t gainRegVal = this->gain_reg_;
+    uint8_t gain_reg_val = this->gain_reg_;
     // increase gain if less than 20% of white channel used and high integration time
     // increase only if not already maximum
     // do not use max gain, as ist will not get better
     if (this->gain_reg_ < 2) {
       if (((float) raw_c / 655.35 < 20.f) && (this->integration_time_ > 600.f)) {
-        gainRegVal = this->gain_reg_ + 1;
+        gain_reg_val = this->gain_reg_ + 1;
         // update integration time to new situation
         integration_time_ideal = integration_time_ideal / 4;
-        // ESP_LOGD(TAG, "TCS34725I Gain increase to %d", 2^gainRegVal);
+        // ESP_LOGD(TAG, "TCS34725I Gain increase to %d", 2^gain_reg_val);
       }
     }
 
     // decrease gain, if very high clear values and integration times alreadey low
     if (this->gain_reg_ > 0) {
       if (70 < ((float) raw_c / 655.35) && (this->integration_time_ < 200)) {
-        gainRegVal = this->gain_reg_ - 1;
+        gain_reg_val = this->gain_reg_ - 1;
         // update integration time to new situation
         integration_time_ideal = integration_time_ideal * 4;
-        // ESP_LOGD(TAG, "TCS34725I Gain adjust to %d", 2^gainRegVal);
+        // ESP_LOGD(TAG, "TCS34725I Gain adjust to %d", 2^gain_reg_val);
       }
     }
 
@@ -277,14 +277,14 @@ void TCS34725Component::update() {
     }
 
     // calculate register value from timing
-    uint8_t regvalATIME = (uint8_t)(256.f - integration_time_next / 2.4f);
+    uint8_t regval_atime = (uint8_t)(256.f - integration_time_next / 2.4f);
     uint8_t actual_gain = pow(4, this->gain_reg_);
     ESP_LOGI(TAG, "Integration time: %.1fms, ideal: %.1fms regval_new %d Gain_reg: %d", this->integration_time_,
-             integration_time_next, regvalATIME, actual_gain);
+             integration_time_next, regval_atime, actual_gain);
 
-    if (this->integration_reg_ != regvalATIME || gainRegVal != this->gain_reg_) {
-      this->integration_reg_ = regvalATIME;
-      this->gain_reg_ = gainRegVal;
+    if (this->integration_reg_ != regval_atime || gain_reg_val != this->gain_reg_) {
+      this->integration_reg_ = regval_atime;
+      this->gain_reg_ = gain_reg_val;
       if (this->write_config_register_(TCS34725_REGISTER_ATIME, this->integration_reg_) != i2c::ERROR_OK ||
           this->write_config_register_(TCS34725_REGISTER_CONTROL, this->gain_reg_) != i2c::ERROR_OK) {
         this->mark_failed();

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -159,7 +159,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   if (r2 == 0) {
     // legacy code
     if (!this->integration_time_auto_) {
-      ESP_LOGW(TAG, 
+      ESP_LOGW(TAG,
                "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
       return;
     }

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -137,8 +137,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   /* Check for saturation and mark the sample as invalid if true */
   if (c >= sat) {
     if (this->integration_time_auto_) {
-      ESP_LOGI(TAG,
-             "Saturation too high, sample discarded, autogain ongoing",);
+      ESP_LOGI(TAG, "Saturation too high, sample discarded, autogain ongoing");
     } else {
       ESP_LOGW(TAG,
              "Saturation too high, sample with saturation %.1f and clear %d treat values carefully or use grey filter",
@@ -159,8 +158,7 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   if (r2 == 0) {
     // legacy code
     if (!this->integration_time_auto_) {
-      ESP_LOGW(TAG, 
-               "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
+      ESP_LOGW(TAG, "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
       return;
     }
   }
@@ -238,7 +236,6 @@ void TCS34725Component::update() {
   // - clear not oversaturated
   // - clear oversaturated but gain and timing cannot go lower
   if (!this->integration_time_auto_ || raw_c < 65530 || (this->gain_reg_ == 0 && this->integration_time_ < 200)) {
-
     if (this->illuminance_sensor_ != nullptr)
       this->illuminance_sensor_->publish_state(this->illuminance_);
 
@@ -289,8 +286,7 @@ void TCS34725Component::update() {
 
     // calculate register value from timing
     uint8_t regval_atime = (uint8_t)(256.f - integration_time_next / 2.4f);
-    ESP_LOGD(TAG, 
-             "Integration time: %.1fms, ideal: %.1fms regval_new %d Gain: %.f Clear channel raw: %d  gain reg: %d",
+    ESP_LOGD(TAG, "Integration time: %.1fms, ideal: %.1fms regval_new %d Gain: %.f Clear channel raw: %d  gain reg: %d",
              this->integration_time_, integration_time_next, regval_atime, this->gain_, raw_c, this->gain_reg_);
 
     if (this->integration_reg_ != regval_atime || gain_reg_val_new != this->gain_reg_) {

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -277,7 +277,7 @@ void TCS34725Component::update() {
     }
 
     // calculate register value from timing
-    uint8_t regvalATIME = (uint8_t) (256.f - integration_time_next / 2.4f);
+    uint8_t regvalATIME = (uint8_t)(256.f - integration_time_next / 2.4f);
     uint8_t actual_gain = pow(4, this->gain_reg_);
     ESP_LOGI(TAG, "Integration time: %.1fms, ideal: %.1fms regval_new %d Gain_reg: %d", this->integration_time_,
              integration_time_next, regvalATIME, actual_gain);

--- a/esphome/components/tcs34725/tcs34725.h
+++ b/esphome/components/tcs34725/tcs34725.h
@@ -82,7 +82,7 @@ class TCS34725Component : public PollingComponent, public i2c::I2CDevice {
 
  private:
   void calculate_temperature_and_lux_(uint16_t r, uint16_t g, uint16_t b, uint16_t c);
-  uint16_t integration_reg_{TCS34725_INTEGRATION_TIME_AUTO};
+  uint16_t integration_reg_;
   uint8_t gain_reg_{TCS34725_GAIN_1X};
 };
 

--- a/esphome/components/tcs34725/tcs34725.h
+++ b/esphome/components/tcs34725/tcs34725.h
@@ -26,6 +26,7 @@ enum TCS34725IntegrationTime {
   TCS34725_INTEGRATION_TIME_540MS = 0x1F,
   TCS34725_INTEGRATION_TIME_600MS = 0x06,
   TCS34725_INTEGRATION_TIME_614MS = 0x00,
+  TCS34725_INTEGRATION_TIME_AUTO = 0x100,
 };
 
 enum TCS34725Gain {
@@ -77,10 +78,11 @@ class TCS34725Component : public PollingComponent, public i2c::I2CDevice {
   float glass_attenuation_{1.0};
   float illuminance_;
   float color_temperature_;
+  bool integration_time_auto_{true};
 
  private:
   void calculate_temperature_and_lux_(uint16_t r, uint16_t g, uint16_t b, uint16_t c);
-  uint8_t integration_reg_{TCS34725_INTEGRATION_TIME_2_4MS};
+  uint16_t integration_reg_{TCS34725_INTEGRATION_TIME_AUTO};
   uint8_t gain_reg_{TCS34725_GAIN_1X};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Feature: add an auto mode for integration time and gain factor. The algorithm tries to achieve high accuracy with good dynamics. The sensor now can deliver proper lux and color temperature from below 1 lux up to 30k lux! 

For my needs I wanted to measure outdoor light with proper color temperature from direct sunshine to almost complete dark. The sensor can deliver, now the software can too.

Further changes:
- In auto mode the readings will never be discarded, even fully saturated. With auto gain this is not very likely to happen often. The old implementation, which is unchanged with fixed timings applied, return a zero brightness after over satuaration which I consider a bad behavior.
- The new default timing is auto, I assume this is what most people would need.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1951


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:


```yaml
sensor:
  - platform: tcs34725
    red_channel:
      name: "TCS34725 Red Channel"
    clear_channel:
      name: "TCS34725 Clear Channel"
    illuminance:
      name: "TCS34725 Illuminance"
    color_temperature:
      name: "TCS34725 Color Temperature"
    integration_time: auto
    address: 0x29
    update_interval: 2s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
