### PR TITLE
Fix panic abort when BLEClient reconnects

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -100,9 +100,15 @@ void ESP32BLETracker::loop() {
           found = true;
           if (client->state() == ClientState::DISCOVERED) {
             esp_ble_gap_stop_scanning();
+#ifdef USE_ARDUINO
             if (xSemaphoreTake(this->scan_end_lock_, 10L / portTICK_PERIOD_MS)) {
               xSemaphoreGive(this->scan_end_lock_);
             }
+#else
+            if (xSemaphoreTake(this->scan_end_lock_, 0L)) {
+              xSemaphoreGive(this->scan_end_lock_);
+            }
+#endif
           }
         }
       }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -101,14 +101,13 @@ void ESP32BLETracker::loop() {
           if (client->state() == ClientState::DISCOVERED) {
             esp_ble_gap_stop_scanning();
 #ifdef USE_ARDUINO
-            if (xSemaphoreTake(this->scan_end_lock_, 10L / portTICK_PERIOD_MS)) {
-              xSemaphoreGive(this->scan_end_lock_);
-            }
+            constexpr TickType_t block_time = 10L / portTICK_PERIOD_MS;
 #else
-            if (xSemaphoreTake(this->scan_end_lock_, 0L)) {
+            constexpr TickType_t block_time = 0L;  // PR #3594
+#endif
+            if (xSemaphoreTake(this->scan_end_lock_, block_time)) {
               xSemaphoreGive(this->scan_end_lock_);
             }
-#endif
           }
         }
       }


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes crash when BLEClient disabled and enabled again with log message:
```assert failed: vTaskPriorityDisinheritAfterTimeout tasks.c:4751 (pxTCB != pxCurrentTCB[xPortGetCoreID()])```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3327

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
