### PR TITLE
Move gas mbus config option being a define to being a build flag

### DIFF
--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -79,7 +79,7 @@ async def to_code(config):
     cg.add(var.set_request_interval(config[CONF_REQUEST_INTERVAL].total_milliseconds))
     cg.add(var.set_receive_timeout(config[CONF_RECEIVE_TIMEOUT].total_milliseconds))
 
-    cg.add_define("DSMR_GAS_MBUS_ID", config[CONF_GAS_MBUS_ID])
+    cg.add_build_flag("-DDSMR_GAS_MBUS_ID=" + str(config[CONF_GAS_MBUS_ID]))
 
     # DSMR Parser
     cg.add_library("glmnet/Dsmr", "0.5")


### PR DESCRIPTION
# What does this implement/fix?

DSMR config option for gas_mbus_id doesn't get compiled in (at least where it matters) since its not in the same scope with DSMR library define. DSMR library will use id 1 regardless of what is assigned to this config option. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/2517>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
no change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
