### PR TITLE
Fix HM3301 AQI int8 overflow

### DIFF
--- a/esphome/components/hm3301/abstract_aqi_calculator.h
+++ b/esphome/components/hm3301/abstract_aqi_calculator.h
@@ -7,7 +7,7 @@ namespace hm3301 {
 
 class AbstractAQICalculator {
  public:
-  virtual uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) = 0;
+  virtual uint16_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) = 0;
 };
 
 }  // namespace hm3301

--- a/esphome/components/hm3301/aqi_calculator.h
+++ b/esphome/components/hm3301/aqi_calculator.h
@@ -7,7 +7,7 @@ namespace hm3301 {
 
 class AQICalculator : public AbstractAQICalculator {
  public:
-  uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
+  uint16_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
     int pm2_5_index = calculate_index_(pm2_5_value, pm2_5_calculation_grid_);
     int pm10_0_index = calculate_index_(pm10_0_value, pm10_0_calculation_grid_);
 

--- a/esphome/components/hm3301/caqi_calculator.h
+++ b/esphome/components/hm3301/caqi_calculator.h
@@ -8,7 +8,7 @@ namespace hm3301 {
 
 class CAQICalculator : public AbstractAQICalculator {
  public:
-  uint8_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
+  uint16_t get_aqi(uint16_t pm2_5_value, uint16_t pm10_0_value) override {
     int pm2_5_index = calculate_index_(pm2_5_value, pm2_5_calculation_grid_);
     int pm10_0_index = calculate_index_(pm10_0_value, pm10_0_calculation_grid_);
 

--- a/esphome/components/hm3301/hm3301.cpp
+++ b/esphome/components/hm3301/hm3301.cpp
@@ -62,7 +62,7 @@ void HM3301Component::update() {
     pm_10_0_value = get_sensor_value_(data_buffer_, PM_10_0_VALUE_INDEX);
   }
 
-  int8_t aqi_value = -1;
+  int16_t aqi_value = -1;
   if (this->aqi_sensor_ != nullptr && pm_2_5_value != -1 && pm_10_0_value != -1) {
     AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
     aqi_value = calculator->get_aqi(pm_2_5_value, pm_10_0_value);


### PR DESCRIPTION
# What does this implement/fix?

HM3301 AQI calculation was overflowing to negative values when AQI > 127 due to usage of int8 where int16 should've been used.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [HM3301 AQI Calculation Is Wrong
](https://github.com/esphome/issues/issues/2365)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).