### PR TITLE
Implement media player volume actions

### DIFF
--- a/esphome/components/i2s_audio/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/i2s_audio_media_player.cpp
@@ -55,7 +55,7 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         float new_volume = this->volume + 0.1f;
         if (new_volume > 1.0f)
           new_volume = 1.0f;
-        this->set_volume_(volume);
+        this->set_volume_(new_volume);
         this->unmute_();
         break;
       }
@@ -63,7 +63,7 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         float new_volume = this->volume - 0.1f;
         if (new_volume < 0.0f)
           new_volume = 0.0f;
-        this->set_volume_(volume);
+        this->set_volume_(new_volume);
         this->unmute_();
         break;
       }

--- a/esphome/components/i2s_audio/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/i2s_audio_media_player.cpp
@@ -51,6 +51,22 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
           this->state = media_player::MEDIA_PLAYER_STATE_PAUSED;
         }
         break;
+      case media_player::MEDIA_PLAYER_COMMAND_VOLUME_UP: {
+        float new_volume = this->volume + 0.1f;
+        if (new_volume > 1.0f)
+          new_volume = 1.0f;
+        this->set_volume_(volume);
+        this->unmute_();
+        break;
+      }
+      case media_player::MEDIA_PLAYER_COMMAND_VOLUME_DOWN: {
+        float new_volume = this->volume - 0.1f;
+        if (new_volume < 0.0f)
+          new_volume = 0.0f;
+        this->set_volume_(volume);
+        this->unmute_();
+        break;
+      }
     }
   }
   this->publish_state();

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -29,6 +29,17 @@ PauseAction = media_player_ns.class_(
 StopAction = media_player_ns.class_(
     "StopAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
+VolumeUpAction = media_player_ns.class_(
+    "VolumeUpAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+VolumeDownAction = media_player_ns.class_(
+    "VolumeDownAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+VolumeSetAction = media_player_ns.class_(
+    "VolumeSetAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+
+CONF_VOLUME = "volume"
 
 
 async def setup_media_player_core_(var, config):
@@ -45,9 +56,7 @@ async def register_media_player(var, config):
 MEDIA_PLAYER_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.Schema({}))
 
 
-MEDIA_PLAYER_ACTION_SCHEMA = maybe_simple_id(
-    {cv.Required(CONF_ID): cv.use_id(MediaPlayer)}
-)
+MEDIA_PLAYER_ACTION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(MediaPlayer)})
 
 
 @automation.register_action("media_player.play", PlayAction, MEDIA_PLAYER_ACTION_SCHEMA)
@@ -58,9 +67,34 @@ MEDIA_PLAYER_ACTION_SCHEMA = maybe_simple_id(
     "media_player.pause", PauseAction, MEDIA_PLAYER_ACTION_SCHEMA
 )
 @automation.register_action("media_player.stop", StopAction, MEDIA_PLAYER_ACTION_SCHEMA)
+@automation.register_action(
+    "media_player.volume_up", VolumeUpAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action(
+    "media_player.volume_down", VolumeDownAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
 async def media_player_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@automation.register_action(
+    "media_player.volume_set",
+    VolumeSetAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(MediaPlayer),
+            cv.Required(CONF_VOLUME): cv.templatable(cv.percentage),
+        },
+        key=CONF_VOLUME,
+    ),
+)
+async def media_player_volume_set_action(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    volume = await cg.templatable(config[CONF_VOLUME], args, float)
+    cg.add(var.set_volume(volume))
     return var
 
 

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -7,28 +7,23 @@ namespace esphome {
 
 namespace media_player {
 
-template<typename... Ts> class PlayAction : public Action<Ts...>, public Parented<MediaPlayer> {
-  void play(Ts... x) override {
-    this->parent_->make_call().set_command(MediaPlayerCommand::MEDIA_PLAYER_COMMAND_PLAY).perform();
-  }
-};
+#define MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(ACTION_CLASS, ACTION_COMMAND) \
+  template<typename... Ts> class ACTION_CLASS : public Action<Ts...>, public Parented<MediaPlayer> { \
+    void play(Ts... x) override { \
+      this->parent_->make_call().set_command(MediaPlayerCommand::MEDIA_PLAYER_COMMAND_##ACTION_COMMAND).perform(); \
+    } \
+  };
 
-template<typename... Ts> class ToggleAction : public Action<Ts...>, public Parented<MediaPlayer> {
-  void play(Ts... x) override {
-    this->parent_->make_call().set_command(MediaPlayerCommand::MEDIA_PLAYER_COMMAND_TOGGLE).perform();
-  }
-};
+MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(PlayAction, PLAY)
+MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(PauseAction, PAUSE)
+MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(StopAction, STOP)
+MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(ToggleAction, TOGGLE)
+MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(VolumeUpAction, VOLUME_UP)
+MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(VolumeDownAction, VOLUME_DOWN)
 
-template<typename... Ts> class PauseAction : public Action<Ts...>, public Parented<MediaPlayer> {
-  void play(Ts... x) override {
-    this->parent_->make_call().set_command(MediaPlayerCommand::MEDIA_PLAYER_COMMAND_PAUSE).perform();
-  }
-};
-
-template<typename... Ts> class StopAction : public Action<Ts...>, public Parented<MediaPlayer> {
-  void play(Ts... x) override {
-    this->parent_->make_call().set_command(MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP).perform();
-  }
+template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Parented<MediaPlayer> {
+  TEMPLATABLE_VALUE(float, volume)
+  void play(Ts... x) override { this->parent_->make_call().set_volume(this->volume_.value(x...)).perform(); }
 };
 
 }  // namespace media_player

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -20,7 +20,9 @@ enum MediaPlayerCommand : uint8_t {
   MEDIA_PLAYER_COMMAND_STOP = 2,
   MEDIA_PLAYER_COMMAND_MUTE = 3,
   MEDIA_PLAYER_COMMAND_UNMUTE = 4,
-  MEDIA_PLAYER_COMMAND_TOGGLE = 5
+  MEDIA_PLAYER_COMMAND_TOGGLE = 5,
+  MEDIA_PLAYER_COMMAND_VOLUME_UP = 6,
+  MEDIA_PLAYER_COMMAND_VOLUME_DOWN = 7,
 };
 const char *media_player_command_to_string(MediaPlayerCommand command);
 

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -604,6 +604,14 @@ touchscreen:
       - logger.log:
           format: Touch at (%d, %d)
           args: ["touch.x", "touch.y"]
+      - media_player.play:
+      - media_player.pause:
+      - media_player.stop:
+      - media_player.toggle:
+      - media_player.volume_up:
+      - media_player.volume_down:
+      - media_player.volume_set: 50%
+
 
 media_player:
   - platform: i2s_audio


### PR DESCRIPTION
# What does this implement/fix?

This adds `media_player.volume_up` / `media_player.volume_down` / `media_player.volume_set` actions.

This can be tested with
```yaml
external_components:
  - source: github://pr#3551
    components: [media_player, i2s_audio]
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
