### PR TITLE
Make custom_fan and custom_preset templatable as per documentation

### DIFF
--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -287,7 +287,9 @@ CLIMATE_CONTROL_ACTION_SCHEMA = cv.Schema(
         cv.Exclusive(CONF_FAN_MODE, "fan_mode"): cv.templatable(
             validate_climate_fan_mode
         ),
-        cv.Exclusive(CONF_CUSTOM_FAN_MODE, "fan_mode"): cv.templatable(cv.string_strict),
+        cv.Exclusive(CONF_CUSTOM_FAN_MODE, "fan_mode"): cv.templatable(
+            cv.string_strict
+        ),
         cv.Exclusive(CONF_PRESET, "preset"): cv.templatable(validate_climate_preset),
         cv.Exclusive(CONF_CUSTOM_PRESET, "preset"): cv.templatable(cv.string_strict),
         cv.Optional(CONF_SWING_MODE): cv.templatable(validate_climate_swing_mode),
@@ -324,13 +326,17 @@ async def climate_control_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(config[CONF_FAN_MODE], args, ClimateFanMode)
         cg.add(var.set_fan_mode(template_))
     if CONF_CUSTOM_FAN_MODE in config:
-        template_ = await cg.templatable(config[CONF_CUSTOM_FAN_MODE], args, cg.std_string)
+        template_ = await cg.templatable(
+            config[CONF_CUSTOM_FAN_MODE], args, cg.std_string
+        )
         cg.add(var.set_custom_fan_mode(template_))
     if CONF_PRESET in config:
         template_ = await cg.templatable(config[CONF_PRESET], args, ClimatePreset)
         cg.add(var.set_preset(template_))
     if CONF_CUSTOM_PRESET in config:
-        template_ = await cg.templatable(config[CONF_CUSTOM_PRESET], args, cg.std_string)
+        template_ = await cg.templatable(
+            config[CONF_CUSTOM_PRESET], args, cg.std_string
+        )
         cg.add(var.set_custom_preset(template_))
     if CONF_SWING_MODE in config:
         template_ = await cg.templatable(

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -287,9 +287,9 @@ CLIMATE_CONTROL_ACTION_SCHEMA = cv.Schema(
         cv.Exclusive(CONF_FAN_MODE, "fan_mode"): cv.templatable(
             validate_climate_fan_mode
         ),
-        cv.Exclusive(CONF_CUSTOM_FAN_MODE, "fan_mode"): cv.string_strict,
+        cv.Exclusive(CONF_CUSTOM_FAN_MODE, "fan_mode"): cv.templatable(cv.string_strict),
         cv.Exclusive(CONF_PRESET, "preset"): cv.templatable(validate_climate_preset),
-        cv.Exclusive(CONF_CUSTOM_PRESET, "preset"): cv.string_strict,
+        cv.Exclusive(CONF_CUSTOM_PRESET, "preset"): cv.templatable(cv.string_strict),
         cv.Optional(CONF_SWING_MODE): cv.templatable(validate_climate_swing_mode),
     }
 )
@@ -324,13 +324,13 @@ async def climate_control_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(config[CONF_FAN_MODE], args, ClimateFanMode)
         cg.add(var.set_fan_mode(template_))
     if CONF_CUSTOM_FAN_MODE in config:
-        template_ = await cg.templatable(config[CONF_CUSTOM_FAN_MODE], args, str)
+        template_ = await cg.templatable(config[CONF_CUSTOM_FAN_MODE], args, cg.std_string)
         cg.add(var.set_custom_fan_mode(template_))
     if CONF_PRESET in config:
         template_ = await cg.templatable(config[CONF_PRESET], args, ClimatePreset)
         cg.add(var.set_preset(template_))
     if CONF_CUSTOM_PRESET in config:
-        template_ = await cg.templatable(config[CONF_CUSTOM_PRESET], args, str)
+        template_ = await cg.templatable(config[CONF_CUSTOM_PRESET], args, cg.std_string)
         cg.add(var.set_custom_preset(template_))
     if CONF_SWING_MODE in config:
         template_ = await cg.templatable(


### PR DESCRIPTION
# What does this implement/fix?

The documentation for [`climate.control`](https://esphome.io/components/climate/index.html#climate-control-action) lists `custom_preset` and `custom_fan_mode` as templatable however the config schema does not correctly reflect this. Additionally the return type of the lambdas generated was the Python `str` type instead of `std::string`. This fixes this issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Discovered whilst testing https://github.com/esphome/esphome/pull/3298#issuecomment-1078549580

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
  then:
    - climate.control:
        id: my_hvac_system
        custom_preset: !lambda |-
          return "My Custom Preset";
        custom_fan_mode: !lambda |-
          return "My Custom Fan Mode";
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
