### PR TITLE
feat: esp32-camera add stream event

### DIFF
--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -282,8 +282,20 @@ void ESP32Camera::set_idle_update_interval(uint32_t idle_update_interval) {
 void ESP32Camera::add_image_callback(std::function<void(std::shared_ptr<CameraImage>)> &&f) {
   this->new_image_callback_.add(std::move(f));
 }
-void ESP32Camera::start_stream(CameraRequester requester) { this->stream_requesters_ |= (1U << requester); }
-void ESP32Camera::stop_stream(CameraRequester requester) { this->stream_requesters_ &= ~(1U << requester); }
+void ESP32Camera::add_stream_start_callback(std::function<void()> &&callback) {
+  this->stream_start_callback_.add(std::move(callback));
+}
+void ESP32Camera::add_stream_stop_callback(std::function<void()> &&callback) {
+  this->stream_stop_callback_.add(std::move(callback));
+}
+void ESP32Camera::start_stream(CameraRequester requester) {
+  this->stream_start_callback_.call();
+  this->stream_requesters_ |= (1U << requester);
+}
+void ESP32Camera::stop_stream(CameraRequester requester) {
+  this->stream_stop_callback_.call();
+  this->stream_requesters_ &= ~(1U << requester);
+}
 void ESP32Camera::request_image(CameraRequester requester) { this->single_requesters_ |= (1U << requester); }
 void ESP32Camera::update_camera_parameters() {
   sensor_t *s = esp_camera_sensor_get();

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -2,6 +2,7 @@
 
 #ifdef USE_ESP32
 
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
@@ -145,6 +146,9 @@ class ESP32Camera : public Component, public EntityBase {
   void request_image(CameraRequester requester);
   void update_camera_parameters();
 
+  void add_stream_start_callback(std::function<void()> &&callback);
+  void add_stream_stop_callback(std::function<void()> &&callback);
+
  protected:
   /* internal methods */
   uint32_t hash_base() override;
@@ -187,6 +191,8 @@ class ESP32Camera : public Component, public EntityBase {
   QueueHandle_t framebuffer_get_queue_;
   QueueHandle_t framebuffer_return_queue_;
   CallbackManager<void(std::shared_ptr<CameraImage>)> new_image_callback_;
+  CallbackManager<void()> stream_start_callback_{};
+  CallbackManager<void()> stream_stop_callback_{};
 
   uint32_t last_idle_request_{0};
   uint32_t last_update_{0};
@@ -194,6 +200,23 @@ class ESP32Camera : public Component, public EntityBase {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern ESP32Camera *global_esp32_camera;
+
+class ESP32CameraStreamStartTrigger : public Trigger<> {
+ public:
+  explicit ESP32CameraStreamStartTrigger(ESP32Camera *parent) {
+    parent->add_stream_start_callback([this]() { this->trigger(); });
+  }
+
+ protected:
+};
+class ESP32CameraStreamStopTrigger : public Trigger<> {
+ public:
+  explicit ESP32CameraStreamStopTrigger(ESP32Camera *parent) {
+    parent->add_stream_stop_callback([this]() { this->trigger(); });
+  }
+
+ protected:
+};
 
 }  // namespace esp32_camera
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

esp32-camera add 'on_stream_start' and 'on_stream_stop' stream event for use in Automotions.
For example, the built-in flash led turn on automatically while viewing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2078

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esp32_camera:
  external_clock:
    pin: GPIO0
    frequency: 20MHz
  i2c_pins:
    sda: GPIO26
    scl: GPIO27
  data_pins: [GPIO5, GPIO18, GPIO19, GPIO21, GPIO36, GPIO39, GPIO34, GPIO35]
  vsync_pin: GPIO25
  href_pin: GPIO23
  pixel_clock_pin: GPIO22
  power_down_pin: GPIO32
  name: camera1
  id: camera1
  vertical_flip: false
  on_stream_start:
    - script.execute: open_flash_script

script:
  - id: open_flash_script
    mode: restart
    then:
      - if:
          condition:
            light.is_off: cam_light
          then:
            - light.turn_on: cam_light
      - delay: 3s
      - light.turn_off: cam_light

light:
  - id: cam_light
    platform: binary
    name: "cam1 light"
    output: light_output
    
output:
  - id: light_output
    platform: gpio
    pin: GPIO4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
