### PR TITLE
Jinja templates in configs

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -808,7 +808,7 @@ class InvalidYAMLError(EsphomeError):
 
 def _load_config(command_line_substitutions):
     try:
-        config = yaml_util.load_yaml(CORE.config_path)
+        config = yaml_util.load_yaml(CORE.config_path, command_line_substitutions)
     except EsphomeError as e:
         raise InvalidYAMLError(e) from e
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -808,7 +808,7 @@ class InvalidYAMLError(EsphomeError):
 
 def _load_config(command_line_substitutions):
     try:
-        config = yaml_util.load_yaml(CORE.config_path, command_line_substitutions)
+        config = yaml_util.load_yaml(CORE.config_path, vars=command_line_substitutions)
     except EsphomeError as e:
         raise InvalidYAMLError(e) from e
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -296,7 +296,7 @@ _TYPE_OVERLOADS = {
     int: type("EInt", (int,), {}),
     float: type("EFloat", (float,), {}),
     str: type("EStr", (str,), {}),
-    dict: type("EDict", (str,), {}),
+    dict: type("EDict", (dict,), {}),
     list: type("EList", (list,), {}),
 }
 

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -10,6 +10,9 @@ import uuid
 import yaml
 import yaml.constructor
 
+from jinja2.nativetypes import NativeEnvironment
+from jinja2.exceptions import TemplateError, TemplateSyntaxError
+
 from esphome import core
 from esphome.config_helpers import read_config_file
 from esphome.core import (
@@ -22,8 +25,6 @@ from esphome.core import (
 )
 from esphome.helpers import add_class_to_obj
 from esphome.util import OrderedDict, filter_yaml_files
-from jinja2.nativetypes import NativeEnvironment
-from jinja2.exceptions import TemplateError, TemplateSyntaxError
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -128,7 +129,9 @@ def _add_data_ref(fn):
     return wrapped
 
 
-class ESPHomeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
+class ESPHomeLoader(
+    yaml.SafeLoader
+):  # pylint: disable=too-many-ancestors,too-many-public-methods
     """Loader class that keeps track of line numbers."""
 
     def __init__(self, content, context=None):
@@ -563,9 +566,6 @@ ESPHomeLoader.add_constructor("!force", ESPHomeLoader.construct_force)
 def load_yaml(fname, clear_secrets=True, vars=None):
     from esphome.const import CONF_SUBSTITUTIONS
 
-    if vars is None:
-        vars = {}
-
     if clear_secrets:
         _SECRET_VALUES.clear()
         _SECRET_CACHE.clear()
@@ -589,6 +589,9 @@ def load_yaml(fname, clear_secrets=True, vars=None):
 
 
 def _load_yaml_string(content, name, context):
+    if context["vars"] is None:
+        context["vars"] = {}
+
     loader = ESPHomeLoader(content, context)
     loader.name = name
     try:

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -159,6 +159,8 @@ class ESPHomeLoader(
     @_add_data_ref
     def construct_yaml_str(self, node):
         st = super().construct_yaml_str(node)
+        if self.disable_str_expansion:
+            return st
 
         def replace_vars(m):
             name = m.group(1)
@@ -223,7 +225,9 @@ class ESPHomeLoader(
 
             if not is_merge_key:
                 # base case, this is a simple key-value pair
+                self.disable_str_expansion = True
                 key = self.construct_object(key_node)
+                self.disable_str_expansion = False
                 value = self.construct_object(value_node)
 
                 # Check if key is hashable

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -327,7 +327,12 @@ class ESPHomeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
         vars = self.context["vars"] if "vars" in self.context else {}
 
         try:
-            env = NativeEnvironment(trim_blocks=True, lstrip_blocks=True)
+            env = NativeEnvironment(
+                trim_blocks=True,
+                lstrip_blocks=True,
+                line_statement_prefix="%%",
+                line_comment_prefix="##",
+            )
             env.add_extension("jinja2.ext.do")
             env.filters["from_yaml"] = jinja_from_yaml
             env.filters["string"] = jinja_string

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -309,15 +309,6 @@ class ESPHomeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
         from jinja2.nativetypes import NativeEnvironment
         from jinja2.exceptions import TemplateError, TemplateSyntaxError
 
-        def include(file, vars={}):
-            if not isinstance(vars, dict):
-                vars = {}
-            result = _load_yaml_internal(
-                self._rel_path(file), {**self.context, "vars": vars}
-            )
-            result = self.substitute_vars(result, vars)
-            return result
-
         def jinja_from_yaml(result):
             if isinstance(result, str):
                 result = _load_yaml_string(
@@ -339,7 +330,6 @@ class ESPHomeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
             env.filters["from_yaml"] = jinja_from_yaml
             env.filters["string"] = jinja_string
             template = env.from_string(node.value)
-            template.globals.update({"include": include})
             result = template.render(vars)
         except TemplateSyntaxError as err:
             raise yaml.MarkedYAMLError(

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -95,7 +95,9 @@ def _add_data_ref(fn):
 class ESPHomeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
     """Loader class that keeps track of line numbers."""
 
-    def __init__(self, content, context={}):
+    def __init__(self, content, context=None):
+        if context is None:
+            context = {}
         self.context = context
         yaml.SafeLoader.__init__(self, content)
 
@@ -322,7 +324,7 @@ class ESPHomeLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
         def jinja_string(st):
             return ForceStr(st)
 
-        vars = "vars" in self.context and self.context["vars"] or {}
+        vars = self.context["vars"] if "vars" in self.context else {}
 
         try:
             env = NativeEnvironment(trim_blocks=True, lstrip_blocks=True)
@@ -429,8 +431,11 @@ ESPHomeLoader.add_constructor("!lambda", ESPHomeLoader.construct_lambda)
 ESPHomeLoader.add_constructor("!force", ESPHomeLoader.construct_force)
 
 
-def load_yaml(fname, clear_secrets=True, vars={}):
+def load_yaml(fname, clear_secrets=True, vars=None):
     from esphome.const import CONF_SUBSTITUTIONS
+
+    if vars is None:
+        vars = {}
 
     if clear_secrets:
         _SECRET_VALUES.clear()
@@ -454,7 +459,7 @@ def load_yaml(fname, clear_secrets=True, vars={}):
     return _load_yaml_internal(fname, {"vars": vars})
 
 
-def _load_yaml_string(content, name, context={}):
+def _load_yaml_string(content, name, context):
     loader = ESPHomeLoader(content, context)
     loader.name = name
     try:
@@ -465,7 +470,7 @@ def _load_yaml_string(content, name, context={}):
         loader.dispose()
 
 
-def _load_yaml_internal(fname, context={}):
+def _load_yaml_internal(fname, context):
     content = read_config_file(fname)
     return _load_yaml_string(content, fname, context)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ click==8.1.3
 esphome-dashboard==20220508.0
 aioesphomeapi==10.10.0
 zeroconf==0.38.4
+jinja2==3.1.2
 
 # esp-idf requires this, but doesn't bundle it by default
 # https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24


### PR DESCRIPTION
# What does this implement/fix?

This is a functioning proposal to have templates in ESPHome configuration files in order to simplify complex configurations and allow for code reusability. I chose Jinja since it is well-known in the HomeAssistant community and other YAML-based configuration languages.

This change is opt-in and backwards compatible. Existing configurations are not affected.

The PR introduces a new tag, `!eval` that renders the jinja template next to it. That YAML node value is replaced with the result of evaluating the template. Therefore, `!eval` can perform math and render number values (for example to calculate modbus register addresses) or even **lists or full pieces of configuration** based on substitution variables in the top-level configuration file, command-line substitutions as well as `!include` variables (as per https://github.com/esphome/esphome/pull/3510), since these values are available to Jinja as Jinja variables.

This implementation covers all the cases described in https://github.com/esphome/feature-requests/issues/805 and builds on the current packages, substitutions and `!include` implementation, while maintaining backwards compatibility.

## Example configuration
Consider a manufacturer of an AC unit "Kool, Inc". Kool provides a modbus interface to manage the fancoil units and physical thermostats in each room of the house. Depending on how the physical structure of the house is, the company will install the units and assign each of the rooms an ID in the modbus interface. In the modbus documentation, the registers to manage different aspects of each room are a function of that ID. The different functions are current room temperature, target temperature and on/off switch for each zone.

Kool, Inc decides to support ESPHome and provides a package in the form of a yaml file or GitHub package so as users we can focus on just defining the names of the rooms and not have to worry about anything else. This package requires 3 parameters: the modbus component id, the modbus slave address and house zones definition. Thus, the package is instantiated like this for our 4-room house:

`configuration.yaml`:
```yaml
esphome:
  name: "test"

esp32:
  board: esp32dev
  variant: esp32
  framework:
    type: arduino

packages:
  hvac: !include
    file: "kool_hvac_controller.yaml"
    vars:
      modbus_id: modbus1
      modbus_address: 0x49
      controller_id: kool_hvac
      zones:
        - name: Living Room
          id: 3
        - name: Kitchen
          id: 7
        - name: Bedroom
          id: 4
        - name: Office
          id: 5
# [...]
```
Nothing new above, except that when defining vars for the package we are not restricted to strings anymore. Arbitrarily complex objects can now be used, like the `zones` parameter above that describes the rooms of the house.

Now let's look at the vendor-provided package file: `kool_hvac_controller.yaml`:
```yaml
modbus_controller:
  - id: ${controller_id} # substitution-type syntax, still valid
    address: !eval "{{modbus_address}}" # new jinja syntax
    modbus_id: ${modbus_id}

# In this example we iterate over the `zones` parameter to render the configuration
# for target temperature adjustment
number: !eval |
  {% for zone in zones %}
  - platform: modbus_controller
    name: {{ zone.name }} Target Temperature
    id: target_temp{{ zone.id }}
    modbus_controller_id: {{ controller_id }}
    address: {{ (zone.id-1)*4 + 1 }} #compute modbus address according to the hvac unit documentation
    value_type: U_WORD
    min_value: 15
    max_value: 35
    step: 0.5
    unit_of_measurement: °C
    lambda: return x*0.5;
    write_lambda: return x*2;
  {% endfor %}

# In this other example we render temperature sensors by 
# invoking a temperature sensor
# definition that is in another file, using !include
# we also show that with a conditional statement we 
# can add the sensor or not.
sensor: !eval |
  {% if enable_temp_sensor %}
  - !include
    file: "temp_sensor.yaml"
    vars:
      zone: {{ zone }}
      controller_id: {{ controller_id }}
  {% endif %}

# In this other example, we use line statements
# to unbloat jinja a little bit
# lines beginning with %% are considered jinja code.
switch: !eval |
  %% for zone in zones
  - platform: modbus_controller
    name: Activate Cooling {{ zone.name }}
    id: cooling_{{ zone.id }}
    modbus_controller_id: {{ controller_id }}
    register_type: holding
    address: {{ (zone.id-1)*4 }}
    bitmask: 1
  %% endfor

```

`temp_sensor.yaml`
```yaml
platform: modbus_controller
name: !eval "{{zone.name}} Current Temperature"
address: !eval "{{ (zone.id-1) * 4 + 2 }}"
register_type: holding
id: !eval "current_temp{{ zone.id }}"
modbus_controller_id: ${controller_id}
state_class: measurement
device_class: temperature
unit_of_measurement: °C
accuracy_decimals: 1
```

## Trying this
You can check out this PR and test `!eval` right now!. I would like to get some feedback about it to see if this is the right way to implementing templates and how it would simplify your configurations.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

https://github.com/esphome/feature-requests/issues/805

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
