### PR TITLE
Create basic ES8388 DAC amplifier component

### DIFF
--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -3,20 +3,13 @@ import esphome.config_validation as cv
 
 from esphome.components import i2c
 from esphome.const import CONF_ID
-from esphome import pins
 
 es8388_ns = cg.esphome_ns.namespace("es8388")
 ES8388Component = es8388_ns.class_("ES8388Component", cg.Component, i2c.I2CDevice)
 
-CONF_POWER_PIN = "power_pin"
 
 CONFIG_SCHEMA = (
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(ES8388Component),
-            cv.Required(CONF_POWER_PIN): pins.gpio_output_pin_schema,
-        }
-    )
+    cv.Schema({cv.GenerateID(): cv.declare_id(ES8388Component)})
     .extend(i2c.i2c_device_schema(0x10))
     .extend(cv.COMPONENT_SCHEMA)
 )
@@ -26,5 +19,3 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
-    pin = await cg.gpio_pin_expression(config[CONF_POWER_PIN])
-    cg.add(var.set_power_pin(pin))

--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+
+from esphome.components import i2c
+from esphome.const import CONF_ID
+from esphome import pins
+
+es8388_ns = cg.esphome_ns.namespace("es8388")
+ES8388Component = es8388_ns.class_("ES8388Component", cg.Component, i2c.I2CDevice)
+
+CONF_POWER_PIN = "power_pin"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ES8388Component),
+            cv.Required(CONF_POWER_PIN): pins.gpio_output_pin_schema,
+        }
+    )
+    .extend(i2c.i2c_device_schema(0x10))
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+    pin = await cg.gpio_pin_expression(config[CONF_POWER_PIN])
+    cg.add(var.set_power_pin(pin))

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -32,7 +32,7 @@ void ES8388Component::setup() {
   this->write_bytes(0x2A, {0x90});
   // DACLRC ADCLRC idem
   this->write_bytes(0x2B, {0x80});
-  this->write_bytes(0x2D, {0x00});
+  this->write_bytes(0x2D, {0x80});
   // DAC volume max
   this->write_bytes(0x1B, {0x00});
   this->write_bytes(0x1A, {0x00});

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -1,5 +1,7 @@
 #include "es8388_component.h"
 
+#include <soc/io_mux_reg.h>
+
 namespace esphome {
 namespace es8388 {
 

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -44,6 +44,9 @@ void ES8388Component::setup() {
   this->write_bytes(0x04, {0x30});
   // unmute
   this->write_bytes(0x19, {0x00});
+
+  this->write_bytes(0x2E, {33});
+  this->write_bytes(0x2F, {33});
 }
 }  // namespace es8388
 }  // namespace esphome

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -1,0 +1,55 @@
+#include "es8388_component.h"
+
+namespace esphome {
+namespace es8388 {
+
+void ES8388Component::setup() {
+  this->power_pin_->setup();
+  this->power_pin_->digital_write(false);
+
+  // reset
+  this->write_bytes(0x00, {0x80}, 1);
+  this->write_bytes(0x00, {0x00}, 1);
+  // mute
+  this->write_bytes(0x19, {0x04}, 1);
+  this->write_bytes(0x01, {0x50}, 1);
+  // powerup
+  this->write_bytes(0x02, {0x00}, 1);
+  // slave mode
+  this->write_bytes(0x08, {0x00}, 1);
+  // DAC powerdown
+  this->write_bytes(0x04, {0xC0}, 1);
+  // vmidsel/500k ADC/DAC idem
+  this->write_bytes(0x00, {0x12}, 1);
+
+  this->write_bytes(0x01, {0x00}, 1);
+  // i2s 16 bits
+  this->write_bytes(0x17, {0x18}, 1);
+  // sample freq 256
+  this->write_bytes(0x18, {0x02}, 1);
+  // LIN2/RIN2 for mixer
+  this->write_bytes(0x26, {0x09}, 1);
+  // left DAC to left mixer
+  this->write_bytes(0x27, {0x90}, 1);
+  // right DAC to right mixer
+  this->write_bytes(0x2A, {0x90}, 1);
+  // DACLRC ADCLRC idem
+  this->write_bytes(0x2B, {0x80}, 1);
+  this->write_bytes(0x2D, {0x00}, 1);
+  // DAC volume max
+  this->write_bytes(0x1B, {0x00}, 1);
+  this->write_bytes(0x1A, {0x00}, 1);
+
+  this->write_bytes(0x02, {0xF0}, 1);
+  this->write_bytes(0x02, {0x00}, 1);
+  this->write_bytes(0x1D, {0x1C}, 1);
+  // DAC power-up LOUT1/ROUT1 enabled
+  this->write_bytes(0x04, {0x30}, 1);
+  // unmute
+  this->write_bytes(0x19, {0x00}, 1);
+
+  // Turn on amplifier
+  this->power_pin_->digital_write(true);
+}
+}  // namespace es8388
+}  // namespace esphome

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -15,7 +15,7 @@ void ES8388Component::setup() {
   this->write_bytes(0x01, {0x50});
   // powerup
   this->write_bytes(0x02, {0x00});
-  // slave mode
+  // worker mode
   this->write_bytes(0x08, {0x00});
   // DAC powerdown
   this->write_bytes(0x04, {0xC0});

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -8,45 +8,45 @@ void ES8388Component::setup() {
   this->power_pin_->digital_write(false);
 
   // reset
-  this->write_bytes(0x00, {0x80}, 1);
-  this->write_bytes(0x00, {0x00}, 1);
+  this->write_bytes(0x00, {0x80});
+  this->write_bytes(0x00, {0x00});
   // mute
-  this->write_bytes(0x19, {0x04}, 1);
-  this->write_bytes(0x01, {0x50}, 1);
+  this->write_bytes(0x19, {0x04});
+  this->write_bytes(0x01, {0x50});
   // powerup
-  this->write_bytes(0x02, {0x00}, 1);
+  this->write_bytes(0x02, {0x00});
   // slave mode
-  this->write_bytes(0x08, {0x00}, 1);
+  this->write_bytes(0x08, {0x00});
   // DAC powerdown
-  this->write_bytes(0x04, {0xC0}, 1);
+  this->write_bytes(0x04, {0xC0});
   // vmidsel/500k ADC/DAC idem
-  this->write_bytes(0x00, {0x12}, 1);
+  this->write_bytes(0x00, {0x12});
 
-  this->write_bytes(0x01, {0x00}, 1);
+  this->write_bytes(0x01, {0x00});
   // i2s 16 bits
-  this->write_bytes(0x17, {0x18}, 1);
+  this->write_bytes(0x17, {0x18});
   // sample freq 256
-  this->write_bytes(0x18, {0x02}, 1);
+  this->write_bytes(0x18, {0x02});
   // LIN2/RIN2 for mixer
-  this->write_bytes(0x26, {0x09}, 1);
+  this->write_bytes(0x26, {0x09});
   // left DAC to left mixer
-  this->write_bytes(0x27, {0x90}, 1);
+  this->write_bytes(0x27, {0x90});
   // right DAC to right mixer
-  this->write_bytes(0x2A, {0x90}, 1);
+  this->write_bytes(0x2A, {0x90});
   // DACLRC ADCLRC idem
-  this->write_bytes(0x2B, {0x80}, 1);
-  this->write_bytes(0x2D, {0x00}, 1);
+  this->write_bytes(0x2B, {0x80});
+  this->write_bytes(0x2D, {0x00});
   // DAC volume max
-  this->write_bytes(0x1B, {0x00}, 1);
-  this->write_bytes(0x1A, {0x00}, 1);
+  this->write_bytes(0x1B, {0x00});
+  this->write_bytes(0x1A, {0x00});
 
-  this->write_bytes(0x02, {0xF0}, 1);
-  this->write_bytes(0x02, {0x00}, 1);
-  this->write_bytes(0x1D, {0x1C}, 1);
+  this->write_bytes(0x02, {0xF0});
+  this->write_bytes(0x02, {0x00});
+  this->write_bytes(0x1D, {0x1C});
   // DAC power-up LOUT1/ROUT1 enabled
-  this->write_bytes(0x04, {0x30}, 1);
+  this->write_bytes(0x04, {0x30});
   // unmute
-  this->write_bytes(0x19, {0x00}, 1);
+  this->write_bytes(0x19, {0x00});
 
   // Turn on amplifier
   this->power_pin_->digital_write(true);

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -4,6 +4,9 @@ namespace esphome {
 namespace es8388 {
 
 void ES8388Component::setup() {
+  PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+  WRITE_PERI_REG(PIN_CTRL, READ_PERI_REG(PIN_CTRL) & 0xFFFFFFF0);
+
   // reset
   this->write_bytes(0x00, {0x80});
   this->write_bytes(0x00, {0x00});

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -4,9 +4,6 @@ namespace esphome {
 namespace es8388 {
 
 void ES8388Component::setup() {
-  this->power_pin_->setup();
-  this->power_pin_->digital_write(false);
-
   // reset
   this->write_bytes(0x00, {0x80});
   this->write_bytes(0x00, {0x00});
@@ -47,9 +44,6 @@ void ES8388Component::setup() {
   this->write_bytes(0x04, {0x30});
   // unmute
   this->write_bytes(0x19, {0x00});
-
-  // Turn on amplifier
-  this->power_pin_->digital_write(true);
 }
 }  // namespace es8388
 }  // namespace esphome

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -1,4 +1,5 @@
 #include "es8388_component.h"
+#include "esphome/core/hal.h"
 
 #include <soc/io_mux_reg.h>
 
@@ -9,49 +10,66 @@ void ES8388Component::setup() {
   PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
   WRITE_PERI_REG(PIN_CTRL, READ_PERI_REG(PIN_CTRL) & 0xFFFFFFF0);
 
-  // reset
-  this->write_bytes(0x00, {0x80});
-  this->write_bytes(0x00, {0x00});
   // mute
-  this->write_bytes(0x19, {0x04});
-  this->write_bytes(0x01, {0x50});
+  this->write_byte(0x19, 0x04);
   // powerup
-  this->write_bytes(0x02, {0x00});
+  this->write_byte(0x01, 0x50);
+  this->write_byte(0x02, 0x00);
   // worker mode
-  this->write_bytes(0x08, {0x00});
+  this->write_byte(0x08, 0x00);
   // DAC powerdown
-  this->write_bytes(0x04, {0xC0});
+  this->write_byte(0x04, 0xC0);
   // vmidsel/500k ADC/DAC idem
-  this->write_bytes(0x00, {0x12});
+  this->write_byte(0x00, 0x12);
 
-  this->write_bytes(0x01, {0x00});
   // i2s 16 bits
-  this->write_bytes(0x17, {0x18});
+  this->write_byte(0x17, 0x18);
   // sample freq 256
-  this->write_bytes(0x18, {0x02});
+  this->write_byte(0x18, 0x02);
   // LIN2/RIN2 for mixer
-  this->write_bytes(0x26, {0x09});
+  this->write_byte(0x26, 0x00);
   // left DAC to left mixer
-  this->write_bytes(0x27, {0x90});
+  this->write_byte(0x27, 0x90);
   // right DAC to right mixer
-  this->write_bytes(0x2A, {0x90});
+  this->write_byte(0x2A, 0x90);
   // DACLRC ADCLRC idem
-  this->write_bytes(0x2B, {0x80});
-  this->write_bytes(0x2D, {0x80});
+  this->write_byte(0x2B, 0x80);
+  this->write_byte(0x2D, 0x00);
   // DAC volume max
-  this->write_bytes(0x1B, {0x00});
-  this->write_bytes(0x1A, {0x00});
+  this->write_byte(0x1B, 0x00);
+  this->write_byte(0x1A, 0x00);
 
-  this->write_bytes(0x02, {0xF0});
-  this->write_bytes(0x02, {0x00});
-  this->write_bytes(0x1D, {0x1C});
+  // ADC poweroff
+  this->write_byte(0x03, 0xFF);
+  // ADC amp 24dB
+  this->write_byte(0x09, 0x88);
+  // LINPUT1/RINPUT1
+  this->write_byte(0x0A, 0x00);
+  // ADC mono left
+  this->write_byte(0x0B, 0x02);
+  // i2S 16b
+  this->write_byte(0x0C, 0x0C);
+  // MCLK 256
+  this->write_byte(0x0D, 0x02);
+  // ADC Volume
+  this->write_byte(0x10, 0x00);
+  this->write_byte(0x11, 0x00);
+  // ALC OFF
+  this->write_byte(0x03, 0x09);
+  this->write_byte(0x2B, 0x80);
+
+  this->write_byte(0x02, 0xF0);
+  delay(1);
+  this->write_byte(0x02, 0x00);
   // DAC power-up LOUT1/ROUT1 enabled
-  this->write_bytes(0x04, {0x30});
+  this->write_byte(0x04, 0x30);
+  this->write_byte(0x03, 0x00);
+  // DAC volume max
+  this->write_byte(0x2E, 0x1C);
+  this->write_byte(0x2F, 0x1C);
   // unmute
-  this->write_bytes(0x19, {0x00});
-
-  this->write_bytes(0x2E, {33});
-  this->write_bytes(0x2F, {33});
+  this->write_byte(0x19, 0x00);
 }
+
 }  // namespace es8388
 }  // namespace esphome

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -2,7 +2,6 @@
 
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/component.h"
-#include "esphome/core/gpio.h"
 
 namespace esphome {
 namespace es8388 {
@@ -10,10 +9,6 @@ namespace es8388 {
 class ES8388Component : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
-  void set_power_pin(GPIOPin *pin) { this->power_pin_ = pin; }
-
- protected:
-  GPIOPin *power_pin_;
 };
 
 }  // namespace es8388

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -9,6 +9,8 @@ namespace es8388 {
 class ES8388Component : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
+
+  float get_setup_priority() const override { return setup_priority::LATE - 1; }
 };
 
 }  // namespace es8388

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/component.h"
+#include "esphome/core/gpio.h"
+
+namespace esphome {
+namespace es8388 {
+
+class ES8388Component : public Component, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void set_power_pin(GPIOPin *pin) { this->power_pin_ = pin; }
+
+ protected:
+  GPIOPin *power_pin_;
+};
+
+}  // namespace es8388
+}  // namespace esphome

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -718,4 +718,3 @@ voice_assistant:
         args: [code.c_str(), message.c_str()]
 
 es8388:
-  power_pin: GPIO21

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -716,3 +716,6 @@ voice_assistant:
     - logger.log:
         format: "Voice assistant error - code %s, message: %s"
         args: [code.c_str(), message.c_str()]
+
+es8388:
+  power_pin: GPIO21


### PR DESCRIPTION
# What does this implement/fix?

This is the DAC used in the Raspiaudio Muse Luxe, and this is a basic implementation which is specific to that device for now.


```yaml
external_components:
  - source: github://pr#3552
    components: [es8388]

es8388:
```


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
