### PR TITLE
Remote NEC: 8-bit command

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -478,7 +478,7 @@ def nec_dumper(var, config):
 async def nec_action(var, config, args):
     template_ = await cg.templatable(config[CONF_ADDRESS], args, cg.uint16)
     cg.add(var.set_address(template_))
-    template_ = await cg.templatable(config[CONF_COMMAND], args, cg.uint16)
+    template_ = await cg.templatable(config[CONF_COMMAND], args, cg.uint8)
     cg.add(var.set_command(template_))
 
 

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -458,7 +458,8 @@ def nec_binary_sensor(var, config):
             cg.StructInitializer(
                 NECData,
                 ("address", config[CONF_ADDRESS]),
-                ("command", config[CONF_COMMAND]),
+                # 0xFF added for backward capability
+                ("command", config[CONF_COMMAND] & 0xFF),
             )
         )
     )

--- a/esphome/components/remote_base/nec_protocol.cpp
+++ b/esphome/components/remote_base/nec_protocol.cpp
@@ -6,68 +6,74 @@ namespace remote_base {
 
 static const char *const TAG = "remote.nec";
 
-static const uint32_t HEADER_HIGH_US = 9000;
-static const uint32_t HEADER_LOW_US = 4500;
-static const uint32_t BIT_HIGH_US = 560;
-static const uint32_t BIT_ONE_LOW_US = 1690;
-static const uint32_t BIT_ZERO_LOW_US = 560;
+static const int32_t NUM_ITEMS = 68;
+static const int32_t TICK_US = 560;
+static const int32_t HEADER_MARK_US = 16 * TICK_US;
+static const int32_t HEADER_SPACE_US = 8 * TICK_US;
+static const int32_t BIT_MARK_US = 1 * TICK_US;
+static const int32_t BIT_ONE_SPACE_US = 3 * TICK_US;
+static const int32_t BIT_ZERO_SPACE_US = 1 * TICK_US;
 
 void NECProtocol::encode(RemoteTransmitData *dst, const NECData &data) {
-  dst->reserve(68);
+  dst->reserve(NUM_ITEMS);
   dst->set_carrier_frequency(38000);
-
-  dst->item(HEADER_HIGH_US, HEADER_LOW_US);
-  for (uint16_t mask = 1; mask; mask <<= 1) {
-    if (data.address & mask) {
-      dst->item(BIT_HIGH_US, BIT_ONE_LOW_US);
-    } else {
-      dst->item(BIT_HIGH_US, BIT_ZERO_LOW_US);
-    }
-  }
-
-  for (uint16_t mask = 1; mask; mask <<= 1) {
-    if (data.command & mask) {
-      dst->item(BIT_HIGH_US, BIT_ONE_LOW_US);
-    } else {
-      dst->item(BIT_HIGH_US, BIT_ZERO_LOW_US);
-    }
-  }
-
-  dst->mark(BIT_HIGH_US);
+  // Header
+  dst->item(HEADER_MARK_US, HEADER_SPACE_US);
+  // Address
+  for (uint16_t mask = 1; mask; mask <<= 1)
+    dst->item(BIT_MARK_US, (data.address & mask) ? BIT_ONE_SPACE_US : BIT_ZERO_SPACE_US);
+  // Command
+  for (uint8_t mask = 1; mask; mask <<= 1)
+    dst->item(BIT_MARK_US, (data.command & mask) ? BIT_ONE_SPACE_US : BIT_ZERO_SPACE_US);
+  // ~Command
+  for (uint8_t mask = 1; mask; mask <<= 1)
+    dst->item(BIT_MARK_US, (data.command & mask) ? BIT_ZERO_SPACE_US : BIT_ONE_SPACE_US);
+  // Final
+  dst->mark(BIT_MARK_US);
 }
+
 optional<NECData> NECProtocol::decode(RemoteReceiveData src) {
   NECData data{
       .address = 0,
       .command = 0,
   };
-  if (!src.expect_item(HEADER_HIGH_US, HEADER_LOW_US))
+  if (src.size() != NUM_ITEMS)
     return {};
-
+  // Header
+  if (!src.expect_item(HEADER_MARK_US, HEADER_SPACE_US))
+    return {};
+  // Address
   for (uint16_t mask = 1; mask; mask <<= 1) {
-    if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
+    if (!src.expect_mark(BIT_MARK_US))
+      return {};
+    if (src.expect_space(BIT_ONE_SPACE_US)) {
       data.address |= mask;
-    } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
-      data.address &= ~mask;
-    } else {
+    } else if (!src.expect_space(BIT_ZERO_SPACE_US)) {
       return {};
     }
   }
-
-  for (uint16_t mask = 1; mask; mask <<= 1) {
-    if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
+  // Command
+  for (uint8_t mask = 1; mask; mask <<= 1) {
+    if (!src.expect_mark(BIT_MARK_US))
+      return {};
+    if (src.expect_space(BIT_ONE_SPACE_US)) {
       data.command |= mask;
-    } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
-      data.command &= ~mask;
-    } else {
+    } else if (!src.expect_space(BIT_ZERO_SPACE_US)) {
       return {};
     }
   }
-
-  src.expect_mark(BIT_HIGH_US);
+  // Check for inverse command
+  for (uint8_t mask = 1; mask; mask <<= 1) {
+    if (!src.expect_item(BIT_MARK_US, (data.command & mask) ? BIT_ZERO_SPACE_US : BIT_ONE_SPACE_US))
+      return {};
+  }
+  if (!src.expect_mark(BIT_MARK_US))
+    return {};
   return data;
 }
+
 void NECProtocol::dump(const NECData &data) {
-  ESP_LOGD(TAG, "Received NEC: address=0x%04X, command=0x%04X", data.address, data.command);
+  ESP_LOGD(TAG, "Received NEC: address=0x%04X, command=0x%02X", data.address, data.command);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/nec_protocol.h
+++ b/esphome/components/remote_base/nec_protocol.h
@@ -7,7 +7,7 @@ namespace remote_base {
 
 struct NECData {
   uint16_t address;
-  uint16_t command;
+  uint8_t command;
 
   bool operator==(const NECData &rhs) const { return address == rhs.address && command == rhs.command; }
 };
@@ -24,7 +24,7 @@ DECLARE_REMOTE_PROTOCOL(NEC)
 template<typename... Ts> class NECAction : public RemoteTransmitterActionBase<Ts...> {
  public:
   TEMPLATABLE_VALUE(uint16_t, address)
-  TEMPLATABLE_VALUE(uint16_t, command)
+  TEMPLATABLE_VALUE(uint8_t, command)
 
   void encode(RemoteTransmitData *dst, Ts... x) override {
     NECData data{};


### PR DESCRIPTION
# What does this implement/fix?

This change was prompted by this PR #3515 

Changes:

1. The command code has been changed to 8 bits. All protocol versions use 8 bit commands, while the next 8 bits are ALWAYS inverted.
2. The following additional decoding checks have been introduced: checking the total number of bits and inverting the last 8 bits of the command. This prevents a longer or erroneous bit sequence from being misinterpreted as an NEC protocol frame.
3. Backwards compatible with previous versions of ESPHome.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
