### PR TITLE
mask deprecated adc_gpio_init() for esp32-s2

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -51,8 +51,9 @@ void ADCSensor::setup() {
     }
   }
 
-  // adc_gpio_init doesn't exist on ESP32-C3 or ESP32-H2
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2)
+  // adc_gpio_init doesn't exist on ESP32-S2, ESP32-C3 or ESP32-H2
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2) \
+    && !defined(USE_ESP32_VARIANT_ESP32S2)
   adc_gpio_init(ADC_UNIT_1, (adc_channel_t) channel_);
 #endif
 #endif  // USE_ESP32

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -52,8 +52,7 @@ void ADCSensor::setup() {
   }
 
   // adc_gpio_init doesn't exist on ESP32-S2, ESP32-C3 or ESP32-H2
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2) \
-    && !defined(USE_ESP32_VARIANT_ESP32S2)
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2) && !defined(USE_ESP32_VARIANT_ESP32S2)
   adc_gpio_init(ADC_UNIT_1, (adc_channel_t) channel_);
 #endif
 #endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Function `adc_gpio_init()` is deprecated in ESP-IDF for ESP32-S2:
https://github.com/espressif/esp-idf/blob/c1bcb8756b89435d1ef6b964ac9ce953b18b6c90/components/driver/adc_deprecated.c#L617

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32-S2
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: esp32s2-01
  platformio_options:
    board_build.variant: esp32s2
    board_build.flash_mode: dout
    board_build.partitions: /config/esp32s2-partitions.csv
    build_flags:
      - "-DBOARD_HAS_PSRAM"

esp32:
  board: esp32-s2-saola-1
  variant: esp32s2
  framework:
    type: arduino
    version: dev
    platform_version: https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream

sensor:
  - platform: adc
    pin: GPIO6
    attenuation: auto
    name: my adc
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
