### PR TITLE
Add support for Mopeka Pro+ Residential sensor

### DIFF
--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -52,7 +52,7 @@ bool MopekaProCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 
   // Now parse the data - See Datasheet for definition
 
-  if (static_cast<SensorType>(manu_data.data[0]) != STANDARD_BOTTOM_UP) {
+  if (static_cast<SensorType>(manu_data.data[0]) != STANDARD_BOTTOM_UP && static_cast<SensorType>(manu_data.data[0]) != PLUS_BOTTOM_UP) {
     ESP_LOGE(TAG, "Unsupported Sensor Type (0x%X)", manu_data.data[0]);
     return false;
   }

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -52,7 +52,8 @@ bool MopekaProCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 
   // Now parse the data - See Datasheet for definition
 
-  if (static_cast<SensorType>(manu_data.data[0]) != STANDARD_BOTTOM_UP && static_cast<SensorType>(manu_data.data[0]) != PLUS_BOTTOM_UP) {
+  if (static_cast<SensorType>(manu_data.data[0]) != STANDARD_BOTTOM_UP &&
+      static_cast<SensorType>(manu_data.data[0]) != PLUS_BOTTOM_UP) {
     ESP_LOGE(TAG, "Unsupported Sensor Type (0x%X)", manu_data.data[0]);
     return false;
   }

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -12,7 +12,8 @@ namespace mopeka_pro_check {
 enum SensorType {
   STANDARD_BOTTOM_UP = 0x03,
   TOP_DOWN_AIR_ABOVE = 0x04,
-  BOTTOM_UP_WATER = 0x05
+  BOTTOM_UP_WATER = 0x05,
+  PLUS_BOTTOM_UP = 0x08
   // all other values are reserved
 };
 


### PR DESCRIPTION
# What does this implement/fix?

The Mopeka Pro+ Residential sensor is very similar to the Pro sensor, but with longer range bluetooth antenna (and radio?). The Pro+ identifies itself as 0x08.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
