### PR TITLE
Update captive portal canHandle function

### DIFF
--- a/esphome/components/captive_portal/captive_portal.h
+++ b/esphome/components/captive_portal/captive_portal.h
@@ -39,17 +39,7 @@ class CaptivePortal : public AsyncWebHandler, public Component {
     if (request->method() == HTTP_GET) {
       if (request->url() == "/")
         return true;
-      if (request->url() == "/stylesheet.css")
-        return true;
-      if (request->url() == "/wifi-strength-1.svg")
-        return true;
-      if (request->url() == "/wifi-strength-2.svg")
-        return true;
-      if (request->url() == "/wifi-strength-3.svg")
-        return true;
-      if (request->url() == "/wifi-strength-4.svg")
-        return true;
-      if (request->url() == "/lock.svg")
+      if (request->url() == "/config.json")
         return true;
       if (request->url() == "/wifisave")
         return true;


### PR DESCRIPTION
# What does this implement/fix?

Updating canHandle function in captive portal to match https://github.com/esphome/esphome/pull/2872.  Main bug fixed is that config.json needs added in order to display list of found Wi-Fi networks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
captive_portal:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
