### PR TITLE
[WIP] Piecewise transformation for time based cover position

### DIFF
--- a/esphome/components/time_based/cover.py
+++ b/esphome/components/time_based/cover.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import cover
+from esphome.components import cover, sensor
 from esphome.const import (
     CONF_CLOSE_ACTION,
     CONF_CLOSE_DURATION,
@@ -10,12 +10,15 @@ from esphome.const import (
     CONF_OPEN_DURATION,
     CONF_STOP_ACTION,
     CONF_ASSUMED_STATE,
+    CONF_FROM,
+    CONF_TO,
 )
 
 time_based_ns = cg.esphome_ns.namespace("time_based")
 TimeBasedCover = time_based_ns.class_("TimeBasedCover", cover.Cover, cg.Component)
 
 CONF_HAS_BUILT_IN_ENDSTOP = "has_built_in_endstop"
+CONF_PIECEWISE = "piecewise"
 
 CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
     {
@@ -25,10 +28,43 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
         cv.Required(CONF_OPEN_DURATION): cv.positive_time_period_milliseconds,
         cv.Required(CONF_CLOSE_ACTION): automation.validate_automation(single=True),
         cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_PIECEWISE): cv.ensure_list(sensor.validate_datapoint),
         cv.Optional(CONF_HAS_BUILT_IN_ENDSTOP, default=False): cv.boolean,
         cv.Optional(CONF_ASSUMED_STATE, default=True): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
+
+def evaluate_piecewise_coefficients(datapoints):
+    """Note that datapoints should be properly ordered and non-degenerated."""
+    print(datapoints)
+    coefficients = []
+    cuts = []
+
+    # on first iteration, "last datapoint" is the first one (index zero)
+    last_dp = datapoints[0]
+    ldpi = last_dp[CONF_FROM]
+    ldpj = last_dp[CONF_TO]
+
+    for dp in datapoints[1:]:
+        dpi = dp[CONF_FROM]
+        dpj = dp[CONF_TO]
+        cuts.append(dpi)
+
+        # slope:
+        # $$ \frac{y_b - y_a}{x_b - x_a} $$
+        m = (dpj - ldpj) / (dpi - ldpi)
+        # point:
+        # $$ y - y_1 = m (x - x_1) $$
+        n = -m * ldpi + ldpj
+        # equation:
+        # $$ y = mx + n $$
+        coefficients.append([m, n])
+
+        ldpi = dpi
+        ldpj = dpj
+
+    return coefficients, cuts
 
 
 async def to_code(config):
@@ -52,3 +88,10 @@ async def to_code(config):
 
     cg.add(var.set_has_built_in_endstop(config[CONF_HAS_BUILT_IN_ENDSTOP]))
     cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))
+
+    if CONF_PIECEWISE in config:
+        coefficients, cuts = evaluate_piecewise_coefficients(config[CONF_PIECEWISE])
+        print(coefficients, cuts)
+
+        cg.add(var.set_cuts(cuts))
+        cg.add(var.set_coefficients(coefficients))

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -19,6 +19,9 @@ class TimeBasedCover : public cover::Cover, public Component {
   Trigger<> *get_stop_trigger() const { return this->stop_trigger_; }
   void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
   void set_close_duration(uint32_t close_duration) { this->close_duration_ = close_duration; }
+  void set_cuts(std::vector<float> &&cuts) { this->piecewise_cuts_ = std::move(cuts); };
+  void set_coefficients(std::vector<std::vector<float>> &&coeffs) { this->piecewise_coeffs_ = std::move(coeffs); };
+
   cover::CoverTraits get_traits() override;
   void set_has_built_in_endstop(bool value) { this->has_built_in_endstop_ = value; }
   void set_assumed_state(bool value) { this->assumed_state_ = value; }
@@ -31,12 +34,17 @@ class TimeBasedCover : public cover::Cover, public Component {
   void start_direction_(cover::CoverOperation dir);
 
   void recompute_position_();
+  void translate_position_();
 
   Trigger<> *open_trigger_{new Trigger<>()};
   uint32_t open_duration_;
   Trigger<> *close_trigger_{new Trigger<>()};
   uint32_t close_duration_;
   Trigger<> *stop_trigger_{new Trigger<>()};
+
+  std::vector<std::vector<float>> piecewise_coeffs_;
+  std::vector<float> piecewise_cuts_;
+  float time_position_;
 
   Trigger<> *prev_command_trigger_{nullptr};
   uint32_t last_recompute_time_{0};


### PR DESCRIPTION
# What does this implement/fix?

Add a mechanism to translate non-linearity of certain curtains (e.g. roller shutter blinds) into the time-based cover component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

Discussion on this feature started at: https://github.com/esphome/feature-requests/issues/739

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

TBD

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
cover:
  - platform: time_based
    ...
    piecewise:
      # Map 0.0 (from time) to 0.0 (true value of openness)
      - 0.0 -> 0.0
      - 0.2 -> 0.1
      - 0.65 -> 0.5
      - 1.0 -> 1.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Pending stuff I stumbled upon

I have no idea how to address the `restore` mechanism. My first approach is to have `position` the _real_ position of the cover and use a `time_position` to track the time. However, the component tracks the `time_position`, but this attribute is not stored in the restore structure, so it cannot be set. This means that the restore does not work as intended.

The decision to use `position` and `time_position` also do not sit well with the idea of the time_based cover that open and close can have diferent durations. Maybe my approach is wrong? Maybe I have to throw this and start from scratch? For my scenario of a "time symmetric" cover it works good enough, but that may not be flexible enough.