### PR TITLE
Add visual step/min/max for webserver climate

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -977,9 +977,10 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
 
     root["mode"] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
 
-    root["max_temperature"] = traits.get_visual_max_temperature();
-    root["min_temperature"] = traits.get_visual_min_temperature();
-    root["temperature_step"] = traits.get_visual_temperature_step();
+
+    root["max_temp"] = traits.get_visual_max_temperature();
+    root["min_temp"] = traits.get_visual_min_temperature();
+    root["step"] = traits.get_visual_temperature_step();
     if (traits.get_supports_action()) {
       root["action"] = PSTR_LOCAL(climate_action_to_string(obj->action));
     }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -977,6 +977,9 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
 
     root["mode"] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
 
+    root["max_temperature"] = traits.get_visual_max_temperature();
+    root["min_temperature"] = traits.get_visual_min_temperature();
+    root["temperature_step"] = traits.get_visual_temperature_step();
     if (traits.get_supports_action()) {
       root["action"] = PSTR_LOCAL(climate_action_to_string(obj->action));
     }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -976,8 +976,6 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
     }
 
     root["mode"] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
-
-
     root["max_temp"] = traits.get_visual_max_temperature();
     root["min_temp"] = traits.get_visual_min_temperature();
     root["step"] = traits.get_visual_temperature_step();


### PR DESCRIPTION
# What does this implement/fix?

Add visual step/min/max for climate to the event so that the UI can set range on sliders

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes <link to issue>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266


