### PR TITLE
Change beginning of file comments to avoid creating doxygen tag for `esphome` namespace

### DIFF
--- a/esphome/components/rc522_spi/rc522_spi.h
+++ b/esphome/components/rc522_spi/rc522_spi.h
@@ -1,3 +1,10 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/rc522/rc522.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome {
 /**
  * Library based on https://github.com/miguelbalboa/rfid
  * and adapted to ESPHome by @glmnet
@@ -6,14 +13,6 @@
  *
  *
  */
-
-#pragma once
-
-#include "esphome/core/component.h"
-#include "esphome/components/rc522/rc522.h"
-#include "esphome/components/spi/spi.h"
-
-namespace esphome {
 namespace rc522_spi {
 
 class RC522Spi : public rc522::RC522,

--- a/esphome/components/sx1509/sx1509_registers.h
+++ b/esphome/components/sx1509/sx1509_registers.h
@@ -1,11 +1,15 @@
-/******************************************************************************
+/*
 sx1509_registers.h
 Register definitions for SX1509.
 Jim Lindblom @ SparkFun Electronics
 Original Creation Date: September 21, 2015
 https://github.com/sparkfun/SparkFun_SX1509_Arduino_Library
+*/
+#pragma once
 
-Here you'll find the Arduino code used to interface with the SX1509 I2C
+namespace esphome {
+/**
+ Here you'll find the Arduino code used to interface with the SX1509 I2C
 16 I/O expander. There are functions to take advantage of everything the
 SX1509 provides - input/output setting, writing pins high/low, reading
 the input value of pins, LED driver utilities (blink, breath, pwm), and
@@ -20,10 +24,7 @@ This code is beerware; if you see me (or any other SparkFun employee) at the
 local, and you've found our code helpful, please buy us a round!
 
 Distributed as-is; no warranty is given.
-******************************************************************************/
-#pragma once
-
-namespace esphome {
+*/
 namespace sx1509 {
 
 const uint8_t REG_INPUT_DISABLE_B =


### PR DESCRIPTION
# What does this implement/fix?

Right now, https://esphome.io/api/namespaceesphome.html shows the `rc522_spi.h` text as the documentation comment for the entire `esphome` namespace, on any doxygen page that includes that namespace.

I believe it belongs on the `rc522_spi` namespace (or class?) instead.

A quick grep across the codebase also found `sx1509_registers.h` with a leading doxygen-styled comment, so I'm pre-emptively changing it too.

Hopefully there aren't more places where this happens

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: **Developer documentation updates**

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
