### PR TITLE
Code cleanup fixes for the select component

### DIFF
--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -23,6 +23,10 @@ void Select::add_on_state_callback(std::function<void(std::string, size_t)> &&ca
   this->state_callback_.add(std::move(callback));
 }
 
+bool Select::has_option(const std::string &option) const { return this->index_of(option).has_value(); }
+
+bool Select::has_index(size_t index) const { return index < this->size(); }
+
 size_t Select::size() const {
   auto options = traits.get_options();
   return options.size();
@@ -46,11 +50,12 @@ optional<size_t> Select::active_index() const {
 }
 
 optional<std::string> Select::at(size_t index) const {
-  auto options = traits.get_options();
-  if (index >= options.size()) {
+  if (this->has_index(index)) {
+    auto options = traits.get_options();
+    return options.at(index);
+  } else {
     return {};
   }
-  return options.at(index);
 }
 
 uint32_t Select::hash_base() { return 2812997003UL; }

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -28,15 +28,28 @@ class Select : public EntityBase {
 
   void publish_state(const std::string &state);
 
-  /// Return whether this select has gotten a full state yet.
+  /// Return whether this select component has gotten a full state yet.
   bool has_state() const { return has_state_; }
 
+  /// Instantiate a SelectCall object to modify this select component's state.
   SelectCall make_call() { return SelectCall(this); }
 
-  // Methods that provide an API to index-based access.
+  /// Return whether this select component contains the provided option.
+  bool has_option(const std::string &option) const;
+
+  /// Return whether this select component contains the provided index offset.
+  bool has_index(size_t index) const;
+
+  /// Return the number of options in this select component.
   size_t size() const;
+
+  /// Find the (optional) index offset of the provided option value.
   optional<size_t> index_of(const std::string &option) const;
+
+  /// Return the (optional) index offset of the currently active option.
   optional<size_t> active_index() const;
+
+  /// Return the (optional) option value at the provided index offset.
   optional<std::string> at(size_t index) const;
 
   void add_on_state_callback(std::function<void(std::string, size_t)> &&callback);

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -32,7 +32,6 @@ class Select : public EntityBase {
   bool has_state() const { return has_state_; }
 
   SelectCall make_call() { return SelectCall(this); }
-  void set(const std::string &value) { make_call().set_option(value).perform(); }
 
   // Methods that provide an API to index-based access.
   size_t size() const;

--- a/esphome/components/select/select_call.cpp
+++ b/esphome/components/select/select_call.cpp
@@ -13,8 +13,6 @@ SelectCall &SelectCall::set_option(const std::string &option) {
 
 SelectCall &SelectCall::set_index(size_t index) { return with_operation(SELECT_OP_SET_INDEX).with_index(index); }
 
-const optional<std::string> &SelectCall::get_option() const { return option_; }
-
 SelectCall &SelectCall::select_next(bool cycle) { return with_operation(SELECT_OP_NEXT).with_cycle(cycle); }
 
 SelectCall &SelectCall::select_previous(bool cycle) { return with_operation(SELECT_OP_PREVIOUS).with_cycle(cycle); }

--- a/esphome/components/select/select_call.h
+++ b/esphome/components/select/select_call.h
@@ -24,7 +24,6 @@ class SelectCall {
 
   SelectCall &set_option(const std::string &option);
   SelectCall &set_index(size_t index);
-  const optional<std::string> &get_option() const;
 
   SelectCall &select_next(bool cycle);
   SelectCall &select_previous(bool cycle);

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -26,7 +26,7 @@ void TemplateSelect::setup() {
       ESP_LOGD(TAG, "State from initial (restored index %d out of bounds): %s",
                index, value.c_str());
     } else {
-      value = this->at(index);
+      value = this->at(index).value();
       ESP_LOGD(TAG, "State from restore: %s", value.c_str());
     }
   }

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -23,8 +23,7 @@ void TemplateSelect::setup() {
       ESP_LOGD(TAG, "State from initial (could not load stored index): %s", value.c_str());
     } else if (index >= this->size()) {
       value = this->initial_option_;
-      ESP_LOGD(TAG, "State from initial (restored index %d out of bounds): %s",
-               index, value.c_str());
+      ESP_LOGD(TAG, "State from initial (restored index %d out of bounds): %s", index, value.c_str());
     } else {
       value = this->at(index).value();
       ESP_LOGD(TAG, "State from restore: %s", value.c_str());

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -21,7 +21,7 @@ void TemplateSelect::setup() {
     if (!this->pref_.load(&index)) {
       value = this->initial_option_;
       ESP_LOGD(TAG, "State from initial (could not load stored index): %s", value.c_str());
-    } else if (index >= this->size()) {
+    } else if (!this->has_index(index)) {
       value = this->initial_option_;
       ESP_LOGD(TAG, "State from initial (restored index %d out of bounds): %s", index, value.c_str());
     } else {
@@ -41,8 +41,7 @@ void TemplateSelect::update() {
   if (!val.has_value())
     return;
 
-  auto index = this->index_of(*val);
-  if (!index.has_value()) {
+  if (!this->has_option(*val)) {
     ESP_LOGE(TAG, "Lambda returned an invalid option: %s", (*val).c_str());
     return;
   }
@@ -58,7 +57,7 @@ void TemplateSelect::control(const std::string &value) {
 
   if (this->restore_value_) {
     auto index = this->index_of(value);
-    this->pref_.save(&index);
+    this->pref_.save(&index.value());
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Some cleanup and fixes as proposed in previous PR:

- Removed the `Select::set(...)` method (using `make_call()` is the designated way to change the select component's state)
- Removed the unused and hardly  useful `SelectCall::get_option()` method
- Added utility methods `Select::has_option(...)` and `Select::has_index(...)`
- Modified template select to make use of the new Select methods
- Fixed a bricking issue in the template select restore code: when the stored select index had a value that was out of bounds for a newly flashed select definition (with less options than before), on state restore time an exception would break the boot process

Flagged this change as a breaking change, since some methods were removed from the code.
I doubt that they are in active use though.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2065

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Verified that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
