### PR TITLE
Support for Arduino 2 and serial port on ESP32-S2 and ESP32-C3

### DIFF
--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -51,7 +51,7 @@ class ImprovSerialComponent : public Component {
   void write_data_(std::vector<uint8_t> &data);
 
 #ifdef USE_ARDUINO
-  HardwareSerial *hw_serial_{nullptr};
+  Stream *hw_serial_{nullptr};
 #endif
 #ifdef USE_ESP_IDF
   uart_port_t uart_num_;

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -149,9 +149,7 @@ void Logger::pre_setup() {
       case UART_SELECTION_UART0_SWAP:
 #endif
         this->hw_serial_ = &Serial;
-#if !ARDUINO_USB_CDC_ON_BOOT
         Serial.begin(this->baud_rate_);
-#endif
 #ifdef USE_ESP8266
         if (this->uart_ == UART_SELECTION_UART0_SWAP) {
           Serial.swap();

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -149,13 +149,29 @@ void Logger::pre_setup() {
       case UART_SELECTION_UART0_SWAP:
 #endif
         this->hw_serial_ = &Serial;
+#if !ARDUINO_USB_CDC_ON_BOOT
+        Serial.begin(this->baud_rate_);
+#endif
+#ifdef USE_ESP8266
+        if (this->uart_ == UART_SELECTION_UART0_SWAP) {
+          Serial.swap();
+        }
+        Serial.setDebugOutput(ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE);
+#endif
         break;
       case UART_SELECTION_UART1:
         this->hw_serial_ = &Serial1;
+#if !ARDUINO_USB_CDC_ON_BOOT
+        Serial1.begin(this->baud_rate_);
+#endif
+#ifdef USE_ESP8266
+        Serial1.setDebugOutput(ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE);
+#endif
         break;
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32S2)
       case UART_SELECTION_UART2:
         this->hw_serial_ = &Serial2;
+        Serial2.begin(this->baud_rate_);
         break;
 #endif
     }
@@ -186,16 +202,6 @@ void Logger::pre_setup() {
     // Install UART driver using an event queue here
     uart_driver_install(uart_num_, uart_buffer_size, uart_buffer_size, 10, nullptr, 0);
 #endif
-
-#ifdef USE_ARDUINO
-    this->hw_serial_->begin(this->baud_rate_);
-#ifdef USE_ESP8266
-    if (this->uart_ == UART_SELECTION_UART0_SWAP) {
-      this->hw_serial_->swap();
-    }
-    this->hw_serial_->setDebugOutput(ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE);
-#endif
-#endif  // USE_ARDUINO
   }
 #ifdef USE_ESP8266
   else {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -159,9 +159,7 @@ void Logger::pre_setup() {
         break;
       case UART_SELECTION_UART1:
         this->hw_serial_ = &Serial1;
-#if !ARDUINO_USB_CDC_ON_BOOT
         Serial1.begin(this->baud_rate_);
-#endif
 #ifdef USE_ESP8266
         Serial1.setDebugOutput(ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE);
 #endif

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -40,7 +40,7 @@ class Logger : public Component {
   void set_baud_rate(uint32_t baud_rate);
   uint32_t get_baud_rate() const { return baud_rate_; }
 #ifdef USE_ARDUINO
-  HardwareSerial *get_hw_serial() const { return hw_serial_; }
+  Stream *get_hw_serial() const { return hw_serial_; }
 #endif
 #ifdef USE_ESP_IDF
   uart_port_t get_uart_num() const { return uart_num_; }
@@ -119,7 +119,7 @@ class Logger : public Component {
   int tx_buffer_size_{0};
   UARTSelection uart_{UART_SELECTION_UART0};
 #ifdef USE_ARDUINO
-  HardwareSerial *hw_serial_{nullptr};
+  Stream *hw_serial_{nullptr};
 #endif
 #ifdef USE_ESP_IDF
   uart_port_t uart_num_;


### PR DESCRIPTION
# What does this implement/fix?

Make logger support USB serial port on ESP32-S2 and ESP32-C3

For ESP32-C3 the compiler emits this error
`src/esphome/components/logger/logger.cpp:151:29: error: cannot convert 'HWCDC*' to 'HardwareSerial*' in assignment`

For ESP32-S2 the compiler emits this error
`src/esphome/components/logger/logger.cpp:151:29: error: cannot convert 'USBCDC*' to 'HardwareSerial*' in assignment`

HardwareSerial, USBCDC and HWCDC inherits Stream, and implements the begin(...) method.

This PR changes previous usage of HardwareSerial to Stream, and changes all call to methods on `this->hw_serial_` to the spepcific Serial* objects instead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

## Test Environment

- [ ] ESP32
- [x] ESP32-S2
- [x] ESP32-C3
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# Common code
external_components:
  - source: github://pr#3436
    components: [ logger ]
    
logger:

interval:
  - interval: 1s
    then:
      - logger.log: "PING"
```
```yaml
# adafruit_qtpy_esp32s2
esphome:
  name: adafruit_qtpy_esp32s2

esp32:
  board: adafruit_qtpy_esp32s2
  variant: esp32s2
  framework:
    type: arduino
    version: 2.0.2
    platform_version: 4.2.0
```
```yaml
# adafruit_qtpy_esp32c3
esphome:
  name: adafruit_qtpy_esp32c3

esp32:
  board: adafruit_qt_py_esp32-c3
  variant: esp32c3
  framework:
    type: arduino
    version: 2.0.3
    source: https://github.com/espressif/arduino-esp32#2.0.3
    platform_version: https://github.com/tasmota/platform-espressif32#v.2.0.3
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).