### PR TITLE
Output a true RMS voltage %

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -121,7 +121,11 @@ void IRAM_ATTR HOT AcDimmerDataStore::gpio_intr() {
       // calculate time until enable in µs: (1.0-value)*cycle_time, but with integer arithmetic
       // also take into account min_power
       auto min_us = this->cycle_time_us * this->min_power / 1000;
-      this->enable_time_us = std::max((uint32_t) 1, ((65535 - this->value) * (this->cycle_time_us - min_us)) / 65535);
+      // calculate required value to provide a true RMS voltage output
+      this->enable_time_us =
+          std::max((uint32_t) 1, (uint32_t)((65535 - (acos(1 - (2 * this->value / 65535.0)) / 3.14159 * 65535)) *
+                                            (this->cycle_time_us - min_us)) /
+                                     65535);
       if (this->method == DIM_METHOD_LEADING_PULSE) {
         // Minimum pulse time should be enough for the triac to trigger when it is close to the ZC zone
         // this is for brightness near 99%


### PR DESCRIPTION
# What does this implement/fix?

ac_dimmer currently outputs a non linear voltage range as the waveform was cut with a simple % of cycle time. This results in an unusable range below 6% and above 94% as the area under the sine wave is not linear.

This will likely have a minor effect on current implementations but is not "breaking"

Here are TRUE before and after outputs from 1-100% requested. 

![Graph of voltage output from 0 to Pi](https://i.imgur.com/ktfgEMl.png)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```
output:
  - platform: ac_dimmer
    id: dimmer1
    min_power: 0.01
    gate_pin: D7
    zero_cross_pin:
      number: D6
      mode:
        input: true
      inverted: yes

fan:
  - platform: speed
    output: dimmer1
    name: Immersion Heater

external_components:
  - source:
      type: git
      url: https://github.com/josephdouce/esphome
      ref: ac-dimmer-true-rms
    components: [ac_dimmer]
    refresh: 0su
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
