### PR TITLE
Bugfix for ExternalRAMAllocator copy constructor

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -600,7 +600,7 @@ template<class T> class ExternalRAMAllocator {
 
   ExternalRAMAllocator() = default;
   ExternalRAMAllocator(Flags flags) : flags_{flags} {}
-  template<class U> constexpr ExternalRAMAllocator(const ExternalRAMAllocator<U> &other) : flags_{other.flags} {}
+  template<class U> constexpr ExternalRAMAllocator(const ExternalRAMAllocator<U> &other) : flags_{other.flags_} {}
 
   T *allocate(size_t n) {
     size_t size = n * sizeof(T);


### PR DESCRIPTION
# What does this implement/fix?

Fixes a typo that prevents usage of [ExternalRAMAllocator](https://github.com/esphome/esphome/commit/f336118eb47ce49d6befb8e6a376822f3ae3d201) copy constructor

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
