### PR TITLE
Make home_assistant imported sensors internal by default

### DIFF
--- a/esphome/components/homeassistant/__init__.py
+++ b/esphome/components/homeassistant/__init__.py
@@ -1,4 +1,20 @@
 import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_INTERNAL
 
 CODEOWNERS = ["@OttoWinter"]
 homeassistant_ns = cg.esphome_ns.namespace("homeassistant")
+
+HOME_ASSISTANT_IMPORT_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ENTITY_ID): cv.entity_id,
+        cv.Optional(CONF_ATTRIBUTE): cv.string,
+        cv.Optional(CONF_INTERNAL, default=True): cv.boolean,
+    }
+)
+
+
+def setup_home_assistant_entity(var, config):
+    cg.add(var.set_entity_id(config[CONF_ENTITY_ID]))
+    if CONF_ATTRIBUTE in config:
+        cg.add(var.set_attribute(config[CONF_ATTRIBUTE]))

--- a/esphome/components/homeassistant/binary_sensor/__init__.py
+++ b/esphome/components/homeassistant/binary_sensor/__init__.py
@@ -1,30 +1,24 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import binary_sensor
-from esphome.const import CONF_ATTRIBUTE, CONF_ENTITY_ID
-from .. import homeassistant_ns
+
+from .. import (
+    HOME_ASSISTANT_IMPORT_SCHEMA,
+    homeassistant_ns,
+    setup_home_assistant_entity,
+)
 
 DEPENDENCIES = ["api"]
+
 HomeassistantBinarySensor = homeassistant_ns.class_(
     "HomeassistantBinarySensor", binary_sensor.BinarySensor, cg.Component
 )
 
-CONFIG_SCHEMA = (
-    binary_sensor.binary_sensor_schema(HomeassistantBinarySensor)
-    .extend(
-        {
-            cv.Required(CONF_ENTITY_ID): cv.entity_id,
-            cv.Optional(CONF_ATTRIBUTE): cv.string,
-        }
-    )
-    .extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(HomeassistantBinarySensor).extend(
+    HOME_ASSISTANT_IMPORT_SCHEMA
 )
 
 
 async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
-
-    cg.add(var.set_entity_id(config[CONF_ENTITY_ID]))
-    if CONF_ATTRIBUTE in config:
-        cg.add(var.set_attribute(config[CONF_ATTRIBUTE]))
+    setup_home_assistant_entity(var, config)

--- a/esphome/components/homeassistant/sensor/__init__.py
+++ b/esphome/components/homeassistant/sensor/__init__.py
@@ -1,12 +1,11 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import sensor
-from esphome.const import (
-    CONF_ATTRIBUTE,
-    CONF_ENTITY_ID,
-    CONF_ID,
+
+from .. import (
+    HOME_ASSISTANT_IMPORT_SCHEMA,
+    homeassistant_ns,
+    setup_home_assistant_entity,
 )
-from .. import homeassistant_ns
 
 DEPENDENCIES = ["api"]
 
@@ -14,19 +13,12 @@ HomeassistantSensor = homeassistant_ns.class_(
     "HomeassistantSensor", sensor.Sensor, cg.Component
 )
 
-CONFIG_SCHEMA = sensor.sensor_schema(HomeassistantSensor, accuracy_decimals=1,).extend(
-    {
-        cv.Required(CONF_ENTITY_ID): cv.entity_id,
-        cv.Optional(CONF_ATTRIBUTE): cv.string,
-    }
+CONFIG_SCHEMA = sensor.sensor_schema(HomeassistantSensor, accuracy_decimals=1).extend(
+    HOME_ASSISTANT_IMPORT_SCHEMA
 )
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
-    await sensor.register_sensor(var, config)
-
-    cg.add(var.set_entity_id(config[CONF_ENTITY_ID]))
-    if CONF_ATTRIBUTE in config:
-        cg.add(var.set_attribute(config[CONF_ATTRIBUTE]))
+    setup_home_assistant_entity(var, config)

--- a/esphome/components/homeassistant/text_sensor/__init__.py
+++ b/esphome/components/homeassistant/text_sensor/__init__.py
@@ -1,9 +1,11 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import text_sensor
-from esphome.const import CONF_ATTRIBUTE, CONF_ENTITY_ID
 
-from .. import homeassistant_ns
+from .. import (
+    HOME_ASSISTANT_IMPORT_SCHEMA,
+    homeassistant_ns,
+    setup_home_assistant_entity,
+)
 
 DEPENDENCIES = ["api"]
 
@@ -11,19 +13,12 @@ HomeassistantTextSensor = homeassistant_ns.class_(
     "HomeassistantTextSensor", text_sensor.TextSensor, cg.Component
 )
 
-CONFIG_SCHEMA = text_sensor.text_sensor_schema().extend(
-    {
-        cv.GenerateID(): cv.declare_id(HomeassistantTextSensor),
-        cv.Required(CONF_ENTITY_ID): cv.entity_id,
-        cv.Optional(CONF_ATTRIBUTE): cv.string,
-    }
+CONFIG_SCHEMA = text_sensor.text_sensor_schema(HomeassistantTextSensor).extend(
+    HOME_ASSISTANT_IMPORT_SCHEMA
 )
 
 
 async def to_code(config):
     var = await text_sensor.new_text_sensor(config)
     await cg.register_component(var, config)
-
-    cg.add(var.set_entity_id(config[CONF_ENTITY_ID]))
-    if CONF_ATTRIBUTE in config:
-        cg.add(var.set_attribute(config[CONF_ATTRIBUTE]))
+    setup_home_assistant_entity(var, config)


### PR DESCRIPTION
# What does this implement/fix?

This makes all sensors/binary_sensors/text_sensors internal by default in ESPHome. Generally there is no reason to expose these back to HA as ESPHome sensors,  just causing more network traffic. 

This is breaking because if someone is using one of the re-exposed sensors it will disappear after updating unless they set `internal: False` in yaml.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
