### PR TITLE
Mark improv_serial and ESP-IDF usb based serial on c3/s2/s3 unsupported

### DIFF
--- a/esphome/components/improv_serial/__init__.py
+++ b/esphome/components/improv_serial/__init__.py
@@ -1,6 +1,8 @@
-from esphome.const import CONF_BAUD_RATE, CONF_ID, CONF_LOGGER
+from esphome.components.logger import USB_CDC, USB_SERIAL_JTAG
+from esphome.const import CONF_BAUD_RATE, CONF_HARDWARE_UART, CONF_ID, CONF_LOGGER
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.core import CORE
 import esphome.final_validate as fv
 
 CODEOWNERS = ["@esphome/core"]
@@ -17,14 +19,19 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-def validate_logger_baud_rate(config):
+def validate_logger(config):
     logger_conf = fv.full_config.get()[CONF_LOGGER]
     if logger_conf[CONF_BAUD_RATE] == 0:
         raise cv.Invalid("improv_serial requires the logger baud_rate to be not 0")
+    if CORE.using_esp_idf:
+        if logger_conf[CONF_HARDWARE_UART] in [USB_SERIAL_JTAG, USB_CDC]:
+            raise cv.Invalid(
+                "improv_serial does not support the selected logger hardware_uart"
+            )
     return config
 
 
-FINAL_VALIDATE_SCHEMA = validate_logger_baud_rate
+FINAL_VALIDATE_SCHEMA = validate_logger
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

Mark improv_serial and ESP-IDF usb based serial on c3/s2/s3 unsupported

This is temporary until support can be added. 

The issue I am facing so far is trying to get the `available` number of bytes from stdin (if that is even possible)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
