### PR TITLE
Code cleanup fixes for the number component

### DIFF
--- a/esphome/components/number/number.h
+++ b/esphome/components/number/number.h
@@ -33,7 +33,6 @@ class Number : public EntityBase {
   void publish_state(float state);
 
   NumberCall make_call() { return NumberCall(this); }
-  void set(float value) { make_call().set_value(value).perform(); }
 
   void add_on_state_callback(std::function<void(float)> &&callback);
 

--- a/esphome/components/number/number_call.h
+++ b/esphome/components/number/number_call.h
@@ -23,8 +23,6 @@ class NumberCall {
   void perform();
 
   NumberCall &set_value(float value);
-  const optional<float> &get_value() const { return value_; }
-
   NumberCall &number_increment(bool cycle);
   NumberCall &number_decrement(bool cycle);
   NumberCall &number_to_min();


### PR DESCRIPTION
# What does this implement/fix?

Some cleanup and fixes as proposed in previous PR:

- Removed the `Number::set(...)` method (using make_call() is the designated way to change the select component's state)
- Removed the unused and hardly useful NumberCall::get_value() method

Flagged this change as a breaking change, since some methods were removed from the code.
I doubt that they are in active use though.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [x]  Verified that the new code works (under tests/ folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
