### PR TITLE
CAN bus: on_frame remote_transmission_request

### DIFF
--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -102,7 +102,11 @@ async def setup_canbus_core_(var, config):
             conf[CONF_TRIGGER_ID], var, can_id, can_id_mask, ext_id
         )
         if CONF_REMOTE_TRANSMISSION_REQUEST in conf:
-            cg.add(trigger.set_remote_transmission_request(conf[CONF_REMOTE_TRANSMISSION_REQUEST]))
+            cg.add(
+                trigger.set_remote_transmission_request(
+                    conf[CONF_REMOTE_TRANSMISSION_REQUEST]
+                )
+            )
         await cg.register_component(trigger, conf)
         await automation.build_automation(
             trigger,

--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -78,6 +78,7 @@ CANBUS_SCHEMA = cv.Schema(
                     min=0, max=0x1FFFFFFF
                 ),
                 cv.Optional(CONF_USE_EXTENDED_ID, default=False): cv.boolean,
+                cv.Optional(CONF_REMOTE_TRANSMISSION_REQUEST): cv.boolean,
             },
             validate_id,
         ),
@@ -100,10 +101,16 @@ async def setup_canbus_core_(var, config):
         trigger = cg.new_Pvariable(
             conf[CONF_TRIGGER_ID], var, can_id, can_id_mask, ext_id
         )
+        if CONF_REMOTE_TRANSMISSION_REQUEST in conf:
+            cg.add(trigger.set_remote_transmission_request(conf[CONF_REMOTE_TRANSMISSION_REQUEST]))
         await cg.register_component(trigger, conf)
         await automation.build_automation(
             trigger,
-            [(cg.std_vector.template(cg.uint8), "x"), (cg.uint32, "can_id")],
+            [
+                (cg.std_vector.template(cg.uint8), "x"),
+                (cg.uint32, "can_id"),
+                (cg.bool_, "remote_transmission_request"),
+            ],
             conf,
         )
 

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -83,7 +83,7 @@ void Canbus::loop() {
       if ((trigger->can_id_ == (can_message.can_id & trigger->can_id_mask_)) &&
           (trigger->use_extended_id_ == can_message.use_extended_id) &&
           (!trigger->remote_transmission_request_.has_value() ||
-            trigger->remote_transmission_request_.value() == can_message.remote_transmission_request)) {
+           trigger->remote_transmission_request_.value() == can_message.remote_transmission_request)) {
         trigger->trigger(data, can_message.can_id, can_message.remote_transmission_request);
       }
     }

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -81,8 +81,10 @@ void Canbus::loop() {
     // fire all triggers
     for (auto *trigger : this->triggers_) {
       if ((trigger->can_id_ == (can_message.can_id & trigger->can_id_mask_)) &&
-          (trigger->use_extended_id_ == can_message.use_extended_id)) {
-        trigger->trigger(data, can_message.can_id);
+          (trigger->use_extended_id_ == can_message.use_extended_id) &&
+          (!trigger->remote_transmission_request_.has_value() ||
+            trigger->remote_transmission_request_.value() == can_message.remote_transmission_request)) {
+        trigger->trigger(data, can_message.can_id, can_message.remote_transmission_request);
       }
     }
   }

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -126,13 +126,18 @@ template<typename... Ts> class CanbusSendAction : public Action<Ts...>, public P
   std::vector<uint8_t> data_static_{};
 };
 
-class CanbusTrigger : public Trigger<std::vector<uint8_t>, uint32_t>, public Component {
+class CanbusTrigger : public Trigger<std::vector<uint8_t>, uint32_t, bool>, public Component {
   friend class Canbus;
 
  public:
   explicit CanbusTrigger(Canbus *parent, const std::uint32_t can_id, const std::uint32_t can_id_mask,
                          const bool use_extended_id)
       : parent_(parent), can_id_(can_id), can_id_mask_(can_id_mask), use_extended_id_(use_extended_id){};
+
+  void set_remote_transmission_request(bool remote_transmission_request) {
+    this->remote_transmission_request_ = remote_transmission_request;
+  }
+
   void setup() override { this->parent_->add_trigger(this); }
 
  protected:
@@ -140,6 +145,7 @@ class CanbusTrigger : public Trigger<std::vector<uint8_t>, uint32_t>, public Com
   uint32_t can_id_;
   uint32_t can_id_mask_;
   bool use_extended_id_;
+  optional<bool> remote_transmission_request_{};
 };
 
 }  // namespace canbus


### PR DESCRIPTION
# What does this implement/fix?

Adds the option to additionally filter incoming CAN bus ``on_frame`` automations by the remote transmission request CAN frame flag. Up to now, all frames (that match ID and mask) will trigger the automation, but in case of frames with the remote transmission request flag set a) the frame data is invalid and b) the sender is actually requesting for the receiver to respond with data for a specific CAN id. With this change, the automation can be configured to e.g. only trigger on data but not on a request to send data (or vice versa).  
Furthermore ``remote_transmission_request`` will now also be passed into the lambda as an additional argument in case the lamba needs to process it itself.


## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2011

## Test Environment

- [x] ESP32

## Example entry for `config.yaml`:
Please see docs PR: https://github.com/esphome/esphome-docs/blob/7587a9c157b1cc74b1ee4307961b55bfcf7a1f82/components/canbus.rst#on_frame

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
