### PR TITLE
Modify the stepper component - direction aware and request_stop.

### DIFF
--- a/esphome/components/stepper/stepper.cpp
+++ b/esphome/components/stepper/stepper.cpp
@@ -12,30 +12,27 @@ static const char *const TAG = "stepper";
  *
  */
 void Stepper::request_stop() {
-
-  if( this->current_speed_ == 0.0f ) {
+  if (this->current_speed_ == 0.0f) {
     this->target_position = this->current_position;
 
   } else {
-
     // Compute steps needed to decelerate:
     float v_squared = this->current_speed_ * this->current_speed_;
     auto steps_to_decelerate = static_cast<int32_t>(v_squared / (2 * this->deceleration_));
 
     // Adjust the target:
 
-    int32_t target_dist = abs( int32_t(this->target_position) - int32_t(this->current_position) );
-    if( target_dist <= steps_to_decelerate ) {
+    int32_t target_dist = abs(int32_t(this->target_position) - int32_t(this->current_position));
+    if (target_dist <= steps_to_decelerate) {
       // Probably already decelerating, so let's not increase the distance
       steps_to_decelerate = target_dist;
     }
 
     // Based on the direction of movement, adjust the target position:
-    if( this->current_speed_ < 0 ) {
+    if (this->current_speed_ < 0) {
       this->target_position = this->current_position - steps_to_decelerate;
     } else
       this->target_position = this->current_position + steps_to_decelerate;
-
   }
 }
 
@@ -50,13 +47,13 @@ void Stepper::calculate_speed_(uint32_t now) {
 
   int32_t target_difference = int32_t(this->target_position) - int32_t(this->current_position);
 
-  if( (target_difference > 0) && (this->current_speed_ < 0 ) ) {
+  if ((target_difference > 0) && (this->current_speed_ < 0)) {
     // wrong direction (negative), need to decelerate:
     this->current_speed_ += this->deceleration_ * dt;
     return;
   }
 
-  if( (target_difference < 0) && (this->current_speed_ > 0 ) ) {
+  if ((target_difference < 0) && (this->current_speed_ > 0)) {
     // wrong direction (positive), need to decelerate:
     this->current_speed_ -= this->deceleration_ * dt;
     return;
@@ -68,16 +65,18 @@ void Stepper::calculate_speed_(uint32_t now) {
   auto steps_to_decelerate = static_cast<int32_t>(v_squared / (2 * this->deceleration_));
   if (num_steps <= steps_to_decelerate) {
     // need to start decelerating
-    if( target_difference > 0 )
+    if (target_difference > 0) {
       this->current_speed_ -= this->deceleration_ * dt;
-    else
+    } else {
       this->current_speed_ += this->deceleration_ * dt;
+    }
   } else {
     // we can still accelerate
-    if( target_difference > 0 )
+    if (target_difference > 0) {
       this->current_speed_ += this->acceleration_ * dt;
-    else
+    } else {
       this->current_speed_ -= this->acceleration_ * dt;
+    }
   }
 
   this->current_speed_ = clamp(this->current_speed_, -this->max_speed_, this->max_speed_);
@@ -91,7 +90,7 @@ int32_t Stepper::should_step_() {
 
   // assumes this method is called in a constant interval
   uint32_t dt = now - this->last_step_;
-  if (dt >= (1. / abs(this->current_speed_)) * 1e6f) {
+  if (dt >= (1. / std::abs(this->current_speed_)) * 1e6f) {
     int32_t mag = this->current_speed_ > 0 ? 1 : -1;
     this->last_step_ = now;
     this->current_position += mag;

--- a/esphome/components/stepper/stepper.cpp
+++ b/esphome/components/stepper/stepper.cpp
@@ -12,30 +12,29 @@ static const char *const TAG = "stepper";
  *
  */
 void Stepper::request_stop() {
-
-  if( this->current_speed_ == 0.0f ) {
+  if (this->current_speed_ == 0.0f) {
     this->target_position = this->current_position;
 
   } else {
 
     // Compute steps needed to decelerate:
     float v_squared = this->current_speed_ * this->current_speed_;
-    auto steps_to_decelerate = static_cast<int32_t>(v_squared / (2 * this->deceleration_));
+    auto steps_to_decelerate =
+        static_cast<int32_t>(v_squared / (2 * this->deceleration_));
 
     // Adjust the target:
 
-    int32_t target_dist = abs( int32_t(this->target_position) - int32_t(this->current_position) );
-    if( target_dist <= steps_to_decelerate ) {
+    int32_t target_dist = abs(int32_t(this->target_position) - int32_t(this->current_position));
+    if (target_dist <= steps_to_decelerate) {
       // Probably already decelerating, so let's not increase the distance
       steps_to_decelerate = target_dist;
     }
 
     // Based on the direction of movement, adjust the target position:
-    if( this->current_speed_ < 0 ) {
+    if (this->current_speed_ < 0) {
       this->target_position = this->current_position - steps_to_decelerate;
     } else
       this->target_position = this->current_position + steps_to_decelerate;
-
   }
 }
 
@@ -50,13 +49,13 @@ void Stepper::calculate_speed_(uint32_t now) {
 
   int32_t target_difference = int32_t(this->target_position) - int32_t(this->current_position);
 
-  if( (target_difference > 0) && (this->current_speed_ < 0 ) ) {
+  if ((target_difference > 0) && (this->current_speed_ < 0)) {
     // wrong direction (negative), need to decelerate:
     this->current_speed_ += this->deceleration_ * dt;
     return;
   }
 
-  if( (target_difference < 0) && (this->current_speed_ > 0 ) ) {
+  if ((target_difference < 0) && (this->current_speed_ > 0)) {
     // wrong direction (positive), need to decelerate:
     this->current_speed_ -= this->deceleration_ * dt;
     return;
@@ -65,16 +64,17 @@ void Stepper::calculate_speed_(uint32_t now) {
   int32_t num_steps = abs(int32_t(this->target_position) - int32_t(this->current_position));
   // (v_0)^2 / 2*a
   float v_squared = this->current_speed_ * this->current_speed_;
-  auto steps_to_decelerate = static_cast<int32_t>(v_squared / (2 * this->deceleration_));
+  auto steps_to_decelerate =
+      static_cast<int32_t>(v_squared / (2 * this->deceleration_));
   if (num_steps <= steps_to_decelerate) {
     // need to start decelerating
-    if( target_difference > 0 )
+    if (target_difference > 0)
       this->current_speed_ -= this->deceleration_ * dt;
     else
       this->current_speed_ += this->deceleration_ * dt;
   } else {
     // we can still accelerate
-    if( target_difference > 0 )
+    if (target_difference > 0)
       this->current_speed_ += this->acceleration_ * dt;
     else
       this->current_speed_ -= this->acceleration_ * dt;
@@ -101,5 +101,5 @@ int32_t Stepper::should_step_() {
   return 0;
 }
 
-}  // namespace stepper
-}  // namespace esphome
+} // namespace stepper
+} // namespace esphome

--- a/esphome/components/stepper/stepper.cpp
+++ b/esphome/components/stepper/stepper.cpp
@@ -7,6 +7,38 @@ namespace stepper {
 
 static const char *const TAG = "stepper";
 
+/**
+ * @brief Decelerates to standstill.
+ *
+ */
+void Stepper::request_stop() {
+
+  if( this->current_speed_ == 0.0f ) {
+    this->target_position = this->current_position;
+
+  } else {
+
+    // Compute steps needed to decelerate:
+    float v_squared = this->current_speed_ * this->current_speed_;
+    auto steps_to_decelerate = static_cast<int32_t>(v_squared / (2 * this->deceleration_));
+
+    // Adjust the target:
+
+    int32_t target_dist = abs( int32_t(this->target_position) - int32_t(this->current_position) );
+    if( target_dist <= steps_to_decelerate ) {
+      // Probably already decelerating, so let's not increase the distance
+      steps_to_decelerate = target_dist;
+    }
+
+    // Based on the direction of movement, adjust the target position:
+    if( this->current_speed_ < 0 ) {
+      this->target_position = this->current_position - steps_to_decelerate;
+    } else
+      this->target_position = this->current_position + steps_to_decelerate;
+
+  }
+}
+
 void Stepper::calculate_speed_(uint32_t now) {
   // delta t since last calculation in seconds
   float dt = (now - this->last_calculation_) * 1e-6f;
@@ -16,19 +48,41 @@ void Stepper::calculate_speed_(uint32_t now) {
     return;
   }
 
+  int32_t target_difference = int32_t(this->target_position) - int32_t(this->current_position);
+
+  if( (target_difference > 0) && (this->current_speed_ < 0 ) ) {
+    // wrong direction (negative), need to decelerate:
+    this->current_speed_ += this->deceleration_ * dt;
+    return;
+  }
+
+  if( (target_difference < 0) && (this->current_speed_ > 0 ) ) {
+    // wrong direction (positive), need to decelerate:
+    this->current_speed_ -= this->deceleration_ * dt;
+    return;
+  }
+
   int32_t num_steps = abs(int32_t(this->target_position) - int32_t(this->current_position));
   // (v_0)^2 / 2*a
   float v_squared = this->current_speed_ * this->current_speed_;
   auto steps_to_decelerate = static_cast<int32_t>(v_squared / (2 * this->deceleration_));
   if (num_steps <= steps_to_decelerate) {
     // need to start decelerating
-    this->current_speed_ -= this->deceleration_ * dt;
+    if( target_difference > 0 )
+      this->current_speed_ -= this->deceleration_ * dt;
+    else
+      this->current_speed_ += this->deceleration_ * dt;
   } else {
     // we can still accelerate
-    this->current_speed_ += this->acceleration_ * dt;
+    if( target_difference > 0 )
+      this->current_speed_ += this->acceleration_ * dt;
+    else
+      this->current_speed_ -= this->acceleration_ * dt;
   }
-  this->current_speed_ = clamp(this->current_speed_, 0.0f, this->max_speed_);
+
+  this->current_speed_ = clamp(this->current_speed_, -this->max_speed_, this->max_speed_);
 }
+
 int32_t Stepper::should_step_() {
   uint32_t now = micros();
   this->calculate_speed_(now);
@@ -37,8 +91,8 @@ int32_t Stepper::should_step_() {
 
   // assumes this method is called in a constant interval
   uint32_t dt = now - this->last_step_;
-  if (dt >= (1 / this->current_speed_) * 1e6f) {
-    int32_t mag = this->target_position > this->current_position ? 1 : -1;
+  if (dt >= (1. / abs(this->current_speed_)) * 1e6f) {
+    int32_t mag = this->current_speed_ > 0 ? 1 : -1;
     this->last_step_ = now;
     this->current_position += mag;
     return mag;

--- a/esphome/components/stepper/stepper.h
+++ b/esphome/components/stepper/stepper.h
@@ -21,6 +21,7 @@ class Stepper {
   void set_max_speed(float max_speed) { this->max_speed_ = max_speed; }
   virtual void on_update_speed() {}
   bool has_reached_target() { return this->current_position == this->target_position; }
+  void request_stop();
 
   int32_t current_position{0};
   int32_t target_position{0};


### PR DESCRIPTION
# What does this implement/fix?

- The stepper is now direction aware, so that when the target position is changed so that it has to step in the other direction, it first decelerates and accelerates in the correct direction instead of only harshly reversing the direction.

- New method request_stop() for the Stepper class: Call this method when you want the stepper motor to smoothly slow down and stop according to the deceleration limit.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2052

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
