### PR TITLE
added prev_frame for animation

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -586,8 +586,8 @@ void Animation::next_frame() {
 }
 void Animation::prev_frame() {
   this->current_frame_--;
-  if (this->current_frame_ < 0 ) {
-    this->current_frame_ = this->animation_frame_count_-1;
+  if (this->current_frame_ < 0) {
+    this->current_frame_ = this->animation_frame_count_ - 1;
   }
 }
 

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -584,6 +584,12 @@ void Animation::next_frame() {
     this->current_frame_ = 0;
   }
 }
+void Animation::prev_frame() {
+  this->current_frame_--;
+  if (this->current_frame_ < 0 ) {
+    this->current_frame_ = this->animation_frame_count_-1;
+  }
+}
 
 DisplayPage::DisplayPage(display_writer_t writer) : writer_(std::move(writer)) {}
 void DisplayPage::show() { this->parent_->show_page(this); }

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -478,6 +478,7 @@ class Animation : public Image {
   int get_animation_frame_count() const;
   int get_current_frame() const;
   void next_frame();
+  void prev_frame();
 
  protected:
   int current_frame_;


### PR DESCRIPTION
# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2048

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
       interval:
          - interval: 5s
              then:
                lambda: |-
                  id(my_animation).prev_frame();

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). [PR](https://github.com/esphome/esphome-docs/pull/2048)
