### PR TITLE
Add support for OpenHaystack

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -145,6 +145,7 @@ esphome/components/nextion/switch/* @senexcrenshaw
 esphome/components/nextion/text_sensor/* @senexcrenshaw
 esphome/components/nfc/* @jesserockz
 esphome/components/number/* @esphome/core
+esphome/components/openhaystack/* @SebastianBar
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core
 esphome/components/pid/* @OttoWinter

--- a/esphome/components/openhaystack/__init__.py
+++ b/esphome/components/openhaystack/__init__.py
@@ -1,0 +1,51 @@
+import base64
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_KEY
+from esphome.core import CORE
+from esphome.components.esp32 import add_idf_sdkconfig_option
+
+DEPENDENCIES = ["esp32"]
+CONFLICTS_WITH = ["esp32_ble_tracker", "esp32_ble_beacon"]
+
+openhaystack_ns = cg.esphome_ns.namespace("openhaystack")
+OpenHaystack = openhaystack_ns.class_("OpenHaystack", cg.Component)
+
+
+def _validate_key(value):
+    try:
+        key = base64.b64decode(value[CONF_KEY])
+        if len(key) != 28:
+            raise cv.Invalid(
+                "Invalid key size. Make sure you're using the base64 advertisement key."
+            )
+    except base64.binascii.Error as base64_error:
+        raise cv.Invalid(
+            "Invalid key. Make sure you're using the base64 advertisement key."
+        ) from base64_error
+
+    return value
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(OpenHaystack),
+            cv.Required(CONF_KEY): cv.string,
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    _validate_key,
+)
+
+
+async def to_code(config):
+    encoded_adv_pub_key = config[CONF_KEY]
+    adv_pub_key = base64.b64decode(encoded_adv_pub_key).hex()
+    adv_pub_key_arr = [
+        int(adv_pub_key[i : i + 2], 16) for i in range(0, len(adv_pub_key), 2)
+    ]
+    var = cg.new_Pvariable(config[CONF_ID], adv_pub_key_arr)
+    await cg.register_component(var, config)
+
+    if CORE.using_esp_idf:
+        add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)

--- a/esphome/components/openhaystack/__init__.py
+++ b/esphome/components/openhaystack/__init__.py
@@ -7,6 +7,7 @@ from esphome.components.esp32 import add_idf_sdkconfig_option
 
 DEPENDENCIES = ["esp32"]
 CONFLICTS_WITH = ["esp32_ble_tracker", "esp32_ble_beacon"]
+CODEOWNERS = ["@SebastianBar"]
 
 openhaystack_ns = cg.esphome_ns.namespace("openhaystack")
 OpenHaystack = openhaystack_ns.class_("OpenHaystack", cg.Component)

--- a/esphome/components/openhaystack/openhaystack.cpp
+++ b/esphome/components/openhaystack/openhaystack.cpp
@@ -1,0 +1,204 @@
+#include "openhaystack.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_ESP32
+
+#include <nvs_flash.h>
+#include <freertos/FreeRTOS.h>
+#include <esp_bt_main.h>
+#include <esp_bt.h>
+#include <freertos/task.h>
+#include <esp_gap_ble_api.h>
+#include <cstring>
+#include "esphome/core/hal.h"
+
+#ifdef USE_ARDUINO
+#include <esp32-hal-bt.h>
+#endif
+
+namespace esphome {
+namespace openhaystack {
+
+static const char *const TAG = "openhaystack";
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static esp_ble_adv_params_t ble_adv_params = {
+    .adv_int_min = 0x0640, // 1s
+    .adv_int_max = 0x0C80, // 2s
+    .adv_type = ADV_TYPE_NONCONN_IND,
+    .own_addr_type = BLE_ADDR_TYPE_RANDOM,
+    .peer_addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+    .peer_addr_type = BLE_ADDR_TYPE_PUBLIC,
+    .channel_map = ADV_CHNL_ALL,
+    .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+};
+
+void OpenHaystack::dump_config() {
+  ESP_LOGCONFIG(TAG, "OpenHaystack:");
+  ESP_LOGCONFIG(TAG,
+                "  Bluetooth MAC: %02X:%02X:%02X:%02X:%02X:%02X",
+                this->random_address_[0],
+                this->random_address_[1],
+                this->random_address_[2],
+                this->random_address_[3],
+                this->random_address_[4],
+                this->random_address_[5]
+  );
+  ESP_LOGCONFIG(TAG,
+                "  Advertising Key (first six digits): %02X %02X %02X %02X %02X %02X",
+                this->advertising_key_[0],
+                this->advertising_key_[1],
+                this->advertising_key_[2],
+                this->advertising_key_[3],
+                this->advertising_key_[4],
+                this->advertising_key_[5]
+  );
+}
+
+void OpenHaystack::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up OpenHaystack device...");
+  global_openhaystack = this;
+
+  xTaskCreatePinnedToCore(OpenHaystack::ble_core_task,
+                          "ble_task",  // name
+                          10000,       // stack size (in words)
+                          nullptr,     // input params
+                          1,           // priority
+                          nullptr,     // Handle, not needed
+                          0            // core
+  );
+}
+
+float OpenHaystack::get_setup_priority() const { return setup_priority::BLUETOOTH; }
+void OpenHaystack::ble_core_task(void *params) {
+  ble_setup();
+
+  while (true) {
+    delay(1000);  // NOLINT
+  }
+}
+
+void OpenHaystack::set_addr_from_key(esp_bd_addr_t addr, uint8_t *public_key) {
+  addr[0] = public_key[0] | 0b11000000;
+  addr[1] = public_key[1];
+  addr[2] = public_key[2];
+  addr[3] = public_key[3];
+  addr[4] = public_key[4];
+  addr[5] = public_key[5];
+}
+
+void OpenHaystack::set_payload_from_key(uint8_t *payload, uint8_t *public_key) {
+  /* copy last 22 bytes */
+  memcpy(&payload[7], &public_key[6], 22);
+  /* append two bits of public key */
+  payload[29] = public_key[0] >> 6;
+}
+
+void OpenHaystack::ble_setup() {
+  // Initialize non-volatile storage for the bluetooth controller
+  esp_err_t err = nvs_flash_init();
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "nvs_flash_init failed: %d", err);
+    return;
+  }
+
+#ifdef USE_ARDUINO
+  if (!btStart()) {
+    ESP_LOGE(TAG, "btStart failed: %d", esp_bt_controller_get_status());
+    return;
+  }
+#else
+  if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED) {
+    // start bt controller
+    if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE) {
+      esp_bt_controller_config_t cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+      err = esp_bt_controller_init(&cfg);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_bt_controller_init failed: %s", esp_err_to_name(err));
+        return;
+      }
+      while (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE)
+        ;
+    }
+    if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
+      err = esp_bt_controller_enable(ESP_BT_MODE_BLE);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_bt_controller_enable failed: %s", esp_err_to_name(err));
+        return;
+      }
+    }
+    if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED) {
+      ESP_LOGE(TAG, "esp bt controller enable failed");
+      return;
+    }
+  }
+#endif
+
+  esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+
+  err = esp_bluedroid_init();
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_bluedroid_init failed: %d", err);
+    return;
+  }
+  err = esp_bluedroid_enable();
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_bluedroid_enable failed: %d", err);
+    return;
+  }
+
+
+  set_addr_from_key(global_openhaystack->random_address_, global_openhaystack->advertising_key_.data());
+  set_payload_from_key(global_openhaystack->adv_data_, global_openhaystack->advertising_key_.data());
+
+  err = esp_ble_gap_register_callback(OpenHaystack::gap_event_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_ble_gap_register_callback failed: %d", err);
+    return;
+  }
+  err = esp_ble_gap_set_rand_addr(global_openhaystack->random_address_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_ble_gap_set_rand_addr failed: %s", esp_err_to_name(err));
+    return;
+  }
+
+  esp_ble_gap_config_adv_data_raw((uint8_t *) &global_openhaystack->adv_data_, sizeof(global_openhaystack->adv_data_));
+}
+
+void OpenHaystack::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+  esp_err_t err;
+  switch (event) {
+    case ESP_GAP_BLE_ADV_DATA_RAW_SET_COMPLETE_EVT: {
+      err = esp_ble_gap_start_advertising(&ble_adv_params);
+      if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_ble_gap_start_advertising failed: %d", err);
+      }
+      break;
+    }
+    case ESP_GAP_BLE_ADV_START_COMPLETE_EVT: {
+      err = param->adv_start_cmpl.status;
+      if (err != ESP_BT_STATUS_SUCCESS) {
+        ESP_LOGE(TAG, "BLE adv start failed: %s", esp_err_to_name(err));
+      }
+      break;
+    }
+    case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT: {
+      err = param->adv_start_cmpl.status;
+      if (err != ESP_BT_STATUS_SUCCESS) {
+        ESP_LOGE(TAG, "BLE adv stop failed: %s", esp_err_to_name(err));
+      } else {
+        ESP_LOGD(TAG, "BLE stopped advertising successfully");
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+OpenHaystack *global_openhaystack = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+}  // namespace openhaystack
+}  // namespace esphome
+
+#endif

--- a/esphome/components/openhaystack/openhaystack.cpp
+++ b/esphome/components/openhaystack/openhaystack.cpp
@@ -134,7 +134,6 @@ void OpenHaystack::ble_setup() {
     return;
   }
 
-
   set_addr_from_key(global_openhaystack->random_address_, global_openhaystack->advertising_key_.data());
   set_payload_from_key(global_openhaystack->adv_data_, global_openhaystack->advertising_key_.data());
 

--- a/esphome/components/openhaystack/openhaystack.cpp
+++ b/esphome/components/openhaystack/openhaystack.cpp
@@ -23,8 +23,8 @@ static const char *const TAG = "openhaystack";
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static esp_ble_adv_params_t ble_adv_params = {
-    .adv_int_min = 0x0640, // 1s
-    .adv_int_max = 0x0C80, // 2s
+    .adv_int_min = 0x0640,  // 1s
+    .adv_int_max = 0x0C80,  // 2s
     .adv_type = ADV_TYPE_NONCONN_IND,
     .own_addr_type = BLE_ADDR_TYPE_RANDOM,
     .peer_addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
@@ -35,24 +35,12 @@ static esp_ble_adv_params_t ble_adv_params = {
 
 void OpenHaystack::dump_config() {
   ESP_LOGCONFIG(TAG, "OpenHaystack:");
-  ESP_LOGCONFIG(TAG,
-                "  Bluetooth MAC: %02X:%02X:%02X:%02X:%02X:%02X",
-                this->random_address_[0],
-                this->random_address_[1],
-                this->random_address_[2],
-                this->random_address_[3],
-                this->random_address_[4],
-                this->random_address_[5]
-  );
-  ESP_LOGCONFIG(TAG,
-                "  Advertising Key (first six digits): %02X %02X %02X %02X %02X %02X",
-                this->advertising_key_[0],
-                this->advertising_key_[1],
-                this->advertising_key_[2],
-                this->advertising_key_[3],
-                this->advertising_key_[4],
-                this->advertising_key_[5]
-  );
+  ESP_LOGCONFIG(TAG, "  Bluetooth MAC: %02X:%02X:%02X:%02X:%02X:%02X", this->random_address_[0],
+                this->random_address_[1], this->random_address_[2], this->random_address_[3], this->random_address_[4],
+                this->random_address_[5]);
+  ESP_LOGCONFIG(TAG, "  Advertising Key (first six digits): %02X %02X %02X %02X %02X %02X", this->advertising_key_[0],
+                this->advertising_key_[1], this->advertising_key_[2], this->advertising_key_[3],
+                this->advertising_key_[4], this->advertising_key_[5]);
 }
 
 void OpenHaystack::setup() {
@@ -78,7 +66,7 @@ void OpenHaystack::ble_core_task(void *params) {
   }
 }
 
-void OpenHaystack::set_addr_from_key(esp_bd_addr_t addr, uint8_t *public_key) {
+void OpenHaystack::set_addr_from_key(esp_bd_addr_t addr, const uint8_t *public_key) {
   addr[0] = public_key[0] | 0b11000000;
   addr[1] = public_key[1];
   addr[2] = public_key[2];
@@ -101,7 +89,6 @@ void OpenHaystack::ble_setup() {
     ESP_LOGE(TAG, "nvs_flash_init failed: %d", err);
     return;
   }
-
 #ifdef USE_ARDUINO
   if (!btStart()) {
     ESP_LOGE(TAG, "btStart failed: %d", esp_bt_controller_get_status());

--- a/esphome/components/openhaystack/openhaystack.h
+++ b/esphome/components/openhaystack/openhaystack.h
@@ -24,9 +24,8 @@ class OpenHaystack : public Component {
   static void set_payload_from_key(uint8_t *payload, uint8_t *public_key);
   static void ble_setup();
 
-
   std::array<uint8_t, 28> advertising_key_;
-  esp_bd_addr_t random_address_ = { 0xFF, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+  esp_bd_addr_t random_address_ = {0xFF, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
   uint8_t adv_data_[31] = {
       0x1e,       /* Length (30) */
       0xff,       /* Manufacturer Specific Data (type 0xff) */

--- a/esphome/components/openhaystack/openhaystack.h
+++ b/esphome/components/openhaystack/openhaystack.h
@@ -20,7 +20,7 @@ class OpenHaystack : public Component {
  protected:
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
   static void ble_core_task(void *params);
-  static void set_addr_from_key(esp_bd_addr_t addr, uint8_t *public_key);
+  static void set_addr_from_key(esp_bd_addr_t addr, const uint8_t *public_key);
   static void set_payload_from_key(uint8_t *payload, uint8_t *public_key);
   static void ble_setup();
 
@@ -28,16 +28,14 @@ class OpenHaystack : public Component {
   std::array<uint8_t, 28> advertising_key_;
   esp_bd_addr_t random_address_ = { 0xFF, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
   uint8_t adv_data_[31] = {
-    0x1e, /* Length (30) */
-    0xff, /* Manufacturer Specific Data (type 0xff) */
-    0x4c, 0x00, /* Company ID (Apple) */
-    0x12, 0x19, /* Offline Finding type and length */
-    0x00, /* State */
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, /* First two bits */
-    0x00, /* Hint (0x00) */
+      0x1e,       /* Length (30) */
+      0xff,       /* Manufacturer Specific Data (type 0xff) */
+      0x4c, 0x00, /* Company ID (Apple) */
+      0x12, 0x19, /* Offline Finding type and length */
+      0x00,       /* State */
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* First two bits */
+      0x00,                                                             /* Hint (0x00) */
   };
 };
 

--- a/esphome/components/openhaystack/openhaystack.h
+++ b/esphome/components/openhaystack/openhaystack.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "esphome/core/component.h"
+
+#ifdef USE_ESP32
+
+#include <esp_gap_ble_api.h>
+
+namespace esphome {
+namespace openhaystack {
+
+class OpenHaystack : public Component {
+ public:
+  explicit OpenHaystack(const std::array<uint8_t, 28> &advertising_key) : advertising_key_(advertising_key) {}
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+ protected:
+  static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
+  static void ble_core_task(void *params);
+  static void set_addr_from_key(esp_bd_addr_t addr, uint8_t *public_key);
+  static void set_payload_from_key(uint8_t *payload, uint8_t *public_key);
+  static void ble_setup();
+
+
+  std::array<uint8_t, 28> advertising_key_;
+  esp_bd_addr_t random_address_ = { 0xFF, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+  uint8_t adv_data_[31] = {
+    0x1e, /* Length (30) */
+    0xff, /* Manufacturer Specific Data (type 0xff) */
+    0x4c, 0x00, /* Company ID (Apple) */
+    0x12, 0x19, /* Offline Finding type and length */
+    0x00, /* State */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, /* First two bits */
+    0x00, /* Hint (0x00) */
+  };
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern OpenHaystack *global_openhaystack;
+
+}  // namespace openhaystack
+}  // namespace esphome
+
+#endif


### PR DESCRIPTION
# What does this implement/fix?

Add support for [OpenHaystack](https://github.com/seemoo-lab/openhaystack). Basically porting the logic as an ESPHome component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** None.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2146

## Test Environment

- [x] ESP32 (`wemos_d1_mini32`)
- [x] ESP32 IDF (`wemos_d1_mini32`, `esp32-c3-devkitm-1`)
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
external_components:
  - source: github://pr#3584
    components: [openhaystack]

openhaystack:
  key: <OpenHaystack key>

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
