### PR TITLE
When merging config sources, merge lists by id if applicable.

### DIFF
--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -38,10 +38,31 @@ def merge_config(full_old, full_new):
         elif isinstance(new, list):
             if not isinstance(old, list):
                 return new
-            return old + new
+            return merge_list(old, new)
         elif new is None:
             return old
 
         return new
+
+    def merge_list(old, new):
+        """Merge lists of dicts using the id field.
+
+        This can usefully merge lists of sensors.
+        """
+        seen_ids = {}
+        out = []
+        merged = old + new
+        for val in merged:
+            if not isinstance(val, dict):
+                return merged
+            if key := val.get("id"):
+                if (index := seen_ids.get(key)) is not None:
+                    out[index] = merge(out[index], val)
+                else:
+                    seen_ids[key] = len(out)
+                    out.append(val)
+            else:
+                out.append(val)
+        return out
 
     return merge(full_old, full_new)

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1148,7 +1148,12 @@ sensor:
     temperature:
       name: Max9611 Temp
     update_interval: 1s
-
+  - id: ${devicename}_uptime_pcg
+    # Customize and add automation to sensor defined in package.
+    update_interval: 60s
+    on_value:
+      lambda: |-
+        ESP_LOGD("main", "Uptime is now: %f", id(${devicename}_uptime_pcg).state);
 
 esp32_touch:
   setup_mode: False


### PR DESCRIPTION
# What does this implement/fix?

When merging config sources, merge sequences of mappings by combining mappings that share an `id` field.

This makes packages more useful by allowing definitions of sensors in packages to be overridden in the importing config.

In particular, this makes it possible to add an automation to a sensor that is defined in a package.

My primary use case is that I've made an ESP32-based PCB that I want to use in a variety of applications. It's helpful to have a base hardware configuration file to separate hardware configuration (pinouts, etc) from the application-specific config that defines how the hardware is used.

With this change, I can define a button in the shared yaml, and add an automation to define what to do when the button is pressed in the per-application config.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

This was previously proposed in #1318, but never merged.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

I recommend two changes to `guides/configuration-types.rst`, in particular:

1. a more in depth explanation of how configurations are merged, and
2. an example where a sensor is defined in `device_base.yaml` and an automation is added in `config.yaml`.

The docs as-is simply say that packages are merged in a non-destructive way. That remains true with this change.

Unfortunately, I won't be able to make those changes under CC BY-NC-SA.

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# config.yaml

packages:
  base: !include base.yaml

sensor:
  - id: tilt_open
    on_press:
      then:
        - script.execute: play_tune
```

```yaml
# base.yaml

sensor:
  - id: tilt_open
    name: Tilt Sensor Open
    platform: gpio
    pin:
      number: 14
      mode: INPUT
```

There's another example added to `tests/test1.yaml`.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
