### PR TITLE
Use correct http defines

### DIFF
--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -93,12 +93,12 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   void handle_css_request(AsyncWebServerRequest *request);
 #endif
 
-#ifdef WEBSERVER_JS_INCLUDE
+#ifdef USE_WEBSERVER_JS_INCLUDE
   /// Handle included js request under '/0.js'.
   void handle_js_request(AsyncWebServerRequest *request);
 #endif
 
-#ifdef USE_WEBSERVER_JS_INCLUDE
+#ifdef USE_SENSOR
   void on_sensor_update(sensor::Sensor *obj, float state) override;
   /// Handle a sensor request under '/sensor/<id>'.
   void handle_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -88,7 +88,7 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   /// Handle an index request under '/'.
   void handle_index_request(AsyncWebServerRequest *request);
 
-#ifdef WEBSERVER_CSS_INCLUDE
+#ifdef USE_WEBSERVER_CSS_INCLUDE
   /// Handle included css request under '/0.css'.
   void handle_css_request(AsyncWebServerRequest *request);
 #endif
@@ -98,7 +98,7 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   void handle_js_request(AsyncWebServerRequest *request);
 #endif
 
-#ifdef USE_SENSOR
+#ifdef USE_WEBSERVER_JS_INCLUDE
   void on_sensor_update(sensor::Sensor *obj, float state) override;
   /// Handle a sensor request under '/sensor/<id>'.
   void handle_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);


### PR DESCRIPTION
# What does this implement/fix?

There is no WEBSERVER_CSS_INCLUDE and USE_WEBSERVER_JS_INCLUDE. Building with _js_include_ and _js_include_ failed with error.

```shell
src/esphome/components/web_server/web_server.cpp:313:66: error: no 'void esphome::web_server::WebServer::handle_css_request(AsyncWebServerRequest*)' member function declared in class 'esphome::web_server::WebServer'
 void WebServer::handle_css_request(AsyncWebServerRequest *request) {
                                                                  ^
src/esphome/components/web_server/web_server.cpp:324:65: error: no 'void esphome::web_server::WebServer::handle_js_request(AsyncWebServerRequest*)' member function declared in class 'esphome::web_server::WebServer'
 void WebServer::handle_js_request(AsyncWebServerRequest *request) {
                                                                 ^
src/esphome/components/web_server/web_server.cpp: In member function 'virtual void esphome::web_server::WebServer::handleRequest(AsyncWebServerRequest*)':
src/esphome/components/web_server/web_server.cpp:1059:11: error: 'class esphome::web_server::WebServer' has no member named 'handle_css_request'
     this->handle_css_request(request);
           ^
src/esphome/components/web_server/web_server.cpp:1066:11: error: 'class esphome::web_server::WebServer' has no member named 'handle_js_request'
     this->handle_js_request(request);
           ^
*** [.pioenvs/niteogmbh-sms-slack/src/esphome/components/web_server/web_server.cpp.o] Error 1
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
web_server:
  port: 80
  version: 1
  js_include: "./empty.js"
  css_include: "./empty.css"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
