### PR TITLE
Fix: Make MQTT over TLS actually work

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -187,7 +187,7 @@ void MQTTClientComponent::start_connect_() {
 
   this->mqtt_backend_.set_credentials(username, password);
 
-  this->mqtt_backend_.set_server((uint32_t) this->ip_, this->credentials_.port);
+  this->mqtt_backend_.set_server(this->credentials_.address.c_str(), this->credentials_.port);
   if (!this->last_will_.topic.empty()) {
     this->mqtt_backend_.set_will(this->last_will_.topic.c_str(), this->last_will_.qos, this->last_will_.retain,
                                  this->last_will_.payload.c_str());


### PR DESCRIPTION
# What does this implement/fix?
Fix the TLS CN check of the MQTT component by passing the actual domain instead of its IP address.

## Types of changes
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** None (Maybe I'm the only one running esphome with TLS?)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not needed,
But I might open one later to report that MbedTLS, the library that does TLS for the underlying esp-idf,
doesn't like wildcard certificates.
The CN check works only if the CN is explicitly reported in the certificate.


mqtt.example.com -> OK
*.example.com -> KO

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# Notice the skip_cert_cn_check, finally can be set to false
mqtt:
  broker: mqtt.example.com
  port: 8883
  username: demo
  password: demo
  log_topic: demo/logs
  skip_cert_cn_check: false
  idf_send_async: false
  topic_prefix: demo
  certificate_authority: !secret isrgrootx1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
