### PR TITLE
Enhances number component, allows to increment by value and toggle to min/max values, adds same feature to web_api for number

### DIFF
--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -35,6 +35,8 @@ ValueRangeTrigger = number_ns.class_(
 
 # Actions
 NumberSetAction = number_ns.class_("NumberSetAction", automation.Action)
+NumberIncAction = number_ns.class_("NumberIncAction", automation.Action)
+NumberTogAction = number_ns.class_("NumberTogAction", automation.Action)
 
 # Conditions
 NumberInRangeCondition = number_ns.class_(
@@ -174,4 +176,38 @@ async def number_set_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_VALUE], args, float)
     cg.add(var.set_value(template_))
+    return var
+
+
+@automation.register_action(
+    "number.inc",
+    NumberIncAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(Number),
+            cv.Required(CONF_VALUE): cv.templatable(cv.float_),
+        }
+    ),
+)
+async def number_inc_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_VALUE], args, float)
+    cg.add(var.set_increment(template_))
+    return var
+
+
+@automation.register_action(
+    "number.tog",
+    NumberTogAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(Number),
+        }
+    ),
+)
+async def number_tog_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    cg.add(var.set_toggle(True))
     return var

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -193,7 +193,7 @@ async def number_inc_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_VALUE], args, float)
-    cg.add(var.set_increment(template_))
+    cg.add(var.set_value(template_))
     return var
 
 
@@ -209,5 +209,4 @@ async def number_inc_to_code(config, action_id, template_arg, args):
 async def number_tog_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    cg.add(var.set_toggle(True))
     return var

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -180,7 +180,7 @@ async def number_set_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "number.inc",
+    "number.increment",
     NumberIncrementAction,
     cv.Schema(
         {
@@ -198,7 +198,7 @@ async def number_inc_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "number.tog",
+    "number.toggle",
     NumberToggleAction,
     cv.Schema(
         {

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -35,8 +35,8 @@ ValueRangeTrigger = number_ns.class_(
 
 # Actions
 NumberSetAction = number_ns.class_("NumberSetAction", automation.Action)
-NumberIncAction = number_ns.class_("NumberIncAction", automation.Action)
-NumberTogAction = number_ns.class_("NumberTogAction", automation.Action)
+NumberIncrementAction = number_ns.class_("NumberIncrementAction", automation.Action)
+NumberToggleAction = number_ns.class_("NumberToggleAction", automation.Action)
 
 # Conditions
 NumberInRangeCondition = number_ns.class_(
@@ -181,7 +181,7 @@ async def number_set_to_code(config, action_id, template_arg, args):
 
 @automation.register_action(
     "number.inc",
-    NumberIncAction,
+    NumberIncrementAction,
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.use_id(Number),
@@ -199,7 +199,7 @@ async def number_inc_to_code(config, action_id, template_arg, args):
 
 @automation.register_action(
     "number.tog",
-    NumberTogAction,
+    NumberToggleAction,
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.use_id(Number),

--- a/esphome/components/number/automation.h
+++ b/esphome/components/number/automation.h
@@ -29,6 +29,35 @@ template<typename... Ts> class NumberSetAction : public Action<Ts...> {
   Number *number_;
 };
 
+template<typename... Ts> class NumberIncrementAction : public Action<Ts...> {
+ public:
+  NumberIncrementAction(Number *number) : number_(number) {}
+  TEMPLATABLE_VALUE(float, value)
+
+  void play(Ts... x) override {
+    auto call = this->number_->make_call();
+    call.set_increment(this->value_.value(x...));
+    call.perform();
+  }
+
+ protected:
+  Number *number_;
+};
+
+template<typename... Ts> class NumberToggleAction : public Action<Ts...> {
+ public:
+  NumberToggleAction(Number *number) : number_(number) {}
+
+  void play(Ts... x) override {
+    auto call = this->number_->make_call();
+    call.set_toggle(true);
+    call.perform();
+  }
+
+ protected:
+  Number *number_;
+};
+
 class ValueRangeTrigger : public Trigger<float>, public Component {
  public:
   explicit ValueRangeTrigger(Number *parent) : parent_(parent) {}

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -8,9 +8,8 @@ static const char *const TAG = "number";
 
 void NumberCall::perform() {
   ESP_LOGD(TAG, "'%s' - Setting/Incrementing/Toggling", this->parent_->get_name().c_str());
-  if ( (!this->value_.has_value() || std::isnan(*this->value_)) &&
-       (!this->increment_.has_value() || std::isnan(*this->increment_)) &&
-       (!this->toggle_.has_value()) ) {
+  if ((!this->value_.has_value() || std::isnan(*this->value_)) &&
+      (!this->increment_.has_value() || std::isnan(*this->increment_)) && (!this->toggle_.has_value())) {
     ESP_LOGW(TAG, "No value, no increment and no toggle set for NumberCall");
     return;
   }
@@ -20,7 +19,7 @@ void NumberCall::perform() {
   auto max_value = traits.get_max_value();
   auto current_state = this->parent_->state;
   auto current_state_valid = this->parent_->has_state();
-  if ( this->value_.has_value() && !std::isnan(*this->value_) ) {
+  if (this->value_.has_value() && !std::isnan(*this->value_)) {
     auto value = *this->value_;
 
     if (value < min_value) {
@@ -35,9 +34,10 @@ void NumberCall::perform() {
     current_state = *this->value_;
     current_state_valid = true;
   }
-  if ( this->increment_.has_value() && !std::isnan(*this->increment_) ) {
+  if (this->increment_.has_value() && !std::isnan(*this->increment_)) {
     // initialize to minimum if not already set
-    if ( !current_state_valid ) current_state = min_value;
+    if (!current_state_valid)
+      current_state = min_value;
     // calculate
     current_state += *this->increment_;
     // limit to min and max values
@@ -51,13 +51,16 @@ void NumberCall::perform() {
     }
     ESP_LOGD(TAG, "  Value after increment: %f", *this->value_);
   }
-  if ( this->toggle_.has_value() && *this->toggle_ == true ) {
+  if (this->toggle_.has_value() && *this->toggle_ == true) {
     if (std::isnan(min_value) || std::isnan(max_value)) {
-      ESP_LOGW(TAG, "  min and max value must both be set to valid numbers for toggle to work (min: %f and max: %f), aborting", min_value, max_value);
+      ESP_LOGW(
+          TAG,
+          "  min and max value must both be set to valid numbers for toggle to work (min: %f and max: %f), aborting",
+          min_value, max_value);
       return;
     }
-    float avg_value = ( min_value + max_value ) / 2.0;
-    if ( current_state > avg_value ) {
+    float avg_value = (min_value + max_value) / 2.0;
+    if (current_state > avg_value) {
       current_state = min_value;
     } else {
       current_state = max_value;

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -51,7 +51,7 @@ void NumberCall::perform() {
     }
     ESP_LOGD(TAG, "  Value after increment: %f", current_state);
   }
-  if (this->toggle_.has_value() && *this->toggle_ ) {
+  if (this->toggle_.has_value() && *this->toggle_) {
     if (std::isnan(min_value) || std::isnan(max_value)) {
       ESP_LOGW(
           TAG,

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -51,7 +51,7 @@ void NumberCall::perform() {
     }
     ESP_LOGD(TAG, "  Value after increment: %f", current_state);
   }
-  if (this->toggle_.has_value() && *this->toggle_ == true) {
+  if (this->toggle_.has_value() && *this->toggle_ ) {
     if (std::isnan(min_value) || std::isnan(max_value)) {
       ESP_LOGW(
           TAG,

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -49,7 +49,7 @@ void NumberCall::perform() {
       ESP_LOGW(TAG, "  Value after increment %f clamped to maximum of %f", current_state, max_value);
       current_state = max_value;
     }
-    ESP_LOGD(TAG, "  Value after increment: %f", *this->value_);
+    ESP_LOGD(TAG, "  Value after increment: %f", current_state);
   }
   if (this->toggle_.has_value() && *this->toggle_ == true) {
     if (std::isnan(min_value) || std::isnan(max_value)) {

--- a/esphome/components/number/number.h
+++ b/esphome/components/number/number.h
@@ -30,10 +30,22 @@ class NumberCall {
     return *this;
   }
   const optional<float> &get_value() const { return value_; }
+  NumberCall &set_increment(float increment) {
+    increment_ = increment;
+    return *this;
+  }
+  const optional<float> &get_increment() const { return increment_; }
+  NumberCall &set_toggle(bool toggle) {
+    toggle_ = toggle;
+    return *this;
+  }
+  const optional<bool> &get_toggle() const { return toggle_; }
 
  protected:
   Number *const parent_;
   optional<float> value_;
+  optional<float> increment_;
+  optional<bool> toggle_;
 };
 
 enum NumberMode : uint8_t {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -716,7 +716,8 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
       request->send(200, "text/json", data.c_str());
       return;
     }
-    if (match.method != "set") {
+    if ( (match.method != "set" && match.method != "inc" && match.method != "tog") ||
+         (!request->hasParam("value") && (match.method == "set" || match.method == "inc")) ){
       request->send(404);
       return;
     }
@@ -725,9 +726,12 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       optional<float> value_f = parse_number<float>(value.c_str());
-      if (value_f.has_value())
-        call.set_value(*value_f);
+      if (value_f.has_value()) {
+        if ( match.method == "set" ) call.set_value(*value_f);
+        if ( match.method == "inc" ) call.set_increment(*value_f);
+      }
     }
+    if ( match.method == "tog" ) call.set_toggle(true);
 
     this->defer([call]() mutable { call.perform(); });
     request->send(200);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -714,8 +714,8 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
       request->send(200, "text/json", data.c_str());
       return;
     }
-    if ((match.method != "set" && match.method != "inc" && match.method != "tog") ||
-        (!request->hasParam("value") && (match.method == "set" || match.method == "inc"))) {
+    if ((match.method != "set" && match.method != "increment" && match.method != "toggle") ||
+        (!request->hasParam("value") && (match.method == "set" || match.method == "increment"))) {
       request->send(404);
       return;
     }
@@ -727,11 +727,11 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
       if (value_f.has_value()) {
         if (match.method == "set")
           call.set_value(*value_f);
-        if (match.method == "inc")
+        if (match.method == "increment")
           call.set_increment(*value_f);
       }
     }
-    if (match.method == "tog")
+    if (match.method == "toggle")
       call.set_toggle(true);
 
     this->defer([call]() mutable { call.perform(); });

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -583,6 +583,8 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
       auto call = obj->turn_on();
       if (request->hasParam("brightness"))
         call.set_brightness(request->getParam("brightness")->value().toFloat() / 255.0f);
+      if (request->hasParam("color_brightness"))
+        call.set_color_brightness(request->getParam("color_brightness")->value().toFloat() / 255.0f);
       if (request->hasParam("r"))
         call.set_red(request->getParam("r")->value().toFloat() / 255.0f);
       if (request->hasParam("g"))

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -716,8 +716,8 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
       request->send(200, "text/json", data.c_str());
       return;
     }
-    if ( (match.method != "set" && match.method != "inc" && match.method != "tog") ||
-         (!request->hasParam("value") && (match.method == "set" || match.method == "inc")) ){
+    if ((match.method != "set" && match.method != "inc" && match.method != "tog") ||
+        (!request->hasParam("value") && (match.method == "set" || match.method == "inc"))) {
       request->send(404);
       return;
     }
@@ -727,11 +727,14 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
       String value = request->getParam("value")->value();
       optional<float> value_f = parse_number<float>(value.c_str());
       if (value_f.has_value()) {
-        if ( match.method == "set" ) call.set_value(*value_f);
-        if ( match.method == "inc" ) call.set_increment(*value_f);
+        if (match.method == "set")
+          call.set_value(*value_f);
+        if (match.method == "inc")
+          call.set_increment(*value_f);
       }
     }
-    if ( match.method == "tog" ) call.set_toggle(true);
+    if (match.method == "tog")
+      call.set_toggle(true);
 
     this->defer([call]() mutable { call.perform(); });
     request->send(200);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -583,8 +583,6 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
       auto call = obj->turn_on();
       if (request->hasParam("brightness"))
         call.set_brightness(request->getParam("brightness")->value().toFloat() / 255.0f);
-      if (request->hasParam("color_brightness"))
-        call.set_color_brightness(request->getParam("color_brightness")->value().toFloat() / 255.0f);
       if (request->hasParam("r"))
         call.set_red(request->getParam("r")->value().toFloat() / 255.0f);
       if (request->hasParam("g"))

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -714,9 +714,15 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
       request->send(200, "text/json", data.c_str());
       return;
     }
-    if ((match.method != "set" && match.method != "increment" && match.method != "toggle") ||
-        (!request->hasParam("value") && (match.method == "set" || match.method == "increment"))) {
-      request->send(404);
+    if (match.method != "set" && match.method != "increment" && match.method != "toggle") {
+      request->send(404, "text/plain", (std::string("unknown request type ") + match.method).c_str());
+      return;
+    }
+    if (!request->hasParam("value") && (match.method == "set" || match.method == "increment")) {
+      request->send(400, "text/plain",
+                    (std::string("set and increment requests require value parameter (e.g. <number>/") + match.method +
+                     std::string("?value=10)"))
+                        .c_str());  // bad request error
       return;
     }
 


### PR DESCRIPTION
# What does this implement/fix?

* Implements increment and toggle calls for the number component, in addition to existing set_value call.
* Adds the same features to web_api for control via http POST requests

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: rgbwone

esp8266:
  board: d1_mini

# Enable logging
logger:

# Enable Home Assistant API
api:
  password: ""

ota:
  password: ""

wifi:
  ssid: "***"
  password: "***"
  
  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "***"
    password: "***"

captive_portal:

number:
  - platform: template
    name: "WhiteBrightness"
    optimistic: true
    min_value: 0
    max_value: 255
    step: 1
    on_value:
      then:
        - light.turn_on:
            id: trial_lights
            transition_length: 0.1s
            white: !lambda "return x/255.0;"
  - platform: template
    name: "RGBBrightness"
    optimistic: true
    min_value: 0
    max_value: 255
    step: 1
    on_value:
      then:
        - light.turn_on:
            id: trial_lights
            transition_length: 0.1s
            color_brightness: !lambda "return x/255.0;"

light:
  - platform: rgbw
    id: trial_lights
    name: "TrialLights"
    red: red_component
    green: green_component
    blue: blue_component
    white: white_component

output:
  - platform: esp8266_pwm
    id: red_component
    pin: D0
  - platform: esp8266_pwm
    id: green_component
    pin: D1
  - platform: esp8266_pwm
    id: blue_component
    pin: D2
  - platform: esp8266_pwm
    id: white_component
    pin: D3

web_server:
  port: 80
  version: 2
  local: true
```
The above can be controlled like this with POST requests via http:

`curl -i -X POST "http://rgbwone.local/number/whitebrightness/increment?value=-10"`
`curl -i -X POST "http://rgbwone.local/number/rgbbrightness/increment?value=-10"`
Reduces white or rgb brightness by 10.

`curl -i -X POST "http://rgbwone.local/number/whitebrightness/increment?value=10"`
`curl -i -X POST "http://rgbwone.local/number/rgbbrightness/increment?value=10"`
Increases white or rgb brightness by 10.

`curl -i -X POST "http://rgbwone.local/number/whitebrightness/set?value=128"`
`curl -i -X POST "http://rgbwone.local/number/rgbbrightness/set?value=128"`
Sets white or rgb brightness to 50%.

`curl -i -X POST "http://rgbwone.local/number/whitebrightness/toggle"`
`curl -i -X POST "http://rgbwone.local/number/rgbbrightness/toggle"`
Toggles white or rgb brightness between min and max values (all off or all on)


```yaml
esphome:
  name: numbertest

esp8266:
  board: d1_mini

# Enable logging
logger:

# Enable Home Assistant API
api:
  
ota:
  password: "***"

wifi:
  ssid: "***"
  password: "***"
  
  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Controltest Fallback Hotspot"
    password: "***"

number:
  - platform: template
    id: testnumber
    name: "TestNumber"
    optimistic: true
    min_value: 0
    max_value: 255
    step: 1

sensor:
  - platform: rotary_encoder
    name: "RotaryEncoder0"
    pin_a:
      number: D1
      inverted: true
      mode:
        input: true
    pin_b:
      number: D2
      inverted: true
      mode:
        input: true
    on_clockwise:
      then:
        - number.increment:
            id: testnumber
            value: +5.0
    on_anticlockwise:
      then:
        - number.increment:
            id: testnumber
            value: -5.0
  - platform: rotary_encoder
    name: "RotaryEncoder1"
    pin_a:
      number: D3
      inverted: true
      mode:
        input: true
    pin_b:
      number: D4
      inverted: true
      mode:
        input: true
    on_clockwise:
      then:
        - number.set:
            id: testnumber
            value: 250
    on_anticlockwise:
      then:
        - number.set:
            id: testnumber
            value: 5

binary_sensor:
  - platform: gpio
    pin:
      number: D6
      mode:
        input: true
        pullup: true
      inverted: true
    name: "Knob0Button"
    filters:
      - delayed_on: 10ms
      - delayed_off: 10ms
    on_press:
      then:
        - number.toggle:
            id: testnumber
  - platform: gpio
    pin:
      number: D5
      mode:
        input: true
        pullup: true
      inverted: true
    name: "Knob1Button"
    filters:
      - delayed_on: 10ms
      - delayed_off: 10ms
    on_press:
      then:
        - number.toggle:
            id: testnumber

captive_portal:

web_server:
  port: 80
  version: 2
  local: true

```

The above shows what i used to test the number.set, number.tog and number.inc actions.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] clang-format has now been run and is PASS

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs) esphome/esphome-docs#2021.
