### PR TITLE
midea: New power_toggle action. Auto-use remote transmitter.

### DIFF
--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -56,6 +56,11 @@ template<typename... Ts> class PowerOffAction : public MideaActionBase<Ts...> {
   void play(Ts... x) override { this->parent_->do_power_off(); }
 };
 
+template<typename... Ts> class PowerInvAction : public MideaActionBase<Ts...> {
+ public:
+  void play(Ts... x) override { this->parent_->do_power_inv(); }
+};
+
 }  // namespace ac
 }  // namespace midea
 }  // namespace esphome

--- a/esphome/components/midea/ac_automations.h
+++ b/esphome/components/midea/ac_automations.h
@@ -56,9 +56,9 @@ template<typename... Ts> class PowerOffAction : public MideaActionBase<Ts...> {
   void play(Ts... x) override { this->parent_->do_power_off(); }
 };
 
-template<typename... Ts> class PowerInvAction : public MideaActionBase<Ts...> {
+template<typename... Ts> class PowerToggleAction : public MideaActionBase<Ts...> {
  public:
-  void play(Ts... x) override { this->parent_->do_power_inv(); }
+  void play(Ts... x) override { this->parent_->do_power_toggle(); }
 };
 
 }  // namespace ac

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -39,6 +39,7 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   void do_beeper_off() { this->set_beeper_feedback(false); }
   void do_power_on() { this->base_.setPowerState(true); }
   void do_power_off() { this->base_.setPowerState(false); }
+  void do_power_inv() { this->base_.setPowerState(this->mode == ClimateMode::CLIMATE_MODE_OFF); }
   void set_supported_modes(const std::set<ClimateMode> &modes) { this->supported_modes_ = modes; }
   void set_supported_swing_modes(const std::set<ClimateSwingMode> &modes) { this->supported_swing_modes_ = modes; }
   void set_supported_presets(const std::set<ClimatePreset> &presets) { this->supported_presets_ = presets; }

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -39,7 +39,7 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   void do_beeper_off() { this->set_beeper_feedback(false); }
   void do_power_on() { this->base_.setPowerState(true); }
   void do_power_off() { this->base_.setPowerState(false); }
-  void do_power_inv() { this->base_.setPowerState(this->mode == ClimateMode::CLIMATE_MODE_OFF); }
+  void do_power_toggle() { this->base_.setPowerState(this->mode == ClimateMode::CLIMATE_MODE_OFF); }
   void set_supported_modes(const std::set<ClimateMode> &modes) { this->supported_modes_ = modes; }
   void set_supported_swing_modes(const std::set<ClimateSwingMode> &modes) { this->supported_swing_modes_ = modes; }
   void set_supported_presets(const std::set<ClimatePreset> &presets) { this->supported_presets_ = presets; }

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -113,7 +113,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PERIOD, default="1s"): cv.time_period,
             cv.Optional(CONF_TIMEOUT, default="2s"): cv.time_period,
             cv.Optional(CONF_NUM_ATTEMPTS, default=3): cv.int_range(min=1, max=5),
-            cv.Optional(CONF_TRANSMITTER_ID): cv.use_id(
+            cv.OnlyWith(CONF_TRANSMITTER_ID, "remote_transmitter"): cv.use_id(
                 remote_transmitter.RemoteTransmitterComponent
             ),
             cv.Optional(CONF_BEEPER, default=False): cv.boolean,

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -163,6 +163,7 @@ BeeperOnAction = midea_ac_ns.class_("BeeperOnAction", automation.Action)
 BeeperOffAction = midea_ac_ns.class_("BeeperOffAction", automation.Action)
 PowerOnAction = midea_ac_ns.class_("PowerOnAction", automation.Action)
 PowerOffAction = midea_ac_ns.class_("PowerOffAction", automation.Action)
+PowerInvAction = midea_ac_ns.class_("PowerInvAction", automation.Action)
 
 MIDEA_ACTION_BASE_SCHEMA = cv.Schema(
     {
@@ -246,6 +247,16 @@ async def power_on_to_code(var, config, args):
     cv.Schema({}),
 )
 async def power_off_to_code(var, config, args):
+    pass
+
+
+# Power Inverse action
+@register_action(
+    "power_inv",
+    PowerInvAction,
+    cv.Schema({}),
+)
+async def power_inv_to_code(var, config, args):
     pass
 
 

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -163,7 +163,7 @@ BeeperOnAction = midea_ac_ns.class_("BeeperOnAction", automation.Action)
 BeeperOffAction = midea_ac_ns.class_("BeeperOffAction", automation.Action)
 PowerOnAction = midea_ac_ns.class_("PowerOnAction", automation.Action)
 PowerOffAction = midea_ac_ns.class_("PowerOffAction", automation.Action)
-PowerInvAction = midea_ac_ns.class_("PowerInvAction", automation.Action)
+PowerToggleAction = midea_ac_ns.class_("PowerToggleAction", automation.Action)
 
 MIDEA_ACTION_BASE_SCHEMA = cv.Schema(
     {
@@ -250,10 +250,10 @@ async def power_off_to_code(var, config, args):
     pass
 
 
-# Power Inverse action
+# Power Toggle action
 @register_action(
-    "power_inv",
-    PowerInvAction,
+    "power_toggle",
+    PowerToggleAction,
     cv.Schema({}),
 )
 async def power_inv_to_code(var, config, args):

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1902,14 +1902,6 @@ script:
 
 switch:
   - platform: template
-    name: MIDEA_AC_TOGGLE_LIGHT
-    turn_on_action:
-      midea_ac.display_toggle:
-  - platform: template
-    name: MIDEA_AC_SWING_STEP
-    turn_on_action:
-      midea_ac.swing_step:
-  - platform: template
     name: MIDEA_AC_BEEPER_CONTROL
     optimistic: true
     turn_on_action:
@@ -2834,3 +2826,23 @@ button:
           id: scd40
       - scd4x.factory_reset:
           id: scd40
+  - platform: template
+    name: Midea Display Toggle
+    on_press:
+      midea_ac.display_toggle:
+  - platform: template
+    name: Midea Swing Step
+    on_press:
+      midea_ac.swing_step:
+  - platform: template
+    name: Midea Power On
+    on_press:
+      midea_ac.power_on:
+  - platform: template
+    name: Midea Power Off
+    on_press:
+      midea_ac.power_off:
+  - platform: template
+    name: Midea Power Inverse
+    on_press:
+      midea_ac.power_inv:

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2845,4 +2845,4 @@ button:
   - platform: template
     name: Midea Power Inverse
     on_press:
-      midea_ac.power_inv:
+      midea_ac.power_toggle:


### PR DESCRIPTION
# What does this implement/fix?

1. Adds a new action `midea_ac.power_toggle` that is useful for reacting to a button click.
2. Now the component automatically detects and uses `remote_transmitter` component. Useful when using packages. By adding a package configuring `remote_transmitter` the `midea` component will automatically start using the extended functionality via IR control.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2094

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
button:
  - platform: template
    name: Midea Power Toggle
    on_press:
      midea_ac.power_toggle:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
