### PR TITLE
Introduces delayed BLE actions

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -17,6 +17,8 @@ from esphome import automation
 CODEOWNERS = ["@buxtronix"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 
+CONF_MAINTAIN_CONNECTION = "maintain_connection"
+
 ble_client_ns = cg.esphome_ns.namespace("ble_client")
 BLEClient = ble_client_ns.class_(
     "BLEClient", cg.Component, esp32_ble_tracker.ESPBTClient
@@ -43,6 +45,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(BLEClient),
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_NAME): cv.string,
+            cv.Optional(CONF_MAINTAIN_CONNECTION, default=True): cv.boolean,
             cv.Optional(CONF_ON_CONNECT): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -114,6 +117,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await esp32_ble_tracker.register_client(var, config)
+    cg.add(var.set_maintain_connection(config[CONF_MAINTAIN_CONNECTION]))
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
     for conf in config.get(CONF_ON_CONNECT, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/components/ble_client/automation.cpp
+++ b/esphome/components/ble_client/automation.cpp
@@ -10,7 +10,7 @@ namespace esphome {
 namespace ble_client {
 static const char *const TAG = "ble_client.automation";
 
-void BLEWriterClientNode::write() {
+void BLEWriterClientNode::write(const std::vector<uint8_t> &value) {
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "Cannot write to BLE characteristic - not connected");
     return;
@@ -29,9 +29,10 @@ void BLEWriterClientNode::write() {
     ESP_LOGE(TAG, "Characteristic %s does not allow writing", this->char_uuid_.to_string().c_str());
     return;
   }
-  ESP_LOGVV(TAG, "Will write %d bytes: %s", this->value_.size(), format_hex_pretty(this->value_).c_str());
-  esp_err_t err = esp_ble_gattc_write_char(this->parent()->gattc_if, this->parent()->conn_id, this->ble_char_handle_,
-                                           value_.size(), value_.data(), write_type, ESP_GATT_AUTH_REQ_NONE);
+  ESP_LOGVV(TAG, "Will write %d bytes: %s", value.size(), format_hex_pretty(value).c_str());
+  esp_err_t err =
+      esp_ble_gattc_write_char(this->parent()->gattc_if, this->parent()->conn_id, this->ble_char_handle_, value.size(),
+                               const_cast<uint8_t *>(value.data()), write_type, ESP_GATT_AUTH_REQ_NONE);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Error writing to characteristic: %s!", esp_err_to_name(err));
   }

--- a/esphome/components/ble_client/automation.cpp
+++ b/esphome/components/ble_client/automation.cpp
@@ -10,6 +10,8 @@ namespace esphome {
 namespace ble_client {
 static const char *const TAG = "ble_client.automation";
 
+// Attempts to write to the configured characteristic. Returns false on retriable errors and true on success or
+// non-retriable errors.
 bool BLEWriterClientNode::write() {
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "Cannot write to BLE characteristic - not connected");
@@ -37,6 +39,8 @@ bool BLEWriterClientNode::write() {
     ESP_LOGE(TAG, "Error writing to characteristic: %s!", esp_err_to_name(err));
     return false;
   }
+
+  ESP_LOGD(TAG, "Success writing to characteristic");
   return true;
 }
 
@@ -76,7 +80,6 @@ void BLEWriterClientNode::loop() {
       return;
     }
 
-    ESP_LOGD(TAG, "Success writing pending value.");
     pending_write_ = false;
 
     // If the BLEClient should not maintain an active connection, tell it to disconnect.

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -77,8 +77,8 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
     has_simple_value_ = false;
   }
 
-  void set_value_simple(std::vector<uint8_t> value) {
-    this->value_simple_ = std::move(value);
+  void set_value_simple(const std::vector<uint8_t> &value) {
+    this->value_simple_ = value;
     has_simple_value_ = true;
   }
 

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -42,10 +42,8 @@ class BLEWriterClientNode : public BLEClientNode {
     ble_client_ = ble_client;
   }
 
-  void set_value(std::vector<uint8_t> value) { value_ = std::move(value); }
-
-  // Attempts to write the contents of value_ to char_uuid_.
-  void write();
+  // Attempts to write the contents of value to char_uuid_.
+  void write(const std::vector<uint8_t> &value);
 
   void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
 
@@ -60,14 +58,34 @@ class BLEWriterClientNode : public BLEClientNode {
   esp_gatt_char_prop_t char_props_;
   espbt::ESPBTUUID service_uuid_;
   espbt::ESPBTUUID char_uuid_;
-  std::vector<uint8_t> value_;
 };
 
 template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, public BLEWriterClientNode {
  public:
   BLEClientWriteAction(BLEClient *ble_client) : BLEWriterClientNode(ble_client) {}
 
-  void play(Ts... x) override { return write(); }
+  void play(Ts... x) override {
+    if (has_simple_value_) {
+      return write(this->value_simple_);
+    } else {
+      return write(this->value_template_(x...));
+    }
+  }
+
+  void set_value_template(std::function<std::vector<uint8_t>(Ts...)> func) {
+    this->value_template_ = std::move(func);
+    has_simple_value_ = false;
+  }
+
+  void set_value_simple(std::vector<uint8_t> value) {
+    this->value_simple_ = std::move(value);
+    has_simple_value_ = true;
+  }
+
+ private:
+  bool has_simple_value_ = true;
+  std::vector<uint8_t> value_simple_;
+  std::function<std::vector<uint8_t>(Ts...)> value_template_{};
 };
 
 }  // namespace ble_client

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -42,8 +42,8 @@ class BLEWriterClientNode : public BLEClientNode {
     ble_client_ = ble_client;
   }
 
-  // Attempts to write the contents of value to char_uuid_.
-  void write();
+  // Attempts to write the contents of value_ to char_uuid_.
+  bool write();
 
   void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
 
@@ -78,7 +78,9 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
     } else {
       this->set_value(this->value_template_(x...));
     }
-    ble_client_->should_connect_ = true;
+    if (!ble_client_->get_maintain_connection()) {
+      ble_client_->set_should_connect(true);
+    }
     pending_write_ = true;
   }
 

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -65,10 +65,10 @@ bool BLEClient::parse_device(const espbt::ESPBTDevice &device) {
 
 std::string BLEClient::address_str() const {
   char buf[20];
-  sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x", (uint8_t) (this->address >> 40) & 0xff,
-          (uint8_t) (this->address >> 32) & 0xff, (uint8_t) (this->address >> 24) & 0xff,
-          (uint8_t) (this->address >> 16) & 0xff, (uint8_t) (this->address >> 8) & 0xff,
-          (uint8_t) (this->address >> 0) & 0xff);
+  sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x", (uint8_t)(this->address >> 40) & 0xff,
+          (uint8_t)(this->address >> 32) & 0xff, (uint8_t)(this->address >> 24) & 0xff,
+          (uint8_t)(this->address >> 16) & 0xff, (uint8_t)(this->address >> 8) & 0xff,
+          (uint8_t)(this->address >> 0) & 0xff);
   std::string ret;
   ret = buf;
   return ret;
@@ -260,43 +260,43 @@ float BLEClient::parse_char_value(uint8_t *value, uint16_t length) {
   if (length == 0)
     return 0;
   if (length == 1)
-    return (float) ((uint8_t) value[0]);
+    return (float)((uint8_t) value[0]);
 
   switch (value[0]) {
     case 0x1:  // boolean.
     case 0x2:  // 2bit.
     case 0x3:  // nibble.
     case 0x4:  // uint8.
-      return (float) ((uint8_t) value[1]);
+      return (float)((uint8_t) value[1]);
     case 0x5:  // uint12.
     case 0x6:  // uint16.
       if (length > 2) {
-        return (float) ((uint16_t) (value[1] << 8) + (uint16_t) value[2]);
+        return (float)((uint16_t)(value[1] << 8) + (uint16_t) value[2]);
       }
     case 0x7:  // uint24.
       if (length > 3) {
-        return (float) ((uint32_t) (value[1] << 16) + (uint32_t) (value[2] << 8) + (uint32_t) (value[3]));
+        return (float)((uint32_t)(value[1] << 16) + (uint32_t)(value[2] << 8) + (uint32_t)(value[3]));
       }
     case 0x8:  // uint32.
       if (length > 4) {
-        return (float) ((uint32_t) (value[1] << 24) + (uint32_t) (value[2] << 16) + (uint32_t) (value[3] << 8) +
-                        (uint32_t) (value[4]));
+        return (float)((uint32_t)(value[1] << 24) + (uint32_t)(value[2] << 16) + (uint32_t)(value[3] << 8) +
+                        (uint32_t)(value[4]));
       }
     case 0xC:  // int8.
-      return (float) ((int8_t) value[1]);
+      return (float)((int8_t) value[1]);
     case 0xD:  // int12.
     case 0xE:  // int16.
       if (length > 2) {
-        return (float) ((int16_t) (value[1] << 8) + (int16_t) value[2]);
+        return (float)((int16_t)(value[1] << 8) + (int16_t) value[2]);
       }
     case 0xF:  // int24.
       if (length > 3) {
-        return (float) ((int32_t) (value[1] << 16) + (int32_t) (value[2] << 8) + (int32_t) (value[3]));
+        return (float)((int32_t)(value[1] << 16) + (int32_t)(value[2] << 8) + (int32_t)(value[3]));
       }
     case 0x10:  // int32.
       if (length > 4) {
-        return (float) ((int32_t) (value[1] << 24) + (int32_t) (value[2] << 16) + (int32_t) (value[3] << 8) +
-                        (int32_t) (value[4]));
+        return (float)((int32_t)(value[1] << 24) + (int32_t)(value[2] << 16) + (int32_t)(value[3] << 8) +
+                        (int32_t)(value[4]));
       }
   }
   ESP_LOGW(TAG, "Cannot parse characteristic value of type 0x%x length %d", value[0], length);

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -65,10 +65,10 @@ bool BLEClient::parse_device(const espbt::ESPBTDevice &device) {
 
 std::string BLEClient::address_str() const {
   char buf[20];
-  sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x", (uint8_t)(this->address >> 40) & 0xff,
-          (uint8_t)(this->address >> 32) & 0xff, (uint8_t)(this->address >> 24) & 0xff,
-          (uint8_t)(this->address >> 16) & 0xff, (uint8_t)(this->address >> 8) & 0xff,
-          (uint8_t)(this->address >> 0) & 0xff);
+  sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x", (uint8_t) (this->address >> 40) & 0xff,
+          (uint8_t) (this->address >> 32) & 0xff, (uint8_t) (this->address >> 24) & 0xff,
+          (uint8_t) (this->address >> 16) & 0xff, (uint8_t) (this->address >> 8) & 0xff,
+          (uint8_t) (this->address >> 0) & 0xff);
   std::string ret;
   ret = buf;
   return ret;
@@ -134,6 +134,11 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
         ESP_LOGW(TAG, "connect to %s failed, status=%d", this->address_str().c_str(), param->open.status);
         this->set_states_(espbt::ClientState::IDLE);
         break;
+      }
+      this->conn_id = param->open.conn_id;
+      auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if, param->open.conn_id);
+      if (ret) {
+        ESP_LOGW(TAG, "esp_ble_gattc_send_mtu_req failed, status=%x", ret);
       }
       break;
     }
@@ -271,32 +276,32 @@ float BLEClient::parse_char_value(uint8_t *value, uint16_t length) {
     case 0x5:  // uint12.
     case 0x6:  // uint16.
       if (length > 2) {
-        return (float) ((uint16_t)(value[1] << 8) + (uint16_t) value[2]);
+        return (float) ((uint16_t) (value[1] << 8) + (uint16_t) value[2]);
       }
     case 0x7:  // uint24.
       if (length > 3) {
-        return (float) ((uint32_t)(value[1] << 16) + (uint32_t)(value[2] << 8) + (uint32_t)(value[3]));
+        return (float) ((uint32_t) (value[1] << 16) + (uint32_t) (value[2] << 8) + (uint32_t) (value[3]));
       }
     case 0x8:  // uint32.
       if (length > 4) {
-        return (float) ((uint32_t)(value[1] << 24) + (uint32_t)(value[2] << 16) + (uint32_t)(value[3] << 8) +
-                        (uint32_t)(value[4]));
+        return (float) ((uint32_t) (value[1] << 24) + (uint32_t) (value[2] << 16) + (uint32_t) (value[3] << 8) +
+                        (uint32_t) (value[4]));
       }
     case 0xC:  // int8.
       return (float) ((int8_t) value[1]);
     case 0xD:  // int12.
     case 0xE:  // int16.
       if (length > 2) {
-        return (float) ((int16_t)(value[1] << 8) + (int16_t) value[2]);
+        return (float) ((int16_t) (value[1] << 8) + (int16_t) value[2]);
       }
     case 0xF:  // int24.
       if (length > 3) {
-        return (float) ((int32_t)(value[1] << 16) + (int32_t)(value[2] << 8) + (int32_t)(value[3]));
+        return (float) ((int32_t) (value[1] << 16) + (int32_t) (value[2] << 8) + (int32_t) (value[3]));
       }
     case 0x10:  // int32.
       if (length > 4) {
-        return (float) ((int32_t)(value[1] << 24) + (int32_t)(value[2] << 16) + (int32_t)(value[3] << 8) +
-                        (int32_t)(value[4]));
+        return (float) ((int32_t) (value[1] << 24) + (int32_t) (value[2] << 16) + (int32_t) (value[3] << 8) +
+                        (int32_t) (value[4]));
       }
   }
   ESP_LOGW(TAG, "Cannot parse characteristic value of type 0x%x length %d", value[0], length);

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -47,6 +47,8 @@ bool BLEClient::parse_device(const espbt::ESPBTDevice &device) {
     return false;
   if (this->state() != espbt::ClientState::IDLE)
     return false;
+  if (!should_connect_)
+    return false;
 
   ESP_LOGD(TAG, "Found device at MAC address [%s]", device.address_str().c_str());
   this->set_states_(espbt::ClientState::DISCOVERED);

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -135,11 +135,6 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
         this->set_states_(espbt::ClientState::IDLE);
         break;
       }
-      this->conn_id = param->open.conn_id;
-      auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if, param->open.conn_id);
-      if (ret) {
-        ESP_LOGW(TAG, "esp_ble_gattc_send_mtu_req failed, status=%x", ret);
-      }
       break;
     }
     case ESP_GATTC_CONNECT_EVT: {
@@ -158,6 +153,7 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
       if (param->cfg_mtu.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "cfg_mtu to %s failed, mtu %d, status %d", this->address_str().c_str(), param->cfg_mtu.mtu,
                  param->cfg_mtu.status);
+        // This is causing some bugs.
         this->set_states_(espbt::ClientState::IDLE);
         break;
       }

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -275,7 +275,7 @@ float BLEClient::parse_char_value(uint8_t *value, uint16_t length) {
       }
     case 0x7:  // uint24.
       if (length > 3) {
-        return (float)((uint32_t)(value[1] << 16) + (uint32_t)(value[2] << 8) + (uint32_t)(value[3]));
+        return (float) ((uint32_t)(value[1] << 16) + (uint32_t)(value[2] << 8) + (uint32_t)(value[3]));
       }
     case 0x8:  // uint32.
       if (length > 4) {

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -153,7 +153,6 @@ void BLEClient::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t es
       if (param->cfg_mtu.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "cfg_mtu to %s failed, mtu %d, status %d", this->address_str().c_str(), param->cfg_mtu.mtu,
                  param->cfg_mtu.status);
-        // This is causing some bugs.
         this->set_states_(espbt::ClientState::IDLE);
         break;
       }

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -260,18 +260,18 @@ float BLEClient::parse_char_value(uint8_t *value, uint16_t length) {
   if (length == 0)
     return 0;
   if (length == 1)
-    return (float)((uint8_t) value[0]);
+    return (float) ((uint8_t) value[0]);
 
   switch (value[0]) {
     case 0x1:  // boolean.
     case 0x2:  // 2bit.
     case 0x3:  // nibble.
     case 0x4:  // uint8.
-      return (float)((uint8_t) value[1]);
+      return (float) ((uint8_t) value[1]);
     case 0x5:  // uint12.
     case 0x6:  // uint16.
       if (length > 2) {
-        return (float)((uint16_t)(value[1] << 8) + (uint16_t) value[2]);
+        return (float) ((uint16_t)(value[1] << 8) + (uint16_t) value[2]);
       }
     case 0x7:  // uint24.
       if (length > 3) {
@@ -279,23 +279,23 @@ float BLEClient::parse_char_value(uint8_t *value, uint16_t length) {
       }
     case 0x8:  // uint32.
       if (length > 4) {
-        return (float)((uint32_t)(value[1] << 24) + (uint32_t)(value[2] << 16) + (uint32_t)(value[3] << 8) +
+        return (float) ((uint32_t)(value[1] << 24) + (uint32_t)(value[2] << 16) + (uint32_t)(value[3] << 8) +
                         (uint32_t)(value[4]));
       }
     case 0xC:  // int8.
-      return (float)((int8_t) value[1]);
+      return (float) ((int8_t) value[1]);
     case 0xD:  // int12.
     case 0xE:  // int16.
       if (length > 2) {
-        return (float)((int16_t)(value[1] << 8) + (int16_t) value[2]);
+        return (float) ((int16_t)(value[1] << 8) + (int16_t) value[2]);
       }
     case 0xF:  // int24.
       if (length > 3) {
-        return (float)((int32_t)(value[1] << 16) + (int32_t)(value[2] << 8) + (int32_t)(value[3]));
+        return (float) ((int32_t)(value[1] << 16) + (int32_t)(value[2] << 8) + (int32_t)(value[3]));
       }
     case 0x10:  // int32.
       if (length > 4) {
-        return (float)((int32_t)(value[1] << 24) + (int32_t)(value[2] << 16) + (int32_t)(value[3] << 8) +
+        return (float) ((int32_t)(value[1] << 24) + (int32_t)(value[2] << 16) + (int32_t)(value[3] << 8) +
                         (int32_t)(value[4]));
       }
   }

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -97,6 +97,18 @@ class BLEClient : public espbt::ESPBTClient, public Component {
 
   void set_enabled(bool enabled);
 
+  void set_maintain_connection(bool maintain_connection) {
+    maintain_connection_ = maintain_connection;
+    // Set the value of should_connect_ to the same as maintain_connection. The goal is
+    // to have sane defaults:
+    // - If maintain_connection, we already will try to connect
+    // - If !maintain_connection, we won't try to connect right away
+    should_connect_ = maintain_connection;
+  }
+  bool get_maintain_connection() const { return maintain_connection_; }
+  void set_should_connect(bool should_connect) { should_connect_ = should_connect; }
+  bool get_should_connect() const { return should_connect_; }
+
   void register_ble_node(BLEClientNode *node) {
     node->client = this;
     node->set_ble_client_parent(this);
@@ -121,10 +133,10 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   bool enabled;
   std::string address_str() const;
 
-  // TODO(rbaron): properly encapsulate should_connect_.
-  bool should_connect_ = false;
-
  protected:
+  bool maintain_connection_ = true;
+  bool should_connect_ = true;
+
   void set_states_(espbt::ClientState st) {
     this->set_state(st);
     for (auto &node : nodes_)

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -91,6 +91,7 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   bool parse_device(const espbt::ESPBTDevice &device) override;
   void on_scan_end() override {}
   void connect() override;
+  void disconnect();
 
   void set_address(uint64_t address) { this->address = address; }
 
@@ -119,6 +120,9 @@ class BLEClient : public espbt::ESPBTClient, public Component {
   uint64_t address;
   bool enabled;
   std::string address_str() const;
+
+  // TODO(rbaron): properly encapsulate should_connect_.
+  bool should_connect_ = false;
 
  protected:
   void set_states_(espbt::ClientState st) {

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -615,3 +615,9 @@ switch:
           service_uuid: F61E3BE9-2826-A81B-970A-4D4DECFABBAE
           characteristic_uuid: 6490FAFE-0734-732C-8705-91B653A081FC
           value: [0x01, 0xab, 0xff]
+      - ble_client.ble_write:
+          id: airthings01
+          service_uuid: F61E3BE9-2826-A81B-970A-4D4DECFABBAE
+          characteristic_uuid: 6490FAFE-0734-732C-8705-91B653A081FC
+          value: !lambda |-
+            return {0x13, 0x37};


### PR DESCRIPTION
# What does this implement/fix?

This PR introduces delayed BLE actions. This may be useful for triggering BLE writes on non-persistent connections. Using a delayed BLE action will cause a BLE connection to be established, a write to be sent to the specified characteristic and a subsequent disconnection. 

This PR also makes BLE action more gracefully handle errors in both delayed (this PR) and eager (#3398) cases. Previously, a write would fail if the connection had not been established at the time of the action execution. Now, the write will be pending until the connection is established, at which point the write will be triggered.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
esphome:
  name: esphome_ble_led_client
  platform: ESP32
  board: lolin32

esp32_ble_tracker:

ble_client:
  - id: esphome_ble_led_ble_client
    mac_address: D0:90:AB:CD:EF:E2
    maintain_connection: false

switch:
  - platform: template
    name: "ESP32 LED Switch"
    optimistic: true
    turn_on_action:
      - ble_client.ble_write:
          id: esphome_ble_led_ble_client
          service_uuid: d7204ebc-4bc5-4a6a-a7e5-7a86f998b7a9
          characteristic_uuid: 9be42785-94ae-4c1b-aa02-cd87c1c647c8
          value: [0x7f, 0xab]
    turn_off_action:
      - ble_client.ble_write:
          id: esphome_ble_led_ble_client
          service_uuid: d7204ebc-4bc5-4a6a-a7e5-7a86f998b7a9
          characteristic_uuid: 9be42785-94ae-4c1b-aa02-cd87c1c647c8
          value: [0x4b, 0x9d]

logger:
  level: DEBUG
```

I've set up a minimal ESP32 Arduino-based BLE service to test this PR with in [rbaron/ble-led](https://github.com/rbaron/ble-led).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
