### PR TITLE
Increase JSON buffer size on overflow

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -26,21 +26,33 @@ std::string build_json(const json_build_t &f) {
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
 #endif
 
-  const size_t request_size = std::min(free_heap, (size_t) 512);
-
-  DynamicJsonDocument json_document(request_size);
-  if (json_document.capacity() == 0) {
-    ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, largest free heap block: %u bytes",
-             request_size, free_heap);
-    return "{}";
+  size_t request_size = std::min(free_heap, (size_t) 512);
+  while (true) {
+    ESP_LOGV(TAG, "Attempting to allocate %u bytes for JSON serialization", request_size);
+    DynamicJsonDocument json_document(request_size);
+    if (json_document.capacity() == 0) {
+      ESP_LOGE(TAG,
+               "Could not allocate memory for JSON document! Requested %u bytes, largest free heap block: %u bytes",
+               request_size, free_heap);
+      return "{}";
+    }
+    JsonObject root = json_document.to<JsonObject>();
+    f(root);
+    if (json_document.overflowed()) {
+      if (request_size == free_heap) {
+        ESP_LOGE(TAG, "Could not allocate memory for JSON document! Overflowed largest free heap block: %u bytes",
+                 free_heap);
+        return "{}";
+      }
+      request_size = std::min(request_size * 2, free_heap);
+      continue;
+    }
+    json_document.shrinkToFit();
+    ESP_LOGV(TAG, "Size after shrink %u bytes", json_document.capacity());
+    std::string output;
+    serializeJson(json_document, output);
+    return output;
   }
-  JsonObject root = json_document.to<JsonObject>();
-  f(root);
-  json_document.shrinkToFit();
-  ESP_LOGV(TAG, "Size after shrink %u bytes", json_document.capacity());
-  std::string output;
-  serializeJson(json_document, output);
-  return output;
 }
 
 void parse_json(const std::string &data, const json_parse_t &f) {


### PR DESCRIPTION
# What does this implement/fix?

When the 512 byte limit is exceeded, further modifications are silently dropped. This can easily produce malformed Home Assistant MQTT discovery messages (e.g. in my case device.name was null, and everything set in MQTTComponent::send_discovery_ after that was completely missing from the message). Increasing the buffer size requires rebuilding the entire message, but I suspect only MQTT discovery is that large, so it's probably an acceptable compromise.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
