### PR TITLE
Add helper overloads for hex print 16-bit

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -213,6 +213,25 @@ std::string format_hex_pretty(const uint8_t *data, size_t length) {
 }
 std::string format_hex_pretty(const std::vector<uint8_t> &data) { return format_hex_pretty(data.data(), data.size()); }
 
+std::string format_hex_pretty(const uint16_t *data, size_t length) {
+  if (length == 0)
+    return "";
+  std::string ret;
+  ret.resize(5 * length - 1);
+  for (size_t i = 0; i < length; i++) {
+    ret[5 * i] = format_hex_pretty_char((data[i] & 0xF000) >> 12);
+    ret[5 * i + 1] = format_hex_pretty_char((data[i] & 0x0F00) >> 8);
+    ret[5 * i + 2] = format_hex_pretty_char((data[i] & 0x00F0) >> 4);
+    ret[5 * i + 3] = format_hex_pretty_char(data[i] & 0x000F);
+    if (i != length - 1)
+      ret[5 * i + 2] = '.';
+  }
+  if (length > 4)
+    return ret + " (" + to_string(length) + ")";
+  return ret;
+}
+std::string format_hex_pretty(const std::vector<uint16_t> &data) { return format_hex_pretty(data.data(), data.size()); }
+
 ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
   if (on == nullptr && strcasecmp(str, "on") == 0)
     return PARSE_ON;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -386,8 +386,12 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> std::stri
 
 /// Format the byte array \p data of length \p len in pretty-printed, human-readable hex.
 std::string format_hex_pretty(const uint8_t *data, size_t length);
+/// Format the word array \p data of length \p len in pretty-printed, human-readable hex.
+std::string format_hex_pretty(const uint16_t *data, size_t length);
 /// Format the vector \p data in pretty-printed, human-readable hex.
 std::string format_hex_pretty(const std::vector<uint8_t> &data);
+/// Format the vector \p data in pretty-printed, human-readable hex.
+std::string format_hex_pretty(const std::vector<uint16_t> &data);
 /// Format an unsigned integer in pretty-printed, human-readable hex, starting with the most significant byte.
 template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> std::string format_hex_pretty(T val) {
   val = convert_big_endian(val);


### PR DESCRIPTION
# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
