### PR TITLE
Serve static files with web_server component

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -1,5 +1,10 @@
+import logging
+import mimetypes
+import os.path
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import core
 from esphome.components import web_server_base
 from esphome.components.web_server_base import CONF_WEB_SERVER_BASE_ID
 from esphome.const import (
@@ -16,13 +21,19 @@ from esphome.const import (
     CONF_OTA,
     CONF_VERSION,
     CONF_LOCAL,
+    CONF_SOURCE,
 )
-from esphome.core import CORE, coroutine_with_priority
+from esphome.core import CORE, coroutine_with_priority, HexInt
+
 
 AUTO_LOAD = ["json", "web_server_base"]
 
 web_server_ns = cg.esphome_ns.namespace("web_server")
 WebServer = web_server_ns.class_("WebServer", cg.Component, cg.Controller)
+
+CONF_APP = "app"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def default_url(config):
@@ -72,6 +83,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INCLUDE_INTERNAL, default=False): cv.boolean,
             cv.Optional(CONF_OTA, default=True): cv.boolean,
             cv.Optional(CONF_LOCAL): cv.boolean,
+            cv.Optional(CONF_APP): cv.Schema(
+                {
+                    cv.Required(CONF_SOURCE): cv.directory,
+                }
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
@@ -112,3 +128,69 @@ async def to_code(config):
     cg.add(var.set_include_internal(config[CONF_INCLUDE_INTERNAL]))
     if CONF_LOCAL in config and config[CONF_LOCAL]:
         cg.add_define("USE_WEBSERVER_LOCAL")
+    if CONF_APP in config:
+        add_web_app(config, var)
+
+
+def add_web_app(config, var):
+    """Embed web application files into flash and configure the web server to serve them.
+
+    For each file in the web app source directory:
+    - detect file MIME type based on file extension (e.g. text/html)
+    - detect transfer encoding type for compressed files based on file extension (e.g. gzip, compress, bzip2)
+    - embed file contents as PROGMEM byte stream
+    - add file descriptor to the list of web app files served by the web server
+
+    See https://docs.python.org/3.8/library/mimetypes.html for internals of file type and encoding detection logic.
+    """
+    mimetypes.init()
+    cg.add_define("USE_WEBSERVER_APP")
+    app_config = config[CONF_APP]
+    source_dir = CORE.relative_config_path(app_config[CONF_SOURCE])
+
+    # add all files in source directory
+    file_index = 0
+    for file_name in os.listdir(source_dir):
+        file_path = os.path.join(source_dir, file_name)
+        # no recursion, process files only
+        if os.path.isfile(file_path):
+            # guess file MIME type & encoding
+            mime_type = mimetypes.guess_type(file_path, False)
+            file_type = mime_type[0]  # e.g. text/html, application/javascript or None
+            # fallback to application/octet-stream for unknown MIME types
+            if file_type is None:
+                _LOGGER.warning(
+                    "Could not detect MIME type for file %s. Using application/octet-stream.",
+                    file_path,
+                )
+                file_type = "application/octet-stream"
+            # handle file encoding (e.g. gzip, compress, ...)
+            file_encoding = mime_type[1]  # e.g. gzip, compress or None
+            if file_encoding is None:
+                file_encoding = "none"
+            else:
+                file_name = os.path.splitext(file_name)[
+                    0
+                ]  # remove compressed file extension
+            # add the file to the list of web server app files
+            with open(file=file_path, mode="rb") as content:
+                data = content.read()
+                _LOGGER.info(
+                    "Adding web app file: %s as app/%s (size %d, %s, encoding %s)",
+                    file_path,
+                    file_name,
+                    len(data),
+                    file_type,
+                    file_encoding,
+                )
+                rhs = [HexInt(x) for x in data]
+                prog_arr = cg.progmem_array(
+                    core.ID(id="web_server_app_file" + str(file_index), type=cg.uint8),
+                    rhs,
+                )
+                cg.add(
+                    var.add_app_file(
+                        file_name, file_type, file_encoding, prog_arr, len(data)
+                    )
+                )
+                file_index += 1

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1050,7 +1050,8 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
 #ifdef USE_WEBSERVER_APP
 void WebServer::handle_app_request(AsyncWebServerRequest *request, const UrlMatch &match) {
   auto filename = match.id;
-  if (filename == "") filename = "index.html";
+  if (filename == "")
+    filename = "index.html";
   if (app_files_.find(filename) == app_files_.end()) {
     ESP_LOGD(TAG, "Web app url '%s': 404 Not found", request->url().c_str());
     request->send(404);
@@ -1059,10 +1060,11 @@ void WebServer::handle_app_request(AsyncWebServerRequest *request, const UrlMatc
   ESP_LOGD(TAG, "Web app url '%s': serving file '%s'", request->url().c_str(), filename.c_str());
   auto file = app_files_[filename];
   auto response = request->beginResponse_P(200, file.type.c_str(), file.data, file.length);
-  if (file.encoding != "" && file.encoding != "none") response->addHeader("Content-Encoding", file.encoding.c_str());
+  if (file.encoding != "" && file.encoding != "none")
+    response->addHeader("Content-Encoding", file.encoding.c_str());
   request->send(response);
 }
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 
 bool WebServer::canHandle(AsyncWebServerRequest *request) {
   if (request->url() == "/")
@@ -1081,7 +1083,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 #ifdef USE_WEBSERVER_APP
   if (request->url() == "/app")
     return true;
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 
   UrlMatch match = match_url(request->url().c_str(), true);
   if (!match.valid)
@@ -1149,7 +1151,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 #ifdef USE_WEBSERVER_APP
   if (request->method() == HTTP_GET && match.domain == "app")
     return true;
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 
   return false;
 }
@@ -1179,7 +1181,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
     request->redirect("/app/");
     return;
   }
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 
   UrlMatch match = match_url(request->url().c_str());
 #ifdef USE_SENSOR
@@ -1272,23 +1274,23 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
     this->handle_app_request(request, match);
     return;
   }
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 }
 
 bool WebServer::isRequestHandlerTrivial() { return false; }
 
 #ifdef USE_WEBSERVER_APP
-void WebServer::add_app_file(const char *name, const char *type, const char *encoding, const uint8_t *data, uint32_t length) {
+void WebServer::add_app_file(const char *name, const char *type, const char *encoding, const uint8_t *data,
+                             uint32_t length) {
   app_files_[name] = {
-    .name = name,
-    .type = type,
-    .encoding = encoding,
-    .data = data,
-    .length = length,
+      .name = name,
+      .type = type,
+      .encoding = encoding,
+      .data = data,
+      .length = length,
   };
 }
-#endif // USE_WEBSERVER_APP
-
+#endif  // USE_WEBSERVER_APP
 
 }  // namespace web_server
 }  // namespace esphome

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -24,14 +24,13 @@ enum JsonDetail { DETAIL_ALL, DETAIL_STATE };
 /// Web application file descriptor: name, mime type, content, length, transfer encoding (gzip, none="")
 #ifdef USE_WEBSERVER_APP
 struct AppFile {
-  std::string name;       ///< File name w/o path
-  std::string type;       ///< File mime type (e.g. text/html)
-  std::string encoding;   ///< Transfer encoding (e.g. gzip)
-  const uint8_t *data;    ///< File content
-  uint32_t length;        ///< File length
+  std::string name;      ///< File name w/o path
+  std::string type;      ///< File mime type (e.g. text/html)
+  std::string encoding;  ///< Transfer encoding (e.g. gzip)
+  const uint8_t *data;   ///< File content
+  uint32_t length;       ///< File length
 };
-#endif // USE_WEBSERVER_APP
-
+#endif  // USE_WEBSERVER_APP
 
 /** This class allows users to create a web server with their ESP nodes.
  *
@@ -224,7 +223,7 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
 #ifdef USE_WEBSERVER_APP
   // Serve web application file.
   void handle_app_request(AsyncWebServerRequest *request, const UrlMatch &match);
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 
   /// Override the web handler's canHandle method.
   bool canHandle(AsyncWebServerRequest *request) override;
@@ -233,11 +232,10 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   /// This web handle is not trivial.
   bool isRequestHandlerTrivial() override;
 
-
 #ifdef USE_WEBSERVER_APP
   /// Adds web application file.
   void add_app_file(const char *name, const char *type, const char *encoding, const uint8_t *data, uint32_t length);
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 
  protected:
   web_server_base::WebServerBase *base_;
@@ -250,7 +248,7 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   bool allow_ota_{true};
 #ifdef USE_WEBSERVER_APP
   std::map<std::string, AppFile> app_files_{};
-#endif // USE_WEBSERVER_APP
+#endif  // USE_WEBSERVER_APP
 };
 
 }  // namespace web_server

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -21,6 +21,18 @@ struct UrlMatch {
 
 enum JsonDetail { DETAIL_ALL, DETAIL_STATE };
 
+/// Web application file descriptor: name, mime type, content, length, transfer encoding (gzip, none="")
+#ifdef USE_WEBSERVER_APP
+struct AppFile {
+  std::string name;       ///< File name w/o path
+  std::string type;       ///< File mime type (e.g. text/html)
+  std::string encoding;   ///< Transfer encoding (e.g. gzip)
+  const uint8_t *data;    ///< File content
+  uint32_t length;        ///< File length
+};
+#endif // USE_WEBSERVER_APP
+
+
 /** This class allows users to create a web server with their ESP nodes.
  *
  * Behind the scenes it's using AsyncWebServer to set up the server. It exposes 3 things:
@@ -209,12 +221,23 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   std::string lock_json(lock::Lock *obj, lock::LockState value, JsonDetail start_config);
 #endif
 
+#ifdef USE_WEBSERVER_APP
+  // Serve web application file.
+  void handle_app_request(AsyncWebServerRequest *request, const UrlMatch &match);
+#endif // USE_WEBSERVER_APP
+
   /// Override the web handler's canHandle method.
   bool canHandle(AsyncWebServerRequest *request) override;
   /// Override the web handler's handleRequest method.
   void handleRequest(AsyncWebServerRequest *request) override;
   /// This web handle is not trivial.
   bool isRequestHandlerTrivial() override;
+
+
+#ifdef USE_WEBSERVER_APP
+  /// Adds web application file.
+  void add_app_file(const char *name, const char *type, const char *encoding, const uint8_t *data, uint32_t length);
+#endif // USE_WEBSERVER_APP
 
  protected:
   web_server_base::WebServerBase *base_;
@@ -225,6 +248,9 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   const char *js_include_{nullptr};
   bool include_internal_{false};
   bool allow_ota_{true};
+#ifdef USE_WEBSERVER_APP
+  std::map<std::string, AppFile> app_files_{};
+#endif // USE_WEBSERVER_APP
 };
 
 }  // namespace web_server


### PR DESCRIPTION
# What does this implement/fix?

Background story: I created a web application for interfacing with ESPHome device in one of my projects (DIY reflow oven - uses ESPHome REST and Event Source APIs to display real-time temperature charts and reflow profiles).

Web application is small (5 files, 180 kB compressed) and could very well be served from the ESPHome device itself instead of having to run it on a server - ESP32 has more than enough flash space for it. Unfortunately, this is currently not possible as web server is limited to serving files required by the generic ESPHome application only. Extending the functionality to serve additional files under a dedicated URL prefix was a no-brainer and now I can run reflow cycles without having to fire up a dedicated web server with the application.

The proposed pull request implements the following:
- ability to configure a local directory where static (web application) files reside;
- all files in the directory are inlined (embedded) as PROGMEM byte arrays and served under app/<file_name> URL;
- correct file media (MIME) types are detected during compilation stage;
- supports serving compressed files by setting Content-Encoding HTTP header; 

Details and inner workings are described in the documentation pull request esphome/esphome-docs#1978.

**NOTES**:
- new functionality in C++ files is guarded with a defined symbol so not using this option adds nothing to the existing compiled code

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1978

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Web app configuration
web_server:
  app:
    source: ../dist/my_app
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
