### PR TITLE
Implement allow_deep_sleep

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -144,6 +144,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 }
 float DeepSleepComponent::get_setup_priority() const { return setup_priority::LATE; }
 void DeepSleepComponent::prevent_deep_sleep() { this->prevent_ = true; }
+void DeepSleepComponent::allow_deep_sleep() { this->prevent_ = false; }
 
 }  // namespace deep_sleep
 }  // namespace esphome

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -90,6 +90,7 @@ class DeepSleepComponent : public Component {
   void begin_sleep(bool manual = false);
 
   void prevent_deep_sleep();
+  void allow_deep_sleep();
 
  protected:
   // Returns nullopt if no run duration is set. Otherwise, returns the run


### PR DESCRIPTION
# What does this implement/fix?

`DeepSleepComponent::unprevent_deep_sleep()`, sets the prevention of deep sleep again to false. Maybe `allow_deep_sleep()` is a better name?

Example use case: when the weather is sunny, the ESP runs on solar power, and I don't need deep sleep. When the weather becomes less perfect, re-enable the deep sleep timer.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes (none that I know)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
text_sensor:
  - platform: homeassistant
    name: "Weather From Home Assistant/OWM"
    entity_id: sensor.openweathermap_condition
    id: weather_condition
    on_value:
      then:
        - lambda: |-
            if (id(weather_condition).state == "sunny") {
              id(deep_sleep_1).prevent_deep_sleep();
            } else {
              id(deep_sleep_1).unprevent_deep_sleep();
            }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

I still have to test this and push the documentation changes. The idea is that I also contribute those, right? Thanks for this great project!