### PR TITLE
Fix sdp3x error checking

### DIFF
--- a/esphome/components/sdp3x/sdp3x.cpp
+++ b/esphome/components/sdp3x/sdp3x.cpp
@@ -40,7 +40,7 @@ void SDP3XComponent::setup() {
     }
 
     uint16_t data[6];
-    if (this->read_data(data, 6) != i2c::ERROR_OK) {
+    if (!this->read_data(data, 6)) {
       ESP_LOGE(TAG, "Read ID SDP3X failed!");
       this->mark_failed();
       return;
@@ -78,8 +78,7 @@ void SDP3XComponent::setup() {
       }
     }
 
-    if (this->write_command(measurement_mode_ == DP_AVG ? SDP3X_START_DP_AVG : SDP3X_START_MASS_FLOW_AVG) !=
-        i2c::ERROR_OK) {
+    if (!this->write_command(measurement_mode_ == DP_AVG ? SDP3X_START_DP_AVG : SDP3X_START_MASS_FLOW_AVG)) {
       ESP_LOGE(TAG, "Start Measurements SDP3X failed!");
       this->mark_failed();
       return;
@@ -98,7 +97,7 @@ void SDP3XComponent::dump_config() {
 
 void SDP3XComponent::read_pressure_() {
   uint16_t data[3];
-  if (this->read_data(data, 3) != i2c::ERROR_OK) {
+  if (!this->read_data(data, 3)) {
     ESP_LOGW(TAG, "Couldn't read SDP3X data!");
     this->status_set_warning();
     return;


### PR DESCRIPTION
# What does this implement/fix?

Some functions in the sdp3x component weren't updated to use the boolean return used by the new sensirion refactor.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [3310](https://github.com/esphome/issues/issues/3310)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - N/A Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
