### PR TITLE
Revert "Allocate smaller amount of buffer for JSON (#3384)"

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -29,7 +29,7 @@ std::string build_json(const json_build_t &f) {
   const size_t request_size = std::min(free_heap - 2048, (size_t) 5120);
 
   DynamicJsonDocument json_document(request_size);
-  if (json_document.memoryPool().buffer() == nullptr) {
+  if (json_document.capacity() == 0) {
     ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, largest free heap block: %u bytes",
              request_size, free_heap);
     return "{}";
@@ -37,7 +37,7 @@ std::string build_json(const json_build_t &f) {
   JsonObject root = json_document.to<JsonObject>();
   f(root);
   json_document.shrinkToFit();
-
+  ESP_LOGV(TAG, "Size after shrink %u bytes", json_document.capacity());
   std::string output;
   serializeJson(json_document, output);
   return output;
@@ -57,7 +57,7 @@ void parse_json(const std::string &data, const json_parse_t &f) {
   size_t request_size = std::min(free_heap - 2048, (size_t)(data.size() * 1.5));
   do {
     DynamicJsonDocument json_document(request_size);
-    if (json_document.memoryPool().buffer() == nullptr) {
+    if (json_document.capacity() == 0) {
       ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
                free_heap);
       return;

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -23,13 +23,13 @@ std::string build_json(const json_build_t &f) {
 #ifdef USE_ESP8266
   const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
 #elif defined(USE_ESP32)
-  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
 #endif
 
-  const size_t request_size = std::min(free_heap, (size_t) 512);
+  const size_t request_size = std::min(free_heap - 2048, (size_t) 5120);
 
   DynamicJsonDocument json_document(request_size);
-  if (json_document.capacity() == 0) {
+  if (json_document.memoryPool().buffer() == nullptr) {
     ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, largest free heap block: %u bytes",
              request_size, free_heap);
     return "{}";
@@ -37,7 +37,7 @@ std::string build_json(const json_build_t &f) {
   JsonObject root = json_document.to<JsonObject>();
   f(root);
   json_document.shrinkToFit();
-  ESP_LOGV(TAG, "Size after shrink %u bytes", json_document.capacity());
+
   std::string output;
   serializeJson(json_document, output);
   return output;
@@ -51,13 +51,13 @@ void parse_json(const std::string &data, const json_parse_t &f) {
 #ifdef USE_ESP8266
   const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
 #elif defined(USE_ESP32)
-  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
 #endif
   bool pass = false;
-  size_t request_size = std::min(free_heap, (size_t)(data.size() * 1.5));
+  size_t request_size = std::min(free_heap - 2048, (size_t)(data.size() * 1.5));
   do {
     DynamicJsonDocument json_document(request_size);
-    if (json_document.capacity() == 0) {
+    if (json_document.memoryPool().buffer() == nullptr) {
       ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
                free_heap);
       return;


### PR DESCRIPTION
This reverts commit https://github.com/esphome/esphome/pull/3384/commits/3a9410f5f6342d56e0a752ac3123b5ab66012882

# What does this implement/fix?

https://github.com/esphome/esphome/pull/3384 reduced the destination buffer allocated in build_json from 5120 bytes to 512 bytes. This causes discovery to fail for complex entities with long config messages: the config message does not fit in the buffer, so it is truncated/invalid and rejected by Home Assistant. As one data point, the entity that exposed this regression for me has a config message 832 bytes long.

This PR simply reverts https://github.com/esphome/esphome/pull/3384.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
fixes https://github.com/esphome/issues/issues/3264
fixes https://github.com/esphome/issues/issues/3256
fixes https://github.com/esphome/issues/issues/3250

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
