### PR TITLE
Tweak ezo timings

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -28,7 +28,7 @@ void EZOSensor::update() {
   this->write(&c, 1);
   this->state_ |= EZO_STATE_WAIT;
   this->start_time_ = millis();
-  this->wait_time_ = 900;
+  this->wait_time_ = 815;
 }
 
 void EZOSensor::loop() {
@@ -39,7 +39,7 @@ void EZOSensor::loop() {
       this->write(buf, len);
       this->state_ = EZO_STATE_WAIT | EZO_STATE_WAIT_TEMP;
       this->start_time_ = millis();
-      this->wait_time_ = 300;
+      this->wait_time_ = 250;
     }
     return;
   }


### PR DESCRIPTION
As taken from the official samples; if a command has been sent to calibrate (C) or take a reading (R) we wait 815ms so that the circuit has time to take the reading. If any other command has been sent we wait only 250ms.

# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
