### PR TITLE
Thermostat preset with modes

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -82,6 +82,8 @@ CLIMATE_MODES = {
 }
 validate_climate_mode = cv.enum(CLIMATE_MODES, upper=True)
 
+ClimatePreset = climate_ns.enum("ClimatePreset")
+
 
 def validate_thermostat(config):
     # verify corresponding action(s) exist(s) for any defined climate mode or action
@@ -531,7 +533,7 @@ async def to_code(config):
     cg.add(var.set_supports_fan_with_heating(config[CONF_FAN_WITH_HEATING]))
 
     cg.add(var.set_use_startup_delay(config[CONF_STARTUP_DELAY]))
-    cg.add(var.set_normal_config(normal_config))
+    cg.add(var.set_preset_config(ClimatePreset.CLIMATE_PRESET_HOME, normal_config))
 
     await automation.build_automation(
         var.get_idle_action_trigger(), [], config[CONF_IDLE_ACTION]
@@ -694,4 +696,4 @@ async def to_code(config):
             away_config = ThermostatClimateTargetTempConfig(
                 away[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]
             )
-        cg.add(var.set_away_config(away_config))
+        cg.add(var.set_preset_config(ClimatePreset.CLIMATE_PRESET_AWAY, away_config))

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -289,7 +289,7 @@ def validate_thermostat(config):
                 preset_config, config, preset_config[CONF_NAME], requirements
             )
 
-    # verify default climate mode is valid given above configuration
+    # Verify default climate mode is valid given above configuration
     default_mode = config[CONF_DEFAULT_MODE]
     requirements = {
         "HEAT_COOL": [CONF_COOL_ACTION, CONF_HEAT_ACTION],
@@ -298,6 +298,7 @@ def validate_thermostat(config):
         "DRY": [CONF_DRY_ACTION],
         "FAN_ONLY": [CONF_FAN_ONLY_ACTION],
         "AUTO": [CONF_COOL_ACTION, CONF_HEAT_ACTION],
+        "OFF": []
     }
     actions_for_default_mode = requirements.get(default_mode, [])
     for req in actions_for_default_mode:
@@ -308,13 +309,62 @@ def validate_thermostat(config):
 
     # Verify that the modes for presets are valid given the configuration
     if CONF_PRESET in config:
+        # Mode validation
         for preset_config in config[CONF_PRESET]:
+            if CONF_MODE not in preset_config:
+                continue
+
             mode = preset_config[CONF_MODE]
 
             for req in requirements[mode]:
                 if req not in config:
                     raise cv.Invalid(
-                        f"{CONF_MODE} is set to {mode} for {preset_config[CONF_NAME]} but {req} is not present in the preset"
+                        f"{CONF_MODE} is set to {mode} for {preset_config[CONF_NAME]} but {req} is not present in the configuration"
+                    )
+
+        # Fan mode requirements
+        requirements = {
+            "ON": [ CONF_FAN_MODE_ON_ACTION ],
+            "OFF": [ CONF_FAN_MODE_OFF_ACTION ],
+            "AUTO": [ CONF_FAN_MODE_AUTO_ACTION ],
+            "LOW": [ CONF_FAN_MODE_LOW_ACTION ],
+            "MEDIUM": [ CONF_FAN_MODE_MEDIUM_ACTION ],
+            "HIGH": [ CONF_FAN_MODE_HIGH_ACTION ],
+            "MIDDLE": [ CONF_FAN_MODE_MIDDLE_ACTION ],
+            "FOCUS": [ CONF_FAN_MODE_FOCUS_ACTION ],
+            "DIFFUSE": [ CONF_FAN_MODE_DIFFUSE_ACTION ],
+        }
+        
+        for preset_config in config[CONF_PRESET]:
+            if CONF_FAN_MODE not in preset_config:
+                continue
+
+            fan_mode = preset_config[CONF_FAN_MODE]
+
+            for req in requirements[fan_mode]:
+                if req not in config:
+                    raise cv.Invalid(
+                        f"{CONF_FAN_MODE} is set to {fan_mode} for {preset_config[CONF_NAME]} but {req} is not present in the configuration"
+                    )
+
+        # Swing mode requirements
+        requirements = {
+            "OFF": [ CONF_SWING_OFF_ACTION ],
+            "BOTH": [CONF_SWING_BOTH_ACTION],
+            "VERTICAL": [CONF_SWING_VERTICAL_ACTION],
+            "HORIZONTAL": [CONF_SWING_HORIZONTAL_ACTION],
+        }
+
+        for preset_config in config[CONF_PRESET]:
+            if CONF_SWING_MODE not in preset_config:
+                continue
+
+            swing_mode = preset_config[CONF_SWING_MODE]
+            
+            for req in requirements[swing_mode]:
+                if req not in config:
+                    raise cv.Invalid(
+                        f"{CONF_SWING_MODE} is set to {swing_mode} for {preset_config[CONF_NAME]} but {req} is not present in the configuration"
                     )
 
     if config[CONF_FAN_WITH_COOLING] is True and CONF_FAN_ONLY_ACTION not in config:

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -104,9 +104,10 @@ PRESET_CONFIG_SCHEMA = cv.Schema(
         ),
     }
 )
- 
-def validate_preset(preset, root_config, name, requirements):
-    # verify an individual preset / default config / away config
+
+
+def validate_temperature_preset(preset, root_config, name, requirements):
+    # verify temperature settings for the provided preset / default / away configuration
     for config_temp, req_actions in requirements.items():
         for req_action in req_actions:
             # verify corresponding default target temperature exists when a given climate action exists
@@ -116,7 +117,9 @@ def validate_preset(preset, root_config, name, requirements):
                 )
             # if a given climate action is NOT defined, it should not have a default target temperature
             if config_temp in preset and req_action not in root_config:
-                raise cv.Invalid(f"{config_temp} is defined in {name} config with no {req_action}")
+                raise cv.Invalid(
+                    f"{config_temp} is defined in {name} config with no {req_action}"
+                )
 
 
 def validate_thermostat(config):
@@ -271,16 +274,20 @@ def validate_thermostat(config):
             CONF_DEFAULT_TARGET_TEMPERATURE_LOW: [CONF_HEAT_ACTION],
         }
 
-    validate_preset(config, config, "default", requirements)
+    # Validate temperature requirements for default configuraation
+    validate_temperature_preset(config, config, "default", requirements)
 
+    # Validate temperature requirements for away configuration
     if CONF_AWAY_CONFIG in config:
         away = config[CONF_AWAY_CONFIG]
-        validate_preset(away, config, "away", requirements)
+        validate_temperature_preset(away, config, "away", requirements)
 
+    # Validate temperature requirements for presets
     if CONF_PRESET in config:
         for preset_config in config[CONF_PRESET]:
-            validate_preset(preset_config, config, preset_config[CONF_NAME], requirements)
-
+            validate_temperature_preset(
+                preset_config, config, preset_config[CONF_NAME], requirements
+            )
 
     # verify default climate mode is valid given above configuration
     default_mode = config[CONF_DEFAULT_MODE]
@@ -298,7 +305,8 @@ def validate_thermostat(config):
             raise cv.Invalid(
                 f"{CONF_DEFAULT_MODE} is set to {default_mode} but {req} is not present in the configuration"
             )
-   
+
+    # Verify that the modes for presets are valid given the configuration
     if CONF_PRESET in config:
         for preset_config in config[CONF_PRESET]:
             mode = preset_config[CONF_MODE]

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -326,23 +326,24 @@ def validate_thermostat(config):
             if CONF_MAX_TEMPERATURE in visual_config:
                 visual_max_temperature = visual_config[CONF_MAX_TEMPERATURE]
 
-            for preset_config in config[CONF_PRESET]:
-                if CONF_DEFAULT_TARGET_TEMPERATURE_LOW in preset_config:
-                    preset_min_temperature = preset_config[
-                        CONF_DEFAULT_TARGET_TEMPERATURE_LOW
-                    ]
-                    if preset_min_temperature < visual_min_temperature:
-                        raise cv.Invalid(
-                            f"{CONF_DEFAULT_TARGET_TEMPERATURE_LOW} for {preset_config[CONF_NAME]} is set to {preset_min_temperature} which is less than the visual minimum temperature of {visual_min_temperature}"
-                        )
-                    if CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in preset_config:
-                        preset_max_temperature = preset_config[
-                            CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
-                        ]
-                        if preset_max_temperature > visual_max_temperature:
-                            raise cv.Invalid(
-                                f"{CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} for {preset_config[CONF_NAME]} is set to {preset_max_temperature} which is more than the visual maximum temperature of {visual_max_temperature}"
-                            )
+        for preset_config in config[CONF_PRESET]:
+            if CONF_DEFAULT_TARGET_TEMPERATURE_LOW in preset_config:
+                preset_min_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_LOW
+                ]
+                if preset_min_temperature < visual_min_temperature:
+                    raise cv.Invalid(
+                        f"{CONF_DEFAULT_TARGET_TEMPERATURE_LOW} for {preset_config[CONF_NAME]} is set to {preset_min_temperature} which is less than the visual minimum temperature of {visual_min_temperature}"
+                    )
+
+            if CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in preset_config:
+                preset_max_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
+                ]
+                if preset_max_temperature > visual_max_temperature:
+                    raise cv.Invalid(
+                        f"{CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} for {preset_config[CONF_NAME]} is set to {preset_max_temperature} which is more than the visual maximum temperature of {visual_max_temperature}"
+                    )
 
         # Mode validation
         for preset_config in config[CONF_PRESET]:

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -58,6 +58,7 @@ from esphome.const import (
     CONF_SWING_OFF_ACTION,
     CONF_SWING_VERTICAL_ACTION,
     CONF_TARGET_TEMPERATURE_CHANGE_ACTION,
+    CONF_PRESET,
 )
 
 CODEOWNERS = ["@kbx81"]
@@ -83,6 +84,13 @@ CLIMATE_MODES = {
 validate_climate_mode = cv.enum(CLIMATE_MODES, upper=True)
 
 ClimatePreset = climate_ns.enum("ClimatePreset")
+
+PRESET_CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_HIGH): cv.temperature,
+        cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.temperature,
+    }
+)
 
 
 def validate_thermostat(config):
@@ -417,6 +425,12 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.temperature,
                 }
             ),
+            cv.Optional(CONF_PRESET): cv.Schema(
+                {
+                    cv.Optional(preset.lower()): PRESET_CONFIG_SCHEMA
+                    for preset in climate.CLIMATE_PRESETS
+                }
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(
@@ -697,3 +711,32 @@ async def to_code(config):
                 away[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]
             )
         cg.add(var.set_preset_config(ClimatePreset.CLIMATE_PRESET_AWAY, away_config))
+
+    if CONF_PRESET in config:
+        for preset in climate.CLIMATE_PRESETS:
+            preset_label = preset.lower()
+
+            if preset_label not in config[CONF_PRESET]:
+                continue
+
+            preset_config = config[CONF_PRESET][preset_label]
+
+            if two_points_available is True:
+                preset_target_config = ThermostatClimateTargetTempConfig(
+                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW],
+                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH],
+                )
+            elif CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in away:
+                preset_target_config = ThermostatClimateTargetTempConfig(
+                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH]
+                )
+            elif CONF_DEFAULT_TARGET_TEMPERATURE_LOW in away:
+                preset_target_config = ThermostatClimateTargetTempConfig(
+                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]
+                )
+
+            cg.add(
+                var.set_preset_config(
+                    climate.CLIMATE_PRESETS[preset], preset_target_config
+                )
+            )

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -301,7 +301,7 @@ def validate_thermostat(config):
         "DRY": [CONF_DRY_ACTION],
         "FAN_ONLY": [CONF_FAN_ONLY_ACTION],
         "AUTO": [CONF_COOL_ACTION, CONF_HEAT_ACTION],
-        "OFF": []
+        "OFF": [],
     }
     actions_for_default_mode = requirements.get(default_mode, [])
     for req in actions_for_default_mode:
@@ -319,22 +319,26 @@ def validate_thermostat(config):
         visual_max_temperature = 30.0
         if CONF_VISUAL in config:
             visual_config = config[CONF_VISUAL]
-            
+
             if CONF_MIN_TEMPERATURE in visual_config:
                 visual_min_temperature = visual_config[CONF_MIN_TEMPERATURE]
-            
+
             if CONF_MAX_TEMPERATURE in visual_config:
                 visual_max_temperature = visual_config[CONF_MAX_TEMPERATURE]
 
             for preset_config in config[CONF_PRESET]:
                 if CONF_DEFAULT_TARGET_TEMPERATURE_LOW in preset_config:
-                    preset_min_temperature = preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]
+                    preset_min_temperature = preset_config[
+                        CONF_DEFAULT_TARGET_TEMPERATURE_LOW
+                    ]
                     if preset_min_temperature < visual_min_temperature:
                         raise cv.Invalid(
                             f"{CONF_DEFAULT_TARGET_TEMPERATURE_LOW} for {preset_config[CONF_NAME]} is set to {preset_min_temperature} which is less than the visual minimum temperature of {visual_min_temperature}"
                         )
                     if CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in preset_config:
-                        preset_max_temperature = preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH]
+                        preset_max_temperature = preset_config[
+                            CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
+                        ]
                         if preset_max_temperature > visual_max_temperature:
                             raise cv.Invalid(
                                 f"{CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} for {preset_config[CONF_NAME]} is set to {preset_max_temperature} which is more than the visual maximum temperature of {visual_max_temperature}"
@@ -355,17 +359,17 @@ def validate_thermostat(config):
 
         # Fan mode requirements
         requirements = {
-            "ON": [ CONF_FAN_MODE_ON_ACTION ],
-            "OFF": [ CONF_FAN_MODE_OFF_ACTION ],
-            "AUTO": [ CONF_FAN_MODE_AUTO_ACTION ],
-            "LOW": [ CONF_FAN_MODE_LOW_ACTION ],
-            "MEDIUM": [ CONF_FAN_MODE_MEDIUM_ACTION ],
-            "HIGH": [ CONF_FAN_MODE_HIGH_ACTION ],
-            "MIDDLE": [ CONF_FAN_MODE_MIDDLE_ACTION ],
-            "FOCUS": [ CONF_FAN_MODE_FOCUS_ACTION ],
-            "DIFFUSE": [ CONF_FAN_MODE_DIFFUSE_ACTION ],
+            "ON": [CONF_FAN_MODE_ON_ACTION],
+            "OFF": [CONF_FAN_MODE_OFF_ACTION],
+            "AUTO": [CONF_FAN_MODE_AUTO_ACTION],
+            "LOW": [CONF_FAN_MODE_LOW_ACTION],
+            "MEDIUM": [CONF_FAN_MODE_MEDIUM_ACTION],
+            "HIGH": [CONF_FAN_MODE_HIGH_ACTION],
+            "MIDDLE": [CONF_FAN_MODE_MIDDLE_ACTION],
+            "FOCUS": [CONF_FAN_MODE_FOCUS_ACTION],
+            "DIFFUSE": [CONF_FAN_MODE_DIFFUSE_ACTION],
         }
-        
+
         for preset_config in config[CONF_PRESET]:
             if CONF_FAN_MODE not in preset_config:
                 continue
@@ -380,7 +384,7 @@ def validate_thermostat(config):
 
         # Swing mode requirements
         requirements = {
-            "OFF": [ CONF_SWING_OFF_ACTION ],
+            "OFF": [CONF_SWING_OFF_ACTION],
             "BOTH": [CONF_SWING_BOTH_ACTION],
             "VERTICAL": [CONF_SWING_VERTICAL_ACTION],
             "HORIZONTAL": [CONF_SWING_HORIZONTAL_ACTION],
@@ -391,7 +395,7 @@ def validate_thermostat(config):
                 continue
 
             swing_mode = preset_config[CONF_SWING_MODE]
-            
+
             for req in requirements[swing_mode]:
                 if req not in config:
                     raise cv.Invalid(

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -3,7 +3,6 @@ import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import climate, sensor
 from esphome.const import (
-    CONF_NAME,
     CONF_AUTO_MODE,
     CONF_AWAY_CONFIG,
     CONF_COOL_ACTION,
@@ -15,6 +14,7 @@ from esphome.const import (
     CONF_DEFAULT_TARGET_TEMPERATURE_LOW,
     CONF_DRY_ACTION,
     CONF_DRY_MODE,
+    CONF_FAN_MODE,
     CONF_FAN_MODE_ON_ACTION,
     CONF_FAN_MODE_OFF_ACTION,
     CONF_FAN_MODE_AUTO_ACTION,
@@ -46,7 +46,10 @@ from esphome.const import (
     CONF_MIN_HEATING_OFF_TIME,
     CONF_MIN_HEATING_RUN_TIME,
     CONF_MIN_IDLE_TIME,
+    CONF_NAME,
+    CONF_MODE,
     CONF_OFF_MODE,
+    CONF_PRESET,
     CONF_SENSOR,
     CONF_SET_POINT_MINIMUM_DIFFERENTIAL,
     CONF_STARTUP_DELAY,
@@ -56,13 +59,10 @@ from esphome.const import (
     CONF_SUPPLEMENTAL_HEATING_DELTA,
     CONF_SWING_BOTH_ACTION,
     CONF_SWING_HORIZONTAL_ACTION,
+    CONF_SWING_MODE,
     CONF_SWING_OFF_ACTION,
     CONF_SWING_VERTICAL_ACTION,
     CONF_TARGET_TEMPERATURE_CHANGE_ACTION,
-    CONF_PRESET,
-    CONF_FAN_MODE,
-    CONF_SWING_MODE,
-    CONF_MODE,
 )
 
 CONF_PRESET_CHANGE = "preset_change"

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -64,6 +64,8 @@ from esphome.const import (
     CONF_MODE,
 )
 
+CONF_PRESET_CHANGE = "preset_change"
+
 CODEOWNERS = ["@kbx81"]
 
 climate_ns = cg.esphome_ns.namespace("climate")
@@ -440,6 +442,9 @@ CONFIG_SCHEMA = cv.All(
                     for preset in climate.CLIMATE_PRESETS
                 }
             ),
+            cv.Optional(CONF_PRESET_CHANGE): automation.validate_automation(
+                single=True
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(
@@ -764,3 +769,8 @@ async def to_code(config):
                 )
 
             cg.add(var.set_preset_config(preset, preset_target_variable))
+
+    if CONF_PRESET_CHANGE in config:
+        await automation.build_automation(
+            var.get_preset_change_trigger(), [], config[CONF_PRESET_CHANGE]
+        )

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -923,7 +923,8 @@ bool ThermostatClimate::supplemental_heating_required_() {
           (this->supplemental_action_ == climate::CLIMATE_ACTION_HEATING));
 }
 
-void ThermostatClimate::dump_preset_config_(const std::string &preset, const ThermostatClimateTargetTempConfig &config) {
+void ThermostatClimate::dump_preset_config_(const std::string &preset,
+                                            const ThermostatClimateTargetTempConfig &config) {
   auto preset_name = preset.c_str();
 
   if (this->supports_heat_) {
@@ -1023,7 +1024,7 @@ void ThermostatClimate::set_preset_config(climate::ClimatePreset preset,
   this->preset_config_[preset] = config;
 }
 
-void ThermostatClimate::set_custom_preset_config(const std::string &name, 
+void ThermostatClimate::set_custom_preset_config(const std::string &name,
                                                  const ThermostatClimateTargetTempConfig &config) {
   this->custom_preset_config_[name] = config;
 }

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -923,7 +923,7 @@ bool ThermostatClimate::supplemental_heating_required_() {
           (this->supplemental_action_ == climate::CLIMATE_ACTION_HEATING));
 }
 
-void ThermostatClimate::dump_preset_config_(std::string preset, const ThermostatClimateTargetTempConfig &config) {
+void ThermostatClimate::dump_preset_config_(const std::string &preset, const ThermostatClimateTargetTempConfig &config) {
   auto preset_name = preset.c_str();
 
   if (this->supports_heat_) {
@@ -939,8 +939,7 @@ void ThermostatClimate::dump_preset_config_(std::string preset, const Thermostat
       ESP_LOGCONFIG(TAG, "      %s Default Target Temperature High: %.1f°C", preset_name,
                     config.default_temperature_high);
     } else {
-      ESP_LOGCONFIG(TAG, "      %s Default Target Temperature High: %.1f°C", preset_name,
-                    config.default_temperature);
+      ESP_LOGCONFIG(TAG, "      %s Default Target Temperature High: %.1f°C", preset_name, config.default_temperature);
     }
   }
 
@@ -972,7 +971,7 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
   }
 }
 
-void ThermostatClimate::change_custom_preset_(std::string custom_preset) {
+void ThermostatClimate::change_custom_preset_(const std::string &custom_preset) {
   auto config = this->custom_preset_config_.find(custom_preset);
 
   if (config != this->custom_preset_config_.end()) {
@@ -1003,13 +1002,11 @@ void ThermostatClimate::change_preset_internal_(const ThermostatClimateTargetTem
 
   if (config.fan_mode_.has_value()) {
     this->fan_mode = *config.fan_mode_;
-    ESP_LOGV(TAG, "Setting fan mode to %s",
-              LOG_STR_ARG(climate::climate_fan_mode_to_string(*config.fan_mode_)));
+    ESP_LOGV(TAG, "Setting fan mode to %s", LOG_STR_ARG(climate::climate_fan_mode_to_string(*config.fan_mode_)));
   }
 
   if (config.swing_mode_.has_value()) {
-    ESP_LOGV(TAG, "Setting swing mode to %s",
-              LOG_STR_ARG(climate::climate_swing_mode_to_string(*config.swing_mode_)));
+    ESP_LOGV(TAG, "Setting swing mode to %s", LOG_STR_ARG(climate::climate_swing_mode_to_string(*config.swing_mode_)));
     this->swing_mode = *config.swing_mode_;
   }
 
@@ -1026,7 +1023,7 @@ void ThermostatClimate::set_preset_config(climate::ClimatePreset preset,
   this->preset_config_[preset] = config;
 }
 
-void ThermostatClimate::set_custom_preset_config(std::string name,
+void ThermostatClimate::set_custom_preset_config(const std::string &name, 
                                                  const ThermostatClimateTargetTempConfig &config) {
   this->custom_preset_config_[name] = config;
 }

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -925,7 +925,7 @@ bool ThermostatClimate::supplemental_heating_required_() {
 
 void ThermostatClimate::dump_preset_config_(const std::string &preset,
                                             const ThermostatClimateTargetTempConfig &config) {
-  auto preset_name = preset.c_str();
+  const auto *preset_name = preset.c_str();
 
   if (this->supports_heat_) {
     if (this->supports_two_points_) {

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1017,6 +1017,8 @@ void ThermostatClimate::change_preset_internal_(const ThermostatClimateTargetTem
     assert(trig != nullptr);
     trig->trigger();
   }
+
+  this->refresh();
 }
 
 void ThermostatClimate::set_preset_config(climate::ClimatePreset preset,

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -236,7 +236,7 @@ climate::ClimateTraits ThermostatClimate::traits() {
   if (supports_swing_mode_vertical_)
     traits.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
 
-  for (auto & it : this->preset_config_) {
+  for (auto &it : this->preset_config_) {
     traits.add_supported_preset(it.first);
   }
 
@@ -930,7 +930,6 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
       this->mode = *config->second.mode_;
       ESP_LOGV(TAG, "Setting mode to %s", LOG_STR_ARG(climate::climate_mode_to_string(*config->second.mode_)));
     }
-
 
     if (config->second.fan_mode_.has_value()) {
       this->fan_mode = *config->second.fan_mode_;

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -236,8 +236,8 @@ climate::ClimateTraits ThermostatClimate::traits() {
   if (supports_swing_mode_vertical_)
     traits.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
 
-  for (auto it = this->preset_config_.begin(); it != this->preset_config_.end(); it++) {
-    traits.add_supported_preset(it->first);
+  for (auto & it : this->preset_config_) {
+    traits.add_supported_preset(it.first);
   }
 
   traits.set_supports_two_point_target_temperature(this->supports_two_points_);
@@ -934,11 +934,13 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
 
     if (config->second.fan_mode_.has_value()) {
       this->fan_mode = *config->second.fan_mode_;
-      ESP_LOGV(TAG, "Setting fan mode to %s", LOG_STR_ARG(climate::climate_fan_mode_to_string(*config->second.fan_mode_)));
+      ESP_LOGV(TAG, "Setting fan mode to %s",
+               LOG_STR_ARG(climate::climate_fan_mode_to_string(*config->second.fan_mode_)));
     }
 
     if (config->second.swing_mode_.has_value()) {
-      ESP_LOGV(TAG, "Setting swing mode to %s", LOG_STR_ARG(climate::climate_swing_mode_to_string(*config->second.swing_mode_)));
+      ESP_LOGV(TAG, "Setting swing mode to %s",
+               LOG_STR_ARG(climate::climate_swing_mode_to_string(*config->second.swing_mode_)));
       this->swing_mode = *config->second.swing_mode_;
     }
 
@@ -955,7 +957,8 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
   }
 }
 
-void ThermostatClimate::set_preset_config(climate::ClimatePreset preset, const ThermostatClimateTargetTempConfig &config) {
+void ThermostatClimate::set_preset_config(climate::ClimatePreset preset,
+                                          const ThermostatClimateTargetTempConfig &config) {
   this->preset_config_[preset] = config;
 }
 
@@ -1206,7 +1209,7 @@ void ThermostatClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Supports SWING MODE HORIZONTAL: %s", YESNO(this->supports_swing_mode_horizontal_));
   ESP_LOGCONFIG(TAG, "  Supports SWING MODE VERTICAL: %s", YESNO(this->supports_swing_mode_vertical_));
   ESP_LOGCONFIG(TAG, "  Supports TWO SET POINTS: %s", YESNO(this->supports_two_points_));
-  
+
   ESP_LOGCONFIG(TAG, "  Supported PRESETS: ");
   for (auto &it : this->preset_config_) {
     const auto *preset_name = LOG_STR_ARG(climate::climate_preset_to_string(it.first));
@@ -1217,8 +1220,7 @@ void ThermostatClimate::dump_config() {
         ESP_LOGCONFIG(TAG, "    %s Default Target Temperature Low: %.1f°C", preset_name,
                       it.second.default_temperature_low);
       } else {
-        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature Low: %.1f°C", preset_name,
-                      it.second.default_temperature);
+        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature Low: %.1f°C", preset_name, it.second.default_temperature);
       }
     }
     if ((this->supports_cool_) || (this->supports_fan_only_)) {

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -942,6 +942,13 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
       this->swing_mode = *config->second.swing_mode_;
     }
 
+    // Fire any preset changed trigger if defined
+    if (this->preset != preset) {
+      Trigger<> *trig = this->preset_change_trigger_;
+      assert(trig != nullptr);
+      trig->trigger();
+    }
+
     this->preset = preset;
   } else {
     ESP_LOGVV(TAG, "Preset %s is not configured, ignoring.", climate::climate_preset_to_string(preset));
@@ -979,7 +986,8 @@ ThermostatClimate::ThermostatClimate()
       swing_mode_off_trigger_(new Trigger<>()),
       swing_mode_horizontal_trigger_(new Trigger<>()),
       swing_mode_vertical_trigger_(new Trigger<>()),
-      temperature_change_trigger_(new Trigger<>()) {}
+      temperature_change_trigger_(new Trigger<>()),
+      preset_change_trigger_(new Trigger<>()) {}
 
 void ThermostatClimate::set_default_mode(climate::ClimateMode default_mode) { this->default_mode_ = default_mode; }
 void ThermostatClimate::set_set_point_minimum_differential(float differential) {
@@ -1128,6 +1136,7 @@ Trigger<> *ThermostatClimate::get_swing_mode_off_trigger() const { return this->
 Trigger<> *ThermostatClimate::get_swing_mode_horizontal_trigger() const { return this->swing_mode_horizontal_trigger_; }
 Trigger<> *ThermostatClimate::get_swing_mode_vertical_trigger() const { return this->swing_mode_vertical_trigger_; }
 Trigger<> *ThermostatClimate::get_temperature_change_trigger() const { return this->temperature_change_trigger_; }
+Trigger<> *ThermostatClimate::get_preset_change_trigger() const { return this->preset_change_trigger_; }
 
 void ThermostatClimate::dump_config() {
   LOG_CLIMATE("", "Thermostat", this);

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -915,7 +915,7 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
   auto config = this->preset_config_.find(preset);
 
   if (config != this->preset_config_.end()) {
-    ESP_LOGVV(TAG, "Switching to preset  %s", climate::climate_preset_to_string(preset));
+    ESP_LOGVV(TAG, "Switching to preset  %s", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
 
     if (this->supports_two_points_) {
       this->target_temperature_low = config->second.default_temperature_low;
@@ -952,7 +952,7 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
 
     this->preset = preset;
   } else {
-    ESP_LOGVV(TAG, "Preset %s is not configured, ignoring.", climate::climate_preset_to_string(preset));
+    ESP_LOGVV(TAG, "Preset %s is not configured, ignoring.", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
   }
 }
 

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -924,6 +924,24 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
       this->target_temperature = config->second.default_temperature;
     }
 
+    // Note: The mode, fan_mode, and swing_mode can all be defined on the preset but if the climate.control call
+    // also specifies them then the control's version will override these for that call
+    if (config->second.mode_.has_value()) {
+      this->mode = *config->second.mode_;
+      ESP_LOGV(TAG, "Setting mode to %s", LOG_STR_ARG(climate::climate_mode_to_string(*config->second.mode_)));
+    }
+
+
+    if (config->second.fan_mode_.has_value()) {
+      this->fan_mode = *config->second.fan_mode_;
+      ESP_LOGV(TAG, "Setting fan mode to %s", LOG_STR_ARG(climate::climate_fan_mode_to_string(*config->second.fan_mode_)));
+    }
+
+    if (config->second.swing_mode_.has_value()) {
+      ESP_LOGV(TAG, "Setting swing mode to %s", LOG_STR_ARG(climate::climate_swing_mode_to_string(*config->second.swing_mode_)));
+      this->swing_mode = *config->second.swing_mode_;
+    }
+
     this->preset = preset;
   } else {
     ESP_LOGVV(TAG, "Preset %s is not configured, ignoring.", climate::climate_preset_to_string(preset));
@@ -1181,23 +1199,40 @@ void ThermostatClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Supports TWO SET POINTS: %s", YESNO(this->supports_two_points_));
   
   ESP_LOGCONFIG(TAG, "  Supported PRESETS: ");
-  for (auto it = this->preset_config_.begin(); it != this->preset_config_.end(); it++) {
-    auto preset_name = LOG_STR_ARG(climate::climate_preset_to_string(it->first));
+  for (auto &it : this->preset_config_) {
+    const auto *preset_name = LOG_STR_ARG(climate::climate_preset_to_string(it.first));
 
     ESP_LOGCONFIG(TAG, "  Supports %s: %s", preset_name, YESNO(true));
     if (this->supports_heat_) {
       if (this->supports_two_points_) {
-        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature Low: %.1f°C", preset_name, it->second.default_temperature_low);
+        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature Low: %.1f°C", preset_name,
+                      it.second.default_temperature_low);
       } else {
-        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature Low: %.1f°C", preset_name, it->second.default_temperature);
+        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature Low: %.1f°C", preset_name,
+                      it.second.default_temperature);
       }
     }
     if ((this->supports_cool_) || (this->supports_fan_only_)) {
       if (this->supports_two_points_) {
-        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature High: %.1f°C", preset_name, it->second.default_temperature_high);
+        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature High: %.1f°C", preset_name,
+                      it.second.default_temperature_high);
       } else {
-        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature High: %.1f°C", preset_name, it->second.default_temperature);
+        ESP_LOGCONFIG(TAG, "    %s Default Target Temperature High: %.1f°C", preset_name,
+                      it.second.default_temperature);
       }
+    }
+
+    if (it.second.mode_.has_value()) {
+      ESP_LOGCONFIG(TAG, "    %s Default Mode: %s", preset_name,
+                    LOG_STR_ARG(climate::climate_mode_to_string(*it.second.mode_)));
+    }
+    if (it.second.fan_mode_.has_value()) {
+      ESP_LOGCONFIG(TAG, "    %s Default Fan Mode: %s", preset_name,
+                    LOG_STR_ARG(climate::climate_fan_mode_to_string(*it.second.fan_mode_)));
+    }
+    if (it.second.swing_mode_.has_value()) {
+      ESP_LOGCONFIG(TAG, "    %s Default Swing Mode: %s", preset_name,
+                    LOG_STR_ARG(climate::climate_swing_mode_to_string(*it.second.swing_mode_)));
     }
   }
 }

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -275,7 +275,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// A false value means that the controller has no such support.
   bool supports_two_points_{false};
 
-    /// Flags indicating if maximum allowable run time was exceeded
+  /// Flags indicating if maximum allowable run time was exceeded
   bool cooling_max_runtime_exceeded_{false};
   bool heating_max_runtime_exceeded_{false};
 
@@ -414,7 +414,6 @@ class ThermostatClimate : public climate::Climate, public Component {
 
   /// Minimum allowable duration in seconds for action timers
   const uint8_t min_timer_duration_{1};
-
 
   /// Climate action timers
   std::vector<ThermostatClimateTimer> timer_{

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -131,6 +131,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   Trigger<> *get_swing_mode_off_trigger() const;
   Trigger<> *get_swing_mode_vertical_trigger() const;
   Trigger<> *get_temperature_change_trigger() const;
+  Trigger<> *get_preset_change_trigger() const;
   /// Get current hysteresis values
   float cool_deadband();
   float cool_overrun();
@@ -369,6 +370,9 @@ class ThermostatClimate : public climate::Climate, public Component {
 
   /// The trigger to call when the target temperature(s) change(es).
   Trigger<> *temperature_change_trigger_{nullptr};
+
+  /// The triggr to call when the preset mode changes
+  Trigger<> *preset_change_trigger_{nullptr};
 
   /// A reference to the trigger that was previously active.
   ///

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -4,6 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
+#include <map>
 
 namespace esphome {
 namespace thermostat {
@@ -94,8 +95,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   void set_supports_swing_mode_vertical(bool supports_swing_mode_vertical);
   void set_supports_two_points(bool supports_two_points);
 
-  void set_normal_config(const ThermostatClimateTargetTempConfig &normal_config);
-  void set_away_config(const ThermostatClimateTargetTempConfig &away_config);
+  void set_preset_config(climate::ClimatePreset preset, const ThermostatClimateTargetTempConfig &config);
 
   Trigger<> *get_cool_action_trigger() const;
   Trigger<> *get_supplemental_cool_action_trigger() const;
@@ -149,8 +149,8 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// Override control to change settings of the climate device.
   void control(const climate::ClimateCall &call) override;
 
-  /// Change the away setting, will reset target temperatures to defaults.
-  void change_away_(bool away);
+  /// Change to a provided preset setting, will reset target temperatures to defaults for that preset
+  void change_preset_(climate::ClimatePreset preset);
 
   /// Return the traits of this controller.
   climate::ClimateTraits traits() override;
@@ -267,12 +267,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// A false value means that the controller has no such support.
   bool supports_two_points_{false};
 
-  /// Whether the controller supports an "away" mode
-  ///
-  /// A false value means that the controller has no such mode.
-  bool supports_away_{false};
-
-  /// Flags indicating if maximum allowable run time was exceeded
+    /// Flags indicating if maximum allowable run time was exceeded
   bool cooling_max_runtime_exceeded_{false};
   bool heating_max_runtime_exceeded_{false};
 
@@ -409,9 +404,6 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// Minimum allowable duration in seconds for action timers
   const uint8_t min_timer_duration_{1};
 
-  /// Temperature data for normal/home and away modes
-  ThermostatClimateTargetTempConfig normal_config_{};
-  ThermostatClimateTargetTempConfig away_config_{};
 
   /// Climate action timers
   std::vector<ThermostatClimateTimer> timer_{
@@ -425,6 +417,9 @@ class ThermostatClimate : public climate::Climate, public Component {
       {"heat_off", false, 0, std::bind(&ThermostatClimate::heating_off_timer_callback_, this)},
       {"heat_on", false, 0, std::bind(&ThermostatClimate::heating_on_timer_callback_, this)},
       {"idle_on", false, 0, std::bind(&ThermostatClimate::idle_on_timer_callback_, this)}};
+
+  /// The set of temperature configurations this thermostat supports (Eg. AWAY, ECO, etc)
+  std::map<climate::ClimatePreset, ThermostatClimateTargetTempConfig> preset_config_{};
 };
 
 }  // namespace thermostat

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -103,7 +103,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   void set_supports_two_points(bool supports_two_points);
 
   void set_preset_config(climate::ClimatePreset preset, const ThermostatClimateTargetTempConfig &config);
-  void set_custom_preset_config(std::string name, const ThermostatClimateTargetTempConfig &config);
+  void set_custom_preset_config(const std::string &name, const ThermostatClimateTargetTempConfig &config);
 
   Trigger<> *get_cool_action_trigger() const;
   Trigger<> *get_supplemental_cool_action_trigger() const;
@@ -161,7 +161,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// Change to a provided preset setting; will reset temperature, mode, fan, and swing modes accordingly
   void change_preset_(climate::ClimatePreset preset);
   /// Change to a provided custom preset setting; will reset temperature, mode, fan, and swing modes accordingly
-  void change_custom_preset_(std::string custom_preset);
+  void change_custom_preset_(const std::string &custom_preset);
 
   /// Applies the temperature, mode, fan, and swing modes of the provded config.
   /// This is agnostic of custom vs built in preset
@@ -225,7 +225,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   bool supplemental_cooling_required_();
   bool supplemental_heating_required_();
 
-  void dump_preset_config_(std::string preset_name, const ThermostatClimateTargetTempConfig &config);
+  void dump_preset_config_(const std::string &preset_name, const ThermostatClimateTargetTempConfig &config);
 
   /// The sensor used for getting the current temperature
   sensor::Sensor *sensor_{nullptr};
@@ -391,7 +391,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   Trigger<> *prev_fan_mode_trigger_{nullptr};
   Trigger<> *prev_mode_trigger_{nullptr};
   Trigger<> *prev_swing_mode_trigger_{nullptr};
-  
+
   /// Store previously-known states
   ///
   /// These are used to determine when a trigger/action needs to be called

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -35,6 +35,10 @@ struct ThermostatClimateTargetTempConfig {
   ThermostatClimateTargetTempConfig(float default_temperature);
   ThermostatClimateTargetTempConfig(float default_temperature_low, float default_temperature_high);
 
+  void set_fan_mode(climate::ClimateFanMode fan_mode) { this->fan_mode_ = fan_mode; }
+  void set_swing_mode(climate::ClimateSwingMode swing_mode) { this->swing_mode_ = swing_mode; }
+  void set_mode(climate::ClimateMode mode) { this->mode_ = mode; }
+
   float default_temperature{NAN};
   float default_temperature_low{NAN};
   float default_temperature_high{NAN};
@@ -42,6 +46,9 @@ struct ThermostatClimateTargetTempConfig {
   float cool_overrun_{NAN};
   float heat_deadband_{NAN};
   float heat_overrun_{NAN};
+  optional<climate::ClimateFanMode> fan_mode_{};
+  optional<climate::ClimateSwingMode> swing_mode_{};
+  optional<climate::ClimateMode> mode_{};
 };
 
 class ThermostatClimate : public climate::Climate, public Component {


### PR DESCRIPTION
# What does this implement/fix?

This introduces the ability to configure additional presets for a Thermostat beyond the existing Home and Away modes. The existing configuration will continue to work. But it also introduces a new configuration list for preset modes. New style presets also support default fan, swing, and operating modes. Additionally a new trigger has been introduced - `preset_change` - which fires when a user has changed the current preset; intended to be used to update visual displays in the same style as the `auto_mode`, etc, triggers. 

The existing Home/Away logic has been consolidated with this generic preset approach.

Apologies for any faux pas in the Python side of it - it's not my forte.

This supersedes #3266 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1966

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
climate:
  - platform: thermostat
    # Kept for backwards compatability
    away_config:
      default_target_temperature_low: 16
      default_target_temperature_high: 26

    preset:
      activity:
        default_target_temperature_low: 21
        default_target_temperature_high: 23
        fan_mode high
        swing_mode: both
      sleep:
        default_target_temperature_low: 17
        default_target_temperature_high: 26
        fan_mode: low
        mode: fan_only
      # etc. Can be any of eco, away, boost, comfort, home, sleep, and activity
    preset_change:
      - logger.log: Preset has been changed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).