### PR TITLE
Early pin init

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -19,6 +19,7 @@ from esphome.helpers import copy_file_if_changed
 
 from .const import (
     CONF_RESTORE_FROM_FLASH,
+    CONF_EARLY_PIN_INIT,
     KEY_BOARD,
     KEY_ESP8266,
     KEY_PIN_INITIAL_STATES,
@@ -148,6 +149,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_BOARD): cv.string_strict,
             cv.Optional(CONF_FRAMEWORK, default={}): ARDUINO_FRAMEWORK_SCHEMA,
             cv.Optional(CONF_RESTORE_FROM_FLASH, default=False): cv.boolean,
+            cv.Optional(CONF_EARLY_PIN_INIT, default=True): cv.boolean,
             cv.Optional(CONF_BOARD_FLASH_MODE, default="dout"): cv.one_of(
                 *BUILD_FLASH_MODES, lower=True
             ),
@@ -196,6 +198,9 @@ async def to_code(config):
 
     if config[CONF_RESTORE_FROM_FLASH]:
         cg.add_define("USE_ESP8266_PREFERENCES_FLASH")
+
+    if config[CONF_EARLY_PIN_INIT]:
+        cg.add_define("USE_ESP8266_EARLY_PIN_INIT")
 
     # Arduino 2 has a non-standards conformant new that returns a nullptr instead of failing when
     # out of memory and exceptions are disabled. Since Arduino 2.6.0, this flag can be used to make

--- a/esphome/components/esp8266/const.py
+++ b/esphome/components/esp8266/const.py
@@ -4,6 +4,7 @@ KEY_ESP8266 = "esp8266"
 KEY_BOARD = "board"
 KEY_PIN_INITIAL_STATES = "pin_initial_states"
 CONF_RESTORE_FROM_FLASH = "restore_from_flash"
+CONF_EARLY_PIN_INIT = "early_pin_init"
 
 # esp8266 namespace is already defined by arduino, manually prefix esphome
 esp8266_ns = cg.global_ns.namespace("esphome").namespace("esp8266")

--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -55,6 +55,7 @@ extern "C" void resetPins() {  // NOLINT
   // ourselves and this causes pins to toggle during reboot.
   force_link_symbols();
 
+#ifdef USE_ESP8266_EARLY_PIN_INIT
   for (int i = 0; i < 16; i++) {
     uint8_t mode = ESPHOME_ESP8266_GPIO_INITIAL_MODE[i];
     uint8_t level = ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[i];
@@ -63,6 +64,7 @@ extern "C" void resetPins() {  // NOLINT
     if (level != 255)
       digitalWrite(i, level);  // NOLINT
   }
+#endif
 }
 
 }  // namespace esphome

--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -1,6 +1,7 @@
 #ifdef USE_ESP8266
 
 #include "core.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "preferences.h"

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1,8 +1,6 @@
 esphome:
   name: $device_name
   comment: $device_comment
-  platform: ESP8266
-  board: d1_mini
   build_path: build/test3
   on_boot:
     - if:
@@ -14,6 +12,10 @@ esphome:
           - logger.log: "Have time"
   includes:
     - custom.h
+
+esp8266:
+  board: d1_mini
+  early_pin_init: True
 
 substitutions:
   device_name: test3


### PR DESCRIPTION
# What does this implement/fix?

Adds a new configuration parameter that makes disabled early PIN initialisation for the ESP8266.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3263

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2054

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
esp8266:
  board: d1_mini
  early_pin_init: True

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
