### PR TITLE
Change rain intensity sensor string

### DIFF
--- a/esphome/components/hydreon_rgxx/sensor.py
+++ b/esphome/components/hydreon_rgxx/sensor.py
@@ -37,7 +37,7 @@ SUPPORTED_SENSORS = {
 PROTOCOL_NAMES = {
     CONF_MOISTURE: "R",
     CONF_ACC: "Acc",
-    CONF_R_INT: "Rint",
+    CONF_R_INT: "RInt",
     CONF_EVENT_ACC: "EventAcc",
     CONF_TOTAL_ACC: "TotalAcc",
 }


### PR DESCRIPTION
# What does this implement/fix?

Rain intensity sensor on RG15 is not recognized

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

 fixes [3248](https://github.com/esphome/issues/issues/3248)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: hydreon_rgxx
    model: "RG_15"
    update_interval: 120s
    acc:
      name: "Rain"
    event_acc:
      name: "Rain Event"
    total_acc:
      name: "Rain Total"
    r_int:
      name: "Rain Intensity"
```

## Checklist:
  - [ x The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
