### PR TITLE
RFC: Create new `remote` platform component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -167,6 +167,7 @@ esphome/components/radon_eye_rd200/* @jeffeb3
 esphome/components/rc522/* @glmnet
 esphome/components/rc522_i2c/* @glmnet
 esphome/components/rc522_spi/* @glmnet
+esphome/components/remote/* @ianchi
 esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz
 esphome/components/rgbct/* @jesserockz

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -43,6 +43,7 @@ service APIConnection {
   rpc button_command (ButtonCommandRequest) returns (void) {}
   rpc lock_command (LockCommandRequest) returns (void) {}
   rpc media_player_command (MediaPlayerCommandRequest) returns (void) {}
+  rpc remote_command (RemoteCommandRequest) returns (void) {}
 }
 
 
@@ -1097,4 +1098,50 @@ message MediaPlayerCommandRequest {
 
   bool has_media_url = 6;
   string media_url = 7;
+}
+
+// ==================== REMOTE ======================
+
+message ListEntitiesRemoteResponse {
+  option (id) = 66;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_REMOTE";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+
+  repeated string supports_transmit = 8; // list of supported protocols
+  repeated string supports_receive = 9; // TODO: not yet implemented
+
+}
+
+enum RemoteCommand  {
+  REMOTE_TURNON = 0;
+  REMOTE_TURNOFF = 1;
+  REMOTE_TOGGLE = 2;
+  REMOTE_SEND = 3;
+  REMOTE_LEARN = 4; // TODO: not yet implemented
+}
+
+message RemoteCommandRequest {
+  option (id) = 67;
+  option (source) = SOURCE_CLIENT;
+  option (no_delay) = true;
+  option (ifdef) = "USE_REMOTE";
+
+  fixed32 key = 1;
+
+  RemoteCommand command = 2;
+
+  // send_command
+  string protocol = 3;
+  repeated sint64 args = 4 [packed=false];
+  fixed32 repeat = 5;
+  fixed32 wait_time = 6;
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -778,6 +778,44 @@ void APIConnection::media_player_command(const MediaPlayerCommandRequest &msg) {
   call.perform();
 }
 #endif
+#ifdef USE_REMOTE
+bool APIConnection::send_remote_info(remote::Remote *a_remote) {
+  ListEntitiesRemoteResponse msg;
+  msg.key = a_remote->get_object_id_hash();
+  msg.object_id = a_remote->get_object_id();
+  msg.name = a_remote->get_name();
+  msg.unique_id = get_default_unique_id("remote", a_remote);
+  msg.icon = a_remote->get_icon();
+  msg.disabled_by_default = a_remote->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(a_remote->get_entity_category());
+  msg.supports_transmit = a_remote->get_capabilities().supports_transmit;
+  msg.supports_receive = a_remote->get_capabilities().supports_receive;
+  return this->send_list_entities_remote_response(msg);
+}
+void APIConnection::remote_command(const RemoteCommandRequest &msg) {
+  remote::Remote *a_remote = App.get_remote_by_key(msg.key);
+  if (a_remote == nullptr)
+    return;
+
+  switch (msg.command) {
+    case enums::REMOTE_TURNON:
+      a_remote->turn_on();
+      break;
+    case enums::REMOTE_TURNOFF:
+      a_remote->turn_off();
+      break;
+    case enums::REMOTE_TOGGLE:
+      // TODO: not yet implemented
+      break;
+    case enums::REMOTE_SEND:
+      a_remote->send_command(msg.repeat, msg.wait_time, msg.protocol, msg.args);
+      break;
+    case enums::REMOTE_LEARN:
+      // TODO: not yet implemented
+      break;
+  }
+}
+#endif
 
 #ifdef USE_ESP32_CAMERA
 void APIConnection::send_camera_state(std::shared_ptr<esp32_camera::CameraImage> image) {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -88,6 +88,10 @@ class APIConnection : public APIServerConnection {
   bool send_media_player_info(media_player::MediaPlayer *media_player);
   void media_player_command(const MediaPlayerCommandRequest &msg) override;
 #endif
+#ifdef USE_REMOTE
+  bool send_remote_info(remote::Remote *a_remote);
+  void remote_command(const RemoteCommandRequest &msg) override;
+#endif
   bool send_log_message(int level, const char *tag, const char *line);
   void send_homeassistant_service_call(const HomeassistantServiceResponse &call) {
     if (!this->service_call_subscription_)

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -338,6 +338,22 @@ template<> const char *proto_enum_to_string<enums::MediaPlayerCommand>(enums::Me
       return "UNKNOWN";
   }
 }
+template<> const char *proto_enum_to_string<enums::RemoteCommand>(enums::RemoteCommand value) {
+  switch (value) {
+    case enums::REMOTE_TURNON:
+      return "REMOTE_TURNON";
+    case enums::REMOTE_TURNOFF:
+      return "REMOTE_TURNOFF";
+    case enums::REMOTE_TOGGLE:
+      return "REMOTE_TOGGLE";
+    case enums::REMOTE_SEND:
+      return "REMOTE_SEND";
+    case enums::REMOTE_LEARN:
+      return "REMOTE_LEARN";
+    default:
+      return "UNKNOWN";
+  }
+}
 bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -4848,6 +4864,210 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
 
   out.append("  media_url: ");
   out.append("'").append(this->media_url).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesRemoteResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesRemoteResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->supports_transmit.push_back(value.as_string());
+      return true;
+    }
+    case 9: {
+      this->supports_receive.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesRemoteResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesRemoteResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  for (auto &it : this->supports_transmit) {
+    buffer.encode_string(8, it, true);
+  }
+  for (auto &it : this->supports_receive) {
+    buffer.encode_string(9, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesRemoteResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesRemoteResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%u", this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  for (const auto &it : this->supports_transmit) {
+    out.append("  supports_transmit: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  for (const auto &it : this->supports_receive) {
+    out.append("  supports_receive: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool RemoteCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->command = value.as_enum<enums::RemoteCommand>();
+      return true;
+    }
+    case 4: {
+      this->args.push_back(value.as_sint64());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool RemoteCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->protocol = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool RemoteCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 5: {
+      this->repeat = value.as_fixed32();
+      return true;
+    }
+    case 6: {
+      this->wait_time = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void RemoteCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::RemoteCommand>(2, this->command);
+  buffer.encode_string(3, this->protocol);
+  for (auto &it : this->args) {
+    buffer.encode_sint64(4, it, true);
+  }
+  buffer.encode_fixed32(5, this->repeat);
+  buffer.encode_fixed32(6, this->wait_time);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void RemoteCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("RemoteCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%u", this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  command: ");
+  out.append(proto_enum_to_string<enums::RemoteCommand>(this->command));
+  out.append("\n");
+
+  out.append("  protocol: ");
+  out.append("'").append(this->protocol).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->args) {
+    out.append("  args: ");
+    sprintf(buffer, "%lld", it);
+    out.append(buffer);
+    out.append("\n");
+  }
+
+  out.append("  repeat: ");
+  sprintf(buffer, "%u", this->repeat);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  wait_time: ");
+  sprintf(buffer, "%u", this->wait_time);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -154,6 +154,13 @@ enum MediaPlayerCommand : uint32_t {
   MEDIA_PLAYER_COMMAND_MUTE = 3,
   MEDIA_PLAYER_COMMAND_UNMUTE = 4,
 };
+enum RemoteCommand : uint32_t {
+  REMOTE_TURNON = 0,
+  REMOTE_TURNOFF = 1,
+  REMOTE_TOGGLE = 2,
+  REMOTE_SEND = 3,
+  REMOTE_LEARN = 4,
+};
 
 }  // namespace enums
 
@@ -1203,6 +1210,45 @@ class MediaPlayerCommandRequest : public ProtoMessage {
   float volume{0.0f};
   bool has_media_url{false};
   std::string media_url{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesRemoteResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::vector<std::string> supports_transmit{};
+  std::vector<std::string> supports_receive{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class RemoteCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::RemoteCommand command{};
+  std::string protocol{};
+  std::vector<int64_t> args{};
+  uint32_t repeat{0};
+  uint32_t wait_time{0};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -185,7 +185,8 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
 #endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
+    const SubscribeHomeAssistantStateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
 #endif
@@ -688,7 +689,8 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(
+    const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -185,8 +185,7 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
 #endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
-    const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
 #endif
@@ -327,6 +326,16 @@ bool APIServerConnectionBase::send_media_player_state_response(const MediaPlayer
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
+#endif
+#ifdef USE_REMOTE
+bool APIServerConnectionBase::send_list_entities_remote_response(const ListEntitiesRemoteResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_remote_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesRemoteResponse>(msg, 66);
+}
+#endif
+#ifdef USE_REMOTE
 #endif
 bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
   switch (msg_type) {
@@ -595,6 +604,17 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #endif
       break;
     }
+    case 67: {
+#ifdef USE_REMOTE
+      RemoteCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_remote_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_remote_command_request(msg);
+#endif
+      break;
+    }
     default:
       return false;
   }
@@ -668,8 +688,7 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(
-    const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;
@@ -853,6 +872,19 @@ void APIServerConnection::on_media_player_command_request(const MediaPlayerComma
     return;
   }
   this->media_player_command(msg);
+}
+#endif
+#ifdef USE_REMOTE
+void APIServerConnection::on_remote_command_request(const RemoteCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->remote_command(msg);
 }
 #endif
 

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -154,6 +154,12 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_MEDIA_PLAYER
   virtual void on_media_player_command_request(const MediaPlayerCommandRequest &value){};
 #endif
+#ifdef USE_REMOTE
+  bool send_list_entities_remote_response(const ListEntitiesRemoteResponse &msg);
+#endif
+#ifdef USE_REMOTE
+  virtual void on_remote_command_request(const RemoteCommandRequest &value){};
+#endif
  protected:
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
 };
@@ -205,6 +211,9 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_MEDIA_PLAYER
   virtual void media_player_command(const MediaPlayerCommandRequest &msg) = 0;
 #endif
+#ifdef USE_REMOTE
+  virtual void remote_command(const RemoteCommandRequest &msg) = 0;
+#endif
  protected:
   void on_hello_request(const HelloRequest &msg) override;
   void on_connect_request(const ConnectRequest &msg) override;
@@ -250,6 +259,9 @@ class APIServerConnection : public APIServerConnectionBase {
 #endif
 #ifdef USE_MEDIA_PLAYER
   void on_media_player_command_request(const MediaPlayerCommandRequest &msg) override;
+#endif
+#ifdef USE_REMOTE
+  void on_remote_command_request(const RemoteCommandRequest &msg) override;
 #endif
 };
 

--- a/esphome/components/api/list_entities.cpp
+++ b/esphome/components/api/list_entities.cpp
@@ -38,6 +38,9 @@ bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) 
 #ifdef USE_LOCK
 bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) { return this->client_->send_lock_info(a_lock); }
 #endif
+#ifdef USE_REMOTE
+bool ListEntitiesIterator::on_remote(remote::Remote *a_remote) { return this->client_->send_remote_info(a_remote); }
+#endif
 
 bool ListEntitiesIterator::on_end() { return this->client_->send_list_info_done(); }
 ListEntitiesIterator::ListEntitiesIterator(APIConnection *client) : client_(client) {}

--- a/esphome/components/api/list_entities.h
+++ b/esphome/components/api/list_entities.h
@@ -55,6 +55,9 @@ class ListEntitiesIterator : public ComponentIterator {
 #ifdef USE_MEDIA_PLAYER
   bool on_media_player(media_player::MediaPlayer *media_player) override;
 #endif
+#ifdef USE_REMOTE
+  bool on_remote(remote::Remote *a_remote) override;
+#endif
   bool on_end() override;
 
  protected:

--- a/esphome/components/api/subscribe_state.h
+++ b/esphome/components/api/subscribe_state.h
@@ -52,6 +52,9 @@ class InitialStateIterator : public ComponentIterator {
 #ifdef USE_MEDIA_PLAYER
   bool on_media_player(media_player::MediaPlayer *media_player) override;
 #endif
+#ifdef USE_REMOTE
+  bool on_remote(remote::Remote *a_remote) override { return true; };
+#endif
  protected:
   APIConnection *client_;
 };

--- a/esphome/components/gpio/remote/__init__.py
+++ b/esphome/components/gpio/remote/__init__.py
@@ -1,0 +1,76 @@
+from remoteprotocols.validators import kebab_to_pascal
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import core, pins
+from esphome.components import remote
+from esphome.const import (
+    CONF_CARRIER_DUTY_PERCENT,
+    CONF_ID,
+    CONF_PROTOCOL,
+)
+from .. import gpio_ns
+
+
+GPIORemote = gpio_ns.class_("GPIORemote", remote.Remote, cg.Component)
+
+
+SUPPORTED_PROTOCOLS = ["duration"]
+
+CONF_TRANSMIT_PIN = "transmit_pin"
+
+
+CONFIG_SCHEMA = remote.REMOTE_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(GPIORemote),
+        cv.Required(CONF_TRANSMIT_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_CARRIER_DUTY_PERCENT): cv.All(
+            cv.percentage_int, cv.Range(min=1, max=100)
+        ),
+        cv.Optional(CONF_PROTOCOL): cv.All(
+            [cv.one_of(*SUPPORTED_PROTOCOLS)], cv.Length(min=1)
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+PROTOCOL_REGISTRY = {}
+
+
+def get_protocol(name):
+
+    # make sure the protocol is valid at the Remote level
+
+    # if more than one remote instance support a protocol, share de codec object
+    if name in PROTOCOL_REGISTRY:
+        return PROTOCOL_REGISTRY[name]
+
+    class_name = kebab_to_pascal(name)
+
+    ProtocolClass = gpio_ns.class_(
+        f"RemoteProtocolCodec{class_name}", remote.RemoteProtocolCodec
+    )
+    codec = cg.new_Pvariable(
+        core.ID(
+            f"gpio_remoteprotocolcodec_{name}", is_declaration=True, type=ProtocolClass
+        )
+    )
+
+    PROTOCOL_REGISTRY[name] = codec
+
+    return codec
+
+
+async def to_code(config):
+    pin = await cg.gpio_pin_expression(config[CONF_TRANSMIT_PIN])
+    var = cg.new_Pvariable(config[CONF_ID], pin)
+    await cg.register_component(var, config)
+    await remote.register_remote(var, config)
+
+    cg.add(var.set_carrier_duty_percent(config[CONF_CARRIER_DUTY_PERCENT]))
+
+    protocols = SUPPORTED_PROTOCOLS
+
+    if CONF_PROTOCOL in config:
+        protocols = config[CONF_PROTOCOL]
+
+    for name in protocols:
+        cg.add(var.add_protocol(get_protocol(name)))

--- a/esphome/components/gpio/remote/gpio_remote.cpp
+++ b/esphome/components/gpio/remote/gpio_remote.cpp
@@ -1,0 +1,25 @@
+#include "gpio_remote.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace gpio {
+
+static const char *const TAG = "remote.gpio";
+
+void GPIORemote::transmit(int repeat, int wait, const std::string &name, const std::vector<remote::arg_t> &args) {
+  RemoteProtocolCodec *protocol = this->get_protocol(name);
+
+  if (protocol == nullptr) {
+    ESP_LOGE(TAG, "Unsupported protocol '%s'", name.c_str());
+    return;
+  }
+
+  this->temp_.reset();
+  protocol->encode(&this->temp_, args);
+  ESP_LOGD(TAG, "Sending command:");
+  protocol->dump(args);
+  this->send_internal_(repeat, wait);
+};
+
+}  // namespace gpio
+}  // namespace esphome

--- a/esphome/components/gpio/remote/gpio_remote.h
+++ b/esphome/components/gpio/remote/gpio_remote.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/remote/remote.h"
+#include "protocol_helper.h"
+
+#ifdef USE_ESP32
+#include <driver/rmt.h>
+#endif
+
+namespace esphome {
+namespace gpio {
+
+#ifdef USE_ESP32
+class GPIORemoteRMTChannel {
+ public:
+  explicit GPIORemoteRMTChannel(uint8_t mem_block_num = 1);
+
+  void config_rmt(rmt_config_t &rmt);
+  void set_clock_divider(uint8_t clock_divider) { this->clock_divider_ = clock_divider; }
+
+ protected:
+  uint32_t from_microseconds_(uint32_t us) {
+    const uint32_t ticks_per_ten_us = 80000000u / this->clock_divider_ / 100000u;
+    return us * ticks_per_ten_us / 10;
+  }
+  uint32_t to_microseconds_(uint32_t ticks) {
+    const uint32_t ticks_per_ten_us = 80000000u / this->clock_divider_ / 100000u;
+    return (ticks * 10) / ticks_per_ten_us;
+  }
+  // RemoteComponentBase *remote_base_;
+  rmt_channel_t channel_{RMT_CHANNEL_0};
+  uint8_t mem_block_num_;
+  uint8_t clock_divider_{80};
+};
+#endif
+
+class GPIORemote : public remote::Remote,
+                   public Component
+#ifdef USE_ESP32
+    ,
+                   public GPIORemoteRMTChannel
+#endif
+
+{
+ public:
+  explicit GPIORemote(InternalGPIOPin *transmit_pin) : transmit_pin_(transmit_pin) {}
+
+  void setup() override;
+
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_carrier_duty_percent(uint8_t carrier_duty_percent) { carrier_duty_percent_ = carrier_duty_percent; }
+
+  void add_protocol(RemoteProtocolCodec *protocol) {
+    protocols_.push_back(protocol);
+    capabilities_.supports_transmit.push_back(protocol->get_name());
+  };
+
+  RemoteProtocolCodec *get_protocol(const std::string &name) {
+    for (auto *proto : protocols_) {
+      if (proto->get_name() == name)
+        return proto;
+    }
+    return nullptr;
+  }
+
+ protected:
+  // Transmitter members
+  void transmit(int repeat, int wait, const std::string &name, const std::vector<remote::arg_t> &args) override;
+  void send_internal_(uint32_t send_times, uint32_t send_wait);
+
+#ifdef USE_ESP8266
+  void calculate_on_off_time_(uint32_t carrier_frequency, uint32_t *on_time_period, uint32_t *off_time_period);
+
+  void mark_(uint32_t on_time, uint32_t off_time, uint32_t usec);
+
+  void space_(uint32_t usec);
+
+  void await_target_time_();
+  uint32_t target_time_;
+#endif
+#ifdef USE_ESP32
+  void configure_rmt_();
+
+  uint32_t current_carrier_frequency_{UINT32_MAX};
+  bool initialized_{false};
+  std::vector<rmt_item32_t> rmt_temp_;
+  esp_err_t error_code_{ESP_OK};
+  bool inverted_{false};
+#endif
+  // properties
+  RemoteSignalData temp_;
+  std::vector<RemoteProtocolCodec *> protocols_;
+  InternalGPIOPin *transmit_pin_;
+  uint8_t carrier_duty_percent_{50};
+};
+}  // namespace gpio
+}  // namespace esphome

--- a/esphome/components/gpio/remote/gpio_remote_esp32.cpp
+++ b/esphome/components/gpio/remote/gpio_remote_esp32.cpp
@@ -1,0 +1,152 @@
+#include "gpio_remote.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace gpio {
+
+static const char *const TAG = "gpio.remote";
+
+// GPIORemoteRMTChannel
+
+GPIORemoteRMTChannel::GPIORemoteRMTChannel(uint8_t mem_block_num) : mem_block_num_(mem_block_num) {
+  static rmt_channel_t next_rmt_channel = RMT_CHANNEL_0;
+  this->channel_ = next_rmt_channel;
+  next_rmt_channel = rmt_channel_t(int(next_rmt_channel) + mem_block_num);
+}
+
+void GPIORemoteRMTChannel::config_rmt(rmt_config_t &rmt) {
+  if (rmt_channel_t(int(this->channel_) + this->mem_block_num_) >= RMT_CHANNEL_MAX) {
+    this->mem_block_num_ = int(RMT_CHANNEL_MAX) - int(this->channel_);
+    ESP_LOGW(TAG, "Not enough RMT memory blocks available, reduced to %i blocks.", this->mem_block_num_);
+  }
+  rmt.channel = this->channel_;
+  rmt.clk_div = this->clock_divider_;
+  rmt.mem_block_num = this->mem_block_num_;
+}
+
+// GPIORemote
+
+void GPIORemote::setup() { this->configure_rmt_(); }
+
+void GPIORemote::dump_config() {
+  ESP_LOGCONFIG(TAG, "GPIO Remote:");
+  ESP_LOGCONFIG(TAG, "  Channel: %d", this->channel_);
+  ESP_LOGCONFIG(TAG, "  RMT memory blocks: %d", this->mem_block_num_);
+  ESP_LOGCONFIG(TAG, "  Clock divider: %u", this->clock_divider_);
+  LOG_PIN("  Pin: ", this->transmit_pin_);
+
+  if (this->current_carrier_frequency_ != 0 && this->carrier_duty_percent_ != 100) {
+    ESP_LOGCONFIG(TAG, "    Carrier Duty: %u%%", this->carrier_duty_percent_);
+  }
+
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Configuring RMT driver failed: %s", esp_err_to_name(this->error_code_));
+  }
+}
+
+void GPIORemote::configure_rmt_() {
+  rmt_config_t c{};
+
+  this->config_rmt(c);
+  c.rmt_mode = RMT_MODE_TX;
+  c.gpio_num = gpio_num_t(this->transmit_pin_->get_pin());
+  c.tx_config.loop_en = false;
+
+  if (this->current_carrier_frequency_ == 0 || this->carrier_duty_percent_ == 100) {
+    c.tx_config.carrier_en = false;
+  } else {
+    c.tx_config.carrier_en = true;
+    c.tx_config.carrier_freq_hz = this->current_carrier_frequency_;
+    c.tx_config.carrier_duty_percent = this->carrier_duty_percent_;
+  }
+
+  c.tx_config.idle_output_en = true;
+  if (!this->transmit_pin_->is_inverted()) {
+    c.tx_config.carrier_level = RMT_CARRIER_LEVEL_HIGH;
+    c.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
+  } else {
+    c.tx_config.carrier_level = RMT_CARRIER_LEVEL_LOW;
+    c.tx_config.idle_level = RMT_IDLE_LEVEL_HIGH;
+    this->inverted_ = true;
+  }
+
+  esp_err_t error = rmt_config(&c);
+  if (error != ESP_OK) {
+    this->error_code_ = error;
+    this->mark_failed();
+    return;
+  }
+
+  if (!this->initialized_) {
+    error = rmt_driver_install(this->channel_, 0, 0);
+    if (error != ESP_OK) {
+      this->error_code_ = error;
+      this->mark_failed();
+      return;
+    }
+    this->initialized_ = true;
+  }
+}
+
+void GPIORemote::send_internal_(uint32_t send_times, uint32_t send_wait) {
+  if (this->is_failed())
+    return;
+
+  if (this->current_carrier_frequency_ != this->temp_.get_carrier_frequency()) {
+    this->current_carrier_frequency_ = this->temp_.get_carrier_frequency();
+    this->configure_rmt_();
+  }
+
+  this->rmt_temp_.clear();
+  this->rmt_temp_.reserve((this->temp_.get_data().size() + 1) / 2);
+  uint32_t rmt_i = 0;
+  rmt_item32_t rmt_item;
+
+  for (int32_t val : this->temp_.get_data()) {
+    bool level = val >= 0;
+    if (!level)
+      val = -val;
+    val = this->from_microseconds_(static_cast<uint32_t>(val));
+
+    do {
+      int32_t item = std::min(val, int32_t(32767));
+      val -= item;
+
+      if (rmt_i % 2 == 0) {
+        rmt_item.level0 = static_cast<uint32_t>(level ^ this->inverted_);
+        rmt_item.duration0 = static_cast<uint32_t>(item);
+      } else {
+        rmt_item.level1 = static_cast<uint32_t>(level ^ this->inverted_);
+        rmt_item.duration1 = static_cast<uint32_t>(item);
+        this->rmt_temp_.push_back(rmt_item);
+      }
+      rmt_i++;
+    } while (val != 0);
+  }
+
+  if (rmt_i % 2 == 1) {
+    rmt_item.level1 = 0;
+    rmt_item.duration1 = 0;
+    this->rmt_temp_.push_back(rmt_item);
+  }
+
+  for (uint32_t i = 0; i < send_times; i++) {
+    esp_err_t error = rmt_write_items(this->channel_, this->rmt_temp_.data(), this->rmt_temp_.size(), true);
+    if (error != ESP_OK) {
+      ESP_LOGW(TAG, "rmt_write_items failed: %s", esp_err_to_name(error));
+      this->status_set_warning();
+    } else {
+      this->status_clear_warning();
+    }
+    if (i + 1 < send_times)
+      delayMicroseconds(send_wait);
+  }
+}
+
+}  // namespace gpio
+}  // namespace esphome
+
+#endif

--- a/esphome/components/gpio/remote/gpio_remote_esp8266.cpp
+++ b/esphome/components/gpio/remote/gpio_remote_esp8266.cpp
@@ -1,0 +1,106 @@
+#include "gpio_remote.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+#ifdef USE_ESP8266
+
+namespace esphome {
+namespace gpio {
+
+static const char *const TAG = "remote.gpio";
+
+void GPIORemote::setup() {
+  this->transmit_pin_->setup();
+  this->transmit_pin_->digital_write(false);
+}
+
+void GPIORemote::dump_config() {
+  ESP_LOGCONFIG(TAG, "GPIO Remote:");
+  ESP_LOGCONFIG(TAG, "  Carrier Duty: %u%%", this->carrier_duty_percent_);
+  LOG_PIN("  Transmit Pin: ", this->transmit_pin_);
+  ESP_LOGCONFIG(TAG, "  Supported Protocols:");
+  for (auto p : this->capabilities_.supports_transmit) {
+    ESP_LOGCONFIG(TAG, "  - %s", p.c_str());
+  }
+}
+
+// Transmitter members
+
+void GPIORemote::calculate_on_off_time_(uint32_t carrier_frequency, uint32_t *on_time_period,
+                                        uint32_t *off_time_period) {
+  if (carrier_frequency == 0) {
+    *on_time_period = 0;
+    *off_time_period = 0;
+    return;
+  }
+  uint32_t period = (1000000UL + carrier_frequency / 2) / carrier_frequency;  // round(1000000/freq)
+  period = std::max(uint32_t(1), period);
+  *on_time_period = (period * this->carrier_duty_percent_) / 100;
+  *off_time_period = period - *on_time_period;
+}
+
+void GPIORemote::await_target_time_() {
+  const uint32_t current_time = micros();
+  if (this->target_time_ == 0) {
+    this->target_time_ = current_time;
+  } else if (this->target_time_ > current_time) {
+    delayMicroseconds(this->target_time_ - current_time);
+  }
+}
+
+void GPIORemote::mark_(uint32_t on_time, uint32_t off_time, uint32_t usec) {
+  this->await_target_time_();
+  this->transmit_pin_->digital_write(true);
+
+  const uint32_t target = this->target_time_ + usec;
+  if (this->carrier_duty_percent_ < 100 && (on_time > 0 || off_time > 0)) {
+    while (true) {  // Modulate with carrier frequency
+      this->target_time_ += on_time;
+      if (this->target_time_ >= target)
+        break;
+      this->await_target_time_();
+      this->transmit_pin_->digital_write(false);
+
+      this->target_time_ += off_time;
+      if (this->target_time_ >= target)
+        break;
+      this->await_target_time_();
+      this->transmit_pin_->digital_write(true);
+    }
+  }
+  this->target_time_ = target;
+}
+
+void GPIORemote::space_(uint32_t usec) {
+  this->await_target_time_();
+  this->transmit_pin_->digital_write(false);
+  this->target_time_ += usec;
+}
+
+void GPIORemote::send_internal_(uint32_t send_times, uint32_t send_wait) {
+  uint32_t on_time, off_time;
+  this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
+  this->target_time_ = 0;
+  for (uint32_t i = 0; i < send_times; i++) {
+    for (int32_t item : this->temp_.get_data()) {
+      if (item > 0) {
+        const auto length = uint32_t(item);
+        this->mark_(on_time, off_time, length);
+      } else {
+        const auto length = uint32_t(-item);
+        this->space_(length);
+      }
+      App.feed_wdt();
+    }
+    this->await_target_time_();  // wait for duration of last pulse
+    this->transmit_pin_->digital_write(false);
+
+    if (i + 1 < send_times)
+      this->target_time_ += send_wait;
+  }
+}
+
+}  // namespace gpio
+}  // namespace esphome
+
+#endif  // USE_ESP8266

--- a/esphome/components/gpio/remote/gpio_remote_esp8266.cpp
+++ b/esphome/components/gpio/remote/gpio_remote_esp8266.cpp
@@ -19,7 +19,7 @@ void GPIORemote::dump_config() {
   ESP_LOGCONFIG(TAG, "  Carrier Duty: %u%%", this->carrier_duty_percent_);
   LOG_PIN("  Transmit Pin: ", this->transmit_pin_);
   ESP_LOGCONFIG(TAG, "  Supported Protocols:");
-  for (auto p : this->capabilities_.supports_transmit) {
+  for (const auto &p : this->capabilities_.supports_transmit) {
     ESP_LOGCONFIG(TAG, "  - %s", p.c_str());
   }
 }

--- a/esphome/components/gpio/remote/protocol_duration.cpp
+++ b/esphome/components/gpio/remote/protocol_duration.cpp
@@ -1,0 +1,34 @@
+#include "protocol_duration.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+using namespace remote;
+namespace gpio {
+
+static const char *const TAG = "remote.gpio.raw";
+
+void RemoteProtocolCodecDuration::encode(RemoteSignalData *dst, const std::vector<arg_t> &args) {
+  dst->set_carrier_frequency(args.back());
+  dst->set_data(args, args.size() - 1);
+}
+
+void RemoteProtocolCodecDuration::dump(const std::vector<arg_t> &args) {
+  std::string buf = "duration:";
+
+  buf.reserve(9 + 7 * args.size());
+
+  auto last = args.end() - 1;
+
+  for (auto it = args.begin(); it != args.end(); it++) {
+    if (it != args.begin() && it != last)
+      buf.append(", ");
+    else if (it == last)
+      buf.append(":");
+    buf.append(to_string(*it));
+  }
+
+  ESP_LOGD(TAG, "Command: %s", buf.c_str());
+}
+
+}  // namespace gpio
+}  // namespace esphome

--- a/esphome/components/gpio/remote/protocol_duration.cpp
+++ b/esphome/components/gpio/remote/protocol_duration.cpp
@@ -20,10 +20,11 @@ void RemoteProtocolCodecDuration::dump(const std::vector<arg_t> &args) {
   auto last = args.end() - 1;
 
   for (auto it = args.begin(); it != args.end(); it++) {
-    if (it != args.begin() && it != last)
+    if (it != args.begin() && it != last) {
       buf.append(", ");
-    else if (it == last)
+    } else if (it == last) {
       buf.append(":");
+    }
     buf.append(to_string(*it));
   }
 

--- a/esphome/components/gpio/remote/protocol_duration.h
+++ b/esphome/components/gpio/remote/protocol_duration.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "protocol_helper.h"
+
+namespace esphome {
+
+namespace gpio {
+
+class RemoteProtocolCodecDuration : public RemoteProtocolCodec {
+ public:
+  RemoteProtocolCodecDuration() : RemoteProtocolCodec("duration") {}
+  void encode(RemoteSignalData *dst, const std::vector<remote::arg_t> &args) override;
+
+  // std::vector<arg_t> decode(const RemoteSignalData &src) override;
+
+  void dump(const std::vector<remote::arg_t> &command) override;
+};
+
+}  // namespace gpio
+}  // namespace esphome

--- a/esphome/components/gpio/remote/protocol_duration.h
+++ b/esphome/components/gpio/remote/protocol_duration.h
@@ -13,7 +13,7 @@ class RemoteProtocolCodecDuration : public RemoteProtocolCodec {
 
   // std::vector<arg_t> decode(const RemoteSignalData &src) override;
 
-  void dump(const std::vector<remote::arg_t> &command) override;
+  void dump(const std::vector<remote::arg_t> &args) override;
 };
 
 }  // namespace gpio

--- a/esphome/components/gpio/remote/protocol_helper.h
+++ b/esphome/components/gpio/remote/protocol_helper.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <utility>
+
+#include "esphome/components/remote/remote.h"
+
+namespace esphome {
+namespace gpio {
+
+class RemoteSignalData {
+ public:
+  void mark(uint32_t length) { this->data_.push_back(length); }
+
+  void space(uint32_t length) { this->data_.push_back(-length); }
+
+  void item(uint32_t mark, uint32_t space) {
+    this->mark(mark);
+    this->space(space);
+  }
+
+  void reserve(uint32_t len) { this->data_.reserve(len); }
+
+  void set_carrier_frequency(uint32_t carrier_frequency) { this->carrier_frequency_ = carrier_frequency; }
+
+  uint32_t get_carrier_frequency() const { return this->carrier_frequency_; }
+
+  const std::vector<int32_t> &get_data() const { return this->data_; }
+
+  template<typename T> void set_data(const std::vector<T> &data, size_t size = 0) {
+    this->data_.clear();
+    this->data_.reserve(data.size());
+    size_t i = 0;
+
+    for (auto it = data.begin(); it != data.end() && (i < size || !size); it++, i++) {
+      this->data_.push_back((int32_t) *it);
+    }
+  }
+
+  void reset() {
+    this->data_.clear();
+    this->carrier_frequency_ = 0;
+  }
+
+  std::vector<int32_t>::iterator begin() { return this->data_.begin(); }
+
+  std::vector<int32_t>::iterator end() { return this->data_.end(); }
+
+ protected:
+  std::vector<int32_t> data_{};
+  uint32_t carrier_frequency_{0};
+};
+
+class RemoteProtocolCodec {
+ public:
+  RemoteProtocolCodec(std::string name) : name_(std::move(name)) {}
+
+  virtual void encode(RemoteSignalData *dst, const std::vector<remote::arg_t> &command) = 0;
+
+  // TODO: make pure virtual and implement receiver function
+  virtual std::vector<remote::arg_t> decode(const RemoteSignalData &src) {
+    std::vector<remote::arg_t> empty;
+    return empty;
+  }
+
+  virtual void dump(const std::vector<remote::arg_t> &command) = 0;
+
+  const std::string &get_name() { return name_; }
+
+ private:
+  std::string name_;
+};
+
+}  // namespace gpio
+}  // namespace esphome

--- a/esphome/components/remote/__init__.py
+++ b/esphome/components/remote/__init__.py
@@ -1,0 +1,110 @@
+from remoteprotocols import ProtocolRegistry
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.const import (
+    CONF_COMMAND,
+    CONF_ID,
+    CONF_ON_TURN_OFF,
+    CONF_ON_TURN_ON,
+    CONF_REPEAT,
+    CONF_TRIGGER_ID,
+    CONF_WAIT_TIME,
+)
+from esphome.core import CORE
+from esphome.coroutine import coroutine_with_priority
+from esphome.cpp_helpers import setup_entity
+
+CODEOWNERS = ["@ianchi"]
+IS_PLATFORM_COMPONENT = True
+
+
+REGISTRY = ProtocolRegistry()
+
+remote_ns = cg.esphome_ns.namespace("remote")
+Remote = remote_ns.class_("Remote", cg.EntityBase)
+RemoteProtocolCodec = remote_ns.class_("RemoteProtocolCodec")
+
+SendCommandAction = remote_ns.class_("SendCommandAction", automation.Action)
+
+RemoteTurnOnTrigger = remote_ns.class_(
+    "RemoteTurnOnTrigger", automation.Trigger.template()
+)
+RemoteTurnOffTrigger = remote_ns.class_(
+    "RemoteTurnOffTrigger", automation.Trigger.template()
+)
+
+REMOTE_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_ON_TURN_ON): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(RemoteTurnOnTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_TURN_OFF): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(RemoteTurnOffTrigger),
+            }
+        ),
+    }
+)
+
+
+def convert_command(command):
+
+    cmd = REGISTRY.convert(command, protocols=["duration"])
+
+    if not cmd:
+        raise cv.Invalid("Cannot convert protocol to supported format")
+
+    return {"name": cmd[0].protocol.name, "args": cmd[0].args}
+
+
+REMOTE_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(Remote),
+        cv.Required(CONF_COMMAND): convert_command,
+        cv.Optional(CONF_REPEAT, 1): cv.int_range(min=1),
+        cv.Optional(CONF_WAIT_TIME, "0s"): cv.positive_time_period_milliseconds,
+    }
+)
+
+
+async def setup_remote_core_(var, config):
+    await setup_entity(var, config)
+
+    for conf in config.get(CONF_ON_TURN_ON, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_TURN_OFF, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+
+
+async def register_remote(var, config):
+    if not CORE.has_id(config[CONF_ID]):
+        var = cg.Pvariable(config[CONF_ID], var)
+    cg.add(cg.App.register_remote(var))
+    await setup_remote_core_(var, config)
+
+
+@automation.register_action(
+    "remote.send_command", SendCommandAction, REMOTE_ACTION_SCHEMA
+)
+async def send_command_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+
+    trigger = cg.new_Pvariable(action_id, template_arg, paren)
+    cg.add(
+        trigger.set_command(config[CONF_COMMAND]["name"], config[CONF_COMMAND]["args"])
+    )
+    cg.add(trigger.set_send_times(config[CONF_REPEAT]))
+    cg.add(trigger.set_send_wait(config[CONF_WAIT_TIME]))
+    return trigger
+
+
+@coroutine_with_priority(100.0)
+async def to_code(config):
+    cg.add_global(remote_ns.using)
+    cg.add_define("USE_REMOTE")

--- a/esphome/components/remote/automation.cpp
+++ b/esphome/components/remote/automation.cpp
@@ -1,0 +1,5 @@
+#include "remote.h"
+
+namespace esphome {
+namespace remote {}
+}  // namespace esphome

--- a/esphome/components/remote/automation.h
+++ b/esphome/components/remote/automation.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "remote.h"
+
+namespace esphome {
+namespace remote {
+
+template<typename... Ts> class SendCommandAction : public Action<Ts...> {
+ public:
+  explicit SendCommandAction(Remote *a_remote) : remote_(a_remote) {}
+
+  TEMPLATABLE_VALUE(uint32_t, send_times);
+  TEMPLATABLE_VALUE(uint32_t, send_wait);
+
+  void play(Ts... x) override {
+    this->remote_->send_command(send_times_.value(x...), send_wait_.value(x...), protocol_, args_);
+  }
+
+  void set_command(std::string protocol, std::vector<int64_t> args) {
+    protocol_ = protocol;
+    args_.clear();
+    args_.reserve(args.size());
+    for (auto arg : args)
+      args_.push_back((arg_t) arg);
+  }
+
+ protected:
+  Remote *remote_;
+  std::string protocol_;
+  std::vector<arg_t> args_;
+};
+
+class RemoteTurnOnTrigger : public Trigger<> {
+ public:
+  RemoteTurnOnTrigger(Remote *a_remote) {
+    a_remote->add_on_state_callback([this](bool state) {
+      if (state) {
+        this->trigger();
+      }
+    });
+  }
+};
+
+class RemoteTurnOffTrigger : public Trigger<> {
+ public:
+  RemoteTurnOffTrigger(Remote *a_remote) {
+    a_remote->add_on_state_callback([this](bool state) {
+      if (!state) {
+        this->trigger();
+      }
+    });
+  }
+};
+
+}  // namespace remote
+}  // namespace esphome

--- a/esphome/components/remote/remote.cpp
+++ b/esphome/components/remote/remote.cpp
@@ -1,0 +1,22 @@
+#include "remote.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace remote {
+
+static const char *const TAG = "remote";
+
+void Remote::turn_on() {
+  ESP_LOGD(TAG, "'%s' Turning ON.", this->get_name().c_str());
+  this->write_state(true);
+  this->state_callback_.call(true);
+}
+void Remote::turn_off() {
+  ESP_LOGD(TAG, "'%s' Turning OFF.", this->get_name().c_str());
+  this->write_state(false);
+  this->state_callback_.call(false);
+}
+
+}  // namespace remote
+
+}  // namespace esphome

--- a/esphome/components/remote/remote.h
+++ b/esphome/components/remote/remote.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "esphome/core/entity_base.h"
+#include "esphome/core/automation.h"
+namespace esphome {
+namespace remote {
+
+typedef int64_t arg_t;
+
+class RemoteCapabilities {
+ public:
+  std::vector<std::string> supports_transmit;
+  std::vector<std::string> supports_receive;
+};
+
+/** Base class for all remotes.
+ *
+ * A Remote allows to send IR/RF commands.
+ */
+class Remote : public EntityBase {
+ public:
+  explicit Remote(){};
+
+  const RemoteCapabilities &get_capabilities() { return capabilities_; }
+
+  /** Turn this remote on. This is called by the front-end.
+   *
+   * For implementing remotes, please override write_state.
+   */
+  void turn_on();
+  /** Turn this remote off. This is called by the front-end.
+   *
+   * For implementing switches, please override write_state.
+   */
+  void turn_off();
+  /** Send specific command thru remote. This is called by the front-end.
+   *
+   * For implementing switches, please override transmit.
+   */
+  void send_command(int repeat, int wait, const std::string &protocol, const std::vector<arg_t> &args) {
+    transmit(repeat, wait, protocol, args);
+  }
+
+  /** Set callback for state changes.
+   *
+   * @param callback The void(bool) callback.
+   */
+  void add_on_state_callback(std::function<void(bool)> &&callback) { state_callback_.add(std::move(callback)); }
+
+ protected:
+  /** Write the given command to hardware. You should implement this
+   * abstract method if you want to create your own Remote.
+   *
+   * In the implementation of this method, you should also call
+   * publish_state to acknowledge that the state was written to the hardware.
+   *
+   */
+  virtual void transmit(int repeat, int wait, const std::string &protocol, const std::vector<arg_t> &args) = 0;
+
+  virtual void write_state(bool state){};
+
+  uint32_t hash_base() override { return 1671990586UL; };
+
+  CallbackManager<void(bool)> state_callback_{};
+  RemoteCapabilities capabilities_{};
+};
+
+}  // namespace remote
+}  // namespace esphome

--- a/esphome/components/remote/remote.h
+++ b/esphome/components/remote/remote.h
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace remote {
 
-typedef int64_t arg_t;
+using arg_t = int64_t;
 
 class RemoteCapabilities {
  public:

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -91,6 +91,12 @@ bool ListEntitiesIterator::on_select(select::Select *select) {
 }
 #endif
 
+#ifdef USE_REMOTE
+bool ListEntitiesIterator::on_remote(remote::Remote *remote) {
+  this->web_server_->events_.send(this->web_server_->remote_json(remote, true, DETAIL_ALL).c_str(), "state");
+  return true;
+}
+#endif
 }  // namespace web_server
 }  // namespace esphome
 

--- a/esphome/components/web_server/list_entities.h
+++ b/esphome/components/web_server/list_entities.h
@@ -49,7 +49,9 @@ class ListEntitiesIterator : public ComponentIterator {
 #ifdef USE_LOCK
   bool on_lock(lock::Lock *a_lock) override;
 #endif
-
+#ifdef USE_REMOTE
+  bool on_remote(remote::Remote *a_remote) override;
+#endif
  protected:
   WebServer *web_server_;
 };

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -212,6 +212,16 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   std::string lock_json(lock::Lock *obj, lock::LockState value, JsonDetail start_config);
 #endif
 
+#ifdef USE_REMOTE
+  void on_remote_update(remote::Remote *obj, bool state) override;
+
+  /// Handle a remote request under '/remote/<id>/</turn_on/turn_off>'.
+  void handle_remote_request(AsyncWebServerRequest *request, const UrlMatch &match);
+
+  /// Dump the remote state with its value as a JSON string.
+  std::string remote_json(remote::Remote *obj, bool value, JsonDetail start_config);
+#endif
+
   /// Override the web handler's canHandle method.
   bool canHandle(AsyncWebServerRequest *request) override;
   /// Override the web handler's handleRequest method.

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -48,6 +48,9 @@
 #ifdef USE_MEDIA_PLAYER
 #include "esphome/components/media_player/media_player.h"
 #endif
+#ifdef USE_REMOTE
+#include "esphome/components/remote/remote.h"
+#endif
 
 namespace esphome {
 
@@ -116,6 +119,9 @@ class Application {
 
 #ifdef USE_MEDIA_PLAYER
   void register_media_player(media_player::MediaPlayer *media_player) { this->media_players_.push_back(media_player); }
+#endif
+#ifdef USE_REMOTE
+  void register_remote(remote::Remote *a_remote) { this->remotes_.push_back(a_remote); }
 #endif
 
   /// Register the component in this Application instance.
@@ -282,6 +288,15 @@ class Application {
     return nullptr;
   }
 #endif
+#ifdef USE_REMOTE
+  const std::vector<remote::Remote *> &get_remotes() { return this->remotes_; }
+  remote::Remote *get_remote_by_key(uint32_t key, bool include_internal = false) {
+    for (auto *obj : this->remotes_)
+      if (obj->get_object_id_hash() == key && (include_internal || !obj->is_internal()))
+        return obj;
+    return nullptr;
+  }
+#endif
 
   Scheduler scheduler;
 
@@ -335,6 +350,9 @@ class Application {
 #endif
 #ifdef USE_MEDIA_PLAYER
   std::vector<media_player::MediaPlayer *> media_players_{};
+#endif
+#ifdef USE_REMOTE
+  std::vector<remote::Remote *> remotes_{};
 #endif
 
   std::string name_;

--- a/esphome/core/component_iterator.cpp
+++ b/esphome/core/component_iterator.cpp
@@ -247,6 +247,21 @@ void ComponentIterator::advance() {
       }
       break;
 #endif
+#ifdef USE_REMOTE
+    case IteratorState::REMOTE:
+      if (this->at_ >= App.get_remotes().size()) {
+        advance_platform = true;
+      } else {
+        auto *a_remote = App.get_remotes()[this->at_];
+        if (a_remote->is_internal()) {
+          success = true;
+          break;
+        } else {
+          success = this->on_remote(a_remote);
+        }
+      }
+      break;
+#endif
     case IteratorState::MAX:
       if (this->on_end()) {
         this->state_ = IteratorState::NONE;

--- a/esphome/core/component_iterator.h
+++ b/esphome/core/component_iterator.h
@@ -66,6 +66,9 @@ class ComponentIterator {
 #ifdef USE_MEDIA_PLAYER
   virtual bool on_media_player(media_player::MediaPlayer *media_player);
 #endif
+#ifdef USE_REMOTE
+  virtual bool on_remote(remote::Remote *a_remote) = 0;
+#endif
   virtual bool on_end();
 
  protected:
@@ -116,6 +119,9 @@ class ComponentIterator {
 #endif
 #ifdef USE_MEDIA_PLAYER
     MEDIA_PLAYER,
+#endif
+#ifdef USE_REMOTE
+    REMOTE,
 #endif
     MAX,
   } state_{IteratorState::NONE};

--- a/esphome/core/controller.h
+++ b/esphome/core/controller.h
@@ -40,7 +40,9 @@
 #ifdef USE_MEDIA_PLAYER
 #include "esphome/components/media_player/media_player.h"
 #endif
-
+#ifdef USE_REMOTE
+#include "esphome/components/remote/remote.h"
+#endif
 namespace esphome {
 
 class Controller {

--- a/esphome/core/controller.h
+++ b/esphome/core/controller.h
@@ -84,6 +84,9 @@ class Controller {
 #ifdef USE_MEDIA_PLAYER
   virtual void on_media_player_update(media_player::MediaPlayer *obj){};
 #endif
+#ifdef USE_REMOTE
+  virtual void on_remote_update(remote::Remote *obj, bool state){};
+#endif
 };
 
 }  // namespace esphome

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -36,6 +36,7 @@
 #define USE_OTA_STATE_CALLBACK
 #define USE_POWER_SUPPLY
 #define USE_QR_CODE
+#define USE_REMOTE
 #define USE_SELECT
 #define USE_SENSOR
 #define USE_STATUS_LED

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ click==8.1.3
 esphome-dashboard==20220508.0
 aioesphomeapi==10.10.0
 zeroconf==0.38.4
+remoteprotocols==0.0.4 # for 'remote' component
 
 # esp-idf requires this, but doesn't bundle it by default
 # https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ click==8.1.3
 esphome-dashboard==20220508.0
 aioesphomeapi==10.10.0
 zeroconf==0.38.4
-remoteprotocols==0.0.4 # for 'remote' component
+remoteprotocols==0.0.7 # for 'remote' component
 
 # esp-idf requires this, but doesn't bundle it by default
 # https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -29,7 +29,7 @@ esphome:
           range_from: 0
           range_to: 100
           red: 100%
-          green: !lambda "return 255;"
+          green: !lambda 'return 255;'
           blue: 0%
           white: 100%
       - http_request.get:
@@ -43,18 +43,18 @@ esphome:
           json:
             key: !lambda |-
               return id(${textname}_text).state;
-            greeting: "Hello World"
+            greeting: 'Hello World'
       - http_request.send:
           method: PUT
           url: https://esphome.io
           headers:
             Content-Type: application/json
-          body: "Some data"
+          body: 'Some data'
           verify_ssl: false
           on_response:
             then:
               - logger.log:
-                  format: "Response status: %d"
+                  format: 'Response status: %d'
                   args:
                     - status_code
   build_path: build/test1
@@ -65,12 +65,12 @@ packages:
 
 wifi:
   networks:
-    - ssid: "MySSID"
-      password: "password1"
-    - ssid: "MySSID2"
-      password: ""
+    - ssid: 'MySSID'
+      password: 'password1'
+    - ssid: 'MySSID2'
+      password: ''
       channel: 14
-      bssid: "A1:63:95:47:D3:1D"
+      bssid: 'A1:63:95:47:D3:1D'
   manual_ip:
     static_ip: 192.168.178.230
     gateway: 192.168.178.1
@@ -89,10 +89,10 @@ http_request:
   timeout: 10s
 
 mqtt:
-  broker: "192.168.178.84"
+  broker: '192.168.178.84'
   port: 1883
-  username: "debug"
-  password: "debug"
+  username: 'debug'
+  password: 'debug'
   client_id: someclient
   use_abbreviations: false
   discovery: True
@@ -154,7 +154,7 @@ mqtt:
                   return effect;
             - light.control:
                 id: ${roomname}_lights
-                brightness: !lambda "return id(${roomname}_lights).current_values.get_brightness() + 0.5;"
+                brightness: !lambda 'return id(${roomname}_lights).current_values.get_brightness() + 0.5;'
             - light.dim_relative:
                 id: ${roomname}_lights
                 relative_brightness: 5%
@@ -223,7 +223,7 @@ uart:
 
 ota:
   safe_mode: True
-  password: "superlongpasswordthatnoonewillknow"
+  password: 'superlongpasswordthatnoonewillknow'
   port: 3286
   reboot_timeout: 2min
   num_attempts: 5
@@ -233,14 +233,14 @@ ota:
         ESP_LOGD("ota", "State %d", state);
   on_begin:
     then:
-      logger.log: "OTA begin"
+      logger.log: 'OTA begin'
   on_progress:
     then:
       lambda: >-
         ESP_LOGD("ota", "Got progress %f", x);
   on_end:
     then:
-      logger.log: "OTA end"
+      logger.log: 'OTA end'
   on_error:
     then:
       lambda: >-
@@ -258,7 +258,7 @@ web_server:
   version: 2
 
 power_supply:
-  id: "atx_power_supply"
+  id: 'atx_power_supply'
   enable_time: 20ms
   keep_on_time: 10s
   pin:
@@ -302,22 +302,22 @@ ble_client:
   - mac_address: C4:4F:33:11:22:33
     id: my_bedjet_ble_client
 mcp23s08:
-  - id: "mcp23s08_hub"
+  - id: 'mcp23s08_hub'
     cs_pin: GPIO12
     deviceaddress: 0
 
 mcp23s17:
-  - id: "mcp23s17_hub"
+  - id: 'mcp23s17_hub'
     cs_pin: GPIO12
     deviceaddress: 1
 
 sensor:
   - platform: ble_client
     ble_client_id: ble_foo
-    name: "Green iTag btn"
-    service_uuid: "ffe0"
-    characteristic_uuid: "ffe1"
-    descriptor_uuid: "ffe2"
+    name: 'Green iTag btn'
+    service_uuid: 'ffe0'
+    characteristic_uuid: 'ffe1'
+    descriptor_uuid: 'ffe2'
     notify: true
     update_interval: never
     lambda: |-
@@ -329,11 +329,11 @@ sensor:
             ESP_LOGD("green_btn", "Button was pressed, val%f", x);
   - platform: adc
     pin: A0
-    name: "Living Room Brightness"
-    update_interval: "1:01"
+    name: 'Living Room Brightness'
+    update_interval: '1:01'
     attenuation: 2.5db
-    unit_of_measurement: "°C"
-    icon: "mdi:water-percent"
+    unit_of_measurement: '°C'
+    icon: 'mdi:water-percent'
     accuracy_decimals: 5
     expire_after: 120s
     setup_priority: -100
@@ -399,9 +399,9 @@ sensor:
           ESP_LOGD("main", "Got raw value %f", x);
       - logger.log:
           level: DEBUG
-          format: "Got raw value %f"
-          args: ["x"]
-      - logger.log: "Got raw value NAN"
+          format: 'Got raw value %f'
+          args: ['x']
+      - logger.log: 'Got raw value NAN'
       - mqtt.publish:
           topic: some/topic
           payload: Hello
@@ -410,7 +410,7 @@ sensor:
   - platform: esp32_hall
     name: ESP32 Hall Sensor
   - platform: ads1115
-    multiplexer: "A0_A1"
+    multiplexer: 'A0_A1'
     gain: 1.024
     id: ${sensorname}_sensor
     filters:
@@ -421,48 +421,48 @@ sensor:
     cs_pin: 5
     phase_a:
       voltage:
-        name: "EMON Line Voltage A"
+        name: 'EMON Line Voltage A'
       current:
-        name: "EMON CT1 Current"
+        name: 'EMON CT1 Current'
       power:
-        name: "EMON Active Power CT1"
+        name: 'EMON Active Power CT1'
       reactive_power:
-        name: "EMON Reactive Power CT1"
+        name: 'EMON Reactive Power CT1'
       power_factor:
-        name: "EMON Power Factor CT1"
+        name: 'EMON Power Factor CT1'
       gain_voltage: 7305
       gain_ct: 27961
     phase_b:
       current:
-        name: "EMON CT2 Current"
+        name: 'EMON CT2 Current'
       power:
-        name: "EMON Active Power CT2"
+        name: 'EMON Active Power CT2'
       reactive_power:
-        name: "EMON Reactive Power CT2"
+        name: 'EMON Reactive Power CT2'
       power_factor:
-        name: "EMON Power Factor CT2"
+        name: 'EMON Power Factor CT2'
       gain_voltage: 7305
       gain_ct: 27961
     phase_c:
       current:
-        name: "EMON CT3 Current"
+        name: 'EMON CT3 Current'
       power:
-        name: "EMON Active Power CT3"
+        name: 'EMON Active Power CT3'
       reactive_power:
-        name: "EMON Reactive Power CT3"
+        name: 'EMON Reactive Power CT3'
       power_factor:
-        name: "EMON Power Factor CT3"
+        name: 'EMON Power Factor CT3'
       gain_voltage: 7305
       gain_ct: 27961
     frequency:
-      name: "EMON Line Frequency"
+      name: 'EMON Line Frequency'
     chip_temperature:
-      name: "EMON Chip Temp A"
+      name: 'EMON Chip Temp A'
     line_frequency: 60Hz
     current_phases: 3
     gain_pga: 2X
   - platform: bh1750
-    name: "Living Room Brightness 3"
+    name: 'Living Room Brightness 3'
     internal: true
     address: 0x23
     update_interval: 30s
@@ -471,7 +471,7 @@ sensor:
     state_topic: livingroom/custom_state_topic
     i2c_id: i2c_bus
   - platform: max44009
-    name: "Outside Brightness 1"
+    name: 'Outside Brightness 1'
     internal: true
     address: 0x4A
     update_interval: 30s
@@ -479,13 +479,13 @@ sensor:
     i2c_id: i2c_bus
   - platform: bme280
     temperature:
-      name: "Outside Temperature"
+      name: 'Outside Temperature'
       oversampling: 16x
     pressure:
-      name: "Outside Pressure"
+      name: 'Outside Pressure'
       oversampling: none
     humidity:
-      name: "Outside Humidity"
+      name: 'Outside Humidity'
       oversampling: 8x
     address: 0x77
     iir_filter: 16x
@@ -493,14 +493,14 @@ sensor:
     i2c_id: i2c_bus
   - platform: bme680
     temperature:
-      name: "Outside Temperature"
+      name: 'Outside Temperature'
       oversampling: 16x
     pressure:
-      name: "Outside Pressure"
+      name: 'Outside Pressure'
     humidity:
-      name: "Outside Humidity"
+      name: 'Outside Humidity'
     gas_resistance:
-      name: "Outside Gas Sensor"
+      name: 'Outside Gas Sensor'
     address: 0x77
     heater:
       temperature: 320
@@ -509,9 +509,9 @@ sensor:
     i2c_id: i2c_bus
   - platform: bmp085
     temperature:
-      name: "Outside Temperature"
+      name: 'Outside Temperature'
     pressure:
-      name: "Outside Pressure"
+      name: 'Outside Pressure'
       filters:
         - lambda: >-
             return x / powf(1.0 - (x / 44330.0), 5.255);
@@ -519,45 +519,45 @@ sensor:
     i2c_id: i2c_bus
   - platform: bmp280
     temperature:
-      name: "Outside Temperature"
+      name: 'Outside Temperature'
       oversampling: 16x
     pressure:
-      name: "Outside Pressure"
+      name: 'Outside Pressure'
     address: 0x77
     update_interval: 15s
     iir_filter: 16x
     i2c_id: i2c_bus
   - platform: dallas
     address: 0x1C0000031EDD2A28
-    name: "Living Room Temperature"
+    name: 'Living Room Temperature'
     resolution: 9
   - platform: dallas
     index: 1
-    name: "Living Room Temperature 2"
+    name: 'Living Room Temperature 2'
   - platform: dht
     pin: GPIO26
     temperature:
-      name: "Living Room Temperature 3"
+      name: 'Living Room Temperature 3'
     humidity:
-      name: "Living Room Humidity 3"
+      name: 'Living Room Humidity 3'
     model: AM2302
     update_interval: 15s
   - platform: dht12
     temperature:
-      name: "Living Room Temperature 4"
+      name: 'Living Room Temperature 4'
     humidity:
-      name: "Living Room Humidity 4"
+      name: 'Living Room Humidity 4'
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: duty_cycle
     pin: GPIO25
     name: Duty Cycle Sensor
   - platform: esp32_hall
-    name: "ESP32 Hall Sensor"
+    name: 'ESP32 Hall Sensor'
     update_interval: 15s
   - platform: ens210
     temperature:
-      name: "Living Room Temperature 5"
+      name: 'Living Room Temperature 5'
     humidity:
       name: 'Living Room Humidity 5'
     update_interval: 15s
@@ -574,14 +574,14 @@ sensor:
     cf_pin: 14
     cf1_pin: 13
     current:
-      name: "HLW8012 Current"
+      name: 'HLW8012 Current'
     voltage:
-      name: "HLW8012 Voltage"
+      name: 'HLW8012 Voltage'
     power:
-      name: "HLW8012 Power"
+      name: 'HLW8012 Power'
       id: hlw8012_power
     energy:
-      name: "HLW8012 Energy"
+      name: 'HLW8012 Energy'
       id: hlw8012_energy
     update_interval: 15s
     current_resistor: 0.001 ohm
@@ -591,54 +591,54 @@ sensor:
     model: hlw8012
   - platform: total_daily_energy
     power_id: hlw8012_power
-    name: "HLW8012 Total Daily Energy"
+    name: 'HLW8012 Total Daily Energy'
   - platform: integration
     sensor: hlw8012_power
-    name: "Integration Sensor"
+    name: 'Integration Sensor'
     time_unit: s
   - platform: integration
     sensor: hlw8012_power
-    name: "Integration Sensor lazy"
+    name: 'Integration Sensor lazy'
     time_unit: s
     min_save_interval: 60s
   - platform: hmc5883l
     address: 0x68
     field_strength_x:
-      name: "HMC5883L Field Strength X"
+      name: 'HMC5883L Field Strength X'
     field_strength_y:
-      name: "HMC5883L Field Strength Y"
+      name: 'HMC5883L Field Strength Y'
     field_strength_z:
-      name: "HMC5883L Field Strength Z"
+      name: 'HMC5883L Field Strength Z'
     heading:
-      name: "HMC5883L Heading"
+      name: 'HMC5883L Heading'
     range: 130uT
     oversampling: 8x
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: honeywellabp
     pressure:
-      name: "Honeywell pressure"
+      name: 'Honeywell pressure'
       min_pressure: 0
       max_pressure: 15
     temperature:
-      name: "Honeywell temperature"
+      name: 'Honeywell temperature'
     cs_pin: GPIO5
   - platform: qmc5883l
     address: 0x0D
     field_strength_x:
-      name: "QMC5883L Field Strength X"
+      name: 'QMC5883L Field Strength X'
     field_strength_y:
-      name: "QMC5883L Field Strength Y"
+      name: 'QMC5883L Field Strength Y'
     field_strength_z:
-      name: "QMC5883L Field Strength Z"
+      name: 'QMC5883L Field Strength Z'
     heading:
-      name: "QMC5883L Heading"
+      name: 'QMC5883L Heading'
     range: 800uT
     oversampling: 256x
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: hx711
-    name: "HX711 Value"
+    name: 'HX711 Value'
     dout_pin: GPIO23
     clk_pin: GPIO25
     gain: 128
@@ -647,13 +647,13 @@ sensor:
     address: 0x40
     shunt_resistance: 0.1 ohm
     current:
-      name: "INA219 Current"
+      name: 'INA219 Current'
     power:
-      name: "INA219 Power"
+      name: 'INA219 Power'
     bus_voltage:
-      name: "INA219 Bus Voltage"
+      name: 'INA219 Bus Voltage'
     shunt_voltage:
-      name: "INA219 Shunt Voltage"
+      name: 'INA219 Shunt Voltage'
     max_voltage: 32.0V
     max_current: 3.2A
     update_interval: 15s
@@ -662,13 +662,13 @@ sensor:
     address: 0x40
     shunt_resistance: 0.1 ohm
     current:
-      name: "INA226 Current"
+      name: 'INA226 Current'
     power:
-      name: "INA226 Power"
+      name: 'INA226 Power'
     bus_voltage:
-      name: "INA226 Bus Voltage"
+      name: 'INA226 Bus Voltage'
     shunt_voltage:
-      name: "INA226 Shunt Voltage"
+      name: 'INA226 Shunt Voltage'
     max_current: 3.2A
     update_interval: 15s
     i2c_id: i2c_bus
@@ -677,17 +677,17 @@ sensor:
     channel_1:
       shunt_resistance: 0.1 ohm
       current:
-        name: "INA3221 Channel 1 Current"
+        name: 'INA3221 Channel 1 Current'
       power:
-        name: "INA3221 Channel 1 Power"
+        name: 'INA3221 Channel 1 Power'
       bus_voltage:
-        name: "INA3221 Channel 1 Bus Voltage"
+        name: 'INA3221 Channel 1 Bus Voltage'
       shunt_voltage:
-        name: "INA3221 Channel 1 Shunt Voltage"
+        name: 'INA3221 Channel 1 Shunt Voltage'
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: kalman_combinator
-    name: "Kalman-filtered temperature"
+    name: 'Kalman-filtered temperature'
     process_std_dev: 0.00139
     sources:
       - source: scd30_temperature
@@ -697,106 +697,106 @@ sensor:
         error: 1.5
   - platform: htu21d
     temperature:
-      name: "Living Room Temperature 6"
+      name: 'Living Room Temperature 6'
     humidity:
-      name: "Living Room Humidity 6"
+      name: 'Living Room Humidity 6'
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: max6675
-    name: "Living Room Temperature"
+    name: 'Living Room Temperature'
     cs_pin: GPIO23
     update_interval: 15s
   - platform: max31855
-    name: "Den Temperature"
+    name: 'Den Temperature'
     cs_pin: GPIO23
     update_interval: 15s
     reference_temperature:
-      name: "MAX31855 Internal Temperature"
+      name: 'MAX31855 Internal Temperature'
   - platform: max31856
-    name: "BBQ Temperature"
+    name: 'BBQ Temperature'
     cs_pin: GPIO17
     update_interval: 15s
     mains_filter: 50Hz
   - platform: max31865
-    name: "Water Tank Temperature"
+    name: 'Water Tank Temperature'
     cs_pin: GPIO23
     update_interval: 15s
-    reference_resistance: "430 Ω"
-    rtd_nominal_resistance: "100 Ω"
+    reference_resistance: '430 Ω'
+    rtd_nominal_resistance: '100 Ω'
   - platform: mhz19
     uart_id: uart0
     co2:
-      name: "MH-Z19 CO2 Value"
+      name: 'MH-Z19 CO2 Value'
     temperature:
-      name: "MH-Z19 Temperature"
+      name: 'MH-Z19 Temperature'
     update_interval: 15s
     automatic_baseline_calibration: false
   - platform: mpu6050
     address: 0x68
     accel_x:
-      name: "MPU6050 Accel X"
+      name: 'MPU6050 Accel X'
     accel_y:
-      name: "MPU6050 Accel Y"
+      name: 'MPU6050 Accel Y'
     accel_z:
-      name: "MPU6050 Accel z"
+      name: 'MPU6050 Accel z'
     gyro_x:
-      name: "MPU6050 Gyro X"
+      name: 'MPU6050 Gyro X'
     gyro_y:
-      name: "MPU6050 Gyro Y"
+      name: 'MPU6050 Gyro Y'
     gyro_z:
-      name: "MPU6050 Gyro z"
+      name: 'MPU6050 Gyro z'
     temperature:
-      name: "MPU6050 Temperature"
+      name: 'MPU6050 Temperature'
     i2c_id: i2c_bus
   - platform: mpu6886
     address: 0x68
     accel_x:
-      name: "MPU6886 Accel X"
+      name: 'MPU6886 Accel X'
     accel_y:
-      name: "MPU6886 Accel Y"
+      name: 'MPU6886 Accel Y'
     accel_z:
-      name: "MPU6886 Accel z"
+      name: 'MPU6886 Accel z'
     gyro_x:
-      name: "MPU6886 Gyro X"
+      name: 'MPU6886 Gyro X'
     gyro_y:
-      name: "MPU6886 Gyro Y"
+      name: 'MPU6886 Gyro Y'
     gyro_z:
-      name: "MPU6886 Gyro z"
+      name: 'MPU6886 Gyro z'
     temperature:
-      name: "MPU6886 Temperature"
+      name: 'MPU6886 Temperature'
     i2c_id: i2c_bus
   - platform: ms5611
     temperature:
-      name: "Outside Temperature"
+      name: 'Outside Temperature'
     pressure:
-      name: "Outside Pressure"
+      name: 'Outside Pressure'
     address: 0x77
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: pmsa003i
     pm_1_0:
-      name: "PMSA003i PM1.0"
+      name: 'PMSA003i PM1.0'
     pm_2_5:
-      name: "PMSA003i PM2.5"
+      name: 'PMSA003i PM2.5'
     pm_10_0:
-      name: "PMSA003i PM10.0"
+      name: 'PMSA003i PM10.0'
     pmc_0_3:
-      name: "PMSA003i PMC <0.3µm"
+      name: 'PMSA003i PMC <0.3µm'
     pmc_0_5:
-      name: "PMSA003i PMC <0.5µm"
+      name: 'PMSA003i PMC <0.5µm'
     pmc_1_0:
-      name: "PMSA003i PMC <1µm"
+      name: 'PMSA003i PMC <1µm'
     pmc_2_5:
-      name: "PMSA003i PMC <2.5µm"
+      name: 'PMSA003i PMC <2.5µm'
     pmc_5_0:
-      name: "PMSA003i PMC <5µm"
+      name: 'PMSA003i PMC <5µm'
     pmc_10_0:
-      name: "PMSA003i PMC <10µm"
+      name: 'PMSA003i PMC <10µm'
     address: 0x12
     standard_units: True
     i2c_id: i2c_bus
   - platform: pulse_counter
-    name: "Pulse Counter"
+    name: 'Pulse Counter'
     pin: GPIO12
     count_mode:
       rising_edge: INCREMENT
@@ -804,7 +804,7 @@ sensor:
     internal_filter: 13us
     update_interval: 15s
   - platform: pulse_meter
-    name: "Pulse Meter"
+    name: 'Pulse Meter'
     id: pulse_meter_sensor
     pin: GPIO12
     internal_filter: 100ms
@@ -814,20 +814,20 @@ sensor:
           id: pulse_meter_sensor
           value: 12345
     total:
-      name: "Pulse Meter Total"
+      name: 'Pulse Meter Total'
   - platform: qmp6988
     temperature:
-      name: "Living Temperature QMP"
+      name: 'Living Temperature QMP'
       oversampling: 32x
     pressure:
-      name: "Living Pressure QMP"
+      name: 'Living Pressure QMP'
       oversampling: 2x
     address: 0x70
     update_interval: 30s
     iir_filter: 16x
     i2c_id: i2c_bus
   - platform: rotary_encoder
-    name: "Rotary Encoder"
+    name: 'Rotary Encoder'
     id: rotary_encoder1
     pin_a: GPIO23
     pin_b: GPIO25
@@ -845,51 +845,51 @@ sensor:
           value: 10
       - sensor.rotary_encoder.set_value:
           id: rotary_encoder1
-          value: !lambda "return -1;"
+          value: !lambda 'return -1;'
     on_clockwise:
-      - logger.log: "Clockwise"
+      - logger.log: 'Clockwise'
     on_anticlockwise:
-      - logger.log: "Anticlockwise"
+      - logger.log: 'Anticlockwise'
   - platform: pulse_width
     name: Pulse Width
     pin: GPIO12
   - platform: sm300d2
     uart_id: uart0
     co2:
-      name: "SM300D2 CO2 Value"
+      name: 'SM300D2 CO2 Value'
     formaldehyde:
-      name: "SM300D2 Formaldehyde Value"
+      name: 'SM300D2 Formaldehyde Value'
     tvoc:
-      name: "SM300D2 TVOC Value"
+      name: 'SM300D2 TVOC Value'
     pm_2_5:
-      name: "SM300D2 PM2.5 Value"
+      name: 'SM300D2 PM2.5 Value'
     pm_10_0:
-      name: "SM300D2 PM10 Value"
+      name: 'SM300D2 PM10 Value'
     temperature:
-      name: "SM300D2 Temperature Value"
+      name: 'SM300D2 Temperature Value'
     humidity:
-      name: "SM300D2 Humidity Value"
+      name: 'SM300D2 Humidity Value'
     update_interval: 60s
   - platform: sht3xd
     temperature:
-      name: "Living Room Temperature 8"
+      name: 'Living Room Temperature 8'
     humidity:
-      name: "Living Room Humidity 8"
+      name: 'Living Room Humidity 8'
     address: 0x44
     i2c_id: i2c_bus
     update_interval: 15s
   - platform: sts3x
-    name: "Living Room Temperature 9"
+    name: 'Living Room Temperature 9'
     address: 0x4A
     i2c_id: i2c_bus
   - platform: scd30
     co2:
-      name: "Living Room CO2 9"
+      name: 'Living Room CO2 9'
     temperature:
       id: scd30_temperature
-      name: "Living Room Temperature 9"
+      name: 'Living Room Temperature 9'
     humidity:
-      name: "Living Room Humidity 9"
+      name: 'Living Room Humidity 9'
     address: 0x61
     update_interval: 15s
     automatic_self_calibration: true
@@ -900,12 +900,12 @@ sensor:
   - platform: scd4x
     id: scd40
     co2:
-      name: "SCD4X CO2"
+      name: 'SCD4X CO2'
     temperature:
       id: scd4x_temperature
-      name: "SCD4X Temperature"
+      name: 'SCD4X Temperature'
     humidity:
-      name: "SCD4X Humidity"
+      name: 'SCD4X Humidity'
     update_interval: 15s
     automatic_self_calibration: true
     altitude_compensation: 10m
@@ -914,63 +914,63 @@ sensor:
     i2c_id: i2c_bus
   - platform: sgp30
     eco2:
-      name: "Workshop eCO2"
+      name: 'Workshop eCO2'
       accuracy_decimals: 1
     tvoc:
-      name: "Workshop TVOC"
+      name: 'Workshop TVOC'
       accuracy_decimals: 1
     address: 0x58
     update_interval: 5s
     i2c_id: i2c_bus
   - platform: sps30
     pm_1_0:
-      name: "Workshop PM <1µm Weight concentration"
-      id: "workshop_PM_1_0"
+      name: 'Workshop PM <1µm Weight concentration'
+      id: 'workshop_PM_1_0'
     pm_2_5:
-      name: "Workshop PM <2.5µm Weight concentration"
-      id: "workshop_PM_2_5"
+      name: 'Workshop PM <2.5µm Weight concentration'
+      id: 'workshop_PM_2_5'
     pm_4_0:
-      name: "Workshop PM <4µm Weight concentration"
-      id: "workshop_PM_4_0"
+      name: 'Workshop PM <4µm Weight concentration'
+      id: 'workshop_PM_4_0'
     pm_10_0:
-      name: "Workshop PM <10µm Weight concentration"
-      id: "workshop_PM_10_0"
+      name: 'Workshop PM <10µm Weight concentration'
+      id: 'workshop_PM_10_0'
     pmc_0_5:
-      name: "Workshop PM <0.5µm Number concentration"
-      id: "workshop_PMC_0_5"
+      name: 'Workshop PM <0.5µm Number concentration'
+      id: 'workshop_PMC_0_5'
     pmc_1_0:
-      name: "Workshop PM <1µm Number concentration"
-      id: "workshop_PMC_1_0"
+      name: 'Workshop PM <1µm Number concentration'
+      id: 'workshop_PMC_1_0'
     pmc_2_5:
-      name: "Workshop PM <2.5µm Number concentration"
-      id: "workshop_PMC_2_5"
+      name: 'Workshop PM <2.5µm Number concentration'
+      id: 'workshop_PMC_2_5'
     pmc_4_0:
-      name: "Workshop PM <4µm Number concentration"
-      id: "workshop_PMC_4_0"
+      name: 'Workshop PM <4µm Number concentration'
+      id: 'workshop_PMC_4_0'
     pmc_10_0:
-      name: "Workshop PM <10µm Number concentration"
-      id: "workshop_PMC_10_0"
+      name: 'Workshop PM <10µm Number concentration'
+      id: 'workshop_PMC_10_0'
     address: 0x69
     update_interval: 10s
     i2c_id: i2c_bus
   - platform: sht4x
     temperature:
-      name: "SHT4X Temperature"
+      name: 'SHT4X Temperature'
     humidity:
-      name: "SHT4X Humidity"
+      name: 'SHT4X Humidity'
     address: 0x44
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: shtcx
     temperature:
-      name: "Living Room Temperature 10"
+      name: 'Living Room Temperature 10'
     humidity:
-      name: "Living Room Humidity 10"
+      name: 'Living Room Humidity 10'
     address: 0x70
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: template
-    name: "Template Sensor"
+    name: 'Template Sensor'
     state_class: measurement
     id: template_sensor
     lambda: |-
@@ -986,9 +986,9 @@ sensor:
           state: 43.0
       - sensor.template.publish:
           id: template_sensor
-          state: !lambda "return NAN;"
+          state: !lambda 'return NAN;'
   - platform: tsl2561
-    name: "TSL2561 Ambient Light"
+    name: 'TSL2561 Ambient Light'
     address: 0x39
     update_interval: 15s
     is_cs_package: true
@@ -1002,17 +1002,17 @@ sensor:
     integration_time: 600ms
     gain: high
     visible:
-      name: "tsl2591 visible"
+      name: 'tsl2591 visible'
       id: tsl2591_vis
-      unit_of_measurement: "pH"
+      unit_of_measurement: 'pH'
     infrared:
-      name: "tsl2591 infrared"
+      name: 'tsl2591 infrared'
       id: tsl2591_ir
     full_spectrum:
-      name: "tsl2591 full_spectrum"
+      name: 'tsl2591 full_spectrum'
       id: tsl2591_fs
     calculated_lux:
-      name: "tsl2591 calculated_lux"
+      name: 'tsl2591 calculated_lux'
       id: tsl2591_cl
     i2c_id: i2c_bus
   - platform: ultrasonic
@@ -1020,17 +1020,17 @@ sensor:
     echo_pin:
       number: GPIO23
       inverted: true
-    name: "Ultrasonic Sensor"
+    name: 'Ultrasonic Sensor'
     timeout: 5.5m
     id: ultrasonic_sensor1
   - platform: uptime
     name: Uptime Sensor
   - platform: wifi_signal
-    name: "WiFi Signal Sensor"
+    name: 'WiFi Signal Sensor'
     update_interval: 15s
   - platform: mqtt_subscribe
-    name: "MQTT Subscribe Sensor 1"
-    topic: "mqtt/topic"
+    name: 'MQTT Subscribe Sensor 1'
+    topic: 'mqtt/topic'
     id: the_sensor
     qos: 2
     on_value:
@@ -1042,9 +1042,9 @@ sensor:
   - platform: sds011
     uart_id: uart0
     pm_2_5:
-      name: "SDS011 PM2.5"
+      name: 'SDS011 PM2.5'
     pm_10_0:
-      name: "SDS011 PM10.0"
+      name: 'SDS011 PM10.0'
     update_interval: 5min
     rx_only: false
   - platform: ccs811
@@ -1057,9 +1057,9 @@ sensor:
     i2c_id: i2c_bus
   - platform: tx20
     wind_speed:
-      name: "Windspeed"
+      name: 'Windspeed'
     wind_direction_degrees:
-      name: "Winddirection Degrees"
+      name: 'Winddirection Degrees'
     pin:
       number: GPIO04
       mode: INPUT
@@ -1067,48 +1067,48 @@ sensor:
     clock_pin: GPIO5
     data_pin: GPIO4
     co2:
-      name: "ZyAura CO2"
+      name: 'ZyAura CO2'
     temperature:
-      name: "ZyAura Temperature"
+      name: 'ZyAura Temperature'
     humidity:
-      name: "ZyAura Humidity"
+      name: 'ZyAura Humidity'
   - platform: as3935
     lightning_energy:
-      name: "Lightning Energy"
+      name: 'Lightning Energy'
     distance:
-      name: "Distance Storm"
+      name: 'Distance Storm'
   - platform: tmp117
-    name: "TMP117 Temperature"
+    name: 'TMP117 Temperature'
     update_interval: 5s
     i2c_id: i2c_bus
   - platform: hm3301
     pm_1_0:
-      name: "PM1.0"
+      name: 'PM1.0'
     pm_2_5:
-      name: "PM2.5"
+      name: 'PM2.5'
     pm_10_0:
-      name: "PM10.0"
+      name: 'PM10.0'
     aqi:
-      name: "AQI"
-      calculation_type: "CAQI"
+      name: 'AQI'
+      calculation_type: 'CAQI'
     i2c_id: i2c_bus
   - platform: teleinfo
-    tag_name: "HCHC"
-    name: "hchc"
-    unit_of_measurement: "Wh"
+    tag_name: 'HCHC'
+    name: 'hchc'
+    unit_of_measurement: 'Wh'
     icon: mdi:flash
     teleinfo_id: myteleinfo
   - platform: mcp9808
-    name: "MCP9808 Temperature"
+    name: 'MCP9808 Temperature'
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: ezo
     id: ph_ezo
     address: 99
-    unit_of_measurement: "pH"
+    unit_of_measurement: 'pH'
     i2c_id: i2c_bus
   - platform: sdp3x
-    name: "HVAC Filter Pressure drop"
+    name: 'HVAC Filter Pressure drop'
     id: filter_pressure
     update_interval: 5s
     accuracy_decimals: 3
@@ -1116,11 +1116,11 @@ sensor:
   - platform: cs5460a
     id: cs5460a1
     current:
-      name: "Socket current"
+      name: 'Socket current'
     voltage:
-      name: "Mains voltage"
+      name: 'Mains voltage'
     power:
-      name: "Socket power"
+      name: 'Socket power'
       on_value:
         then:
           cs5460a.restart: cs5460a1
@@ -1149,7 +1149,6 @@ sensor:
       name: Max9611 Temp
     update_interval: 1s
 
-
 esp32_touch:
   setup_mode: False
   iir_filter: 10ms
@@ -1161,7 +1160,7 @@ esp32_touch:
 
 binary_sensor:
   - platform: gpio
-    name: "MCP23S08 Pin #1"
+    name: 'MCP23S08 Pin #1'
     pin:
       mcp23xxx: mcp23s08_hub
       # Use pin number 1
@@ -1170,7 +1169,7 @@ binary_sensor:
       mode: INPUT_PULLUP
       inverted: False
   - platform: gpio
-    name: "MCP23S17 Pin #1"
+    name: 'MCP23S17 Pin #1'
     pin:
       mcp23xxx: mcp23s17_hub
       # Use pin number 1
@@ -1179,7 +1178,7 @@ binary_sensor:
       mode: INPUT_PULLUP
       inverted: False
   - platform: gpio
-    name: "MCP23S17 Pin #1 with interrupt"
+    name: 'MCP23S17 Pin #1 with interrupt'
     pin:
       mcp23xxx: mcp23s17_hub
       # Use pin number 1
@@ -1190,7 +1189,7 @@ binary_sensor:
       interrupt: FALLING
   - platform: gpio
     pin: GPIO9
-    name: "Living Room Window"
+    name: 'Living Room Window'
     device_class: window
     filters:
       - invert:
@@ -1230,7 +1229,7 @@ binary_sensor:
           - OFF for at least 0.2s
         then:
           - logger.log:
-              format: "Multi Clicked TWO"
+              format: 'Multi Clicked TWO'
               level: warn
       - timing:
           - OFF for 1s to 2s
@@ -1238,30 +1237,30 @@ binary_sensor:
           - OFF for at least 0.5s
         then:
           - logger.log:
-              format: "Multi Clicked LONG SINGLE"
+              format: 'Multi Clicked LONG SINGLE'
               level: warn
       - timing:
           - ON for at most 1s
           - OFF for at least 0.5s
         then:
           - logger.log:
-              format: "Multi Clicked SINGLE"
+              format: 'Multi Clicked SINGLE'
               level: warn
     id: binary_sensor1
   - platform: gpio
     pin:
       number: GPIO9
       mode: INPUT_PULLUP
-    name: "Living Room Window 2"
+    name: 'Living Room Window 2'
   - platform: status
-    name: "Living Room Status"
+    name: 'Living Room Status'
   - platform: esp32_touch
-    name: "ESP32 Touch Pad GPIO27"
+    name: 'ESP32 Touch Pad GPIO27'
     pin: GPIO27
     threshold: 1000
     id: btn_left
   - platform: template
-    name: "Garage Door Open"
+    name: 'Garage Door Open'
     id: garage_door
     lambda: |-
       if (isnan(id(${sensorname}_sensor).state)) {
@@ -1285,37 +1284,37 @@ binary_sensor:
           frequency: 500.0Hz
       - output.ledc.set_frequency:
           id: gpio_19
-          frequency: !lambda "return 500.0;"
+          frequency: !lambda 'return 500.0;'
   - platform: pn532
     pn532_id: pn532_bs
     uid: 74-10-37-94
-    name: "PN532 NFC Tag"
+    name: 'PN532 NFC Tag'
   - platform: rdm6300
     uid: 7616525
-    name: "RDM6300 NFC Tag"
+    name: 'RDM6300 NFC Tag'
   - platform: gpio
-    name: "PCF binary sensor"
+    name: 'PCF binary sensor'
     pin:
       pcf8574: pcf8574_hub
       number: 1
       mode: INPUT
       inverted: True
   - platform: gpio
-    name: "MCP21 binary sensor"
+    name: 'MCP21 binary sensor'
     pin:
       mcp23xxx: mcp23017_hub
       number: 1
       mode: INPUT
       inverted: True
   - platform: gpio
-    name: "MCP22 binary sensor"
+    name: 'MCP22 binary sensor'
     pin:
       mcp23xxx: mcp23008_hub
       number: 7
       mode: INPUT_PULLUP
       inverted: False
   - platform: gpio
-    name: "MCP23 binary sensor"
+    name: 'MCP23 binary sensor'
     pin:
       mcp23016: mcp23016_hub
       number: 7
@@ -1323,7 +1322,7 @@ binary_sensor:
       inverted: False
 
   - platform: remote_receiver
-    name: "Raw Remote Receiver Test"
+    name: 'Raw Remote Receiver Test'
     raw:
       code:
         [
@@ -1364,7 +1363,7 @@ binary_sensor:
           1709,
         ]
   - platform: as3935
-    name: "Storm Alert"
+    name: 'Storm Alert'
   - platform: analog_threshold
     name: Analog Trheshold 1
     sensor_id: template_sensor
@@ -1443,39 +1442,39 @@ output:
   - platform: tlc59208f
     id: tlc_0
     channel: 0
-    tlc59208f_id: "tlc59208f_1"
+    tlc59208f_id: 'tlc59208f_1'
   - platform: tlc59208f
     id: tlc_1
     channel: 1
-    tlc59208f_id: "tlc59208f_1"
+    tlc59208f_id: 'tlc59208f_1'
   - platform: tlc59208f
     id: tlc_2
     channel: 2
-    tlc59208f_id: "tlc59208f_1"
+    tlc59208f_id: 'tlc59208f_1'
   - platform: tlc59208f
     id: tlc_3
     channel: 0
-    tlc59208f_id: "tlc59208f_2"
+    tlc59208f_id: 'tlc59208f_2'
   - platform: tlc59208f
     id: tlc_4
     channel: 1
-    tlc59208f_id: "tlc59208f_2"
+    tlc59208f_id: 'tlc59208f_2'
   - platform: tlc59208f
     id: tlc_5
     channel: 2
-    tlc59208f_id: "tlc59208f_2"
+    tlc59208f_id: 'tlc59208f_2'
   - platform: tlc59208f
     id: tlc_6
     channel: 0
-    tlc59208f_id: "tlc59208f_3"
+    tlc59208f_id: 'tlc59208f_3'
   - platform: tlc59208f
     id: tlc_7
     channel: 1
-    tlc59208f_id: "tlc59208f_3"
+    tlc59208f_id: 'tlc59208f_3'
   - platform: tlc59208f
     id: tlc_8
     channel: 2
-    tlc59208f_id: "tlc59208f_3"
+    tlc59208f_id: 'tlc59208f_3'
   - platform: gpio
     id: id2
     pin:
@@ -1563,12 +1562,12 @@ e131:
 
 light:
   - platform: binary
-    name: "Desk Lamp"
+    name: 'Desk Lamp'
     output: gpio_26
     effects:
       - strobe:
       - strobe:
-          name: "My Strobe"
+          name: 'My Strobe'
           colors:
             - state: True
               duration: 250ms
@@ -1583,7 +1582,7 @@ light:
           id: livingroom_lights
           state: yes
   - platform: monochromatic
-    name: "Kitchen Lights"
+    name: 'Kitchen Lights'
     id: kitchen
     output: gpio_19
     gamma_correct: 2.8
@@ -1592,7 +1591,7 @@ light:
       - strobe:
       - flicker:
       - flicker:
-          name: "My Flicker"
+          name: 'My Flicker'
           alpha: 98%
           intensity: 1.5%
       - lambda:
@@ -1604,20 +1603,20 @@ light:
             if (state == 4)
               state = 0;
   - platform: rgb
-    name: "Living Room Lights"
+    name: 'Living Room Lights'
     id: ${roomname}_lights
     red: pca_0
     green: pca_1
     blue: pca_2
   - platform: rgbw
-    name: "Living Room Lights 2"
+    name: 'Living Room Lights 2'
     red: pca_3
     green: pca_4
     blue: pca_5
     white: pca_6
     color_interlock: true
   - platform: rgbww
-    name: "Living Room Lights 2"
+    name: 'Living Room Lights 2'
     red: pca_3
     green: pca_4
     blue: pca_5
@@ -1627,7 +1626,7 @@ light:
     warm_white_color_temperature: 500 mireds
     color_interlock: true
   - platform: rgbct
-    name: "Living Room Lights 2"
+    name: 'Living Room Lights 2'
     red: pca_3
     green: pca_4
     blue: pca_5
@@ -1637,14 +1636,14 @@ light:
     warm_white_color_temperature: 500 mireds
     color_interlock: true
   - platform: cwww
-    name: "Living Room Lights 2"
+    name: 'Living Room Lights 2'
     cold_white: pca_6
     warm_white: pca_6
     cold_white_color_temperature: 153 mireds
     warm_white_color_temperature: 500 mireds
     constant_brightness: true
   - platform: color_temperature
-    name: "Living Room Lights 2"
+    name: 'Living Room Lights 2'
     color_temperature: pca_6
     brightness: pca_6
     cold_white_color_temperature: 153 mireds
@@ -1658,7 +1657,7 @@ light:
     max_refresh_rate: 20ms
     power_supply: atx_power_supply
     color_correct: [75%, 100%, 50%]
-    name: "FastLED WS2811 Light"
+    name: 'FastLED WS2811 Light'
     effects:
       - addressable_color_wipe:
       - addressable_color_wipe:
@@ -1701,7 +1700,7 @@ light:
           update_interval: 16ms
           intensity: 5%
       - addressable_lambda:
-          name: "Test For Custom Lambda Effect"
+          name: 'Test For Custom Lambda Effect'
           lambda: |-
             if (initial_run) {
               it[0] = current_color;
@@ -1737,10 +1736,10 @@ light:
     data_rate: 2MHz
     num_leds: 60
     rgb_order: BRG
-    name: "FastLED SPI Light"
+    name: 'FastLED SPI Light'
   - platform: neopixelbus
     id: addr3
-    name: "Neopixelbus Light"
+    name: 'Neopixelbus Light'
     gamma_correct: 2.8
     color_correct: [0.0, 0.0, 0.0, 0.0]
     default_transition_length: 10s
@@ -1756,7 +1755,7 @@ light:
     num_leds: 60
     pin: GPIO23
   - platform: partition
-    name: "Partition Light"
+    name: 'Partition Light'
     segments:
       - id: addr1
         from: 0
@@ -1770,15 +1769,15 @@ light:
       - single_light_id: ${roomname}_lights
 
   - platform: shelly_dimmer
-    name: "Shelly Dimmer Light"
+    name: 'Shelly Dimmer Light'
     power:
-      name: "Shelly Dimmer Power"
+      name: 'Shelly Dimmer Power'
     voltage:
-      name: "Shelly Dimmer Voltage"
+      name: 'Shelly Dimmer Voltage'
     current:
-      name: "Shelly Dimmer Current"
+      name: 'Shelly Dimmer Current'
     max_brightness: 500
-    firmware: "51.6"
+    firmware: '51.6'
     uart_id: uart0
 
 remote_transmitter:
@@ -1846,7 +1845,7 @@ climate:
     use_fahrenheit: true
   - platform: midea
     on_state:
-      logger.log: "State changed!"
+      logger.log: 'State changed!'
     id: midea_unit
     uart_id: uart0
     name: Midea Climate
@@ -1880,11 +1879,11 @@ climate:
       - HORIZONTAL
       - BOTH
     outdoor_temperature:
-      name: "Temp"
+      name: 'Temp'
     power_usage:
-      name: "Power"
+      name: 'Power'
     humidity_setpoint:
-      name: "Humidity"
+      name: 'Humidity'
   - platform: anova
     name: Anova cooker
     ble_client_id: ble_blah
@@ -1922,7 +1921,7 @@ switch:
       remote_transmitter.transmit_midea:
         code: [0xA2, 0x08, 0xFF, 0xFF, 0xFF]
   - platform: gpio
-    name: "MCP23S08 Pin #0"
+    name: 'MCP23S08 Pin #0'
     pin:
       mcp23xxx: mcp23s08_hub
       # Use pin number 0
@@ -1930,7 +1929,7 @@ switch:
       mode: OUTPUT
       inverted: False
   - platform: gpio
-    name: "MCP23S17 Pin #0"
+    name: 'MCP23S17 Pin #0'
     pin:
       mcp23xxx: mcp23s17_hub
       # Use pin number 0
@@ -1939,8 +1938,8 @@ switch:
       inverted: False
   - platform: gpio
     pin: GPIO25
-    name: "Living Room Dehumidifier"
-    icon: "mdi:restart"
+    name: 'Living Room Dehumidifier'
+    icon: 'mdi:restart'
     inverted: True
     command_topic: custom_command_topic
     command_retain: true
@@ -2010,14 +2009,14 @@ switch:
     name: RC Switch Raw
     turn_on_action:
       remote_transmitter.transmit_rc_switch_raw:
-        code: "00101001100111110101xxxx"
+        code: '00101001100111110101xxxx'
         protocol: 1
   - platform: template
     name: RC Switch Type A
     turn_on_action:
       remote_transmitter.transmit_rc_switch_type_a:
-        group: "11001"
-        device: "01000"
+        group: '11001'
+        device: '01000'
         state: True
         protocol:
           pulse_length: 175
@@ -2036,7 +2035,7 @@ switch:
     name: RC Switch Type C
     turn_on_action:
       remote_transmitter.transmit_rc_switch_type_c:
-        family: "a"
+        family: 'a'
         group: 1
         device: 2
         state: True
@@ -2044,7 +2043,7 @@ switch:
     name: RC Switch Type D
     turn_on_action:
       remote_transmitter.transmit_rc_switch_type_d:
-        group: "a"
+        group: 'a'
         device: 2
         state: True
   - platform: template
@@ -2070,19 +2069,19 @@ switch:
           level: 50%
       - output.set_level:
           id: gpio_19
-          level: !lambda "return 0.5;"
+          level: !lambda 'return 0.5;'
       - output.set_level:
           id: dac_output
           level: 50%
       - output.set_level:
           id: dac_output
-          level: !lambda "return 0.5;"
+          level: !lambda 'return 0.5;'
       - output.set_level:
           id: mcp4725_dac_output
-          level: !lambda "return 0.5;"
+          level: !lambda 'return 0.5;'
       - output.set_level:
           id: mcp4728_dac_output_a
-          level: !lambda "return 0.5;"
+          level: !lambda 'return 0.5;'
     turn_off_action:
       - switch.turn_on: living_room_lights_off
     restore_state: False
@@ -2091,16 +2090,16 @@ switch:
           id: livingroom_lights
           state: yes
   - platform: restart
-    name: "Living Room Restart"
+    name: 'Living Room Restart'
   - platform: safe_mode
-    name: "Living Room Restart (Safe Mode)"
+    name: 'Living Room Restart (Safe Mode)'
   - platform: shutdown
-    name: "Living Room Shutdown"
+    name: 'Living Room Shutdown'
   - platform: output
-    name: "Generic Output"
+    name: 'Generic Output'
     output: pca_6
   - platform: template
-    name: "Template Switch"
+    name: 'Template Switch'
     id: my_switch
     lambda: |-
       if (id(binary_sensor1).state) {
@@ -2123,18 +2122,18 @@ switch:
     on_turn_off:
       - switch.template.publish:
           id: my_switch
-          state: !lambda "return false;"
+          state: !lambda 'return false;'
   - platform: uart
     uart_id: uart0
-    name: "UART String Output"
-    data: "DataToSend"
+    name: 'UART String Output'
+    data: 'DataToSend'
   - platform: uart
     uart_id: uart0
-    name: "UART Bytes Output"
+    name: 'UART Bytes Output'
     data: [0xDE, 0xAD, 0xBE, 0xEF]
   - platform: uart
     uart_id: uart0
-    name: "UART Recurring Output"
+    name: 'UART Recurring Output'
     data: [0xDE, 0xAD, 0xBE, 0xEF]
     send_every: 1s
   - platform: template
@@ -2155,7 +2154,7 @@ switch:
           position: 0
 
   - platform: gpio
-    name: "SN74HC595 Pin #0"
+    name: 'SN74HC595 Pin #0'
     pin:
       sn74hc595: sn74hc595_hub
       # Use pin number 0
@@ -2172,7 +2171,7 @@ switch:
 fan:
   - platform: binary
     output: gpio_26
-    name: "Living Room Fan 1"
+    name: 'Living Room Fan 1'
     oscillation_output: gpio_19
     direction_output: gpio_26
   - platform: speed
@@ -2180,7 +2179,7 @@ fan:
     icon: mdi:weather-windy
     output: pca_6
     speed_count: 10
-    name: "Living Room Fan 2"
+    name: 'Living Room Fan 2'
     oscillation_output: gpio_19
     direction_output: gpio_26
     oscillation_state_topic: oscillation/state/topic
@@ -2191,10 +2190,10 @@ fan:
     speed_command_topic: speed/command/topic
     on_speed_set:
       then:
-        - logger.log: "Fan speed was changed!"
+        - logger.log: 'Fan speed was changed!'
   - platform: copy
     source_id: fan_speed
-    name: "Fan Speed Copy"
+    name: 'Fan Speed Copy'
 
 interval:
   - interval: 10s
@@ -2219,7 +2218,7 @@ interval:
               id: display1
               page_id: page1
           then:
-            - logger.log: "Seeing page 1"
+            - logger.log: 'Seeing page 1'
 
 color:
   - id: kbx_red
@@ -2291,7 +2290,7 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ssd1306_i2c
-    model: "SSD1306_128X64"
+    model: 'SSD1306_128X64'
     reset_pin: GPIO23
     address: 0x3C
     id: display1
@@ -2312,28 +2311,28 @@ display:
           ESP_LOGD("display", "1 -> 2");
     i2c_id: i2c_bus
   - platform: ssd1306_spi
-    model: "SSD1306 128x64"
+    model: 'SSD1306 128x64'
     cs_pin: GPIO23
     dc_pin: GPIO23
     reset_pin: GPIO23
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ssd1322_spi
-    model: "SSD1322 256x64"
+    model: 'SSD1322 256x64'
     cs_pin: GPIO23
     dc_pin: GPIO23
     reset_pin: GPIO23
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ssd1325_spi
-    model: "SSD1325 128x64"
+    model: 'SSD1325 128x64'
     cs_pin: GPIO23
     dc_pin: GPIO23
     reset_pin: GPIO23
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ssd1327_i2c
-    model: "SSD1327 128X128"
+    model: 'SSD1327 128X128'
     reset_pin: GPIO23
     address: 0x3D
     id: display1327
@@ -2347,7 +2346,7 @@ display:
           // Nothing
     i2c_id: i2c_bus
   - platform: ssd1327_spi
-    model: "SSD1327 128x128"
+    model: 'SSD1327 128x128'
     cs_pin: GPIO23
     dc_pin: GPIO23
     reset_pin: GPIO23
@@ -2360,7 +2359,7 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ssd1351_spi
-    model: "SSD1351 128x128"
+    model: 'SSD1351 128x128'
     cs_pin: GPIO23
     dc_pin: GPIO23
     reset_pin: GPIO23
@@ -2382,7 +2381,7 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: st7735
-    model: "INITR_BLACKTAB"
+    model: 'INITR_BLACKTAB'
     cs_pin: GPIO5
     dc_pin: GPIO16
     reset_pin: GPIO23
@@ -2394,7 +2393,7 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ili9341
-    model: "TFT 2.4"
+    model: 'TFT 2.4'
     cs_pin: GPIO5
     dc_pin: GPIO4
     reset_pin: GPIO22
@@ -2404,7 +2403,7 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ili9341
-    model: "TFT 2.4"
+    model: 'TFT 2.4'
     cs_pin: GPIO5
     dc_pin: GPIO4
     reset_pin: GPIO22
@@ -2440,13 +2439,13 @@ pn532_spi:
         ESP_LOGD("main", "Found tag %s", x.c_str());
     - mqtt.publish:
         topic: the/topic
-        payload: !lambda "return x;"
+        payload: !lambda 'return x;'
   on_tag_removed:
     - lambda: |-
         ESP_LOGD("main", "Removed tag %s", x.c_str());
     - mqtt.publish:
         topic: the/topic
-        payload: !lambda "return x;"
+        payload: !lambda 'return x;'
 
 pn532_i2c:
   i2c_id: i2c_bus
@@ -2491,7 +2490,7 @@ time:
       - 1.pool.ntp.org
       - 192.168.178.1
     on_time:
-      cron: "/30 0-30,30/5 * ? JAN-DEC MON,SAT-SUN,TUE-FRI"
+      cron: '/30 0-30,30/5 * ? JAN-DEC MON,SAT-SUN,TUE-FRI'
       then:
         - lambda: 'ESP_LOGD("main", "time");'
   - platform: gps
@@ -2509,7 +2508,7 @@ time:
 
 cover:
   - platform: template
-    name: "Template Cover"
+    name: 'Template Cover'
     id: template_cover
     lambda: |-
       if (id(binary_sensor1).state) {
@@ -2526,7 +2525,7 @@ cover:
     has_position: yes
     position_state_topic: position/state/topic
     position_command_topic: position/command/topic
-    tilt_lambda: !lambda "return 0.5;"
+    tilt_lambda: !lambda 'return 0.5;'
     tilt_state_topic: tilt/state/topic
     tilt_command_topic: tilt/command/topic
     on_open:
@@ -2536,7 +2535,7 @@ cover:
       then:
         - lambda: 'ESP_LOGD("cover", "closed");'
   - platform: am43
-    name: "Test AM43"
+    name: 'Test AM43'
     id: am43_test
     ble_client_id: ble_foo
     icon: mdi:blinds
@@ -2555,24 +2554,24 @@ tca9548a:
     i2c_id: multiplex0_chan0
 
 pcf8574:
-  - id: "pcf8574_hub"
+  - id: 'pcf8574_hub'
     address: 0x21
     pcf8575: False
     i2c_id: i2c_bus
 
 mcp23017:
-  - id: "mcp23017_hub"
-    open_drain_interrupt: "true"
+  - id: 'mcp23017_hub'
+    open_drain_interrupt: 'true'
     i2c_id: i2c_bus
 
 mcp23008:
-  - id: "mcp23008_hub"
+  - id: 'mcp23008_hub'
     address: 0x22
-    open_drain_interrupt: "true"
+    open_drain_interrupt: 'true'
     i2c_id: i2c_bus
 
 mcp23016:
-  - id: "mcp23016_hub"
+  - id: 'mcp23016_hub'
     address: 0x23
     i2c_id: i2c_bus
 
@@ -2590,15 +2589,15 @@ globals:
   - id: glob_int
     type: int
     restore_value: yes
-    initial_value: "0"
+    initial_value: '0'
   - id: glob_float
     type: float
     restore_value: yes
-    initial_value: "0.0f"
+    initial_value: '0.0f'
   - id: glob_bool
     type: bool
     restore_value: no
-    initial_value: "true"
+    initial_value: 'true'
   - id: glob_string
     type: std::string
     restore_value: no
@@ -2606,7 +2605,7 @@ globals:
   - id: glob_bool_processed
     type: bool
     restore_value: no
-    initial_value: "false"
+    initial_value: 'false'
 
 text_sensor:
   - platform: ble_client
@@ -2622,8 +2621,8 @@ text_sensor:
         - lambda: |-
             ESP_LOGD("green_btn", "Location changed: %s", x.c_str());
   - platform: mqtt_subscribe
-    name: "MQTT Subscribe Text"
-    topic: "the/topic"
+    name: 'MQTT Subscribe Text'
+    topic: 'the/topic'
     qos: 2
     on_value:
       - text_sensor.template.publish:
@@ -2635,7 +2634,7 @@ text_sensor:
             return "Hello World2";
       - globals.set:
           id: glob_int
-          value: "0"
+          value: '0'
       - canbus.send:
           canbus_id: mcp2515_can
           can_id: 23
@@ -2659,25 +2658,25 @@ text_sensor:
     id: ${textname}_text
   - platform: wifi_info
     scan_results:
-      name: "Scan Results"
+      name: 'Scan Results'
     ip_address:
-      name: "IP Address"
+      name: 'IP Address'
     ssid:
-      name: "SSID"
+      name: 'SSID'
     bssid:
-      name: "BSSID"
+      name: 'BSSID'
     mac_address:
-      name: "Mac Address"
+      name: 'Mac Address'
   - platform: version
-    name: "ESPHome Version No Timestamp"
+    name: 'ESPHome Version No Timestamp'
     hide_timestamp: True
   - platform: teleinfo
-    tag_name: "OPTARIF"
-    name: "optarif"
+    tag_name: 'OPTARIF'
+    name: 'optarif'
     teleinfo_id: myteleinfo
 
 sn74hc595:
-  - id: "sn74hc595_hub"
+  - id: 'sn74hc595_hub'
     data_pin: GPIO21
     clock_pin: GPIO23
     latch_pin: GPIO22
@@ -2703,10 +2702,10 @@ canbus:
         then:
           - if:
               condition:
-                lambda: "return x[0] == 0x11;"
+                lambda: 'return x[0] == 0x11;'
               then:
                 light.toggle: ${roomname}_lights
-      - can_id:      0b00000000000000000000001000000
+      - can_id: 0b00000000000000000000001000000
         can_id_mask: 0b11111000000000011111111000000
         use_extended_id: true
         then:
@@ -2741,10 +2740,10 @@ canbus:
         then:
           - if:
               condition:
-                lambda: "return x[0] == 0x11;"
+                lambda: 'return x[0] == 0x11;'
               then:
                 light.toggle: ${roomname}_lights
-      - can_id:      0b00000000000000000000001000000
+      - can_id: 0b00000000000000000000001000000
         can_id_mask: 0b11111000000000011111111000000
         use_extended_id: true
         then:
@@ -2800,7 +2799,7 @@ qr_code:
 lock:
   - platform: template
     id: test_lock1
-    name: "Template Switch"
+    name: 'Template Switch'
     lambda: |-
       if (id(binary_sensor1).state) {
         return LOCK_STATE_LOCKED;
@@ -2812,13 +2811,13 @@ lock:
     on_unlock:
       - lock.template.publish:
           id: test_lock1
-          state: !lambda "return LOCK_STATE_UNLOCKED;"
+          state: !lambda 'return LOCK_STATE_UNLOCKED;'
     on_lock:
       - lock.template.publish:
           id: test_lock1
-          state: !lambda "return LOCK_STATE_LOCKED;"
+          state: !lambda 'return LOCK_STATE_LOCKED;'
   - platform: output
-    name: "Generic Output Lock"
+    name: 'Generic Output Lock'
     id: test_lock2
     output: pca_6
   - platform: copy
@@ -2827,7 +2826,7 @@ lock:
 
 button:
   - platform: template
-    name: "Start calibration"
+    name: 'Start calibration'
     on_press:
       - scd4x.perform_forced_calibration:
           value: 419
@@ -2854,3 +2853,16 @@ button:
     name: Midea Power Inverse
     on_press:
       midea_ac.power_toggle:
+  - platform: template
+    name: Send Vol UP Compact
+    on_press:
+      - remote.send_command:
+          id: my_remote
+          command: nec:0x857A:0xE5
+remote:
+  - platform: gpio
+    id: my_remote
+    name: my_remote
+    transmit_pin: GPIO5
+    carrier_duty_percent: 50%
+    protocol: ['duration']

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -9,7 +9,7 @@ esphome:
           - wifi.connected
           - time.has_time
         then:
-          - logger.log: "Have time"
+          - logger.log: 'Have time'
   includes:
     - custom.h
 
@@ -294,39 +294,38 @@ wled:
 
 adalight:
 
-
 sensor:
   - platform: daly_bms
     voltage:
-      name: "Battery Voltage"
+      name: 'Battery Voltage'
     current:
-      name: "Battery Current"
+      name: 'Battery Current'
     battery_level:
-      name: "Battery Level"
+      name: 'Battery Level'
     max_cell_voltage:
-      name: "Max Cell Voltage"
+      name: 'Max Cell Voltage'
     max_cell_voltage_number:
-      name: "Max Cell Voltage Number"
+      name: 'Max Cell Voltage Number'
     min_cell_voltage:
-      name: "Min Cell Voltage"
+      name: 'Min Cell Voltage'
     min_cell_voltage_number:
-      name: "Min Cell Voltage Number"
+      name: 'Min Cell Voltage Number'
     max_temperature:
-      name: "Max Temperature"
+      name: 'Max Temperature'
     max_temperature_probe_number:
-      name: "Max Temperature Probe Number"
+      name: 'Max Temperature Probe Number'
     min_temperature:
-      name: "Min Temperature"
+      name: 'Min Temperature'
     min_temperature_probe_number:
-      name: "Min Temperature Probe Number"
+      name: 'Min Temperature Probe Number'
     remaining_capacity:
-      name: "Remaining Capacity"
+      name: 'Remaining Capacity'
     cells_number:
-      name: "Cells Number"
+      name: 'Cells Number'
     temperature_1:
-      name: "Temperature 1"
+      name: 'Temperature 1'
     temperature_2:
-      name: "Temperature 2"
+      name: 'Temperature 2'
   - platform: apds9960
     type: proximity
     name: APDS9960 Proximity
@@ -657,21 +656,21 @@ sensor:
     address: 99
     unit_of_measurement: 'pH'
   - platform: tof10120
-    name: "Distance sensor"
+    name: 'Distance sensor'
     update_interval: 5s
   - platform: fingerprint_grow
     fingerprint_count:
-      name: "Fingerprint Count"
+      name: 'Fingerprint Count'
     status:
-      name: "Fingerprint Status"
+      name: 'Fingerprint Status'
     capacity:
-      name: "Fingerprint Capacity"
+      name: 'Fingerprint Capacity'
     security_level:
-      name: "Fingerprint Security Level"
+      name: 'Fingerprint Security Level'
     last_finger_id:
-      name: "Fingerprint Last Finger ID"
+      name: 'Fingerprint Last Finger ID'
     last_confidence:
-      name: "Fingerprint Last Confidence"
+      name: 'Fingerprint Last Confidence'
   - platform: sdm_meter
     phase_a:
       current:
@@ -744,16 +743,16 @@ sensor:
   - platform: mlx90393
     oversampling: 1
     filter: 0
-    gain: "3X"
+    gain: '3X'
     x_axis:
-      name: "mlxxaxis"
+      name: 'mlxxaxis'
     y_axis:
-      name: "mlxyaxis"
+      name: 'mlxyaxis'
     z_axis:
-      name: "mlxzaxis"
+      name: 'mlxzaxis'
       resolution: 17BIT
     temperature:
-      name: "mlxtemp"
+      name: 'mlxtemp'
       oversampling: 2
 time:
   - platform: homeassistant
@@ -769,9 +768,9 @@ mpr121:
 binary_sensor:
   - platform: daly_bms
     charging_mos_enabled:
-      name: "Charging MOS"
+      name: 'Charging MOS'
     discharging_mos_enabled:
-      name: "Discharging MOS"
+      name: 'Discharging MOS'
   - platform: apds9960
     direction: up
     name: APDS9960 Up
@@ -822,7 +821,7 @@ binary_sensor:
     channel: 1
     name: TTP229 BSF Test
   - platform: fingerprint_grow
-    name: "Fingerprint Enrolling"
+    name: 'Fingerprint Enrolling'
   - platform: custom
     lambda: |-
       auto s = new CustomBinarySensor();
@@ -870,7 +869,7 @@ status_led:
 text_sensor:
   - platform: daly_bms
     status:
-      name: "BMS Status"
+      name: 'BMS Status'
   - platform: version
     name: 'ESPHome Version'
     icon: mdi:icon
@@ -912,9 +911,9 @@ text_sensor:
     component_name: text0
   - platform: dsmr
     identification:
-      name: "dsmr_identification"
+      name: 'dsmr_identification'
     p1_version:
-      name: "dsmr_p1_version"
+      name: 'dsmr_p1_version'
 
 script:
   - id: my_script
@@ -1155,7 +1154,7 @@ cover:
       - switch.turn_on: gpio_switch2
     close_duration: 4.5min
   - platform: current_based
-    name: "Current Based Cover"
+    name: 'Current Based Cover'
     open_sensor: ade7953_current_a
     open_moving_current_threshold: 0.5
     open_obstacle_current_threshold: 0.8
@@ -1176,7 +1175,7 @@ cover:
     malfunction_detection: true
     malfunction_action:
       then:
-        - logger.log: "Malfunction Detected"
+        - logger.log: 'Malfunction Detected'
   - platform: template
     name: Template Cover with Tilt
     tilt_lambda: 'return 0.5;'
@@ -1439,9 +1438,22 @@ button:
     target_mac_address: 12:34:56:78:90:ab
     name: wol_test_1
     id: wol_1
-
+  - platform: template
+    name: Send Vol UP Compact
+    on_press:
+      - remote.send_command:
+          id: my_remote
+          command: nec:0x857A:0xE5
 cd74hc4067:
   pin_s0: GPIO12
   pin_s1: GPIO13
   pin_s2: GPIO14
   pin_s3: GPIO15
+
+remote:
+  - platform: gpio
+    id: my_remote
+    name: my_remote
+    transmit_pin: GPIO5
+    carrier_duty_percent: 50%
+    protocol: ['duration']


### PR DESCRIPTION
# What does this implement/fix?

Current components to manage IR transmitter/receiver are stand-alone components that are not integrated to Home Assistant natively, and depend on user defined services.

Though this works, it doesn't allow to build any standard feature on top of it, as there is no standard API.
This PR proposes to move `remote` as a *platform component* that integrates into the existing HA `remote` domain, and uses it's api.

Currently the PR implements only the *transmit* path, but once we settle this, I'll add the *receive/learn* path also. It is also currently only converting GPIO, but latter `RF Bridge` will also be added as `efm8bb1` platform. The gpio.remote itself is just the remote_transmitter code, rewrapped to have a unified api.

This PR is complemented with changes in [aioesphomeapi](https://github.com/ianchi/aioesphomeapi/tree/remote) and in [HA core](https://github.com/ianchi/core/tree/esphome_remote). Both are available in my branches (linked), and will be converted into corresponding PR once this one is settled.

### The broader vision 

This PR is only a step in a much larger change needed to simplify the use of IR blaster for home automation.
Currently they are completely manual and device specific, not only in ESPHome, but also in HA. A lot of effort must be made in order to take full advantage of blasters. And this effort is spread among every single user, and cannot be easily reused by the community.

My ultimate goal is to be able to only do something as simple as this, and "magically" have the remote working:

```yaml
# HA config
media_player:
  - platform: remote
    transmitter: my_esphome_remote #or my_broadlink_remote or my_miio_remote or....
    device: LG.TV_model_xxx    
```

This PR includes two steps in this direction:
- integrates ESPHome to use HA remote api, which will later allow to grow in functionality
- it introduces a python library ([remoteprotocols](https://pypi.org/project/remoteprotocols/0.0.4/)) that centrally handles all protocols to encode/decode and convert to raw formats. This will allow to have central IR code pages per device in their native protocol, but send commands to each device in its own supported format

The same library is used in ESPHome, so though only the raw (*duration*) format is implemented at the moment in firmware, you can specify in the config file commands in any possible format. The same when calling from HA api.
This decouples protocols from emitting devices and will allow to share codes between different kind of devices (ESPHome/Broadlink/etc), so that each user won't need to manually collect or find his own codes for his brand of emitter.

In spite of this, the structure of the `gpio.remote` allows to define additional protocols in the firmware, for other local use cases. These can be discussed later.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
remote:
  - platform: gpio
    id: my_remote
    name: my_remote
    transmit_pin: GPIO5
    carrier_duty_percent: 50%
    protocol: ["duration"] # only compile in these

button:
  - platform: template
    name: Send Vol UP Compact
    on_press:
      - remote.send_command:
          id: my_remote
          command: nec:0x857A:0xE5

#api:
# no user defined service.
# Integrates automatically in HA 'remote'

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
