### PR TITLE
Fix bogus reading on no communication with MAX31865

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,6 +102,7 @@ esphome/components/lilygo_t5_47/touchscreen/* @jesserockz
 esphome/components/lock/* @esphome/core
 esphome/components/logger/* @esphome/core
 esphome/components/ltr390/* @sjtrny
+esphome/components/max31865/* @DAVe3283
 esphome/components/max44009/* @berfenger
 esphome/components/max7219digit/* @rspaargaren
 esphome/components/max9611/* @mckaymatthew

--- a/esphome/components/max31865/__init__.py
+++ b/esphome/components/max31865/__init__.py
@@ -1,2 +1,0 @@
-CODEOWNERS = ["@DAVe3283"]
-DEPENDENCIES = ["spi"]

--- a/esphome/components/max31865/__init__.py
+++ b/esphome/components/max31865/__init__.py
@@ -1,0 +1,2 @@
+CODEOWNERS = ["@DAVe3283"]
+DEPENDENCIES = ["spi"]

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -94,6 +94,14 @@ void MAX31865Sensor::read_data_() {
   const uint16_t rtd_resistance_register = this->read_register_16_(RTD_RESISTANCE_MSB_REG);
   this->write_config_(0b11000000, 0b00000000);
 
+  // Check for bad connection
+  if (rtd_resistance_register == 0b0000000000000000 || rtd_resistance_register == 0b1111111111111111) {
+    ESP_LOGE(TAG, "SPI bus read all 0 or all 1 (0x%04X), check MAX31865 wiring & power.", rtd_resistance_register);
+    this->publish_state(NAN);
+    this->status_set_error();
+    return;
+  }
+
   // Check faults
   const uint8_t faults = this->read_register_(FAULT_STATUS_REG);
   if ((has_fault_ = faults & 0b00111100)) {

--- a/esphome/components/max31865/sensor.py
+++ b/esphome/components/max31865/sensor.py
@@ -11,6 +11,9 @@ from esphome.const import (
     UNIT_CELSIUS,
 )
 
+CODEOWNERS = ["@DAVe3283"]
+DEPENDENCIES = ["spi"]
+
 max31865_ns = cg.esphome_ns.namespace("max31865")
 MAX31865Sensor = max31865_ns.class_(
     "MAX31865Sensor", sensor.Sensor, cg.PollingComponent, spi.SPIDevice


### PR DESCRIPTION
# What does this implement/fix?

Prevents bogus reading when MAX31865 has no communication.
Explicitly checks for all zeros or all ones in the RTD registers (virtually impossible when the chip is operating in datasheet specs) and reports an error instead of -242.02°C.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#3289

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: d1-mini-proto

esp8266:
  board: d1_mini

# Enable logging
logger:
  # Get detailed output from max31865
  level: VERY_VERBOSE
  logs:
    # Silence unrelated chatty components
    api: DEBUG
    api.connection: DEBUG
    api.service: DEBUG
    app: DEBUG
    json: DEBUG
    scheduler: DEBUG
    sensor.filter: DEBUG
    sensor: DEBUG

# Enable Home Assistant API
api:
  password: !secret d1_mini_proto_api
  encryption:
    key: !secret d1_mini_proto_key

ota:
  password: !secret d1_mini_proto_ota

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "D1-Mini-Proto Fallback Hotspot"
    password: !secret d1_mini_proto_ota

captive_portal:

spi:
  clk_pin: GPIO14
  mosi_pin: MOSI
  miso_pin: MISO

#  Override internal version with proposed patch
external_components:
  - source: github://DAVe3283/esphome@dev
    components: ["max31865"]

sensor:
  - platform: max31865
    name: "PT1000 Test"
    cs_pin: GPIO15
    reference_resistance: 4.3 kΩ
    rtd_nominal_resistance: 1 kΩ
    rtd_wires: 3
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
