### PR TITLE
Ezo Pump functionality and Ezo Sensor Calibration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,7 +41,7 @@ esphome/components/esp32_ble/* @jesserockz
 esphome/components/esp32_ble_server/* @jesserockz
 esphome/components/esp32_improv/* @jesserockz
 esphome/components/exposure_notifications/* @OttoWinter
-esphome/components/ezo/* @ssieb
+esphome/components/ezo/* @senexcrenshaw @ssieb
 esphome/components/fastled_base/* @OttoWinter
 esphome/components/fingerprint_grow/* @OnFreund @loongyh
 esphome/components/globals/* @esphome/core

--- a/esphome/components/ezo/automation.h
+++ b/esphome/components/ezo/automation.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <utility>
+
 #include "esphome/core/automation.h"
 #include "ezo.h"
 
@@ -15,35 +17,35 @@ class LedTrigger : public Trigger<bool> {
 class CustomTrigger : public Trigger<std::string> {
  public:
   explicit CustomTrigger(EZOSensor *ezo) {
-    ezo->add_custom_callback([this](std::string value) { this->trigger(value); });
+    ezo->add_custom_callback([this](std::string value) { this->trigger(std::move(value)); });
   }
 };
 
 class TTrigger : public Trigger<std::string> {
  public:
   explicit TTrigger(EZOSensor *ezo) {
-    ezo->add_t_callback([this](std::string value) { this->trigger(value); });
+    ezo->add_t_callback([this](std::string value) { this->trigger(std::move(value)); });
   }
 };
 
 class CalibrationTrigger : public Trigger<std::string> {
  public:
   explicit CalibrationTrigger(EZOSensor *ezo) {
-    ezo->add_calibration_callback([this](std::string value) { this->trigger(value); });
+    ezo->add_calibration_callback([this](std::string value) { this->trigger(std::move(value)); });
   }
 };
 
 class SlopeTrigger : public Trigger<std::string> {
  public:
   explicit SlopeTrigger(EZOSensor *ezo) {
-    ezo->add_slope_callback([this](std::string value) { this->trigger(value); });
+    ezo->add_slope_callback([this](std::string value) { this->trigger(std::move(value)); });
   }
 };
 
 class DeviceInformationTrigger : public Trigger<std::string> {
  public:
   explicit DeviceInformationTrigger(EZOSensor *ezo) {
-    ezo->add_device_infomation_callback([this](std::string value) { this->trigger(value); });
+    ezo->add_device_infomation_callback([this](std::string value) { this->trigger(std::move(value)); });
   }
 };
 

--- a/esphome/components/ezo/automation.h
+++ b/esphome/components/ezo/automation.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "esphome/core/automation.h"
+#include "ezo.h"
+
+namespace esphome {
+namespace ezo {
+
+class LedTrigger : public Trigger<bool> {
+ public:
+  explicit LedTrigger(EZOSensor *ezo) {
+    ezo->add_led_state_callback([this](bool value) { this->trigger(value); });
+  }
+};
+
+}  // namespace ezo
+}  // namespace esphome

--- a/esphome/components/ezo/automation.h
+++ b/esphome/components/ezo/automation.h
@@ -12,6 +12,13 @@ class LedTrigger : public Trigger<bool> {
   }
 };
 
+class TTrigger : public Trigger<std::string> {
+ public:
+  explicit TTrigger(EZOSensor *ezo) {
+    ezo->add_calibration_callback([this](std::string value) { this->trigger(value); });
+  }
+};
+
 class CalibrationTrigger : public Trigger<std::string> {
  public:
   explicit CalibrationTrigger(EZOSensor *ezo) {

--- a/esphome/components/ezo/automation.h
+++ b/esphome/components/ezo/automation.h
@@ -12,10 +12,17 @@ class LedTrigger : public Trigger<bool> {
   }
 };
 
+class CustomTrigger : public Trigger<std::string> {
+ public:
+  explicit CustomTrigger(EZOSensor *ezo) {
+    ezo->add_custom_callback([this](std::string value) { this->trigger(value); });
+  }
+};
+
 class TTrigger : public Trigger<std::string> {
  public:
   explicit TTrigger(EZOSensor *ezo) {
-    ezo->add_calibration_callback([this](std::string value) { this->trigger(value); });
+    ezo->add_t_callback([this](std::string value) { this->trigger(value); });
   }
 };
 

--- a/esphome/components/ezo/automation.h
+++ b/esphome/components/ezo/automation.h
@@ -12,5 +12,26 @@ class LedTrigger : public Trigger<bool> {
   }
 };
 
+class CalibrationTrigger : public Trigger<std::string> {
+ public:
+  explicit CalibrationTrigger(EZOSensor *ezo) {
+    ezo->add_calibration_callback([this](std::string value) { this->trigger(value); });
+  }
+};
+
+class SlopeTrigger : public Trigger<std::string> {
+ public:
+  explicit SlopeTrigger(EZOSensor *ezo) {
+    ezo->add_slope_callback([this](std::string value) { this->trigger(value); });
+  }
+};
+
+class DeviceInformationTrigger : public Trigger<std::string> {
+ public:
+  explicit DeviceInformationTrigger(EZOSensor *ezo) {
+    ezo->add_device_infomation_callback([this](std::string value) { this->trigger(value); });
+  }
+};
+
 }  // namespace ezo
 }  // namespace esphome

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -73,11 +73,11 @@ void EZOSensor::loop() {
   if (millis() - this->start_time_ < to_run->delay_ms)
     return;
 
-  uint8_t buf[20];
+  uint8_t buf[32];
 
   buf[0] = 0;
 
-  if (!this->read_bytes_raw(buf, 20)) {
+  if (!this->read_bytes_raw(buf, 32)) {
     ESP_LOGE(TAG, "read error");
     delete to_run;
     this->commands_.pop_front();
@@ -101,6 +101,11 @@ void EZOSensor::loop() {
   }
 
   ESP_LOGD(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
+
+  for (int index = 0; index < 32; ++i) {
+    ESP_LOGD(TAG, "Received buffer index: %d char: \"%c\" %d", i, buf[i], buf[i]);
+  }
+
   if (buf[0] == 1) {
     std::string payload = reinterpret_cast<char *>(&buf[1]);
     if (!payload.empty()) {
@@ -143,7 +148,9 @@ void EZOSensor::loop() {
           this->t_callback_.call(payload);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
     }
   }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -149,7 +149,7 @@ void EZOSensor::loop() {
           break;
         }
         case EzoCommandType::EZO_CUSTOM: {
-          this->t_callback_.call(payload);
+          this->custom_callback_.call(payload);
           break;
         }
         default: {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -152,9 +152,7 @@ void EZOSensor::loop() {
           this->custom_callback_.call(payload);
           break;
         }
-        default: {
-          break;
-        }
+        default: { break; }
       }
     }
   }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -40,7 +40,7 @@ void EZOSensor::loop() {
 
     for (uint8_t i = 0; i < to_run->command.length(); i++) {
       uint8_t d = to_run->command[i];
-      ESP_LOGD(TAG, "Sending command index: %d char: \"%c\" hex: 0x%02X", i, to_run->command[i], to_run->command[i]);
+      ESP_LOGD(TAG, "Sending index: %d char: \"%c\" hex: 0x%02X", i, to_run->command[i], to_run->command[i]);
 
       this->write_bytes_raw(&d, 1);
     }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -44,6 +44,13 @@ void EZOSensor::loop() {
 
     this->write_bytes_raw(data, to_run->command.length());
 
+    if (to_run->command_type == EzoCommandType::EZO_SLEEP ||
+        to_run->command_type == EzoCommandType::EZO_I2C) {  // Commands with no return data
+      delete to_run;
+      this->commands_.pop_front();
+      return;
+    }
+
     this->start_time_ = millis();
     to_run->command_sent = true;
     return;
@@ -51,12 +58,6 @@ void EZOSensor::loop() {
 
   if (millis() - this->start_time_ < to_run->delay_ms)
     return;
-
-  if (to_run->command_type == EzoCommandType::EZO_SLEEP) {  // Dont read data
-    delete to_run;
-    this->commands_.pop_front();
-    return;
-  }
 
   uint8_t buf[20];
 
@@ -105,11 +106,23 @@ void EZOSensor::loop() {
       case EzoCommandType::EZO_CALIBRATION: {
         break;
       }
+      case EzoCommandType::EZO_T: {
+        break;
+      }
+      default: {
+        break;
+      }
     }
   }
 
   delete to_run;
   this->commands_.pop_front();
+}
+
+// T
+void EZOSensor::set_t(std::string value) {
+  std::string to_send = "T," + value;
+  this->add_command(to_send, EzoCommandType::EZO_T);
 }
 
 // Calibration

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -148,7 +148,13 @@ void EZOSensor::loop() {
           this->t_callback_.call(payload);
           break;
         }
-        default: { break; }
+        case EzoCommandType::EZO_CUSTOM: {
+          this->t_callback_.call(payload);
+          break;
+        }
+        default: {
+          break;
+        }
       }
     }
   }
@@ -177,6 +183,9 @@ void EZOSensor::set_led_state(bool on) {
   to_send += on ? "1" : "0";
   this->add_command(to_send, EzoCommandType::EZO_LED);
 }
+
+// Custom
+void EZOSensor::set_custom(const std::string &to_send) { this->add_command(to_send, EzoCommandType::EZO_CUSTOM); }
 
 }  // namespace ezo
 }  // namespace esphome

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -76,7 +76,6 @@ void EZOSensor::loop() {
       ESP_LOGE(TAG, "device returned an unknown response: %d", buf[0]);
       break;
   }
-  ezo_command *to_run = this->commands_.front();
 
   ESP_LOGD(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
   if (buf[0] == 1) {
@@ -92,7 +91,7 @@ void EZOSensor::loop() {
     }
   }
 
-  delete this->commands_.front();
+  delete to_run;
   this->commands_.pop_front();
 }
 

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -6,10 +6,6 @@ namespace ezo {
 
 static const char *const TAG = "ezo.sensor";
 
-static const uint16_t EZO_STATE_WAIT = 1;
-static const uint16_t EZO_STATE_SEND_TEMP = 2;
-static const uint16_t EZO_STATE_WAIT_TEMP = 4;
-
 void EZOSensor::dump_config() {
   LOG_SENSOR("", "EZO", this);
   LOG_I2C_DEVICE(this);
@@ -137,8 +133,6 @@ void EZOSensor::set_led_state(bool on) {
   to_send += on ? "1" : "0";
   this->add_command(to_send, EzoCommandType::EZO_LED);
 }
-
-void EZOSensor::set_tempcomp_value(float temp) {}
 
 }  // namespace ezo
 }  // namespace esphome

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -94,7 +94,6 @@ void EZOSensor::loop() {
           } else {
             this->publish_state(*val);
           }
-
           break;
         }
         case EzoCommandType::EZO_LED: {
@@ -105,12 +104,15 @@ void EZOSensor::loop() {
           break;
         }
         case EzoCommandType::EZO_SLOPE: {
+          this->slope_callback_.call(payload);
           break;
         }
         case EzoCommandType::EZO_CALIBRATION: {
+          this->calibration_callback_.call(payload);
           break;
         }
         case EzoCommandType::EZO_T: {
+          this->t_callback_.call(payload);
           break;
         }
         default: {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -148,9 +148,7 @@ void EZOSensor::loop() {
           this->t_callback_.call(payload);
           break;
         }
-        default: {
-          break;
-        }
+        default: { break; }
       }
     }
   }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -19,7 +19,7 @@ void EZOSensor::dump_config() {
 }
 
 void EZOSensor::update() {
-  if (!this->commands_.empty()) {
+  if (!this->commands_.empty()) {  // Maybe check if a read is in there already and if not insert in second position?
     ESP_LOGE(TAG, "update overrun, still waiting for previous response");  // Not sure if we care to log
     return;
   }
@@ -35,12 +35,17 @@ void EZOSensor::loop() {
   ezo_command *to_run = this->commands_.front();
 
   if (!to_run->command_sent) {
-    auto data = reinterpret_cast<const uint8_t *>(&to_run->command.c_str()[0]);
-    for (int i = 0; i < to_run->command.length(); i++) {
-      ESP_LOGD(TAG, "Sending command index: %d char: \"%c\" hex: 0x%02X", i, data[i], data[i]);
+    // auto data = reinterpret_cast<const uint8_t *>(&to_run->command.c_str());
+    ESP_LOGD(TAG, "Sending command \"%s\"", to_run->command.c_str());
+
+    for (uint8_t i = 0; i < to_run->command.length(); i++) {
+      uint8_t d = to_run->command[i];
+      ESP_LOGD(TAG, "Sending command index: %d char: \"%c\" hex: 0x%02X", i, to_run->command[i], to_run->command[i]);
+
+      this->write_bytes_raw(&d, 1);
     }
 
-    this->write_bytes_raw(data, to_run->command.length());
+    // this->write_bytes_raw(data, to_run->command.length());
 
     this->start_time_ = millis();
     to_run->command_sent = true;

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -98,21 +98,21 @@ void EZOSensor::loop() {
         }
         case EzoCommandType::EZO_DEVICE_INFORMATION: {
           int start_location = 0;
-          if ((start_location = payload.find(",")) != std::string::npos) {
+          if ((start_location = payload.find(',')) != std::string::npos) {
             this->device_infomation_callback_.call(payload.substr(start_location + 1));
           }
           break;
         }
         case EzoCommandType::EZO_SLOPE: {
           int start_location = 0;
-          if ((start_location = payload.find(",")) != std::string::npos) {
+          if ((start_location = payload.find(',')) != std::string::npos) {
             this->slope_callback_.call(payload.substr(start_location + 1));
           }
           break;
         }
         case EzoCommandType::EZO_CALIBRATION: {
           int start_location = 0;
-          if ((start_location = payload.find(",")) != std::string::npos) {
+          if ((start_location = payload.find(',')) != std::string::npos) {
             this->calibration_callback_.call(payload.substr(start_location + 1));
           }
           break;

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -86,8 +86,14 @@ void EZOSensor::loop() {
   if (buf[0] == 1) {
     switch (to_run->command_type) {
       case EzoCommandType::EZO_READ: {
-        float val = atof((char *) &buf[1]);
-        this->publish_state(val);
+        std::string payload = reinterpret_cast<char *>(&buf[1]);
+        auto val = parse_float(payload);
+        if (!val.has_value()) {
+          ESP_LOGW(TAG, "Can't convert '%s' to number!", payload.c_str());
+        } else {
+          this->publish_state(*val);
+        }
+
         break;
       }
       case EzoCommandType::EZO_LED: {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -93,22 +93,28 @@ void EZOSensor::loop() {
           break;
         }
         case EzoCommandType::EZO_LED: {
-          this->led_callback_(payload.back == "1");
+          this->led_callback_.call(payload.back() == '1');
           break;
         }
         case EzoCommandType::EZO_DEVICE_INFORMATION: {
           int start_location = 0;
-          if (start_location = payload.find(",") != std::string::npos) {
+          if ((start_location = payload.find(",")) != std::string::npos) {
             this->device_infomation_callback_.call(payload.substr(start_location + 1));
           }
           break;
         }
         case EzoCommandType::EZO_SLOPE: {
-          this->slope_callback_.call(payload);
+          int start_location = 0;
+          if ((start_location = payload.find(",")) != std::string::npos) {
+            this->slope_callback_.call(payload.substr(start_location + 1));
+          }
           break;
         }
         case EzoCommandType::EZO_CALIBRATION: {
-          this->calibration_callback_.call(payload);
+          int start_location = 0;
+          if ((start_location = payload.find(",")) != std::string::npos) {
+            this->calibration_callback_.call(payload.substr(start_location + 1));
+          }
           break;
         }
         case EzoCommandType::EZO_T: {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -101,6 +101,7 @@ void EZOSensor::loop() {
           break;
         }
         case EzoCommandType::EZO_DEVICE_INFORMATION: {
+          this->device_infomation_callback_.call(payload);
           break;
         }
         case EzoCommandType::EZO_SLOPE: {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -20,7 +20,7 @@ void EZOSensor::dump_config() {
 
 void EZOSensor::update() {
   if (!this->commands_.empty()) {
-    ESP_LOGE(TAG, "update overrun, still waiting for previous response");  // Not sure if we care
+    ESP_LOGE(TAG, "update overrun, still waiting for previous response");  // Not sure if we care to log
     return;
   }
 
@@ -38,7 +38,6 @@ void EZOSensor::update() {
   this->write_bytes_raw(data, to_run->command.length());
 
   this->start_time_ = millis();
-  // this->wait_time_ = to_run->delay_ms;
 }
 
 void EZOSensor::loop() {
@@ -98,10 +97,7 @@ void EZOSensor::loop() {
 // LED control
 void EZOSensor::set_led_state(bool on) { this->add_command("L," + on ? "1" : "0", EZO_COMMAND_TYPE::EZO_LED); }
 
-void EZOSensor::set_tempcomp_value(float temp) {
-  // this->tempcomp_ = temp;
-  // this->state_ |= EZO_STATE_SEND_TEMP;
-}
+void EZOSensor::set_tempcomp_value(float temp) {}
 
 }  // namespace ezo
 }  // namespace esphome

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -34,10 +34,6 @@ void EZOSensor::loop() {
     auto data = reinterpret_cast<const uint8_t *>(&to_run->command.c_str()[0]);
     ESP_LOGD(TAG, "Sending command \"%s\"", data);
 
-    // for (uint8_t i = 0; i < to_run->command.length(); i++) {
-    //   ESP_LOGD(TAG, "Sending index: %d char: \"%c\" hex: 0x%02X", i, data[i], data[i]);
-    // }
-
     this->write_bytes_raw(data, to_run->command.length());
 
     if (to_run->command_type == EzoCommandType::EZO_SLEEP ||
@@ -97,10 +93,14 @@ void EZOSensor::loop() {
           break;
         }
         case EzoCommandType::EZO_LED: {
+          this->led_callback_(payload.back == "1");
           break;
         }
         case EzoCommandType::EZO_DEVICE_INFORMATION: {
-          this->device_infomation_callback_.call(payload);
+          int start_location = 0;
+          if (start_location = payload.find(",") != std::string::npos) {
+            this->device_infomation_callback_.call(payload.substr(start_location + 1));
+          }
           break;
         }
         case EzoCommandType::EZO_SLOPE: {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -54,7 +54,7 @@ void EZOSensor::loop() {
 
   if (!to_run->command_sent) {
     auto data = reinterpret_cast<const uint8_t *>(&to_run->command.c_str()[0]);
-    ESP_LOGD(TAG, "Sending command \"%s\"", data);
+    ESP_LOGVV(TAG, "Sending command \"%s\"", data);
 
     this->write_bytes_raw(data, to_run->command.length());
 
@@ -100,13 +100,13 @@ void EZOSensor::loop() {
       break;
   }
 
-  ESP_LOGD(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
+  ESP_LOGVV(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
 
-  for (int index = 0; index < 32; ++index) {
-    ESP_LOGD(TAG, "Received buffer index: %d char: \"%c\" %d", index, buf[index], buf[index]);
-  }
+  // for (int index = 0; index < 32; ++index) {
+  //   ESP_LOGD(TAG, "Received buffer index: %d char: \"%c\" %d", index, buf[index], buf[index]);
+  // }
 
-  if (buf[0] == 1 || (to_run->command_type == EzoCommandType::EZO_CALIBRATION)) {  // EZO_CALIBRATION returns 0-3
+  if (buf[0] == 1 || to_run->command_type == EzoCommandType::EZO_CALIBRATION) {  // EZO_CALIBRATION returns 0-3
     std::string payload = reinterpret_cast<char *>(&buf[1]);
     if (!payload.empty()) {
       switch (to_run->command_type) {
@@ -148,9 +148,7 @@ void EZOSensor::loop() {
           this->t_callback_.call(payload);
           break;
         }
-        default: {
-          break;
-        }
+        default: { break; }
       }
     }
   }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -102,11 +102,11 @@ void EZOSensor::loop() {
 
   ESP_LOGD(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
 
-  for (int index = 0; index < 32; ++i) {
-    ESP_LOGD(TAG, "Received buffer index: %d char: \"%c\" %d", i, buf[i], buf[i]);
+  for (int index = 0; index < 32; ++index) {
+    ESP_LOGD(TAG, "Received buffer index: %d char: \"%c\" %d", index, buf[index], buf[index]);
   }
 
-  if (buf[0] == 1 || (to_run->command_type == EzoCommandType::EZO_CALIBRATION)) {
+  if (buf[0] == 1 || (to_run->command_type == EzoCommandType::EZO_CALIBRATION)) {  // EZO_CALIBRATION returns 0-3
     std::string payload = reinterpret_cast<char *>(&buf[1]);
     if (!payload.empty()) {
       switch (to_run->command_type) {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -100,7 +100,7 @@ void EZOSensor::loop() {
       break;
   }
 
-  ESP_LOGVV(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
+  ESP_LOGVV(TAG, "Received buffer \"%s\" for command type %s", buf, EZO_COMMAND_TYPE_STRINGS[to_run->command_type]);
 
   // for (int index = 0; index < 32; ++index) {
   //   ESP_LOGD(TAG, "Received buffer index: %d char: \"%c\" %d", index, buf[index], buf[index]);
@@ -152,7 +152,9 @@ void EZOSensor::loop() {
           this->custom_callback_.call(payload);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
     }
   }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -144,7 +144,9 @@ void EZOSensor::loop() {
           this->t_callback_.call(payload);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
     }
   }
@@ -160,9 +162,11 @@ void EZOSensor::set_t(std::string value) {
 }
 
 // Calibration
+void EZOSensor::clear_calibration() { this->add_command("Cal,clear", EzoCommandType::EZO_CALIBRATION); }
+
 void EZOSensor::set_calibration(std::string point, std::string value) {
   std::string to_send = "Cal," + point + "," + value;
-  this->add_command(to_send, EzoCommandType::EZO_CALIBRATION);
+  this->add_command(to_send, EzoCommandType::EZO_CALIBRATION, 900);
 }
 
 // LED control

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -84,35 +84,37 @@ void EZOSensor::loop() {
 
   ESP_LOGD(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
   if (buf[0] == 1) {
-    switch (to_run->command_type) {
-      case EzoCommandType::EZO_READ: {
-        std::string payload = reinterpret_cast<char *>(&buf[1]);
-        auto val = parse_float(payload);
-        if (!val.has_value()) {
-          ESP_LOGW(TAG, "Can't convert '%s' to number!", payload.c_str());
-        } else {
-          this->publish_state(*val);
-        }
+    std::string payload = reinterpret_cast<char *>(&buf[1]);
+    if (!payload.empty()) {
+      switch (to_run->command_type) {
+        case EzoCommandType::EZO_READ: {
+          auto val = parse_float(payload);
+          if (!val.has_value()) {
+            ESP_LOGW(TAG, "Can't convert '%s' to number!", payload.c_str());
+          } else {
+            this->publish_state(*val);
+          }
 
-        break;
-      }
-      case EzoCommandType::EZO_LED: {
-        break;
-      }
-      case EzoCommandType::EZO_DEVICE_INFORMATION: {
-        break;
-      }
-      case EzoCommandType::EZO_SLOPE: {
-        break;
-      }
-      case EzoCommandType::EZO_CALIBRATION: {
-        break;
-      }
-      case EzoCommandType::EZO_T: {
-        break;
-      }
-      default: {
-        break;
+          break;
+        }
+        case EzoCommandType::EZO_LED: {
+          break;
+        }
+        case EzoCommandType::EZO_DEVICE_INFORMATION: {
+          break;
+        }
+        case EzoCommandType::EZO_SLOPE: {
+          break;
+        }
+        case EzoCommandType::EZO_CALIBRATION: {
+          break;
+        }
+        case EzoCommandType::EZO_T: {
+          break;
+        }
+        default: {
+          break;
+        }
       }
     }
   }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -19,44 +19,47 @@ void EZOSensor::dump_config() {
 }
 
 void EZOSensor::update() {
-  if (this->state_ & EZO_STATE_WAIT) {
-    ESP_LOGE(TAG, "update overrun, still waiting for previous response");
+  if (!this->commands_.empty()) {
+    ESP_LOGE(TAG, "update overrun, still waiting for previous response");  // Not sure if we care
     return;
   }
-  if (!this->commands_.empty()) {
-    this->add_command("R", "", "");
+
+  if (this->commands_.empty()) {  // Read if nothing to do
+    this->get_state();
   }
 
   ezo_command *to_run = this->commands_.front();
 
-  auto data = reinterpret_cast<const uint8_t *>(&to_run[0]);
+  auto data = reinterpret_cast<const uint8_t *>(&to_run->command.c_str()[0]);
+  for (int i = 0; i < to_run->command.length(); i++) {
+    ESP_LOGD(TAG, "Sending command index: %d char: \"%c\" hex: 0x%02X", i, data[i], data[i]);
+  }
+
   this->write_bytes_raw(data, to_run->command.length());
 
-  this->state_ |= EZO_STATE_WAIT;
   this->start_time_ = millis();
-  this->wait_time_ = 900;
+  // this->wait_time_ = to_run->delay_ms;
 }
 
 void EZOSensor::loop() {
-  uint8_t buf[20];
-  if (!(this->state_ & EZO_STATE_WAIT)) {
-    if (this->state_ & EZO_STATE_SEND_TEMP) {
-      int len = sprintf((char *) buf, "T,%0.3f", this->tempcomp_);
-      this->write_bytes_raw(buf, len);
-      this->state_ = EZO_STATE_WAIT | EZO_STATE_WAIT_TEMP;
-      this->start_time_ = millis();
-      this->wait_time_ = 300;
-    }
+  if (this->commands_.empty()) {
     return;
   }
-  if (millis() - this->start_time_ < this->wait_time_)
+
+  if (millis() - this->start_time_ < this->commands_.front()->delay_ms)
     return;
+
+  uint8_t buf[20];
+
   buf[0] = 0;
+
   if (!this->read_bytes_raw(buf, 20)) {
     ESP_LOGE(TAG, "read error");
-    this->state_ = 0;
+    delete this->commands_.front();
+    this->commands_.pop_front();
     return;
   }
+
   switch (buf[0]) {
     case 1:
       break;
@@ -72,21 +75,32 @@ void EZOSensor::loop() {
       ESP_LOGE(TAG, "device returned an unknown response: %d", buf[0]);
       break;
   }
-  if (this->state_ & EZO_STATE_WAIT_TEMP) {
-    this->state_ = 0;
-    return;
-  }
-  this->state_ &= ~EZO_STATE_WAIT;
-  if (buf[0] != 1)
-    return;
+  ezo_command *to_run = this->commands_.front();
 
-  float val = atof((char *) &buf[1]);
-  this->publish_state(val);
+  ESP_LOGD(TAG, "Received buffer \"%s\" for command type %s", buf, EzoCommandTypeStrings[to_run->command_type]);
+  if (buf[0] == 1) {
+    switch (to_run->command_type) {
+      case EZO_COMMAND_TYPE::EZO_READ: {
+        float val = atof((char *) &buf[1]);
+        this->publish_state(val);
+        break;
+      }
+      case EZO_COMMAND_TYPE::EZO_LED: {
+        break;
+      }
+    }
+  }
+
+  delete this->commands_.front();
+  this->commands_.pop_front();
 }
 
+// LED control
+void EZOSensor::set_led_state(bool on) { this->add_command("L," + on ? "1" : "0", EZO_COMMAND_TYPE::EZO_LED); }
+
 void EZOSensor::set_tempcomp_value(float temp) {
-  this->tempcomp_ = temp;
-  this->state_ |= EZO_STATE_SEND_TEMP;
+  // this->tempcomp_ = temp;
+  // this->state_ |= EZO_STATE_SEND_TEMP;
 }
 
 }  // namespace ezo

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -148,7 +148,9 @@ void EZOSensor::loop() {
           this->t_callback_.call(payload);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
     }
   }
@@ -158,7 +160,7 @@ void EZOSensor::loop() {
 }
 
 // T
-void EZOSensor::set_t(std::string value) {
+void EZOSensor::set_t(const std::string &value) {
   std::string to_send = "T," + value;
   this->add_command(to_send, EzoCommandType::EZO_T);
 }
@@ -166,7 +168,7 @@ void EZOSensor::set_t(std::string value) {
 // Calibration
 void EZOSensor::clear_calibration() { this->add_command("Cal,clear", EzoCommandType::EZO_CALIBRATION); }
 
-void EZOSensor::set_calibration(std::string point, std::string value) {
+void EZOSensor::set_calibration(const std::string &point, const std::string &value) {
   std::string to_send = "Cal," + point + "," + value;
   this->add_command(to_send, EzoCommandType::EZO_CALIBRATION, 900);
 }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -15,9 +15,11 @@ void EZOSensor::dump_config() {
 }
 
 void EZOSensor::update() {
-  bool found = false;
+  // Check if a read is in there already and if not insert on in the second position
+
   if (!this->commands_.empty() && this->commands_.front()->command_type != EzoCommandType::EZO_READ &&
-      this->commands_.size() > 1) {  // Check if a read is in there already and if not insert in second position
+      this->commands_.size() > 1) {
+    bool found = false;
 
     for (auto &i : this->commands_) {
       if (i->command_type == EzoCommandType::EZO_READ) {
@@ -35,9 +37,6 @@ void EZOSensor::update() {
       std::deque<EzoCommand *>::iterator it = this->commands_.begin();
       ++it;
       this->commands_.insert(it, ezo_command);
-
-    } else {
-      ESP_LOGE(TAG, "update overrun, still waiting for previous response");  // Not sure if we care to log this
     }
 
     return;
@@ -144,9 +143,7 @@ void EZOSensor::loop() {
           this->t_callback_.call(payload);
           break;
         }
-        default: {
-          break;
-        }
+        default: { break; }
       }
     }
   }

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -106,7 +106,7 @@ void EZOSensor::loop() {
     ESP_LOGD(TAG, "Received buffer index: %d char: \"%c\" %d", i, buf[i], buf[i]);
   }
 
-  if (buf[0] == 1) {
+  if (buf[0] == 1 || (to_run->command_type == EzoCommandType::EZO_CALIBRATION)) {
     std::string payload = reinterpret_cast<char *>(&buf[1]);
     if (!payload.empty()) {
       switch (to_run->command_type) {

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -49,7 +49,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void get_state(int pos = 0) { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
   // I2C
-  void set_i2c() { this->add_command("I2c,100", EzoCommandType::EZO_I2C); }  // NOLINT
+  void set_i2c() { this->add_command("I2c,100", EzoCommandType::EZO_I2C); }  // NOLINT otherwise we get set_i2_c
 
   // Sleep
   void set_sleep() { this->add_command("Sleep", EzoCommandType::EZO_SLEEP); }

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -51,7 +51,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void get_state() { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
   // I2C
-  void set_I2C() { this->add_command("I2c,100", EzoCommandType::EZO_I2C); }
+  void set_i2c() { this->add_command("I2c,100", EzoCommandType::EZO_I2C); }  // NOLINT
 
   // Sleep
   void set_sleep() { this->add_command("Sleep", EzoCommandType::EZO_SLEEP); }

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -3,9 +3,17 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
+#include <deque>
 
 namespace esphome {
 namespace ezo {
+
+class ezo_command {
+ public:
+  std::string command;
+  std::string arguments;
+  std::string return_message;
+};
 
 /// This class implements support for the EZO circuits in i2c mode
 class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
@@ -16,10 +24,19 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   float get_setup_priority() const override { return setup_priority::DATA; };
 
   void set_tempcomp_value(float temp);
+  void add_command(std::string command, std::string arguments, std::string return_message) {
+    ezo_command *e_command = new ezo_command;
+    e_command->command = command;
+    e_command->arguments = arguments;
+    e_command->return_message = return_message;
+    this->commands_.push_back(e_command);
+  };
 
  protected:
-  uint32_t start_time_ = 0;
-  uint32_t wait_time_ = 0;
+  std::deque<ezo_command *> commands_;
+
+  unsigned long start_time_ = 0;
+  unsigned long wait_time_ = 0;
   uint16_t state_ = 0;
   float tempcomp_;
 };

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -88,7 +88,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void add_t_callback(std::function<void(std::string)> &&callback) { this->t_callback_.add(std::move(callback)); }
 
   // Custom
-  void set_custom(const std::string &value);
+  void set_custom(const std::string &to_send);
   void add_custom_callback(std::function<void(std::string)> &&callback) {
     this->custom_callback_.add(std::move(callback));
   }

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -38,11 +38,11 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   float get_setup_priority() const override { return setup_priority::DATA; };
 
   void add_command(std::string command, EzoCommandType command_type, uint16_t delay_ms = 300) {
-    EzoCommand *e_command = new EzoCommand;
-    e_command->command = command;
-    e_command->command_type = command_type;
-    e_command->delay_ms = delay_ms;
-    this->commands_.push_back(e_command);
+    EzoCommand *ezo_command = new EzoCommand;
+    ezo_command->command = command;
+    ezo_command->command_type = command_type;
+    ezo_command->delay_ms = delay_ms;
+    this->commands_.push_back(ezo_command);
   };
 
   // R

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -22,7 +22,7 @@ static const char *EzoCommandTypeStrings[] = {"EZO_READ",  "EZO_LED",         "E
 class EzoCommand {
  public:
   std::string command;
-  uint32_t delay_ms = 300;
+  uint16_t delay_ms = 0;
   bool command_sent = false;
   EzoCommandType command_type;
 };
@@ -35,22 +35,22 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; };
 
-  void add_command(std::string command, EzoCommandType command_type) {
+  void add_command(std::string command, EzoCommandType command_type, uint16_t delay_ms = 300) {
     EzoCommand *e_command = new EzoCommand;
     e_command->command = command;
     e_command->command_type = command_type;
-
+    e_command->delay_ms = delay_ms;
     this->commands_.push_back(e_command);
   };
 
   void set_tempcomp_value(float temp);
-  void get_state() { this->add_command("R", EzoCommandType::EZO_READ); }
+  void get_state() { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
   // Sleep
   void set_sleep() { this->add_command("Sleep", EzoCommandType::EZO_SLEEP); }
 
   // Calibration
-  void get_calibration() { this->add_command("Cal,?", EzoCommandType::EZO_CALIBRATION); }
+  void get_calibration() { this->add_command("Cal,?", EzoCommandType::EZO_CALIBRATION, 900); }
   void set_calibration(std::string point, std::string value);
   void add_calibration_callback(std::function<void(std::string)> &&callback) {
     this->calibration_callback_.add(std::move(callback));

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -46,7 +46,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   };
 
   // R
-  void get_state() { this->add_command("R", EzoCommandType::EZO_READ, 900); }
+  void get_state(int pos = 0) { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
   // I2C
   void set_i2c() { this->add_command("I2c,100", EzoCommandType::EZO_I2C); }  // NOLINT

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -8,11 +8,14 @@
 namespace esphome {
 namespace ezo {
 
+enum EZO_COMMAND_TYPE : uint8_t { EZO_READ = 0, EZO_LED = 1 };
+static const char *EzoCommandTypeStrings[] = {"EZO_READ", "EZO_LED"};
+
 class ezo_command {
  public:
   std::string command;
-  std::string arguments;
-  std::string return_message;
+  uint32_t delay_ms = 300;
+  EZO_COMMAND_TYPE command_type;
 };
 
 /// This class implements support for the EZO circuits in i2c mode
@@ -23,22 +26,30 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; };
 
-  void set_tempcomp_value(float temp);
-  void add_command(std::string command, std::string arguments, std::string return_message) {
+  void add_command(std::string command, EZO_COMMAND_TYPE command_type) {
     ezo_command *e_command = new ezo_command;
     e_command->command = command;
-    e_command->arguments = arguments;
-    e_command->return_message = return_message;
+    e_command->command_type = command_type;
+
     this->commands_.push_back(e_command);
   };
 
+  void set_tempcomp_value(float temp);
+  void get_state() { this->add_command("R", EZO_COMMAND_TYPE::EZO_READ); }
+
+  // LED
+  void set_led_state(bool on);
+  void get_led_state() { this->add_command("L,?", EZO_COMMAND_TYPE::EZO_LED); }
+  void add_led_state_callback(std::function<void(bool)> &&callback) { this->led_callback_.add(std::move(callback)); }
+
  protected:
   std::deque<ezo_command *> commands_;
+  CallbackManager<void(bool)> led_callback_{};
 
   unsigned long start_time_ = 0;
-  unsigned long wait_time_ = 0;
-  uint16_t state_ = 0;
-  float tempcomp_;
+  // unsigned long wait_time_ = 0;
+  // uint16_t state_ = 0;
+  // float tempcomp_;
 };
 
 }  // namespace ezo

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -47,9 +47,6 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   CallbackManager<void(bool)> led_callback_{};
 
   unsigned long start_time_ = 0;
-  // unsigned long wait_time_ = 0;
-  // uint16_t state_ = 0;
-  // float tempcomp_;
 };
 
 }  // namespace ezo

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -37,7 +37,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; };
 
-  void add_command(std::string command, EzoCommandType command_type, uint16_t delay_ms = 300) {
+  void add_command(const std::string &command, EzoCommandType command_type, uint16_t delay_ms = 300) {
     EzoCommand *ezo_command = new EzoCommand;
     ezo_command->command = command;
     ezo_command->command_type = command_type;
@@ -56,7 +56,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
 
   // Calibration
   void get_calibration() { this->add_command("Cal,?", EzoCommandType::EZO_CALIBRATION); }
-  void set_calibration(std::string point, std::string value);
+  void set_calibration(const std::string &point, const std::string &value);
   void clear_calibration();
   void add_calibration_callback(std::function<void(std::string)> &&callback) {
     this->calibration_callback_.add(std::move(callback));
@@ -82,7 +82,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   // T
   void set_tempcomp_value(float temp) { this->set_t(to_string(temp)); }  // For backwards compatibility
   void get_t() { this->add_command("T,?", EzoCommandType::EZO_T); }
-  void set_t(std::string value);
+  void set_t(const std::string &value);
   void add_t_callback(std::function<void(std::string)> &&callback) { this->t_callback_.add(std::move(callback)); }
 
  protected:

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -15,6 +15,7 @@ class ezo_command {
  public:
   std::string command;
   uint32_t delay_ms = 300;
+  bool command_sent = false;
   EZO_COMMAND_TYPE command_type;
 };
 

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -57,6 +57,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   // Calibration
   void get_calibration() { this->add_command("Cal,?", EzoCommandType::EZO_CALIBRATION, 900); }
   void set_calibration(std::string point, std::string value);
+  void clear_calibration();
   void add_calibration_callback(std::function<void(std::string)> &&callback) {
     this->calibration_callback_.add(std::move(callback));
   }

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -55,7 +55,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void set_sleep() { this->add_command("Sleep", EzoCommandType::EZO_SLEEP); }
 
   // Calibration
-  void get_calibration() { this->add_command("Cal,?", EzoCommandType::EZO_CALIBRATION, 900); }
+  void get_calibration() { this->add_command("Cal,?", EzoCommandType::EZO_CALIBRATION); }
   void set_calibration(std::string point, std::string value);
   void clear_calibration();
   void add_calibration_callback(std::function<void(std::string)> &&callback) {

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -45,7 +45,8 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
     this->commands_.push_back(e_command);
   };
 
-  void set_tempcomp_value(float temp);
+  void set_tempcomp_value(float temp) { this->set_t(to_string(temp)); }
+
   void get_state() { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
   // I2C

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -47,6 +47,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
 
   void set_tempcomp_value(float temp) { this->set_t(to_string(temp)); }
 
+  // R
   void get_state() { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
   // I2C

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -16,10 +16,12 @@ enum EzoCommandType : uint8_t {
   EZO_CALIBRATION,
   EZO_SLEEP = 4,
   EZO_I2C = 5,
-  EZO_T = 6
+  EZO_T = 6,
+  EZO_CUSTOM = 7
 };
-static const char *EzoCommandTypeStrings[] = {
-    "EZO_READ", "EZO_LED", "EZO_DEVICE_INFORMATION", "EZO_SLOPE", "EZO_CALIBRATION", "EZO_SLEEP", "EZO_I2C", "EZO_T"};
+static const char *EzoCommandTypeStrings[] = {"EZO_READ",  "EZO_LED",         "EZO_DEVICE_INFORMATION",
+                                              "EZO_SLOPE", "EZO_CALIBRATION", "EZO_SLEEP",
+                                              "EZO_I2C",   "EZO_T",           "EZO_CUSTOM"};
 
 class EzoCommand {
  public:
@@ -85,6 +87,12 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void set_t(const std::string &value);
   void add_t_callback(std::function<void(std::string)> &&callback) { this->t_callback_.add(std::move(callback)); }
 
+  // Custom
+  void set_custom(const std::string &value);
+  void add_custom_callback(std::function<void(std::string)> &&callback) {
+    this->custom_callback_.add(std::move(callback));
+  }
+
  protected:
   std::deque<EzoCommand *> commands_;
 
@@ -92,6 +100,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   CallbackManager<void(std::string)> calibration_callback_{};
   CallbackManager<void(std::string)> slope_callback_{};
   CallbackManager<void(std::string)> t_callback_{};
+  CallbackManager<void(std::string)> custom_callback_{};
   CallbackManager<void(bool)> led_callback_{};
 
   unsigned long start_time_ = 0;

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -19,9 +19,9 @@ enum EzoCommandType : uint8_t {
   EZO_T = 6,
   EZO_CUSTOM = 7
 };
-static const char *EzoCommandTypeStrings[] = {"EZO_READ",  "EZO_LED",         "EZO_DEVICE_INFORMATION",
-                                              "EZO_SLOPE", "EZO_CALIBRATION", "EZO_SLEEP",
-                                              "EZO_I2C",   "EZO_T",           "EZO_CUSTOM"};
+static const char *const EZO_COMMAND_TYPE_STRINGS[] = {"EZO_READ",  "EZO_LED",         "EZO_DEVICE_INFORMATION",
+                                                       "EZO_SLOPE", "EZO_CALIBRATION", "EZO_SLEEP",
+                                                       "EZO_I2C",   "EZO_T",           "EZO_CUSTOM"};
 
 class EzoCommand {
  public:
@@ -103,7 +103,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   CallbackManager<void(std::string)> custom_callback_{};
   CallbackManager<void(bool)> led_callback_{};
 
-  unsigned long start_time_ = 0;
+  uint32_t start_time_ = 0;
 };
 
 }  // namespace ezo

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -45,8 +45,6 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
     this->commands_.push_back(e_command);
   };
 
-  void set_tempcomp_value(float temp) { this->set_t(to_string(temp)); }
-
   // R
   void get_state() { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
@@ -81,6 +79,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void add_led_state_callback(std::function<void(bool)> &&callback) { this->led_callback_.add(std::move(callback)); }
 
   // T
+  void set_tempcomp_value(float temp) { this->set_t(to_string(temp)); }  // For backwards compatibility
   void get_t() { this->add_command("T,?", EzoCommandType::EZO_T); }
   void set_t(std::string value);
   void add_t_callback(std::function<void(std::string)> &&callback) { this->t_callback_.add(std::move(callback)); }

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -8,15 +8,15 @@
 namespace esphome {
 namespace ezo {
 
-enum EZO_COMMAND_TYPE : uint8_t { EZO_READ = 0, EZO_LED = 1 };
+enum EzoCommandType : uint8_t { EZO_READ = 0, EZO_LED = 1 };
 static const char *EzoCommandTypeStrings[] = {"EZO_READ", "EZO_LED"};
 
-class ezo_command {
+class EzoCommand {
  public:
   std::string command;
   uint32_t delay_ms = 300;
   bool command_sent = false;
-  EZO_COMMAND_TYPE command_type;
+  EzoCommandType command_type;
 };
 
 /// This class implements support for the EZO circuits in i2c mode
@@ -27,8 +27,8 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; };
 
-  void add_command(std::string command, EZO_COMMAND_TYPE command_type) {
-    ezo_command *e_command = new ezo_command;
+  void add_command(std::string command, EzoCommandType command_type) {
+    EzoCommand *e_command = new EzoCommand;
     e_command->command = command;
     e_command->command_type = command_type;
 
@@ -36,15 +36,15 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   };
 
   void set_tempcomp_value(float temp);
-  void get_state() { this->add_command("R", EZO_COMMAND_TYPE::EZO_READ); }
+  void get_state() { this->add_command("R", EzoCommandType::EZO_READ); }
 
   // LED
   void set_led_state(bool on);
-  void get_led_state() { this->add_command("L,?", EZO_COMMAND_TYPE::EZO_LED); }
+  void get_led_state() { this->add_command("L,?", EzoCommandType::EZO_LED); }
   void add_led_state_callback(std::function<void(bool)> &&callback) { this->led_callback_.add(std::move(callback)); }
 
  protected:
-  std::deque<ezo_command *> commands_;
+  std::deque<EzoCommand *> commands_;
   CallbackManager<void(bool)> led_callback_{};
 
   unsigned long start_time_ = 0;

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -14,10 +14,12 @@ enum EzoCommandType : uint8_t {
   EZO_DEVICE_INFORMATION = 2,
   EZO_SLOPE = 3,
   EZO_CALIBRATION,
-  EZO_SLEEP = 4
+  EZO_SLEEP = 4,
+  EZO_I2C = 5,
+  EZO_T = 6
 };
-static const char *EzoCommandTypeStrings[] = {"EZO_READ",  "EZO_LED",         "EZO_DEVICE_INFORMATION",
-                                              "EZO_SLOPE", "EZO_CALIBRATION", "EZO_SLEEP"};
+static const char *EzoCommandTypeStrings[] = {
+    "EZO_READ", "EZO_LED", "EZO_DEVICE_INFORMATION", "EZO_SLOPE", "EZO_CALIBRATION", "EZO_SLEEP", "EZO_I2C", "EZO_T"};
 
 class EzoCommand {
  public:
@@ -46,6 +48,9 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void set_tempcomp_value(float temp);
   void get_state() { this->add_command("R", EzoCommandType::EZO_READ, 900); }
 
+  // I2C
+  void set_I2C() { this->add_command("I2c,100", EzoCommandType::EZO_I2C); }
+
   // Sleep
   void set_sleep() { this->add_command("Sleep", EzoCommandType::EZO_SLEEP); }
 
@@ -73,13 +78,18 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void get_led_state() { this->add_command("L,?", EzoCommandType::EZO_LED); }
   void add_led_state_callback(std::function<void(bool)> &&callback) { this->led_callback_.add(std::move(callback)); }
 
-  // / I2C / / T
+  // T
+  void get_t() { this->add_command("T,?", EzoCommandType::EZO_T); }
+  void set_t(std::string value);
+  void add_t_callback(std::function<void(std::string)> &&callback) { this->t_callback_.add(std::move(callback)); }
+
  protected:
   std::deque<EzoCommand *> commands_;
 
   CallbackManager<void(std::string)> device_infomation_callback_{};
   CallbackManager<void(std::string)> calibration_callback_{};
   CallbackManager<void(std::string)> slope_callback_{};
+  CallbackManager<void(std::string)> t_callback_{};
   CallbackManager<void(bool)> led_callback_{};
 
   unsigned long start_time_ = 0;

--- a/esphome/components/ezo/sensor.py
+++ b/esphome/components/ezo/sensor.py
@@ -91,24 +91,24 @@ async def to_code(config):
 
     for conf in config.get(CONF_ON_CUSTOM, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_LED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        yield automation.build_automation(trigger, [(bool, "x")], conf)
+        await automation.build_automation(trigger, [(bool, "x")], conf)
 
     for conf in config.get(CONF_ON_DEVICE_INFORMATION, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_SLOPE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_CALIBRATION, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_T, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)

--- a/esphome/components/ezo/sensor.py
+++ b/esphome/components/ezo/sensor.py
@@ -4,7 +4,7 @@ from esphome import automation
 from esphome.components import i2c, sensor
 from esphome.const import CONF_ID, CONF_TRIGGER_ID
 
-CODEOWNERS = ["@ssieb"]
+CODEOWNERS = ["@ssieb", "@senexcrenshaw"]
 
 DEPENDENCIES = ["i2c"]
 

--- a/esphome/components/ezo/sensor.py
+++ b/esphome/components/ezo/sensor.py
@@ -9,6 +9,9 @@ CODEOWNERS = ["@ssieb"]
 DEPENDENCIES = ["i2c"]
 
 CONF_ON_LED = "on_led"
+CONF_ON_DEVICE_INFORMATION = "on_device_information"
+CONF_ON_SLOPE = "on_slope"
+CONF_ON_CALIBRATION = "on_calibration"
 
 ezo_ns = cg.esphome_ns.namespace("ezo")
 
@@ -16,13 +19,39 @@ EZOSensor = ezo_ns.class_(
     "EZOSensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
 
-LedTrigger = ezo_ns.class_("LedTrigger", automation.Trigger.template(cg.bool_))
+SlopeTrigger = ezo_ns.class_("SlopeTrigger", automation.Trigger.template(cg.std_string))
 
+CalibrationTrigger = ezo_ns.class_(
+    "CalibrationTrigger", automation.Trigger.template(cg.std_string)
+)
+
+DeviceInformationTrigger = ezo_ns.class_(
+    "DeviceInformationTrigger", automation.Trigger.template(cg.std_string)
+)
+
+LedTrigger = ezo_ns.class_("LedTrigger", automation.Trigger.template(cg.bool_))
 
 CONFIG_SCHEMA = (
     sensor.SENSOR_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(EZOSensor),
+            cv.Optional(CONF_ON_CALIBRATION): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CalibrationTrigger),
+                }
+            ),
+            cv.Optional(CONF_ON_SLOPE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SlopeTrigger),
+                }
+            ),
+            cv.Optional(CONF_ON_DEVICE_INFORMATION): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        DeviceInformationTrigger
+                    ),
+                }
+            ),
             cv.Optional(CONF_ON_LED): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(LedTrigger),
@@ -44,3 +73,15 @@ async def to_code(config):
     for conf in config.get(CONF_ON_LED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         yield automation.build_automation(trigger, [(bool, "x")], conf)
+
+    for conf in config.get(CONF_ON_DEVICE_INFORMATION, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
+    for conf in config.get(CONF_ON_SLOPE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
+    for conf in config.get(CONF_ON_CALIBRATION, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)

--- a/esphome/components/ezo/sensor.py
+++ b/esphome/components/ezo/sensor.py
@@ -1,11 +1,14 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import automation
 from esphome.components import i2c, sensor
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_TRIGGER_ID
 
 CODEOWNERS = ["@ssieb"]
 
 DEPENDENCIES = ["i2c"]
+
+CONF_ON_LED = "on_led"
 
 ezo_ns = cg.esphome_ns.namespace("ezo")
 
@@ -13,10 +16,18 @@ EZOSensor = ezo_ns.class_(
     "EZOSensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
 
+LedTrigger = ezo_ns.class_("LedTrigger", automation.Trigger.template(cg.bool_))
+
+
 CONFIG_SCHEMA = (
     sensor.SENSOR_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(EZOSensor),
+            cv.Optional(CONF_ON_LED): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(LedTrigger),
+                }
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -29,3 +40,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     await sensor.register_sensor(var, config)
     await i2c.register_i2c_device(var, config)
+
+    for conf in config.get(CONF_ON_LED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [(bool, "x")], conf)

--- a/esphome/components/ezo/sensor.py
+++ b/esphome/components/ezo/sensor.py
@@ -12,12 +12,15 @@ CONF_ON_LED = "on_led"
 CONF_ON_DEVICE_INFORMATION = "on_device_information"
 CONF_ON_SLOPE = "on_slope"
 CONF_ON_CALIBRATION = "on_calibration"
+CONF_ON_T = "on_t"
 
 ezo_ns = cg.esphome_ns.namespace("ezo")
 
 EZOSensor = ezo_ns.class_(
     "EZOSensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
+
+TTrigger = ezo_ns.class_("TTrigger", automation.Trigger.template(cg.std_string))
 
 SlopeTrigger = ezo_ns.class_("SlopeTrigger", automation.Trigger.template(cg.std_string))
 
@@ -43,6 +46,11 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_ON_SLOPE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SlopeTrigger),
+                }
+            ),
+            cv.Optional(CONF_ON_T): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(TTrigger),
                 }
             ),
             cv.Optional(CONF_ON_DEVICE_INFORMATION): automation.validate_automation(
@@ -83,5 +91,9 @@ async def to_code(config):
         yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_CALIBRATION, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
+    for conf in config.get(CONF_ON_T, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)

--- a/esphome/components/ezo/sensor.py
+++ b/esphome/components/ezo/sensor.py
@@ -13,12 +13,18 @@ CONF_ON_DEVICE_INFORMATION = "on_device_information"
 CONF_ON_SLOPE = "on_slope"
 CONF_ON_CALIBRATION = "on_calibration"
 CONF_ON_T = "on_t"
+CONF_ON_CUSTOM = "on_custom"
 
 ezo_ns = cg.esphome_ns.namespace("ezo")
 
 EZOSensor = ezo_ns.class_(
     "EZOSensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
+
+CustomTrigger = ezo_ns.class_(
+    "CustomTrigger", automation.Trigger.template(cg.std_string)
+)
+
 
 TTrigger = ezo_ns.class_("TTrigger", automation.Trigger.template(cg.std_string))
 
@@ -38,6 +44,11 @@ CONFIG_SCHEMA = (
     sensor.SENSOR_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(EZOSensor),
+            cv.Optional(CONF_ON_CUSTOM): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CustomTrigger),
+                }
+            ),
             cv.Optional(CONF_ON_CALIBRATION): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CalibrationTrigger),
@@ -77,6 +88,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await sensor.register_sensor(var, config)
     await i2c.register_i2c_device(var, config)
+
+    for conf in config.get(CONF_ON_CUSTOM, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        yield automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_LED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -203,14 +203,14 @@ ota:
         ESP_LOGD("ota", "State %d", state);
   on_begin:
     then:
-      logger.log: "OTA begin"
+      logger.log: 'OTA begin'
   on_progress:
     then:
       lambda: >-
         ESP_LOGD("ota", "Got progress %f", x);
   on_end:
     then:
-      logger.log: "OTA end"
+      logger.log: 'OTA end'
   on_error:
     then:
       lambda: >-
@@ -910,9 +910,9 @@ sensor:
       name: 'AQI'
       calculation_type: 'CAQI'
   - platform: teleinfo
-    tag_name: "HCHC"
-    name: "hchc"
-    unit_of_measurement: "Wh"
+    tag_name: 'HCHC'
+    name: 'hchc'
+    unit_of_measurement: 'Wh'
     icon: mdi:flash
     teleinfo_id: myteleinfo
   - platform: mcp9808
@@ -925,11 +925,11 @@ sensor:
   - platform: cs5460a
     id: cs5460a1
     current:
-      name: "Socket current"
+      name: 'Socket current'
     voltage:
-      name: "Mains voltage"
+      name: 'Mains voltage'
     power:
-      name: "Socket power"
+      name: 'Socket power'
       on_value:
         then:
           cs5460a.restart: cs5460a1
@@ -2167,8 +2167,8 @@ text_sensor:
     name: 'ESPHome Version No Timestamp'
     hide_timestamp: True
   - platform: teleinfo
-    tag_name: "OPTARIF"
-    name: "optarif"
+    tag_name: 'OPTARIF'
+    name: 'optarif'
     teleinfo_id: myteleinfo
 
 sn74hc595:

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -918,25 +918,6 @@ sensor:
   - platform: mcp9808
     name: 'MCP9808 Temperature'
     update_interval: 15s
-  - platform: ezo
-    id: ph_ezo
-    address: 99
-    unit_of_measurement: 'pH'
-    on_led:
-      - lambda: |-
-          ESP_LOGD("TEST","Triggered with %s", x);
-    on_device_information:
-      - lambda: |-
-          ESP_LOGD("TEST","Triggered with %s", x);
-    on_slope:
-      - lambda: |-
-          ESP_LOGD("TEST","Triggered with %s", x);
-    on_calibration:
-      - lambda: |-
-          ESP_LOGD("TEST","Triggered with %s", x);
-    on_t:
-      - lambda: |-
-          ESP_LOGD("TEST","Triggered with %s", x);
   - platform: cs5460a
     id: cs5460a1
     current:

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -922,6 +922,21 @@ sensor:
     id: ph_ezo
     address: 99
     unit_of_measurement: 'pH'
+    on_led:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x);
+    on_device_information:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x);
+    on_slope:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x);
+    on_calibration:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x);
+    on_t:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x);
   - platform: cs5460a
     id: cs5460a1
     current:

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -236,6 +236,26 @@ sensor:
     id: freezer_temp_source
     reference_voltage: 3.19
     number: 0
+  - platform: ezo
+    id: ph_ezo
+    address: 99
+    unit_of_measurement: 'pH'
+    on_led:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", ONOFF(x));
+    on_device_information:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x.c_str());
+    on_slope:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x.c_str());
+    on_calibration:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x.c_str());
+    on_t:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x.c_str());
+
 time:
   - platform: homeassistant
     on_time:

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -255,6 +255,10 @@ sensor:
     on_t:
       - lambda: |-
           ESP_LOGD("TEST","Triggered with %s", x.c_str());
+    on_custom:
+      - lambda: |-
+          ESP_LOGD("TEST","Triggered with %s", x.c_str());
+
 
 time:
   - platform: homeassistant


### PR DESCRIPTION
# What does this implement/fix?

I'm hoping to revive a request that looked to be so close to the finish line.  Currently the EZO platform works to read sensor data, but there isn't a way to set calibrations.  There are also EZO Peristaltic Pumps that don't have the ability to read as a switch or button so they can't be controlled in esphome and are essentially useless if the accompanying sensors are configured with the same esp32 device.

- If there was a card that, when enabled, could read constant sensor states (or change the frequency to read every .5s for example) and had the ability to set the calibration amount with a button press.
- If EZO circuits could be set up to be used with both the sensor and switch platforms, or if there was a new "i2c_switch" component created for broader use.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
