### PR TITLE
Multi conf for Teleinfo component

### DIFF
--- a/esphome/components/teleinfo/__init__.py
+++ b/esphome/components/teleinfo/__init__.py
@@ -4,6 +4,7 @@ from esphome.components import uart
 from esphome.const import CONF_ID
 
 CODEOWNERS = ["@0hax"]
+MULTI_CONF = True
 
 teleinfo_ns = cg.esphome_ns.namespace("teleinfo")
 TeleInfo = teleinfo_ns.class_("TeleInfo", cg.PollingComponent, uart.UARTDevice)


### PR DESCRIPTION
# What does this implement/fix?

Add multi conf in teleinfo component,
It is useful to configure two linky, for consumption and production.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml

uart:
  - id: uart_bus1
    rx_pin: GPIO3 # Pin Rx
    baud_rate: 1200
    parity: EVEN
    data_bits: 7
  - id: uart_bus2
    rx_pin: GPIO16 # Pin Rx
    baud_rate: 1200
    parity: EVEN
    data_bits: 7

teleinfo:
  - id: teleinfoConso
    update_interval: 20s
    historical_mode: true
    uart_id: uart_bus1
  - id: teleinfoProd
    update_interval: 60s
    historical_mode: true
    uart_id: uart_bus2

sensor:
  - platform: teleinfo
    tag_name: "ADSC"
    name: "Address conso"
    unit_of_measurement: ""
    icon: mdi:eye
    teleinfo_id: teleinfoConso
  - platform: teleinfo
    tag_name: "ADSC"
    name: "Address prod"
    unit_of_measurement: ""
    icon: mdi:eye
    teleinfo_id: teleinfoProd

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

