### PR TITLE
Bm3xx: Fix typo

### DIFF
--- a/esphome/components/bmp3xx/sensor.py
+++ b/esphome/components/bmp3xx/sensor.py
@@ -25,7 +25,7 @@ OVERSAMPLING_OPTIONS = {
     "4X": Oversampling.OVERSAMPLING_X4,
     "8X": Oversampling.OVERSAMPLING_X8,
     "16X": Oversampling.OVERSAMPLING_X16,
-    "32x": Oversampling.OVERSAMPLING_X32,
+    "32X": Oversampling.OVERSAMPLING_X32,
 }
 
 IIRFilter = bmp3xx_ns.enum("IIRFilter")


### PR DESCRIPTION
Should be 32X in oversampling

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
