### PR TITLE
Reserve less memory for json

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -70,6 +70,7 @@ void parse_json(const std::string &data, const json_parse_t &f) {
 
     if (err == DeserializationError::Ok) {
       pass = true;
+      f(root);
     } else if (err == DeserializationError::NoMemory) {
       if (request_size * 2 >= free_heap) {
         ESP_LOGE(TAG, "Can not allocate more memory for deserialization. Consider making source string smaller");
@@ -82,8 +83,6 @@ void parse_json(const std::string &data, const json_parse_t &f) {
       return;
     }
   } while (!pass);
-
-  f(root);
 }
 
 }  // namespace json

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -55,7 +55,7 @@ void parse_json(const std::string &data, const json_parse_t &f) {
 #endif
   bool pass = false;
   do {
-    const size_t request_size = std::min(free_heap - 2048, (size_t) (data.size() * 1.5));
+    const size_t request_size = std::min(free_heap - 2048, (size_t)(data.size() * 1.5));
 
     DynamicJsonDocument json_document(request_size);
     if (json_document.memoryPool().buffer() == nullptr) {

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -16,8 +16,8 @@ static const char *const TAG = "json";
 static std::vector<char> global_json_build_buffer;  // NOLINT
 
 std::string build_json(const json_build_t &f) {
-  // Here we are allocating up to 10kb of memory,
-  // with the heap size minus 2kb to be safe if less than 10kb
+  // Here we are allocating up to 5kb of memory,
+  // with the heap size minus 2kb to be safe if less than 5kb
   // as we can not have a true dynamic sized document.
   // The excess memory is freed below with `shrinkToFit()`
 #ifdef USE_ESP8266
@@ -26,7 +26,7 @@ std::string build_json(const json_build_t &f) {
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
 #endif
 
-  const size_t request_size = std::min(free_heap - 2048, (size_t) 10240);
+  const size_t request_size = std::min(free_heap - 2048, (size_t) 5120);
 
   DynamicJsonDocument json_document(request_size);
   if (json_document.memoryPool().buffer() == nullptr) {
@@ -44,8 +44,8 @@ std::string build_json(const json_build_t &f) {
 }
 
 void parse_json(const std::string &data, const json_parse_t &f) {
-  // Here we are allocating up to 10kb of memory,
-  // with the heap size minus 2kb to be safe if less than 10kb
+  // Here we are allocating 1.5 times the data size,
+  // with the heap size minus 2kb to be safe if less than that
   // as we can not have a true dynamic sized document.
   // The excess memory is freed below with `shrinkToFit()`
 #ifdef USE_ESP8266
@@ -53,24 +53,35 @@ void parse_json(const std::string &data, const json_parse_t &f) {
 #elif defined(USE_ESP32)
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
 #endif
+  bool pass = false;
+  do {
+    const size_t request_size = std::min(free_heap - 2048, (size_t) (data.size() * 1.5));
 
-  const size_t request_size = std::min(free_heap - 2048, (size_t) 10240);
+    DynamicJsonDocument json_document(request_size);
+    if (json_document.memoryPool().buffer() == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
+               free_heap);
+      return;
+    }
+    DeserializationError err = deserializeJson(json_document, data);
+    json_document.shrinkToFit();
 
-  DynamicJsonDocument json_document(request_size);
-  if (json_document.memoryPool().buffer() == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
-             free_heap);
-    return;
-  }
-  DeserializationError err = deserializeJson(json_document, data);
-  json_document.shrinkToFit();
+    JsonObject root = json_document.as<JsonObject>();
 
-  JsonObject root = json_document.as<JsonObject>();
-
-  if (err) {
-    ESP_LOGW(TAG, "Parsing JSON failed.");
-    return;
-  }
+    if (err == DeserializationError::Ok) {
+      pass = true;
+    } else if (err == DeserializationError::NoMemory) {
+      if (request_size * 2 >= free_heap) {
+        ESP_LOGE(TAG, "Can not allocate more memory for deserialization. Consider making source string smaller");
+        return;
+      }
+      ESP_LOGW(TAG, "Increasing memory allocation.");
+      continue;
+    } else {
+      ESP_LOGE(TAG, "JSON parse error: %s", err.c_str());
+      return;
+    }
+  } while (!pass);
 
   f(root);
 }

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -30,8 +30,8 @@ std::string build_json(const json_build_t &f) {
 
   DynamicJsonDocument json_document(request_size);
   if (json_document.memoryPool().buffer() == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
-             free_heap);
+    ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, largest free heap block: %u bytes",
+             request_size, free_heap);
     return "{}";
   }
   JsonObject root = json_document.to<JsonObject>();


### PR DESCRIPTION
# What does this implement/fix?

It seems that even though the response from `heap_caps_get_largest_free_block` can be around 30kb (in my local testing), `malloc` fails to allocate giving a nullptr buffer which means json can not be built or parsed.

If 10kb is not enough of a maximum, then we might be able to increase it via config variable?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3112

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
