### PR TITLE
Fix SHTC3 sensor detection

### DIFF
--- a/esphome/components/shtcx/shtcx.cpp
+++ b/esphome/components/shtcx/shtcx.cpp
@@ -35,15 +35,17 @@ void SHTCXComponent::setup() {
     return;
   }
 
-  uint16_t device_id_register[1];
-  if (!this->read_data_(device_id_register, 1)) {
+  uint16_t device_id_register;
+  if (!this->read_data_(&device_id_register, 1)) {
     ESP_LOGE(TAG, "Error reading Device ID");
     this->mark_failed();
     return;
   }
 
-  if (((device_id_register[0] << 2) & 0x1C) == 0x1C) {
-    if ((device_id_register[0] & 0x847) == 0x847) {
+  this->sensor_id_ = device_id_register;
+
+  if ((device_id_register & 0x3F) == 0x07) {
+    if (device_id_register & 0x800) {
       this->type_ = SHTCX_TYPE_SHTC3;
     } else {
       this->type_ = SHTCX_TYPE_SHTC1;
@@ -51,11 +53,11 @@ void SHTCXComponent::setup() {
   } else {
     this->type_ = SHTCX_TYPE_UNKNOWN;
   }
-  ESP_LOGCONFIG(TAG, "  Device identified: %s", to_string(this->type_));
+  ESP_LOGCONFIG(TAG, "  Device identified: %s (%04x)", to_string(this->type_), device_id_register);
 }
 void SHTCXComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SHTCx:");
-  ESP_LOGCONFIG(TAG, "  Model: %s", to_string(this->type_));
+  ESP_LOGCONFIG(TAG, "  Model: %s (%04x)", to_string(this->type_), this->sensor_id_);
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication with SHTCx failed!");
@@ -75,21 +77,28 @@ void SHTCXComponent::update() {
     this->wake_up();
   }
   if (!this->write_command_(SHTCX_COMMAND_POLLING_H)) {
+    ESP_LOGE(TAG, "sensor polling failed");
+    if (this->temperature_sensor_ != nullptr)
+      this->temperature_sensor_->publish_state(NAN);
+    if (this->humidity_sensor_ != nullptr)
+      this->humidity_sensor_->publish_state(NAN);
     this->status_set_warning();
     return;
   }
 
   this->set_timeout(50, [this]() {
+    float temperature = NAN;
+    float humidity = NAN;
     uint16_t raw_data[2];
     if (!this->read_data_(raw_data, 2)) {
+      ESP_LOGE(TAG, "sensor read failed");
       this->status_set_warning();
-      return;
+    } else {
+      temperature = 175.0f * float(raw_data[0]) / 65536.0f - 45.0f;
+      humidity = 100.0f * float(raw_data[1]) / 65536.0f;
+
+      ESP_LOGD(TAG, "Got temperature=%.2f°C humidity=%.2f%%", temperature, humidity);
     }
-
-    float temperature = 175.0f * float(raw_data[0]) / 65536.0f - 45.0f;
-    float humidity = 100.0f * float(raw_data[1]) / 65536.0f;
-
-    ESP_LOGD(TAG, "Got temperature=%.2f°C humidity=%.2f%%", temperature, humidity);
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
     if (this->humidity_sensor_ != nullptr)

--- a/esphome/components/shtcx/shtcx.h
+++ b/esphome/components/shtcx/shtcx.h
@@ -27,6 +27,7 @@ class SHTCXComponent : public PollingComponent, public i2c::I2CDevice {
   bool write_command_(uint16_t command);
   bool read_data_(uint16_t *data, uint8_t len);
   SHTCXType type_;
+  uint16_t sensor_id_;
   sensor::Sensor *temperature_sensor_;
   sensor::Sensor *humidity_sensor_;
 };


### PR DESCRIPTION
# What does this implement/fix?

This fixes the incorrect SHTCx detection, adds a bit more logging for errors, and publishes NAN if an error occurs.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3206

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
