### PR TITLE
Media Player: added play_media action

### DIFF
--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -53,6 +53,8 @@ StateTrigger = media_player_ns.class_("StateTrigger", automation.Trigger.templat
 IdleTrigger = media_player_ns.class_("IdleTrigger", automation.Trigger.template())
 PlayTrigger = media_player_ns.class_("PlayTrigger", automation.Trigger.template())
 PauseTrigger = media_player_ns.class_("PauseTrigger", automation.Trigger.template())
+IsIdleCondition = media_player_ns.class_("IsIdleCondition", automation.Condition)
+IsPlayingCondition = media_player_ns.class_("IsPlayingCondition", automation.Condition)
 
 
 async def setup_media_player_core_(var, config):
@@ -139,6 +141,12 @@ async def media_player_play_media_action(config, action_id, template_arg, args):
 )
 @automation.register_action(
     "media_player.volume_down", VolumeDownAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_condition(
+    "media_player.is_idle", IsIdleCondition, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_condition(
+    "media_player.is_playing", IsPlayingCondition, MEDIA_PLAYER_ACTION_SCHEMA
 )
 async def media_player_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -20,6 +20,9 @@ MediaPlayer = media_player_ns.class_("MediaPlayer")
 PlayAction = media_player_ns.class_(
     "PlayAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
+PlayMediaAction = media_player_ns.class_(
+    "PlayMediaAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
 ToggleAction = media_player_ns.class_(
     "ToggleAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
@@ -44,6 +47,7 @@ CONF_VOLUME = "volume"
 CONF_ON_IDLE = "on_idle"
 CONF_ON_PLAY = "on_play"
 CONF_ON_PAUSE = "on_pause"
+CONF_MEDIA_URL = "media_url"
 
 StateTrigger = media_player_ns.class_("StateTrigger", automation.Trigger.template())
 IdleTrigger = media_player_ns.class_("IdleTrigger", automation.Trigger.template())
@@ -101,6 +105,25 @@ MEDIA_PLAYER_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
 
 
 MEDIA_PLAYER_ACTION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(MediaPlayer)})
+
+
+@automation.register_action(
+    "media_player.play_media",
+    PlayMediaAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(MediaPlayer),
+            cv.Required(CONF_MEDIA_URL): cv.templatable(cv.string_strict),
+        },
+        key=CONF_MEDIA_URL,
+    ),
+)
+async def media_player_play_media_action(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    media_url = await cg.templatable(config[CONF_MEDIA_URL], args, cg.std_string)
+    cg.add(var.set_media_url(media_url))
+    return var
 
 
 @automation.register_action("media_player.play", PlayAction, MEDIA_PLAYER_ACTION_SCHEMA)

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -115,7 +115,7 @@ MEDIA_PLAYER_ACTION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(MediaPl
     cv.maybe_simple_value(
         {
             cv.GenerateID(): cv.use_id(MediaPlayer),
-            cv.Required(CONF_MEDIA_URL): cv.templatable(cv.string_strict),
+            cv.Required(CONF_MEDIA_URL): cv.templatable(cv.url),
         },
         key=CONF_MEDIA_URL,
     ),

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -32,6 +32,11 @@ MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(ToggleAction, TOGGLE)
 MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(VolumeUpAction, VOLUME_UP)
 MEDIA_PLAYER_SIMPLE_COMMAND_ACTION(VolumeDownAction, VOLUME_DOWN)
 
+template<typename... Ts> class PlayMediaAction : public Action<Ts...>, public Parented<MediaPlayer> {
+  TEMPLATABLE_VALUE(std::string, media_url)
+  void play(Ts... x) override { this->parent_->make_call().set_media_url(this->media_url_.value(x...)).perform(); }
+};
+
 template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Parented<MediaPlayer> {
   TEMPLATABLE_VALUE(float, volume)
   void play(Ts... x) override { this->parent_->make_call().set_volume(this->volume_.value(x...)).perform(); }

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "esphome/core/automation.h"
+#include "esphome/core/base_automation.h"
 #include "media_player.h"
 
 namespace esphome {
@@ -17,7 +17,7 @@ namespace media_player {
 #define MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(TRIGGER_CLASS, TRIGGER_STATE) \
   class TRIGGER_CLASS : public Trigger<> { \
    public: \
-    TRIGGER_CLASS(MediaPlayer *player) { \
+    explicit TRIGGER_CLASS(MediaPlayer *player) { \
       player->add_on_state_callback([this, player]() { \
         if (player->state == MediaPlayerState::MEDIA_PLAYER_STATE_##TRIGGER_STATE) \
           this->trigger(); \
@@ -44,7 +44,7 @@ template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Pa
 
 class StateTrigger : public Trigger<> {
  public:
-  StateTrigger(MediaPlayer *player) {
+  explicit StateTrigger(MediaPlayer *player) {
     player->add_on_state_callback([this]() { this->trigger(); });
   }
 };
@@ -52,6 +52,16 @@ class StateTrigger : public Trigger<> {
 MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(IdleTrigger, IDLE)
 MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(PlayTrigger, PLAYING)
 MEDIA_PLAYER_SIMPLE_STATE_TRIGGER(PauseTrigger, PAUSED)
+
+template<typename... Ts> class IsIdleCondition : public Condition<Ts...>, public Parented<MediaPlayer> {
+ public:
+  bool check(Ts... x) override { return this->parent_->state == MediaPlayerState::MEDIA_PLAYER_STATE_IDLE; }
+};
+
+template<typename... Ts> class IsPlayingCondition : public Condition<Ts...>, public Parented<MediaPlayer> {
+ public:
+  bool check(Ts... x) override { return this->parent_->state == MediaPlayerState::MEDIA_PLAYER_STATE_PLAYING; }
+};
 
 }  // namespace media_player
 }  // namespace esphome

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "esphome/core/base_automation.h"
+#include "esphome/core/automation.h"
 #include "media_player.h"
 
 namespace esphome {

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -623,6 +623,10 @@ media_player:
       - media_player.stop:
     on_pause:
       - media_player.toggle:
+      - wait_until:
+          media_player.is_idle:
+      - wait_until:
+          media_player.is_playing:
       - media_player.volume_up:
       - media_player.volume_down:
       - media_player.volume_set: 50%

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -615,6 +615,8 @@ media_player:
     mute_pin: GPIO14
     on_state:
       - media_player.play:
+      - media_player.play_media: http://localhost/media.mp3
+      - media_player.play_media: !lambda 'return "http://localhost/media.mp3";'
     on_idle:
       - media_player.pause:
     on_play:


### PR DESCRIPTION
# What does this implement/fix?

`play_media` action
`is_playing`, `is_idle` conditions

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2145

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
    on_...:
      - media_player.play_media: http://localhost/media.mp3
      - wait_until:
            media_player.is_idle:
      - media_player.play_media: !lambda 'return "http://localhost/media.mp3";'
      - wait_until:
            media_player.is_idle:
      - media_player.play_media:
          id: player_id
          media_url: http://localhost/media.mp3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
