### PR TITLE
#3358 Correct temperature validity detection issue in some conditions of pu…

### DIFF
--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -134,7 +134,6 @@ void DallasComponent::update() {
         return;
       }
       if (!sensor->check_scratch_pad()) {
-        ESP_LOGW(TAG, "'%s' - Scratch pad invalid!", sensor->get_name().c_str());
         sensor->publish_state(NAN);
         this->status_set_warning();
         return;

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -243,9 +243,12 @@ bool DallasTemperatureSensor::check_scratch_pad() {
   bool chksum_validity = (crc8(this->scratch_pad_, 8) == this->scratch_pad_[8]);
   bool config_validity = false;
 
-  switch(this->get_address8()[0]) {
-    case DALLAS_MODEL_DS18B20: config_validity=((this->scratch_pad_[4] & 0x9F)==0x1F); break;
-    default: config_validity=((this->scratch_pad_[4] & 0x10)==0x10);
+  switch (this->get_address8()[0]) {
+    case DALLAS_MODEL_DS18B20:
+      config_validity = ((this->scratch_pad_[4] & 0x9F) == 0x1F);
+      break;
+    default:
+      config_validity = ((this->scratch_pad_[4] & 0x10) == 0x10);
   }
 
 #ifdef ESPHOME_LOG_LEVEL_VERY_VERBOSE
@@ -256,8 +259,7 @@ bool DallasTemperatureSensor::check_scratch_pad() {
 #endif
   if (!chksum_validity) {
     ESP_LOGW(TAG, "'%s' - Scratch pad checksum invalid!", this->get_name().c_str());
-  }
-  else if (!config_validity) {
+  } else if (!config_validity) {
     ESP_LOGW(TAG, "'%s' - Scratch pad config register invalid!", this->get_name().c_str());
   }
   return chksum_validity && config_validity;

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -241,21 +241,21 @@ bool DallasTemperatureSensor::setup_sensor() {
   return true;
 }
 bool DallasTemperatureSensor::check_scratch_pad() {
-  bool chksumValidity = (crc8(this->scratch_pad_, 8) == this->scratch_pad_[8]);
-  bool configValidity = ((this->scratch_pad_[4] & 0x9F)==0x1F);
+  bool chksum_validity = (crc8(this->scratch_pad_, 8) == this->scratch_pad_[8]);
+  bool config_validity = ((this->scratch_pad_[4] & 0x9F)==0x1F);
 #ifdef ESPHOME_LOG_LEVEL_VERY_VERBOSE
   ESP_LOGVV(TAG, "Scratch pad: %02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X (%02X)", this->scratch_pad_[0],
             this->scratch_pad_[1], this->scratch_pad_[2], this->scratch_pad_[3], this->scratch_pad_[4],
             this->scratch_pad_[5], this->scratch_pad_[6], this->scratch_pad_[7], this->scratch_pad_[8],
             crc8(this->scratch_pad_, 8));
 #endif
-  if (!chksumValidity) {
+  if (!chksum_validity) {
     ESP_LOGW(TAG, "'%s' - Scratch pad checksum invalid!", this->get_name().c_str());
   }
-  if (!configValidity) {
+  if (!config_validity) {
     ESP_LOGW(TAG, "'%s' - Scratch pad config register invalid!", this->get_name().c_str());
   }
-  return chksumValidity && configValidity;
+  return chksum_validity && config_validity;
 }
 float DallasTemperatureSensor::get_temp_c() {
   int16_t temp = (int16_t(this->scratch_pad_[1]) << 11) | (int16_t(this->scratch_pad_[0]) << 3);

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -257,7 +257,7 @@ bool DallasTemperatureSensor::check_scratch_pad() {
   if (!chksum_validity) {
     ESP_LOGW(TAG, "'%s' - Scratch pad checksum invalid!", this->get_name().c_str());
   }
-  if (!config_validity) {
+  else if (!config_validity) {
     ESP_LOGW(TAG, "'%s' - Scratch pad config register invalid!", this->get_name().c_str());
   }
   return chksum_validity && config_validity;

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -241,8 +241,8 @@ bool DallasTemperatureSensor::setup_sensor() {
   return true;
 }
 bool DallasTemperatureSensor::check_scratch_pad() {
-  bool chksumValidity=(crc8(this->scratch_pad_, 8) == this->scratch_pad_[8]);
-  bool configValidity=((this->scratch_pad_[4] & 0x9F)==0x1F);
+  bool chksumValidity = (crc8(this->scratch_pad_, 8) == this->scratch_pad_[8]);
+  bool configValidity = ((this->scratch_pad_[4] & 0x9F)==0x1F);
 #ifdef ESPHOME_LOG_LEVEL_VERY_VERBOSE
   ESP_LOGVV(TAG, "Scratch pad: %02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X (%02X)", this->scratch_pad_[0],
             this->scratch_pad_[1], this->scratch_pad_[2], this->scratch_pad_[3], this->scratch_pad_[4],

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -241,7 +241,13 @@ bool DallasTemperatureSensor::setup_sensor() {
 }
 bool DallasTemperatureSensor::check_scratch_pad() {
   bool chksum_validity = (crc8(this->scratch_pad_, 8) == this->scratch_pad_[8]);
-  bool config_validity = ((this->scratch_pad_[4] & 0x9F)==0x1F);
+  bool config_validity = false;
+
+  switch(this->get_address8()[0]) {
+    case DALLAS_MODEL_DS18B20: config_validity=((this->scratch_pad_[4] & 0x9F)==0x1F); break;
+    default: config_validity=((this->scratch_pad_[4] & 0x10)==0x10);
+  }
+
 #ifdef ESPHOME_LOG_LEVEL_VERY_VERBOSE
   ESP_LOGVV(TAG, "Scratch pad: %02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X (%02X)", this->scratch_pad_[0],
             this->scratch_pad_[1], this->scratch_pad_[2], this->scratch_pad_[3], this->scratch_pad_[4],


### PR DESCRIPTION
…ll up and wire length

# What does this implement/fix?

Improve scratchpad validity detection by checking config register content [(https://github.com/esphome/issues/issues/3358)]

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [(https://github.com/esphome/issues/issues/3358)]

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
 - platform: dallas
   name: "Sensor 1"
   address: 0xXX000000XXXXXX28


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
