### PR TITLE
big_endian_bytes_to_word helper method

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -239,6 +239,15 @@ template<typename T> constexpr14 T convert_little_endian(T val) {
 #endif
 }
 
+/// Create a uint16_t value from big endian bytes (most significant byte first) order.
+uint16_t constexpr14 big_endian_bytes_to_word(uint8_t first, uint8_t second) {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return first | second << 8;
+#else
+  return first << 8 | second;
+#endif
+}
+
 ///@}
 
 /// @name Strings


### PR DESCRIPTION
# What does this implement/fix?

add a helper method to create an uint16_t value from big endian bytes. 
Converting 2 bytes to int is quite common and most devices use big endian. 


Example: 
```C
uint16_t value = big_endian_bytes_to_word(byte1, byte2); 
```
(A better idea for the function name  is welcome) 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
