### PR TITLE
Fix / Reverse order shutdown

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -125,17 +125,24 @@ void IRAM_ATTR HOT Application::feed_wdt() {
 }
 void Application::reboot() {
   ESP_LOGI(TAG, "Forcing a reboot...");
-  for (auto *comp : this->components_)
-    comp->on_shutdown();
+  for (auto it = this->components_.rbegin(); it != this->components_.rend(); ++it) {
+    (*it)->on_shutdown();
+  }
   arch_restart();
 }
 void Application::safe_reboot() {
   ESP_LOGI(TAG, "Rebooting safely...");
-  for (auto *comp : this->components_)
-    comp->on_safe_shutdown();
-  for (auto *comp : this->components_)
-    comp->on_shutdown();
+  run_safe_shutdown_hooks();
   arch_restart();
+}
+
+void Application::run_safe_shutdown_hooks() {
+  for (auto it = this->components_.rbegin(); it != this->components_.rend(); ++it) {
+    (*it)->on_safe_shutdown();
+  }
+  for (auto it = this->components_.rbegin(); it != this->components_.rend(); ++it) {
+    (*it)->on_shutdown();
+  }
 }
 
 void Application::calculate_looping_components_() {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -161,14 +161,7 @@ class Application {
 
   void safe_reboot();
 
-  void run_safe_shutdown_hooks() {
-    for (auto *comp : this->components_) {
-      comp->on_safe_shutdown();
-    }
-    for (auto *comp : this->components_) {
-      comp->on_shutdown();
-    }
-  }
+  void run_safe_shutdown_hooks();
 
   uint32_t get_app_state() const { return this->app_state_; }
 


### PR DESCRIPTION
# What does this implement/fix?
This change changes the shutdown order to reverse.
After `setup` the components are ordered in the vector based on their setup priority. Performing the shutdown in the same order could lead to dependency issues. E.g. shutting down `preferenes` (performing last sync) before the last _restoring_ sensor / variable has had their value written.

Required for: #3586 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
