### PR TITLE
Retry Tuya init commands

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -11,6 +11,7 @@ namespace tuya {
 static const char *const TAG = "tuya";
 static const int COMMAND_DELAY = 10;
 static const int RECEIVE_TIMEOUT = 300;
+static const int MAX_RETRIES = 5;
 
 void Tuya::setup() {
   this->set_interval("heartbeat", 15000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
@@ -31,8 +32,12 @@ void Tuya::loop() {
 void Tuya::dump_config() {
   ESP_LOGCONFIG(TAG, "Tuya:");
   if (this->init_state_ != TuyaInitState::INIT_DONE) {
-    ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",
-                  static_cast<uint8_t>(this->init_state_));
+    if (this->init_failed_)
+      ESP_LOGCONFIG(TAG, "  Initialization failed. Current init_state: %u",
+                    static_cast<uint8_t>(this->init_state_));
+    else
+      ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",
+                    static_cast<uint8_t>(this->init_state_));
     ESP_LOGCONFIG(TAG, "  If no further output is received, confirm that this is a supported Tuya device.");
     return;
   }
@@ -54,7 +59,7 @@ void Tuya::dump_config() {
     }
   }
   if ((this->status_pin_reported_ != -1) || (this->reset_pin_reported_ != -1)) {
-    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d (not supported)",
+    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d",
                   this->status_pin_reported_, this->reset_pin_reported_);
   }
   if (this->status_pin_.has_value()) {
@@ -135,6 +140,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
   if (this->expected_response_.has_value() && this->expected_response_ == command_type) {
     this->expected_response_.reset();
     this->command_queue_.erase(command_queue_.begin());
+    this->init_retries_ = 0;
   }
 
   switch (command_type) {
@@ -397,6 +403,16 @@ void Tuya::process_command_queue_() {
 
   if (this->expected_response_.has_value() && delay > RECEIVE_TIMEOUT) {
     this->expected_response_.reset();
+    if (init_state_ != TuyaInitState::INIT_DONE) {
+      if (++this->init_retries_ >= MAX_RETRIES) {
+        this->init_failed_ = true;
+        ESP_LOGE(TAG, "Initialization failed at init_state %u", static_cast<uint8_t>(this->init_state_));
+        this->command_queue_.erase(command_queue_.begin());
+        this->init_retries_ = 0;
+      }
+    } else {
+      this->command_queue_.erase(command_queue_.begin());
+    }
   }
 
   // Left check of delay since last command in case there's ever a command sent by calling send_raw_command_ directly

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -134,6 +134,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
 
   if (this->expected_response_.has_value() && this->expected_response_ == command_type) {
     this->expected_response_.reset();
+    this->command_queue_.erase(command_queue_.begin());
   }
 
   switch (command_type) {
@@ -402,7 +403,8 @@ void Tuya::process_command_queue_() {
   if (delay > COMMAND_DELAY && !this->command_queue_.empty() && this->rx_message_.empty() &&
       !this->expected_response_.has_value()) {
     this->send_raw_command_(command_queue_.front());
-    this->command_queue_.erase(command_queue_.begin());
+    if (!this->expected_response_.has_value())
+      this->command_queue_.erase(command_queue_.begin());
   }
 }
 

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -32,12 +32,12 @@ void Tuya::loop() {
 void Tuya::dump_config() {
   ESP_LOGCONFIG(TAG, "Tuya:");
   if (this->init_state_ != TuyaInitState::INIT_DONE) {
-    if (this->init_failed_)
-      ESP_LOGCONFIG(TAG, "  Initialization failed. Current init_state: %u",
-                    static_cast<uint8_t>(this->init_state_));
-    else
+    if (this->init_failed_) {
+      ESP_LOGCONFIG(TAG, "  Initialization failed. Current init_state: %u", static_cast<uint8_t>(this->init_state_));
+    } else {
       ESP_LOGCONFIG(TAG, "  Configuration will be reported when setup is complete. Current init_state: %u",
                     static_cast<uint8_t>(this->init_state_));
+    }
     ESP_LOGCONFIG(TAG, "  If no further output is received, confirm that this is a supported Tuya device.");
     return;
   }
@@ -59,8 +59,8 @@ void Tuya::dump_config() {
     }
   }
   if ((this->status_pin_reported_ != -1) || (this->reset_pin_reported_ != -1)) {
-    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d",
-                  this->status_pin_reported_, this->reset_pin_reported_);
+    ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d", this->status_pin_reported_,
+                  this->reset_pin_reported_);
   }
   if (this->status_pin_.has_value()) {
     LOG_PIN("  Status Pin: ", this->status_pin_.value());

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -124,6 +124,8 @@ class Tuya : public Component, public uart::UARTDevice {
   optional<time::RealTimeClock *> time_id_{};
 #endif
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
+  bool init_failed_{false};
+  int init_retries_{0};
   uint8_t protocol_version_ = -1;
   optional<InternalGPIOPin *> status_pin_{};
   int status_pin_reported_ = -1;


### PR DESCRIPTION
# What does this implement/fix?

It implements retry for the init commands in case the MCU doesn't respond

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3270

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
