### PR TITLE
Shelly dimmer: Use unique_ptr to handle the lifetime of stm32_t

### DIFF
--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -158,11 +158,8 @@ bool ShellyDimmer::upgrade_firmware_() {
   ESP_LOGW(TAG, "Starting STM32 firmware upgrade");
   this->reset_dfu_boot_();
 
-  // Could be constexpr in c++17
-  static const auto CLOSE = [](stm32_t *stm32) { stm32_close(stm32); };
-
   // Cleanup with RAII
-  std::unique_ptr<stm32_t, decltype(CLOSE)> stm32{stm32_init(this, STREAM_SERIAL, 1), CLOSE};
+  auto stm32 = stm32_init(this, STREAM_SERIAL, 1);
 
   if (!stm32) {
     ESP_LOGW(TAG, "Failed to initialize STM32");
@@ -170,7 +167,7 @@ bool ShellyDimmer::upgrade_firmware_() {
   }
 
   // Erase STM32 flash.
-  if (stm32_erase_memory(stm32.get(), 0, STM32_MASS_ERASE) != STM32_ERR_OK) {
+  if (stm32_erase_memory(stm32, 0, STM32_MASS_ERASE) != STM32_ERR_OK) {
     ESP_LOGW(TAG, "Failed to erase STM32 flash memory");
     return false;
   }
@@ -196,7 +193,7 @@ bool ShellyDimmer::upgrade_firmware_() {
     std::memcpy(buffer, p, BUFFER_SIZE);
     p += BUFFER_SIZE;
 
-    if (stm32_write_memory(stm32.get(), addr, buffer, len) != STM32_ERR_OK) {
+    if (stm32_write_memory(stm32, addr, buffer, len) != STM32_ERR_OK) {
       ESP_LOGW(TAG, "Failed to write to STM32 flash memory");
       return false;
     }

--- a/esphome/components/shelly_dimmer/stm32flash.cpp
+++ b/esphome/components/shelly_dimmer/stm32flash.cpp
@@ -479,7 +479,6 @@ template<typename T> stm32_unique_ptr make_stm32_with_deletor(T ptr) {
     if (stm32) {
       free(stm32->cmd);  // NOLINT
     }
-
     free(stm32);  // NOLINT
   };
 
@@ -501,8 +500,7 @@ namespace shelly_dimmer {
 stm32_unique_ptr stm32_init(uart::UARTDevice *stream, const uint8_t flags, const char init) {
   uint8_t buf[257];
 
-  auto stm = make_stm32_with_deletor(static_cast<stm32_t *>(calloc(sizeof(stm32_t), 1))  // NOLINT
-  );
+  auto stm = make_stm32_with_deletor(static_cast<stm32_t *>(calloc(sizeof(stm32_t), 1)));  // NOLINT
 
   if (!stm) {
     return make_stm32_with_deletor(nullptr);

--- a/esphome/components/shelly_dimmer/stm32flash.cpp
+++ b/esphome/components/shelly_dimmer/stm32flash.cpp
@@ -168,12 +168,9 @@ stm32_err_t stm32_get_ack_timeout(const stm32_unique_ptr &stm, uint32_t timeout)
   } while (true);
 }
 
-stm32_err_t stm32_get_ack(const stm32_unique_ptr &stm) {
-  return stm32_get_ack_timeout(stm, 0);
-}
+stm32_err_t stm32_get_ack(const stm32_unique_ptr &stm) { return stm32_get_ack_timeout(stm, 0); }
 
-stm32_err_t stm32_send_command_timeout(const stm32_unique_ptr &stm, const uint8_t cmd,
-                                       const uint32_t timeout) {
+stm32_err_t stm32_send_command_timeout(const stm32_unique_ptr &stm, const uint8_t cmd, const uint32_t timeout) {
   auto *const stream = stm->stream;
 
   static constexpr auto BUFFER_SIZE = 2;
@@ -241,8 +238,7 @@ stm32_err_t stm32_resync(const stm32_unique_ptr &stm) {
  *
  * len is value of the first byte in the frame.
  */
-stm32_err_t stm32_guess_len_cmd(const stm32_unique_ptr &stm, const uint8_t cmd,
-                                uint8_t *const data, unsigned int len) {
+stm32_err_t stm32_guess_len_cmd(const stm32_unique_ptr &stm, const uint8_t cmd, uint8_t *const data, unsigned int len) {
   auto *const stream = stm->stream;
 
   if (stm32_send_command(stm, cmd) != STM32_ERR_OK)
@@ -368,8 +364,7 @@ template<typename T> std::unique_ptr<T[], void (*)(T *memory)> malloc_array_raii
                                                  DELETOR};
 }
 
-stm32_err_t stm32_pages_erase(const stm32_unique_ptr &stm, const uint32_t spage,
-                              const uint32_t pages) {
+stm32_err_t stm32_pages_erase(const stm32_unique_ptr &stm, const uint32_t spage, const uint32_t pages) {
   auto *const stream = stm->stream;
   uint8_t cs = 0;
   int i = 0;
@@ -503,8 +498,7 @@ namespace shelly_dimmer {
 /* find newer command by higher code */
 #define newer(prev, a) (((prev) == STM32_CMD_ERR) ? (a) : (((prev) > (a)) ? (prev) : (a)))
 
-stm32_unique_ptr stm32_init(uart::UARTDevice *stream, const uint8_t flags,
-                                                         const char init) {
+stm32_unique_ptr stm32_init(uart::UARTDevice *stream, const uint8_t flags, const char init) {
   uint8_t buf[257];
 
   auto stm = make_stm32_with_deletor(static_cast<stm32_t *>(calloc(sizeof(stm32_t), 1))  // NOLINT
@@ -664,8 +658,8 @@ stm32_unique_ptr stm32_init(uart::UARTDevice *stream, const uint8_t flags,
   return stm;
 }
 
-stm32_err_t stm32_read_memory(const stm32_unique_ptr &stm, const uint32_t address,
-                              uint8_t *data, const unsigned int len) {
+stm32_err_t stm32_read_memory(const stm32_unique_ptr &stm, const uint32_t address, uint8_t *data,
+                              const unsigned int len) {
   auto *const stream = stm->stream;
 
   if (!len)
@@ -703,8 +697,8 @@ stm32_err_t stm32_read_memory(const stm32_unique_ptr &stm, const uint32_t addres
   return STM32_ERR_OK;
 }
 
-stm32_err_t stm32_write_memory(const stm32_unique_ptr &stm, uint32_t address,
-                               const uint8_t *data, const unsigned int len) {
+stm32_err_t stm32_write_memory(const stm32_unique_ptr &stm, uint32_t address, const uint8_t *data,
+                               const unsigned int len) {
   auto *const stream = stm->stream;
 
   if (!len)
@@ -816,8 +810,7 @@ stm32_err_t stm32_readprot_memory(const stm32_unique_ptr &stm) {
                                  []() { ESP_LOGD(TAG, "Error: Failed to READOUT PROTECT"); });
 }
 
-stm32_err_t stm32_erase_memory(const stm32_unique_ptr &stm, uint32_t spage,
-                               uint32_t pages) {
+stm32_err_t stm32_erase_memory(const stm32_unique_ptr &stm, uint32_t spage, uint32_t pages) {
   if (!pages || spage > STM32_MAX_PAGES || ((pages != STM32_MASS_ERASE) && ((spage + pages) > STM32_MAX_PAGES)))
     return STM32_ERR_OK;
 
@@ -859,8 +852,8 @@ stm32_err_t stm32_erase_memory(const stm32_unique_ptr &stm, uint32_t spage,
   return STM32_ERR_OK;
 }
 
-static stm32_err_t stm32_run_raw_code(const stm32_unique_ptr &stm, uint32_t target_address,
-                                      const uint8_t *code, uint32_t code_size) {
+static stm32_err_t stm32_run_raw_code(const stm32_unique_ptr &stm, uint32_t target_address, const uint8_t *code,
+                                      uint32_t code_size) {
   static constexpr uint32_t BUFFER_SIZE = 256;
 
   const auto stack_le = le_u32(0x20002000);
@@ -939,8 +932,8 @@ stm32_err_t stm32_reset_device(const stm32_unique_ptr &stm) {
   }
 }
 
-stm32_err_t stm32_crc_memory(const stm32_unique_ptr &stm, const uint32_t address,
-                             const uint32_t length, uint32_t *const crc) {
+stm32_err_t stm32_crc_memory(const stm32_unique_ptr &stm, const uint32_t address, const uint32_t length,
+                             uint32_t *const crc) {
   static constexpr auto BUFFER_SIZE = 5;
   auto *const stream = stm->stream;
 
@@ -1035,8 +1028,7 @@ uint32_t stm32_sw_crc(uint32_t crc, uint8_t *buf, unsigned int len) {
   return crc;
 }
 
-stm32_err_t stm32_crc_wrapper(const stm32_unique_ptr &stm, uint32_t address,
-                              uint32_t length, uint32_t *crc) {
+stm32_err_t stm32_crc_wrapper(const stm32_unique_ptr &stm, uint32_t address, uint32_t length, uint32_t *crc) {
   static constexpr uint32_t CRC_INIT_VALUE = 0xFFFFFFFF;
   static constexpr uint32_t BUFFER_SIZE = 256;
 

--- a/esphome/components/shelly_dimmer/stm32flash.cpp
+++ b/esphome/components/shelly_dimmer/stm32flash.cpp
@@ -654,7 +654,6 @@ stm32_unique_ptr stm32_init(uart::UARTDevice *stream, const uint8_t flags, const
     return make_stm32_with_deletor(nullptr);
   }
 
-  // Release ownership of unique_ptr
   return stm;
 }
 

--- a/esphome/components/shelly_dimmer/stm32flash.h
+++ b/esphome/components/shelly_dimmer/stm32flash.h
@@ -109,23 +109,25 @@ struct VarlenCmd {
   uint8_t length;
 };
 
-std::unique_ptr<stm32_t, void (*)(stm32_t *)> stm32_init(uart::UARTDevice *stream, uint8_t flags, char init);
+using stm32_unique_ptr = std::unique_ptr<stm32_t, void (*)(stm32_t *)>;
+
+stm32_unique_ptr stm32_init(uart::UARTDevice *stream, uint8_t flags, char init);
 void stm32_close(stm32_t *stm);
-stm32_err_t stm32_read_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address, uint8_t *data,
+stm32_err_t stm32_read_memory(const stm32_unique_ptr &stm, uint32_t address, uint8_t *data,
                               unsigned int len);
-stm32_err_t stm32_write_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address,
+stm32_err_t stm32_write_memory(const stm32_unique_ptr &stm, uint32_t address,
                                const uint8_t *data, unsigned int len);
-stm32_err_t stm32_wunprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
-stm32_err_t stm32_wprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
-stm32_err_t stm32_erase_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t spage,
+stm32_err_t stm32_wunprot_memory(const stm32_unique_ptr &stm);
+stm32_err_t stm32_wprot_memory(const stm32_unique_ptr &stm);
+stm32_err_t stm32_erase_memory(const stm32_unique_ptr &stm, uint32_t spage,
                                uint32_t pages);
-stm32_err_t stm32_go(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address);
-stm32_err_t stm32_reset_device(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
-stm32_err_t stm32_readprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
-stm32_err_t stm32_runprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
-stm32_err_t stm32_crc_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address,
+stm32_err_t stm32_go(const stm32_unique_ptr &stm, uint32_t address);
+stm32_err_t stm32_reset_device(const stm32_unique_ptr &stm);
+stm32_err_t stm32_readprot_memory(const stm32_unique_ptr &stm);
+stm32_err_t stm32_runprot_memory(const stm32_unique_ptr &stm);
+stm32_err_t stm32_crc_memory(const stm32_unique_ptr &stm, uint32_t address,
                              uint32_t length, uint32_t *crc);
-stm32_err_t stm32_crc_wrapper(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address,
+stm32_err_t stm32_crc_wrapper(const stm32_unique_ptr &stm, uint32_t address,
                               uint32_t length, uint32_t *crc);
 uint32_t stm32_sw_crc(uint32_t crc, uint8_t *buf, unsigned int len);
 

--- a/esphome/components/shelly_dimmer/stm32flash.h
+++ b/esphome/components/shelly_dimmer/stm32flash.h
@@ -23,6 +23,7 @@
 #ifdef USE_SHD_FIRMWARE_DATA
 
 #include <cstdint>
+#include <memory>
 #include "esphome/components/uart/uart.h"
 
 namespace esphome {
@@ -108,19 +109,24 @@ struct VarlenCmd {
   uint8_t length;
 };
 
-stm32_t *stm32_init(uart::UARTDevice *stream, uint8_t flags, char init);
+std::unique_ptr<stm32_t, void (*)(stm32_t *)> stm32_init(uart::UARTDevice *stream, uint8_t flags, char init);
 void stm32_close(stm32_t *stm);
-stm32_err_t stm32_read_memory(const stm32_t *stm, uint32_t address, uint8_t *data, unsigned int len);
-stm32_err_t stm32_write_memory(const stm32_t *stm, uint32_t address, const uint8_t *data, unsigned int len);
-stm32_err_t stm32_wunprot_memory(const stm32_t *stm);
-stm32_err_t stm32_wprot_memory(const stm32_t *stm);
-stm32_err_t stm32_erase_memory(const stm32_t *stm, uint32_t spage, uint32_t pages);
-stm32_err_t stm32_go(const stm32_t *stm, uint32_t address);
-stm32_err_t stm32_reset_device(const stm32_t *stm);
-stm32_err_t stm32_readprot_memory(const stm32_t *stm);
-stm32_err_t stm32_runprot_memory(const stm32_t *stm);
-stm32_err_t stm32_crc_memory(const stm32_t *stm, uint32_t address, uint32_t length, uint32_t *crc);
-stm32_err_t stm32_crc_wrapper(const stm32_t *stm, uint32_t address, uint32_t length, uint32_t *crc);
+stm32_err_t stm32_read_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address, uint8_t *data,
+                              unsigned int len);
+stm32_err_t stm32_write_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address,
+                               const uint8_t *data, unsigned int len);
+stm32_err_t stm32_wunprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
+stm32_err_t stm32_wprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
+stm32_err_t stm32_erase_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t spage,
+                               uint32_t pages);
+stm32_err_t stm32_go(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address);
+stm32_err_t stm32_reset_device(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
+stm32_err_t stm32_readprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
+stm32_err_t stm32_runprot_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm);
+stm32_err_t stm32_crc_memory(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address,
+                             uint32_t length, uint32_t *crc);
+stm32_err_t stm32_crc_wrapper(const std::unique_ptr<stm32_t, void (*)(stm32_t *)> &stm, uint32_t address,
+                              uint32_t length, uint32_t *crc);
 uint32_t stm32_sw_crc(uint32_t crc, uint8_t *buf, unsigned int len);
 
 }  // namespace shelly_dimmer

--- a/esphome/components/shelly_dimmer/stm32flash.h
+++ b/esphome/components/shelly_dimmer/stm32flash.h
@@ -112,22 +112,17 @@ struct VarlenCmd {
 using stm32_unique_ptr = std::unique_ptr<stm32_t, void (*)(stm32_t *)>;
 
 stm32_unique_ptr stm32_init(uart::UARTDevice *stream, uint8_t flags, char init);
-stm32_err_t stm32_read_memory(const stm32_unique_ptr &stm, uint32_t address, uint8_t *data,
-                              unsigned int len);
-stm32_err_t stm32_write_memory(const stm32_unique_ptr &stm, uint32_t address,
-                               const uint8_t *data, unsigned int len);
+stm32_err_t stm32_read_memory(const stm32_unique_ptr &stm, uint32_t address, uint8_t *data, unsigned int len);
+stm32_err_t stm32_write_memory(const stm32_unique_ptr &stm, uint32_t address, const uint8_t *data, unsigned int len);
 stm32_err_t stm32_wunprot_memory(const stm32_unique_ptr &stm);
 stm32_err_t stm32_wprot_memory(const stm32_unique_ptr &stm);
-stm32_err_t stm32_erase_memory(const stm32_unique_ptr &stm, uint32_t spage,
-                               uint32_t pages);
+stm32_err_t stm32_erase_memory(const stm32_unique_ptr &stm, uint32_t spage, uint32_t pages);
 stm32_err_t stm32_go(const stm32_unique_ptr &stm, uint32_t address);
 stm32_err_t stm32_reset_device(const stm32_unique_ptr &stm);
 stm32_err_t stm32_readprot_memory(const stm32_unique_ptr &stm);
 stm32_err_t stm32_runprot_memory(const stm32_unique_ptr &stm);
-stm32_err_t stm32_crc_memory(const stm32_unique_ptr &stm, uint32_t address,
-                             uint32_t length, uint32_t *crc);
-stm32_err_t stm32_crc_wrapper(const stm32_unique_ptr &stm, uint32_t address,
-                              uint32_t length, uint32_t *crc);
+stm32_err_t stm32_crc_memory(const stm32_unique_ptr &stm, uint32_t address, uint32_t length, uint32_t *crc);
+stm32_err_t stm32_crc_wrapper(const stm32_unique_ptr &stm, uint32_t address, uint32_t length, uint32_t *crc);
 uint32_t stm32_sw_crc(uint32_t crc, uint8_t *buf, unsigned int len);
 
 }  // namespace shelly_dimmer

--- a/esphome/components/shelly_dimmer/stm32flash.h
+++ b/esphome/components/shelly_dimmer/stm32flash.h
@@ -112,7 +112,6 @@ struct VarlenCmd {
 using stm32_unique_ptr = std::unique_ptr<stm32_t, void (*)(stm32_t *)>;
 
 stm32_unique_ptr stm32_init(uart::UARTDevice *stream, uint8_t flags, char init);
-void stm32_close(stm32_t *stm);
 stm32_err_t stm32_read_memory(const stm32_unique_ptr &stm, uint32_t address, uint8_t *data,
                               unsigned int len);
 stm32_err_t stm32_write_memory(const stm32_unique_ptr &stm, uint32_t address,


### PR DESCRIPTION
# What does this implement/fix?
Automatic lifetime handling of stm32_init (stm32_t) via unique_ptr.

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
