### PR TITLE
The Samsung protocol is LSB, has a 16bit address, 1 or 2 8bit command fields

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1028,8 +1028,9 @@ def rc_switch_dumper(var, config):
 ) = declare_protocol("Samsung")
 SAMSUNG_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_DATA): cv.hex_uint64_t,
-        cv.Optional(CONF_NBITS, default=32): cv.int_range(32, 64),
+        cv.Optional(CONF_DATA, default=0): cv.hex_uint64_t,
+        cv.Optional(CONF_ADDRESS, default=0): cv.int_range(0, 0xFFFF),
+        cv.Optional(CONF_COMMAND, default=0): cv.int_range(0, 0xFFFF),
     }
 )
 
@@ -1041,7 +1042,8 @@ def samsung_binary_sensor(var, config):
             cg.StructInitializer(
                 SamsungData,
                 ("data", config[CONF_DATA]),
-                ("nbits", config[CONF_NBITS]),
+                ("address", config[CONF_ADDRESS]),
+                ("command", config[CONF_COMMAND]),
             )
         )
     )
@@ -1061,8 +1063,10 @@ def samsung_dumper(var, config):
 async def samsung_action(var, config, args):
     template_ = await cg.templatable(config[CONF_DATA], args, cg.uint64)
     cg.add(var.set_data(template_))
-    template_ = await cg.templatable(config[CONF_NBITS], args, cg.uint8)
-    cg.add(var.set_nbits(template_))
+    template_ = await cg.templatable(config[CONF_ADDRESS], args, cg.uint16)
+    cg.add(var.set_address(template_))
+    template_ = await cg.templatable(config[CONF_COMMAND], args, cg.uint16)
+    cg.add(var.set_command(template_))
 
 
 # Samsung36

--- a/esphome/components/remote_base/samsung_protocol.cpp
+++ b/esphome/components/remote_base/samsung_protocol.cpp
@@ -17,12 +17,40 @@ static const uint32_t FOOTER_LOW_US = 560;
 
 void SamsungProtocol::encode(RemoteTransmitData *dst, const SamsungData &data) {
   dst->set_carrier_frequency(38000);
-  dst->reserve(4 + data.nbits * 2u);
+
+  uint64_t raw{0};
+
+  if (!data.data) {
+    for (uint32_t mask = 1; mask < 0x10000; mask <<= 1) {
+      raw = raw << 1 | ((data.address & mask) > 0);
+    }
+    for (uint32_t mask = 1; mask < 0x100; mask <<= 1) {
+      raw = raw << 1 | ((data.command & mask) > 0);
+    }
+    for (uint32_t mask = 1; mask < 0x100; mask <<= 1) {
+      raw = raw << 1 | ((data.command & mask) == 0);
+    }
+    for (uint32_t mask = 0x100; mask < 0x10000; mask <<= 1) {
+      raw = raw << 1 | ((data.command & mask) > 0);
+    }
+    for (uint32_t mask = 0x100; mask < 0x10000; mask <<= 1) {
+      raw = raw << 1 | ((data.command & mask) == 0);
+    }
+  } else {
+    raw = data.data;
+  }
+
+  uint8_t length{32};
+  if (raw > 0xFFFFFF) {
+    length = 48;
+  }
+
+  dst->reserve(4 + length * 2u);
 
   dst->item(HEADER_HIGH_US, HEADER_LOW_US);
 
-  for (uint8_t bit = data.nbits; bit > 0; bit--) {
-    if ((data.data >> (bit - 1)) & 1) {
+  for (uint8_t bit = length; bit > 0; bit--) {
+    if ((raw >> (bit - 1)) & 1) {
       dst->item(BIT_HIGH_US, BIT_ONE_LOW_US);
     } else {
       dst->item(BIT_HIGH_US, BIT_ZERO_LOW_US);
@@ -32,33 +60,62 @@ void SamsungProtocol::encode(RemoteTransmitData *dst, const SamsungData &data) {
   dst->item(FOOTER_HIGH_US, FOOTER_LOW_US);
 }
 optional<SamsungData> SamsungProtocol::decode(RemoteReceiveData src) {
-  SamsungData out{
+  SamsungData data{
       .data = 0,
-      .nbits = 0,
+      .address = 0,
+      .command = 0,
   };
-  if (!src.expect_item(HEADER_HIGH_US, HEADER_LOW_US))
-    return {};
+  uint32_t command_buffer{0};
 
-  for (out.nbits = 0; out.nbits < 64; out.nbits++) {
+  if (!src.expect_item(HEADER_HIGH_US, HEADER_LOW_US)) {
+    return {};
+  }
+
+  for (int i = 0; i < 16; i++) {
     if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
-      out.data = (out.data << 1) | 1;
+      data.address = (data.address >> 1) | 0x8000;
+      data.data = (data.data << 1) | 1;
     } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
-      out.data = (out.data << 1) | 0;
-    } else if (out.nbits >= 31) {
-      if (!src.expect_mark(FOOTER_HIGH_US))
-        return {};
-      return out;
+      data.address = (data.address >> 1) | 0;
+      data.data = (data.data << 1) | 0;
     } else {
       return {};
     }
   }
 
-  if (!src.expect_mark(FOOTER_HIGH_US))
+  for (int i = 0; i < 32; i++) {
+    if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
+      command_buffer = (command_buffer >> 1) | 0x80000000;
+      data.data = (data.data << 1) | 1;
+    } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
+      command_buffer = (command_buffer >> 1) | 0;
+      data.data = (data.data << 1) | 0;
+    } else if (i == 16) {
+      if (!src.peek_mark(FOOTER_HIGH_US)) {
+        return {};
+      }
+      command_buffer >>= 16;
+      break;
+    } else {
+      return {};
+    }
+  }
+
+  if (!src.expect_mark(FOOTER_HIGH_US)) {
     return {};
-  return out;
+  }
+
+  uint16_t mask{static_cast<uint16_t>(((0xFF000000 & command_buffer) >> 16) | ((0x0000FF00 & command_buffer) >> 8))};
+  data.command = ((0x00FF0000 & command_buffer) >> 8) | ((0x000000FF & command_buffer));
+
+  if ((data.command & mask) != 0) {
+    return {};
+  }
+
+  return data;
 }
 void SamsungProtocol::dump(const SamsungData &data) {
-  ESP_LOGD(TAG, "Received Samsung: data=0x%" PRIX64 ", nbits=%d", data.data, data.nbits);
+  ESP_LOGD(TAG, "Received Samsung: address=0x%02X, command=0x%04X", data.address, data.command);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/samsung_protocol.h
+++ b/esphome/components/remote_base/samsung_protocol.h
@@ -8,9 +8,12 @@ namespace remote_base {
 
 struct SamsungData {
   uint64_t data;
-  uint8_t nbits;
+  uint16_t address;
+  uint16_t command;
 
-  bool operator==(const SamsungData &rhs) const { return data == rhs.data && nbits == rhs.nbits; }
+  bool operator==(const SamsungData &rhs) const {
+    return data == rhs.data && address == rhs.address && command == rhs.command;
+  }
 };
 
 class SamsungProtocol : public RemoteProtocol<SamsungData> {
@@ -25,12 +28,14 @@ DECLARE_REMOTE_PROTOCOL(Samsung)
 template<typename... Ts> class SamsungAction : public RemoteTransmitterActionBase<Ts...> {
  public:
   TEMPLATABLE_VALUE(uint64_t, data)
-  TEMPLATABLE_VALUE(uint8_t, nbits)
+  TEMPLATABLE_VALUE(uint16_t, address)
+  TEMPLATABLE_VALUE(uint16_t, command)
 
   void encode(RemoteTransmitData *dst, Ts... x) override {
     SamsungData data{};
     data.data = this->data_.value(x...);
-    data.nbits = this->nbits_.value(x...);
+    data.address = this->address_.value(x...);
+    data.command = this->command_.value(x...);
     SamsungProtocol().encode(dst, data);
   }
 };


### PR DESCRIPTION
# What does this implement/fix?

The Samsung protocol is LSB, has a 16bit address field and either 1 or 2 8bit command fields, both with inverses for error checking.

I suspected receivers accepting 16bit commands will gracefully accept 8bit commands without the trailing zeros in the additional command field, just like we do. But I have no device to confirm this.

The SamsungData struct now accepts an address and command or the raw payload for backwards compatibility.

This patch will break existing implementations that rely on receiving "made up" commands that fail the error checking.

This patch will break existing implementations that pass the removed "nbits" parameter.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> WIP

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
switch:
  - platform: template
    name: Transmit Samgung 16bit
    turn_on_action:
      - remote_transmitter.transmit_samsung:
          address: 0x629D
          command: 0x90AF
  - platform: template
    name: Transmit Samgung 8bit
    turn_on_action:
      - remote_transmitter.transmit_samsung:
          address: 0x707
          command: 0x02

remote_receiver:  
  pin:
    number: ?
    inverted: ?
  dump:
    - samsung
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
