### PR TITLE
add "GET /states" REST API call that dumps the current component state

### DIFF
--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -13,159 +13,140 @@ ListEntitiesIterator::ListEntitiesIterator(WebServer *web_server) : web_server_(
 
 #ifdef USE_BINARY_SENSOR
 bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(
-      this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(
+      this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL));
 }
 #endif
 #ifdef USE_COVER
 bool ListEntitiesIterator::on_cover(cover::Cover *cover) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->cover_json(cover, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->cover_json(cover, DETAIL_ALL));
 }
 #endif
 #ifdef USE_FAN
 bool ListEntitiesIterator::on_fan(fan::Fan *fan) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->fan_json(fan, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->fan_json(fan, DETAIL_ALL));
 }
 #endif
 #ifdef USE_LIGHT
 bool ListEntitiesIterator::on_light(light::LightState *light) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->light_json(light, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->light_json(light, DETAIL_ALL));
 }
 #endif
 #ifdef USE_SENSOR
 bool ListEntitiesIterator::on_sensor(sensor::Sensor *sensor) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL));
 }
 #endif
 #ifdef USE_SWITCH
 bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->switch_json(a_switch, a_switch->state, DETAIL_ALL).c_str(),
-                                  "state");
-  return true;
+  return this->process(this->web_server_->switch_json(a_switch, a_switch->state, DETAIL_ALL));
 }
 #endif
 #ifdef USE_BUTTON
 bool ListEntitiesIterator::on_button(button::Button *button) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->button_json(button, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->button_json(button, DETAIL_ALL));
 }
 #endif
 #ifdef USE_TEXT_SENSOR
 bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(
-      this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(
+      this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL));
 }
 #endif
 #ifdef USE_LOCK
 bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_VALVE
 bool ListEntitiesIterator::on_valve(valve::Valve *valve) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->valve_json(valve, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->valve_json(valve, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_CLIMATE
 bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->climate_json(climate, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->climate_json(climate, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_NUMBER
 bool ListEntitiesIterator::on_number(number::Number *number) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->number_json(number, number->state, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_DATETIME_DATE
 bool ListEntitiesIterator::on_date(datetime::DateEntity *date) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->date_json(date, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->date_json(date, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_DATETIME_TIME
 bool ListEntitiesIterator::on_time(datetime::TimeEntity *time) {
-  this->web_server_->events_.send(this->web_server_->time_json(time, DETAIL_ALL).c_str(), "state");
-  return true;
+  if (!this->has_connected_client())
+    return true;
+  return this->process(this->web_server_->time_json(time, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_DATETIME_DATETIME
 bool ListEntitiesIterator::on_datetime(datetime::DateTimeEntity *datetime) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->datetime_json(datetime, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->datetime_json(datetime, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_TEXT
 bool ListEntitiesIterator::on_text(text::Text *text) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->text_json(text, text->state, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->text_json(text, text->state, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_SELECT
 bool ListEntitiesIterator::on_select(select::Select *select) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->select_json(select, select->state, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_ALARM_CONTROL_PANEL
 bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(
-      this->web_server_->alarm_control_panel_json(a_alarm_control_panel, a_alarm_control_panel->get_state(), DETAIL_ALL)
-          .c_str(),
-      "state");
-  return true;
+  return this->process(
+      this->web_server_->alarm_control_panel_json(a_alarm_control_panel, a_alarm_control_panel->get_state(), DETAIL_ALL));
 }
 #endif
 
@@ -173,19 +154,26 @@ bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmCont
 bool ListEntitiesIterator::on_event(event::Event *event) {
   // Null event type, since we are just iterating over entities
   const std::string null_event_type = "";
-  this->web_server_->events_.send(this->web_server_->event_json(event, null_event_type, DETAIL_ALL).c_str(), "state");
-  return true;
+  if (!this->has_connected_client())
+    return true;  
+  return this->process(this->web_server_->event_json(event, null_event_type, DETAIL_ALL));
 }
 #endif
 
 #ifdef USE_UPDATE
 bool ListEntitiesIterator::on_update(update::UpdateEntity *update) {
-  if (this->web_server_->events_.count() == 0)
+  if (!this->has_connected_client())
     return true;
-  this->web_server_->events_.send(this->web_server_->update_json(update, DETAIL_ALL).c_str(), "state");
-  return true;
+  return this->process(this->web_server_->update_json(update, DETAIL_ALL));
 }
 #endif
+
+bool ListEntitiesIterator::has_connected_client() { return this->web_server_->events_.count() > 0; }
+
+bool ListEntitiesIterator::process(std::string s) {
+  this->web_server_->events_.send(s.c_str(), "state");
+  return true;
+}
 
 }  // namespace web_server
 }  // namespace esphome

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -15,8 +15,7 @@ ListEntitiesIterator::ListEntitiesIterator(WebServer *web_server) : web_server_(
 bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
   if (!this->has_connected_client())
     return true;
-  return this->process(
-      this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL));
+  return this->process(this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL));
 }
 #endif
 #ifdef USE_COVER
@@ -65,8 +64,7 @@ bool ListEntitiesIterator::on_button(button::Button *button) {
 bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
   if (!this->has_connected_client())
     return true;
-  return this->process(
-      this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL));
+  return this->process(this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL));
 }
 #endif
 #ifdef USE_LOCK
@@ -145,8 +143,8 @@ bool ListEntitiesIterator::on_select(select::Select *select) {
 bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
   if (!this->has_connected_client())
     return true;
-  return this->process(
-      this->web_server_->alarm_control_panel_json(a_alarm_control_panel, a_alarm_control_panel->get_state(), DETAIL_ALL));
+  return this->process(this->web_server_->alarm_control_panel_json(a_alarm_control_panel,
+                                                                   a_alarm_control_panel->get_state(), DETAIL_ALL));
 }
 #endif
 
@@ -155,7 +153,7 @@ bool ListEntitiesIterator::on_event(event::Event *event) {
   // Null event type, since we are just iterating over entities
   const std::string null_event_type = "";
   if (!this->has_connected_client())
-    return true;  
+    return true;
   return this->process(this->web_server_->event_json(event, null_event_type, DETAIL_ALL));
 }
 #endif

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -63,10 +63,14 @@ bool ListEntitiesIterator::on_button(button::Button *button) {
 #endif
 #ifdef USE_TEXT_SENSOR
 bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
+<<<<<<< HEAD
   if (!this->has_connected_client())
     return true;
   return this->process(
       this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL));
+=======
+  return this->process(this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL));
+>>>>>>> 4d9a3ae3c (make lint checker happier)
 }
 #endif
 #ifdef USE_LOCK

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -63,14 +63,10 @@ bool ListEntitiesIterator::on_button(button::Button *button) {
 #endif
 #ifdef USE_TEXT_SENSOR
 bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
-<<<<<<< HEAD
   if (!this->has_connected_client())
     return true;
   return this->process(
       this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL));
-=======
-  return this->process(this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL));
->>>>>>> 4d9a3ae3c (make lint checker happier)
 }
 #endif
 #ifdef USE_LOCK
@@ -174,7 +170,7 @@ bool ListEntitiesIterator::on_update(update::UpdateEntity *update) {
 
 bool ListEntitiesIterator::has_connected_client() { return this->web_server_->events_.count() > 0; }
 
-bool ListEntitiesIterator::process(std::string s) {
+bool ListEntitiesIterator::process(const std::string &s) {
   this->web_server_->events_.send(s.c_str(), "state");
   return true;
 }

--- a/esphome/components/web_server/list_entities.h
+++ b/esphome/components/web_server/list_entities.h
@@ -75,6 +75,8 @@ class ListEntitiesIterator : public ComponentIterator {
 
  protected:
   WebServer *web_server_;
+  bool has_connected_client();
+  virtual bool process(std::string s);
 };
 
 }  // namespace web_server

--- a/esphome/components/web_server/list_entities.h
+++ b/esphome/components/web_server/list_entities.h
@@ -75,8 +75,8 @@ class ListEntitiesIterator : public ComponentIterator {
 
  protected:
   WebServer *web_server_;
-  bool has_connected_client();
-  virtual bool process(std::string s);
+  virtual bool has_connected_client();
+  virtual bool process(const std::string &s);
 };
 
 }  // namespace web_server

--- a/esphome/components/web_server/states.cpp
+++ b/esphome/components/web_server/states.cpp
@@ -9,7 +9,7 @@ namespace esphome {
 namespace web_server {
 
 StatesIterator::StatesIterator(WebServer *web_server) : ListEntitiesIterator::ListEntitiesIterator(web_server) {}
-  
+
 bool StatesIterator::has_connected_client() { return true; }
 
 bool StatesIterator::process(const std::string &s) {

--- a/esphome/components/web_server/states.cpp
+++ b/esphome/components/web_server/states.cpp
@@ -12,7 +12,7 @@ StatesIterator::StatesIterator(WebServer *web_server) : ListEntitiesIterator::Li
   
 bool StatesIterator::has_connected_client() { return true; }
 
-bool StatesIterator::process(std::string s) {
+bool StatesIterator::process(const std::string &s) {
   this->str_ = s;
   return true;
 }

--- a/esphome/components/web_server/states.cpp
+++ b/esphome/components/web_server/states.cpp
@@ -1,0 +1,35 @@
+#ifdef USE_ARDUINO
+
+#include "list_entities.h"
+#include "esphome/core/application.h"
+
+#include "web_server.h"
+
+namespace esphome {
+namespace web_server {
+
+StatesIterator::StatesIterator(WebServer *web_server) : ListEntitiesIterator::ListEntitiesIterator(web_server) {}
+  
+bool StatesIterator::has_connected_client() { return true; }
+
+bool StatesIterator::process(std::string s) {
+  this->str_ = s;
+  return true;
+}
+
+optional<std::string> StatesIterator::next() {
+  while (this->state_ != IteratorState::MAX) {
+    this->str_ = nullopt;
+    this->advance();
+    if(this->str_.has_value()) {
+      return this->str_;
+    }
+  }
+  this->str_ = nullopt;
+  return nullopt;
+}
+				    
+}  // namespace web_server
+}  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/web_server/states.cpp
+++ b/esphome/components/web_server/states.cpp
@@ -1,5 +1,3 @@
-#ifdef USE_ARDUINO
-
 #include "list_entities.h"
 #include "esphome/core/application.h"
 
@@ -31,5 +29,3 @@ optional<std::string> StatesIterator::next() {
 
 }  // namespace web_server
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/web_server/states.cpp
+++ b/esphome/components/web_server/states.cpp
@@ -21,14 +21,14 @@ optional<std::string> StatesIterator::next() {
   while (this->state_ != IteratorState::MAX) {
     this->str_ = nullopt;
     this->advance();
-    if(this->str_.has_value()) {
+    if (this->str_.has_value()) {
       return this->str_;
     }
   }
   this->str_ = nullopt;
   return nullopt;
 }
-				    
+
 }  // namespace web_server
 }  // namespace esphome
 

--- a/esphome/components/web_server/states.h
+++ b/esphome/components/web_server/states.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifdef USE_ARDUINO
+
+#include "list_entities.h"
+#include "esphome/core/component.h"
+#include "esphome/core/component_iterator.h"
+#include "esphome/core/defines.h"
+#include "esphome/components/web_server_base/web_server_base.h"
+
+namespace esphome {
+namespace web_server {
+
+class WebServer;
+
+class StatesIterator : public ListEntitiesIterator {
+ public:
+  StatesIterator(WebServer *web_server);
+  optional<std::string> next();
+  
+ protected:
+  // WebServer *web_server_;
+  optional<std::string> str_;
+  virtual bool process(std::string s);
+};
+
+}  // namespace web_server
+}  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/web_server/states.h
+++ b/esphome/components/web_server/states.h
@@ -21,7 +21,7 @@ class StatesIterator : public ListEntitiesIterator {
  protected:
   // WebServer *web_server_;
   optional<std::string> str_;
-  bool process(std::string s) override;
+  bool process(const std::string &s) override;
 };
 
 }  // namespace web_server

--- a/esphome/components/web_server/states.h
+++ b/esphome/components/web_server/states.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifdef USE_ARDUINO
-
 #include "list_entities.h"
 #include "esphome/core/component.h"
 #include "esphome/core/component_iterator.h"
@@ -28,5 +26,3 @@ class StatesIterator : public ListEntitiesIterator {
 
 }  // namespace web_server
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/web_server/states.h
+++ b/esphome/components/web_server/states.h
@@ -21,7 +21,7 @@ class StatesIterator : public ListEntitiesIterator {
  protected:
   // WebServer *web_server_;
   optional<std::string> str_;
-  virtual bool process(std::string s);
+  bool process(std::string s) override;
 };
 
 }  // namespace web_server

--- a/esphome/components/web_server/states.h
+++ b/esphome/components/web_server/states.h
@@ -21,7 +21,7 @@ class StatesIterator : public ListEntitiesIterator {
  protected:
   // WebServer *web_server_;
   optional<std::string> str_;
-  
+
   bool has_connected_client() override;
   bool process(const std::string &s) override;
 };

--- a/esphome/components/web_server/states.h
+++ b/esphome/components/web_server/states.h
@@ -21,6 +21,8 @@ class StatesIterator : public ListEntitiesIterator {
  protected:
   // WebServer *web_server_;
   optional<std::string> str_;
+  
+  bool has_connected_client() override;
   bool process(const std::string &s) override;
 };
 

--- a/esphome/components/web_server/states.h
+++ b/esphome/components/web_server/states.h
@@ -17,7 +17,7 @@ class StatesIterator : public ListEntitiesIterator {
  public:
   StatesIterator(WebServer *web_server);
   optional<std::string> next();
-  
+
  protected:
   // WebServer *web_server_;
   optional<std::string> str_;

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -204,14 +204,14 @@ void WebServer::handle_states_request(AsyncWebServerRequest *request) {
   StatesIterator states_it = StatesIterator(this);
   states_it.begin();
   optional<std::string> s;
-  stream->print(F("{"));
+  stream->print(F("["));
   int i = 0;
   while((s = states_it.next()) != nullopt) {
     if (i++)
       stream->print(F(","));
     stream->print(s->c_str());
   }
-  stream->print(F("}\n"));
+  stream->print(F("]\n"));
   request->send(stream);
 }
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -206,7 +206,7 @@ void WebServer::handle_states_request(AsyncWebServerRequest *request) {
   optional<std::string> s;
   stream->print(F("["));
   int i = 0;
-  while((s = states_it.next()) != nullopt) {
+  while ((s = states_it.next()) != nullopt) {
     if (i++)
       stream->print(F(","));
     stream->print(s->c_str());

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -199,6 +199,22 @@ void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 }
 #endif
 
+void WebServer::handle_states_request(AsyncWebServerRequest *request) {
+  AsyncResponseStream *stream = request->beginResponseStream("text/json");
+  StatesIterator states_it = StatesIterator(this);
+  states_it.begin();
+  optional<std::string> s;
+  stream->print(F("{"));
+  int i = 0;
+  while((s = states_it.next()) != nullopt) {
+    if (i++)
+      stream->print(F(","));
+    stream->print(s->c_str());
+  }
+  stream->print(F("}\n"));
+  request->send(stream);
+}
+
 #define set_json_id(root, obj, sensor, start_config) \
   (root)["id"] = sensor; \
   if (((start_config) == DETAIL_ALL)) { \
@@ -1553,6 +1569,9 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
   if (request->url() == "/")
     return true;
 
+  if (request->url() == "/states")
+    return true;
+
 #ifdef USE_WEBSERVER_CSS_INCLUDE
   if (request->url() == "/0.css")
     return true;
@@ -1683,6 +1702,11 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 void WebServer::handleRequest(AsyncWebServerRequest *request) {
   if (request->url() == "/") {
     this->handle_index_request(request);
+    return;
+  }
+
+  if (request->url() == "/states") {
+    this->handle_states_request(request);
     return;
   }
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -200,7 +200,7 @@ void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 #endif
 
 void WebServer::handle_states_request(AsyncWebServerRequest *request) {
-  AsyncResponseStream *stream = request->beginResponseStream("text/json");
+  AsyncResponseStream *stream = request->beginResponseStream("application/json");
   StatesIterator states_it = StatesIterator(this);
   states_it.begin();
   optional<std::string> s;

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "list_entities.h"
+#include "states.h"
 
 #include "esphome/components/web_server_base/web_server_base.h"
 #ifdef USE_WEBSERVER
@@ -147,6 +148,9 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   // Handle Private Network Access CORS OPTIONS request
   void handle_pna_cors_request(AsyncWebServerRequest *request);
 #endif
+
+  /// Handle a states request under '/states'.
+  void handle_states_request(AsyncWebServerRequest *request);
 
 #ifdef USE_SENSOR
   void on_sensor_update(sensor::Sensor *obj, float state) override;


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a `/states` REST API call that dumps the current component state as a JSON array.

As described in the feature request, this is useful for feeding sensor values into a monitoring system like Zabbix or for a quick status overview on the commandline like:

`curl -s http://devname/states | python3  -m json.tool`

Unfortunately I am not a C++ developer, so I'd appreciate any feedback.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1455

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4003

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
