### PR TITLE
Fix cover set position by force pushing position_id datapoint (simila…

### DIFF
--- a/esphome/components/tuya/cover/tuya_cover.cpp
+++ b/esphome/components/tuya/cover/tuya_cover.cpp
@@ -66,7 +66,7 @@ void TuyaCover::control(const cover::CoverCall &call) {
       auto position_int = static_cast<uint32_t>(pos * this->value_range_);
       position_int = position_int + this->min_value_;
 
-      parent_->set_integer_datapoint_value(*this->position_id_, position_int);
+      parent_->force_set_integer_datapoint_value(*this->position_id_, position_int);
     }
   }
   if (call.get_position().has_value()) {
@@ -82,7 +82,7 @@ void TuyaCover::control(const cover::CoverCall &call) {
       auto position_int = static_cast<uint32_t>(pos * this->value_range_);
       position_int = position_int + this->min_value_;
 
-      parent_->set_integer_datapoint_value(*this->position_id_, position_int);
+      parent_->force_set_integer_datapoint_value(*this->position_id_, position_int);
     }
   }
 


### PR DESCRIPTION
# What does this implement/fix?

The `position_datapoint` is not updated on open and close commands so that the cover cannot be set to the same datapoint after a open or close command. A force write to the `position_datapoint` resolves this issue. This feature was implemented in: [78e216c](https://github.com/esphome/esphome/pull/2637/commits/78e216c777019b42c0eb7e74018b8b8b31858791).

Example:
1. Set cover `position_datapoint` to 50% -> cover moves to requested position
2. Close the cover `control_datapoint` -> cover closes
3. Set cover `position_datapoint` to 50% -> reports 'Not sending unchanged value'

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes #3260

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  tx_pin: GPIO01
  rx_pin: GPIO03
  baud_rate: 9600

tuya:

cover:
  - platform: tuya
    name: "Living room curtain"
    device_class: curtain
    control_datapoint: 1
    direction_datapoint: 5
    position_datapoint: 2
    position_report_datapoint: 3
    invert_position: True
    restore_mode: RESTORE

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
