### PR TITLE
Remove conflict between esp32_ble_beacon and esp32_ble_tracker

### DIFF
--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -1,27 +1,32 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_TYPE, CONF_UUID
-from esphome.core import CORE
-from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.const import CONF_ID, CONF_TX_POWER, CONF_TYPE, CONF_UUID
+from esphome.components import esp32_ble_tracker
 
-DEPENDENCIES = ["esp32"]
-CONFLICTS_WITH = ["esp32_ble_tracker"]
+DEPENDENCIES = ["esp32_ble_tracker"]
 
 esp32_ble_beacon_ns = cg.esphome_ns.namespace("esp32_ble_beacon")
 ESP32BLEBeacon = esp32_ble_beacon_ns.class_("ESP32BLEBeacon", cg.Component)
 
 CONF_MAJOR = "major"
 CONF_MINOR = "minor"
+MEASURED_POWER = "measured_power"
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(ESP32BLEBeacon),
-        cv.Required(CONF_TYPE): cv.one_of("IBEACON", upper=True),
-        cv.Required(CONF_UUID): cv.uuid,
-        cv.Optional(CONF_MAJOR, default=10167): cv.uint16_t,
-        cv.Optional(CONF_MINOR, default=61958): cv.uint16_t,
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ESP32BLEBeacon),
+            cv.Required(CONF_TYPE): cv.one_of("IBEACON", upper=True),
+            cv.Required(CONF_UUID): cv.uuid,
+            cv.Optional(CONF_MAJOR, default=10167): cv.uint16_t,
+            cv.Optional(CONF_MINOR, default=61958): cv.uint16_t,
+            cv.Optional(CONF_TX_POWER, default=7): cv.int_range(0, 7),
+            cv.Optional(MEASURED_POWER, default=-59): cv.int_range(-100, 9),
+        }
+    )
+    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):
@@ -29,8 +34,9 @@ async def to_code(config):
     uuid_arr = [cg.RawExpression(f"0x{uuid[i:i + 2]}") for i in range(0, len(uuid), 2)]
     var = cg.new_Pvariable(config[CONF_ID], uuid_arr)
     await cg.register_component(var, config)
+    await esp32_ble_tracker.register_client(var, config)
+
     cg.add(var.set_major(config[CONF_MAJOR]))
     cg.add(var.set_minor(config[CONF_MINOR]))
-
-    if CORE.using_esp_idf:
-        add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
+    cg.add(var.set_txpower_level(config[CONF_TX_POWER]))
+    cg.add(var.set_measured_power(config[MEASURED_POWER]))

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -45,95 +45,23 @@ void ESP32BLEBeacon::dump_config() {
 
 void ESP32BLEBeacon::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ESP32 BLE beacon...");
-  global_esp32_ble_beacon = this;
-
-  xTaskCreatePinnedToCore(ESP32BLEBeacon::ble_core_task,
-                          "ble_task",  // name
-                          10000,       // stack size (in words)
-                          nullptr,     // input params
-                          1,           // priority
-                          nullptr,     // Handle, not needed
-                          0            // core
-  );
-}
-
-float ESP32BLEBeacon::get_setup_priority() const { return setup_priority::BLUETOOTH; }
-void ESP32BLEBeacon::ble_core_task(void *params) {
-  ble_setup();
-
-  while (true) {
-    delay(1000);  // NOLINT
-  }
-}
-
-void ESP32BLEBeacon::ble_setup() {
-  // Initialize non-volatile storage for the bluetooth controller
-  esp_err_t err = nvs_flash_init();
+  esp_err_t err = esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, this->txpower_level_);
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "nvs_flash_init failed: %d", err);
-    return;
-  }
-
-#ifdef USE_ARDUINO
-  if (!btStart()) {
-    ESP_LOGE(TAG, "btStart failed: %d", esp_bt_controller_get_status());
-    return;
-  }
-#else
-  if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED) {
-    // start bt controller
-    if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE) {
-      esp_bt_controller_config_t cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-      err = esp_bt_controller_init(&cfg);
-      if (err != ESP_OK) {
-        ESP_LOGE(TAG, "esp_bt_controller_init failed: %s", esp_err_to_name(err));
-        return;
-      }
-      while (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE)
-        ;
-    }
-    if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
-      err = esp_bt_controller_enable(ESP_BT_MODE_BLE);
-      if (err != ESP_OK) {
-        ESP_LOGE(TAG, "esp_bt_controller_enable failed: %s", esp_err_to_name(err));
-        return;
-      }
-    }
-    if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED) {
-      ESP_LOGE(TAG, "esp bt controller enable failed");
-      return;
-    }
-  }
-#endif
-
-  esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
-
-  err = esp_bluedroid_init();
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_init failed: %d", err);
-    return;
-  }
-  err = esp_bluedroid_enable();
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_enable failed: %d", err);
-    return;
-  }
-  err = esp_ble_gap_register_callback(ESP32BLEBeacon::gap_event_handler);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_ble_gap_register_callback failed: %d", err);
+    ESP_LOGE(TAG, "esp_ble_tx_power_set failed: %s", esp_err_to_name(err));
     return;
   }
 
   esp_ble_ibeacon_t ibeacon_adv_data;
   memcpy(&ibeacon_adv_data.ibeacon_head, &IBEACON_COMMON_HEAD, sizeof(esp_ble_ibeacon_head_t));
-  memcpy(&ibeacon_adv_data.ibeacon_vendor.proximity_uuid, global_esp32_ble_beacon->uuid_.data(),
+  memcpy(&ibeacon_adv_data.ibeacon_vendor.proximity_uuid, this->uuid_.data(),
          sizeof(ibeacon_adv_data.ibeacon_vendor.proximity_uuid));
-  ibeacon_adv_data.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->minor_);
-  ibeacon_adv_data.ibeacon_vendor.major = ENDIAN_CHANGE_U16(global_esp32_ble_beacon->major_);
-  ibeacon_adv_data.ibeacon_vendor.measured_power = 0xC5;
-
+  ibeacon_adv_data.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(this->minor_);
+  ibeacon_adv_data.ibeacon_vendor.major = ENDIAN_CHANGE_U16(this->major_);
+  ibeacon_adv_data.ibeacon_vendor.measured_power = this->measured_power_;
   esp_ble_gap_config_adv_data_raw((uint8_t *) &ibeacon_adv_data, sizeof(ibeacon_adv_data));
 }
+
+float ESP32BLEBeacon::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 
 void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
   esp_err_t err;
@@ -165,8 +93,6 @@ void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap
       break;
   }
 }
-
-ESP32BLEBeacon *global_esp32_ble_beacon = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace esp32_ble_beacon
 }  // namespace esphome

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
 #ifdef USE_ESP32
 
 #include <esp_gap_ble_api.h>
+#include <esp_bt.h>
 
 namespace esphome {
 namespace esp32_ble_beacon {
@@ -32,7 +34,7 @@ typedef struct {
   esp_ble_ibeacon_vendor_t ibeacon_vendor;
 } __attribute__((packed)) esp_ble_ibeacon_t;
 
-class ESP32BLEBeacon : public Component {
+class ESP32BLEBeacon : public Component, public esp32_ble_tracker::ESPBTClient {
  public:
   explicit ESP32BLEBeacon(const std::array<uint8_t, 16> &uuid) : uuid_(uuid) {}
 
@@ -42,19 +44,22 @@ class ESP32BLEBeacon : public Component {
 
   void set_major(uint16_t major) { this->major_ = major; }
   void set_minor(uint16_t minor) { this->minor_ = minor; }
+  void set_txpower_level(uint16_t level) { this->txpower_level_ = (esp_power_level_t) level; }
+  void set_measured_power(int16_t power) { this->measured_power_ = power; }
 
  protected:
-  static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
-  static void ble_core_task(void *params);
-  static void ble_setup();
+  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override { return false; };
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override{};
+  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
+  void connect() override{};
 
   std::array<uint8_t, 16> uuid_;
   uint16_t major_{};
   uint16_t minor_{};
+  esp_power_level_t txpower_level_{};
+  int16_t measured_power_{};
 };
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-extern ESP32BLEBeacon *global_esp32_ble_beacon;
 
 }  // namespace esp32_ble_beacon
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR resolves the conflict between `esp32_ble_beacon` and `esp32_ble_tracker` so you can use the `esp32_ble_beacon` and other ble sensors on the same device. Instead of doing it's own `ble_setup` `esp32_ble_beacon` will use the setup of the `esp32_ble_tracker` and will depend on it rather than conflict with it. It also introduces the functionality to set `tx_power` and `measured_power` of the `esp32_ble_beacon` which builds on @GrumpyMeow s PR https://github.com/esphome/esphome/pull/3299.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2079

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->



```yaml
# Example config.yaml
esp32_ble_tracker:

esp32_ble_beacon:
  type: iBeacon
  uuid: "c29ce823-e67a-4e71-bff2-abaa32e77a98"
  tx_power: 7
  measured_power: -59
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
