### PR TITLE
Add display_type property to DisplayBuffer

### DIFF
--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -40,6 +40,8 @@ class AddressableLightDisplay : public display::DisplayBuffer, public PollingCom
   void setup() override;
   void display();
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
  protected:
   int get_width_internal() override;
   int get_height_internal() override;

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -85,6 +85,12 @@ enum ImageType {
   IMAGE_TYPE_RGB565 = 4,
 };
 
+enum DisplayType {
+  DISPLAY_TYPE_BINARY = 1,
+  DISPLAY_TYPE_GRAYSCALE = 2,
+  DISPLAY_TYPE_COLOR = 3,
+};
+
 enum DisplayRotation {
   DISPLAY_ROTATION_0_DEGREES = 0,
   DISPLAY_ROTATION_90_DEGREES = 90,
@@ -360,6 +366,11 @@ class DisplayBuffer {
   virtual int get_height_internal() = 0;
   virtual int get_width_internal() = 0;
   DisplayRotation get_rotation() const { return this->rotation_; }
+
+  /** Get the type of display that the buffer corresponds to. In case of dynamically configurable displays,
+   * returns the type the display is currently configured to.
+   */
+  virtual DisplayType get_display_type() = 0;
 
  protected:
   void vprintf_(int x, int y, Font *font, Color color, TextAlign align, const char *format, va_list arg);

--- a/esphome/components/ili9341/ili9341_display.h
+++ b/esphome/components/ili9341/ili9341_display.h
@@ -48,6 +48,8 @@ class ILI9341Display : public PollingComponent,
     this->initialize();
   }
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   void setup_pins_();

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -86,6 +86,10 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
 
   void block_partial() { this->block_partial_ = true; }
 
+  display::DisplayType get_display_type() override {
+    return get_greyscale() ? display::DisplayType::DISPLAY_TYPE_GRAYSCALE : display::DisplayType::DISPLAY_TYPE_BINARY;
+  }
+
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   void display1b_();

--- a/esphome/components/max7219digit/max7219digit.h
+++ b/esphome/components/max7219digit/max7219digit.h
@@ -93,6 +93,8 @@ class MAX7219Component : public PollingComponent,
   uint8_t strftimedigit(const char *format, time::ESPTime time) __attribute__((format(strftime, 2, 0)));
 #endif
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
  protected:
   void send_byte_(uint8_t a_register, uint8_t data);
   void send_to_all_(uint8_t a_register, uint8_t data);

--- a/esphome/components/pcd8544/pcd_8544.h
+++ b/esphome/components/pcd8544/pcd_8544.h
@@ -52,6 +52,8 @@ class PCD8544 : public PollingComponent,
     this->initialize();
   }
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
 

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -48,6 +48,8 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
  protected:
   virtual void command(uint8_t value) = 0;
   virtual void write_display_data() = 0;

--- a/esphome/components/ssd1322_base/ssd1322_base.h
+++ b/esphome/components/ssd1322_base/ssd1322_base.h
@@ -30,6 +30,8 @@ class SSD1322 : public PollingComponent, public display::DisplayBuffer {
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_GRAYSCALE; }
+
  protected:
   virtual void command(uint8_t value) = 0;
   virtual void data(uint8_t value) = 0;

--- a/esphome/components/ssd1325_base/ssd1325_base.h
+++ b/esphome/components/ssd1325_base/ssd1325_base.h
@@ -35,6 +35,8 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
  protected:
   virtual void command(uint8_t value) = 0;
   virtual void write_display_data() = 0;

--- a/esphome/components/ssd1327_base/ssd1327_base.h
+++ b/esphome/components/ssd1327_base/ssd1327_base.h
@@ -30,6 +30,8 @@ class SSD1327 : public PollingComponent, public display::DisplayBuffer {
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_GRAYSCALE; }
+
  protected:
   virtual void command(uint8_t value) = 0;
   virtual void write_display_data() = 0;

--- a/esphome/components/ssd1331_base/ssd1331_base.h
+++ b/esphome/components/ssd1331_base/ssd1331_base.h
@@ -25,6 +25,8 @@ class SSD1331 : public PollingComponent, public display::DisplayBuffer {
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
  protected:
   virtual void command(uint8_t value) = 0;
   virtual void write_display_data() = 0;

--- a/esphome/components/ssd1351_base/ssd1351_base.h
+++ b/esphome/components/ssd1351_base/ssd1351_base.h
@@ -31,6 +31,8 @@ class SSD1351 : public PollingComponent, public display::DisplayBuffer {
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
   void fill(Color color) override;
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
  protected:
   virtual void command(uint8_t value) = 0;
   virtual void data(uint8_t value) = 0;

--- a/esphome/components/st7735/st7735.h
+++ b/esphome/components/st7735/st7735.h
@@ -53,6 +53,8 @@ class ST7735 : public PollingComponent,
   void set_dc_pin(GPIOPin *value) { dc_pin_ = value; }
   size_t get_buffer_length();
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
  protected:
   void sendcommand_(uint8_t cmd, const uint8_t *data_bytes, uint8_t num_data_bytes);
   void senddata_(const uint8_t *data_bytes, uint8_t num_data_bytes);

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -126,7 +126,7 @@ class ST7789V : public PollingComponent,
 
   void write_display_data();
 
-  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
 
  protected:
   GPIOPin *dc_pin_;

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -126,6 +126,8 @@ class ST7789V : public PollingComponent,
 
   void write_display_data();
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
  protected:
   GPIOPin *dc_pin_;
   GPIOPin *reset_pin_{nullptr};

--- a/esphome/components/st7920/st7920.h
+++ b/esphome/components/st7920/st7920.h
@@ -29,6 +29,8 @@ class ST7920 : public PollingComponent,
   void fill(Color color) override;
   void write_display_data();
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   int get_height_internal() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -36,6 +36,8 @@ class WaveshareEPaper : public PollingComponent,
 
   void on_safe_shutdown() override;
 
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
 


### PR DESCRIPTION
Add the possibility for DisplayBuffer clients to know which kind of
images (monochrome/grayscale/color) the Display is capable of displaying.

# What does this implement/fix?

I some cases (e.g. PR #3255) it would be good if code using a DisplayBuffer object would be able to check which kind of images the displaybuffer is capable of displaying. Added an abstract method to get that information in the base DisplayBuffer class, and implemented it on all display components I could find in the code.

This might break compilation of custom_component displays that are built out of tree. The fix is easy (implement the one-liner method), but would need to be done on each custom display.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** needed by #3255 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
