### PR TITLE
Allow specifying deep sleep wakup clock time

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -1,13 +1,18 @@
 import esphome.codegen as cg
+from esphome.components import time
 import esphome.config_validation as cv
 from esphome import pins, automation
 from esphome.const import (
+    CONF_HOUR,
     CONF_ID,
+    CONF_MINUTE,
     CONF_MODE,
     CONF_NUMBER,
     CONF_PINS,
     CONF_RUN_DURATION,
+    CONF_SECOND,
     CONF_SLEEP_DURATION,
+    CONF_TIME_ID,
     CONF_WAKEUP_PIN,
 )
 
@@ -87,6 +92,7 @@ CONF_TOUCH_WAKEUP = "touch_wakeup"
 CONF_DEFAULT = "default"
 CONF_GPIO_WAKEUP_REASON = "gpio_wakeup_reason"
 CONF_TOUCH_WAKEUP_REASON = "touch_wakeup_reason"
+CONF_UNTIL = "until"
 
 WAKEUP_CAUSES_SCHEMA = cv.Schema(
     {
@@ -177,13 +183,19 @@ async def to_code(config):
     cg.add_define("USE_DEEP_SLEEP")
 
 
-DEEP_SLEEP_ENTER_SCHEMA = automation.maybe_simple_id(
-    {
-        cv.GenerateID(): cv.use_id(DeepSleepComponent),
-        cv.Optional(CONF_SLEEP_DURATION): cv.templatable(
-            cv.positive_time_period_milliseconds
-        ),
-    }
+DEEP_SLEEP_ENTER_SCHEMA = cv.All(
+    automation.maybe_simple_id(
+        {
+            cv.GenerateID(): cv.use_id(DeepSleepComponent),
+            cv.Exclusive(CONF_SLEEP_DURATION, "time"): cv.templatable(
+                cv.positive_time_period_milliseconds
+            ),
+            # Only on ESP32 due to how long the RTC on ESP8266 can stay asleep
+            cv.Exclusive(CONF_UNTIL, "time"): cv.All(cv.only_on_esp32, cv.time_of_day),
+            cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+        }
+    ),
+    cv.has_none_or_all_keys(CONF_UNTIL, CONF_TIME_ID),
 )
 
 
@@ -203,6 +215,14 @@ async def deep_sleep_enter_to_code(config, action_id, template_arg, args):
     if CONF_SLEEP_DURATION in config:
         template_ = await cg.templatable(config[CONF_SLEEP_DURATION], args, cg.int32)
         cg.add(var.set_sleep_duration(template_))
+
+    if CONF_UNTIL in config:
+        until = config[CONF_UNTIL]
+        cg.add(var.set_until(until[CONF_HOUR], until[CONF_MINUTE], until[CONF_SECOND]))
+
+        time_ = await cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time(time_))
+
     return var
 
 

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -1,6 +1,7 @@
 #include "deep_sleep_component.h"
-#include "esphome/core/log.h"
+#include <cinttypes>
 #include "esphome/core/application.h"
+#include "esphome/core/log.h"
 
 #ifdef USE_ESP8266
 #include <Esp.h>
@@ -101,6 +102,8 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 #endif
 
   ESP_LOGI(TAG, "Beginning Deep Sleep");
+  if (this->sleep_duration_.has_value())
+    ESP_LOGI(TAG, "Sleeping for %" PRId64 "us", *this->sleep_duration_);
 
   App.run_safe_shutdown_hooks();
 

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -182,13 +182,7 @@ int32_t ESPTime::timezone_offset() {
   time_t now = ::time(nullptr);
   auto local = ESPTime::from_epoch_local(now);
   auto utc = ESPTime::from_epoch_utc(now);
-  bool negative = false;
-
-  if (utc.second > local.second) {
-    local.second += 60;
-    local.minute -= 1;
-  }
-  offset += local.second - utc.second;
+  bool negative = utc.hour > local.hour && local.day_of_year <= utc.day_of_year;
 
   if (utc.minute > local.minute) {
     local.minute += 60;
@@ -196,13 +190,14 @@ int32_t ESPTime::timezone_offset() {
   }
   offset += (local.minute - utc.minute) * 60;
 
-  if (utc.hour > local.hour) {
-    local.hour += 24;
-    negative = true;
+  if (negative) {
+    offset -= (utc.hour - local.hour) * 3600;
+  } else {
+    if (utc.hour > local.hour) {
+      local.hour += 24;
+    }
+    offset += (local.hour - utc.hour) * 3600;
   }
-  offset += (local.hour - utc.hour) * 3600;
-  if (negative)
-    offset *= -1;
   return offset;
 }
 

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -176,6 +176,36 @@ void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
   res += this->second;
   this->timestamp = res;
 }
+
+int32_t ESPTime::timezone_offset() {
+  int32_t offset = 0;
+  time_t now = ::time(nullptr);
+  auto local = ESPTime::from_epoch_local(now);
+  auto utc = ESPTime::from_epoch_utc(now);
+  bool negative = false;
+
+  if (utc.second > local.second) {
+    local.second += 60;
+    local.minute -= 1;
+  }
+  offset += local.second - utc.second;
+
+  if (utc.minute > local.minute) {
+    local.minute += 60;
+    local.hour -= 1;
+  }
+  offset += (local.minute - utc.minute) * 60;
+
+  if (utc.hour > local.hour) {
+    local.hour += 24;
+    negative = true;
+  }
+  offset += (local.hour - utc.hour) * 3600;
+  if (negative)
+    offset *= -1;
+  return offset;
+}
+
 bool ESPTime::operator<(ESPTime other) { return this->timestamp < other.timestamp; }
 bool ESPTime::operator<=(ESPTime other) { return this->timestamp <= other.timestamp; }
 bool ESPTime::operator==(ESPTime other) { return this->timestamp == other.timestamp; }

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -88,6 +88,8 @@ struct ESPTime {
   /// Convert this ESPTime instance back to a tm struct.
   struct tm to_c_tm();
 
+  static int32_t timezone_offset();
+
   /// Increment this clock instance by one second.
   void increment_second();
   /// Increment this clock instance by one day.


### PR DESCRIPTION
# What does this implement/fix?

This allows you to specify the `hour:minute:second` that the deep sleep timer will be set for.
It does this by calculating the current timestamp, the desired timestamp and getting the difference. Because of this, it requires a `time` component.

The configuration variable is a string in format `hour:minute:second`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2012

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
on_...:
  - deep_sleep.enter:
      until: "20:00:00"
      time_id: my_time_id
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).