### PR TITLE
Add support for XGZP6897D pressure sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -226,6 +226,7 @@ esphome/components/version/* @esphome/core
 esphome/components/wake_on_lan/* @willwill2will54
 esphome/components/web_server_base/* @OttoWinter
 esphome/components/whirlpool/* @glmnet
+esphome/components/xgzp6897d/* @hurzhurz
 esphome/components/xiaomi_lywsd03mmc/* @ahpohl
 esphome/components/xiaomi_mhoc303/* @drug123
 esphome/components/xiaomi_mhoc401/* @vevsvevs

--- a/esphome/components/xgzp6897d/__init__.py
+++ b/esphome/components/xgzp6897d/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@hurzhurz"]

--- a/esphome/components/xgzp6897d/sensor.py
+++ b/esphome/components/xgzp6897d/sensor.py
@@ -1,0 +1,105 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_OVERSAMPLING,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_HECTOPASCAL,
+)
+
+CONF_PRESSURE_RANGE = "pressure_range"
+CONF_CONTINUES_MODE = "continues_mode"
+CONF_SLEEP_TIME = "sleep_time"
+
+DEPENDENCIES = ["i2c"]
+
+xgzp6897d_ns = cg.esphome_ns.namespace("xgzp6897d")
+XGZP6897DOversampling = xgzp6897d_ns.enum("XGZP6897DOversampling")
+OVERSAMPLING_OPTIONS = {
+    "256X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_256X,
+    "512X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_512X,
+    "1024X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_1024X,
+    "2048X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_2048X,
+    "4096X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_4096X,
+    "8192X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_8192X,
+    "16384X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_16384X,
+    "32768X": XGZP6897DOversampling.XGZP6897D_OVERSAMPLING_32768X,
+}
+
+XGZP6897DComponent = xgzp6897d_ns.class_(
+    "XGZP6897DComponent", cg.PollingComponent, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(XGZP6897DComponent),
+            cv.Required(CONF_PRESSURE_RANGE): cv.float_range(min=0.0, max=260.0),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_HECTOPASCAL,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_PRESSURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_OVERSAMPLING, default="1024X"): cv.enum(
+                OVERSAMPLING_OPTIONS, upper=True
+            ),
+            cv.Optional(CONF_CONTINUES_MODE, default=False): cv.boolean,
+            cv.Optional(CONF_SLEEP_TIME, default=0): cv.int_range(min=0, max=15),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x6D))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    conf = config[CONF_PRESSURE_RANGE]
+    if conf > 131:
+        cg.add(var.set_kvalue(32))
+    elif conf > 65:
+        cg.add(var.set_kvalue(64))
+    elif conf > 32:
+        cg.add(var.set_kvalue(128))
+    elif conf > 16:
+        cg.add(var.set_kvalue(256))
+    elif conf > 8:
+        cg.add(var.set_kvalue(512))
+    elif conf > 4:
+        cg.add(var.set_kvalue(1024))
+    elif conf >= 2:
+        cg.add(var.set_kvalue(2048))
+    elif conf >= 1:
+        cg.add(var.set_kvalue(4096))
+    else:
+        cg.add(var.set_kvalue(8192))
+
+    if CONF_TEMPERATURE in config:
+        conf = config[CONF_TEMPERATURE]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_temperature_sensor(sens))
+
+    if CONF_PRESSURE in config:
+        conf = config[CONF_PRESSURE]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_pressure_sensor(sens))
+
+    cg.add(var.set_oversampling(config[CONF_OVERSAMPLING]))
+    cg.add(var.set_continuous_mode(config[CONF_CONTINUES_MODE]))
+    cg.add(var.set_sleep_time(config[CONF_SLEEP_TIME]))

--- a/esphome/components/xgzp6897d/xgzp6897d.cpp
+++ b/esphome/components/xgzp6897d/xgzp6897d.cpp
@@ -1,0 +1,172 @@
+#include "xgzp6897d.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace xgzp6897d {
+
+static const char *const TAG = "xgzp6897d.sensor";
+
+static const uint8_t XGZP6897D_REGISTER_DATA = 0x06;
+static const uint8_t XGZP6897D_REGISTER_CMD = 0x30;
+static const uint8_t XGZP6897D_REGISTER_SYSCONFIG = 0xA5;
+static const uint8_t XGZP6897D_REGISTER_PCONFIG = 0xA6;
+
+static const char *oversampling_to_str(XGZP6897DOversampling oversampling) {
+  switch (oversampling) {
+    case XGZP6897D_OVERSAMPLING_256X:
+      return "256x";
+    case XGZP6897D_OVERSAMPLING_512X:
+      return "512x";
+    case XGZP6897D_OVERSAMPLING_1024X:
+      return "1024x";
+    case XGZP6897D_OVERSAMPLING_2048X:
+      return "2048x";
+    case XGZP6897D_OVERSAMPLING_4096X:
+      return "4096x";
+    case XGZP6897D_OVERSAMPLING_8192X:
+      return "8192x";
+    case XGZP6897D_OVERSAMPLING_16384X:
+      return "16384x";
+    case XGZP6897D_OVERSAMPLING_32768X:
+      return "32768x";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+static const char *kvalue_to_str(uint16_t kvalue) {
+  switch (kvalue) {
+    case 32:
+      return "131 < kPa <= 260";
+    case 64:
+      return "65 < kPa <= 131";
+    case 128:
+      return "32 < kPa <= 65";
+    case 256:
+      return "16 < kPa <= 32";
+    case 512:
+      return "8 < kPa <= 16";
+    case 1024:
+      return "4 < kPa <= 8";
+    case 2048:
+      return "2 <= kPa <= 4";
+    case 4096:
+      return "1 <= kPa < 2";
+    case 8192:
+      return "kPa < 1";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+void XGZP6897DComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up XGZP6897D...");
+
+  uint8_t pconfig;
+  if (!this->read_byte(XGZP6897D_REGISTER_PCONFIG, &pconfig)) {
+    this->mark_failed();
+    return;
+  }
+
+  pconfig &= ~0b00000111;
+  pconfig |= this->oversampling_;
+
+  if (!this->write_byte(XGZP6897D_REGISTER_PCONFIG, pconfig)) {
+    this->mark_failed();
+    return;
+  }
+
+  if (this->continuous_mode_) {
+    // Set continuous mode
+    uint8_t cmd = 0b1011;
+
+    cmd |= ((sleep_time_ & 0b1111) << 4);
+
+    if (!this->write_byte(XGZP6897D_REGISTER_CMD, cmd)) {
+      this->mark_failed();
+      return;
+    }
+  }
+}
+void XGZP6897DComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "XGZP6897D:");
+  LOG_I2C_DEVICE(this);
+  switch (this->error_code_) {
+    case COMMUNICATION_FAILED:
+      ESP_LOGE(TAG, "Communication with XGZP6897D failed!");
+      break;
+    case NONE:
+    default:
+      break;
+  }
+  LOG_UPDATE_INTERVAL(this);
+
+  ESP_LOGCONFIG(TAG, "  Pressure Range: %s", kvalue_to_str(this->kvalue_));
+  ESP_LOGCONFIG(TAG, "  Continues Mode: %s (Sleep Time: %.1fms)", (this->continuous_mode_ ? "true" : "false"),
+                (sleep_time_ * 62.5f));
+  ESP_LOGCONFIG(TAG, "  Oversampling: %s", oversampling_to_str(this->oversampling_));
+  LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+}
+float XGZP6897DComponent::get_setup_priority() const { return setup_priority::DATA; }
+
+void XGZP6897DComponent::update() {
+  if (!this->continuous_mode_) {
+    ESP_LOGV(TAG, "Sending conversion request...");
+    uint8_t cmd = 0b1010;
+    if (!this->write_byte(XGZP6897D_REGISTER_CMD, cmd)) {
+      this->status_set_warning();
+      return;
+    }
+
+    uint32_t start = millis();
+    while (this->read_byte(XGZP6897D_REGISTER_CMD, &cmd) && (cmd & 0b1000) > 0) {
+      if (millis() - start > 100) {
+        ESP_LOGW(TAG, "Reading XGZP6897D timed out");
+        this->status_set_warning();
+        return;
+      }
+      delay(1);
+    }
+    ESP_LOGV(TAG, "Conversion took %dms.", millis() - start);
+  }
+
+  uint8_t data[5];
+  if (!this->read_bytes(XGZP6897D_REGISTER_DATA, data, 5)) {
+    ESP_LOGW(TAG, "Error reading registers.");
+    this->status_set_warning();
+    return;
+  }
+
+  float pressure = this->read_pressure_(data);
+  float temperature = this->read_temperature_(data);
+
+  ESP_LOGV(TAG, "Got pressure=%.2fhPa temperature=%.1f°C", pressure, temperature);
+  if (this->pressure_sensor_ != nullptr)
+    this->pressure_sensor_->publish_state(pressure);
+  if (this->temperature_sensor_ != nullptr)
+    this->temperature_sensor_->publish_state(temperature);
+  this->status_clear_warning();
+}
+
+float XGZP6897DComponent::read_pressure_(const uint8_t *data) {
+  int32_t pressure = (data[0] << 16) | (data[1] << 8) | data[2];
+
+  if (pressure & (1 << 23))
+    pressure = pressure - (1 << 24);
+
+  return ((float) pressure / (float) kvalue_) / 100.0f;
+}
+
+float XGZP6897DComponent::read_temperature_(const uint8_t *data) {
+  int32_t temperature = (data[3] << 8) | data[4];
+
+  if (temperature & (1 << 15))
+    temperature = temperature - (1 << 16);
+
+  return (float) temperature / 256.0f;
+}
+
+}  // namespace xgzp6897d
+}  // namespace esphome

--- a/esphome/components/xgzp6897d/xgzp6897d.h
+++ b/esphome/components/xgzp6897d/xgzp6897d.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace xgzp6897d {
+
+/** Enum listing all Oversampling values for the XGZP6897D.
+ *
+ * Oversampling basically means measuring a condition multiple times. Higher oversampling
+ * values therefore increase the time required to read sensor values but increase accuracy.
+ */
+enum XGZP6897DOversampling {
+  XGZP6897D_OVERSAMPLING_256X = 0b100,
+  XGZP6897D_OVERSAMPLING_512X = 0b101,
+  XGZP6897D_OVERSAMPLING_1024X = 0b000,
+  XGZP6897D_OVERSAMPLING_2048X = 0b001,
+  XGZP6897D_OVERSAMPLING_4096X = 0b010,
+  XGZP6897D_OVERSAMPLING_8192X = 0b011,
+  XGZP6897D_OVERSAMPLING_16384X = 0b110,
+  XGZP6897D_OVERSAMPLING_32768X = 0b111,
+};
+
+/// This class implements support for the XGZP6897D Differential Pressure i2c sensor.
+class XGZP6897DComponent : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
+
+  /// Set the oversampling value
+  void set_oversampling(XGZP6897DOversampling over_sampling) { this->oversampling_ = over_sampling; }
+
+  // Set kvalue, needed to calculated pressure and depends on the pressure range of the sensor
+  void set_kvalue(uint16_t kvalue) { kvalue_ = kvalue; }
+
+  void set_continuous_mode(bool continuous_mode) { continuous_mode_ = continuous_mode; }
+  void set_sleep_time(uint8_t sleep_time) { sleep_time_ = sleep_time; }
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  void update() override;
+
+ protected:
+  /// Read the pressure value in hPa.
+  float read_pressure_(const uint8_t *data);
+  /// Read the temperature value.
+  float read_temperature_(const uint8_t *data);
+
+  XGZP6897DOversampling oversampling_{XGZP6897D_OVERSAMPLING_1024X};
+  sensor::Sensor *temperature_sensor_;
+  sensor::Sensor *pressure_sensor_;
+  uint16_t kvalue_{32};
+  bool continuous_mode_{false};
+  uint8_t sleep_time_{0};
+  enum ErrorCode {
+    NONE = 0,
+    COMMUNICATION_FAILED,
+  } error_code_{NONE};
+};
+
+}  // namespace xgzp6897d
+}  // namespace esphome

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -748,6 +748,16 @@ sensor:
     temperature:
       name: "mlxtemp"
       oversampling: 2
+
+  - platform: xgzp6897d
+    pressure_range: 50
+    pressure:
+      name: "XGZP6897D Pressure"
+    temperature:
+      name: "XGZP6897D Internal Temperature"
+    oversampling: 32768x
+    update_interval: 60s
+
 time:
   - platform: homeassistant
 


### PR DESCRIPTION
# What does this implement/fix?

This adds the support for the XGZP6897D Digital Air Differential Pressure Sensor

https://www.cfsensor.com/proinfo/28.html

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2040

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: xgzp6897d
    pressure_range: 50
    pressure:
      name: "XGZP6897D Pressure"
    temperature:
      name: "XGZP6897D Internal Temperature"
    update_interval: 60s
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
