### PR TITLE
Add optimistic config flag to modbus select.

### DIFF
--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import select
-from esphome.const import CONF_ADDRESS, CONF_ID, CONF_LAMBDA
+from esphome.const import CONF_ADDRESS, CONF_ID, CONF_LAMBDA, CONF_OPTIMISTIC
 from esphome.jsonschema import jschema_composite
 
 from .. import (
@@ -79,6 +79,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FORCE_NEW_RANGE, default=False): cv.boolean,
             cv.Required(CONF_OPTIONSMAP): ensure_option_map(),
             cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
+            cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
             cv.Optional(CONF_LAMBDA): cv.returning_lambda,
             cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
         },
@@ -112,6 +113,7 @@ async def to_code(config):
     cg.add(parent.add_sensor_item(var))
     cg.add(var.set_parent(parent))
     cg.add(var.set_use_write_mutiple(config[CONF_USE_WRITE_MULTIPLE]))
+    cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
 
     if CONF_LAMBDA in config:
         template_ = await cg.process_lambda(

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -80,6 +80,9 @@ void ModbusSelect::control(const std::string &value) {
   }
 
   parent_->queue_command(write_cmd);
+
+  if (this->optimistic_)
+    this->publish_state(value);
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -32,6 +32,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
 
   void set_parent(ModbusController *const parent) { this->parent_ = parent; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
+  void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
   void set_template(transform_func_t &&f) { this->transform_func_ = f; }
   void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
 
@@ -43,6 +44,7 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   std::vector<int64_t> mapping_;
   ModbusController *parent_;
   bool use_write_multiple_{false};
+  bool optimistic_{false};
   optional<transform_func_t> transform_func_;
   optional<write_transform_func_t> write_transform_func_;
 };


### PR DESCRIPTION
# What does this implement/fix?

Adds a new configuration flag `optimistic` to the modbus select platform.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/feature-requests#1641

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1949

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
select:
  - platform: modbus_controller
    modbus_controller_id: simpleevse_device
    id: analog_input_config
    address: 2003
    skip_updates: ${setup_skip_values}
    name: ${devicename} Analog Input Config
    entity_category: config
    optimistic: true
    optionsmap:
      "analog input": 0
      "1A step": 1
      "2A step": 2
      "3A step": 3
      "4A step": 4
      "5A step": 5
      "6A step": 6
      "7A step": 7
      "8A step": 8
      "9A step": 9
      "10A step": 10
      "mapping table": 11
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
