### PR TITLE
Fix wrong type for voc_state*_ in sgp4x component

### DIFF
--- a/esphome/components/sgp4x/sensor.py
+++ b/esphome/components/sgp4x/sensor.py
@@ -139,6 +139,4 @@ async def to_code(config):
                     cfg[CONF_GAIN_FACTOR],
                 )
             )
-    cg.add_library(
-        None, None, "https://github.com/Sensirion/arduino-gas-index-algorithm.git"
-    )
+    cg.add_library("sensirion/Sensirion Gas Index Algorithm", "^3.2.1")

--- a/esphome/components/sgp4x/sensor.py
+++ b/esphome/components/sgp4x/sensor.py
@@ -139,4 +139,4 @@ async def to_code(config):
                     cfg[CONF_GAIN_FACTOR],
                 )
             )
-    cg.add_library("sensirion/Sensirion Gas Index Algorithm", "^3.2.1")
+    cg.add_library("sensirion/Sensirion Gas Index Algorithm", "3.2.1")

--- a/esphome/components/sgp4x/sensor.py
+++ b/esphome/components/sgp4x/sensor.py
@@ -139,4 +139,8 @@ async def to_code(config):
                     cfg[CONF_GAIN_FACTOR],
                 )
             )
-    cg.add_library("sensirion/Sensirion Gas Index Algorithm", "3.2.1")
+    cg.add_library(
+        None,
+        None,
+        "https://github.com/Sensirion/arduino-gas-index-algorithm.git#3.2.1",
+    )

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -170,8 +170,8 @@ bool SGP4xComponent::measure_gas_indices_(int32_t &voc, int32_t &nox) {
   // much
   if (this->store_baseline_ && this->seconds_since_last_store_ > SHORTEST_BASELINE_STORE_INTERVAL) {
     voc_algorithm_.get_states(this->voc_state0_, this->voc_state1_);
-    if ((uint32_t) abs(this->voc_baselines_storage_.state0 - this->voc_state0_) > MAXIMUM_STORAGE_DIFF ||
-        (uint32_t) abs(this->voc_baselines_storage_.state1 - this->voc_state1_) > MAXIMUM_STORAGE_DIFF) {
+    if (std::abs(this->voc_baselines_storage_.state0 - this->voc_state0_) > MAXIMUM_STORAGE_DIFF ||
+        std::abs(this->voc_baselines_storage_.state1 - this->voc_state1_) > MAXIMUM_STORAGE_DIFF) {
       this->seconds_since_last_store_ = 0;
       this->voc_baselines_storage_.state0 = this->voc_state0_;
       this->voc_baselines_storage_.state1 = this->voc_state1_;
@@ -234,8 +234,8 @@ bool SGP4xComponent::measure_raw_(uint16_t &voc_raw, uint16_t &nox_raw) {
       response_words = 2;
     }
   }
-  uint16_t rhticks = llround((uint16_t)((humidity * 65535) / 100));
-  uint16_t tempticks = (uint16_t)(((temperature + 45) * 65535) / 175);
+  uint16_t rhticks = llround((uint16_t) ((humidity * 65535) / 100));
+  uint16_t tempticks = (uint16_t) (((temperature + 45) * 65535) / 175);
   // first paramater are the relative humidity ticks
   data[0] = rhticks;
   // secomd paramater are the temperature ticks

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -234,8 +234,8 @@ bool SGP4xComponent::measure_raw_(uint16_t &voc_raw, uint16_t &nox_raw) {
       response_words = 2;
     }
   }
-  uint16_t rhticks = llround((uint16_t) ((humidity * 65535) / 100));
-  uint16_t tempticks = (uint16_t) (((temperature + 45) * 65535) / 175);
+  uint16_t rhticks = llround((uint16_t)((humidity * 65535) / 100));
+  uint16_t tempticks = (uint16_t)(((temperature + 45) * 65535) / 175);  
   // first paramater are the relative humidity ticks
   data[0] = rhticks;
   // secomd paramater are the temperature ticks

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -235,7 +235,7 @@ bool SGP4xComponent::measure_raw_(uint16_t &voc_raw, uint16_t &nox_raw) {
     }
   }
   uint16_t rhticks = llround((uint16_t)((humidity * 65535) / 100));
-  uint16_t tempticks = (uint16_t)(((temperature + 45) * 65535) / 175);  
+  uint16_t tempticks = (uint16_t)(((temperature + 45) * 65535) / 175);
   // first paramater are the relative humidity ticks
   data[0] = rhticks;
   // secomd paramater are the temperature ticks

--- a/esphome/components/sgp4x/sgp4x.h
+++ b/esphome/components/sgp4x/sgp4x.h
@@ -49,7 +49,7 @@ static const uint16_t SPG41_SELFTEST_TIME = 320;  // 320 ms for self test
 static const uint16_t SGP40_MEASURE_TIME = 30;
 static const uint16_t SGP41_MEASURE_TIME = 55;
 // Store anyway if the baseline difference exceeds the max storage diff value
-const uint32_t MAXIMUM_STORAGE_DIFF = 50.0;
+const float MAXIMUM_STORAGE_DIFF = 50.0f;
 
 class SGP4xComponent;
 

--- a/esphome/components/sgp4x/sgp4x.h
+++ b/esphome/components/sgp4x/sgp4x.h
@@ -49,7 +49,7 @@ static const uint16_t SPG41_SELFTEST_TIME = 320;  // 320 ms for self test
 static const uint16_t SGP40_MEASURE_TIME = 30;
 static const uint16_t SGP41_MEASURE_TIME = 55;
 // Store anyway if the baseline difference exceeds the max storage diff value
-const uint32_t MAXIMUM_STORAGE_DIFF = 50;
+const uint32_t MAXIMUM_STORAGE_DIFF = 50.0;
 
 class SGP4xComponent;
 

--- a/esphome/components/sgp4x/sgp4x.h
+++ b/esphome/components/sgp4x/sgp4x.h
@@ -120,8 +120,8 @@ class SGP4xComponent : public PollingComponent, public sensor::Sensor, public se
   sensor::Sensor *voc_sensor_{nullptr};
   VOCGasIndexAlgorithm voc_algorithm_;
   optional<GasTuning> voc_tuning_params_;
-  int32_t voc_state0_;
-  int32_t voc_state1_;
+  float voc_state0_;
+  float voc_state1_;
   int32_t voc_index_ = 0;
 
   sensor::Sensor *nox_sensor_{nullptr};

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,8 +39,7 @@ lib_deps =
     bblanchon/ArduinoJson@6.18.5           ; json
     wjtje/qr-code-generator-library@1.7.0  ; qr_code
     functionpointer/arduino-MLX90393@1.0.0 ; mlx90393
-    ; This is using the repository until a new release is published to PlatformIO
-    https://github.com/Sensirion/arduino-gas-index-algorithm.git ; Sensirion Gas Index Algorithm Arduino Library
+    sensirion/Sensirion Gas Index Algorithm@3.2.1
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE
 src_filter =

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,8 @@ lib_deps =
     bblanchon/ArduinoJson@6.18.5           ; json
     wjtje/qr-code-generator-library@1.7.0  ; qr_code
     functionpointer/arduino-MLX90393@1.0.0 ; mlx90393
-    sensirion/Sensirion Gas Index Algorithm@3.2.1
+    ; This is using the repository until a new release is published to PlatformIO
+    https://github.com/Sensirion/arduino-gas-index-algorithm.git#3.2.1 ; Sensirion Gas Index Algorithm Arduino Library
 build_flags =
     -DESPHOME_LOG_LEVEL=ESPHOME_LOG_LEVEL_VERY_VERBOSE
 src_filter =


### PR DESCRIPTION
# What does this implement/fix?

This fixes the compilation error in the spg4x component (esphome/issues/issues/3376). This is done by changing the types of voc_state0_ and voc_state1_ from int32_t to float, which is required for the get_states function from the <[Sensirion arduino gas index algorithm](https://github.com/Sensirion/arduino-gas-index-algorithm)> version 3.2.1. They committed a change on 16 June 2022 to use float types <[dbf2982](https://github.com/Sensirion/arduino-gas-index-algorithm/commit/dbf298208a9049454e0c4c80adf2efb1a21f45f9)>.
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <[link to issue](https://github.com/esphome/issues/issues/3376)>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: sgp4x
    voc:
      name: "VOC Index"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
