### PR TITLE
tca9548a fix channel selection

### DIFF
--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -41,7 +41,7 @@ i2c::ErrorCode TCA9548AComponent::switch_to_channel(uint8_t channel) {
     return i2c::ERROR_OK;
 
   uint8_t channel_val = 1 << channel;
-  auto err = this->write(&channel_val,1);
+  auto err = this->write(&channel_val, 1);
   if (err == i2c::ERROR_OK) {
     current_channel_ = channel;
   }

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -41,7 +41,7 @@ i2c::ErrorCode TCA9548AComponent::switch_to_channel(uint8_t channel) {
     return i2c::ERROR_OK;
 
   uint8_t channel_val = 1 << channel;
-  auto err = this->write_register(0x70, &channel_val, 1);
+  auto err = this->write(channel_val);
   if (err == i2c::ERROR_OK) {
     current_channel_ = channel;
   }

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -41,7 +41,7 @@ i2c::ErrorCode TCA9548AComponent::switch_to_channel(uint8_t channel) {
     return i2c::ERROR_OK;
 
   uint8_t channel_val = 1 << channel;
-  auto err = this->write(channel_val);
+  auto err = this->write(&channel_val,1);
   if (err == i2c::ERROR_OK) {
     current_channel_ = channel;
   }


### PR DESCRIPTION
# What does this implement/fix?

selecting the channel  shouldn't write to register 0x70  but write the new channel directly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3215

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
