### PR TITLE
Added "tx_power" parameter to esp32_ble_beacon + minor fix

### DIFF
--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_TYPE, CONF_UUID
+from esphome.const import CONF_ID, CONF_TX_POWER, CONF_TYPE, CONF_UUID
 from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
 
@@ -20,6 +20,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_UUID): cv.uuid,
         cv.Optional(CONF_MAJOR, default=10167): cv.uint16_t,
         cv.Optional(CONF_MINOR, default=61958): cv.uint16_t,
+        cv.Optional(CONF_TX_POWER, default=7): cv.int_range(0, 7),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -31,6 +32,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     cg.add(var.set_major(config[CONF_MAJOR]))
     cg.add(var.set_minor(config[CONF_MINOR]))
+    cg.add(var.set_txpower_level(config[CONF_TX_POWER]))
 
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -124,6 +124,12 @@ void ESP32BLEBeacon::ble_setup() {
     return;
   }
 
+  err = esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, global_esp32_ble_beacon->txpower_level_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_ble_tx_power_set failed: %s", esp_err_to_name(err));
+    return;
+  }
+
   esp_ble_ibeacon_t ibeacon_adv_data;
   memcpy(&ibeacon_adv_data.ibeacon_head, &IBEACON_COMMON_HEAD, sizeof(esp_ble_ibeacon_head_t));
   memcpy(&ibeacon_adv_data.ibeacon_vendor.proximity_uuid, global_esp32_ble_beacon->uuid_.data(),
@@ -131,7 +137,6 @@ void ESP32BLEBeacon::ble_setup() {
   ibeacon_adv_data.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->minor_);
   ibeacon_adv_data.ibeacon_vendor.major = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->major_);
   ibeacon_adv_data.ibeacon_vendor.measured_power = 0xC5;
-
   esp_ble_gap_config_adv_data_raw((uint8_t *) &ibeacon_adv_data, sizeof(ibeacon_adv_data));
 }
 
@@ -139,11 +144,6 @@ void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap
   esp_err_t err;
   switch (event) {
     case ESP_GAP_BLE_ADV_DATA_RAW_SET_COMPLETE_EVT: {
-      err = esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, this->txpower_level_);
-      if (err != ESP_OK) {
-        ESP_LOGE(TAG, "esp_ble_tx_power_set failed: %s", esp_err_to_name(err));
-        return;
-      }
       err = esp_ble_gap_start_advertising(&ble_adv_params);
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_ble_gap_start_advertising failed: %d", err);

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -42,6 +42,7 @@ class ESP32BLEBeacon : public Component {
 
   void set_major(uint16_t major) { this->major_ = major; }
   void set_minor(uint16_t minor) { this->minor_ = minor; }
+  void set_txpower_level(uint16_t level) { this->txpower_level_ = level; }
 
  protected:
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
@@ -51,6 +52,7 @@ class ESP32BLEBeacon : public Component {
   std::array<uint8_t, 16> uuid_;
   uint16_t major_{};
   uint16_t minor_{};
+  uint16_t txpower_level_{};
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -5,6 +5,7 @@
 #ifdef USE_ESP32
 
 #include <esp_gap_ble_api.h>
+#include <esp_bt.h>
 
 namespace esphome {
 namespace esp32_ble_beacon {
@@ -42,7 +43,7 @@ class ESP32BLEBeacon : public Component {
 
   void set_major(uint16_t major) { this->major_ = major; }
   void set_minor(uint16_t minor) { this->minor_ = minor; }
-  void set_txpower_level(uint16_t level) { this->txpower_level_ = level; }
+  void set_txpower_level(uint16_t level) { this->txpower_level_ = (esp_power_level_t) level; }
 
  protected:
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
@@ -52,7 +53,7 @@ class ESP32BLEBeacon : public Component {
   std::array<uint8_t, 16> uuid_;
   uint16_t major_{};
   uint16_t minor_{};
-  uint16_t txpower_level_{};
+  esp_power_level_t txpower_level_{};
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

This PR implements a parameter to set the transmit power level of the ESP32_ble_beacon. This allows for better deployment of ibeacons. 
In this PR i also fixed a small implementation issue.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
esp32_ble_beacon:
  type: iBeacon
  uuid: "11111111-1111-1111-1111-111111111111"
  major: 1
  minor: 4

  tx_power: 7
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
