### PR TITLE
Cleanup deprecated EntityBase::hash_base()

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -69,7 +69,6 @@ void BinarySensor::add_filters(const std::vector<Filter *> &filters) {
   }
 }
 bool BinarySensor::has_state() const { return this->has_state_; }
-uint32_t BinarySensor::hash_base() { return 1210250844UL; }
 bool BinarySensor::is_status_binary_sensor() const { return false; }
 
 }  // namespace binary_sensor

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -76,8 +76,6 @@ class BinarySensor : public EntityBase {
   virtual std::string device_class();
 
  protected:
-  uint32_t hash_base() override;
-
   CallbackManager<void(bool)> state_callback_{};
   optional<std::string> device_class_{};  ///< Stores the override of the device class
   Filter *filter_list_{nullptr};

--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -11,8 +11,6 @@ namespace ble_client {
 
 static const char *const TAG = "ble_sensor";
 
-uint32_t BLESensor::hash_base() { return 343459825UL; }
-
 void BLESensor::loop() {}
 
 void BLESensor::dump_config() {

--- a/esphome/components/ble_client/sensor/ble_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_sensor.h
@@ -37,7 +37,6 @@ class BLESensor : public sensor::Sensor, public PollingComponent, public BLEClie
   uint16_t handle;
 
  protected:
-  uint32_t hash_base() override;
   float parse_data_(uint8_t *value, uint16_t value_len);
   optional<data_to_value_t> data_to_value_func_{};
   bool notify_;

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
@@ -14,8 +14,6 @@ static const char *const TAG = "ble_text_sensor";
 
 static const std::string EMPTY = "";
 
-uint32_t BLETextSensor::hash_base() { return 193967603UL; }
-
 void BLETextSensor::loop() {}
 
 void BLETextSensor::dump_config() {

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.h
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.h
@@ -35,7 +35,6 @@ class BLETextSensor : public text_sensor::TextSensor, public PollingComponent, p
   uint16_t handle;
 
  protected:
-  uint32_t hash_base() override;
   bool notify_;
   espbt::ESPBTUUID service_uuid_;
   espbt::ESPBTUUID char_uuid_;

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -15,7 +15,6 @@ void Button::press() {
   this->press_callback_.call();
 }
 void Button::add_on_press_callback(std::function<void()> &&callback) { this->press_callback_.add(std::move(callback)); }
-uint32_t Button::hash_base() { return 1495763804UL; }
 
 void Button::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
 std::string Button::get_device_class() { return this->device_class_; }

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -47,8 +47,6 @@ class Button : public EntityBase {
    */
   virtual void press_action() = 0;
 
-  uint32_t hash_base() override;
-
   CallbackManager<void()> press_callback_{};
   std::string device_class_{};
 };

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -419,7 +419,6 @@ void Climate::publish_state() {
   // Save state
   this->save_state_();
 }
-uint32_t Climate::hash_base() { return 3104134496UL; }
 
 ClimateTraits Climate::get_traits() {
   auto traits = this->traits();

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -282,7 +282,6 @@ class Climate : public EntityBase {
    */
   void save_state_();
 
-  uint32_t hash_base() override;
   void dump_traits_(const char *tag);
 
   CallbackManager<void()> state_callback_{};

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -33,8 +33,6 @@ const char *cover_operation_to_str(CoverOperation op) {
 
 Cover::Cover(const std::string &name) : EntityBase(name), position{COVER_OPEN} {}
 
-uint32_t Cover::hash_base() { return 1727367479UL; }
-
 CoverCall::CoverCall(Cover *parent) : parent_(parent) {}
 CoverCall &CoverCall::set_command(const char *command) {
   if (strcasecmp(command, "OPEN") == 0) {

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -177,7 +177,6 @@ class Cover : public EntityBase {
   virtual std::string device_class();
 
   optional<CoverRestoreState> restore_state_();
-  uint32_t hash_base() override;
 
   CallbackManager<void()> state_callback_{};
   optional<std::string> device_class_override_{};

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -322,7 +322,6 @@ void ESP32Camera::update_camera_parameters() {
 }
 
 /* ---------------- Internal methods ---------------- */
-uint32_t ESP32Camera::hash_base() { return 3010542557UL; }
 bool ESP32Camera::has_requested_image_() const { return this->single_requesters_ || this->stream_requesters_; }
 bool ESP32Camera::can_return_image_() const { return this->current_image_.use_count() == 1; }
 void ESP32Camera::framebuffer_task(void *pv) {

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -151,7 +151,6 @@ class ESP32Camera : public Component, public EntityBase {
 
  protected:
   /* internal methods */
-  uint32_t hash_base() override;
   bool has_requested_image_() const;
   bool can_return_image_() const;
 

--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -152,7 +152,6 @@ void Fan::dump_traits_(const char *tag, const char *prefix) {
   if (this->get_traits().supports_direction())
     ESP_LOGCONFIG(tag, "%s  Direction: YES", prefix);
 }
-uint32_t Fan::hash_base() { return 418001110UL; }
 
 }  // namespace fan
 }  // namespace esphome

--- a/esphome/components/fan/fan.h
+++ b/esphome/components/fan/fan.h
@@ -136,7 +136,6 @@ class Fan : public EntityBase {
   void save_state_();
 
   void dump_traits_(const char *tag, const char *prefix);
-  uint32_t hash_base() override;
 
   CallbackManager<void()> state_callback_{};
   ESPPreferenceObject rtc_;

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -145,7 +145,6 @@ void LightState::loop() {
 }
 
 float LightState::get_setup_priority() const { return setup_priority::HARDWARE - 1.0f; }
-uint32_t LightState::hash_base() { return 1114400283; }
 
 void LightState::publish_state() { this->remote_values_callback_.call(); }
 

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -150,8 +150,6 @@ class LightState : public EntityBase, public Component {
   friend LightCall;
   friend class AddressableLight;
 
-  uint32_t hash_base() override;
-
   /// Internal method to start an effect with the given index
   void start_effect_(uint32_t effect_index);
   /// Internal method to get the currently active effect

--- a/esphome/components/lock/lock.cpp
+++ b/esphome/components/lock/lock.cpp
@@ -57,7 +57,6 @@ void Lock::publish_state(LockState state) {
 }
 
 void Lock::add_on_state_callback(std::function<void()> &&callback) { this->state_callback_.add(std::move(callback)); }
-uint32_t Lock::hash_base() { return 856245656UL; }
 
 void LockCall::perform() {
   ESP_LOGD(TAG, "'%s' - Setting", this->parent_->get_name().c_str());

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -167,8 +167,6 @@ class Lock : public EntityBase {
    */
   virtual void control(const LockCall &call) = 0;
 
-  uint32_t hash_base() override;
-
   CallbackManager<void()> state_callback_{};
   Deduplicator<LockState> publish_dedup_;
   ESPPreferenceObject rtc_;

--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -107,7 +107,6 @@ MediaPlayerCall &MediaPlayerCall::set_volume(float volume) {
 void MediaPlayer::add_on_state_callback(std::function<void()> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
-uint32_t MediaPlayer::hash_base() { return 1938496157UL; }
 
 void MediaPlayer::publish_state() { this->state_callback_.call(); }
 

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -82,7 +82,6 @@ class MediaPlayer : public EntityBase {
   friend MediaPlayerCall;
 
   virtual void control(const MediaPlayerCall &call) = 0;
-  uint32_t hash_base() override;
 
   CallbackManager<void()> state_callback_{};
 };

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -17,7 +17,5 @@ void Number::add_on_state_callback(std::function<void(float)> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 
-uint32_t Number::hash_base() { return 2282307003UL; }
-
 }  // namespace number
 }  // namespace esphome

--- a/esphome/components/number/number.h
+++ b/esphome/components/number/number.h
@@ -52,8 +52,6 @@ class Number : public EntityBase {
    */
   virtual void control(float value) = 0;
 
-  uint32_t hash_base() override;
-
   CallbackManager<void(float)> state_callback_;
   bool has_state_{false};
 };

--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -58,7 +58,5 @@ optional<std::string> Select::at(size_t index) const {
   }
 }
 
-uint32_t Select::hash_base() { return 2812997003UL; }
-
 }  // namespace select
 }  // namespace esphome

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -65,8 +65,6 @@ class Select : public EntityBase {
    */
   virtual void control(const std::string &value) = 0;
 
-  uint32_t hash_base() override;
-
   CallbackManager<void(std::string, size_t)> state_callback_;
   bool has_state_{false};
 };

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -126,7 +126,6 @@ void Sensor::internal_send_state_to_frontend(float state) {
   this->callback_.call(state);
 }
 bool Sensor::has_state() const { return this->has_state_; }
-uint32_t Sensor::hash_base() { return 2455723294UL; }
 
 }  // namespace sensor
 }  // namespace esphome

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -174,8 +174,6 @@ class Sensor : public EntityBase {
    */
   virtual StateClass state_class();  // NOLINT
 
-  uint32_t hash_base() override;
-
   CallbackManager<void(float)> raw_callback_;  ///< Storage for raw state callbacks.
   CallbackManager<void(float)> callback_;      ///< Storage for filtered state callbacks.
 

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -43,7 +43,6 @@ void Switch::add_on_state_callback(std::function<void(bool)> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 void Switch::set_inverted(bool inverted) { this->inverted_ = inverted; }
-uint32_t Switch::hash_base() { return 3129890955UL; }
 bool Switch::is_inverted() const { return this->inverted_; }
 
 std::string Switch::get_device_class() {

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -107,8 +107,6 @@ class Switch : public EntityBase {
    */
   virtual void write_state(bool state) = 0;
 
-  uint32_t hash_base() override;
-
   CallbackManager<void(bool)> state_callback_{};
   bool inverted_{false};
   Deduplicator<bool> publish_dedup_;

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -70,7 +70,6 @@ void TextSensor::internal_send_state_to_frontend(const std::string &state) {
 
 std::string TextSensor::unique_id() { return ""; }
 bool TextSensor::has_state() { return this->has_state_; }
-uint32_t TextSensor::hash_base() { return 334300109UL; }
 
 }  // namespace text_sensor
 }  // namespace esphome

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -59,8 +59,6 @@ class TextSensor : public EntityBase {
   void internal_send_state_to_frontend(const std::string &state);
 
  protected:
-  uint32_t hash_base() override;
-
   CallbackManager<void(std::string)> raw_callback_;  ///< Storage for raw state callbacks.
   CallbackManager<void(std::string)> callback_;      ///< Storage for filtered state callbacks.
 

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -46,7 +46,9 @@ class EntityBase {
   void set_icon(const std::string &name);
 
  protected:
-  virtual uint32_t hash_base() = 0;
+  /// The hash_base() function has been deprecated. It is kept in this
+  /// class for now, to prevent external components from not compiling.
+  virtual uint32_t hash_base() { return 0L; }
   void calc_object_id_();
 
   std::string name_;


### PR DESCRIPTION
# What does this implement/fix?

While the method `EntityBase::hash_base()` method has been implemented dutifully in many classes, it is actually never called in the code base. Let's save @jesserockz some work (quote from DIscord: "Man, I mashed my keyboard for random numbers for nothing 🤣"), by deprecating this code.

I left the `hash_base()` method in the `EntityBase`, but with an empty default implementation, instead of having it there as a pure virtual method that must be implemented by derived classes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
