### PR TITLE
Allow to set user defined characters on LCD

### DIFF
--- a/esphome/components/lcd_base/__init__.py
+++ b/esphome/components/lcd_base/__init__.py
@@ -18,19 +18,34 @@ def validate_lcd_dimensions(value):
     return value
 
 
+def validate_user_characters(value):
+    positions = set()
+    for conf in value:
+        if conf[CONF_POSITION] in positions:
+            raise cv.Invalid(
+                f"Duplicate user defined character at position {conf[CONF_POSITION]}"
+            )
+        positions.add(conf[CONF_POSITION])
+    return value
+
+
 LCD_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
     {
         cv.Required(CONF_DIMENSIONS): validate_lcd_dimensions,
-        cv.Optional(CONF_USER_CHARACTERS): cv.ensure_list(
-            cv.Schema(
-                {
-                    cv.Required(CONF_POSITION): cv.int_range(min=0, max=7),
-                    cv.Required(CONF_DATA): cv.All(
-                        cv.ensure_list(cv.int_range(min=0, max=31)),
-                        cv.Length(min=8, max=8),
-                    ),
-                }
+        cv.Optional(CONF_USER_CHARACTERS): cv.All(
+            cv.ensure_list(
+                cv.Schema(
+                    {
+                        cv.Required(CONF_POSITION): cv.int_range(min=0, max=7),
+                        cv.Required(CONF_DATA): cv.All(
+                            cv.ensure_list(cv.int_range(min=0, max=31)),
+                            cv.Length(min=8, max=8),
+                        ),
+                    }
+                ),
             ),
+            cv.Length(max=8),
+            validate_user_characters,
         ),
     }
 ).extend(cv.polling_component_schema("1s"))

--- a/esphome/components/lcd_base/__init__.py
+++ b/esphome/components/lcd_base/__init__.py
@@ -26,7 +26,7 @@ LCD_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
                 {
                     cv.Required(CONF_POSITION): cv.int_range(min=0, max=7),
                     cv.Required(CONF_DATA): cv.All(
-                        cv.ensure_list(cv.uint8_t),
+                        cv.ensure_list(cv.int_range(min=0, max=31)),
                         cv.Length(min=8, max=8),
                     ),
                 }

--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -66,10 +66,10 @@ void LCDDisplay::setup() {
   }
 
   // store user defined characters
-  for (auto usr = this->user_defined_chars_.begin(); usr != this->user_defined_chars_.end(); ++usr) {
-    this->command_(LCD_DISPLAY_COMMAND_SET_CGRAM_ADDR | (usr->first << 3));
-    for (auto data = usr->second.begin(); data != usr->second.end(); ++data)
-      this->send(*data, true);
+  for (auto &user_defined_char : this->user_defined_chars_) {
+    this->command_(LCD_DISPLAY_COMMAND_SET_CGRAM_ADDR | (user_defined_char.first << 3));
+    for (auto data : user_defined_char.second)
+      this->send(data, true);
   }
 
   this->command_(LCD_DISPLAY_COMMAND_FUNCTION_SET | display_function);

--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -65,6 +65,13 @@ void LCDDisplay::setup() {
     this->command_(LCD_DISPLAY_COMMAND_FUNCTION_SET | display_function);
   }
 
+  // store user defined characters
+  for (auto usr = this->user_defined_chars_.begin(); usr != this->user_defined_chars_.end(); ++usr) {
+    this->command_(LCD_DISPLAY_COMMAND_SET_CGRAM_ADDR | (usr->first << 3));
+    for (auto data = usr->second.begin(); data != usr->second.end(); ++data)
+      this->send(*data, true);
+  }
+
   this->command_(LCD_DISPLAY_COMMAND_FUNCTION_SET | display_function);
   uint8_t display_control = LCD_DISPLAY_DISPLAY_ON;
   this->command_(LCD_DISPLAY_COMMAND_DISPLAY_CONTROL | display_control);

--- a/esphome/components/lcd_base/lcd_display.h
+++ b/esphome/components/lcd_base/lcd_display.h
@@ -7,6 +7,8 @@
 #include "esphome/components/time/real_time_clock.h"
 #endif
 
+#include <map>
+
 namespace esphome {
 namespace lcd_base {
 
@@ -18,6 +20,8 @@ class LCDDisplay : public PollingComponent {
     this->columns_ = columns;
     this->rows_ = rows;
   }
+
+  void set_user_defined_char(uint8_t pos, const std::vector<uint8_t> &data) { this->user_defined_chars_[pos] = data; }
 
   void setup() override;
   float get_setup_priority() const override;
@@ -58,6 +62,7 @@ class LCDDisplay : public PollingComponent {
   uint8_t columns_;
   uint8_t rows_;
   uint8_t *buffer_{nullptr};
+  std::map<uint8_t, std::vector<uint8_t> > user_defined_chars_;
 };
 
 }  // namespace lcd_base

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2220,7 +2220,15 @@ display:
     address: 0x3F
     user_characters:
       - position: 0
-        data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x11, 0x0e, 0x00 ]
+        data:
+          - 0b00000
+          - 0b01010
+          - 0b00000
+          - 0b00100
+          - 0b00100
+          - 0b10001
+          - 0b01110
+          - 0b00000
     lambda: |-
       it.print("Hello World!");
     i2c_id: i2c_bus

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2218,6 +2218,9 @@ display:
   - platform: lcd_pcf8574
     dimensions: 18x4
     address: 0x3F
+    user_characters:
+      - position: 0
+        data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x11, 0x0e, 0x00 ]
     lambda: |-
       it.print("Hello World!");
     i2c_id: i2c_bus


### PR DESCRIPTION
# What does this implement/fix?

The LCD displays driven by lcd_base support the definition of user defined characters. This PR allows the user to use this feature.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1980

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  - platform: lcd_pcf8574
    id: my_lcd
    dimensions: 20x4
    address: 0x27
    user_characters:
      - position: 0
        data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x11, 0x0e, 0x00 ]
      - position: 7
        data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x00, 0x0e, 0x11 ]
      - position: 4
        data: [ 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 ]
    lambda: |-
      it.print("Hello, world \x08 \x04 \x07!");

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
