### PR TITLE
Fix BME280 setup() when the sensor is marked as failed.

### DIFF
--- a/esphome/components/bme280/bme280.cpp
+++ b/esphome/components/bme280/bme280.cpp
@@ -81,6 +81,11 @@ static const char *iir_filter_to_str(BME280IIRFilter filter) {
 void BME280Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up BME280...");
   uint8_t chip_id = 0;
+
+  // Mark as not failed before initializing. Some devices will turn off sensors to save on batteries
+  // and when they come back on, the COMPONENT_STATE_FAILED bit must be unset on the component.
+  this->component_state_ &= ~COMPONENT_STATE_FAILED;
+
   if (!this->read_byte(BME280_REGISTER_CHIPID, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();


### PR DESCRIPTION
# What does this implement/fix?

Some devices, like the t-higrow sensor from lilygo, power off all the sensors in order to save on batteries and then go on deep sleep.

When the esp comes back from deep sleep, the sensors are powered on again.

In the case of BLE280, it needs to be re-initialized, so the setup() method must be called.

This method should also clear the FAILED flag because, in case a read has been tried while the sensor was powered off, it would be permanently marked as failed.
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3226


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
