### PR TITLE
Add entity_category_diagnostics to SGP30 baseline sensors

### DIFF
--- a/esphome/components/sgp30/sensor.py
+++ b/esphome/components/sgp30/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     UNIT_PARTS_PER_MILLION,
     UNIT_PARTS_PER_BILLION,
     ICON_MOLECULE_CO2,
+    ENTITY_CATEGORY_DIAGNOSTIC,
 )
 
 DEPENDENCIES = ["i2c"]
@@ -49,10 +50,12 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_ECO2_BASELINE): sensor.sensor_schema(
                 icon=ICON_MOLECULE_CO2,
                 accuracy_decimals=0,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_TVOC_BASELINE): sensor.sensor_schema(
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_STORE_BASELINE, default=True): cv.boolean,
             cv.Optional(CONF_BASELINE): cv.Schema(


### PR DESCRIPTION
Added entity category diagnostics to baseline sensors.

# What does this implement/fix?
For the sensors that expose the latest baseline the SGP30 is using the sensor has been given the diagnostics category. 

Quick description and explanation of changes
instead of manualy adding this configuration in the ESPHome YAML of the SGP30 sensor this is now default behavior:


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Example with the entity category in it. this is not nessesary anymore when this pull request is merged.

```
  - platform: sgp30
    eco2:
      name: "eCO2"
      accuracy_decimals: 1
    tvoc:
      name: "TVOC"
      accuracy_decimals: 1
      filters:
    store_baseline: yes
    eco2_baseline:
      name: "eCO2 Baseline"
      entity_category: "diagnostic"
    tvoc_baseline:
      name: "TVOC Baseline"
      entity_category: "diagnostic"
    address: 0x58
    update_interval: 1s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
