### PR TITLE
Add on_initialized automation to tuya component

### DIFF
--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -12,6 +12,8 @@ CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS = "ignore_mcu_update_on_datapoints"
 CONF_ON_DATAPOINT_UPDATE = "on_datapoint_update"
 CONF_DATAPOINT_TYPE = "datapoint_type"
 
+CONF_ON_INITIALIZED = "on_initialized"
+
 tuya_ns = cg.esphome_ns.namespace("tuya")
 Tuya = tuya_ns.class_("Tuya", cg.Component, uart.UARTDevice)
 
@@ -70,6 +72,10 @@ DATAPOINT_TRIGGERS = {
     ),
 }
 
+INITIALIZED_TRIGGER = tuya_ns.class_(
+    "TuyaInitializedTrigger", automation.Trigger.template()
+)
+
 
 def assign_declare_id(value):
     value = value.copy()
@@ -100,6 +106,11 @@ CONFIG_SCHEMA = (
                 },
                 extra_validators=assign_declare_id,
             ),
+            cv.Optional(CONF_ON_INITIALIZED): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(INITIALIZED_TRIGGER),
+                }
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -124,3 +135,6 @@ async def to_code(config):
         await automation.build_automation(
             trigger, [(DATAPOINT_TYPES[conf[CONF_DATAPOINT_TYPE]], "x")], conf
         )
+    for conf in config.get(CONF_ON_INITIALIZED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)

--- a/esphome/components/tuya/automation.h
+++ b/esphome/components/tuya/automation.h
@@ -7,6 +7,13 @@
 namespace esphome {
 namespace tuya {
 
+class TuyaInitializedTrigger : public Trigger<> {
+ public:
+  explicit TuyaInitializedTrigger(Tuya *parent) {
+   parent->add_on_initialized_callback([this]() { this->trigger(); });
+  }
+};
+
 class TuyaDatapointUpdateTrigger : public Trigger<TuyaDatapoint> {
  public:
   explicit TuyaDatapointUpdateTrigger(Tuya *parent, uint8_t sensor_id) {

--- a/esphome/components/tuya/automation.h
+++ b/esphome/components/tuya/automation.h
@@ -10,7 +10,7 @@ namespace tuya {
 class TuyaInitializedTrigger : public Trigger<> {
  public:
   explicit TuyaInitializedTrigger(Tuya *parent) {
-   parent->add_on_initialized_callback([this]() { this->trigger(); });
+    parent->add_on_initialized_callback([this]() { this->trigger(); });
   }
 };
 

--- a/esphome/components/tuya/number/__init__.py
+++ b/esphome/components/tuya/number/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_NUMBER_DATAPOINT,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
+    CONF_RESTORE_VALUE,
     CONF_STEP,
 )
 from .. import tuya_ns, CONF_TUYA_ID, Tuya
@@ -31,6 +32,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MAX_VALUE): cv.float_,
             cv.Required(CONF_MIN_VALUE): cv.float_,
             cv.Required(CONF_STEP): cv.positive_float,
+            cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     validate_min_max,
@@ -52,3 +54,6 @@ async def to_code(config):
     cg.add(var.set_tuya_parent(paren))
 
     cg.add(var.set_number_id(config[CONF_NUMBER_DATAPOINT]))
+
+    if CONF_RESTORE_VALUE in config:
+        cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))

--- a/esphome/components/tuya/number/tuya_number.h
+++ b/esphome/components/tuya/number/tuya_number.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/number/number.h"
+#include "esphome/core/preferences.h"
 
 namespace esphome {
 namespace tuya {
@@ -12,6 +13,7 @@ class TuyaNumber : public number::Number, public Component {
   void setup() override;
   void dump_config() override;
   void set_number_id(uint8_t number_id) { this->number_id_ = number_id; }
+  void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
 
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
 
@@ -21,6 +23,9 @@ class TuyaNumber : public number::Number, public Component {
   Tuya *parent_;
   uint8_t number_id_{0};
   TuyaDatapointType type_{};
+  bool restore_value_{false};
+
+  ESPPreferenceObject pref_;
 };
 
 }  // namespace tuya

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -197,7 +197,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       if (this->init_state_ == TuyaInitState::INIT_DATAPOINT) {
         this->init_state_ = TuyaInitState::INIT_DONE;
         this->set_timeout("datapoint_dump", 1000, [this] { this->dump_config(); });
-        this->initialized_callback_.call();
+        this->set_timeout("initialized_cb", 1000, [this] { this->initialized_callback_.call(); });
       }
       this->handle_datapoints_(buffer, len);
       break;


### PR DESCRIPTION
This trigger is called at completion of tuya initialisation.

# What does this implement/fix?

This patch adds an automation called at the completion of initialization of the tuya component.
It can be used for tasks such as setting tuya datapoints which cannot be done on esphome:on_boot
due to tuya being (possibly) uninitialised at that time.

**Note:** please review the change in tuya.cpp. I found that without the delay it did not work as intended, perhaps because the subsequent handle_datapoints reset the datapoints to those just received from the MCU, perhaps there is a better place to make this call without the timeout ?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
tuya:
  on_initialized:
    then:
      - number.set:
          id: light_duration
          value: 35

number:
  - platform: tuya
    id: light_duration
    name: "Light Duration"
    number_datapoint: 104
    unit_of_measurement: "Seconds"
    min_value: 0
    max_value: 3600
    step: 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
