### PR TITLE
Actually increase request memory for json parsing

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -54,7 +54,7 @@ void parse_json(const std::string &data, const json_parse_t &f) {
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
 #endif
   bool pass = false;
-  size_t request_size = std::min(free_heap - 2048, (size_t) (data.size() * 1.5));
+  size_t request_size = std::min(free_heap - 2048, (size_t)(data.size() * 1.5));
   do {
     DynamicJsonDocument json_document(request_size);
     if (json_document.memoryPool().buffer() == nullptr) {

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -54,9 +54,8 @@ void parse_json(const std::string &data, const json_parse_t &f) {
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
 #endif
   bool pass = false;
+  size_t request_size = std::min(free_heap - 2048, (size_t) (data.size() * 1.5));
   do {
-    const size_t request_size = std::min(free_heap - 2048, (size_t)(data.size() * 1.5));
-
     DynamicJsonDocument json_document(request_size);
     if (json_document.memoryPool().buffer() == nullptr) {
       ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
@@ -76,7 +75,8 @@ void parse_json(const std::string &data, const json_parse_t &f) {
         ESP_LOGE(TAG, "Can not allocate more memory for deserialization. Consider making source string smaller");
         return;
       }
-      ESP_LOGW(TAG, "Increasing memory allocation.");
+      ESP_LOGV(TAG, "Increasing memory allocation.");
+      request_size *= 2;
       continue;
     } else {
       ESP_LOGE(TAG, "JSON parse error: %s", err.c_str());


### PR DESCRIPTION
# What does this implement/fix?

- Actually increase request memory for json parsing
- Change log to verbose

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3177

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
