### PR TITLE
Webserver utilize Component Iterator to not overload eventstream

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -23,7 +23,7 @@ static const char *const TAG = "api.connection";
 static const int ESP32_CAMERA_STOP_STREAM = 5000;
 
 APIConnection::APIConnection(std::unique_ptr<socket::Socket> sock, APIServer *parent)
-    : parent_(parent), initial_state_iterator_(parent, this), list_entities_iterator_(parent, this) {
+    : parent_(parent), initial_state_iterator_(this), list_entities_iterator_(this) {
   this->proto_write_buffer_.reserve(64);
 
 #if defined(USE_API_PLAINTEXT)

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -7,7 +7,6 @@
 #include "esphome/components/socket/socket.h"
 #include "api_pb2.h"
 #include "api_pb2_service.h"
-#include "util.h"
 #include "list_entities.h"
 #include "subscribe_state.h"
 #include "user_services.h"

--- a/esphome/components/api/list_entities.cpp
+++ b/esphome/components/api/list_entities.cpp
@@ -40,8 +40,7 @@ bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) { return this->client_->s
 #endif
 
 bool ListEntitiesIterator::on_end() { return this->client_->send_list_info_done(); }
-ListEntitiesIterator::ListEntitiesIterator(APIServer *server, APIConnection *client)
-    : ComponentIterator(server), client_(client) {}
+ListEntitiesIterator::ListEntitiesIterator(APIConnection *client) : client_(client) {}
 bool ListEntitiesIterator::on_service(UserServiceDescriptor *service) {
   auto resp = service->encode_list_service_response();
   return this->client_->send_list_entities_services_response(resp);

--- a/esphome/components/api/list_entities.h
+++ b/esphome/components/api/list_entities.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/component_iterator.h"
 #include "esphome/core/defines.h"
-#include "util.h"
 
 namespace esphome {
 namespace api {
@@ -11,7 +11,7 @@ class APIConnection;
 
 class ListEntitiesIterator : public ComponentIterator {
  public:
-  ListEntitiesIterator(APIServer *server, APIConnection *client);
+  ListEntitiesIterator(APIConnection *client);
 #ifdef USE_BINARY_SENSOR
   bool on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) override;
 #endif
@@ -60,5 +60,3 @@ class ListEntitiesIterator : public ComponentIterator {
 
 }  // namespace api
 }  // namespace esphome
-
-#include "api_server.h"

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -1,5 +1,4 @@
 #include "proto.h"
-#include "util.h"
 #include "esphome/core/log.h"
 
 namespace esphome {

--- a/esphome/components/api/subscribe_state.cpp
+++ b/esphome/components/api/subscribe_state.cpp
@@ -50,8 +50,7 @@ bool InitialStateIterator::on_select(select::Select *select) {
 #ifdef USE_LOCK
 bool InitialStateIterator::on_lock(lock::Lock *a_lock) { return this->client_->send_lock_state(a_lock, a_lock->state); }
 #endif
-InitialStateIterator::InitialStateIterator(APIServer *server, APIConnection *client)
-    : ComponentIterator(server), client_(client) {}
+InitialStateIterator::InitialStateIterator(APIConnection *client) : client_(client) {}
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/subscribe_state.h
+++ b/esphome/components/api/subscribe_state.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/component_iterator.h"
 #include "esphome/core/controller.h"
 #include "esphome/core/defines.h"
-#include "util.h"
 
 namespace esphome {
 namespace api {
@@ -12,7 +12,7 @@ class APIConnection;
 
 class InitialStateIterator : public ComponentIterator {
  public:
-  InitialStateIterator(APIServer *server, APIConnection *client);
+  InitialStateIterator(APIConnection *client);
 #ifdef USE_BINARY_SENSOR
   bool on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) override;
 #endif
@@ -55,5 +55,3 @@ class InitialStateIterator : public ComponentIterator {
 
 }  // namespace api
 }  // namespace esphome
-
-#include "api_server.h"

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -3,94 +3,87 @@
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 
+#include "web_server.h"
+
 namespace esphome {
 namespace web_server {
 
-ListEntitiesIterator::ListEntitiesIterator(AsyncEventSourceClient *client, WebServer *web_server)
-    : client_(client), web_server_(web_server) {}
-
-bool ListEntitiesIterator::on_begin() {
-  this->done_ = false;
-  return true;
-}
-bool ListEntitiesIterator::on_end() {
-  this->done_ = true;
-  return true;
-}
+ListEntitiesIterator::ListEntitiesIterator(WebServer *web_server) : web_server_(web_server) {}
 
 #ifdef USE_BINARY_SENSOR
 bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
-  this->client_->send(this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(),
-                      "state");
+  this->web_server_->events_.send(this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_COVER
 bool ListEntitiesIterator::on_cover(cover::Cover *cover) {
-  this->client_->send(this->web_server_->cover_json(cover, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->cover_json(cover, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_FAN
 bool ListEntitiesIterator::on_fan(fan::Fan *fan) {
-  this->client_->send(this->web_server_->fan_json(fan, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->fan_json(fan, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_LIGHT
 bool ListEntitiesIterator::on_light(light::LightState *light) {
-  this->client_->send(this->web_server_->light_json(light, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->light_json(light, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_SENSOR
 bool ListEntitiesIterator::on_sensor(sensor::Sensor *sensor) {
-  this->client_->send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_SWITCH
 bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) {
-  this->client_->send(this->web_server_->switch_json(a_switch, a_switch->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->switch_json(a_switch, a_switch->state, DETAIL_ALL).c_str(),
+                                  "state");
   return true;
 }
 #endif
 #ifdef USE_BUTTON
 bool ListEntitiesIterator::on_button(button::Button *button) {
-  this->client_->send(this->web_server_->button_json(button, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->button_json(button, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_TEXT_SENSOR
 bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
-  this->client_->send(this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL).c_str(),
-                      "state");
+  this->web_server_->events_.send(
+      this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_LOCK
 bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
-  this->client_->send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "state") return true;
+  this->web_server_->events_.send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "state");
+  return true;
 }
 #endif
 
 #ifdef USE_CLIMATE
 bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
-  this->client_->send(this->web_server_->climate_json(climate, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->climate_json(climate, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 
 #ifdef USE_NUMBER
 bool ListEntitiesIterator::on_number(number::Number *number) {
-  this->client_->send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 
 #ifdef USE_SELECT
 bool ListEntitiesIterator::on_select(select::Select *select) {
-  this->client_->send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -1,0 +1,99 @@
+#include "list_entities.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+#include "esphome/core/util.h"
+
+namespace esphome {
+namespace web_server {
+
+ListEntitiesIterator::ListEntitiesIterator(AsyncEventSourceClient *client, WebServer *web_server)
+    : client_(client), web_server_(web_server) {}
+
+bool ListEntitiesIterator::on_begin() {
+  this->done_ = false;
+  return true;
+}
+bool ListEntitiesIterator::on_end() {
+  this->done_ = true;
+  return true;
+}
+
+#ifdef USE_BINARY_SENSOR
+bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
+  this->client_->send(this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(),
+                      "state");
+  return true;
+}
+#endif
+#ifdef USE_COVER
+bool ListEntitiesIterator::on_cover(cover::Cover *cover) {
+  this->client_->send(this->web_server_->cover_json(cover, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+#ifdef USE_FAN
+bool ListEntitiesIterator::on_fan(fan::Fan *fan) {
+  this->client_->send(this->web_server_->fan_json(fan, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+#ifdef USE_LIGHT
+bool ListEntitiesIterator::on_light(light::LightState *light) {
+  this->client_->send(this->web_server_->light_json(light, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+#ifdef USE_SENSOR
+bool ListEntitiesIterator::on_sensor(sensor::Sensor *sensor) {
+  this->client_->send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+#ifdef USE_SWITCH
+bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) {
+  this->client_->send(this->web_server_->switch_json(a_switch, a_switch->state, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+#ifdef USE_BUTTON
+bool ListEntitiesIterator::on_button(button::Button *button) {
+  this->client_->send(this->web_server_->button_json(button, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+#ifdef USE_TEXT_SENSOR
+bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
+  this->client_->send(this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL).c_str(),
+                      "state");
+  return true;
+}
+#endif
+#ifdef USE_LOCK
+bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
+  this->client_->send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "state") return true;
+}
+#endif
+
+#ifdef USE_CLIMATE
+bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
+  this->client_->send(this->web_server_->climate_json(climate, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+
+#ifdef USE_NUMBER
+bool ListEntitiesIterator::on_number(number::Number *number) {
+  this->client_->send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+
+#ifdef USE_SELECT
+bool ListEntitiesIterator::on_select(select::Select *select) {
+  this->client_->send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
+
+}  // namespace web_server
+}  // namespace esphome

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -1,3 +1,5 @@
+#ifdef USE_ARDUINO
+
 #include "list_entities.h"
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
@@ -90,3 +92,5 @@ bool ListEntitiesIterator::on_select(select::Select *select) {
 
 }  // namespace web_server
 }  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -14,7 +14,8 @@ ListEntitiesIterator::ListEntitiesIterator(WebServer *web_server) : web_server_(
 
 #ifdef USE_BINARY_SENSOR
 bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
-  this->web_server_->events_.send(this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(
+      this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif

--- a/esphome/components/web_server/list_entities.h
+++ b/esphome/components/web_server/list_entities.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/component_iterator.h"
+#include "esphome/core/defines.h"
+#include "web_server.h"
+
+#include <ESPAsyncWebServer.h>
+
+namespace esphome {
+namespace web_server {
+
+class ListEntitiesIterator : public ComponentIterator {
+ public:
+  ListEntitiesIterator(AsyncEventSourceClient *client, WebServer *web_server);
+#ifdef USE_BINARY_SENSOR
+  bool on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) override;
+#endif
+#ifdef USE_COVER
+  bool on_cover(cover::Cover *cover) override;
+#endif
+#ifdef USE_FAN
+  bool on_fan(fan::Fan *fan) override;
+#endif
+#ifdef USE_LIGHT
+  bool on_light(light::LightState *light) override;
+#endif
+#ifdef USE_SENSOR
+  bool on_sensor(sensor::Sensor *sensor) override;
+#endif
+#ifdef USE_SWITCH
+  bool on_switch(switch_::Switch *a_switch) override;
+#endif
+#ifdef USE_BUTTON
+  bool on_button(button::Button *button) override;
+#endif
+#ifdef USE_TEXT_SENSOR
+  bool on_text_sensor(text_sensor::TextSensor *text_sensor) override;
+#endif
+#ifdef USE_CLIMATE
+  bool on_climate(climate::Climate *climate) override;
+#endif
+#ifdef USE_NUMBER
+  bool on_number(number::Number *number) override;
+#endif
+#ifdef USE_SELECT
+  bool on_select(select::Select *select) override;
+#endif
+#ifdef USE_LOCK
+  bool on_lock(lock::Lock *a_lock) override;
+#endif
+  bool on_begin() override;
+  bool on_end() override;
+
+  bool is_done() { return this->done_; }
+
+ protected:
+  AsyncEventSourceClient *client_;
+  WebServer *web_server_;
+  bool done_{false};
+};
+
+}  // namespace web_server
+}  // namespace esphome

--- a/esphome/components/web_server/list_entities.h
+++ b/esphome/components/web_server/list_entities.h
@@ -3,16 +3,17 @@
 #include "esphome/core/component.h"
 #include "esphome/core/component_iterator.h"
 #include "esphome/core/defines.h"
-#include "web_server.h"
 
 #include <ESPAsyncWebServer.h>
 
 namespace esphome {
 namespace web_server {
 
+class WebServer;
+
 class ListEntitiesIterator : public ComponentIterator {
  public:
-  ListEntitiesIterator(AsyncEventSourceClient *client, WebServer *web_server);
+  ListEntitiesIterator(WebServer *web_server);
 #ifdef USE_BINARY_SENSOR
   bool on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) override;
 #endif
@@ -49,15 +50,9 @@ class ListEntitiesIterator : public ComponentIterator {
 #ifdef USE_LOCK
   bool on_lock(lock::Lock *a_lock) override;
 #endif
-  bool on_begin() override;
-  bool on_end() override;
-
-  bool is_done() { return this->done_; }
 
  protected:
-  AsyncEventSourceClient *client_;
   WebServer *web_server_;
-  bool done_{false};
 };
 
 }  // namespace web_server

--- a/esphome/components/web_server/list_entities.h
+++ b/esphome/components/web_server/list_entities.h
@@ -1,11 +1,10 @@
 #pragma once
 
+#ifdef USE_ARDUINO
+
 #include "esphome/core/component.h"
 #include "esphome/core/component_iterator.h"
 #include "esphome/core/defines.h"
-
-#include <ESPAsyncWebServer.h>
-
 namespace esphome {
 namespace web_server {
 
@@ -57,3 +56,5 @@ class ListEntitiesIterator : public ComponentIterator {
 
 }  // namespace web_server
 }  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1,7 +1,6 @@
 #ifdef USE_ARDUINO
 
 #include "web_server.h"
-#include "list_entities.h"
 
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
@@ -108,19 +107,7 @@ void WebServer::setup() {
                  }).c_str(),
                  "ping", millis(), 30000);
 
-    std::shared_ptr<ListEntitiesIterator> iterator = std::make_shared<ListEntitiesIterator>(client, this);
-    iterator->begin(this->include_internal_);
-    this->set_interval("iterate", 0, [this, client, iterator]() {
-      if (client->connected()) {
-        iterator->advance();
-      } else {
-        this->cancel_interval("iterate");
-        return;
-      }
-      if (iterator->is_done()) {
-        this->cancel_interval("iterate");
-      }
-    });
+    this->entities_iterator_.begin(this->include_internal_);
   });
 
 #ifdef USE_LOGGER
@@ -136,6 +123,9 @@ void WebServer::setup() {
     this->base_->add_ota_handler();
 
   this->set_interval(10000, [this]() { this->events_.send("", "ping", millis(), 30000); });
+}
+void WebServer::loop() {
+  this->entities_iterator_.advance();
 }
 void WebServer::dump_config() {
   ESP_LOGCONFIG(TAG, "Web Server:");

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -124,9 +124,7 @@ void WebServer::setup() {
 
   this->set_interval(10000, [this]() { this->events_.send("", "ping", millis(), 30000); });
 }
-void WebServer::loop() {
-  this->entities_iterator_.advance();
-}
+void WebServer::loop() { this->entities_iterator_.advance(); }
 void WebServer::dump_config() {
   ESP_LOGCONFIG(TAG, "Web Server:");
   ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->base_->get_port());

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -2,6 +2,8 @@
 
 #ifdef USE_ARDUINO
 
+#include "list_entities.h"
+
 #include "esphome/components/web_server_base/web_server_base.h"
 #include "esphome/core/component.h"
 #include "esphome/core/controller.h"
@@ -32,7 +34,7 @@ enum JsonDetail { DETAIL_ALL, DETAIL_STATE };
  */
 class WebServer : public Controller, public Component, public AsyncWebHandler {
  public:
-  WebServer(web_server_base::WebServerBase *base) : base_(base) {}
+  WebServer(web_server_base::WebServerBase *base) : base_(base), entities_iterator_(ListEntitiesIterator(this)) {}
 
   /** Set the URL to the CSS <link> that's sent to each client. Defaults to
    * https://esphome.io/_static/webserver-v1.min.css
@@ -76,6 +78,7 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   // (In most use cases you won't need these)
   /// Setup the internal web server and register handlers.
   void setup() override;
+  void loop() override;
 
   void dump_config() override;
 
@@ -217,8 +220,10 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   bool isRequestHandlerTrivial() override;
 
  protected:
+  friend ListEntitiesIterator;
   web_server_base::WebServerBase *base_;
   AsyncEventSource events_{"/events"};
+  ListEntitiesIterator entities_iterator_;
   const char *css_url_{nullptr};
   const char *css_include_{nullptr};
   const char *js_url_{nullptr};

--- a/esphome/core/component_iterator.h
+++ b/esphome/core/component_iterator.h
@@ -1,23 +1,24 @@
 #pragma once
 
-#include "esphome/core/helpers.h"
 #include "esphome/core/component.h"
 #include "esphome/core/controller.h"
+#include "esphome/core/helpers.h"
+
 #ifdef USE_ESP32_CAMERA
 #include "esphome/components/esp32_camera/esp32_camera.h"
 #endif
 
 namespace esphome {
-namespace api {
 
-class APIServer;
+#ifdef USE_API
+namespace api {
 class UserServiceDescriptor;
+}  // namespace api
+#endif
 
 class ComponentIterator {
  public:
-  ComponentIterator(APIServer *server);
-
-  void begin();
+  void begin(bool include_internal = false);
   void advance();
   virtual bool on_begin();
 #ifdef USE_BINARY_SENSOR
@@ -44,7 +45,9 @@ class ComponentIterator {
 #ifdef USE_TEXT_SENSOR
   virtual bool on_text_sensor(text_sensor::TextSensor *text_sensor) = 0;
 #endif
-  virtual bool on_service(UserServiceDescriptor *service);
+#ifdef USE_API
+  virtual bool on_service(api::UserServiceDescriptor *service);
+#endif
 #ifdef USE_ESP32_CAMERA
   virtual bool on_camera(esp32_camera::ESP32Camera *camera);
 #endif
@@ -90,7 +93,9 @@ class ComponentIterator {
 #ifdef USE_TEXT_SENSOR
     TEXT_SENSOR,
 #endif
+#ifdef USE_API
     SERVICE,
+#endif
 #ifdef USE_ESP32_CAMERA
     CAMERA,
 #endif
@@ -109,9 +114,7 @@ class ComponentIterator {
     MAX,
   } state_{IteratorState::NONE};
   size_t at_{0};
-
-  APIServer *server_;
+  bool include_internal_{false};
 };
 
-}  // namespace api
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

The eventstream only has a queue size of 32, so if you have more than 32 components/entities, then the first 32 will send and the rest will not make it to the frontend.

This takes the concept of the `ComponentIterator` from the api list_entities, moves it to core code and utilises it for the web_server too with an `interval` of 0 to send 1 entity/component per `loop`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
