### PR TITLE
Define touchscreen support when in use.

### DIFF
--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -39,3 +39,8 @@ async def register_touchscreen(var, config):
             [(TouchPoint, "touch")],
             config[CONF_ON_TOUCH],
         )
+        
+@coroutine_with_priority(100.0)
+async def to_code(config):
+    cg.add_global(touchscreen_ns.using)
+    cg.add_define("USE_TOUCHSCREEN")

--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -4,6 +4,7 @@ import esphome.codegen as cg
 from esphome.components import display
 from esphome import automation
 from esphome.const import CONF_ON_TOUCH
+from esphome.core import coroutine_with_priority
 
 CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = ["display"]
@@ -39,7 +40,8 @@ async def register_touchscreen(var, config):
             [(TouchPoint, "touch")],
             config[CONF_ON_TOUCH],
         )
-        
+
+
 @coroutine_with_priority(100.0)
 async def to_code(config):
     cg.add_global(touchscreen_ns.using)

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -40,6 +40,7 @@
 #define USE_SWITCH
 #define USE_TEXT_SENSOR
 #define USE_TIME
+#define USE_TOUCHSCREEN
 #define USE_UART_DEBUGGER
 #define USE_WIFI
 


### PR DESCRIPTION
# What does this implement/fix?

This is a really small change that adds the `USE_TOUCHSCREEN`  define in cases that you want to optionally enable/disable touchscreen support in an external module.   This is the same thing done for other platform components eg. BinarySensor, TextSensor, Button.  Do I need to add this define to `esphome/core/defines.h` also?   Please advise.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Test Environment 

In theory shouldn't matter but I have tested with esp32.  

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

NA

**I am not sure if these below are required:**

## Checklist:
  - [X ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
