### PR TITLE
[scd4x] Expose force calibration action

### DIFF
--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -203,16 +203,16 @@ void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
   }
 }
 
-void SCD4XComponent::restart_periodic_measurements_after_forced_calibration() {
-    if (!this->write_command(SCD4X_CMD_START_CONTINUOUS_MEASUREMENTS)) {
-      ESP_LOGE(TAG, "Error restarting continuous measurements.");
-      this->error_code_ = MEASUREMENT_INIT_FAILED;
-      this->mark_failed();
-      return;
-    }
+void SCD4XComponent::restart_periodic_measurements_after_forced_calibration_() {
+  if (!this->write_command(SCD4X_CMD_START_CONTINUOUS_MEASUREMENTS)) {
+    ESP_LOGE(TAG, "Error restarting continuous measurements.");
+    this->error_code_ = MEASUREMENT_INIT_FAILED;
+    this->mark_failed();
+    return;
+  }
 
-    ESP_LOGD(TAG, "Sensor back to regular operation");
-    initialized_ = true;
+  ESP_LOGD(TAG, "Sensor back to regular operation");
+  initialized_ = true;
 }
 
 void SCD4XComponent::perform_forced_calibration(uint16_t target_co2) {
@@ -237,7 +237,7 @@ void SCD4XComponent::perform_forced_calibration(uint16_t target_co2) {
     ESP_LOGD(TAG, "Performing forced calibration with target co2 concentration of %ippm", target_co2);
     if (!this->write_command(SCD4X_CMD_PERFORM_FORCED_CALIBRATION, target_co2)) {
       ESP_LOGE(TAG, "Failed to perform forced calibration");
-      restart_periodic_measurements_after_forced_calibration();
+      restart_periodic_measurements_after_forced_calibration_();
     } else {
       // Spec says perform_forced_recalibration takes 400ms
       this->set_timeout(400, [this]() {
@@ -248,7 +248,7 @@ void SCD4XComponent::perform_forced_calibration(uint16_t target_co2) {
           ESP_LOGI(TAG, "Forced recalibration successful, corrected by %ippm", raw_frc_correction - 0x8000);
         }
 
-        restart_periodic_measurements_after_forced_calibration();
+        restart_periodic_measurements_after_forced_calibration_();
       });
     }
   });

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -237,7 +237,7 @@ void SCD4XComponent::perform_forced_calibration(uint16_t target_co2) {
     ESP_LOGD(TAG, "Performing forced calibration with target co2 concentration of %ippm", target_co2);
     if (!this->write_command(SCD4X_CMD_PERFORM_FORCED_CALIBRATION, target_co2)) {
       ESP_LOGE(TAG, "Failed to perform forced calibration");
-      restart_periodic_measurements_after_forced_calibration_();
+      this->restart_periodic_measurements_after_forced_calibration_();
     } else {
       // Spec says perform_forced_recalibration takes 400ms
       this->set_timeout(400, [this]() {
@@ -248,7 +248,7 @@ void SCD4XComponent::perform_forced_calibration(uint16_t target_co2) {
           ESP_LOGI(TAG, "Forced recalibration successful, corrected by %ippm", raw_frc_correction - 0x8000);
         }
 
-        restart_periodic_measurements_after_forced_calibration_();
+        this->restart_periodic_measurements_after_forced_calibration_();
       });
     }
   });

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -31,7 +31,7 @@ class SCD4XComponent : public PollingComponent, public sensirion_common::Sensiri
 
  protected:
   bool update_ambient_pressure_compensation_(uint16_t pressure_in_hpa);
-  void restart_periodic_measurements_after_forced_calibration();
+  void restart_periodic_measurements_after_forced_calibration_();
 
   ERRORCODE error_code_;
 
@@ -49,7 +49,6 @@ class SCD4XComponent : public PollingComponent, public sensirion_common::Sensiri
   // used for compensation
   sensor::Sensor *ambient_pressure_source_{nullptr};
 };
-
 
 template<typename... Ts> class PerformForcedCalibration : public Action<Ts...> {
  public:

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -55,7 +55,7 @@ template<typename... Ts> class PerformForcedCalibration : public Action<Ts...> {
   PerformForcedCalibration(SCD4XComponent *scd4x) : scd4x_(scd4x) {}
   TEMPLATABLE_VALUE(uint16_t, target_co2)
 
-  void play(Ts... x) override { scd4x_->perform_forced_calibration(this->target_co2_.value(x...)); }
+  void play(Ts... x) override { this->scd4x_->perform_forced_calibration(this->target_co2_.value(x...)); }
 
  protected:
   SCD4XComponent *scd4x_;

--- a/esphome/components/scd4x/sensor.py
+++ b/esphome/components/scd4x/sensor.py
@@ -1,5 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import automation
+from esphome.automation import maybe_simple_id
 from esphome.components import i2c, sensor
 from esphome.components import sensirion_common
 from esphome.const import (
@@ -27,6 +29,7 @@ scd4x_ns = cg.esphome_ns.namespace("scd4x")
 SCD4XComponent = scd4x_ns.class_(
     "SCD4XComponent", cg.PollingComponent, sensirion_common.SensirionI2CDevice
 )
+PerformForcedCalibration = scd4x_ns.class_("PerformForcedCalibration", automation.Action)
 
 CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
 CONF_ALTITUDE_COMPENSATION = "altitude_compensation"
@@ -106,3 +109,22 @@ async def to_code(config):
     if CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE in config:
         sens = await cg.get_variable(config[CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE])
         cg.add(var.set_ambient_pressure_source(sens))
+
+
+@automation.register_action(
+    "scd4x.perform_forced_calibration",
+    PerformForcedCalibration,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(SCD4XComponent),
+            cv.Optional(CONF_CO2, 410): cv.templatable(cv.uint16_t),
+        },
+        key=CONF_CO2
+    ),
+)
+async def scd4x_action_perform_forced_calibration_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_CO2], args, cg.uint16)
+    cg.add(var.set_target_co2(template_))
+    return var

--- a/esphome/components/scd4x/sensor.py
+++ b/esphome/components/scd4x/sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.automation import maybe_simple_id
 from esphome.components import i2c, sensor
 from esphome.components import sensirion_common
 from esphome.const import (
@@ -29,7 +28,9 @@ scd4x_ns = cg.esphome_ns.namespace("scd4x")
 SCD4XComponent = scd4x_ns.class_(
     "SCD4XComponent", cg.PollingComponent, sensirion_common.SensirionI2CDevice
 )
-PerformForcedCalibration = scd4x_ns.class_("PerformForcedCalibration", automation.Action)
+PerformForcedCalibration = scd4x_ns.class_(
+    "PerformForcedCalibration", automation.Action
+)
 
 CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
 CONF_ALTITUDE_COMPENSATION = "altitude_compensation"
@@ -119,10 +120,10 @@ async def to_code(config):
             cv.GenerateID(): cv.use_id(SCD4XComponent),
             cv.Optional(CONF_CO2, 410): cv.templatable(cv.uint16_t),
         },
-        key=CONF_CO2
+        key=CONF_CO2,
     ),
 )
-async def scd4x_action_perform_forced_calibration_code(config, action_id, template_arg, args):
+async def scd4x_perform_forced_calibration_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_CO2], args, cg.uint16)

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -885,6 +885,10 @@ sensor:
   - platform: scd4x
     co2:
       name: "SCD4X CO2"
+      on_value:
+        then:
+          - scd4x.perform_forced_calibration:
+              co2: 1234
     temperature:
       id: scd4x_temperature
       name: "SCD4X Temperature"


### PR DESCRIPTION
# What does this implement/fix?

See https://sensirion.com/media/documents/C4B87CE6/61652F80/Sensirion_CO2_Sensors_SCD4x_Datasheet.pdf `perform_forced_recalibration`
Allows to manually calibrate the co2 sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

Doc PR https://github.com/esphome/esphome-docs/pull/2055

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

Exposed as a service which I think would be rather typical as calibration is not something done on a regular basis.
```
api:
  services:
    - service: perform_forced_calibration
      variables:
        current_co2: int
      then:
        - scd4x.perform_forced_calibration:
            co2: !lambda 'return current_co2;'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
