### PR TITLE
Allow Prometheus component to export internal components

### DIFF
--- a/esphome/components/prometheus/__init__.py
+++ b/esphome/components/prometheus/__init__.py
@@ -1,6 +1,9 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import CONF_ID
+from esphome.const import (
+    CONF_ID,
+    CONF_INCLUDE_INTERNAL,
+)
 from esphome.components.web_server_base import CONF_WEB_SERVER_BASE_ID
 from esphome.components import web_server_base
 
@@ -15,6 +18,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_WEB_SERVER_BASE_ID): cv.use_id(
             web_server_base.WebServerBase
         ),
+        cv.Optional(CONF_INCLUDE_INTERNAL, default=False): cv.boolean,
     },
     cv.only_with_arduino,
 ).extend(cv.COMPONENT_SCHEMA)
@@ -27,3 +31,5 @@ async def to_code(config):
 
     var = cg.new_Pvariable(config[CONF_ID], paren)
     await cg.register_component(var, config)
+
+    cg.add(var.set_include_internal(config[CONF_INCLUDE_INTERNAL]))

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -61,7 +61,7 @@ void PrometheusHandler::sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_sensor_failed GAUGE\n"));
 }
 void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj) {
-  if (obj->is_internal())
+  if (obj->is_internal() && !this->include_internal_)
     return;
   if (!std::isnan(obj->state)) {
     // We have a valid value, output this value
@@ -98,7 +98,7 @@ void PrometheusHandler::binary_sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_binary_sensor_failed GAUGE\n"));
 }
 void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj) {
-  if (obj->is_internal())
+  if (obj->is_internal() && !this->include_internal_)
     return;
   if (obj->has_state()) {
     // We have a valid value, output this value
@@ -134,7 +134,7 @@ void PrometheusHandler::fan_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_fan_oscillation GAUGE\n"));
 }
 void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj) {
-  if (obj->is_internal())
+  if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_fan_failed{id=\""));
   stream->print(obj->get_object_id().c_str());
@@ -179,7 +179,7 @@ void PrometheusHandler::light_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_light_effect_active GAUGE\n"));
 }
 void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightState *obj) {
-  if (obj->is_internal())
+  if (obj->is_internal() && !this->include_internal_)
     return;
   // State
   stream->print(F("esphome_light_state{id=\""));
@@ -255,7 +255,7 @@ void PrometheusHandler::cover_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_cover_failed GAUGE\n"));
 }
 void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *obj) {
-  if (obj->is_internal())
+  if (obj->is_internal() && !this->include_internal_)
     return;
   if (!std::isnan(obj->position)) {
     // We have a valid value, output this value
@@ -298,7 +298,7 @@ void PrometheusHandler::switch_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_switch_failed GAUGE\n"));
 }
 void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch *obj) {
-  if (obj->is_internal())
+  if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_switch_failed{id=\""));
   stream->print(obj->get_object_id().c_str());
@@ -322,7 +322,7 @@ void PrometheusHandler::lock_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_lock_failed GAUGE\n"));
 }
 void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj) {
-  if (obj->is_internal())
+  if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_lock_failed{id=\""));
   stream->print(obj->get_object_id().c_str());

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -13,6 +13,13 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
  public:
   PrometheusHandler(web_server_base::WebServerBase *base) : base_(base) {}
 
+  /** Determine whether internal components should be exported as metrics.
+   * Defaults to false.
+   *
+   * @param include_internal Whether internal components should be exported.
+   */
+  void set_include_internal(bool include_internal) { include_internal_ = include_internal; }
+
   bool canHandle(AsyncWebServerRequest *request) override {
     if (request->method() == HTTP_GET) {
       if (request->url() == "/metrics")
@@ -84,6 +91,7 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
 #endif
 
   web_server_base::WebServerBase *base_;
+  bool include_internal_{false};
 };
 
 }  // namespace prometheus


### PR DESCRIPTION
# What does this implement/fix?

This will add a configuration option to allow the Prometheus component to also export internal components (like the web server already has).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1746

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2099

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
prometheus:
  include_internal: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
