### PR TITLE
Fix WDT reset during dallas search algorithm

### DIFF
--- a/esphome/components/dallas/esp_one_wire.cpp
+++ b/esphome/components/dallas/esp_one_wire.cpp
@@ -142,7 +142,6 @@ void IRAM_ATTR ESPOneWire::select(uint64_t address) {
 void IRAM_ATTR ESPOneWire::reset_search() {
   this->last_discrepancy_ = 0;
   this->last_device_flag_ = false;
-  this->last_family_discrepancy_ = 0;
   this->rom_number_ = 0;
 }
 uint64_t IRAM_ATTR ESPOneWire::search() {
@@ -195,9 +194,6 @@ uint64_t IRAM_ATTR ESPOneWire::search() {
 
         if (!branch) {
           last_zero = id_bit_number;
-          if (last_zero < 9) {
-            this->last_family_discrepancy_ = last_zero;
-          }
         }
       }
 

--- a/esphome/components/dallas/esp_one_wire.cpp
+++ b/esphome/components/dallas/esp_one_wire.cpp
@@ -196,7 +196,7 @@ uint64_t IRAM_ATTR ESPOneWire::search() {
         if (!branch) {
           last_zero = id_bit_number;
           if (last_zero < 9) {
-            this->last_discrepancy_ = last_zero;
+            this->last_family_discrepancy_ = last_zero;
           }
         }
       }

--- a/esphome/components/dallas/esp_one_wire.h
+++ b/esphome/components/dallas/esp_one_wire.h
@@ -60,7 +60,6 @@ class ESPOneWire {
 
   ISRInternalGPIOPin pin_;
   uint8_t last_discrepancy_{0};
-  uint8_t last_family_discrepancy_{0};
   bool last_device_flag_{false};
   uint64_t rom_number_{0};
 };


### PR DESCRIPTION
# What does this implement/fix?

Fixes a WDT reset bootloop caused by the dallas sensor search algorithm never terminating for certain combinations of found sensor IDs. This fix was implemented by cross-checking against [Paul Stoffregen's OneWire Arduino library](https://github.com/PaulStoffregen/OneWire/).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3107

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
