### PR TITLE
bump FastLed from 3.3.2 to 3.5

### DIFF
--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -41,8 +41,5 @@ async def new_fastled_light(config):
         cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))
 
     await light.register_light(var, config)
-    # https://github.com/FastLED/FastLED/blob/master/library.json
-    # 3.3.3 has an issue on ESP32 with RMT and fastled_clockless:
-    # https://github.com/esphome/issues/issues/1375
-    cg.add_library("fastled/FastLED", "3.3.2")
+    cg.add_library("fastled/FastLED", "3.5")
     return var

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,7 +56,7 @@ lib_deps =
     Wire                                                  ; i2c (Arduino built-int)
     ottowinter/AsyncMqttClient-esphome@0.8.6              ; mqtt
     esphome/ESPAsyncWebServer-esphome@2.1.0               ; web_server_base
-    fastled/FastLED@3.3.2                                 ; fastled_base
+    fastled/FastLED@3.5                                   ; fastled_base
     mikalhart/TinyGPSPlus@1.0.2                           ; gps
     freekode/TM1651@1.0.1                                 ; tm1651
     glmnet/Dsmr@0.5                                       ; dsmr


### PR DESCRIPTION
# What does this implement/fix?

Bump FastLed to current version. 
I'm not seeing the crash from https://github.com/esphome/issues/issues/1375 with FastLed 3.5 anymore

This version also fixes the deprecated warning when compiling with Arduino 2
```
piolibdeps/testm5/FastLED@3.3.2/platforms/esp/32/clockless_rmt_esp32.h: In member function 'void ClocklessController<DATA_PIN, T1, T2, T3, RGB_ORDER, XTRA0, FLIP, WAIT_TIME>::startOnChannel(int)':
.piolibdeps/testm5/FastLED@3.3.2/platforms/esp/32/clockless_rmt_esp32.h:399:52: warning: 'esp_err_t rmt_set_pin(rmt_channel_t, rmt_mode_t, gpio_num_t)' is deprecated: use rmt_set_gpio instead [-Wdeprecated-declarations]
         rmt_set_pin(mRMT_channel, RMT_MODE_TX, mPin);
                                                    ^
```

https://github.com/FastLED/FastLED/compare/3.3.2...3.5.0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
