### PR TITLE
Fix pulse_meter filter logic

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -14,7 +14,6 @@ void PulseMeterSensor::setup() {
 
   this->pulse_width_us_ = 0;
   this->last_detected_edge_us_ = 0;
-  this->last_valid_low_edge_us_ = 0;
   this->last_valid_high_edge_us_ = 0;
   this->sensor_is_high_ = this->isr_pin_.digital_read();
   this->has_valid_high_edge_ = false;
@@ -28,17 +27,14 @@ void PulseMeterSensor::loop() {
   const uint32_t time_since_valid_edge_us =
       now - this->last_valid_high_edge_us_;
   if ((this->has_valid_high_edge_) &&
-      (time_since_valid_edge_us > this->timeout_us_) &&
-      (this->pulse_width_us_ != 0)) {
-    
+      (time_since_valid_edge_us > this->timeout_us_)) {
+
     ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min",
              time_since_valid_edge_us / 1000000);
     this->pulse_width_us_ = 0;
     this->last_detected_edge_us_ = 0;
-    this->last_valid_low_edge_us_ = 0;
     this->last_valid_high_edge_us_ = 0;
     this->has_valid_high_edge_ = false;
-
   }
 
   // We quantize our pulse widths to 1 ms to avoid unnecessary jitter
@@ -131,7 +127,6 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
       // Only consider LOW pulses and "new" edges if sensor state is HIGH
       else if (sensor->sensor_is_high_ && !sensor->isr_pin_.digital_read()) {
         sensor->sensor_is_high_ = false;
-        sensor->last_valid_low_edge_us_ = sensor->last_detected_edge_us_;
       }
     }
   }

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -9,8 +9,7 @@ static const char *const TAG = "pulse_meter";
 void PulseMeterSensor::setup() {
   this->pin_->setup();
   this->isr_pin_ = pin_->to_isr();
-  this->pin_->attach_interrupt(PulseMeterSensor::gpio_intr, this,
-                               gpio::INTERRUPT_ANY_EDGE);
+  this->pin_->attach_interrupt(PulseMeterSensor::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
 
   this->pulse_width_us_ = 0;
   this->last_detected_edge_us_ = 0;
@@ -30,9 +29,7 @@ void PulseMeterSensor::loop() {
   // 0 pulses/min until we get at least two valid pulses.
   const uint32_t time_since_valid_edge_us = now - last_valid_high_edge_us;
   if ((has_valid_high_edge) && (time_since_valid_edge_us > this->timeout_us_)) {
-
-    ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min",
-             time_since_valid_edge_us / 1000000);
+    ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min", time_since_valid_edge_us / 1000000);
 
     this->pulse_width_us_ = 0;
     this->last_detected_edge_us_ = 0;
@@ -61,23 +58,17 @@ void PulseMeterSensor::loop() {
   }
 }
 
-void PulseMeterSensor::set_total_pulses(uint32_t pulses) {
-  this->total_pulses_ = pulses;
-}
+void PulseMeterSensor::set_total_pulses(uint32_t pulses) { this->total_pulses_ = pulses; }
 
 void PulseMeterSensor::dump_config() {
   LOG_SENSOR("", "Pulse Meter", this);
   LOG_PIN("  Pin: ", this->pin_);
   if (this->filter_mode_ == FILTER_EDGE) {
-    ESP_LOGCONFIG(TAG, "  Filtering rising edges less than %u µs apart",
-                  this->filter_us_);
+    ESP_LOGCONFIG(TAG, "  Filtering rising edges less than %u µs apart", this->filter_us_);
   } else {
-    ESP_LOGCONFIG(TAG, "  Filtering pulses shorter than %u µs",
-                  this->filter_us_);
+    ESP_LOGCONFIG(TAG, "  Filtering pulses shorter than %u µs", this->filter_us_);
   }
-  ESP_LOGCONFIG(TAG,
-                "  Assuming 0 pulses/min after not receiving a pulse for %us",
-                this->timeout_us_ / 1000000);
+  ESP_LOGCONFIG(TAG, "  Assuming 0 pulses/min after not receiving a pulse for %us", this->timeout_us_ / 1000000);
 }
 
 void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
@@ -99,13 +90,11 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
 
   // Check to see if we should filter this edge out
   if (sensor->filter_mode_ == FILTER_EDGE) {
-    if ((sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_) >=
-        sensor->filter_us_) {
+    if ((sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_) >= sensor->filter_us_) {
       // Don't measure the first valid pulse (we need at least two pulses to
       // measure the width)
       if (sensor->has_valid_high_edge_) {
-        sensor->pulse_width_us_ =
-            (sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_);
+        sensor->pulse_width_us_ = (sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_);
       }
       sensor->total_pulses_++;
       sensor->last_valid_high_edge_us_ = sensor->last_detected_edge_us_;
@@ -119,8 +108,7 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
         // Don't measure the first valid pulse (we need at least two pulses to
         // measure the width)
         if (sensor->has_valid_high_edge_) {
-          sensor->pulse_width_us_ = (sensor->last_detected_edge_us_ -
-                                     sensor->last_valid_high_edge_us_);
+          sensor->pulse_width_us_ = (sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_);
         }
         sensor->sensor_is_high_ = true;
         sensor->total_pulses_++;
@@ -135,5 +123,5 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
   }
 }
 
-} // namespace pulse_meter
-} // namespace esphome
+}  // namespace pulse_meter
+}  // namespace esphome

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -37,6 +37,7 @@ void PulseMeterSensor::loop() {
     this->last_detected_edge_us_ = 0;
     this->last_valid_high_edge_us_ = 0;
     this->last_valid_low_edge_us_ = 0;
+    this->has_detected_edge_ = false;
     this->has_valid_high_edge_ = false;
     this->has_valid_low_edge_ = false;
   }
@@ -110,7 +111,7 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
       return;
     }
     // Make sure the signal has been stable long enough
-    if (now - sensor->last_detected_edge_us_ >= sensor->filter_us_) {
+    if (sensor->has_detected_edge_ && (now - sensor->last_detected_edge_us_ >= sensor->filter_us_)) {
       if (pin_val) {
         sensor->has_valid_high_edge_ = true;
         sensor->last_valid_high_edge_us_ = sensor->last_detected_edge_us_;
@@ -126,6 +127,7 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
         sensor->sensor_is_high_ = false;
       }
     }
+    sensor->has_detected_edge_ = true;
     sensor->last_detected_edge_us_ = now;
   }
 }

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -20,17 +20,20 @@ void PulseMeterSensor::setup() {
 }
 
 void PulseMeterSensor::loop() {
+  // Get a local copy of the volatile sensor values, to make sure they are not
+  // by the ISR. This could cause overflow in the following arithmetic
+  const uint32_t last_valid_high_edge_us = this->last_valid_high_edge_us_;
+  const bool has_valid_high_edge = this->has_valid_high_edge_;
   const uint32_t now = micros();
 
   // If we've exceeded our timeout interval without receiving any pulses, assume
   // 0 pulses/min until we get at least two valid pulses.
-  const uint32_t time_since_valid_edge_us =
-      now - this->last_valid_high_edge_us_;
-  if ((this->has_valid_high_edge_) &&
-      (time_since_valid_edge_us > this->timeout_us_)) {
+  const uint32_t time_since_valid_edge_us = now - last_valid_high_edge_us;
+  if ((has_valid_high_edge) && (time_since_valid_edge_us > this->timeout_us_)) {
 
     ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min",
              time_since_valid_edge_us / 1000000);
+
     this->pulse_width_us_ = 0;
     this->last_detected_edge_us_ = 0;
     this->last_valid_high_edge_us_ = 0;

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -9,31 +9,44 @@ static const char *const TAG = "pulse_meter";
 void PulseMeterSensor::setup() {
   this->pin_->setup();
   this->isr_pin_ = pin_->to_isr();
-  this->pin_->attach_interrupt(PulseMeterSensor::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
+  this->pin_->attach_interrupt(PulseMeterSensor::gpio_intr, this,
+                               gpio::INTERRUPT_ANY_EDGE);
 
+  this->pulse_width_us_ = 0;
   this->last_detected_edge_us_ = 0;
   this->last_valid_low_edge_us_ = 0;
   this->last_valid_high_edge_us_ = 0;
   this->sensor_is_high_ = this->isr_pin_.digital_read();
+  this->has_valid_high_edge_ = false;
 }
 
 void PulseMeterSensor::loop() {
   const uint32_t now = micros();
 
-  // If we've exceeded our timeout interval without receiving any pulses, assume 0 pulses/min until
-  // we get at least two valid pulses.
-  const uint32_t time_since_valid_edge_us = now - this->last_valid_high_edge_us_;
-  if ((this->last_valid_high_edge_us_ != 0) && (time_since_valid_edge_us > this->timeout_us_) &&
+  // If we've exceeded our timeout interval without receiving any pulses, assume
+  // 0 pulses/min until we get at least two valid pulses.
+  const uint32_t time_since_valid_edge_us =
+      now - this->last_valid_high_edge_us_;
+  if ((this->has_valid_high_edge_) &&
+      (time_since_valid_edge_us > this->timeout_us_) &&
       (this->pulse_width_us_ != 0)) {
-    ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min", time_since_valid_edge_us / 1000000);
+    
+    ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min",
+             time_since_valid_edge_us / 1000000);
     this->pulse_width_us_ = 0;
+    this->last_detected_edge_us_ = 0;
+    this->last_valid_low_edge_us_ = 0;
+    this->last_valid_high_edge_us_ = 0;
+    this->has_valid_high_edge_ = false;
+
   }
 
   // We quantize our pulse widths to 1 ms to avoid unnecessary jitter
   const uint32_t pulse_width_ms = this->pulse_width_us_ / 1000;
   if (this->pulse_width_dedupe_.next(pulse_width_ms)) {
     if (pulse_width_ms == 0) {
-      // Treat 0 pulse width as 0 pulses/min (normally because we've not detected any pulses for a while)
+      // Treat 0 pulse width as 0 pulses/min (normally because we've not
+      // detected any pulses for a while)
       this->publish_state(0);
     } else {
       // Calculate pulses/min from the pulse width in ms
@@ -49,30 +62,32 @@ void PulseMeterSensor::loop() {
   }
 }
 
-void PulseMeterSensor::set_total_pulses(uint32_t pulses) { this->total_pulses_ = pulses; }
+void PulseMeterSensor::set_total_pulses(uint32_t pulses) {
+  this->total_pulses_ = pulses;
+}
 
 void PulseMeterSensor::dump_config() {
   LOG_SENSOR("", "Pulse Meter", this);
   LOG_PIN("  Pin: ", this->pin_);
   if (this->filter_mode_ == FILTER_EDGE) {
-    ESP_LOGCONFIG(TAG, "  Filtering rising edges less than %u µs apart", this->filter_us_);
+    ESP_LOGCONFIG(TAG, "  Filtering rising edges less than %u µs apart",
+                  this->filter_us_);
   } else {
-    ESP_LOGCONFIG(TAG, "  Filtering pulses shorter than %u µs", this->filter_us_);
+    ESP_LOGCONFIG(TAG, "  Filtering pulses shorter than %u µs",
+                  this->filter_us_);
   }
-  ESP_LOGCONFIG(TAG, "  Assuming 0 pulses/min after not receiving a pulse for %us", this->timeout_us_ / 1000000);
+  ESP_LOGCONFIG(TAG,
+                "  Assuming 0 pulses/min after not receiving a pulse for %us",
+                this->timeout_us_ / 1000000);
 }
 
 void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
-  // This is an interrupt handler - we can't call any virtual method from this method
+  // This is an interrupt handler - we can't call any virtual method from this
+  // method
 
-  // Get the current time before we do anything else so the measurements are consistent
+  // Get the current time before we do anything else so the measurements are
+  // consistent
   const uint32_t now = micros();
-  static uint32_t last_now = 0;
-
-  if (now < last_now) {
-    ESP_LOGD(TAG, "\nmicros() overflow\n");
-  }
-  last_now = now;
 
   // We only look at rising edges in EDGE mode, and all edges in PULSE mode
   if (sensor->filter_mode_ == FILTER_EDGE) {
@@ -85,26 +100,33 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
 
   // Check to see if we should filter this edge out
   if (sensor->filter_mode_ == FILTER_EDGE) {
-    if ((sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_) >= sensor->filter_us_) {
-      // Don't measure the first valid pulse (we need at least two pulses to measure the width)
-      if (sensor->last_valid_high_edge_us_ != 0) {
-        sensor->pulse_width_us_ = (sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_);
+    if ((sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_) >=
+        sensor->filter_us_) {
+      // Don't measure the first valid pulse (we need at least two pulses to
+      // measure the width)
+      if (sensor->has_valid_high_edge_) {
+        sensor->pulse_width_us_ =
+            (sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_);
       }
       sensor->total_pulses_++;
       sensor->last_valid_high_edge_us_ = sensor->last_detected_edge_us_;
+      sensor->has_valid_high_edge_ = true;
     }
   } else {
     // Make sure the signal has been stable long enough
     if ((now - sensor->last_detected_edge_us_) >= sensor->filter_us_) {
       // Only consider HIGH pulses and "new" edges if sensor state is LOW
       if (!sensor->sensor_is_high_ && sensor->isr_pin_.digital_read()) {
-        // Don't measure the first valid pulse (we need at least two pulses to measure the width)
-        if (sensor->last_valid_high_edge_us_ != 0) {
-          sensor->pulse_width_us_ = (sensor->last_detected_edge_us_ - sensor->last_valid_high_edge_us_);
+        // Don't measure the first valid pulse (we need at least two pulses to
+        // measure the width)
+        if (sensor->has_valid_high_edge_) {
+          sensor->pulse_width_us_ = (sensor->last_detected_edge_us_ -
+                                     sensor->last_valid_high_edge_us_);
         }
         sensor->sensor_is_high_ = true;
         sensor->total_pulses_++;
         sensor->last_valid_high_edge_us_ = sensor->last_detected_edge_us_;
+        sensor->has_valid_high_edge_ = true;
       }
       // Only consider LOW pulses and "new" edges if sensor state is HIGH
       else if (sensor->sensor_is_high_ && !sensor->isr_pin_.digital_read()) {
@@ -115,5 +137,5 @@ void IRAM_ATTR PulseMeterSensor::gpio_intr(PulseMeterSensor *sensor) {
   }
 }
 
-}  // namespace pulse_meter
-}  // namespace esphome
+} // namespace pulse_meter
+} // namespace esphome

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -47,6 +47,7 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   volatile uint32_t pulse_width_us_ = 0;
   volatile uint32_t total_pulses_ = 0;
   volatile bool sensor_is_high_ = false;
+  volatile bool has_detected_edge_ = false;
   volatile bool has_valid_high_edge_ = false;
   volatile bool has_valid_low_edge_ = false;
 };

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -9,7 +9,7 @@ namespace esphome {
 namespace pulse_meter {
 
 class PulseMeterSensor : public sensor::Sensor, public Component {
-public:
+ public:
   enum InternalFilterMode {
     FILTER_EDGE = 0,
     FILTER_PULSE,
@@ -19,9 +19,7 @@ public:
   void set_filter_us(uint32_t filter) { this->filter_us_ = filter; }
   void set_filter_mode(InternalFilterMode mode) { this->filter_mode_ = mode; }
   void set_timeout_us(uint32_t timeout) { this->timeout_us_ = timeout; }
-  void set_total_sensor(sensor::Sensor *sensor) {
-    this->total_sensor_ = sensor;
-  }
+  void set_total_sensor(sensor::Sensor *sensor) { this->total_sensor_ = sensor; }
 
   void set_total_pulses(uint32_t pulses);
 
@@ -30,7 +28,7 @@ public:
   float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
-protected:
+ protected:
   static void gpio_intr(PulseMeterSensor *sensor);
 
   InternalGPIOPin *pin_ = nullptr;
@@ -51,5 +49,5 @@ protected:
   volatile bool has_valid_high_edge_ = false;
 };
 
-} // namespace pulse_meter
-} // namespace esphome
+}  // namespace pulse_meter
+}  // namespace esphome

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -43,10 +43,12 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
 
   volatile uint32_t last_detected_edge_us_ = 0;
   volatile uint32_t last_valid_high_edge_us_ = 0;
+  volatile uint32_t last_valid_low_edge_us_ = 0;
   volatile uint32_t pulse_width_us_ = 0;
   volatile uint32_t total_pulses_ = 0;
   volatile bool sensor_is_high_ = false;
   volatile bool has_valid_high_edge_ = false;
+  volatile bool has_valid_low_edge_ = false;
 };
 
 }  // namespace pulse_meter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -47,6 +47,7 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   volatile uint32_t pulse_width_us_ = 0;
   volatile uint32_t total_pulses_ = 0;
   volatile bool sensor_is_high_ = false;
+  volatile bool has_valid_high_edge_ = false;
 };
 
 }  // namespace pulse_meter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
-#include "esphome/components/sensor/sensor.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace pulse_meter {
 
 class PulseMeterSensor : public sensor::Sensor, public Component {
- public:
+public:
   enum InternalFilterMode {
     FILTER_EDGE = 0,
     FILTER_PULSE,
@@ -19,7 +19,9 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   void set_filter_us(uint32_t filter) { this->filter_us_ = filter; }
   void set_filter_mode(InternalFilterMode mode) { this->filter_mode_ = mode; }
   void set_timeout_us(uint32_t timeout) { this->timeout_us_ = timeout; }
-  void set_total_sensor(sensor::Sensor *sensor) { this->total_sensor_ = sensor; }
+  void set_total_sensor(sensor::Sensor *sensor) {
+    this->total_sensor_ = sensor;
+  }
 
   void set_total_pulses(uint32_t pulses);
 
@@ -28,7 +30,7 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
- protected:
+protected:
   static void gpio_intr(PulseMeterSensor *sensor);
 
   InternalGPIOPin *pin_ = nullptr;
@@ -42,7 +44,6 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   Deduplicator<uint32_t> total_dedupe_;
 
   volatile uint32_t last_detected_edge_us_ = 0;
-  volatile uint32_t last_valid_low_edge_us_ = 0;
   volatile uint32_t last_valid_high_edge_us_ = 0;
   volatile uint32_t pulse_width_us_ = 0;
   volatile uint32_t total_pulses_ = 0;
@@ -50,5 +51,5 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   volatile bool has_valid_high_edge_ = false;
 };
 
-}  // namespace pulse_meter
-}  // namespace esphome
+} // namespace pulse_meter
+} // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?
Moves filter logic to into ISR. Fixes bugs that where caused due to de-synchronization of volatile variables when interrupts fired when in loop(). Made additional changes to make code more robust against micros() rollover and untimely interrupts.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3143

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
########## Electricity Meter ##########
sensor:
  - platform: pulse_meter
    name: 'Electricity Meter'
    icon: mdi:flash-outline
    unit_of_measurement: 'W'
    state_class: measurement
    device_class: power
    pin:
      number: GPIO5
      mode: INPUT_PULLUP
    internal_filter: 75ms
    internal_filter_mode: "EDGE" # with/without this line, and tried "PULSE"
    accuracy_decimals: 1
    filters:
      - multiply: 18.75
    total:
      name: 'Total Electricity'
      unit_of_measurement: 'kWh'
      icon: mdi:circle-slice-3
      state_class: total_increasing
      device_class: energy
      accuracy_decimals: 3
      filters:
        - multiply: 0.0003125

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
