### PR TITLE
Add the possibility to transform strings for LCD displays

### DIFF
--- a/esphome/components/lcd_base/__init__.py
+++ b/esphome/components/lcd_base/__init__.py
@@ -4,6 +4,7 @@ from esphome.components import display
 from esphome.const import CONF_DIMENSIONS, CONF_POSITION, CONF_DATA
 
 CONF_USER_CHARACTERS = "user_characters"
+CONF_TRANSFORM = "transform"
 
 lcd_base_ns = cg.esphome_ns.namespace("lcd_base")
 LCDDisplay = lcd_base_ns.class_("LCDDisplay", cg.PollingComponent)
@@ -47,6 +48,7 @@ LCD_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
             cv.Length(max=8),
             validate_user_characters,
         ),
+        cv.Optional(CONF_TRANSFORM): cv.returning_lambda,
     }
 ).extend(cv.polling_component_schema("1s"))
 
@@ -58,3 +60,8 @@ async def setup_lcd_display(var, config):
     if CONF_USER_CHARACTERS in config:
         for usr in config[CONF_USER_CHARACTERS]:
             cg.add(var.set_user_defined_char(usr[CONF_POSITION], usr[CONF_DATA]))
+    if CONF_TRANSFORM in config:
+        lambda_ = await cg.process_lambda(
+            config[CONF_TRANSFORM], [(cg.std_string, "x")], return_type=cg.std_string
+        )
+        cg.add(var.set_transform(lambda_))

--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -117,10 +117,11 @@ void LCDDisplay::update() {
   this->display();
 }
 void LCDDisplay::command_(uint8_t value) { this->send(value, false); }
-void LCDDisplay::print(uint8_t column, uint8_t row, const char *str) {
+void LCDDisplay::print(uint8_t column, uint8_t row, const std::string &str) {
+  std::string print_str = this->transform_.has_value() ? this->transform_.value()(str) : str;
   uint8_t pos = column + row * this->columns_;
-  for (; *str != '\0'; str++) {
-    if (*str == '\n') {
+  for (auto it : print_str) {
+    if (it == '\n') {
       pos = ((pos / this->columns_) + 1) * this->columns_;
       continue;
     }
@@ -129,13 +130,13 @@ void LCDDisplay::print(uint8_t column, uint8_t row, const char *str) {
       break;
     }
 
-    this->buffer_[pos] = *reinterpret_cast<const uint8_t *>(str);
+    this->buffer_[pos] = static_cast<uint8_t>(it);
     pos++;
   }
 }
-void LCDDisplay::print(uint8_t column, uint8_t row, const std::string &str) { this->print(column, row, str.c_str()); }
-void LCDDisplay::print(const char *str) { this->print(0, 0, str); }
-void LCDDisplay::print(const std::string &str) { this->print(0, 0, str.c_str()); }
+void LCDDisplay::print(uint8_t column, uint8_t row, const char *str) { this->print(column, row, std::string(str)); }
+void LCDDisplay::print(const char *str) { this->print(0, 0, std::string(str)); }
+void LCDDisplay::print(const std::string &str) { this->print(0, 0, str); }
 void LCDDisplay::printf(uint8_t column, uint8_t row, const char *format, ...) {
   va_list arg;
   va_start(arg, format);

--- a/esphome/components/lcd_base/lcd_display.h
+++ b/esphome/components/lcd_base/lcd_display.h
@@ -14,6 +14,8 @@ namespace lcd_base {
 
 class LCDDisplay;
 
+using transform_function_t = std::function<std::string(const std::string &)>;
+
 class LCDDisplay : public PollingComponent {
  public:
   void set_dimensions(uint8_t columns, uint8_t rows) {
@@ -22,6 +24,7 @@ class LCDDisplay : public PollingComponent {
   }
 
   void set_user_defined_char(uint8_t pos, const std::vector<uint8_t> &data) { this->user_defined_chars_[pos] = data; }
+  void set_transform(transform_function_t &&transform) { this->transform_ = transform; }
 
   void setup() override;
   float get_setup_priority() const override;
@@ -66,6 +69,7 @@ class LCDDisplay : public PollingComponent {
   uint8_t rows_;
   uint8_t *buffer_{nullptr};
   std::map<uint8_t, std::vector<uint8_t> > user_defined_chars_;
+  optional<transform_function_t> transform_{};
 };
 
 }  // namespace lcd_base

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2257,6 +2257,8 @@ display:
           - 0b10001
           - 0b01110
           - 0b00000
+    transform: |-
+      return x;
     lambda: |-
       it.print("Hello World!");
     i2c_id: i2c_bus


### PR DESCRIPTION
# What does this implement/fix?

The LCD displays are produced with several ROM variants defining different character sets. On the other hand the native character encoding of the yaml configuration and most of code editors is UTF-8. An `it.printf("Temp %4.1f °C", id(temp).state);` lambda cannot be used as is.

The `transform` lambda allows the user to define a transformation function run immediately before the string is output to the LCD.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2134

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
display:
  - platform: lcd_pcf8574
    ...
    transform: |-
      std::string str = x;
      static const std::string degree = "°";
      for (size_t index = str.find(degree, 0);
          index != std::string::npos;
          index = str.find(degree, index + 1) )
        str.replace(index, degree.length(), "\xdf");
      return str;
    lambda: |-
      it.printf("Temp %4.1f °C", id(temp).state);
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
