### PR TITLE
Fix endless 'WiFi Unknown connection status 0' loop

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -555,6 +555,7 @@ void WiFiComponent::check_connecting_finished() {
   }
 
   ESP_LOGW(TAG, "WiFi Unknown connection status %d", (int) status);
+  this->retry_connect();
 }
 
 void WiFiComponent::retry_connect() {


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an endless loop in which the wifi component can end up after certain connection issues.
The behvior in the log from the related issue:

```
[17:33:13][W][wifi_esp32:495]: Event: Disconnected ssid='erykah' bssid=64:66:B3:ED:08:C4 reason='Association Expired'
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
[17:33:13][W][wifi:557]: WiFi Unknown connection status 0
```

My fix simply restarts the wifi connection flow when the device ends up in this state.
In my case, this retry did fix the connection state after two more failed tries. That is way better than having the `status 0` endless loop.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** (partly?) fixes [#3182](https://github.com/esphome/issues/issues/3182)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
