### PR TITLE
Fix power_delivered/produced_phase sensor deviceclass in DSMR

### DIFF
--- a/esphome/components/dsmr/sensor.py
+++ b/esphome/components/dsmr/sensor.py
@@ -143,37 +143,37 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional("power_delivered_l1"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOWATT,
             accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
+            device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional("power_delivered_l2"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOWATT,
             accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
+            device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional("power_delivered_l3"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOWATT,
             accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
+            device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional("power_returned_l1"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOWATT,
             accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
+            device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional("power_returned_l2"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOWATT,
             accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
+            device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional("power_returned_l3"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOWATT,
             accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
+            device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional("reactive_power_delivered_l1"): sensor.sensor_schema(


### PR DESCRIPTION
# What does this implement/fix?

The "power_delivered_phase_number" and "power_produced_phase_number" sensors of DSMR have a wrong device_class. They are currently `DEVICE_CLASS_CURRENT`, but should be `DEVICE_CLASS_POWER`.

This used to be correct, but was broken about 2 months ago with this commit:
https://github.com/esphome/esphome/commit/3b8bb09ae3709d844b6bc3aecc4e0b32c5b5d166

I found out since I just upgraded my SlimmeLezer from EspHome 2022.1.3 to 2022.3.2 and statistics in Home Assistant broke for the mentioned sensors.

FYI @zuidwijk since it might also impact other users of SlimmeLezer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

I chose "Other" since it might give issues with statistics collected in Home Assistant however it is wrong so should still be fixed.

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

I am not sure how to test this, as I am having issues setting up a working dev environment. 
But the change seems trivial.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
