### PR TITLE
added color_brightness to web_server light api interface for seperated control of white and rgb channels

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -583,6 +583,8 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
       auto call = obj->turn_on();
       if (request->hasParam("brightness"))
         call.set_brightness(request->getParam("brightness")->value().toFloat() / 255.0f);
+      if (request->hasParam("color_brightness"))
+        call.set_color_brightness(request->getParam("color_brightness")->value().toFloat() / 255.0f);
       if (request->hasParam("r"))
         call.set_red(request->getParam("r")->value().toFloat() / 255.0f);
       if (request->hasParam("g"))


### PR DESCRIPTION
added color_brightness to web_server light api interface for seperated control of white and rgb channels on rgbw light strips

# What does this implement/fix?

Currently, the light api of webserver does not support setting color_brightness. So the only remaining brightness setting (brightness) is affecting both the white and rgb channels at the same time. However, it is usually intentional to set the white channel independently of the RGB channels. For this purpose the light component turn_on action already supports a color_brightness  variable, it is only missing in the light api of the web_server component. This very simple pull request intends to fix that ;)

## Types of changes

This is a non-breaking change (only adds a functionality that is transparent if not used)

## Test Environment

- [x] ESP8266

## Example entry for `config.yaml`:
Go to http://rgbwone.local/ to see the resulting logs of the actions, eg use

  curl -i -X POST "http://rgbwone.local/light/trial_lights/turn_on?color_brightness=128&r=0&g=0&b=255&white_value=128"

from command line to send a command that can set both color_brightness and white_value independently from each other (brightness not needed to be changed from 255).



```yaml
light:
  - platform: rgbw
    id: trial_lights
    name: "Trial Lights"
    red: red_component
    green: green_component
    blue: blue_component
    white: white_component

output:
  - platform: esp8266_pwm
    id: red_component
    pin: D0
  - platform: esp8266_pwm
    id: green_component
    pin: D1
  - platform: esp8266_pwm
    id: blue_component
    pin: D2
  - platform: esp8266_pwm
    id: white_component
    pin: D3

web_server:
  port: 80
  version: 2
  local: true

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
(i will add a second pull request for the documentation update later today (should also be like 2 lines to be changed only for the documentation of this small change) (DONE now at esphome/esphome-docs#1984)
