### PR TITLE
Fix slow_pwm output glitch

### DIFF
--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -42,12 +42,12 @@ void SlowPWMOutput::loop() {
   uint32_t now = millis();
   float scaled_state = this->state_ * this->period_;
 
-  if (now >= this->period_start_time_ + this->period_) {
+  if (now - this->period_start_time_ >= this->period_) {
     ESP_LOGVV(TAG, "End of period. State: %f, Scaled state: %f", this->state_, scaled_state);
     this->period_start_time_ += this->period_;
   }
 
-  this->set_output_state_(now < this->period_start_time_ + scaled_state);
+  this->set_output_state_(scaled_state > now - this->period_start_time_);
 }
 
 void SlowPWMOutput::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

A problem with slow_pwm was apparently introduced by https://github.com/esphome/esphome/pull/3004 into espHome 2022.2, file esphome/components/slow_pwm/slow_pwm_output.cpp. The code was changed to improved readability, but in doing so an issue has been introduced which only becomes apparent after several hours running.

When the slow_pwm output is set to 100% it would be expected to remain 'On' at all time. Initially this is the case, but after several hours running the output switches 'Off' briefly near the end of the period. Over time the problem becomes worse, with the output apparently flickering 'On' and 'Off' at random. The issue first occurs after approx 4 hours 40 mins of uptime (possibly as the millisecond counter passes 2^24 = 16777216 and can no longer be accurately represented by a float?).

This PR partially reversed PR#3004 to revert two of the ms timestamp comparissions. 

The original pre PR#3004 code was written to follow the guidance given in this article, which explains how this type of issue can be avoided. The code introduced by PR#3004 introduced exactly the issue that this article warns about:
[https://www.norwegiancreations.com/2018/10/arduino-tutorial-avoiding-the-overflow-issue-when-using-millis-and-micros/](url)

This PR has been tested with the millisecond count being initialised to zero and to 1 day (86400000). It has also been tested with the millisecond count set to just below the rollover value (0xFFFFFFFF - 60) to verify that the rollover does not cause a glitch on the output.

There is an opportunity to further improve the slow_pwm code by removing the use of a float variable from the comparissons. However, I feel that the risk of introducing another unintended problem is greater than any benefit at this time. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3393

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```
output:
  - platform: slow_pwm
    id: power_led_pwm
    period: 4s
    restart_cycle_on_state_change: false
    state_change_action:
      - lambda: |-
          ESP_LOGI("main", "power_led_pwm output = %d", state);

switch:
  - platform: gpio
    name: ${device_name} Relay
    pin:
      number: GPIO25
      inverted: no
    id: switch_relay
    on_turn_on:
      - output.set_level:
          id: power_led_pwm
          level: 100%
    on_turn_off:
      - output.set_level:
          id: power_led_pwm
          level: 0%
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
