### PR TITLE
Changes accuracy of single cell voltage

### DIFF
--- a/esphome/components/daly_bms/sensor.py
+++ b/esphome/components/daly_bms/sensor.py
@@ -98,6 +98,8 @@ CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
     unit_of_measurement=UNIT_VOLT,
     device_class=DEVICE_CLASS_VOLTAGE,
     state_class=STATE_CLASS_MEASUREMENT,
+	icon=ICON_FLASH,
+    accuracy_decimals=3,
 )
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/daly_bms/sensor.py
+++ b/esphome/components/daly_bms/sensor.py
@@ -98,7 +98,7 @@ CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
     unit_of_measurement=UNIT_VOLT,
     device_class=DEVICE_CLASS_VOLTAGE,
     state_class=STATE_CLASS_MEASUREMENT,
-	icon=ICON_FLASH,
+    icon=ICON_FLASH,
     accuracy_decimals=3,
 )
 


### PR DESCRIPTION
Single cell voltage ist useless with an accuracy of 0 decimals. 3 decimals are needet to see cell drifts

useless accuracy of cell voltage sensor

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
