### PR TITLE
feat: support ble_client that use security w/o pin codes

### DIFF
--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -11,6 +11,7 @@
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
 #include <esp_bt_defs.h>
+#include <esp_gatt_common_api.h>
 
 namespace esphome {
 namespace ble_client {
@@ -86,6 +87,7 @@ class BLEClient : public espbt::ESPBTClient, public Component {
 
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
+  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
   bool parse_device(const espbt::ESPBTDevice &device) override;
   void on_scan_end() override {}
   void connect() override;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -262,6 +262,9 @@ void ESP32BLETracker::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_
     default:
       break;
   }
+  for (auto *client : global_esp32_ble_tracker->clients_) {
+    client->gap_event_handler(event, param);
+  }
 }
 
 void ESP32BLETracker::gap_scan_set_param_complete_(const esp_ble_gap_cb_param_t::ble_scan_param_cmpl_evt_param &param) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -155,6 +155,7 @@ class ESPBTClient : public ESPBTDeviceListener {
  public:
   virtual void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) = 0;
+  virtual void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) = 0;
   virtual void connect() = 0;
   void set_state(ClientState st) { this->state_ = st; }
   ClientState state() const { return state_; }


### PR DESCRIPTION
# What does this implement/fix?

Implements basic BLE auth/security required by some bluetooth devices. Specifically, i'm testing with an Ikea Idasen desk (which uses Linak components). In addition, every connection attempt I noticed we were trying to configure the mtu, but the response event always said it failed. Looking at the [esp-idf walkthrough](https://github.com/espressif/esp-idf/blob/2f9d47c708/examples/bluetooth/bluedroid/ble/gatt_client/tutorial/Gatt_Client_Example_Walkthrough.md#configuring-the-mtu-size), they showed the MTU should be configured in the connect event. I moved the MTU configuration to there and that resolved mtu config errors.

### Extra background info
I was attempting to use a custom component found [here](https://github.com/j5lien/esphome-idasen-desk-controller), but quickly found out that in version 2.0.0+ the developer has moved away from managing the bluetooth connection in that custom component, using the arduino library to use the `ble_client` component baked into ESPHome. However, when they did that, they didn't know that new devices were unable to pair. As a workaround, people would first run an older version that used the Arduino library to complete the pairing process and then once it was paired, they could simply run the newer version and the pairing seems to stick.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

fixes:
- j5lien/esphome-idasen-desk-controller#42
- j5lien/esphome-idasen-desk-controller#37
- j5lien/esphome-idasen-desk-controller#28
- j5lien/esphome-idasen-desk-controller#26
- j5lien/esphome-idasen-desk-controller#25

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF (does this meaning testing with the esp-idf framework instead of the default arduino framework?)
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
esphome:
  name: office-desk-controller-frontier

esp32:
  board: esp32dev
  framework:
    type: arduino

# Enable logging
logger:
  level: VERBOSE

# Enable Home Assistant API
api:

ota:
  password: "SNIP"

wifi:
  ssid: "SNIP"
  password: "SNIP"

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Office-Desk-Controller-Frontier"
    password: "SNIP"

captive_portal:

external_components:
  - source: github://j5lien/esphome-idasen-desk-controller@v3.0.0

globals:
  # To store the Desk Connection Status
  - id: ble_client_connected
    type: bool
    initial_value: 'false'

esp32_ble_tracker:

ble_client:
  - mac_address: "00:00:00:00:00:00" # Replace with the desk bluetooth mac address
    id: idasen_desk
    on_connect:
      then:
        # Update the Desk Connection Status
        - lambda: |-
            id(ble_client_connected) = true;
        - delay: 5s
        # Update desk height and speed sensors after bluetooth is connected
        - lambda: |-
            id(desk_height).update();
            id(desk_speed).update();
    on_disconnect:
      then:
        # Update the Desk Connection Status
        - lambda: |-
            id(ble_client_connected) = false;

idasen_desk_controller:
    # Reference to the ble client component id
    # -----------
    # Required
    ble_client_id: idasen_desk
    # Fallback to use only up and down commands (less precise)
    # -----------
    # Optional
    only_up_down_command: true

cover:
  - platform: idasen_desk_controller
    name: "Office Desk"

sensor:
  # Desk Height Sensor
  - platform: ble_client
    ble_client_id: idasen_desk
    id: desk_height
    name: 'Desk Height'
    service_uuid: '99fa0020-338a-1024-8a49-009c0215f78a'
    characteristic_uuid: '99fa0021-338a-1024-8a49-009c0215f78a'
    icon: 'mdi:arrow-up-down'
    unit_of_measurement: 'cm'
    accuracy_decimals: 1
    update_interval: never
    notify: true
    lambda: |-
      uint16_t raw_height = ((uint16_t)x[1] << 8) | x[0];
      unsigned short height_mm = raw_height / 10;

      return (float) height_mm / 10;

  # Desk Speed Sensor
  - platform: ble_client
    ble_client_id: idasen_desk
    id: desk_speed
    name: 'Desk Speed'
    service_uuid: '99fa0020-338a-1024-8a49-009c0215f78a'
    characteristic_uuid: '99fa0021-338a-1024-8a49-009c0215f78a'
    icon: 'mdi:speedometer'
    unit_of_measurement: 'cm/min' # I'm not sure this unit is correct
    accuracy_decimals: 0
    update_interval: never
    notify: true
    lambda: |-
      uint16_t raw_speed = ((uint16_t)x[3] << 8) | x[2];
      return raw_speed / 100;

binary_sensor:
  # Desk Bluetooth Connection Status
  - platform: template
    name: 'Desk Connection'
    id: desk_connection
    lambda: 'return id(ble_client_connected);'

  # Desk Moving Status
  - platform: template
    name: 'Desk Moving'
    id: desk_moving
    lambda: 'return id(desk_speed).state > 0;'

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~
