### PR TITLE
[scd4x] Fix not passing arguments to templatable value for perform_forced_calibration

### DIFF
--- a/esphome/components/scd4x/automation.h
+++ b/esphome/components/scd4x/automation.h
@@ -11,7 +11,7 @@ template<typename... Ts> class PerformForcedCalibrationAction : public Action<Ts
  public:
   void play(Ts... x) override {
     if (this->value_.has_value()) {
-      this->parent_->perform_forced_calibration(value_.value());
+      this->parent_->perform_forced_calibration(this->value_.value(x...));
     }
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fix subtle bug causing this error
```
src/esphome\components\scd4x\automation.h:14:7: error: no matching function for call to 'esphome::TemplatableValue<short unsigned int, int>::value()'
       this->parent_->perform_forced_calibration(value_.value());
       ^
```
for this config
```yaml
    - service: perform_forced_calibration
      variables:
        current_co2: int
      then:
        - scd4x.perform_forced_calibration:
            value: !lambda 'return current_co2;'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  n/a

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
