### PR TITLE
Add mqtt.on_connect and mqtt.on_disconnect triggers

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -572,6 +572,14 @@ void MQTTClientComponent::on_shutdown() {
   this->mqtt_backend_.disconnect();
 }
 
+void MQTTClientComponent::set_on_connect(mqtt_on_connect_callback_t &&callback) {
+  this->mqtt_backend_.set_on_connect(std::forward<mqtt_on_connect_callback_t>(callback));
+}
+
+void MQTTClientComponent::set_on_disconnect(mqtt_on_disconnect_callback_t &&callback) {
+  this->mqtt_backend_.set_on_disconnect(std::forward<mqtt_on_disconnect_callback_t>(callback));
+}
+
 #if ASYNC_TCP_SSL_ENABLED
 void MQTTClientComponent::add_ssl_fingerprint(const std::array<uint8_t, SHA1_SIZE> &fingerprint) {
   this->mqtt_backend_.setSecure(true);

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -337,14 +337,14 @@ class MQTTJsonMessageTrigger : public Trigger<JsonObjectConst> {
 
 class MQTTConnectTrigger : public Trigger<> {
  public:
-  explicit MQTTConnectTrigger(MQTTClientComponent*& client) {
+  explicit MQTTConnectTrigger(MQTTClientComponent *&client) {
     client->set_on_connect([this](bool session_present) { this->trigger(); });
   }
 };
 
 class MQTTDisconnectTrigger : public Trigger<> {
  public:
-  explicit MQTTDisconnectTrigger(MQTTClientComponent*& client) {
+  explicit MQTTDisconnectTrigger(MQTTClientComponent *&client) {
     client->set_on_disconnect([this](MQTTClientDisconnectReason reason) { this->trigger(); });
   }
 };

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -19,6 +19,11 @@
 namespace esphome {
 namespace mqtt {
 
+/** Callback for MQTT events.
+ */
+using mqtt_on_connect_callback_t = std::function<MQTTBackend::on_connect_callback_t>;
+using mqtt_on_disconnect_callback_t = std::function<MQTTBackend::on_disconnect_callback_t>;
+
 /** Callback for MQTT subscriptions.
  *
  * First parameter is the topic, the second one is the payload.
@@ -240,6 +245,8 @@ class MQTTClientComponent : public Component {
   void set_username(const std::string &username) { this->credentials_.username = username; }
   void set_password(const std::string &password) { this->credentials_.password = password; }
   void set_client_id(const std::string &client_id) { this->credentials_.client_id = client_id; }
+  void set_on_connect(mqtt_on_connect_callback_t &&callback);
+  void set_on_disconnect(mqtt_on_disconnect_callback_t &&callback);
 
  protected:
   /// Reconnect to the MQTT broker if not already connected.
@@ -325,6 +332,20 @@ class MQTTJsonMessageTrigger : public Trigger<JsonObjectConst> {
   explicit MQTTJsonMessageTrigger(const std::string &topic, uint8_t qos) {
     global_mqtt_client->subscribe_json(
         topic, [this](const std::string &topic, JsonObject root) { this->trigger(root); }, qos);
+  }
+};
+
+class MQTTConnectTrigger : public Trigger<> {
+ public:
+  explicit MQTTConnectTrigger(MQTTClientComponent*& client) {
+    client->set_on_connect([this](bool session_present) { this->trigger(); });
+  }
+};
+
+class MQTTDisconnectTrigger : public Trigger<> {
+ public:
+  explicit MQTTDisconnectTrigger(MQTTClientComponent*& client) {
+    client->set_on_disconnect([this](MQTTClientDisconnectReason reason) { this->trigger(); });
   }
 };
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -168,6 +168,13 @@ mqtt:
                 id: uart0
                 data: !lambda |-
                   return {};
+  on_connect:
+    - light.turn_on: ${roomname}_lights
+    - mqtt.publish:
+        topic: some/topic
+        payload: Hello
+  on_disconnect:
+    - light.turn_off: ${roomname}_lights
 
 i2c:
   sda: 21


### PR DESCRIPTION
# What does this implement/fix?

Add mqtt.on_connect and mqtt.on_disconnect triggers

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** partially addresses esphome/feature-requests#746

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2105

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
mqtt:
  on_connect:
    - logger.log: "Yay! We're connected!"
  on_disconnect:
    - logger.log: "Bah! Disconnected again!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). Add the on_connect / on_disconnect to test3.yaml

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
