### PR TITLE
publish fan speed count for discovery

### DIFF
--- a/esphome/components/mqtt/mqtt_fan.cpp
+++ b/esphome/components/mqtt/mqtt_fan.cpp
@@ -114,6 +114,7 @@ void MQTTFanComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig
   if (this->state_->get_traits().supports_speed()) {
     root[MQTT_PERCENTAGE_COMMAND_TOPIC] = this->get_speed_level_command_topic();
     root[MQTT_PERCENTAGE_STATE_TOPIC] = this->get_speed_level_state_topic();
+    root[MQTT_SPEED_RANGE_MAX] = this->state_->get_traits().supported_speed_count();
   }
 }
 bool MQTTFanComponent::publish_state() {


### PR DESCRIPTION
# What does this implement/fix?

This fixes fans accessed over mqtt.  It lets HA send speeds instead of percents.

## Types of changes

- [X Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
