### PR TITLE
Add EMC2101 support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -61,6 +61,7 @@ esphome/components/dht/* @OttoWinter
 esphome/components/ds1307/* @badbadc0ffee
 esphome/components/dsmr/* @glmnet @zuidwijk
 esphome/components/ektf2232/* @jesserockz
+esphome/components/emc2101/* @ellull
 esphome/components/ens210/* @itn3rd77
 esphome/components/esp32/* @esphome/core
 esphome/components/esp32_ble/* @jesserockz

--- a/esphome/components/emc2101/__init__.py
+++ b/esphome/components/emc2101/__init__.py
@@ -1,0 +1,74 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c
+from esphome.const import CONF_ID, CONF_INVERTED, CONF_RESOLUTION
+
+DEPENDENCIES = ["i2c"]
+
+CONF_I2C_ADDR = 0x4C
+
+CONF_PWM = "pwm"
+CONF_DIVIDER = "divider"
+CONF_DAC = "dac"
+CONF_CONVERSION_RATE = "conversion_rate"
+
+emc2101_ns = cg.esphome_ns.namespace("emc2101")
+Emc2101Component = emc2101_ns.class_("Emc2101Component", cg.Component, i2c.I2CDevice)
+
+Emc2101DACConversionRate = emc2101_ns.enum("Emc2101DACConversionRate")
+CONVERSIONS_PER_SECOND = {
+    "1/16": Emc2101DACConversionRate.Emc2101_DAC_1_EVERY_16S,
+    "1/8": Emc2101DACConversionRate.Emc2101_DAC_1_EVERY_8S,
+    "1/4": Emc2101DACConversionRate.Emc2101_DAC_1_EVERY_4S,
+    "1/2": Emc2101DACConversionRate.Emc2101_DAC_1_EVERY_2S,
+    "1": Emc2101DACConversionRate.Emc2101_DAC_1_EVERY_SECOND,
+    "2": Emc2101DACConversionRate.Emc2101_DAC_2_EVERY_SECOND,
+    "4": Emc2101DACConversionRate.Emc2101_DAC_4_EVERY_SECOND,
+    "8": Emc2101DACConversionRate.Emc2101_DAC_8_EVERY_SECOND,
+    "16": Emc2101DACConversionRate.Emc2101_DAC_16_EVERY_SECOND,
+    "32": Emc2101DACConversionRate.Emc2101_DAC_32_EVERY_SECOND,
+}
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Emc2101Component),
+            cv.Optional(CONF_PWM): cv.Schema(
+                {
+                    cv.Optional(CONF_RESOLUTION, default=0x17): cv.int_range(
+                        min=0x00, max=0x1F
+                    ),
+                    cv.Optional(CONF_DIVIDER, default=0x01): cv.uint8_t,
+                }
+            ),
+            cv.Optional(CONF_DAC): cv.Schema(
+                {
+                    cv.Optional(
+                        CONF_CONVERSION_RATE, default=CONVERSIONS_PER_SECOND["16"]
+                    ): cv.enum(CONVERSIONS_PER_SECOND),
+                }
+            ),
+            cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(CONF_I2C_ADDR)),
+    cv.has_at_most_one_key(CONF_PWM, CONF_DAC),
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_PWM in config:
+        cg.add(var.set_dac_mode(False))
+        pwm_config = config[CONF_PWM]
+        cg.add(var.set_pwm_resolution(pwm_config[CONF_RESOLUTION]))
+        cg.add(var.set_pwm_divider(pwm_config[CONF_DIVIDER]))
+    if CONF_DAC in config:
+        cg.add(var.set_dac_mode(True))
+        dac_config = config[CONF_DAC]
+        cg.add(var.set_dac_conversion_rate(dac_config[CONF_CONVERSION_RATE]))
+    cg.add(var.set_inverted(config[CONF_INVERTED]))

--- a/esphome/components/emc2101/__init__.py
+++ b/esphome/components/emc2101/__init__.py
@@ -3,6 +3,8 @@ import esphome.config_validation as cv
 from esphome.components import i2c
 from esphome.const import CONF_ID, CONF_INVERTED, CONF_RESOLUTION
 
+CODEOWNERS = ["@ellull"]
+
 DEPENDENCIES = ["i2c"]
 
 CONF_I2C_ADDR = 0x4C

--- a/esphome/components/emc2101/emc2101.cpp
+++ b/esphome/components/emc2101/emc2101.cpp
@@ -1,0 +1,199 @@
+// Implementation based on:
+//  - Adafruit_EMC2101: https://github.com/adafruit/Adafruit_EMC2101
+//  - Official Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/2101.pdf
+
+#include "esphome/core/log.h"
+#include "emc2101.h"
+
+namespace esphome {
+namespace emc2101 {
+
+static const char *const TAG = "EMC2101";
+
+#define EMC2101_CHIP_ID (0x16)      // EMC2101 default device id from part id
+#define EMC2101_ALT_CHIP_ID (0x28)  // EMC2101 alternate device id from part id
+
+// EMC2101 registers from the datasheet. We only define what we use.
+#define EMC2101_REGISTER_INTERNAL_TEMP (0x00)      // The internal temperature register
+#define EMC2101_REGISTER_EXTERNAL_TEMP_MSB (0x01)  // high byte for the external temperature reading
+#define EMC2101_REGISTER_DAC_CONV_RATE (0x04)      // DAC convesion rate config
+#define EMC2101_REGISTER_EXTERNAL_TEMP_LSB (0x10)  // low byte for the external temperature reading
+#define EMC2101_REGISTER_CONFIG (0x03)             // configuration register
+#define EMC2101_REGISTER_TACH_LSB (0x46)           // Tach RPM data low byte
+#define EMC2101_REGISTER_TACH_MSB (0x47)           // Tach RPM data high byte
+#define EMC2101_REGISTER_FAN_CONFIG (0x4A)         // General fan config register
+#define EMC2101_REGISTER_FAN_SETTING (0x4C)        // Fan speed for non-LUT settings, as a % PWM duty cycle
+#define EMC2101_REGISTER_PWM_FREQ (0x4D)           // PWM frequency setting
+#define EMC2101_REGISTER_PWM_DIV (0x4E)            // PWM frequency divisor
+#define EMC2101_REGISTER_WHOAMI (0xFD)             // Chip ID register
+
+// EMC2101 configuration bits from the datasheet. We only define what we use.
+#define EMC2101_ALT_TCH_BIT \
+  1 << 2  // Determines the funcionallity of the ALERT/TACH pin.
+          // 0 (default): The ALERT/TECH pin will function as an open drain, active low interrupt.
+          // 1: The ALERT/TECH pin will function as a high impedance TACH input. This may require an
+          // external pull-up resistor to set the proper signaling levels.
+#define EMC2101_DAC_BIT \
+  1 << 4  // Determines the FAN output mode.
+          // 0 (default): PWM output enabled at FAN pin.
+          // 1: DAC output enabled at FAN ping.
+#define EMC2101_CLK_OVR_BIT \
+  1 << 2  // Overrides the CLK_SEL bit and uses the Frequency Divide Register to determine
+          // the base PWM frequency. It is recommended that this bit be set for maximum PWM resolution.
+          // 0 (default): The base clock frequency for the PWM is determined by the CLK_SEL bit.
+          // 1 (recommended): The base clock that is used to determine the PWM frequency is set by the
+          // Frequency Divide Register
+#define EMC2101_POLARITY_BIT \
+  1 << 4  // Sets the polarity of the Fan output driver.
+          // 0 (default): The polarity of the Fan output driver is non-inverted. A '00h' setting will
+          // correspond to a 0% duty cycle or a minimum DAC output voltage.
+          // 1: The polarity of the Fan output driver is inverted. A '00h' setting will correspond to a
+          // 100% duty cycle or a maximum DAC output voltage.
+
+float Emc2101Component::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+void Emc2101Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up Emc2101 sensor...");
+
+  // make sure we're talking to the right chip
+  uint8_t chip_id = reg(EMC2101_REGISTER_WHOAMI).get();
+  if ((chip_id != EMC2101_CHIP_ID) && (chip_id != EMC2101_ALT_CHIP_ID)) {
+    ESP_LOGE(TAG, "Wrong chip ID %02X", chip_id);
+    this->mark_failed();
+    return;
+  }
+
+  // Configure EMC2101
+  i2c::I2CRegister config = reg(EMC2101_REGISTER_CONFIG);
+  config |= EMC2101_ALT_TCH_BIT;
+  if (this->dac_mode_) {
+    config |= EMC2101_DAC_BIT;
+  }
+  if (this->inverted_) {
+    config |= EMC2101_POLARITY_BIT;
+  }
+
+  if (this->dac_mode_) {  // DAC mode configurations
+    // set DAC conversion rate
+    reg(EMC2101_REGISTER_DAC_CONV_RATE) = this->dac_conversion_rate_;
+  } else {  // PWM mode configurations
+    // set PWM divider
+    reg(EMC2101_REGISTER_FAN_CONFIG) |= EMC2101_CLK_OVR_BIT;
+    reg(EMC2101_REGISTER_PWM_DIV) = this->pwm_divider_;
+
+    // set PWM resolution
+    reg(EMC2101_REGISTER_PWM_FREQ) = this->pwm_resolution_;
+  }
+}
+
+void Emc2101Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "Emc2101 component:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with EMC2101 failed!");
+  }
+  ESP_LOGCONFIG(TAG, "  Mode: %s", this->dac_mode_ ? "DAC" : "PWM");
+  if (this->dac_mode_) {
+    ESP_LOGCONFIG(TAG, "  DAC Conversion Rate: %X", this->dac_conversion_rate_);
+  } else {
+    ESP_LOGCONFIG(TAG, "  PWM Resolution: %02X", this->pwm_resolution_);
+    ESP_LOGCONFIG(TAG, "  PWM Divider: %02X", this->pwm_divider_);
+  }
+  ESP_LOGCONFIG(TAG, "  Inverted: %s", YESNO(this->inverted_));
+}
+
+void Emc2101Component::set_duty_cycle_(float value) {
+  uint8_t duty_cycle = remap(value, 0.0f, 1.0f, (uint8_t) 0, this->max_output_value_);
+  ESP_LOGD(TAG, "Setting duty fan setting to %02X", duty_cycle);
+  if (!this->write_byte(EMC2101_REGISTER_FAN_SETTING, duty_cycle)) {
+    ESP_LOGE(TAG, "Communication with EMC2101 failed!");
+    this->status_set_warning();
+    return;
+  }
+}
+
+float Emc2101Component::get_duty_cycle_percent_() {
+  uint8_t duty_cycle;
+  if (!this->read_byte(EMC2101_REGISTER_FAN_SETTING, &duty_cycle)) {
+    ESP_LOGE(TAG, "Communication with EMC2101 failed!");
+    this->status_set_warning();
+    return NAN;
+  }
+  return remap(duty_cycle, (uint8_t) 0, this->max_output_value_, 0.0f, 100.0f);
+}
+
+float Emc2101Component::get_internal_temperature_() {
+  uint8_t temperature;
+  if (!this->read_byte(EMC2101_REGISTER_INTERNAL_TEMP, &temperature)) {
+    ESP_LOGE(TAG, "Communication with EMC2101 failed!");
+    this->status_set_warning();
+    return NAN;
+  }
+  return temperature;
+}
+
+float Emc2101Component::get_external_temperature_() {
+  // Read **MSB** first to match 'Data Read Interlock' behavoior from 6.1 of datasheet
+  uint8_t lsb, msb;
+  if (!this->read_byte(EMC2101_REGISTER_EXTERNAL_TEMP_MSB, &msb) ||
+      !this->read_byte(EMC2101_REGISTER_EXTERNAL_TEMP_LSB, &lsb)) {
+    ESP_LOGE(TAG, "Communication with EMC2101 failed!");
+    this->status_set_warning();
+    return NAN;
+  }
+
+  // join msb and lsb (5 least significant bits are not used)
+  uint16_t raw = (msb << 8 | lsb) >> 5;
+  return raw * 0.125;
+}
+
+float Emc2101Component::get_speed_() {
+  // Read **LSB** first to match 'Data Read Interlock' behavoior from 6.1 of datasheet
+  uint8_t lsb, msb;
+  if (!this->read_byte(EMC2101_REGISTER_TACH_LSB, &lsb) || !this->read_byte(EMC2101_REGISTER_TACH_MSB, &msb)) {
+    ESP_LOGE(TAG, "Communication with EMC2101 failed!");
+    this->status_set_warning();
+    return NAN;
+  }
+
+  // calculate RPMs
+  uint16_t tach = msb << 8 | lsb;
+  return tach == 0xFFFF ? 0.0f : 5400000.0f / tach;
+}
+
+void EMC2101Output::write_state(float state) { this->parent_->set_duty_cycle_(state); }
+
+float EMC2101Sensor::get_setup_priority() const { return setup_priority::DATA; }
+
+void EMC2101Sensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Emc2101 sensor:");
+  LOG_SENSOR("  ", "Internal temperature", this->internal_temperature_sensor_);
+  LOG_SENSOR("  ", "External temperature", this->external_temperature_sensor_);
+  LOG_SENSOR("  ", "Speed", this->speed_sensor_);
+  LOG_SENSOR("  ", "Duty cycle", this->duty_cycle_sensor_);
+}
+
+void EMC2101Sensor::update() {
+  if (this->internal_temperature_sensor_ != nullptr) {
+    float internal_temperature = this->parent_->get_internal_temperature_();
+    this->internal_temperature_sensor_->publish_state(internal_temperature);
+  }
+
+  if (this->external_temperature_sensor_ != nullptr) {
+    float external_temperature = this->parent_->get_external_temperature_();
+    this->external_temperature_sensor_->publish_state(external_temperature);
+  }
+
+  if (this->speed_sensor_ != nullptr) {
+    float speed = this->parent_->get_speed_();
+    this->speed_sensor_->publish_state(speed);
+  }
+
+  if (this->duty_cycle_sensor_ != nullptr) {
+    float duty_cycle = this->parent_->get_duty_cycle_percent_();
+    this->duty_cycle_sensor_->publish_state(duty_cycle);
+  }
+}
+
+}  // namespace emc2101
+}  // namespace esphome

--- a/esphome/components/emc2101/emc2101.h
+++ b/esphome/components/emc2101/emc2101.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/output/float_output.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace emc2101 {
+
+/** Enum listing all DAC conversion rates for the EMC2101.
+ *
+ * Specific values of the enum constants are register values taken from the EMC2101 datasheet.
+ */
+enum Emc2101DACConversionRate {
+  EMC2101_DAC_1_EVERY_16_S,
+  EMC2101_DAC_1_EVERY_8_S,
+  EMC2101_DAC_1_EVERY_4_S,
+  EMC2101_DAC_1_EVERY_2_S,
+  EMC2101_DAC_1_EVERY_SECOND,
+  EMC2101_DAC_2_EVERY_SECOND,
+  EMC2101_DAC_4_EVERY_SECOND,
+  EMC2101_DAC_8_EVERY_SECOND,
+  EMC2101_DAC_16_EVERY_SECOND,
+  EMC2101_DAC_32_EVERY_SECOND,
+};
+
+/// This class includes support for the EMC2101 i2c fan controller.
+/// The device has an output (PWM or DAC) and several sensors and this
+/// class is for the EMC2101 configuration.
+class Emc2101Component : public Component, public i2c::I2CDevice {
+ public:
+  /** Sets the mode of the output.
+   *
+   * @param dac_mode false for PWM output and true for DAC mode.
+   */
+  void set_dac_mode(bool dac_mode) {
+    this->dac_mode_ = dac_mode;
+    this->max_output_value_ = 63;
+  }
+
+  /** Sets the PWM resolution.
+   *
+   * @param resolution the PWM resolution.
+   */
+  void set_pwm_resolution(uint8_t resolution) {
+    this->pwm_resolution_ = resolution;
+    this->max_output_value_ = 2 * resolution;
+  }
+
+  /** Sets the PWM divider used to derive the PWM frequency.
+   *
+   * @param divider The PWM divider.
+   */
+  void set_pwm_divider(uint8_t divider) { this->pwm_divider_ = divider; }
+
+  /** Sets the DAC conversion rate (how many conversions per second).
+   *
+   * @param conversion_rate The DAC conversion rate.
+   */
+  void set_dac_conversion_rate(Emc2101DACConversionRate conversion_rate) {
+    this->dac_conversion_rate_ = conversion_rate;
+  }
+
+  /** Inverts the polarity of the Fan output.
+   *
+   * @param inverted Invert or not the Fan output.
+   */
+  void set_inverted(bool inverted) { this->inverted_ = inverted; }
+
+  /** Used by ESPHome framework. */
+  void setup() override;
+  /** Used by ESPHome framework. */
+  void dump_config() override;
+  /** Used by ESPHome framework. */
+  float get_setup_priority() const override;
+
+ protected:
+  friend class EMC2101Output;
+  friend class EMC2101Sensor;
+
+  /** Sets the Fan output duty cycle
+   *
+   * @param value The duty cycle value, from 0.0f to 1.0f.
+   */
+  void set_duty_cycle_(float value);
+
+  /** Gets the Fan output duty cycle percentage
+   *
+   * @return The duty cycle percentage from 0.0f to 100.0f.
+   */
+  float get_duty_cycle_percent_();
+
+  /** Gets the internal temperature sensor reading.
+   *
+   * @return The temperature in degrees celsius.
+   */
+  float get_internal_temperature_();
+
+  /** Gets the external temperature sensor reading.
+   *
+   * @return The temperature in degrees celsius.
+   */
+  float get_external_temperature_();
+
+  /** Gets the tachometer speed sensor reading.
+   *
+   * @return The fan speed in RPMs.
+   */
+  float get_speed_();
+
+  bool dac_mode_{false};
+  bool inverted_{false};
+  uint8_t max_output_value_;
+  uint8_t pwm_resolution_;
+  uint8_t pwm_divider_;
+  Emc2101DACConversionRate dac_conversion_rate_;
+};
+
+/// This class allows to control the EMC2101 output.
+class EMC2101Output : public output::FloatOutput {
+ public:
+  EMC2101Output(Emc2101Component *parent) : parent_(parent) {}
+
+ protected:
+  /** Used by ESPHome framework. */
+  void write_state(float state) override;
+
+  Emc2101Component *parent_;
+};
+
+/// This class exposes the EMC2101 sensors.
+class EMC2101Sensor : public PollingComponent {
+ public:
+  EMC2101Sensor(Emc2101Component *parent) : parent_(parent) {}
+  /** Used by ESPHome framework. */
+  void dump_config() override;
+  /** Used by ESPHome framework. */
+  void update() override;
+  /** Used by ESPHome framework. */
+  float get_setup_priority() const override;
+
+  /** Used by ESPHome framework. */
+  void set_internal_temperature_sensor(sensor::Sensor *sensor) { internal_temperature_sensor_ = sensor; }
+  /** Used by ESPHome framework. */
+  void set_external_temperature_sensor(sensor::Sensor *sensor) { external_temperature_sensor_ = sensor; }
+  /** Used by ESPHome framework. */
+  void set_speed_sensor(sensor::Sensor *sensor) { speed_sensor_ = sensor; }
+  /** Used by ESPHome framework. */
+  void set_duty_cycle_sensor(sensor::Sensor *sensor) { duty_cycle_sensor_ = sensor; }
+
+ protected:
+  Emc2101Component *parent_;
+  sensor::Sensor *internal_temperature_sensor_{nullptr};
+  sensor::Sensor *external_temperature_sensor_{nullptr};
+  sensor::Sensor *speed_sensor_{nullptr};
+  sensor::Sensor *duty_cycle_sensor_{nullptr};
+};
+
+}  // namespace emc2101
+}  // namespace esphome

--- a/esphome/components/emc2101/output.py
+++ b/esphome/components/emc2101/output.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import output
+from esphome.const import CONF_ID
+from . import Emc2101Component, emc2101_ns
+
+DEPENDENCIES = ["emc2101"]
+
+EMC2101Output = emc2101_ns.class_("EMC2101Output", output.FloatOutput, cg.Component)
+CONF_EMC2101_ID = "emc2101_id"
+
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(EMC2101Output),
+        cv.GenerateID(CONF_EMC2101_ID): cv.use_id(Emc2101Component),
+    }
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_EMC2101_ID])
+    var = cg.new_Pvariable(config[CONF_ID], paren)
+    await output.register_output(var, config)

--- a/esphome/components/emc2101/sensor.py
+++ b/esphome/components/emc2101/sensor.py
@@ -1,0 +1,74 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_SPEED,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_PERCENT,
+)
+from . import Emc2101Component, emc2101_ns
+
+DEPENDENCIES = ["emc2101"]
+
+CONF_INTERNAL_TEMPERATURE = "internal_temperature"
+CONF_EXTERNAL_TEMPERATURE = "external_temperature"
+CONF_DUTY_CYCLE = "duty_cycle"
+
+EMC2101Sensor = emc2101_ns.class_("EMC2101Sensor", cg.PollingComponent)
+CONF_EMC2101_ID = "emc2101_id"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(EMC2101Sensor),
+        cv.GenerateID(CONF_EMC2101_ID): cv.use_id(Emc2101Component),
+        cv.Optional(CONF_INTERNAL_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_EXTERNAL_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=3,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_SPEED): sensor.sensor_schema(
+            unit_of_measurement="RPM",
+            accuracy_decimals=2,
+            state_class=STATE_CLASS_MEASUREMENT,
+            icon="mdi:fan",
+        ),
+        cv.Optional(CONF_DUTY_CYCLE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=2,
+            state_class=STATE_CLASS_MEASUREMENT,
+            icon="mdi:percent",
+        ),
+    }
+).extend(cv.polling_component_schema("60s"))
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_EMC2101_ID])
+    var = cg.new_Pvariable(config[CONF_ID], paren)
+    await cg.register_component(var, config)
+
+    if CONF_INTERNAL_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_INTERNAL_TEMPERATURE])
+        cg.add(var.set_internal_temperature_sensor(sens))
+
+    if CONF_EXTERNAL_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_EXTERNAL_TEMPERATURE])
+        cg.add(var.set_external_temperature_sensor(sens))
+
+    if CONF_SPEED in config:
+        sens = await sensor.new_sensor(config[CONF_SPEED])
+        cg.add(var.set_speed_sensor(sens))
+
+    if CONF_DUTY_CYCLE in config:
+        sens = await sensor.new_sensor(config[CONF_DUTY_CYCLE])
+        cg.add(var.set_duty_cycle_sensor(sens))


### PR DESCRIPTION
# What does this implement/fix?

Adds support for Adafruit EMC2101 Fan controller and temperature sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1679

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
i2c:
  sda: GPIO8
  scl: GPIO9

emc2101:
  pwm:
    resolution: 8

output:
  - platform: emc2101
    id: fan_duty_cycle

fan:
  - platform: speed
    name: "Hall Cabinet Fan"
    output: fan_duty_cycle
    speed_count: 16

sensor:
  - platform: emc2101
    internal_temperature:
      id: internal_temperature_sensor
      name: "Internal Temperature Sensor"
    speed:
      id: speed_sensor
      name: "Speed Sensor"
    duty_cycle:
      id: duty_cycle_sensor
      name: "Duty Cycle Sensor"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
