### PR TITLE
Upgrade rweather/Crypto from 0.2.0 to 0.4.0

### DIFF
--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -85,4 +85,4 @@ async def to_code(config):
     cg.add_library("glmnet/Dsmr", "0.5")
 
     # Crypto
-    cg.add_library("rweather/Crypto", "0.2.0")
+    cg.add_library("rweather/Crypto", "0.4.0")

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,7 @@ lib_deps =
     mikalhart/TinyGPSPlus@1.0.2                           ; gps
     freekode/TM1651@1.0.1                                 ; tm1651
     glmnet/Dsmr@0.5                                       ; dsmr
-    rweather/Crypto@0.2.0                                 ; dsmr
+    rweather/Crypto@0.4.0                                 ; dsmr
     dudanov/MideaUART@1.1.8                               ; midea
     tonia/HeatpumpIR@1.0.20                               ; heatpumpir
 build_flags =


### PR DESCRIPTION
# What does this implement/fix?

This fixes esphome/issues#3392 by upgrading `rweather/Crypto` from 0.2.0 to 0.4.0 (the latest release as of this date).

Not only does it solve the compiler issue, but I've also tested it on the actual hardware (ESP32 connecting to Dutch Smart Meter) and it works like a charm.

Fortunately, the DSMR component seems to be the only one that depends on `rweather/Crypto`, fortunately making this a relatively simple fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#3392

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml
esp32:
  board: frogboard
  framework:
    type: arduino
    version: 2.0.3
    platform_version: 4.4.0

# ... snip common config, like device name, wifi parameters, etc.

dsmr:
  uart_id: uart_dsmr
  request_interval: 5s

uart:
  id: uart_dsmr
  baud_rate: 115200
  rx_pin:
    number: GPIO21
    inverted: true
  rx_buffer_size: 1700

sensor:
  - platform: dsmr
    energy_delivered_tariff1:
      name: Energieverbruik Laagtarief
    energy_delivered_tariff2:
      name: Energieverbruik Hoogtarief
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
