### PR TITLE
Restore RealTimeClock's local TZ after epoch sync

### DIFF
--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -137,6 +137,7 @@ class RealTimeClock : public PollingComponent {
   void synchronize_epoch_(uint32_t epoch);
 
   std::string timezone_{};
+  void apply_timezone_();
 
   CallbackManager<void()> time_sync_callback_;
 };


### PR DESCRIPTION
# What does this implement/fix?

When `RealTimeClock::synchronize_epoch_(...)` was called, the timezone would momentarily be moved to UTC, causing time functions to report the time as UTC time for a little while. This caused weird 2 hour jumps on my time display (the UTC time would show for a second, after which the actual local time would be showed).

This was also visible in the logging, which showed:
```
[11:01:23][D][time:039]: Synchronized time: 2022-05-11 09:01:23
```

while it was in fact `11:01:23` in local time. 
By applying the timezone after the sync operation, this behavior was fixed for me.
No more time traveling on my time display, and when syncing the time, I now get the expected log:
```
[11:18:29][D][time:042]: Synchronized time: 2022-05-11 11:18:28
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# I use a setup where an RTC module is combined with NTP to keep track of time.
esphome:
  on_boot:
    then:
      ds1307.read_time
      
time:
  # The RTC time is the main time source.
  - platform: ds1307
    id: rtc_time
    i2c_id: rtc_module_bus
    timezone: Europe/Amsterdam
    update_interval: never

  # NTP for syncing the RTC module's time.
  - platform: sntp
    id: sntp_time
    timezone: Europe/Amsterdam
    on_time_sync:
      then:
        - ds1307.write_time:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
