### PR TITLE
Add option to lock a switch.

### DIFF
--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -33,7 +33,17 @@ SwitchPtr = Switch.operator("ptr")
 ToggleAction = switch_ns.class_("ToggleAction", automation.Action)
 TurnOffAction = switch_ns.class_("TurnOffAction", automation.Action)
 TurnOnAction = switch_ns.class_("TurnOnAction", automation.Action)
+
+LockToggleAction = switch_ns.class_("LockToggleAction", automation.Action)
+LockTurnOffAction = switch_ns.class_("LockTurnOffAction", automation.Action)
+LockTurnOnAction = switch_ns.class_("LockTurnOnAction", automation.Action)
+LockAction = switch_ns.class_("LockAction", automation.Action)
+UnLockAction = switch_ns.class_("UnLockAction", automation.Action)
+
 SwitchPublishAction = switch_ns.class_("SwitchPublishAction", automation.Action)
+
+IsLockedCondition = switch_ns.class_("IsLockedCondition", Condition)
+IsUnLockedCondition = switch_ns.class_("IsUnLockedCondition", Condition)
 
 SwitchCondition = switch_ns.class_("SwitchCondition", Condition)
 SwitchTurnOnTrigger = switch_ns.class_(
@@ -98,6 +108,15 @@ SWITCH_ACTION_SCHEMA = maybe_simple_id(
     }
 )
 
+
+@automation.register_action("switch.lock_toggle", LockToggleAction, SWITCH_ACTION_SCHEMA)
+@automation.register_action("switch.lock_turn_off", LockTurnOffAction, SWITCH_ACTION_SCHEMA)
+@automation.register_action("switch.lock_turn_on", LockTurnOnAction, SWITCH_ACTION_SCHEMA)
+@automation.register_action("switch.lock", LockAction, SWITCH_ACTION_SCHEMA)
+@automation.register_action("switch.unlock", UnLockAction, SWITCH_ACTION_SCHEMA)
+
+@automation.register_condition("switch.is_locked", IsLockedCondition, SWITCH_ACTION_SCHEMA)
+@automation.register_condition("switch.is_unlocked", IsUnLockedCondition, SWITCH_ACTION_SCHEMA)
 
 @automation.register_action("switch.toggle", ToggleAction, SWITCH_ACTION_SCHEMA)
 @automation.register_action("switch.turn_off", TurnOffAction, SWITCH_ACTION_SCHEMA)

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -109,15 +109,23 @@ SWITCH_ACTION_SCHEMA = maybe_simple_id(
 )
 
 
-@automation.register_action("switch.lock_toggle", LockToggleAction, SWITCH_ACTION_SCHEMA)
-@automation.register_action("switch.lock_turn_off", LockTurnOffAction, SWITCH_ACTION_SCHEMA)
-@automation.register_action("switch.lock_turn_on", LockTurnOnAction, SWITCH_ACTION_SCHEMA)
+@automation.register_action(
+    "switch.lock_toggle", LockToggleAction, SWITCH_ACTION_SCHEMA
+)
+@automation.register_action(
+    "switch.lock_turn_off", LockTurnOffAction, SWITCH_ACTION_SCHEMA
+)
+@automation.register_action(
+    "switch.lock_turn_on", LockTurnOnAction, SWITCH_ACTION_SCHEMA
+)
 @automation.register_action("switch.lock", LockAction, SWITCH_ACTION_SCHEMA)
 @automation.register_action("switch.unlock", UnLockAction, SWITCH_ACTION_SCHEMA)
-
-@automation.register_condition("switch.is_locked", IsLockedCondition, SWITCH_ACTION_SCHEMA)
-@automation.register_condition("switch.is_unlocked", IsUnLockedCondition, SWITCH_ACTION_SCHEMA)
-
+@automation.register_condition(
+    "switch.is_locked", IsLockedCondition, SWITCH_ACTION_SCHEMA
+)
+@automation.register_condition(
+    "switch.is_unlocked", IsUnLockedCondition, SWITCH_ACTION_SCHEMA
+)
 @automation.register_action("switch.toggle", ToggleAction, SWITCH_ACTION_SCHEMA)
 @automation.register_action("switch.turn_off", TurnOffAction, SWITCH_ACTION_SCHEMA)
 @automation.register_action("switch.turn_on", TurnOnAction, SWITCH_ACTION_SCHEMA)

--- a/esphome/components/switch/automation.h
+++ b/esphome/components/switch/automation.h
@@ -47,6 +47,77 @@ template<typename... Ts> class SwitchCondition : public Condition<Ts...> {
   bool state_;
 };
 
+template<typename... Ts> class LockTurnOnAction : public Action<Ts...> {
+ public:
+  explicit LockTurnOnAction(Switch *a_switch) : switch_(a_switch) {}
+
+  void play(Ts... x) override { this->switch_->lock_turn_on(); }
+
+ protected:
+  Switch *switch_;
+};
+
+template<typename... Ts> class LockTurnOffAction : public Action<Ts...> {
+ public:
+  explicit LockTurnOffAction(Switch *a_switch) : switch_(a_switch) {}
+
+  void play(Ts... x) override { this->switch_->lock_turn_off(); }
+
+ protected:
+  Switch *switch_;
+};
+
+template<typename... Ts> class LockToggleAction : public Action<Ts...> {
+ public:
+  explicit LockToggleAction(Switch *a_switch) : switch_(a_switch) {}
+
+  void play(Ts... x) override { this->switch_->lock_toggle(); }
+
+ protected:
+  Switch *switch_;
+};
+
+template<typename... Ts> class UnLockAction : public Action<Ts...> {
+ public:
+  explicit UnLockAction(Switch *a_switch) : switch_(a_switch) {}
+
+  void play(Ts... x) override { this->switch_->unlock(); }
+
+ protected:
+  Switch *switch_;
+};
+
+
+template<typename... Ts> class LockAction : public Action<Ts...> {
+ public:
+  explicit LockAction(Switch *a_switch) : switch_(a_switch) {}
+
+  void play(Ts... x) override { this->switch_->lock(); }
+
+ protected:
+  Switch *switch_;
+};
+
+template<typename... Ts> class IsLockedCondition : public Condition<Ts...> {
+ public:
+  explicit IsLockedCondition(Switch *a_switch) : switch_(a_switch) {}
+
+  bool check(Ts... x) override { return this->switch_->is_locked(); }
+
+ protected:
+  Switch *switch_;
+};
+
+template<typename... Ts> class IsUnLockedCondition : public Condition<Ts...> {
+ public:
+  explicit IsUnLockedCondition(Switch *a_switch) : switch_(a_switch) {}
+
+  bool check(Ts... x) override { return this->switch_->is_unlocked(); }
+
+ protected:
+  Switch *switch_;
+};
+
 class SwitchTurnOnTrigger : public Trigger<> {
  public:
   SwitchTurnOnTrigger(Switch *a_switch) {

--- a/esphome/components/switch/automation.h
+++ b/esphome/components/switch/automation.h
@@ -87,7 +87,6 @@ template<typename... Ts> class UnLockAction : public Action<Ts...> {
   Switch *switch_;
 };
 
-
 template<typename... Ts> class LockAction : public Action<Ts...> {
  public:
   explicit LockAction(Switch *a_switch) : switch_(a_switch) {}

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -10,31 +10,31 @@ Switch::Switch(const std::string &name) : EntityBase(name), state(false) {}
 Switch::Switch() : Switch("") {}
 
 void Switch::write_state_on_(bool set_lock) {
-  if(this->is_locked()) {
+  if (this->is_locked()) {
     ESP_LOGD(TAG, "'%s' can not turn ON because LOCKED.", this->get_name().c_str());
     return;
   }
-  if(set_lock)
+  if (set_lock)
     this->lock();
   ESP_LOGD(TAG, "'%s' Turning ON.", this->get_name().c_str());
   this->write_state(!this->inverted_);
 }
 void Switch::write_state_off_(bool set_lock) {
-  if(this->is_locked()) {
+  if (this->is_locked()) {
     ESP_LOGD(TAG, "'%s' can not turn OFF because LOCKED.", this->get_name().c_str());
     return;
   }
-  if(set_lock)
+  if (set_lock)
     this->lock();
   ESP_LOGD(TAG, "'%s' Turning OFF.", this->get_name().c_str());
   this->write_state(this->inverted_);
 }
 void Switch::write_state_toggle_(bool set_lock) {
-  if(this->is_locked()) {
+  if (this->is_locked()) {
     ESP_LOGD(TAG, "'%s' can not Toggle because LOCKED.", this->get_name().c_str());
     return;
   }
-  if(set_lock)
+  if (set_lock)
     this->lock();
   ESP_LOGD(TAG, "'%s' Toggling %s.", this->get_name().c_str(), this->state ? "OFF" : "ON");
   this->write_state(this->inverted_ == this->state);
@@ -49,16 +49,34 @@ void Switch::unlock() {
   this->locked_ = false;
 }
 
-void Switch::turn_on()  { bool set_lock = false; this->write_state_on_(set_lock); }
-void Switch::turn_off() { bool set_lock = false; this->write_state_off_(set_lock); }
-void Switch::toggle()   { bool set_lock = false; this->write_state_toggle_(set_lock); }
+void Switch::turn_on() {
+  bool set_lock = false;
+  this->write_state_on_(set_lock);
+}
+void Switch::turn_off() {
+  bool set_lock = false;
+  this->write_state_off_(set_lock);
+}
+void Switch::toggle() {
+  bool set_lock = false;
+  this->write_state_toggle_(set_lock);
+}
 
-void Switch::lock_turn_on()  { bool set_lock = true; this->write_state_on_(set_lock); }
-void Switch::lock_turn_off() { bool set_lock = true; this->write_state_off_(set_lock); }
-void Switch::lock_toggle()   { bool set_lock = true; this->write_state_toggle_(set_lock); }
+void Switch::lock_turn_on() {
+  bool set_lock = true;
+  this->write_state_on_(set_lock);
+}
+void Switch::lock_turn_off() {
+  bool set_lock = true;
+  this->write_state_off_(set_lock);
+}
+void Switch::lock_toggle() {
+  bool set_lock = true;
+  this->write_state_toggle_(set_lock);
+}
 
 bool Switch::is_locked() { return this->locked_; }
-bool Switch::is_unlocked() { return ! this->locked_; }
+bool Switch::is_unlocked() { return !this->locked_; }
 
 optional<bool> Switch::get_initial_state() {
   this->rtc_ = global_preferences->make_preference<bool>(this->get_object_id_hash());

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -63,6 +63,36 @@ class Switch : public EntityBase {
    */
   void toggle();
 
+  /** Turn this switch on and locks the switch.
+   *  A locked switch cannot be switched by the front-end
+   *  until unlock() is called.
+   */
+  void lock_turn_on();
+  /** Turn this switch off and locks the switch.
+   */
+  void lock_turn_off();
+  /** Toggle this switch and locks the switch.
+   */
+  void lock_toggle();
+  /** This unlocks the switch. After unlock the switch can
+   * be switched from the front-end
+   */
+  void unlock();
+
+  /** This returns true if the switch is locked
+   */
+  bool is_locked();
+
+  /** This returns true if the switch is unlocked
+   */
+  bool is_unlocked();
+
+  /** this locks the switch. A Locked switch can not be
+   * switched by the front-end until unlock()
+   */
+  void lock();
+
+
   /** Set whether the state should be treated as inverted.
    *
    * To the developer and user an inverted switch will act just like a non-inverted one.
@@ -114,6 +144,17 @@ class Switch : public EntityBase {
   Deduplicator<bool> publish_dedup_;
   ESPPreferenceObject rtc_;
   optional<std::string> device_class_;
+  /** Turn this switch on. This is called by the public classes
+   */
+  void write_state_on_(bool set_lock);
+  /** Turn this switch off. This is called by the public classes
+   */
+  void write_state_off_(bool set_lock);
+  /** Toggle this switch. This is called by the public classes
+   */
+  void write_state_toggle_(bool set_lock);
+  bool locked_{false};
+
 };
 
 }  // namespace switch_

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -92,7 +92,6 @@ class Switch : public EntityBase {
    */
   void lock();
 
-
   /** Set whether the state should be treated as inverted.
    *
    * To the developer and user an inverted switch will act just like a non-inverted one.
@@ -154,7 +153,6 @@ class Switch : public EntityBase {
    */
   void write_state_toggle_(bool set_lock);
   bool locked_{false};
-
 };
 
 }  // namespace switch_


### PR DESCRIPTION
# What does this implement/fix?
This PR adds a feature to lock a switch. When a switch is locked it can not be switched 
from the frontend until unlocked.

This code adds
the following actions:
switch.lock: Lock the switch
switch.unlock: Unlock the switch
switch.lock_turn_off:  Turn OFF and lock
switch.lock_turn_on:  Turn ON and lock
switch.lock_toggle:  Toggle and lock

and the following conditions:
switch.is_locked: true when switch is locked
switch.is_unlocked: true when switch is unlocked

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml

switch:
  - platform: gpio
    pin: 25
    name: "Water Pump Relay"
    id: pump_relay


binary_sensor:
  - platform: gpio
    # ...
    on_press:
      min_length: 150ms
      then:
        if:
          condition:
              switch.is_locked: pump_switch
          then:
            - switch.unlock: pump_switch
          else:
            - logger.log: "Not locked, do not need to unlock"

    on_release:
      then:
            - switch.lock_turn_off: pump_switch



```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
