### PR TITLE
Esp32c3 deepsleep fix

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -109,7 +109,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 
   App.run_safe_shutdown_hooks();
 
-#if defined(USE_ESP32) 
+#if defined(USE_ESP32)
 #if !defined(USE_ESP32_VARIANT_ESP32C3)
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
@@ -137,13 +137,12 @@ void DeepSleepComponent::begin_sleep(bool manual) {
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
     }
-    esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
+    esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), 
+                                      static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
   }
 #endif
   esp_deep_sleep_start();
 #endif
-
-
 
 #ifdef USE_ESP8266
   ESP.deepSleep(*this->sleep_duration_);  // NOLINT(readability-static-accessed-through-instance)

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -76,11 +76,13 @@ void DeepSleepComponent::set_sleep_duration(uint32_t time_ms) { this->sleep_dura
 void DeepSleepComponent::set_wakeup_pin_mode(WakeupPinMode wakeup_pin_mode) {
   this->wakeup_pin_mode_ = wakeup_pin_mode;
 }
+#if !defined(USE_ESP32_VARIANT_ESP32C3)
 void DeepSleepComponent::set_ext1_wakeup(Ext1Wakeup ext1_wakeup) { this->ext1_wakeup_ = ext1_wakeup; }
 void DeepSleepComponent::set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
 void DeepSleepComponent::set_run_duration(WakeupCauseToRunDuration wakeup_cause_to_run_duration) {
   wakeup_cause_to_run_duration_ = wakeup_cause_to_run_duration;
 }
+#endif
 #endif
 void DeepSleepComponent::set_run_duration(uint32_t time_ms) { this->run_duration_ = time_ms; }
 void DeepSleepComponent::begin_sleep(bool manual) {
@@ -137,7 +139,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
     }
-    esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), level);
+    esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
   }
 #endif
 

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -137,7 +137,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
     }
-    esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), 
+    esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()),
                                       static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
   }
 #endif

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -109,7 +109,8 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 
   App.run_safe_shutdown_hooks();
 
-#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
+#if defined(USE_ESP32) 
+#if !defined(USE_ESP32_VARIANT_ESP32C3)
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
@@ -127,10 +128,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
     esp_sleep_enable_touchpad_wakeup();
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
   }
-
-  esp_deep_sleep_start();
 #endif
-
 #ifdef USE_ESP32_VARIANT_ESP32C3
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
@@ -142,6 +140,10 @@ void DeepSleepComponent::begin_sleep(bool manual) {
     esp_deep_sleep_enable_gpio_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
   }
 #endif
+  esp_deep_sleep_start();
+#endif
+
+
 
 #ifdef USE_ESP8266
   ESP.deepSleep(*this->sleep_duration_);  // NOLINT(readability-static-accessed-through-instance)


### PR DESCRIPTION
# What does this implement/fix?

Fix deep sleep for ESP32-C3 modules. Mask wake-up sources unavailable on ESP32-C3 and typecast gpio wake-up mode.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#3077

## Test Environment

- [x] ESP32-C3

## Example entry for `config.yaml`:

```yaml
esphome:
  name: t01c3_02
  platformio_options:
    board_build.variant: esp32c3
    board_build.flash_mode: dio
    # run with 80 MHz
    board_build.f_cpu: 80000000L

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: arduino
    version: dev
    platform_version: https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream

deep_sleep:
  run_duration: 1min
  sleep_duration: 1min

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

