### PR TITLE
[BedJet] Add configurable heating strategy

### DIFF
--- a/esphome/components/bedjet/bedjet.h
+++ b/esphome/components/bedjet/bedjet.h
@@ -40,6 +40,8 @@ class Bedjet : public climate::Climate, public esphome::ble_client::BLEClientNod
   void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
 #endif
   void set_status_timeout(uint32_t timeout) { this->timeout_ = timeout; }
+  /** Sets the default strategy to use for climate::CLIMATE_MODE_HEAT. */
+  void set_heating_mode(BedjetHeatMode mode) { this->heating_mode_ = mode; }
 
   /** Attempts to check for and apply firmware updates. */
   void upgrade_firmware();
@@ -68,12 +70,15 @@ class Bedjet : public climate::Climate, public esphome::ble_client::BLEClientNod
         // We could fetch biodata from bedjet and set these names that way.
         // But then we have to invert the lookup in order to send the right preset.
         // For now, we can leave them as M1-3 to match the remote buttons.
-        // EXT HT added to match remote button.
-        "EXT HT",
         "M1",
         "M2",
         "M3",
     });
+    if (this->heating_mode_ == HEAT_MODE_EXTENDED) {
+      traits.add_supported_custom_preset("LTD HT");
+    } else {
+      traits.add_supported_custom_preset("EXT HT");
+    }
     traits.set_visual_min_temperature(19.0);
     traits.set_visual_max_temperature(43.0);
     traits.set_visual_temperature_step(1.0);
@@ -90,6 +95,7 @@ class Bedjet : public climate::Climate, public esphome::ble_client::BLEClientNod
 #endif
 
   uint32_t timeout_{DEFAULT_STATUS_TIMEOUT};
+  BedjetHeatMode heating_mode_ = HEAT_MODE_HEAT;
 
   static const uint32_t MIN_NOTIFY_THROTTLE = 5000;
   static const uint32_t NOTIFY_WARN_THRESHOLD = 300000;

--- a/esphome/components/bedjet/bedjet_const.h
+++ b/esphome/components/bedjet/bedjet_const.h
@@ -24,6 +24,14 @@ enum BedjetMode : uint8_t {
   MODE_WAIT = 6,
 };
 
+/** Optional heating strategies to use for climate::CLIMATE_MODE_HEAT. */
+enum BedjetHeatMode {
+  /// HVACMode.HEAT is handled using BTN_HEAT (default)
+  HEAT_MODE_HEAT,
+  /// HVACMode.HEAT is handled using BTN_EXTHT
+  HEAT_MODE_EXTENDED,
+};
+
 enum BedjetButton : uint8_t {
   /// Turn BedJet off
   BTN_OFF = 0x1,

--- a/esphome/components/bedjet/climate.py
+++ b/esphome/components/bedjet/climate.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate, ble_client, time
 from esphome.const import (
+    CONF_HEAT_MODE,
     CONF_ID,
     CONF_RECEIVE_TIMEOUT,
     CONF_TIME_ID,
@@ -14,11 +15,19 @@ bedjet_ns = cg.esphome_ns.namespace("bedjet")
 Bedjet = bedjet_ns.class_(
     "Bedjet", climate.Climate, ble_client.BLEClientNode, cg.PollingComponent
 )
+BedjetHeatMode = bedjet_ns.enum("BedjetHeatMode")
+BEDJET_HEAT_MODES = {
+    "heat": BedjetHeatMode.HEAT_MODE_HEAT,
+    "extended": BedjetHeatMode.HEAT_MODE_EXTENDED,
+}
 
 CONFIG_SCHEMA = (
     climate.CLIMATE_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(Bedjet),
+            cv.Optional(CONF_HEAT_MODE, default="heat"): cv.enum(
+                BEDJET_HEAT_MODES, lower=True
+            ),
             cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
             cv.Optional(
                 CONF_RECEIVE_TIMEOUT, default="0s"
@@ -35,6 +44,8 @@ async def to_code(config):
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await ble_client.register_ble_node(var, config)
+    if CONF_HEAT_MODE in config:
+        cg.add(var.set_heating_mode(config[CONF_HEAT_MODE]))
     if CONF_TIME_ID in config:
         time_ = await cg.get_variable(config[CONF_TIME_ID])
         cg.add(var.set_time_id(time_))

--- a/esphome/components/bedjet/climate.py
+++ b/esphome/components/bedjet/climate.py
@@ -44,8 +44,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await ble_client.register_ble_node(var, config)
-    if CONF_HEAT_MODE in config:
-        cg.add(var.set_heating_mode(config[CONF_HEAT_MODE]))
+    cg.add(var.set_heating_mode(config[CONF_HEAT_MODE]))
     if CONF_TIME_ID in config:
         time_ = await cg.get_variable(config[CONF_TIME_ID])
         cg.add(var.set_time_id(time_))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1886,6 +1886,7 @@ climate:
   - platform: bedjet
     name: My Bedjet
     ble_client_id: my_bedjet_ble_client
+    heat_mode: extended
 
 script:
   - id: climate_custom


### PR DESCRIPTION
A new `heat_mode` configuration entry is added, supporting one of:

* "heat": hvac_mode=heat handled using BTN_HEAT
* "extended": hvac_mode=heat handled using BTN_EXTHT

Depending on the configured heating mode, we'll also switch the
supported presets to continue handling the non-primary heating mode.

# What does this implement/fix?

Add an optional configuration to control the behavior of `HVACMode.HEAT`, allowing the user to select whether that will use the BedJet's HEAT mode or EXT HEAT mode. Whichever mode is not selected will be made available as a preset.

This was a compromise reached in https://github.com/esphome/issues/issues/3314

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3314

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/2102

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
    climate:
      - platform: bedjet
        id: my_bedjet_fan
        name: "My BedJet Fan"
        ble_client_id: ble_bedjet
        # default = "heat"
        heat_mode: extended
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
