### PR TITLE
Add cg.with_local_variable

### DIFF
--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -22,6 +22,7 @@ from esphome.cpp_generator import (  # noqa
     static_const_array,
     statement,
     variable,
+    with_local_variable,
     new_variable,
     Pvariable,
     new_Pvariable,

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -332,8 +332,7 @@ def manual_ip(config):
     )
 
 
-def wifi_network(config, static_ip):
-    ap = cg.variable(config[CONF_ID], WiFiAP())
+def wifi_network(config, ap, static_ip):
     if CONF_SSID in config:
         cg.add(ap.set_ssid(config[CONF_SSID]))
     if CONF_PASSWORD in config:
@@ -360,14 +359,21 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_use_address(config[CONF_USE_ADDRESS]))
 
-    for network in config.get(CONF_NETWORKS, []):
+    def add_sta(ap, network):
         ip_config = network.get(CONF_MANUAL_IP, config.get(CONF_MANUAL_IP))
-        cg.add(var.add_sta(wifi_network(network, ip_config)))
+        cg.add(var.add_sta(wifi_network(network, ap, ip_config)))
+
+    for network in config.get(CONF_NETWORKS, []):
+        cg.with_local_variable(network[CONF_ID], WiFiAP(), add_sta, network)
 
     if CONF_AP in config:
         conf = config[CONF_AP]
         ip_config = conf.get(CONF_MANUAL_IP, config.get(CONF_MANUAL_IP))
-        cg.add(var.set_ap(wifi_network(conf, ip_config)))
+        cg.with_local_variable(
+            conf[CONF_ID],
+            WiFiAP(),
+            lambda ap: cg.add(var.set_ap(wifi_network(conf, ap, ip_config))),
+        )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
 
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))


### PR DESCRIPTION
# What does this implement/fix?

On projects with a large number of component instances such as the config in https://github.com/esphome/issues/issues/855, a stack overflow occurs on boot and the device enters a loop...

### I don't want to read all this! Gimme the solution now!
Until this PR is merged, try adding this to your configuration and see if it solves the problem:
```yaml
external_components:
  - source: github://epiclabs-uc/esphome@fix-885-old
    components: wifi 
    refresh: 0s
```
To support this PR, please report to this thread if this indeed fixed your issue.

So, as I was saying, ...
# What does this implement/fix?

On projects with a large number of component instances such as the config in https://github.com/esphome/issues/issues/855, a stack overflow occurs on boot and the device enters a loop.

The solution suggested in that thread is to increase the stack size to 32k which in my opinion works around the issue masking the root cause, but does not fix it.

After an in-depth investigation disassembling the output .elf and trying different configurations and every component one by one, I figured that due to some obscure compiler behavior, when the `wifi` component code generator instantiates  `wifi::WiFiAP wifi_wifiap` as a local variable, it causes the reserved stack frame for the `setup()` function to **grow in size proportionally to the size of the code in that function (!)** , which is proportional to the number of components in the configuration YAML.

The solution proposed here is simple: Instantiate `wifi::WiFiAP` as a local pointer variable, cleaning it up once the component is configured.

How to reproduce and verify this issue:

1. Take the config in issue 855 OP (https://github.com/esphome/issues/issues/855#issue-524128559) and add the following under `esphome:`:
```yaml
esphome:
  platformio_options:
    build_flags:
      - -Wframe-larger-than=100
```
This compiler flag will report any function whose stack frame exceeds 100 bytes. Many functions exceed 100 bytes of stack, but this will help us see the stack size of `setup()` 

2. Compile with `esphome compile config.yaml` 

Look for the following warning message (should be the last warning): 
```
config.yaml: In function 'void setup()':
config.yaml:717:1: warning: the frame size of 9040 bytes is larger than 100 bytes [-Wframe-larger-than=]
```
Note that an unwieldy stack frame of 9040 bytes was generated, which will immediately cause a stack overflow, since the default maximum is 8192 bytes.
For other configurations that have a resulting `setup()` stack frame of slightly lower than the default 8kB, you will also get a stack overflow bootlop the moment code hits the first `printf` (which is notorious for requiring a huge amount of free stack), most usually when the logger component is activated, but could also manifest itself randomly and drive you crazy. This was my case and what brought me here.

3. Now switch to this branch with the fix and compile again
Look for the following warning message (should be the last warning): 
```
config.yaml: In function 'void setup()':
config.yaml:717:1: warning: the frame size of 560 bytes is larger than 100 bytes [-Wframe-larger-than=]
```
Woah! the stack frame size is down to 560 bytes from 9040. Escapes me why the compiler behaves like this, if someone can enlighten me I would really appreciate it.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
fixes https://github.com/esphome/issues/issues/855
should also fix https://github.com/syssi/esphome-ant-bms/issues/36

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
You can use the `config.yaml` in 885's OP: https://github.com/esphome/issues/issues/855#issue-524128559