### PR TITLE
sm2135 fix and added configuration options

### DIFF
--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -16,13 +16,9 @@ SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 CONF_RGB_CURRENT = "rgb_current"
 CONF_CW_CURRENT = "cw_current"
 
-DRIVE_STRENGTHS_CW = {
-10,15,20,25,30,40,45,50,55,60
-}
+DRIVE_STRENGTHS_CW = {10, 15, 20, 25, 30, 40, 45, 50, 55, 60}
 
-DRIVE_STRENGTHS_RGB = {
-10,15,20,25,30,40,45
-}
+DRIVE_STRENGTHS_RGB = {10, 15, 20, 25, 30, 40, 45}
 
 
 MULTI_CONF = True
@@ -32,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_RGB_CURRENT): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
-        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True)
+        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -48,3 +44,4 @@ async def to_code(config):
 
     cg.add(var.set_rgb_current(config[CONF_RGB_CURRENT]))
     cg.add(var.set_cw_current(config[CONF_CW_CURRENT]))
+

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -13,12 +13,26 @@ CODEOWNERS = ["@BoukeHaarsma23"]
 sm2135_ns = cg.esphome_ns.namespace("sm2135")
 SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 
+CONF_RGB_CURRENT = "rgb_current"
+CONF_CW_CURRENT = "cw_current"
+
+DRIVE_STRENGTHS_CW = {
+10,15,20,25,30,40,45,50,55,60
+}
+
+DRIVE_STRENGTHS_RGB = {
+10,15,20,25,30,40,45
+}
+
+
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(SM2135),
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_RGB_CURRENT): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
+        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True)
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -31,3 +45,6 @@ async def to_code(config):
     cg.add(var.set_data_pin(data))
     clock = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
     cg.add(var.set_clock_pin(clock))
+
+    cg.add(var.set_rgb_current(config[CONF_RGB_CURRENT]))
+    cg.add(var.set_cw_current(config[CONF_CW_CURRENT]))

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -19,7 +19,6 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
-
 static const uint8_t SM2135_10MA = 0x00;
 static const uint8_t SM2135_15MA = 0x01;
 static const uint8_t SM2135_20MA = 0x02;
@@ -31,7 +30,6 @@ static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
 static const uint8_t SM2135_50MA = 0x08;
 static const uint8_t SM2135_55MA = 0x09;
 static const uint8_t SM2135_60MA = 0x0A;
-
 
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
@@ -59,7 +57,7 @@ void SM2135::loop() {
   if (!this->update_)
     return;
 
-  Sm2135Start_();
+  sm2135_start_();
   write_byte_(SM2135_ADDR_MC);
   write_byte_(current_mask_);
 
@@ -67,9 +65,9 @@ void SM2135::loop() {
     // No color so must be Cold/Warm
 
     write_byte_(SM2135_CW);
-    Sm2135Stop_();
+    sm2135_stop_();
     delay(1);
-    Sm2135Start_();
+    sm2135_start_();
     write_byte_(SM2135_ADDR_C);
     write_byte_(this->pwm_amounts_[4]);  // Warm
     write_byte_(this->pwm_amounts_[3]);  // Cold
@@ -82,11 +80,10 @@ void SM2135::loop() {
     write_byte_(this->pwm_amounts_[2]);  // Blue
   }
 
-  Sm2135Stop_();
+  sm2135_stop_();
 
   this->update_ = false;
 }
-
 
 }  // namespace sm2135
 }  // namespace esphome

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -19,11 +19,12 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
+
 static const uint8_t SM2135_10MA = 0x00;
 static const uint8_t SM2135_15MA = 0x01;
-static const uint8_t SM2135_20MA = 0x02;  // RGB max current (Chip default)
+static const uint8_t SM2135_20MA = 0x02;
 static const uint8_t SM2135_25MA = 0x03;
-static const uint8_t SM2135_30MA = 0x04;  // CW max current (Chip default)
+static const uint8_t SM2135_30MA = 0x04;
 static const uint8_t SM2135_35MA = 0x05;
 static const uint8_t SM2135_40MA = 0x06;
 static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
@@ -31,51 +32,61 @@ static const uint8_t SM2135_50MA = 0x08;
 static const uint8_t SM2135_55MA = 0x09;
 static const uint8_t SM2135_60MA = 0x0A;
 
-static const uint8_t SM2135_CURRENT = (SM2135_20MA << 4) | SM2135_10MA;
 
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
   this->data_pin_->setup();
-  this->data_pin_->digital_write(true);
+  this->data_pin_->digital_write(false);
+  this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
   this->clock_pin_->setup();
-  this->clock_pin_->digital_write(true);
+  this->clock_pin_->digital_write(false);
+  this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+
+  this->data_pin_->pin_mode(gpio::FLAG_PULLUP);
+  this->clock_pin_->pin_mode(gpio::FLAG_PULLUP);
+
   this->pwm_amounts_.resize(5, 0);
 }
 void SM2135::dump_config() {
   ESP_LOGCONFIG(TAG, "SM2135:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
+  ESP_LOGCONFIG(TAG, "  CW Current: %d", this->cw_current_);
+  ESP_LOGCONFIG(TAG, "  RGB Current: %d", this->rgb_current_);
 }
 
 void SM2135::loop() {
   if (!this->update_)
     return;
 
-  uint8_t data[6];
+  Sm2135Start_();
+  write_byte_(SM2135_ADDR_MC);
+  write_byte_(current_mask_);
+
   if (this->update_channel_ == 3 || this->update_channel_ == 4) {
     // No color so must be Cold/Warm
-    data[0] = SM2135_ADDR_MC;
-    data[1] = SM2135_CURRENT;
-    data[2] = SM2135_CW;
-    this->write_buffer_(data, 3);
+
+    write_byte_(SM2135_CW);
+    Sm2135Stop_();
     delay(1);
-    data[0] = SM2135_ADDR_C;
-    data[1] = this->pwm_amounts_[4];  // Warm
-    data[2] = this->pwm_amounts_[3];  // Cold
-    this->write_buffer_(data, 3);
+    Sm2135Start_();
+    write_byte_(SM2135_ADDR_C);
+    write_byte_(this->pwm_amounts_[4]);  // Warm
+    write_byte_(this->pwm_amounts_[3]);  // Cold
   } else {
     // Color
-    data[0] = SM2135_ADDR_MC;
-    data[1] = SM2135_CURRENT;
-    data[2] = SM2135_RGB;
-    data[3] = this->pwm_amounts_[1];  // Green
-    data[4] = this->pwm_amounts_[0];  // Red
-    data[5] = this->pwm_amounts_[2];  // Blue
-    this->write_buffer_(data, 6);
+
+    write_byte_(SM2135_RGB);
+    write_byte_(this->pwm_amounts_[1]);  // Green
+    write_byte_(this->pwm_amounts_[0]);  // Red
+    write_byte_(this->pwm_amounts_[2]);  // Blue
   }
+
+  Sm2135Stop_();
 
   this->update_ = false;
 }
+
 
 }  // namespace sm2135
 }  // namespace esphome

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -15,6 +15,18 @@ class SM2135 : public Component {
   void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }
   void set_clock_pin(GPIOPin *clock_pin) { clock_pin_ = clock_pin; }
 
+  void set_rgb_current(uint8 rgb_current) {
+   rgb_current_ = rgb_current;
+   current_mask_ = (convert_ma_to_bitmask(rgb_current_) << 4) | \
+     convert_ma_to_bitmask(cw_current_);
+  }
+
+  void set_cw_current(uint8 cw_current) {
+   cw_current_ = cw_current;
+   current_mask_ = (convert_ma_to_bitmask(rgb_current_) << 4) | \
+     convert_ma_to_bitmask(cw_current_);
+  }
+
   void setup() override;
 
   void dump_config() override;
@@ -40,6 +52,9 @@ class SM2135 : public Component {
   };
 
  protected:
+
+  const uint8_t SM2135_DELAY = 4;
+
   void set_channel_value_(uint8_t channel, uint8_t value) {
     if (this->pwm_amounts_[channel] != value) {
       this->update_ = true;
@@ -47,36 +62,76 @@ class SM2135 : public Component {
     }
     this->pwm_amounts_[channel] = value;
   }
-  void write_bit_(bool value) {
-    this->clock_pin_->digital_write(false);
-    this->data_pin_->digital_write(value);
-    this->clock_pin_->digital_write(true);
+
+  void Sm2135SetLow_(GPIOPin *pin) {
+    pin->digital_write(false);
+    pin->pin_mode(gpio::FLAG_OUTPUT);
+  }
+
+  void Sm2135SetHigh_(GPIOPin *pin) {
+      pin->pin_mode(gpio::FLAG_PULLUP);
+  }
+
+  void Sm2135Start_(void) {
+    Sm2135SetLow_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetLow_(this->clock_pin_);
+  }
+
+  void Sm2135Stop_(void) {
+    Sm2135SetLow_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetHigh_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetHigh_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
   }
 
   void write_byte_(uint8_t data) {
     for (uint8_t mask = 0x80; mask; mask >>= 1) {
-      this->write_bit_(data & mask);
+      if(mask & data) {
+        Sm2135SetHigh_(this->data_pin_);
+      } else {
+        Sm2135SetLow_(this->data_pin_);
+      }
+
+      Sm2135SetHigh_(clock_pin_);
+      delayMicroseconds(SM2135_DELAY);
+      Sm2135SetLow_(clock_pin_);
     }
-    this->clock_pin_->digital_write(false);
-    this->data_pin_->digital_write(true);
-    this->clock_pin_->digital_write(true);
+
+    Sm2135SetHigh_(this->data_pin_);
+    Sm2135SetHigh_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY / 2);
+    Sm2135SetLow_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY / 2);
+    Sm2135SetLow_(this->data_pin_);
   }
 
   void write_buffer_(uint8_t *buffer, uint8_t size) {
+    Sm2135Start_();
+
     this->data_pin_->digital_write(false);
     for (uint32_t i = 0; i < size; i++) {
       this->write_byte_(buffer[i]);
     }
-    this->clock_pin_->digital_write(false);
-    this->clock_pin_->digital_write(true);
-    this->data_pin_->digital_write(true);
+
+    Sm2135Stop_();
+  }
+
+  uint8_t convert_ma_to_bitmask(uint8_t ma) {
+    return (ma-10) / 5;
   }
 
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;
+  uint8 current_mask_;
+  uint8 rgb_current_;
+  uint8 cw_current_;
   uint8_t update_channel_;
   std::vector<uint8_t> pwm_amounts_;
   bool update_{true};
+
 };
 
 }  // namespace sm2135

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -870,6 +870,8 @@ script:
 sm2135:
   data_pin: GPIO12
   clock_pin: GPIO14
+  rgb_current: 20
+  cw_current: 60
 
 switch:
   - platform: template


### PR DESCRIPTION
# What does this implement/fix?

- Updated the code to reflect the tasmota code. Fixes flickering and wrong colors
- Added cw_current and rgb_current settings and made it a requirement because wrong current could damage the LEDs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sm2135:
  data_pin: GPIO12
  clock_pin: GPIO14
  rgb_current: 20
  cw_current: 60
 
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
