### PR TITLE
Provide new PollinComponent::reschedule_update to re-register update interval

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -188,7 +188,12 @@ void PollingComponent::call_setup() {
 }
 
 uint32_t PollingComponent::get_update_interval() const { return this->update_interval_; }
-void PollingComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
+
+void PollingComponent::set_update_interval(uint32_t update_interval) {
+  this->update_interval_ = update_interval;
+  this->cancel_interval("update");
+  this->set_interval("update", this->get_update_interval(), [this]() { this->update(); });
+}
 
 WarnIfComponentBlockingGuard::WarnIfComponentBlockingGuard(Component *component)
     : started_(millis()), component_(component) {}

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -189,8 +189,11 @@ void PollingComponent::call_setup() {
 
 uint32_t PollingComponent::get_update_interval() const { return this->update_interval_; }
 
-void PollingComponent::set_update_interval(uint32_t update_interval) {
-  this->update_interval_ = update_interval;
+void PollingComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
+
+void PollingComponent::reschedule_update(uint32_t update_interval) {
+  if (update_interval > 0)
+    this->set_update_interval(update_interval);
   this->cancel_interval("update");
   this->set_interval("update", this->get_update_interval(), [this]() { this->update(); });
 }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -281,6 +281,15 @@ class PollingComponent : public Component {
    */
   virtual void set_update_interval(uint32_t update_interval);
 
+  /** Re-set the update interval in ms for this polling object.
+   *
+   * Cancels the update interval and registers a new one with the given or
+   * previously set (default if argument is omitted) update_interval
+   *
+   * @param update_interval The update interval in ms.
+   */
+  void reschedule_update(uint32_t update_interval = 0);
+
   // ========== OVERRIDE METHODS ==========
   // (You'll only need this when creating your own custom sensor)
   virtual void update() = 0;


### PR DESCRIPTION
# What does this implement/fix?

I tried modifying the update_interval of a display component by using the `set_update_interval` method without success.
It turns out that the PollingComponent base class only saves the update_interval variable in this method, but it is never used.
I changed it so that it cancels the original update interval and creates a new one with the new value.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
  - lambda: 'id(my_display).set_update_interval(5000);'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
