### PR TITLE
Tidy up casting, explicit HttpResponse lifetime

### DIFF
--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<HttpResponse> HttpRequestIDF::send() {
     return nullptr;
   }
 
-  HttpResponse response = {};
+  HttpResponse response = {}; // used as user_data, by http_event_handler, in esp_http_client_perform
   esp_http_client_config_t config = {};
 
   config.url = this->url_.c_str();

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -35,9 +35,9 @@ esp_err_t http_event_handler(esp_http_client_event_t *evt) {
        */
       if (!esp_http_client_is_chunked_response(evt->client)) {
         if (global_http_request->get_capture_response()) {
-          auto& response = *reinterpret_cast<HttpResponse *>(evt->user_data);
-          const auto data_begin = reinterpret_cast<char *>(evt->data);
-          const auto data_end = data_begin + evt->data_len;
+          auto &response = *reinterpret_cast<HttpResponse *>(evt->user_data);
+          auto *const data_begin = reinterpret_cast<char *>(evt->data);
+          auto *const data_end = data_begin + evt->data_len;
           response.data.insert(response.data.end(), data_begin, data_end);
         }
       }
@@ -80,7 +80,7 @@ std::unique_ptr<HttpResponse> HttpRequestIDF::send() {
     return nullptr;
   }
 
-  HttpResponse response = {}; // used as user_data, by http_event_handler, in esp_http_client_perform
+  HttpResponse response = {};  // used as user_data, by http_event_handler, in esp_http_client_perform
   esp_http_client_config_t config = {};
 
   config.url = this->url_.c_str();

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -121,7 +121,7 @@ std::unique_ptr<HttpResponse> HttpRequestIDF::send() {
   if (status_code < 200 || status_code >= 300) {
     ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", this->url_.c_str(), status_code);
     this->status_set_warning();
-    return response;
+    return make_unique<HttpResponse>(std::move(response));
   }
 
   this->status_clear_warning();
@@ -129,7 +129,7 @@ std::unique_ptr<HttpResponse> HttpRequestIDF::send() {
 
   esp_http_client_cleanup(client);
 
-  return std::unique_ptr<HttpResponse>(new HttpResponse(std::move(response)));
+  return make_unique<HttpResponse>(std::move(response));
 }
 
 }  // namespace http_request


### PR DESCRIPTION
Hopefully this is an improvement on documenting the explicit lifetime of `HttpResponse` (as implemented in https://github.com/esphome/esphome/pull/3256) and helps others in understanding how the response is used by the `http_event_handler`.

(I omitted the usual PR pre-amble as this is between branches, not to `dev`)