### PR TITLE
Fix modbus user-defined function handling

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -76,7 +76,12 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     // installed, but wait, there is the CRC, and if we get a hit there is a good
     // chance that this is a complete message ... admittedly there is a small chance is
     // isn't but that is quite small given the purpose of the CRC in the first place
-    data_len = at;
+
+    // Fewer than 2 bytes can't calc CRC
+    if (at < 2)
+      return true;
+
+    data_len = at - 2;
     data_offset = 1;
 
     uint16_t computed_crc = crc16(raw, data_offset + data_len);


### PR DESCRIPTION
# What does this implement/fix?

Modbus user-defined functions data length was incorrect leading to the handling system sometimes generating two outgoing messages to get the CRC match to work ... this only succeeded because the stl container implementation happened to reuse the same area of memory and therefore the second request happened to find the first request's CRC already in memory. It also sometime manifested as a function not being able to be processed at all.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

n/a

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
