### PR TITLE
protobuf: fix incomplete 64 bits implementation

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -195,6 +195,20 @@ class ProtoWriteBuffer {
     this->write((value >> 16) & 0xFF);
     this->write((value >> 24) & 0xFF);
   }
+  void encode_fixed64(uint32_t field_id, uint64_t value, bool force = false) {
+    if (value == 0 && !force)
+      return;
+
+    this->encode_field_raw(field_id, 5);
+    this->write((value >> 0) & 0xFF);
+    this->write((value >> 8) & 0xFF);
+    this->write((value >> 16) & 0xFF);
+    this->write((value >> 24) & 0xFF);
+    this->write((value >> 32) & 0xFF);
+    this->write((value >> 40) & 0xFF);
+    this->write((value >> 48) & 0xFF);
+    this->write((value >> 56) & 0xFF);
+  }
   template<typename T> void encode_enum(uint32_t field_id, T value, bool force = false) {
     this->encode_uint32(field_id, static_cast<uint32_t>(value), force);
   }
@@ -228,6 +242,15 @@ class ProtoWriteBuffer {
       uvalue = value << 1;
     }
     this->encode_uint32(field_id, uvalue, force);
+  }
+  void encode_sint64(uint32_t field_id, int64_t value, bool force = false) {
+    uint64_t uvalue;
+    if (value < 0) {
+      uvalue = ~(value << 1);
+    } else {
+      uvalue = value << 1;
+    }
+    this->encode_uint64(field_id, uvalue, force);
   }
   template<class C> void encode_message(uint32_t field_id, const C &value, bool force = false) {
     this->encode_field_raw(field_id, 2);

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -236,7 +236,7 @@ class Int64Type(TypeInfo):
     encode_func = "encode_int64"
 
     def dump(self, name):
-        o = f'sprintf(buffer, "%ll", {name});\n'
+        o = f'sprintf(buffer, "%lld", {name});\n'
         o += f"out.append(buffer);"
         return o
 
@@ -249,7 +249,7 @@ class UInt64Type(TypeInfo):
     encode_func = "encode_uint64"
 
     def dump(self, name):
-        o = f'sprintf(buffer, "%ull", {name});\n'
+        o = f'sprintf(buffer, "%llu", {name});\n'
         o += f"out.append(buffer);"
         return o
 
@@ -275,7 +275,7 @@ class Fixed64Type(TypeInfo):
     encode_func = "encode_fixed64"
 
     def dump(self, name):
-        o = f'sprintf(buffer, "%ull", {name});\n'
+        o = f'sprintf(buffer, "%llu", {name});\n'
         o += f"out.append(buffer);"
         return o
 
@@ -417,7 +417,7 @@ class SFixed64Type(TypeInfo):
     encode_func = "encode_sfixed64"
 
     def dump(self, name):
-        o = f'sprintf(buffer, "%ll", {name});\n'
+        o = f'sprintf(buffer, "%lld", {name});\n'
         o += f"out.append(buffer);"
         return o
 
@@ -440,10 +440,10 @@ class SInt64Type(TypeInfo):
     cpp_type = "int64_t"
     default_value = "0"
     decode_varint = "value.as_sint64()"
-    encode_func = "encode_sin64"
+    encode_func = "encode_sint64"
 
     def dump(self, name):
-        o = f'sprintf(buffer, "%ll", {name});\n'
+        o = f'sprintf(buffer, "%lld", {name});\n'
         o += f"out.append(buffer);"
         return o
 
@@ -622,13 +622,13 @@ def build_message_type(desc):
         protected_content.insert(0, prot)
     if decode_64bit:
         decode_64bit.append("default:\n  return false;")
-        o = f"bool {desc.name}::decode_64bit(uint32_t field_id, Proto64bit value) {{\n"
+        o = f"bool {desc.name}::decode_64bit(uint32_t field_id, Proto64Bit value) {{\n"
         o += "  switch (field_id) {\n"
         o += indent("\n".join(decode_64bit), "    ") + "\n"
         o += "  }\n"
         o += "}\n"
         cpp += o
-        prot = "bool decode_64bit(uint32_t field_id, Proto64bit value) override;"
+        prot = "bool decode_64bit(uint32_t field_id, Proto64Bit value) override;"
         protected_content.insert(0, prot)
 
     o = f"void {desc.name}::encode(ProtoWriteBuffer buffer) const {{"


### PR DESCRIPTION
# What does this implement/fix?

Fix typos in protobuf for 64 bit integers and add missing code.
As they are not used the bug is not triggered, but currently it won't compile if 64bit integers where used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
