### PR TITLE
Media Player: added triggers

### DIFF
--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -38,15 +38,31 @@ VolumeDownAction = media_player_ns.class_(
 VolumeSetAction = media_player_ns.class_(
     "VolumeSetAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
-StateTrigger = media_player_ns.class_("StateTrigger", automation.Trigger.template())
 
 
 CONF_VOLUME = "volume"
+CONF_ON_IDLE = "on_idle"
+CONF_ON_PLAY = "on_play"
+CONF_ON_PAUSE = "on_pause"
+
+StateTrigger = media_player_ns.class_("StateTrigger", automation.Trigger.template())
+IdleTrigger = media_player_ns.class_("IdleTrigger", automation.Trigger.template())
+PlayTrigger = media_player_ns.class_("PlayTrigger", automation.Trigger.template())
+PauseTrigger = media_player_ns.class_("PauseTrigger", automation.Trigger.template())
 
 
 async def setup_media_player_core_(var, config):
     await setup_entity(var, config)
     for conf in config.get(CONF_ON_STATE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_IDLE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_PLAY, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_PAUSE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
 
@@ -63,6 +79,21 @@ MEDIA_PLAYER_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
         cv.Optional(CONF_ON_STATE): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(StateTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_IDLE): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(IdleTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_PLAY): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PlayTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_PAUSE): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PauseTrigger),
             }
         ),
     }

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -14,6 +14,17 @@ namespace media_player {
     } \
   };
 
+#define MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(TRIGGER_CLASS, TRIGGER_STATE) \
+  class TRIGGER_CLASS : public Trigger<> { \
+   public: \
+    TRIGGER_CLASS(MediaPlayer *player) { \
+      player->add_on_state_callback([this, player]() { \
+        if (player->state == MediaPlayerState::MEDIA_PLAYER_STATE_##TRIGGER_STATE) \
+          this->trigger(); \
+      }); \
+    } \
+  };
+
 MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(PlayAction, PLAY)
 MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(PauseAction, PAUSE)
 MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(StopAction, STOP)
@@ -32,6 +43,10 @@ class StateTrigger : public Trigger<> {
     player->add_on_state_callback([this]() { this->trigger(); });
   }
 };
+
+MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(IdleTrigger, IDLE)
+MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(PlayTrigger, PLAYING)
+MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(PauseTrigger, PAUSED)
 
 }  // namespace media_player
 }  // namespace esphome

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -26,5 +26,12 @@ template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Pa
   void play(Ts... x) override { this->parent_->make_call().set_volume(this->volume_.value(x...)).perform(); }
 };
 
+class StateTrigger : public Trigger<> {
+ public:
+  StateTrigger(MediaPlayer *player) {
+    player->add_on_state_callback([this]() { this->trigger(); });
+  }
+};
+
 }  // namespace media_player
 }  // namespace esphome

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -621,4 +621,3 @@ media_player:
       - media_player.volume_up:
       - media_player.volume_down:
       - media_player.volume_set: 50%
-  

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -615,8 +615,11 @@ media_player:
     mute_pin: GPIO14
     on_state:
       - media_player.play:
+    on_idle:
       - media_player.pause:
+    on_play:
       - media_player.stop:
+    on_pause:
       - media_player.toggle:
       - media_player.volume_up:
       - media_player.volume_down:

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -604,14 +604,6 @@ touchscreen:
       - logger.log:
           format: Touch at (%d, %d)
           args: ["touch.x", "touch.y"]
-      - media_player.play:
-      - media_player.pause:
-      - media_player.stop:
-      - media_player.toggle:
-      - media_player.volume_up:
-      - media_player.volume_down:
-      - media_player.volume_set: 50%
-
 
 media_player:
   - platform: i2s_audio
@@ -621,3 +613,12 @@ media_player:
     i2s_dout_pin: GPIO25
     i2s_bclk_pin: GPIO27
     mute_pin: GPIO14
+    on_state:
+      - media_player.play:
+      - media_player.pause:
+      - media_player.stop:
+      - media_player.toggle:
+      - media_player.volume_up:
+      - media_player.volume_down:
+      - media_player.volume_set: 50%
+  


### PR DESCRIPTION
# What does this implement/fix?

`on_state`, `on_idle`, `on_play`, `on_pause` triggers

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2142

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration entry
media_player:
  - platform: i2s_audio
    name: '${friendly_name}'
    mode: mono
    dac_type: external
    i2s_lrclk_pin: GPIO33
    i2s_dout_pin: GPIO27
    i2s_bclk_pin: GPIO26
    on_state:
      - light.turn_on:
          id: led_status
          flash_length: 50ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
