### PR TITLE
Fix percentage validation for wrong data type input

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1098,7 +1098,9 @@ def possibly_negative_percentage(value):
                 msg += " Please put a percent sign after the number!"
             raise Invalid(msg)
     except TypeError:
-        raise Invalid("Expected percentage or float between -1.0 and 1.0")
+        raise Invalid(
+            "Expected percentage or float between -1.0 and 1.0"
+        )  # pylint: disable=raise-missing-from
     return negative_one_to_one_float(value)
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1098,9 +1098,9 @@ def possibly_negative_percentage(value):
                 msg += " Please put a percent sign after the number!"
             raise Invalid(msg)
     except TypeError:
-        raise Invalid(
+        raise Invalid(  # pylint: disable=raise-missing-from
             "Expected percentage or float between -1.0 and 1.0"
-        )  # pylint: disable=raise-missing-from
+        )
     return negative_one_to_one_float(value)
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1086,16 +1086,19 @@ def possibly_negative_percentage(value):
         except ValueError:
             # pylint: disable=raise-missing-from
             raise Invalid("invalid number")
-    if value > 1:
-        msg = "Percentage must not be higher than 100%."
-        if not has_percent_sign:
-            msg += " Please put a percent sign after the number!"
-        raise Invalid(msg)
-    if value < -1:
-        msg = "Percentage must not be smaller than -100%."
-        if not has_percent_sign:
-            msg += " Please put a percent sign after the number!"
-        raise Invalid(msg)
+    try:
+        if value > 1:
+            msg = "Percentage must not be higher than 100%."
+            if not has_percent_sign:
+                msg += " Please put a percent sign after the number!"
+            raise Invalid(msg)
+        if value < -1:
+            msg = "Percentage must not be smaller than -100%."
+            if not has_percent_sign:
+                msg += " Please put a percent sign after the number!"
+            raise Invalid(msg)
+    except TypeError:
+        raise Invalid("Expected percentage or float between -1.0 and 1.0")
     return negative_one_to_one_float(value)
 
 


### PR DESCRIPTION
# What does this implement/fix?

When a wrong datatype is used for a percentage YAML config field, then a long confusing backtrace is shown at compile time, instead of explaining that a percentage was expected. This PR fixes this behavior. This backtrace ends with the error:

```
File "..path-to-my-esphome../esphome/config_validation.py", line 1089, in possibly_negative_percentage
    if value > 1:
TypeError: '>' not supported between instances of 'OrderedDict' and 'int'
```

This can especially be breaking when using a schema that uses `cv.maybe_simple_value(...)`, where the percentage is the key.
This is the construction that failed for me, for an automation that I'm working on:

```yaml
    cv.Any(
        cv.maybe_simple_value(
            {
                cv.GenerateID(): cv.use_id(VS10XX),
                cv.Required(CONF_VOLUME): cv.templatable(cv.percentage),
            },
            key=CONF_VOLUME,
        ),
        cv.Schema(
            {
                cv.GenerateID(): cv.use_id(VS10XX),
                cv.Optional(CONF_LEFT): cv.templatable(cv.percentage),
                cv.Optional(CONF_RIGHT): cv.templatable(cv.percentage),
            }
        ),
    )
```

When one woud use a valid config for the last schema:

```yaml
vs10xx.set_volume:
  id: audio_decoder
  left: 32%
  right: 20%
```

then compilation would fail, because the `cv.maybe_simple_value` would get a dict as its input, and that would trigger the type issue because the percentage validation code doesn't handle that gracefully.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml that triggers the issue
esphome:
  name: test-percentage-issue
  on_boot:
    then:
      output.set_level:
        id: test-output
        level:
          this: is
          not: a
          percentage: string

esp32:
  board: esp32dev

output:
  - platform: esp8266_pwm
    id: test-output
    pin: D1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
