### PR TITLE
Suppress first rotary encoder event

### DIFF
--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -103,7 +103,7 @@ void IRAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensorStore 
     rotation_dir = -1;
   }
 
-  if (rotation_dir != 0) {
+  if (rotation_dir != 0 && !arg->first_read) {
     auto *first_zero = std::find(arg->rotation_events.begin(), arg->rotation_events.end(), 0);  // find first zero
     if (first_zero == arg->rotation_events.begin()  // are we at the start (first event this loop iteration)
         || std::signbit(*std::prev(first_zero)) !=
@@ -119,6 +119,7 @@ void IRAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensorStore 
       *std::prev(first_zero) += rotation_dir;  // store the rotation into the previous slot
     }
   }
+  arg->first_read = false;
 
   arg->state = new_state;
 }

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -34,6 +34,7 @@ struct RotaryEncoderSensorStore {
   int32_t max_value{INT32_MAX};
   int32_t last_read{0};
   uint8_t state{0};
+  bool first_read{true};
 
   std::array<int8_t, 8> rotation_events{};
   bool rotation_events_overflow{false};


### PR DESCRIPTION
# What does this implement/fix?

When the rotary encoder initializes, it's in a counter-clockwise state, which is not really true since the encoder has not moved since boot. This causes a wrong behavior when rotating te encoder for the first time after boot. Halfway towards the next click (regardless of rotating cw or ccw), a counter-clockwise event is triggered.

When setting up a rotary encoder that simply logs rotation events, I see the following:

```
[10:32:49][D][main:422]: anti-clockwise    (rotating clockwise, halfway to the next click)
[10:32:49][D][main:416]: clockwise         (rotating clockwise, next click reached)
[10:32:51][D][main:416]: clockwise         (rotating clockwise, next click reached)
[10:32:51][D][main:416]: clockwise         (rotating clockwise, next click reached)
```

and

```
[10:33:08][D][main:422]: anti-clockwise   (rotating anti-clockwise, halfway to the next click)
[10:33:08][D][main:422]: anti-clockwise   (rotating anti-clockwise, next click reached)
[10:33:10][D][main:422]: anti-clockwise   (rotating anti-clockwise, next click reached)
```

This PR fixes the behavior by simply suppressing the first event.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: rotary_encoder
    pin_a:
      number: GPIO26
      mode: INPUT_PULLUP
    pin_b:
      number: GPIO27
      mode: INPUT_PULLUP
    on_clockwise:
      then:
        - logger.log: "clockwise"
    on_anticlockwise:
      then:
        - logger.log: "anti-clockwise"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
