### PR TITLE
support rotated ILI9341 (ILI9342)

### DIFF
--- a/esphome/components/ili9341/display.py
+++ b/esphome/components/ili9341/display.py
@@ -24,6 +24,7 @@ ili9341 = ili9341_ns.class_(
 )
 ILI9341M5Stack = ili9341_ns.class_("ILI9341M5Stack", ili9341)
 ILI9341TFT24 = ili9341_ns.class_("ILI9341TFT24", ili9341)
+ILI9341TFT24R = ili9341_ns.class_("ILI9341TFT24R", ili9341)
 
 ILI9341Model = ili9341_ns.enum("ILI9341Model")
 ILI9341ColorMode = ili9341_ns.enum("ILI9341ColorMode")
@@ -31,6 +32,7 @@ ILI9341ColorMode = ili9341_ns.enum("ILI9341ColorMode")
 MODELS = {
     "M5STACK": ILI9341Model.M5STACK,
     "TFT_2.4": ILI9341Model.TFT_24,
+    "TFT_2.4R": ILI9341Model.TFT_24R,
 }
 
 ILI9341_MODEL = cv.enum(MODELS, upper=True, space="_")
@@ -60,6 +62,8 @@ async def to_code(config):
         lcd_type = ILI9341M5Stack
     if config[CONF_MODEL] == "TFT_2.4":
         lcd_type = ILI9341TFT24
+    if config[CONF_MODEL] == "TFT_2.4R":
+        lcd_type = ILI9341TFT24R
     rhs = lcd_type.new()
     var = cg.Pvariable(config[CONF_ID], rhs)
 

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -263,5 +263,13 @@ void ILI9341TFT24::initialize() {
   this->fill_internal_(Color::BLACK);
 }
 
+//   24_TFT rotated display
+void ILI9341TFT24R::initialize() {
+  this->init_lcd_(INITCMD_TFT);
+  this->width_ = 320;
+  this->height_ = 240;
+  this->fill_internal_(Color::BLACK);
+}
+
 }  // namespace ili9341
 }  // namespace esphome

--- a/esphome/components/ili9341/ili9341_display.h
+++ b/esphome/components/ili9341/ili9341_display.h
@@ -12,6 +12,7 @@ namespace ili9341 {
 enum ILI9341Model {
   M5STACK = 0,
   TFT_24,
+  TFT_24R,
 };
 
 enum ILI9341ColorMode {
@@ -102,5 +103,12 @@ class ILI9341TFT24 : public ILI9341Display {
  public:
   void initialize() override;
 };
+
+//-----------   ILI9341_24_TFT rotated display --------------
+class ILI9341TFT24R : public ILI9341Display {
+ public:
+  void initialize() override;
+};
+
 }  // namespace ili9341
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the rotated ILI9341 which may be called ILI9342.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2943

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/2112

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: ili9341
    model: TFT_2.4R

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
