### PR TITLE
SPS30: Add fan action

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -182,6 +182,7 @@ esphome/components/sm2135/* @BoukeHaarsma23
 esphome/components/socket/* @esphome/core
 esphome/components/sonoff_d1/* @anatoly-savchenkov
 esphome/components/spi/* @esphome/core
+esphome/components/sps30/* @martgras
 esphome/components/ssd1322_base/* @kbx81
 esphome/components/ssd1322_spi/* @kbx81
 esphome/components/ssd1325_base/* @kbx81

--- a/esphome/components/sps30/automation.h
+++ b/esphome/components/sps30/automation.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "sps30.h"
+
+namespace esphome {
+namespace sps30 {
+
+template<typename... Ts> class StartFanAction : public Action<Ts...> {
+ public:
+  explicit StartFanAction(SPS30Component *sps30) : sps30_(sps30) {}
+
+  void play(Ts... x) override { this->sps30_->start_fan_cleaning(); }
+
+ protected:
+  SPS30Component *sps30_;
+};
+
+}  // namespace sps30
+}  // namespace esphome

--- a/esphome/components/sps30/sensor.py
+++ b/esphome/components/sps30/sensor.py
@@ -1,6 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c, sensor, sensirion_common
+from esphome import automation
+from esphome.automation import maybe_simple_id
 from esphome.const import (
     CONF_ID,
     CONF_PM_1_0,
@@ -32,6 +34,11 @@ sps30_ns = cg.esphome_ns.namespace("sps30")
 SPS30Component = sps30_ns.class_(
     "SPS30Component", cg.PollingComponent, sensirion_common.SensirionI2CDevice
 )
+
+# Actions
+StartFanAction = sps30_ns.class_("StartFanAction", automation.Action)
+
+CONF_AUTO_CLEANING_INTERVAL = "auto_cleaning_interval"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -100,6 +107,7 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_AUTO_CLEANING_INTERVAL): cv.update_interval,
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -151,3 +159,21 @@ async def to_code(config):
     if CONF_PM_SIZE in config:
         sens = await sensor.new_sensor(config[CONF_PM_SIZE])
         cg.add(var.set_pm_size_sensor(sens))
+
+    if CONF_AUTO_CLEANING_INTERVAL in config:
+        cg.add(var.set_auto_cleaning_interval(config[CONF_AUTO_CLEANING_INTERVAL]))
+
+
+SPS30_ACTION_SCHEMA = maybe_simple_id(
+    {
+        cv.Required(CONF_ID): cv.use_id(SPS30Component),
+    }
+)
+
+
+@automation.register_action(
+    "sps30.start_fan_autoclean", StartFanAction, SPS30_ACTION_SCHEMA
+)
+async def sps30_fan_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/sps30/sensor.py
+++ b/esphome/components/sps30/sensor.py
@@ -27,6 +27,7 @@ from esphome.const import (
     ICON_RULER,
 )
 
+CODEOWNERS = ["@martgras"]
 DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["sensirion_common"]
 

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -22,11 +22,13 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   void set_pmc_10_0_sensor(sensor::Sensor *pmc_10_0) { pmc_10_0_sensor_ = pmc_10_0; }
 
   void set_pm_size_sensor(sensor::Sensor *pm_size) { pm_size_sensor_ = pm_size; }
-
+  void set_auto_cleaning_interval(uint32_t auto_cleaning_interval) { fan_interval_ = auto_cleaning_interval; }
   void setup() override;
   void update() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
+
+  bool start_fan_cleaning();
 
  protected:
   char serial_number_[17] = {0};  /// Terminating NULL character
@@ -54,6 +56,7 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   sensor::Sensor *pmc_4_0_sensor_{nullptr};
   sensor::Sensor *pmc_10_0_sensor_{nullptr};
   sensor::Sensor *pm_size_sensor_{nullptr};
+  optional<uint32_t> fan_interval_;
 };
 
 }  // namespace sps30


### PR DESCRIPTION
# What does this implement/fix?

- Add action to start  fan claning
- Add option to configure autoclean interval

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2033

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml

sensor:
  - platform: sps30
    id: my_sps30
    pm_1_0:
      name: " PM <1µm Weight concentration"
      id: "PM_1_0"
    auto_cleaning_interval: 1200s

button:
  - platform: template
    name: "Start Autoclean"
    on_press:
      - sps30.start_fan_autoclean: my_sps30

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
