### PR TITLE
RG15 data is float/double, not int

### DIFF
--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -195,7 +195,7 @@ void HydreonRGxxComponent::process_line_() {
       if (n == std::string::npos) {
         continue;
       }
-      double data = strtof(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i])).c_str(), nullptr);
+      float data = parse_number<float>(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i]))).value();
       this->sensors_[i]->publish_state(data);
       ESP_LOGD(TAG, "Received %s: %f", PROTOCOL_NAMES[i], this->sensors_[i]->get_raw_state());
       this->sensors_received_ |= (1 << i);

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -195,7 +195,7 @@ void HydreonRGxxComponent::process_line_() {
       if (n == std::string::npos) {
         continue;
       }
-      int data = strtol(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i])).c_str(), nullptr, 10);
+      double data = strtof(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i])).c_str(), nullptr);
       this->sensors_[i]->publish_state(data);
       ESP_LOGD(TAG, "Received %s: %f", PROTOCOL_NAMES[i], this->sensors_[i]->get_raw_state());
       this->sensors_received_ |= (1 << i);

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -195,8 +195,11 @@ void HydreonRGxxComponent::process_line_() {
       if (n == std::string::npos) {
         continue;
       }
-      float data = parse_number<float>(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i]))).value();
-      this->sensors_[i]->publish_state(data);
+      auto data = parse_number<float>(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i])));
+      if (!data.has_value())
+        continue;
+      float d = data.value();
+      this->sensors_[i]->publish_state(d);
       ESP_LOGD(TAG, "Received %s: %f", PROTOCOL_NAMES[i], this->sensors_[i]->get_raw_state());
       this->sensors_received_ |= (1 << i);
     }

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -195,11 +195,8 @@ void HydreonRGxxComponent::process_line_() {
       if (n == std::string::npos) {
         continue;
       }
-      auto data = parse_number<float>(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i])));
-      if (!data.has_value())
-        continue;
-      float d = data.value();
-      this->sensors_[i]->publish_state(d);
+      float data = strtof(this->buffer_.substr(n + strlen(PROTOCOL_NAMES[i])).c_str(), nullptr);
+      this->sensors_[i]->publish_state(data);
       ESP_LOGD(TAG, "Received %s: %f", PROTOCOL_NAMES[i], this->sensors_[i]->get_raw_state());
       this->sensors_received_ |= (1 << i);
     }


### PR DESCRIPTION
# What does this implement/fix?

Hydreon RG15 delivers data (as string) floating point values, this fixes the parsing

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

fixes https://github.com/esphome/issues/issues/3323

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: hydreon_rgxx                                                                                model: "RG_15"
    update_interval: 120s
    acc:
      name: "Rain"
    event_acc:
      name: "Rain Event"
    total_acc:
      name: "Rain Total"
    r_int:
      name: "Rain Intensity"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
