### PR TITLE
Allocate smaller amount of buffer for JSON

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -23,13 +23,13 @@ std::string build_json(const json_build_t &f) {
 #ifdef USE_ESP8266
   const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
 #elif defined(USE_ESP32)
-  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
 #endif
 
-  const size_t request_size = std::min(free_heap - 2048, (size_t) 5120);
+  const size_t request_size = std::min(free_heap, (size_t) 512);
 
   DynamicJsonDocument json_document(request_size);
-  if (json_document.memoryPool().buffer() == nullptr) {
+  if (json_document.capacity() == 0) {
     ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, largest free heap block: %u bytes",
              request_size, free_heap);
     return "{}";
@@ -37,7 +37,7 @@ std::string build_json(const json_build_t &f) {
   JsonObject root = json_document.to<JsonObject>();
   f(root);
   json_document.shrinkToFit();
-
+  ESP_LOGV(TAG, "Size after shrink %u bytes", json_document.capacity());
   std::string output;
   serializeJson(json_document, output);
   return output;
@@ -51,13 +51,13 @@ void parse_json(const std::string &data, const json_parse_t &f) {
 #ifdef USE_ESP8266
   const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
 #elif defined(USE_ESP32)
-  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
 #endif
   bool pass = false;
-  size_t request_size = std::min(free_heap - 2048, (size_t)(data.size() * 1.5));
+  size_t request_size = std::min(free_heap, (size_t)(data.size() * 1.5));
   do {
     DynamicJsonDocument json_document(request_size);
-    if (json_document.memoryPool().buffer() == nullptr) {
+    if (json_document.capacity() == 0) {
       ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
                free_heap);
       return;


### PR DESCRIPTION
# What does this implement/fix?

I noticed a lot of errors in logger related to JSON buffer allocation. It was more apparent when BLE stack was in use, which creates more memory pressure.

Logs:
```shell
[I][json:033]: Requesting 5120 bytes in build_json, largest free heap block: 10324 bytes, with internal capacity 5120
[V][esp32_improv.component:169]: Setting state: 0
[V][esp32_improv.component:169]: Setting state: 0
[V][esp32_ble:193]: (BLE) gatts_event [esp_gatt_if: 4] - 13
[I][json:033]: Requesting 5120 bytes in build_json, largest free heap block: 9096 bytes, with internal capacity 0
[E][json:038]: Could not allocate memory for JSON document! Requested 5120 bytes, largest free heap block: 9096 bytes, with internal capacity 0
[I][json:033]: Requesting 5120 bytes in build_json, largest free heap block: 15740 bytes, with internal capacity 5120
[I][json:033]: Requesting 5120 bytes in build_json, largest free heap block: 11564 bytes, with internal capacity 5120
[I][json:033]: Requesting 5120 bytes in build_json, largest free heap block: 7336 bytes, with internal capacity 5120
[I][json:033]: Requesting 5120 bytes in build_json, largest free heap block: 15692 bytes, with internal capacity 5120
[I][json:033]: Requesting 5120 bytes in build_json, largest free heap block: 15692 bytes, with internal capacity 5120
```

Lowering the allocated memory, also seems to be fine since most payloads are below 100 bytes, so 512 should be plenty enough.

```shell
[V][json:033]: Requesting 512 bytes, largest free heap block: 14600 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 68
[V][json:033]: Requesting 512 bytes, largest free heap block: 8900 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 128
[V][json:033]: Requesting 512 bytes, largest free heap block: 15356 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 68
[V][json:033]: Requesting 512 bytes, largest free heap block: 16240 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 124
[V][json:033]: Requesting 512 bytes, largest free heap block: 12364 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 136
[V][json:033]: Requesting 512 bytes, largest free heap block: 6028 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 120
[V][json:033]: Requesting 512 bytes, largest free heap block: 16268 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 56
[V][json:033]: Requesting 512 bytes, largest free heap block: 10068 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 80
[V][json:033]: Requesting 512 bytes, largest free heap block: 16268 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 64
[V][json:033]: Requesting 512 bytes, largest free heap block: 16220 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 128
[V][json:033]: Requesting 512 bytes, largest free heap block: 9904 bytes, with internal capacity 512
[V][json:044]: Internal capacity  after shrink 128
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
- Some discussion here https://discord.com/channels/429907082951524364/524177279270780928/963377565156929556
- 
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

ota:
  password: !secret ota

esp32_improv:
  authorizer: none

web_server:
  port: 80
  #local: true
  version: 1

time:
  - platform: sntp
    id: esptime

uart:
  baud_rate: 9600
  tx_pin: GPIO27
  rx_pin: GPIO26

sim800l:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
