### PR TITLE
Add parameter to control i2c stop signal at endTransmission

### DIFF
--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -46,21 +46,21 @@ class I2CDevice {
   I2CRegister reg(uint8_t a_register) { return {this, a_register}; }
 
   ErrorCode read(uint8_t *data, size_t len) { return bus_->read(address_, data, len); }
-  ErrorCode read_register(uint8_t a_register, uint8_t *data, size_t len) {
-    ErrorCode err = this->write(&a_register, 1);
+  ErrorCode read_register(uint8_t a_register, uint8_t *data, size_t len, bool stop = true) {
+    ErrorCode err = this->write(&a_register, 1, stop);
     if (err != ERROR_OK)
       return err;
     return this->read(data, len);
   }
 
-  ErrorCode write(const uint8_t *data, uint8_t len) { return bus_->write(address_, data, len); }
-  ErrorCode write_register(uint8_t a_register, const uint8_t *data, size_t len) {
+  ErrorCode write(const uint8_t *data, uint8_t len, bool stop = true) { return bus_->write(address_, data, len, stop); }
+  ErrorCode write_register(uint8_t a_register, const uint8_t *data, size_t len, bool stop = true) {
     WriteBuffer buffers[2];
     buffers[0].data = &a_register;
     buffers[0].len = 1;
     buffers[1].data = data;
     buffers[1].len = len;
-    return bus_->writev(address_, buffers, 2);
+    return bus_->writev(address_, buffers, 2, stop);
   }
 
   // Compat APIs
@@ -93,7 +93,9 @@ class I2CDevice {
     return true;
   }
 
-  bool read_byte(uint8_t a_register, uint8_t *data) { return read_register(a_register, data, 1) == ERROR_OK; }
+  bool read_byte(uint8_t a_register, uint8_t *data, bool stop = true) {
+    return read_register(a_register, data, 1, stop) == ERROR_OK;
+  }
 
   optional<uint8_t> read_byte(uint8_t a_register) {
     uint8_t data;
@@ -104,8 +106,8 @@ class I2CDevice {
 
   bool read_byte_16(uint8_t a_register, uint16_t *data) { return read_bytes_16(a_register, data, 1); }
 
-  bool write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len) {
-    return write_register(a_register, data, len) == ERROR_OK;
+  bool write_bytes(uint8_t a_register, const uint8_t *data, uint8_t len, bool stop = true) {
+    return write_register(a_register, data, len, stop) == ERROR_OK;
   }
 
   bool write_bytes(uint8_t a_register, const std::vector<uint8_t> &data) {
@@ -118,7 +120,9 @@ class I2CDevice {
 
   bool write_bytes_16(uint8_t a_register, const uint16_t *data, uint8_t len);
 
-  bool write_byte(uint8_t a_register, uint8_t data) { return write_bytes(a_register, &data, 1); }
+  bool write_byte(uint8_t a_register, uint8_t data, bool stop = true) {
+    return write_bytes(a_register, &data, 1, stop);
+  }
 
   bool write_byte_16(uint8_t a_register, uint16_t data) { return write_bytes_16(a_register, &data, 1); }
 

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -35,13 +35,19 @@ class I2CBus {
     return readv(address, &buf, 1);
   }
   virtual ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) = 0;
-  virtual ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len, bool stop = true) {
+  virtual ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len) {
+    return write(address, buffer, len, true);
+  }
+  virtual ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len, bool stop) {
     WriteBuffer buf;
     buf.data = buffer;
     buf.len = len;
     return writev(address, &buf, 1, stop);
   }
-  virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) = 0;
+  virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt) {
+    return writev(address, buffers, cnt, true);
+  }
+  virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) = 0;
 
  protected:
   void i2c_scan_() {

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -35,13 +35,13 @@ class I2CBus {
     return readv(address, &buf, 1);
   }
   virtual ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) = 0;
-  virtual ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len) {
+  virtual ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len, bool stop = true) {
     WriteBuffer buf;
     buf.data = buffer;
     buf.len = len;
-    return writev(address, &buf, 1);
+    return writev(address, &buf, 1, stop);
   }
-  virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt) = 0;
+  virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) = 0;
 
  protected:
   void i2c_scan_() {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -104,7 +104,7 @@ ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt)
 
   return ERROR_OK;
 }
-ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt) {
+ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) {
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them
   if (!initialized_) {
@@ -139,7 +139,7 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
       return ERROR_UNKNOWN;
     }
   }
-  uint8_t status = wire_->endTransmission(true);
+  uint8_t status = wire_->endTransmission(stop);
   if (status == 0) {
     return ERROR_OK;
   } else if (status == 1) {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -104,7 +104,7 @@ ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt)
 
   return ERROR_OK;
 }
-ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) {
+ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) {
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them
   if (!initialized_) {

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -20,7 +20,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   void setup() override;
   void dump_config() override;
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
-  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt) override;
+  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
 
   void set_scan(bool scan) { scan_ = scan; }

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -20,7 +20,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   void setup() override;
   void dump_config() override;
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
-  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) override;
+  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
 
   void set_scan(bool scan) { scan_ = scan; }

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -142,7 +142,7 @@ ErrorCode IDFI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {
 
   return ERROR_OK;
 }
-ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) {
+ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) {
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them
   if (!initialized_) {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -142,7 +142,7 @@ ErrorCode IDFI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {
 
   return ERROR_OK;
 }
-ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt) {
+ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) {
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them
   if (!initialized_) {

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -20,7 +20,7 @@ class IDFI2CBus : public I2CBus, public Component {
   void setup() override;
   void dump_config() override;
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
-  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) override;
+  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
 
   void set_scan(bool scan) { scan_ = scan; }

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -20,7 +20,7 @@ class IDFI2CBus : public I2CBus, public Component {
   void setup() override;
   void dump_config() override;
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
-  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt) override;
+  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop = true) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
 
   void set_scan(bool scan) { scan_ = scan; }

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -12,11 +12,11 @@ i2c::ErrorCode TCA9548AChannel::readv(uint8_t address, i2c::ReadBuffer *buffers,
     return err;
   return parent_->bus_->readv(address, buffers, cnt);
 }
-i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt) {
+i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) {
   auto err = parent_->switch_to_channel(channel_);
   if (err != i2c::ERROR_OK)
     return err;
-  return parent_->bus_->writev(address, buffers, cnt);
+  return parent_->bus_->writev(address, buffers, cnt, stop);
 }
 
 void TCA9548AComponent::setup() {

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -13,7 +13,7 @@ class TCA9548AChannel : public i2c::I2CBus {
   void set_parent(TCA9548AComponent *parent) { parent_ = parent; }
 
   i2c::ErrorCode readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) override;
-  i2c::ErrorCode writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt) override;
+  i2c::ErrorCode writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop = true) override;
 
  protected:
   uint8_t channel_;

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -13,7 +13,7 @@ class TCA9548AChannel : public i2c::I2CBus {
   void set_parent(TCA9548AComponent *parent) { parent_ = parent; }
 
   i2c::ErrorCode readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) override;
-  i2c::ErrorCode writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop = true) override;
+  i2c::ErrorCode writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) override;
 
  protected:
   uint8_t channel_;


### PR DESCRIPTION
# What does this implement/fix?
 The i2c implementation currently always calls `wire_->endTransmission(true);` when writing which causes an extra stop message to be sent (see https://docs.particle.io/cards/firmware/wire-i2c/endtransmission/).  This can cause issues when communication with some devices.

This change makes the stop signal configurable, defaulting to `true`

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
