### PR TITLE
Add component for the input multiplexer cd74hc4051 on basis of the cd74hc5067

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,6 +41,7 @@ esphome/components/canbus/* @danielschramm @mvturnho
 esphome/components/cap1188/* @MrEditor97
 esphome/components/captive_portal/* @OttoWinter
 esphome/components/ccs811/* @habbie
+esphome/components/cd74hc4051/* @asoehlke @dj-bauer
 esphome/components/cd74hc4067/* @asoehlke
 esphome/components/climate/* @esphome/core
 esphome/components/climate_ir/* @glmnet

--- a/esphome/components/cd74hc4051/__init__.py
+++ b/esphome/components/cd74hc4051/__init__.py
@@ -1,0 +1,50 @@
+import esphome.codegen as cg
+from esphome import pins
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_DELAY,
+    CONF_ID,
+)
+
+AUTO_LOAD = ["sensor", "voltage_sampler"]
+CODEOWNERS = ["@asoehlke", "@dj-bauer"]
+MULTI_CONF = True
+
+cd74hc4051_ns = cg.esphome_ns.namespace("cd74hc4051")
+
+CD74HC4051Component = cd74hc4051_ns.class_(
+    "CD74HC4051Component", cg.Component, cg.PollingComponent
+)
+
+CONF_PIN_S0 = "pin_s0"
+CONF_PIN_S1 = "pin_s1"
+CONF_PIN_S2 = "pin_s2"
+
+DEFAULT_DELAY = "2ms"
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(CD74HC4051Component),
+        cv.Required(CONF_PIN_S0): pins.internal_gpio_output_pin_schema,
+        cv.Required(CONF_PIN_S1): pins.internal_gpio_output_pin_schema,
+        cv.Required(CONF_PIN_S2): pins.internal_gpio_output_pin_schema,
+        cv.Optional(
+            CONF_DELAY, default=DEFAULT_DELAY
+        ): cv.positive_time_period_milliseconds,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    pin_s0 = await cg.gpio_pin_expression(config[CONF_PIN_S0])
+    cg.add(var.set_pin_s0(pin_s0))
+    pin_s1 = await cg.gpio_pin_expression(config[CONF_PIN_S1])
+    cg.add(var.set_pin_s1(pin_s1))
+    pin_s2 = await cg.gpio_pin_expression(config[CONF_PIN_S2])
+    cg.add(var.set_pin_s2(pin_s2))
+
+    cg.add(var.set_switch_delay(config[CONF_DELAY]))

--- a/esphome/components/cd74hc4051/cd74hc4051.cpp
+++ b/esphome/components/cd74hc4051/cd74hc4051.cpp
@@ -25,7 +25,6 @@ void CD74HC4051Component::dump_config() {
   LOG_PIN("  S0 Pin: ", this->pin_s0_);
   LOG_PIN("  S1 Pin: ", this->pin_s1_);
   LOG_PIN("  S2 Pin: ", this->pin_s2_);
-  LOG_PIN("  S3 Pin: ", this->pin_s3_);
   ESP_LOGCONFIG(TAG, "switch delay: %d", this->switch_delay_);
 }
 

--- a/esphome/components/cd74hc4051/cd74hc4051.cpp
+++ b/esphome/components/cd74hc4051/cd74hc4051.cpp
@@ -33,7 +33,7 @@ void CD74HC4051Component::activate_pin(uint8_t pin) {
   if (this->active_pin_ != pin) {
     ESP_LOGD(TAG, "switch to input %d", pin);
 
-    static int mux_channel[16][4] = {
+    static int mux_channel[8][3] = {
         {0, 0, 0},  // channel 0
         {1, 0, 0},  // channel 1
         {0, 1, 0},  // channel 2

--- a/esphome/components/cd74hc4051/cd74hc4051.cpp
+++ b/esphome/components/cd74hc4051/cd74hc4051.cpp
@@ -1,0 +1,76 @@
+#include "cd74hc4051.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace cd74hc4051 {
+
+static const char *const TAG = "cd74hc4051";
+
+float CD74HC4051Component::get_setup_priority() const { return setup_priority::DATA; }
+
+void CD74HC4051Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up CD74HC4051...");
+
+  this->pin_s0_->setup();
+  this->pin_s1_->setup();
+  this->pin_s2_->setup();
+
+  // set other pin, so that activate_pin will really switch
+  this->active_pin_ = 1;
+  this->activate_pin(0);
+}
+
+void CD74HC4051Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "CD74HC4051 Multiplexer:");
+  LOG_PIN("  S0 Pin: ", this->pin_s0_);
+  LOG_PIN("  S1 Pin: ", this->pin_s1_);
+  LOG_PIN("  S2 Pin: ", this->pin_s2_);
+  LOG_PIN("  S3 Pin: ", this->pin_s3_);
+  ESP_LOGCONFIG(TAG, "switch delay: %d", this->switch_delay_);
+}
+
+void CD74HC4051Component::activate_pin(uint8_t pin) {
+  if (this->active_pin_ != pin) {
+    ESP_LOGD(TAG, "switch to input %d", pin);
+
+    static int mux_channel[16][4] = {
+        {0, 0, 0},  // channel 0
+        {1, 0, 0},  // channel 1
+        {0, 1, 0},  // channel 2
+        {1, 1, 0},  // channel 3
+        {0, 0, 1},  // channel 4
+        {1, 0, 1},  // channel 5
+        {0, 1, 1},  // channel 6
+        {1, 1, 1}  // channel 7
+    };
+    this->pin_s0_->digital_write(mux_channel[pin][0]);
+    this->pin_s1_->digital_write(mux_channel[pin][1]);
+    this->pin_s2_->digital_write(mux_channel[pin][2]);
+    // small delay is needed to let the multiplexer switch
+    delay(this->switch_delay_);
+    this->active_pin_ = pin;
+  }
+}
+
+CD74HC4051Sensor::CD74HC4051Sensor(CD74HC4051Component *parent) : parent_(parent) {}
+
+void CD74HC4051Sensor::update() {
+  float value_v = this->sample();
+  this->publish_state(value_v);
+}
+
+float CD74HC4051Sensor::get_setup_priority() const { return this->parent_->get_setup_priority() - 1.0f; }
+
+float CD74HC4051Sensor::sample() {
+  this->parent_->activate_pin(this->pin_);
+  return this->source_->sample();
+}
+
+void CD74HC4051Sensor::dump_config() {
+  LOG_SENSOR(TAG, "CD74HC4051 Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+}  // namespace cd74hc4051
+}  // namespace esphome

--- a/esphome/components/cd74hc4051/cd74hc4051.cpp
+++ b/esphome/components/cd74hc4051/cd74hc4051.cpp
@@ -40,7 +40,7 @@ void CD74HC4051Component::activate_pin(uint8_t pin) {
         {0, 0, 1},  // channel 4
         {1, 0, 1},  // channel 5
         {0, 1, 1},  // channel 6
-        {1, 1, 1}  // channel 7
+        {1, 1, 1}   // channel 7
     };
     this->pin_s0_->digital_write(mux_channel[pin][0]);
     this->pin_s1_->digital_write(mux_channel[pin][1]);

--- a/esphome/components/cd74hc4051/cd74hc4051.h
+++ b/esphome/components/cd74hc4051/cd74hc4051.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/voltage_sampler/voltage_sampler.h"
+
+namespace esphome {
+namespace cd74hc4051 {
+
+class CD74HC4051Component : public Component {
+ public:
+  /// Set up the internal sensor array.
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  /// setting pin active by setting the right combination of the four multiplexer input pins
+  void activate_pin(uint8_t pin);
+
+  /// set the pin connected to multiplexer control pin 0
+  void set_pin_s0(InternalGPIOPin *pin) { this->pin_s0_ = pin; }
+  /// set the pin connected to multiplexer control pin 1
+  void set_pin_s1(InternalGPIOPin *pin) { this->pin_s1_ = pin; }
+  /// set the pin connected to multiplexer control pin 2
+  void set_pin_s2(InternalGPIOPin *pin) { this->pin_s2_ = pin; }
+
+  /// set the delay needed after an input switch
+  void set_switch_delay(uint32_t switch_delay) { this->switch_delay_ = switch_delay; }
+
+ private:
+  InternalGPIOPin *pin_s0_;
+  InternalGPIOPin *pin_s1_;
+  InternalGPIOPin *pin_s2_;
+  /// the currently active pin
+  uint8_t active_pin_;
+  uint32_t switch_delay_;
+};
+
+class CD74HC4051Sensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
+ public:
+  CD74HC4051Sensor(CD74HC4051Component *parent);
+
+  void update() override;
+
+  void dump_config() override;
+  /// `HARDWARE_LATE` setup priority.
+  float get_setup_priority() const override;
+  void set_pin(uint8_t pin) { this->pin_ = pin; }
+  void set_source(voltage_sampler::VoltageSampler *source) { this->source_ = source; }
+
+  float sample() override;
+
+ protected:
+  CD74HC4051Component *parent_;
+  /// The sampling source to read values from.
+  voltage_sampler::VoltageSampler *source_;
+
+  uint8_t pin_;
+};
+}  // namespace cd74hc4041
+}  // namespace esphome

--- a/esphome/components/cd74hc4051/cd74hc4051.h
+++ b/esphome/components/cd74hc4051/cd74hc4051.h
@@ -58,5 +58,5 @@ class CD74HC4051Sensor : public sensor::Sensor, public PollingComponent, public 
 
   uint8_t pin_;
 };
-}  // namespace cd74hc4041
+}  // namespace cd74hc4051
 }  // namespace esphome

--- a/esphome/components/cd74hc4051/sensor.py
+++ b/esphome/components/cd74hc4051/sensor.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.GenerateID(CONF_CD74HC4051_ID): cv.use_id(CD74HC4051Component),
-            cv.Required(CONF_NUMBER): cv.int_range(0, 15),
+            cv.Required(CONF_NUMBER): cv.int_range(0, 7),
             cv.Required(CONF_SENSOR): cv.use_id(voltage_sampler.VoltageSampler),
         }
     )

--- a/esphome/components/cd74hc4051/sensor.py
+++ b/esphome/components/cd74hc4051/sensor.py
@@ -1,0 +1,55 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, voltage_sampler
+from esphome.const import (
+    CONF_ID,
+    CONF_SENSOR,
+    CONF_NUMBER,
+    ICON_FLASH,
+    UNIT_VOLT,
+    STATE_CLASS_MEASUREMENT,
+    DEVICE_CLASS_VOLTAGE,
+)
+from . import cd74hc4051_ns, CD74HC4051Component
+
+DEPENDENCIES = ["cd74hc4051"]
+
+CD74HC4051Sensor = cd74hc4051_ns.class_(
+    "CD74HC4051Sensor",
+    sensor.Sensor,
+    cg.PollingComponent,
+    voltage_sampler.VoltageSampler,
+)
+
+CONF_CD74HC4051_ID = "cd74hc4051_id"
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        CD74HC4051Sensor,
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=3,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        icon=ICON_FLASH,
+    )
+    .extend(
+        {
+            cv.GenerateID(CONF_CD74HC4051_ID): cv.use_id(CD74HC4051Component),
+            cv.Required(CONF_NUMBER): cv.int_range(0, 15),
+            cv.Required(CONF_SENSOR): cv.use_id(voltage_sampler.VoltageSampler),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_CD74HC4051_ID])
+
+    var = cg.new_Pvariable(config[CONF_ID], parent)
+    await sensor.register_sensor(var, config)
+    await cg.register_component(var, config)
+    cg.add(var.set_pin(config[CONF_NUMBER]))
+
+    sens = await cg.get_variable(config[CONF_SENSOR])
+    cg.add(var.set_source(sens))


### PR DESCRIPTION
# What does this implement/fix?
It basically copied the code from the 4067 16-bit multiplexer over to the 4051 8-bit multiplexer

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
cd74hc4051:
  - id: "sensors"
    pin_s0: GPIO0
    pin_s1: GPIO4
    pin_s2: GPIO5

sensor:
  - platform: adc
    id: adc_sensor
    update_interval: 60s
    internal: true
    pin: A0
  - platform: cd74hc4051
    sensor: adc_sensor
    name: "Analog value 0"
    update_interval: 60s
    number: 0
  - platform: cd74hc4051
    sensor: adc_sensor
    name: "Analog value 1"
    update_interval: 60s
    number: 1


```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
