### PR TITLE
RestoringGlobalsComponent: Store value on shutdown

### DIFF
--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -45,6 +45,17 @@ template<typename T> class RestoringGlobalsComponent : public Component {
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
   void loop() override {
+    store_value();
+  }
+
+  void on_shutdown() override {
+    store_value();
+  }
+
+  void set_name_hash(uint32_t name_hash) { this->name_hash_ = name_hash; }
+
+ protected:
+  void store_value() {
     int diff = memcmp(&this->value_, &this->prev_value_, sizeof(T));
     if (diff != 0) {
       this->rtc_.save(&this->value_);
@@ -52,9 +63,6 @@ template<typename T> class RestoringGlobalsComponent : public Component {
     }
   }
 
-  void set_name_hash(uint32_t name_hash) { this->name_hash_ = name_hash; }
-
- protected:
   T value_{};
   T prev_value_{};
   uint32_t name_hash_{};

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -44,18 +44,14 @@ template<typename T> class RestoringGlobalsComponent : public Component {
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  void loop() override {
-    store_value();
-  }
+  void loop() override { store_value_(); }
 
-  void on_shutdown() override {
-    store_value();
-  }
+  void on_shutdown() override { store_value_(); }
 
   void set_name_hash(uint32_t name_hash) { this->name_hash_ = name_hash; }
 
  protected:
-  void store_value() {
+  void store_value_() {
     int diff = memcmp(&this->value_, &this->prev_value_, sizeof(T));
     if (diff != 0) {
       this->rtc_.save(&this->value_);


### PR DESCRIPTION
# What does this implement/fix?

This change will ensure the last value of a `RestoringGlobalsComponent` is stored to flash before shutdown is called. For example when in a lambda a value is stored right before `App.reboot();` is called.

Requires PR #3585 to work propperly!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
...

globals:
  - id: failure_restart_count
    type: uint32_t
    initial_value: '0'
    restore_value: yes

logger:
  on_message:
    level: WARN
    then:
      - lambda: |-
          static uint8_t failure_count = 0;
          if(strstr(message, "cirtical failure")) {
            failure_count++;
          }
          if (failure_count >= 5) {
            id(failure_restart_count) += 1;
            delay(250);  // NOLINT
            App.safe_reboot();
          }
...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
