### PR TITLE
Packages evaluation in the right order

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -1,7 +1,4 @@
-import logging
-
 import re
-from collections import OrderedDict
 from pathlib import Path
 from esphome.core import EsphomeError
 from esphome.config_helpers import merge_config
@@ -20,8 +17,6 @@ from esphome.const import (
 import esphome.config_validation as cv
 
 DOMAIN = CONF_PACKAGES
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def validate_git_package(config: dict):
@@ -140,17 +135,17 @@ def do_packages_pass(config: dict):
         return config
     packages = config[CONF_PACKAGES]
 
-    config_before_packages = OrderedDict()
-    config_after_packages = OrderedDict()
+    config_before_packages = config.copy()
+    config_after_packages = config.copy()
     packages_not_yet_hit = True
     for k, r in config.items():
         if k == CONF_PACKAGES:
             packages_not_yet_hit = False
             continue
         if packages_not_yet_hit:
-            config_before_packages[k] = r
+            config_after_packages.pop(k)
         else:
-            config_after_packages[k] = r
+            config_before_packages.pop(k)
 
     with cv.prepend_path(CONF_PACKAGES):
         packages = CONFIG_SCHEMA(packages)

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -139,19 +139,19 @@ def do_packages_pass(config: dict):
     if CONF_PACKAGES not in config:
         return config
     packages = config[CONF_PACKAGES]
-    
+
     config_before_packages = OrderedDict()
     config_after_packages = OrderedDict()
     packages_not_yet_hit = True
-    for k,r in config.items():
-      if k == CONF_PACKAGES:
-        packages_not_yet_hit = False
-        continue
-      if packages_not_yet_hit:
-        config_before_packages[k] = r
-      else:
-        config_after_packages[k] = r
-        
+    for k, r in config.items():
+        if k == CONF_PACKAGES:
+            packages_not_yet_hit = False
+            continue
+        if packages_not_yet_hit:
+            config_before_packages[k] = r
+        else:
+            config_after_packages[k] = r
+
     with cv.prepend_path(CONF_PACKAGES):
         packages = CONFIG_SCHEMA(packages)
 
@@ -170,5 +170,5 @@ def do_packages_pass(config: dict):
                 config_before_packages = merge_config(config_before_packages, recursive_package)
 
         config = merge_config(config_before_packages, config_after_packages)
-      
+
     return config

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -148,7 +148,7 @@ def do_packages_pass(config: dict):
                     package_config = _process_base_package(package_config)
                 if isinstance(package_config, dict):
                     recursive_package = do_packages_pass(package_config)
-                config = merge_config(recursive_package, config)
+                config = merge_config(config, recursive_package)
 
         del config[CONF_PACKAGES]
     return config

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -167,7 +167,9 @@ def do_packages_pass(config: dict):
                     package_config = _process_base_package(package_config)
                 if isinstance(package_config, dict):
                     recursive_package = do_packages_pass(package_config)
-                config_before_packages = merge_config(config_before_packages, recursive_package)
+                config_before_packages = merge_config(
+                    config_before_packages, recursive_package
+                )
 
         config = merge_config(config_before_packages, config_after_packages)
 

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -138,7 +138,8 @@ def do_packages_pass(config: dict):
     config_before_packages = config.copy()
     config_after_packages = config.copy()
     packages_not_yet_hit = True
-    for k, r in config.items():
+
+    for k in config.keys():
         if k == CONF_PACKAGES:
             packages_not_yet_hit = False
             continue


### PR DESCRIPTION
Packages evaluation in the right order esphome/issues#3354

# What does this implement/fix?

Package evaluation taking both existing config and subsequent packages into account.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/3354

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
```
[d1test_packages_test2.zip](https://github.com/esphome/esphome/files/8873334/d1test_packages_test2.zip)

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
