### PR TITLE
Remove min_save_interval from intergration and total_daily_energy

### DIFF
--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -10,9 +10,9 @@ static const char *const TAG = "integration";
 
 void IntegrationSensor::setup() {
   if (this->restore_) {
-    this->rtc_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+    this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
     float preference_value = 0;
-    this->rtc_.load(&preference_value);
+    this->pref_.load(&preference_value);
     this->result_ = preference_value;
   }
 

--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -17,7 +17,6 @@ void IntegrationSensor::setup() {
   }
 
   this->last_update_ = millis();
-  this->last_save_ = this->last_update_;
 
   this->publish_and_save_(this->result_);
   this->sensor_->add_on_state_callback([this](float state) { this->process_sensor_value_(state); });

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -57,7 +57,7 @@ class IntegrationSensor : public sensor::Sensor, public Component {
     this->publish_state(result);
     if (this->restore_) {
       float result_f = result;
-      this->rtc_.save(&result_f);
+      this->pref_.save(&result_f);
     }
   }
 
@@ -65,7 +65,7 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   IntegrationSensorTime time_;
   IntegrationMethod method_;
   bool restore_;
-  ESPPreferenceObject rtc_;
+  ESPPreferenceObject pref_;
 
   uint32_t last_update_;
   double result_{0.0f};

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -28,7 +28,6 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
-  void set_min_save_interval(uint32_t min_interval) { this->min_save_interval_ = min_interval; }
   void set_sensor(Sensor *sensor) { sensor_ = sensor; }
   void set_time(IntegrationSensorTime time) { time_ = time; }
   void set_method(IntegrationMethod method) { method_ = method; }
@@ -57,10 +56,6 @@ class IntegrationSensor : public sensor::Sensor, public Component {
     this->result_ = result;
     this->publish_state(result);
     float result_f = result;
-    const uint32_t now = millis();
-    if (now - this->last_save_ < this->min_save_interval_)
-      return;
-    this->last_save_ = now;
     this->rtc_.save(&result_f);
   }
 
@@ -70,8 +65,6 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   bool restore_;
   ESPPreferenceObject rtc_;
 
-  uint32_t last_save_{0};
-  uint32_t min_save_interval_{0};
   uint32_t last_update_;
   double result_{0.0f};
   float last_value_{0.0f};

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -55,8 +55,10 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   void publish_and_save_(double result) {
     this->result_ = result;
     this->publish_state(result);
-    float result_f = result;
-    this->rtc_.save(&result_f);
+    if (this->restore_) {
+      float result_f = result;
+      this->rtc_.save(&result_f);
+    }
   }
 
   sensor::Sensor *sensor_;

--- a/esphome/components/integration/sensor.py
+++ b/esphome/components/integration/sensor.py
@@ -35,7 +35,6 @@ INTEGRATION_METHODS = {
 
 CONF_TIME_UNIT = "time_unit"
 CONF_INTEGRATION_METHOD = "integration_method"
-CONF_MIN_SAVE_INTERVAL = "min_save_interval"
 
 
 def inherit_unit_of_measurement(uom, config):
@@ -58,9 +57,9 @@ CONFIG_SCHEMA = sensor.SENSOR_SCHEMA.extend(
             INTEGRATION_METHODS, lower=True
         ),
         cv.Optional(CONF_RESTORE, default=False): cv.boolean,
-        cv.Optional(
-            CONF_MIN_SAVE_INTERVAL, default="0s"
-        ): cv.positive_time_period_milliseconds,
+        cv.Optional("min_save_interval"): cv.invalid(
+            "min_save_interval was removed in 2022.6.0. Please use the `preferences` -> `flash_write_interval` to adjust."
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -97,7 +96,6 @@ async def to_code(config):
     cg.add(var.set_time(config[CONF_TIME_UNIT]))
     cg.add(var.set_method(config[CONF_INTEGRATION_METHOD]))
     cg.add(var.set_restore(config[CONF_RESTORE]))
-    cg.add(var.set_min_save_interval(config[CONF_MIN_SAVE_INTERVAL]))
 
 
 @automation.register_action(

--- a/esphome/components/integration/sensor.py
+++ b/esphome/components/integration/sensor.py
@@ -58,7 +58,7 @@ CONFIG_SCHEMA = sensor.SENSOR_SCHEMA.extend(
         ),
         cv.Optional(CONF_RESTORE, default=False): cv.boolean,
         cv.Optional("min_save_interval"): cv.invalid(
-            "min_save_interval was removed in 2022.6.0. Please use the `preferences` -> `flash_write_interval` to adjust."
+            "min_save_interval was removed in 2022.8.0. Please use the `preferences` -> `flash_write_interval` to adjust."
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -17,7 +17,6 @@ from esphome.core.entity_helpers import inherit_property_from
 DEPENDENCIES = ["time"]
 
 CONF_POWER_ID = "power_id"
-CONF_MIN_SAVE_INTERVAL = "min_save_interval"
 total_daily_energy_ns = cg.esphome_ns.namespace("total_daily_energy")
 TotalDailyEnergyMethod = total_daily_energy_ns.enum("TotalDailyEnergyMethod")
 TOTAL_DAILY_ENERGY_METHODS = {
@@ -49,9 +48,9 @@ CONFIG_SCHEMA = (
             cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
             cv.Required(CONF_POWER_ID): cv.use_id(sensor.Sensor),
             cv.Optional(CONF_RESTORE, default=True): cv.boolean,
-            cv.Optional(
-                CONF_MIN_SAVE_INTERVAL, default="0s"
-            ): cv.positive_time_period_milliseconds,
+            cv.Optional("min_save_interval"): cv.invalid(
+                "`min_save_interval` was removed in 2022.6.0. Please use the `preferences` -> `flash_write_interval` to adjust."
+            ),
             cv.Optional(CONF_METHOD, default="right"): cv.enum(
                 TOTAL_DAILY_ENERGY_METHODS, lower=True
             ),
@@ -90,5 +89,4 @@ async def to_code(config):
     time_ = await cg.get_variable(config[CONF_TIME_ID])
     cg.add(var.set_time(time_))
     cg.add(var.set_restore(config[CONF_RESTORE]))
-    cg.add(var.set_min_save_interval(config[CONF_MIN_SAVE_INTERVAL]))
     cg.add(var.set_method(config[CONF_METHOD]))

--- a/esphome/components/total_daily_energy/total_daily_energy.cpp
+++ b/esphome/components/total_daily_energy/total_daily_energy.cpp
@@ -42,7 +42,9 @@ void TotalDailyEnergy::loop() {
 void TotalDailyEnergy::publish_state_and_save(float state) {
   this->total_energy_ = state;
   this->publish_state(state);
-  this->pref_.save(&state);
+  if (this->restore_) {
+    this->pref_.save(&state);
+  }
 }
 
 void TotalDailyEnergy::process_new_state_(float state) {

--- a/esphome/components/total_daily_energy/total_daily_energy.cpp
+++ b/esphome/components/total_daily_energy/total_daily_energy.cpp
@@ -16,7 +16,6 @@ void TotalDailyEnergy::setup() {
   this->publish_state_and_save(initial_value);
 
   this->last_update_ = millis();
-  this->last_save_ = this->last_update_;
 
   this->parent_->add_on_state_callback([this](float state) { this->process_new_state_(state); });
 }
@@ -43,11 +42,6 @@ void TotalDailyEnergy::loop() {
 void TotalDailyEnergy::publish_state_and_save(float state) {
   this->total_energy_ = state;
   this->publish_state(state);
-  const uint32_t now = millis();
-  if (now - this->last_save_ < this->min_save_interval_) {
-    return;
-  }
-  this->last_save_ = now;
   this->pref_.save(&state);
 }
 

--- a/esphome/components/total_daily_energy/total_daily_energy.h
+++ b/esphome/components/total_daily_energy/total_daily_energy.h
@@ -18,7 +18,6 @@ enum TotalDailyEnergyMethod {
 class TotalDailyEnergy : public sensor::Sensor, public Component {
  public:
   void set_restore(bool restore) { restore_ = restore; }
-  void set_min_save_interval(uint32_t min_interval) { this->min_save_interval_ = min_interval; }
   void set_time(time::RealTimeClock *time) { time_ = time; }
   void set_parent(Sensor *parent) { parent_ = parent; }
   void set_method(TotalDailyEnergyMethod method) { method_ = method; }
@@ -39,7 +38,6 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   uint16_t last_day_of_year_{};
   uint32_t last_update_{0};
   uint32_t last_save_{0};
-  uint32_t min_save_interval_{0};
   bool restore_;
   float total_energy_{0.0f};
   float last_power_state_{0.0f};

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -593,7 +593,6 @@ sensor:
     sensor: hlw8012_power
     name: "Integration Sensor lazy"
     time_unit: s
-    min_save_interval: 60s
   - platform: hmc5883l
     address: 0x68
     field_strength_x:


### PR DESCRIPTION
# What does this implement/fix?

Remove min_save_interval from intergration and total_daily_energy.
Due to the recent changes to `preferences` this is no longer needed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2162

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
