### PR TITLE
fix EDict to dict mapping in helpers.py

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -296,7 +296,7 @@ _TYPE_OVERLOADS = {
     int: type("EInt", (int,), {}),
     float: type("EFloat", (float,), {}),
     str: type("EStr", (str,), {}),
-    dict: type("EDict", (str,), {}),
+    dict: type("EDict", (dict,), {}),
     list: type("EList", (list,), {}),
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Small typo in `helpers.py` maps the wrong types

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
