### PR TITLE
Tuya status gpio support

### DIFF
--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -1,5 +1,6 @@
 from esphome.components import time
 from esphome import automation
+from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
@@ -11,6 +12,7 @@ CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS = "ignore_mcu_update_on_datapoints"
 
 CONF_ON_DATAPOINT_UPDATE = "on_datapoint_update"
 CONF_DATAPOINT_TYPE = "datapoint_type"
+CONF_STATUS_PIN = "status_pin"
 
 tuya_ns = cg.esphome_ns.namespace("tuya")
 Tuya = tuya_ns.class_("Tuya", cg.Component, uart.UARTDevice)
@@ -88,6 +90,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS): cv.ensure_list(
                 cv.uint8_t
             ),
+            cv.Optional(CONF_STATUS_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_ON_DATAPOINT_UPDATE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -114,6 +117,9 @@ async def to_code(config):
     if CONF_TIME_ID in config:
         time_ = await cg.get_variable(config[CONF_TIME_ID])
         cg.add(var.set_time_id(time_))
+    if CONF_STATUS_PIN in config:
+        status_pin_ = await cg.gpio_pin_expression(config[CONF_STATUS_PIN])
+        cg.add(var.set_status_pin(status_pin_))
     if CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS in config:
         for dp in config[CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS]:
             cg.add(var.add_ignore_mcu_update_on_datapoints(dp))

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -54,8 +54,8 @@ void Tuya::dump_config() {
     }
   }
   if ((this->status_pin_reported_ != -1) || (this->reset_pin_reported_ != -1)) {
-    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d (not supported)", this->status_pin_reported_,
-                  this->reset_pin_reported_);
+    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d (not supported)",
+                  this->status_pin_reported_, this->reset_pin_reported_);
   }
   if (this->status_pin_.has_value()) {
     LOG_PIN("  Status Pin: ", this->status_pin_.value());
@@ -179,14 +179,15 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
         if (this->status_pin_reported_ != -1) {
           this->init_state_ = TuyaInitState::INIT_DATAPOINT;
           this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
-          bool is_pin_equals = this->status_pin_.has_value() &&
-            this->status_pin_.value()->get_pin() == this->status_pin_reported_;
+          bool is_pin_equals = 
+              this->status_pin_.has_value() && this->status_pin_.value()->get_pin() == this->status_pin_reported_;
           // Configure status pin toggling (if reported and configured) or WIFI_STATE periodic send
           if (is_pin_equals) {
             ESP_LOGV(TAG, "Configured status pin %i", this->status_pin_reported_);
             this->set_interval("wifi", 1000, [this] { this->set_status_pin_(); });
           } else {
-            ESP_LOGW(TAG, "Supplied status_pin does not equals the reported pin %i. TuyaMcu will work in limited mode.", this->status_pin_reported_);
+            ESP_LOGW(TAG, "Supplied status_pin does not equals the reported pin %i. TuyaMcu will work in limited mode.",
+                     this->status_pin_reported_);
           }
         } else {
           this->init_state_ = TuyaInitState::INIT_WIFI;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -179,7 +179,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
         if (this->status_pin_reported_ != -1) {
           this->init_state_ = TuyaInitState::INIT_DATAPOINT;
           this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
-          bool is_pin_equals = 
+          bool is_pin_equals =
               this->status_pin_.has_value() && this->status_pin_.value()->get_pin() == this->status_pin_reported_;
           // Configure status pin toggling (if reported and configured) or WIFI_STATE periodic send
           if (is_pin_equals) {

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -3,6 +3,7 @@
 #include "esphome/components/network/util.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/util.h"
+#include "esphome/core/gpio.h"
 
 namespace esphome {
 namespace tuya {
@@ -13,6 +14,9 @@ static const int RECEIVE_TIMEOUT = 300;
 
 void Tuya::setup() {
   this->set_interval("heartbeat", 15000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
+  if (this->status_pin_.has_value()) {
+    this->status_pin_.value()->digital_write(false);
+  }
 }
 
 void Tuya::loop() {
@@ -52,6 +56,9 @@ void Tuya::dump_config() {
   if ((this->status_pin_reported_ != -1) || (this->reset_pin_reported_ != -1)) {
     ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d (not supported)", this->status_pin_reported_,
                   this->reset_pin_reported_);
+  }
+  if (this->status_pin_.has_value()) {
+    LOG_PIN("  Status Pin: ", this->status_pin_.value());
   }
   ESP_LOGCONFIG(TAG, "  Product: '%s'", this->product_.c_str());
   this->check_uart_settings(9600);
@@ -173,7 +180,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
           this->init_state_ = TuyaInitState::INIT_DATAPOINT;
           this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
           bool is_pin_equals = this->status_pin_.has_value() &&
-            this->status_pin_.value()->get_pin() != this->status_pin_reported_;
+            this->status_pin_.value()->get_pin() == this->status_pin_reported_;
           // Configure status pin toggling (if reported and configured) or WIFI_STATE periodic send
           if (is_pin_equals) {
             ESP_LOGV(TAG, "Configured status pin %i", this->status_pin_reported_);

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -79,6 +79,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void set_raw_datapoint_value(uint8_t datapoint_id, const std::vector<uint8_t> &value);
   void set_boolean_datapoint_value(uint8_t datapoint_id, bool value);
   void set_integer_datapoint_value(uint8_t datapoint_id, uint32_t value);
+  void set_status_pin(InternalGPIOPin *status_pin) { this->status_pin_ = status_pin; }
   void set_string_datapoint_value(uint8_t datapoint_id, const std::string &value);
   void set_enum_datapoint_value(uint8_t datapoint_id, uint8_t value);
   void set_bitmask_datapoint_value(uint8_t datapoint_id, uint32_t value, uint8_t length);
@@ -115,6 +116,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void set_string_datapoint_value_(uint8_t datapoint_id, const std::string &value, bool forced);
   void set_raw_datapoint_value_(uint8_t datapoint_id, const std::vector<uint8_t> &value, bool forced);
   void send_datapoint_command_(uint8_t datapoint_id, TuyaDatapointType datapoint_type, std::vector<uint8_t> data);
+  void set_status_pin_();
   void send_wifi_status_();
 
 #ifdef USE_TIME
@@ -123,8 +125,9 @@ class Tuya : public Component, public uart::UARTDevice {
 #endif
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   uint8_t protocol_version_ = -1;
-  int gpio_status_ = -1;
-  int gpio_reset_ = -1;
+  optional<InternalGPIOPin *> status_pin_{};
+  int status_pin_reported_ = -1;
+  int reset_pin_reported_ = -1;
   uint32_t last_command_timestamp_ = 0;
   uint32_t last_rx_char_timestamp_ = 0;
   std::string product_ = "";

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -57,6 +57,9 @@ time:
 
 tuya:
   time_id: sntp_time
+  status_pin:
+    number: 14
+    inverted: true
 
 pipsolar:
     id: inverter0


### PR DESCRIPTION
# What does this implement/fix?

Some tuya devices (as my BECA ME-81H thermostat) uses the gpio pin to tell the mcu about network connection status. This status pin number reported as the response to the [query working mode command](https://developer.tuya.com/en/docs/iot-device-dev/tuya-gateway-mcu-access-communication-protocol?id=K9fo8c0m7hkd0#title-5-Query%20working%20mode%20of%20the%20module%20set%20by%20MCU).
The logic is following:
- if status status pin reported we MUST use that gpio pin to indicate network connection
- if status status pin is not reported, we MUST send [report network status command](https://developer.tuya.com/en/docs/iot-device-dev/tuya-gateway-mcu-access-communication-protocol?id=K9fo8c0m7hkd0#title-6-Report%20the%20network%20status%20of%20the%20device)

This pull request fixes the inability of my BECA thermostat to know about succesfull network connection which leads to wifi icon not lit up and not synchronized time.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2072

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
tuya:
  time_id: sntp_time
  status_pin: 
    number: 14
    inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
