### PR TITLE
Shelly Dimmer: Delete obsolete LICENSE.txt

### DIFF
--- a/esphome/components/shelly_dimmer/LICENSE.txt
+++ b/esphome/components/shelly_dimmer/LICENSE.txt
@@ -1,2 +1,0 @@
-The firmware files for the STM microcontroller (shelly-dimmer-stm32_*.bin) are taken from
-https://github.com/jamesturton/shelly-dimmer-stm32 and GPLv3 licensed.


### PR DESCRIPTION

# What does this implement/fix?

As the STM firmware binaries are not included in the repository anymore, we do not need to state their license..

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
