### PR TITLE
Extend/override component configuration declared in packages #2

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -7,7 +7,6 @@ from esphome import git, yaml_util
 from esphome.const import (
     CONF_FILE,
     CONF_FILES,
-    CONF_ID,
     CONF_PACKAGES,
     CONF_REF,
     CONF_REFRESH,

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -7,6 +7,7 @@ from esphome import git, yaml_util
 from esphome.const import (
     CONF_FILE,
     CONF_FILES,
+    CONF_ID,
     CONF_PACKAGES,
     CONF_REF,
     CONF_REFRESH,

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -26,7 +26,7 @@ def read_config_file(path):
     return read_file(path)
 
 
-def merge_config(full_old, full_new):
+def merge_config(old, new):
     def merge_lists(old, new):
         # Merge list entries if CONF_ID is present and identical in both
         res = []
@@ -39,28 +39,25 @@ def merge_config(full_old, full_new):
         for v in new:
             if isinstance(v, dict) and CONF_ID in v and v[CONF_ID] in to_merge:
                 id = v[CONF_ID]
-                to_merge[id] = merge(to_merge[id], v)
+                to_merge[id] = merge_config(to_merge[id], v)
             else:
                 res.append(v)
         return res + list(to_merge.values())
 
-    def merge(old, new):
-        # pylint: disable=no-else-return
-        if isinstance(new, dict):
-            if not isinstance(old, dict):
-                return new
-            res = old.copy()
-            for k, v in new.items():
-                res[k] = merge(old[k], v) if k in old else v
-            return res
-        elif isinstance(new, list):
-            if isinstance(old, list):
-                return merge_lists(old, new)
+    # pylint: disable=no-else-return
+    if isinstance(new, dict):
+        if not isinstance(old, dict):
             return new
-
-        elif new is None:
-            return old
-
+        res = old.copy()
+        for k, v in new.items():
+            res[k] = merge_config(old[k], v) if k in old else v
+        return res
+    elif isinstance(new, list):
+        if isinstance(old, list):
+            return merge_lists(old, new)
         return new
 
-    return merge(full_old, full_new)
+    elif new is None:
+        return old
+
+    return new

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1,0 +1,264 @@
+"""Tests for the packages component."""
+
+import pytest
+
+
+from esphome.const import (
+    CONF_DOMAIN,
+    CONF_ESPHOME,
+    CONF_FILTERS,
+    CONF_ID,
+    CONF_MULTIPLY,
+    CONF_NAME,
+    CONF_OFFSET,
+    CONF_PACKAGES,
+    CONF_PASSWORD,
+    CONF_PLATFORM,
+    CONF_SENSOR,
+    CONF_SSID,
+    CONF_UPDATE_INTERVAL,
+    CONF_WIFI,
+)
+from esphome.components.packages import do_packages_pass
+import esphome.config_validation as cv
+
+# Test strings
+TEST_DEVICE_NAME = "test_device_name"
+TEST_PLATFORM = "test_platform"
+TEST_WIFI_SSID = "test_wifi_ssid"
+TEST_PACKAGE_WIFI_SSID = "test_package_wifi_ssid"
+TEST_PACKAGE_WIFI_PASSWORD = "test_package_wifi_password"
+TEST_DOMAIN = "test_domain_name"
+TEST_SENSOR_PLATFORM_1 = "test_sensor_platform_1"
+TEST_SENSOR_PLATFORM_2 = "test_sensor_platform_2"
+TEST_SENSOR_NAME_1 = "test_sensor_name_1"
+TEST_SENSOR_NAME_2 = "test_sensor_name_2"
+TEST_SENSOR_ID_1 = "test_sensor_id_1"
+TEST_SENSOR_ID_2 = "test_sensor_id_2"
+TEST_SENSOR_UPDATE_INTERVAL = "test_sensor_update_interval"
+
+
+@pytest.fixture(name="basic_wifi")
+def fixture_basic_wifi():
+    return {
+        CONF_SSID: TEST_PACKAGE_WIFI_SSID,
+        CONF_PASSWORD: TEST_PACKAGE_WIFI_PASSWORD,
+    }
+
+
+@pytest.fixture(name="basic_esphome")
+def fixture_basic_esphome():
+    return {CONF_NAME: TEST_DEVICE_NAME, CONF_PLATFORM: TEST_PLATFORM}
+
+
+def test_package_unused(basic_esphome, basic_wifi):
+    """
+    Ensures do_package_pass does not change a config if packages aren't used.
+    """
+    config = {CONF_ESPHOME: basic_esphome, CONF_WIFI: basic_wifi}
+
+    actual = do_packages_pass(config)
+    assert actual == config
+
+
+def test_package_invalid_dict(basic_esphome, basic_wifi):
+    """
+    Ensures an error is raised if packages is not valid.
+
+    """
+    config = {CONF_ESPHOME: basic_esphome, CONF_PACKAGES: basic_wifi}
+
+    with pytest.raises(cv.Invalid):
+        do_packages_pass(config)
+
+
+def test_package_include(basic_wifi, basic_esphome):
+    """
+    Tests the simple case where an independent config present in a package is added to the top-level config as is.
+
+    In this test, the CONF_WIFI config is expected to be simply added to the top-level config.
+    """
+    config = {
+        CONF_ESPHOME: basic_esphome,
+        CONF_PACKAGES: {"network": {CONF_WIFI: basic_wifi}},
+    }
+
+    expected = {CONF_ESPHOME: basic_esphome, CONF_WIFI: basic_wifi}
+
+    actual = do_packages_pass(config)
+    assert actual == expected
+
+
+def test_package_append(basic_wifi, basic_esphome):
+    """
+    Tests the case where a key is present in both a package and top-level config.
+
+    In this test, CONF_WIFI is defined in a package, and CONF_DOMAIN is added to it at the top level.
+    """
+    config = {
+        CONF_ESPHOME: basic_esphome,
+        CONF_PACKAGES: {"network": {CONF_WIFI: basic_wifi}},
+        CONF_WIFI: {CONF_DOMAIN: TEST_DOMAIN},
+    }
+
+    expected = {
+        CONF_ESPHOME: basic_esphome,
+        CONF_WIFI: {
+            CONF_SSID: TEST_PACKAGE_WIFI_SSID,
+            CONF_PASSWORD: TEST_PACKAGE_WIFI_PASSWORD,
+            CONF_DOMAIN: TEST_DOMAIN,
+        },
+    }
+
+    actual = do_packages_pass(config)
+    assert actual == expected
+
+
+def test_package_override(basic_wifi, basic_esphome):
+    """
+    Ensures that the top-level configuration takes precedence over duplicate keys defined in a package.
+
+    In this test, CONF_SSID should be overwritten by that defined in the top-level config.
+    """
+    config = {
+        CONF_ESPHOME: basic_esphome,
+        CONF_PACKAGES: {"network": {CONF_WIFI: basic_wifi}},
+        CONF_WIFI: {CONF_SSID: TEST_WIFI_SSID},
+    }
+
+    expected = {
+        CONF_ESPHOME: basic_esphome,
+        CONF_WIFI: {
+            CONF_SSID: TEST_WIFI_SSID,
+            CONF_PASSWORD: TEST_PACKAGE_WIFI_PASSWORD,
+        },
+    }
+
+    actual = do_packages_pass(config)
+    assert actual == expected
+
+
+def test_package_list_merge():
+    """
+    Ensures lists defined in both a package and the top-level config are merged correctly
+    """
+    config = {
+        CONF_PACKAGES: {
+            "package_sensors": {
+                CONF_SENSOR: [
+                    {
+                        CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
+                        CONF_NAME: TEST_SENSOR_NAME_1,
+                    },
+                    {
+                        CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
+                        CONF_NAME: TEST_SENSOR_NAME_2,
+                    },
+                ]
+            }
+        },
+        CONF_SENSOR: [
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_1},
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_2},
+        ],
+    }
+
+    expected = {
+        CONF_SENSOR: [
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_1, CONF_NAME: TEST_SENSOR_NAME_1},
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_1, CONF_NAME: TEST_SENSOR_NAME_2},
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_1},
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_2},
+        ]
+    }
+
+    actual = do_packages_pass(config)
+    assert actual == expected
+
+
+def test_package_list_merge_by_id():
+    """
+    Ensures that components with matching IDs are merged correctly.
+
+    In this test, a sensor is defined in a package, and a CONF_UPDATE_INTERVAL is added at the top level,
+    and a sensor name is overridden in another sensor.
+    """
+    config = {
+        CONF_PACKAGES: {
+            "package_sensors": {
+                CONF_SENSOR: [
+                    {
+                        CONF_ID: TEST_SENSOR_ID_1,
+                        CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
+                        CONF_NAME: TEST_SENSOR_NAME_1,
+                    },
+                    {
+                        CONF_ID: TEST_SENSOR_ID_2,
+                        CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
+                        CONF_NAME: TEST_SENSOR_NAME_2,
+                    },
+                ]
+            }
+        },
+        CONF_SENSOR: [
+            {
+                CONF_ID: TEST_SENSOR_ID_1,
+                CONF_UPDATE_INTERVAL: TEST_SENSOR_UPDATE_INTERVAL,
+            },
+            {CONF_ID: TEST_SENSOR_ID_2, CONF_NAME: TEST_SENSOR_NAME_1},
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_2},
+        ],
+    }
+
+    expected = {
+        CONF_SENSOR: [
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_2},
+            {
+                CONF_ID: TEST_SENSOR_ID_1,
+                CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
+                CONF_NAME: TEST_SENSOR_NAME_1,
+                CONF_UPDATE_INTERVAL: TEST_SENSOR_UPDATE_INTERVAL,
+            },
+            {
+                CONF_ID: TEST_SENSOR_ID_2,
+                CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
+                CONF_NAME: TEST_SENSOR_NAME_1,
+            },
+        ]
+    }
+
+    actual = do_packages_pass(config)
+    assert actual == expected
+
+
+def test_package_merge_by_id_with_list():
+    """
+    Ensures that components with matching IDs are merged correctly when their configuration contains lists.
+
+    For example, a sensor with filters defined in both a package and the top level config should be merged.
+    """
+
+    config = {
+        CONF_PACKAGES: {
+            "sensors": {
+                CONF_SENSOR: [
+                    {CONF_ID: TEST_SENSOR_ID_1, CONF_FILTERS: [{CONF_MULTIPLY: 42.0}]}
+                ]
+            }
+        },
+        CONF_SENSOR: [
+            {CONF_ID: TEST_SENSOR_ID_1, CONF_FILTERS: [{CONF_OFFSET: 146.0}]}
+        ],
+    }
+
+    expected = {
+        CONF_SENSOR: [
+            {
+                CONF_ID: TEST_SENSOR_ID_1,
+                CONF_FILTERS: [{CONF_MULTIPLY: 42.0}, {CONF_OFFSET: 146.0}],
+            }
+        ]
+    }
+
+    actual = do_packages_pass(config)
+    assert actual == expected

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -212,7 +212,6 @@ def test_package_list_merge_by_id():
 
     expected = {
         CONF_SENSOR: [
-            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_2},
             {
                 CONF_ID: TEST_SENSOR_ID_1,
                 CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
@@ -224,6 +223,7 @@ def test_package_list_merge_by_id():
                 CONF_PLATFORM: TEST_SENSOR_PLATFORM_1,
                 CONF_NAME: TEST_SENSOR_NAME_1,
             },
+            {CONF_PLATFORM: TEST_SENSOR_PLATFORM_2, CONF_NAME: TEST_SENSOR_NAME_2},
         ]
     }
 


### PR DESCRIPTION
# What does this implement/fix?

This combines #2264 and #3555 - credit goes to @quentinmit for the merge code and @paulmonigatti for the test

Adds the ability to override or extend package components by declaring a component with a matching ID in the main yaml file.

Example use case: The configuration package for an off-the-shelf power monitor/switch is declared by the manufacturer as a package file. The end user wants to implement a software-adjustable circuit breaker with minimal effort.

```yaml
# Example fancy-smart-switch.yaml
# Contains everything needed to operate as an off-the-shelf smart switch, as prepared by the manufacturer/community

esphome:
  name: $devicename
  platform: xx
  ...

sensor:
  - id: power_sensor
    platform: xx
    ...

switch:
  - id: relay
    platform: xx
    ...
```

```yaml
# Example my-circuit-breaker.yaml
substitutions:
  - devicename: real-safe-circuit-breaker

packages:
  network: !include common/network.yaml
  device: !include ots/fancy-smart-switch.yaml

sensor:
  - id: power_sensor
    on_value:
      - if:
          condition:
            lambda: return x > id(threshold).state;
          then:
            - switch.turn_off: relay

number:
  - platform: template
    id: threshold
    name: ${devicename}_breaker_threshold
    ...
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#1457 or esphome/esphome-docs#2126


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
