### PR TITLE
Extend mcp3204 to support 8 channels (mcp3208 variant)

### DIFF
--- a/esphome/components/mcp3204/mcp3204.cpp
+++ b/esphome/components/mcp3204/mcp3204.cpp
@@ -20,7 +20,7 @@ void MCP3204::dump_config() {
 }
 
 float MCP3204::read_data(uint8_t pin) {
-  uint8_t adc_primary_config = 0b00000110 & 0b00000111;
+  uint8_t adc_primary_config = 0b00000110 | (pin >> 2);
   uint8_t adc_secondary_config = pin << 6;
   this->enable();
   this->transfer_byte(adc_primary_config);

--- a/esphome/components/mcp3204/sensor/__init__.py
+++ b/esphome/components/mcp3204/sensor/__init__.py
@@ -17,7 +17,7 @@ CONFIG_SCHEMA = sensor.SENSOR_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(MCP3204Sensor),
         cv.GenerateID(CONF_MCP3204_ID): cv.use_id(MCP3204),
-        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=3),
+        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=7),
     }
 ).extend(cv.polling_component_schema("60s"))
 


### PR DESCRIPTION
# What does this implement/fix?

There are two variants of mcp32xx ADC which share common datasheet and only differ in number of channels. This patch extends the current mcp3204 component to support mcp3208 use case. We only need to handle the extra channels.

We already have an 8 channel SPI ADC in esphome, the mcp3008, which also supports it's 4 channel variant (the mcp3004). It is a bit unfortunate that the 4 channel mcp3204 was added first, it may be a bit confusing if 8 ch. support is added to a 4 ch part, but this should be viewed as an easy quick-win with low maintenance burden. If this is viewed as unacceptable, I am also willing to create a dedicated mcp3208 component, but I am worried that the code duplication and maintenance effort is not justified.

If this proposal is accepted, I will prepare updates to esphome-docs for mcp3204 component to explain the added functionality.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2006

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `device.yaml`:

```yaml
  - platform: mcp3204
    name: "$devicename Supply Voltage"
    update_interval: 1s
    id: supply_voltage
    accuracy_decimals: 3
    filters:
      - multiply: 2
    number: 7
    entity_category: diagnostic
    unit_of_measurement: "V"
    device_class: voltage
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
