### PR TITLE
Add a FastLED component which allows to use parts of the bus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,6 +89,9 @@ esphome/components/ezo_pmp/* @carlos-sarmiento
 esphome/components/factory_reset/* @anatoly-savchenkov
 esphome/components/fastled_base/* @OttoWinter
 esphome/components/feedback/* @ianchi
+esphome/components/fastled_bus/* @mabels
+esphome/components/fastled_bus_clockless/* @mabels
+esphome/components/fastled_bus_spi/* @mabels
 esphome/components/fingerprint_grow/* @OnFreund @loongyh
 esphome/components/globals/* @esphome/core
 esphome/components/gpio/* @esphome/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -88,10 +88,10 @@ esphome/components/ezo/* @ssieb
 esphome/components/ezo_pmp/* @carlos-sarmiento
 esphome/components/factory_reset/* @anatoly-savchenkov
 esphome/components/fastled_base/* @OttoWinter
-esphome/components/feedback/* @ianchi
 esphome/components/fastled_bus/* @mabels
 esphome/components/fastled_bus_clockless/* @mabels
 esphome/components/fastled_bus_spi/* @mabels
+esphome/components/feedback/* @ianchi
 esphome/components/fingerprint_grow/* @OnFreund @loongyh
 esphome/components/globals/* @esphome/core
 esphome/components/gpio/* @esphome/core

--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -10,6 +10,7 @@
 # pylint: disable=unused-import
 from esphome.cpp_generator import (  # noqa
     Expression,
+    AssignmentExpression,
     RawExpression,
     RawStatement,
     TemplateArguments,

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -1,4 +1,6 @@
 import esphome.codegen as cg
+from esphome.components import fastled_bus
+from esphome.components.fastled_bus import CONF_BUS
 import esphome.config_validation as cv
 from esphome.components import light
 from esphome.const import (
@@ -14,21 +16,14 @@ FastLEDLightOutput = fastled_base_ns.class_(
     "FastLEDLightOutput", light.AddressableLight
 )
 
-RGB_ORDERS = [
-    "RGB",
-    "RBG",
-    "GRB",
-    "GBR",
-    "BRG",
-    "BGR",
-]
 
 BASE_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(FastLEDLightOutput),
         cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
-        cv.Optional(CONF_RGB_ORDER): cv.one_of(*RGB_ORDERS, upper=True),
+        cv.Optional(CONF_RGB_ORDER): cv.one_of(*fastled_bus.RGB_ORDERS, upper=True),
         cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
+        cv.Optional(CONF_BUS): cv.declare_id(fastled_bus.FastLEDBus),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_MAX_REFRESH_RATE,
 )
 
+AUTO_LOAD = ["fastled_bus"]
 CODEOWNERS = ["@OttoWinter"]
 fastled_base_ns = cg.esphome_ns.namespace("fastled_base")
 FastLEDLightOutput = fastled_base_ns.class_(
@@ -48,7 +49,7 @@ CLOCKLESS_CHIPSETS = [
 BASE_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(FastLEDLightOutput),
-        cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
+        cv.Optional(CONF_NUM_LEDS): cv.positive_not_null_int,
         cv.Optional(CONF_RGB_ORDER): cv.one_of(*fastled_bus.RGB_ORDERS, upper=True),
         cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
         cv.Optional(CONF_BUS): cv.declare_id(fastled_bus.FastLEDBus),

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -16,6 +16,34 @@ FastLEDLightOutput = fastled_base_ns.class_(
     "FastLEDLightOutput", light.AddressableLight
 )
 
+CLOCKLESS_CHIPSETS = [
+    "NEOPIXEL",
+    "TM1829",
+    "TM1809",
+    "TM1804",
+    "TM1803",
+    "UCS1903",
+    "UCS1903B",
+    "UCS1904",
+    "UCS2903",
+    "WS2812",
+    "WS2852",
+    "WS2812B",
+    "SK6812",
+    "SK6822",
+    "APA106",
+    "PL9823",
+    "WS2811",
+    "WS2813",
+    "APA104",
+    "WS2811_400",
+    "GW6205",
+    "GW6205_400",
+    "LPD1886",
+    "LPD1886_8BIT",
+    "SM16703",
+]
+
 
 BASE_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
     {

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "fastled";
 
 void FastLEDLightOutput::setup() {
   this->bus_->setup();
-  this->leds_ = (CRGB*)this->bus_->chips();
+  this->leds_ = (CRGB *) this->bus_->chips();
   this->num_leds_ = this->bus_->num_chips_;
   this->effect_data_ = this->bus_->effect_data();
   ESP_LOGCONFIG(TAG, "Setting up FastLED light...:%p", this->leds_);

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -10,12 +10,15 @@ static const char *const TAG = "fastled";
 
 void FastLEDLightOutput::setup() {
   ESP_LOGCONFIG(TAG, "Setting up FastLED light...");
-  this->controller_->init();
-  this->controller_->setLeds(this->leds_, this->num_leds_);
-  this->effect_data_ = new uint8_t[this->num_leds_];  // NOLINT
-  if (!this->max_refresh_rate_.has_value()) {
-    this->set_max_refresh_rate(this->controller_->getMaxRefreshRate());
-  }
+  this->bus_->setup();
+  this->leds_ = (CRGB*)this->bus_->chips();
+  this->effect_data_ = this->bus_->effect_data();
+  // this->controller_->init();
+  // this->controller_->setLeds(this->leds_, this->num_leds_);
+  // this->effect_data_ = new uint8_t[this->num_leds_];  // NOLINT
+  // if (!this->max_refresh_rate_.has_value()) {
+  //   this->set_max_refresh_rate(this->controller_->getMaxRefreshRate());
+  // }
 }
 void FastLEDLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "FastLED light:");
@@ -23,18 +26,19 @@ void FastLEDLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "  Max refresh rate: %u", *this->max_refresh_rate_);
 }
 void FastLEDLightOutput::write_state(light::LightState *state) {
-  // protect from refreshing too often
-  uint32_t now = micros();
-  if (*this->max_refresh_rate_ != 0 && (now - this->last_refresh_) < *this->max_refresh_rate_) {
-    // try again next loop iteration, so that this change won't get lost
-    this->schedule_show();
-    return;
-  }
-  this->last_refresh_ = now;
-  this->mark_shown_();
+  this->bus_->schedule_refresh();
+  // // protect from refreshing too often
+  // uint32_t now = micros();
+  // if (*this->max_refresh_rate_ != 0 && (now - this->last_refresh_) < *this->max_refresh_rate_) {
+  //   // try again next loop iteration, so that this change won't get lost
+  //   this->schedule_show();
+  //   return;
+  // }
+  // this->last_refresh_ = now;
+  // this->mark_shown_();
 
-  ESP_LOGVV(TAG, "Writing RGB values to bus...");
-  this->controller_->showLeds();
+  // ESP_LOGVV(TAG, "Writing RGB values to bus...");
+  // this->controller_->showLeds();
 }
 
 }  // namespace fastled_base

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "fastled";
 
 void FastLEDLightOutput::setup() {
   this->bus_->setup();
-  this->leds_ = (CRGB *) this->bus_->chips();
+  this->leds_ = (CRGB *) this->bus_->channels();
   this->num_leds_ = this->bus_->num_chips_;
   this->effect_data_ = this->bus_->effect_data();
   ESP_LOGCONFIG(TAG, "Setting up FastLED light...:%p", this->leds_);

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -9,10 +9,11 @@ namespace fastled_base {
 static const char *const TAG = "fastled";
 
 void FastLEDLightOutput::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up FastLED light...");
   this->bus_->setup();
   this->leds_ = (CRGB*)this->bus_->chips();
+  this->num_leds_ = this->bus_->num_chips_;
   this->effect_data_ = this->bus_->effect_data();
+  ESP_LOGCONFIG(TAG, "Setting up FastLED light...:%p", this->leds_);
   // this->controller_->init();
   // this->controller_->setLeds(this->leds_, this->num_leds_);
   // this->effect_data_ = new uint8_t[this->num_leds_];  // NOLINT
@@ -26,6 +27,17 @@ void FastLEDLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "  Max refresh rate: %u", *this->max_refresh_rate_);
 }
 void FastLEDLightOutput::write_state(light::LightState *state) {
+  ESP_LOGCONFIG(TAG, "FastLED light:write_state:%p:%d:%p", state, this->size(), this->leds_);
+  // float red;
+  // float green;
+  // float blue;
+  // state->get_rgb(&red, &green, &blue);
+  // this->bus_->write_mapping(this->mapping_, red);
+  // for (int i = 0; i < this->size(); i++) {
+  //     this->leds_[i][0] = 0x60;
+  //     this->leds_[i][1] = 0x60;
+  //     this->leds_[i][2] = 0x60;
+  // }
   this->bus_->schedule_refresh();
   // // protect from refreshing too often
   // uint32_t now = micros();

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -4,6 +4,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/components/fastled_bus/fastled_bus.h"
 #include "esphome/components/light/addressable_light.h"
 
 #define FASTLED_ESP8266_RAW_PIN_ORDER
@@ -15,6 +16,7 @@
 
 #include "FastLED.h"
 
+using FastLEDBus = esphome::fastled_bus::FastLEDBus;
 namespace esphome {
 namespace fastled_base {
 
@@ -27,6 +29,8 @@ class FastLEDLightOutput : public light::AddressableLight {
 
   /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
   void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
+
+  void set_bus(FastLEDBus *bus) { this->bus_ = bus; }
 
   /// Add some LEDS, can only be called once.
   CLEDController &add_leds(CLEDController *controller, int num_leds) {
@@ -229,6 +233,7 @@ class FastLEDLightOutput : public light::AddressableLight {
             &this->effect_data_[index], &this->correction_};
   }
 
+  FastLEDBus *bus_{nullptr};
   CLEDController *controller_{nullptr};
   CRGB *leds_{nullptr};
   uint8_t *effect_data_{nullptr};

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -23,192 +23,192 @@ namespace fastled_base {
 class FastLEDLightOutput : public light::AddressableLight {
  public:
   /// Only for custom effects: Get the internal controller.
-  CLEDController *get_controller() const { return this->controller_; }
+  CLEDController *get_controller() const { return this->bus_->controller(); }
 
   inline int32_t size() const override { return this->num_leds_; }
 
   /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
-  void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
+  void set_max_refresh_rate(uint32_t interval_us) { this->bus_->set_max_refresh_rate(interval_us); }
 
   void set_bus(FastLEDBus *bus) { this->bus_ = bus; }
 
   /// Add some LEDS, can only be called once.
-  CLEDController &add_leds(CLEDController *controller, int num_leds) {
-    this->controller_ = controller;
-    this->num_leds_ = num_leds;
-    this->leds_ = new CRGB[num_leds];  // NOLINT
+  // CLEDController &add_leds(CLEDController *controller, int num_leds) {
+  //   this->controller_ = controller;
+  //   this->num_leds_ = num_leds;
+  //   this->leds_ = new CRGB[num_leds];  // NOLINT
 
-    for (int i = 0; i < this->num_leds_; i++)
-      this->leds_[i] = CRGB::Black;
+  //   for (int i = 0; i < this->num_leds_; i++)
+  //     this->leds_[i] = CRGB::Black;
 
-    return *this->controller_;
-  }
+  //   return *this->controller_;
+  // }
 
-  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER, uint32_t SPI_DATA_RATE>
-  CLEDController &add_leds(int num_leds) {
-    switch (CHIPSET) {
-      case LPD8806: {
-        static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case WS2801: {
-        static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case WS2803: {
-        static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case SM16716: {
-        static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case P9813: {
-        static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case DOTSTAR:
-      case APA102: {
-        static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case SK9822: {
-        static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
-      }
-    }
-  }
+//   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER, uint32_t SPI_DATA_RATE>
+//   CLEDController &add_leds(int num_leds) {
+//     switch (CHIPSET) {
+//       case LPD8806: {
+//         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case WS2801: {
+//         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case WS2803: {
+//         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case SM16716: {
+//         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case P9813: {
+//         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case DOTSTAR:
+//       case APA102: {
+//         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case SK9822: {
+//         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//     }
+//   }
 
-  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> CLEDController &add_leds(int num_leds) {
-    switch (CHIPSET) {
-      case LPD8806: {
-        static LPD8806Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case WS2801: {
-        static WS2801Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case WS2803: {
-        static WS2803Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case SM16716: {
-        static SM16716Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case P9813: {
-        static P9813Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case DOTSTAR:
-      case APA102: {
-        static APA102Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case SK9822: {
-        static SK9822Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
-      }
-    }
-  }
+//   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> CLEDController &add_leds(int num_leds) {
+//     switch (CHIPSET) {
+//       case LPD8806: {
+//         static LPD8806Controller<DATA_PIN, CLOCK_PIN> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case WS2801: {
+//         static WS2801Controller<DATA_PIN, CLOCK_PIN> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case WS2803: {
+//         static WS2803Controller<DATA_PIN, CLOCK_PIN> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case SM16716: {
+//         static SM16716Controller<DATA_PIN, CLOCK_PIN> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case P9813: {
+//         static P9813Controller<DATA_PIN, CLOCK_PIN> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case DOTSTAR:
+//       case APA102: {
+//         static APA102Controller<DATA_PIN, CLOCK_PIN> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case SK9822: {
+//         static SK9822Controller<DATA_PIN, CLOCK_PIN> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//     }
+//   }
 
-  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER>
-  CLEDController &add_leds(int num_leds) {
-    switch (CHIPSET) {
-      case LPD8806: {
-        static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case WS2801: {
-        static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case WS2803: {
-        static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case SM16716: {
-        static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case P9813: {
-        static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case DOTSTAR:
-      case APA102: {
-        static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
-      }
-      case SK9822: {
-        static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
-      }
-    }
-  }
+//   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER>
+//   CLEDController &add_leds(int num_leds) {
+//     switch (CHIPSET) {
+//       case LPD8806: {
+//         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case WS2801: {
+//         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case WS2803: {
+//         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case SM16716: {
+//         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case P9813: {
+//         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case DOTSTAR:
+//       case APA102: {
+//         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//       case SK9822: {
+//         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+//         return add_leds(&controller, num_leds);
+//       }
+//     }
+//   }
 
-#ifdef FASTLED_HAS_CLOCKLESS
-  template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN, EOrder RGB_ORDER>
-  CLEDController &add_leds(int num_leds) {
-    static CHIPSET<DATA_PIN, RGB_ORDER> controller;
-    return add_leds(&controller, num_leds);
-  }
+// #ifdef FASTLED_HAS_CLOCKLESS
+//   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN, EOrder RGB_ORDER>
+//   CLEDController &add_leds(int num_leds) {
+//     static CHIPSET<DATA_PIN, RGB_ORDER> controller;
+//     return add_leds(&controller, num_leds);
+//   }
 
-  template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN>
-  CLEDController &add_leds(int num_leds) {
-    static CHIPSET<DATA_PIN, RGB> controller;
-    return add_leds(&controller, num_leds);
-  }
+//   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN>
+//   CLEDController &add_leds(int num_leds) {
+//     static CHIPSET<DATA_PIN, RGB> controller;
+//     return add_leds(&controller, num_leds);
+//   }
 
-  template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> CLEDController &add_leds(int num_leds) {
-    static CHIPSET<DATA_PIN> controller;
-    return add_leds(&controller, num_leds);
-  }
-#endif
+//   template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> CLEDController &add_leds(int num_leds) {
+//     static CHIPSET<DATA_PIN> controller;
+//     return add_leds(&controller, num_leds);
+//   }
+// #endif
 
-  template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
-    static CHIPSET<RGB_ORDER> controller;
-    return add_leds(&controller, num_leds);
-  }
+//   template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
+//     static CHIPSET<RGB_ORDER> controller;
+//     return add_leds(&controller, num_leds);
+//   }
 
-  template<template<EOrder RGB_ORDER> class CHIPSET> CLEDController &add_leds(int num_leds) {
-    static CHIPSET<RGB> controller;
-    return add_leds(&controller, num_leds);
-  }
+//   template<template<EOrder RGB_ORDER> class CHIPSET> CLEDController &add_leds(int num_leds) {
+//     static CHIPSET<RGB> controller;
+//     return add_leds(&controller, num_leds);
+//   }
 
-#ifdef FASTLED_HAS_BLOCKLESS
-  template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
-    switch (CHIPSET) {
-#ifdef PORTA_FIRST_PIN
-      case WS2811_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>(),
-            num_leds);
-      case WS2811_400_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>(),
-            num_leds);
-      case WS2813_PORTA:
-        return add_leds(new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640),
-                                                           RGB_ORDER, 0, false, 300>(),
-                        num_leds);
-      case TM1803_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_ORDER>(),
-            num_leds);
-      case UCS1903_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_ORDER>(),
-            num_leds);
-#endif
-    }
-  }
+// #ifdef FASTLED_HAS_BLOCKLESS
+//   template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
+//     switch (CHIPSET) {
+// #ifdef PORTA_FIRST_PIN
+//       case WS2811_PORTA:
+//         return add_leds(
+//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>(),
+//             num_leds);
+//       case WS2811_400_PORTA:
+//         return add_leds(
+//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>(),
+//             num_leds);
+//       case WS2813_PORTA:
+//         return add_leds(new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640),
+//                                                            RGB_ORDER, 0, false, 300>(),
+//                         num_leds);
+//       case TM1803_PORTA:
+//         return add_leds(
+//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_ORDER>(),
+//             num_leds);
+//       case UCS1903_PORTA:
+//         return add_leds(
+//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_ORDER>(),
+//             num_leds);
+// #endif
+//     }
+//   }
 
-  template<EBlockChipsets CHIPSET, int NUM_LANES> CLEDController &add_leds(int num_leds) {
-    return add_leds<CHIPSET, NUM_LANES, GRB>(num_leds);
-  }
-#endif
+//   template<EBlockChipsets CHIPSET, int NUM_LANES> CLEDController &add_leds(int num_leds) {
+//     return add_leds<CHIPSET, NUM_LANES, GRB>(num_leds);
+//   }
+// #endif
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -216,6 +216,9 @@ class FastLEDLightOutput : public light::AddressableLight {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::RGB});
     return traits;
+  }
+  void loop() override {
+    this->bus_->loop();
   }
   void setup() override;
   void dump_config() override;

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -44,171 +44,171 @@ class FastLEDLightOutput : public light::AddressableLight {
   //   return *this->controller_;
   // }
 
-//   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER, uint32_t SPI_DATA_RATE>
-//   CLEDController &add_leds(int num_leds) {
-//     switch (CHIPSET) {
-//       case LPD8806: {
-//         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case WS2801: {
-//         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case WS2803: {
-//         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case SM16716: {
-//         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case P9813: {
-//         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case DOTSTAR:
-//       case APA102: {
-//         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case SK9822: {
-//         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//     }
-//   }
+  //   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER, uint32_t SPI_DATA_RATE>
+  //   CLEDController &add_leds(int num_leds) {
+  //     switch (CHIPSET) {
+  //       case LPD8806: {
+  //         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case WS2801: {
+  //         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case WS2803: {
+  //         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case SM16716: {
+  //         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case P9813: {
+  //         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case DOTSTAR:
+  //       case APA102: {
+  //         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case SK9822: {
+  //         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //     }
+  //   }
 
-//   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> CLEDController &add_leds(int num_leds) {
-//     switch (CHIPSET) {
-//       case LPD8806: {
-//         static LPD8806Controller<DATA_PIN, CLOCK_PIN> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case WS2801: {
-//         static WS2801Controller<DATA_PIN, CLOCK_PIN> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case WS2803: {
-//         static WS2803Controller<DATA_PIN, CLOCK_PIN> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case SM16716: {
-//         static SM16716Controller<DATA_PIN, CLOCK_PIN> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case P9813: {
-//         static P9813Controller<DATA_PIN, CLOCK_PIN> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case DOTSTAR:
-//       case APA102: {
-//         static APA102Controller<DATA_PIN, CLOCK_PIN> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case SK9822: {
-//         static SK9822Controller<DATA_PIN, CLOCK_PIN> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//     }
-//   }
+  //   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> CLEDController &add_leds(int num_leds) {
+  //     switch (CHIPSET) {
+  //       case LPD8806: {
+  //         static LPD8806Controller<DATA_PIN, CLOCK_PIN> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case WS2801: {
+  //         static WS2801Controller<DATA_PIN, CLOCK_PIN> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case WS2803: {
+  //         static WS2803Controller<DATA_PIN, CLOCK_PIN> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case SM16716: {
+  //         static SM16716Controller<DATA_PIN, CLOCK_PIN> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case P9813: {
+  //         static P9813Controller<DATA_PIN, CLOCK_PIN> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case DOTSTAR:
+  //       case APA102: {
+  //         static APA102Controller<DATA_PIN, CLOCK_PIN> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case SK9822: {
+  //         static SK9822Controller<DATA_PIN, CLOCK_PIN> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //     }
+  //   }
 
-//   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER>
-//   CLEDController &add_leds(int num_leds) {
-//     switch (CHIPSET) {
-//       case LPD8806: {
-//         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case WS2801: {
-//         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case WS2803: {
-//         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case SM16716: {
-//         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case P9813: {
-//         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case DOTSTAR:
-//       case APA102: {
-//         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//       case SK9822: {
-//         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-//         return add_leds(&controller, num_leds);
-//       }
-//     }
-//   }
+  //   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER>
+  //   CLEDController &add_leds(int num_leds) {
+  //     switch (CHIPSET) {
+  //       case LPD8806: {
+  //         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case WS2801: {
+  //         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case WS2803: {
+  //         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case SM16716: {
+  //         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case P9813: {
+  //         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case DOTSTAR:
+  //       case APA102: {
+  //         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //       case SK9822: {
+  //         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
+  //         return add_leds(&controller, num_leds);
+  //       }
+  //     }
+  //   }
 
-// #ifdef FASTLED_HAS_CLOCKLESS
-//   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN, EOrder RGB_ORDER>
-//   CLEDController &add_leds(int num_leds) {
-//     static CHIPSET<DATA_PIN, RGB_ORDER> controller;
-//     return add_leds(&controller, num_leds);
-//   }
+  // #ifdef FASTLED_HAS_CLOCKLESS
+  //   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN, EOrder RGB_ORDER>
+  //   CLEDController &add_leds(int num_leds) {
+  //     static CHIPSET<DATA_PIN, RGB_ORDER> controller;
+  //     return add_leds(&controller, num_leds);
+  //   }
 
-//   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN>
-//   CLEDController &add_leds(int num_leds) {
-//     static CHIPSET<DATA_PIN, RGB> controller;
-//     return add_leds(&controller, num_leds);
-//   }
+  //   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN>
+  //   CLEDController &add_leds(int num_leds) {
+  //     static CHIPSET<DATA_PIN, RGB> controller;
+  //     return add_leds(&controller, num_leds);
+  //   }
 
-//   template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> CLEDController &add_leds(int num_leds) {
-//     static CHIPSET<DATA_PIN> controller;
-//     return add_leds(&controller, num_leds);
-//   }
-// #endif
+  //   template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> CLEDController &add_leds(int num_leds) {
+  //     static CHIPSET<DATA_PIN> controller;
+  //     return add_leds(&controller, num_leds);
+  //   }
+  // #endif
 
-//   template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
-//     static CHIPSET<RGB_ORDER> controller;
-//     return add_leds(&controller, num_leds);
-//   }
+  //   template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
+  //     static CHIPSET<RGB_ORDER> controller;
+  //     return add_leds(&controller, num_leds);
+  //   }
 
-//   template<template<EOrder RGB_ORDER> class CHIPSET> CLEDController &add_leds(int num_leds) {
-//     static CHIPSET<RGB> controller;
-//     return add_leds(&controller, num_leds);
-//   }
+  //   template<template<EOrder RGB_ORDER> class CHIPSET> CLEDController &add_leds(int num_leds) {
+  //     static CHIPSET<RGB> controller;
+  //     return add_leds(&controller, num_leds);
+  //   }
 
-// #ifdef FASTLED_HAS_BLOCKLESS
-//   template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
-//     switch (CHIPSET) {
-// #ifdef PORTA_FIRST_PIN
-//       case WS2811_PORTA:
-//         return add_leds(
-//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>(),
-//             num_leds);
-//       case WS2811_400_PORTA:
-//         return add_leds(
-//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>(),
-//             num_leds);
-//       case WS2813_PORTA:
-//         return add_leds(new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640),
-//                                                            RGB_ORDER, 0, false, 300>(),
-//                         num_leds);
-//       case TM1803_PORTA:
-//         return add_leds(
-//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_ORDER>(),
-//             num_leds);
-//       case UCS1903_PORTA:
-//         return add_leds(
-//             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_ORDER>(),
-//             num_leds);
-// #endif
-//     }
-//   }
+  // #ifdef FASTLED_HAS_BLOCKLESS
+  //   template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
+  //     switch (CHIPSET) {
+  // #ifdef PORTA_FIRST_PIN
+  //       case WS2811_PORTA:
+  //         return add_leds(
+  //             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>(),
+  //             num_leds);
+  //       case WS2811_400_PORTA:
+  //         return add_leds(
+  //             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>(),
+  //             num_leds);
+  //       case WS2813_PORTA:
+  //         return add_leds(new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640),
+  //                                                            RGB_ORDER, 0, false, 300>(),
+  //                         num_leds);
+  //       case TM1803_PORTA:
+  //         return add_leds(
+  //             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700),
+  //             RGB_ORDER>(), num_leds);
+  //       case UCS1903_PORTA:
+  //         return add_leds(
+  //             new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500),
+  //             RGB_ORDER>(), num_leds);
+  // #endif
+  //     }
+  //   }
 
-//   template<EBlockChipsets CHIPSET, int NUM_LANES> CLEDController &add_leds(int num_leds) {
-//     return add_leds<CHIPSET, NUM_LANES, GRB>(num_leds);
-//   }
-// #endif
+  //   template<EBlockChipsets CHIPSET, int NUM_LANES> CLEDController &add_leds(int num_leds) {
+  //     return add_leds<CHIPSET, NUM_LANES, GRB>(num_leds);
+  //   }
+  // #endif
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -217,9 +217,7 @@ class FastLEDLightOutput : public light::AddressableLight {
     traits.set_supported_color_modes({light::ColorMode::RGB});
     return traits;
   }
-  void loop() override {
-    this->bus_->loop();
-  }
+  void loop() override { this->bus_->loop(); }
   void setup() override;
   void dump_config() override;
   void write_state(light::LightState *state) override;

--- a/esphome/components/fastled_bus/__init__.py
+++ b/esphome/components/fastled_bus/__init__.py
@@ -13,6 +13,7 @@ CONF_CHIP_CHANNELS = "chip_channels"
 bus_ns = cg.esphome_ns.namespace("fastled_bus")
 
 FastLEDBus = bus_ns.class_("FastLEDBus", cg.Component)
+CLEDControllerFactory = bus_ns.namespace("CLEDControllerFactory")
 
 CONFIG_BUS_SCHEMA = cv.COMPONENT_SCHEMA.extend(
     {

--- a/esphome/components/fastled_bus/__init__.py
+++ b/esphome/components/fastled_bus/__init__.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_MAX_REFRESH_RATE, CONF_NUM_CHIPS, CONF_RGB_ORDER
 
 CODEOWNERS = ["@mabels"]
+AUTO_LOAD = ["output"]
 CONF_BUS = "bus"
 
 CONF_CHANNEL_OFFSET = "channel_offset"

--- a/esphome/components/fastled_bus/__init__.py
+++ b/esphome/components/fastled_bus/__init__.py
@@ -8,6 +8,7 @@ AUTO_LOAD = ["output"]
 CONF_BUS = "bus"
 
 CONF_CHANNEL_OFFSET = "channel_offset"
+CONF_CHIP_OFFSET = "chip_offset"
 CONF_REPEAT_DISTANCE = "repeat_distance"
 CONF_CHIP_CHANNELS = "chip_channels"
 

--- a/esphome/components/fastled_bus/__init__.py
+++ b/esphome/components/fastled_bus/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 
-from esphome.const import CONF_MAX_REFRESH_RATE, CONF_NUM_CHIPS
+from esphome.const import CONF_MAX_REFRESH_RATE, CONF_NUM_CHIPS, CONF_RGB_ORDER
 
 CODEOWNERS = ["@mabels"]
 CONF_BUS = "bus"
@@ -10,10 +10,21 @@ CONF_CHANNEL_OFFSET = "channel_offset"
 CONF_REPEAT_DISTANCE = "repeat_distance"
 CONF_CHIP_CHANNELS = "chip_channels"
 
+RGB_ORDERS = [
+    "RGB",
+    "RBG",
+    "GRB",
+    "GBR",
+    "BRG",
+    "BGR",
+]
+
 bus_ns = cg.esphome_ns.namespace("fastled_bus")
 
 FastLEDBus = bus_ns.class_("FastLEDBus", cg.Component)
 CLEDControllerFactory = bus_ns.namespace("CLEDControllerFactory")
+
+FastledBusId = cv.declare_id(FastLEDBus)
 
 CONFIG_BUS_SCHEMA = cv.COMPONENT_SCHEMA.extend(
     {
@@ -21,6 +32,7 @@ CONFIG_BUS_SCHEMA = cv.COMPONENT_SCHEMA.extend(
         # 3 means RGB for SK6812 you need 4
         cv.Optional(CONF_CHIP_CHANNELS, default=3): cv.positive_not_null_int,
         cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
+        cv.Optional(CONF_RGB_ORDER): cv.one_of(*RGB_ORDERS, upper=True),
     }
 )
 
@@ -30,6 +42,12 @@ REQUIRED_FRAMEWORK = cv.require_framework_version(
     max_version=True,
     extra_message="Please see note on documentation for FastLED",
 )
+
+
+def rgb_order(config):
+    return cg.RawExpression(
+        config[CONF_RGB_ORDER] if CONF_RGB_ORDER in config else "RGB"
+    )
 
 
 def new_fastled_bus(var, config):

--- a/esphome/components/fastled_bus/__init__.py
+++ b/esphome/components/fastled_bus/__init__.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+
+from esphome.const import CONF_MAX_REFRESH_RATE, CONF_NUM_CHIPS
+
+CODEOWNERS = ["@mabels"]
+CONF_BUS = "bus"
+
+CONF_CHANNEL_OFFSET = "channel_offset"
+CONF_REPEAT_DISTANCE = "repeat_distance"
+CONF_CHIP_CHANNELS = "chip_channels"
+
+bus_ns = cg.esphome_ns.namespace("fastled_bus")
+
+FastLEDBus = bus_ns.class_("FastLEDBus", cg.Component)
+
+CONFIG_BUS_SCHEMA = cv.COMPONENT_SCHEMA.extend(
+    {
+        cv.Required(CONF_NUM_CHIPS): cv.positive_not_null_int,
+        # 3 means RGB for SK6812 you need 4
+        cv.Optional(CONF_CHIP_CHANNELS, default=3): cv.positive_not_null_int,
+        cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
+    }
+)
+
+REQUIRED_FRAMEWORK = cv.require_framework_version(
+    esp8266_arduino=cv.Version(2, 7, 4),
+    esp32_arduino=cv.Version(99, 0, 0),
+    max_version=True,
+    extra_message="Please see note on documentation for FastLED",
+)
+
+
+def new_fastled_bus(var, config):
+    if CONF_MAX_REFRESH_RATE in config:
+        cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))
+
+    # https://github.com/FastLED/FastLED/blob/master/library.json
+    # 3.3.3 has an issue on ESP32 with RMT and fastled_clockless:
+    # https://github.com/esphome/issues/issues/1375
+    cg.add_library("fastled/FastLED", "3.3.2")

--- a/esphome/components/fastled_bus/cled_controller_factory.h
+++ b/esphome/components/fastled_bus/cled_controller_factory.h
@@ -78,7 +78,6 @@ template<ESPIChipsets CHIPSET, EOrder RGB_Order, uint8_t DATA_PIN, uint8_t CLOCK
 template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, EOrder RGB_Order, uint8_t DATA_PIN>
 static CLEDController *create() {
   auto cs = new CHIPSET<DATA_PIN, RGB_Order>();
-  ESP_LOGCONFIG("fastled:bus:", "Clockless-Controller:%p", cs);
   return cs;
 }
 #endif

--- a/esphome/components/fastled_bus/cled_controller_factory.h
+++ b/esphome/components/fastled_bus/cled_controller_factory.h
@@ -77,7 +77,9 @@ template<ESPIChipsets CHIPSET, EOrder RGB_Order, uint8_t DATA_PIN, uint8_t CLOCK
 #ifdef FASTLED_HAS_CLOCKLESS
 template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, EOrder RGB_Order, uint8_t DATA_PIN>
 static CLEDController *create() {
-  return new CHIPSET<DATA_PIN, RGB_Order>();
+  auto cs = new CHIPSET<DATA_PIN, RGB_Order>();
+  ESP_LOGCONFIG("fastled:bus:", "Clockless-Controller:%p", cs);
+  return cs;
 }
 #endif
 

--- a/esphome/components/fastled_bus/cled_controller_factory.h
+++ b/esphome/components/fastled_bus/cled_controller_factory.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#ifdef USE_ARDUINO
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+
+#define FASTLED_ESP8266_RAW_PIN_ORDER
+#define FASTLED_ESP32_RAW_PIN_ORDER
+#define FASTLED_RMT_BUILTIN_DRIVER true
+
+// Avoid annoying compiler messages
+#define FASTLED_INTERNAL
+#include "FastLED.h"
+
+#include "fastled_bus.h"
+
+namespace esphome {
+namespace fastled_bus {
+
+namespace CLEDControllerFactory {
+template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, uint32_t SPI_DATA_RATE>
+static CLEDController *create() {
+  switch (CHIPSET) {
+    case LPD8806: {
+      return new LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+    }
+    case WS2801: {
+      return new WS2801Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+    }
+    case WS2803: {
+      return new WS2803Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+    }
+    case SM16716: {
+      return new SM16716Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+    }
+    case P9813: {
+      return new P9813Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+    }
+    case DOTSTAR:
+    case APA102: {
+      return new APA102Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+    }
+    case SK9822: {
+      return new SK9822Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+    }
+  }
+}
+
+template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> static CLEDController *create() {
+  switch (CHIPSET) {
+    case LPD8806: {
+      return new LPD8806Controller<DATA_PIN, CLOCK_PIN>();
+    }
+    case WS2801: {
+      return new WS2801Controller<DATA_PIN, CLOCK_PIN>();
+    }
+    case WS2803: {
+      return new WS2803Controller<DATA_PIN, CLOCK_PIN>();
+    }
+    case SM16716: {
+      return new SM16716Controller<DATA_PIN, CLOCK_PIN>();
+    }
+    case P9813: {
+      return new P9813Controller<DATA_PIN, CLOCK_PIN>();
+    }
+    case DOTSTAR:
+    case APA102: {
+      return new APA102Controller<DATA_PIN, CLOCK_PIN>();
+    }
+    case SK9822: {
+      return new SK9822Controller<DATA_PIN, CLOCK_PIN>();
+    }
+  }
+}
+
+template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> static CLEDController *create(int num_leds) {
+  switch (CHIPSET) {
+    case LPD8806: {
+      return new LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB>();
+    }
+    case WS2801: {
+      return new WS2801Controller<DATA_PIN, CLOCK_PIN, RGB>();
+    }
+    case WS2803: {
+      return new WS2803Controller<DATA_PIN, CLOCK_PIN, RGB>();
+    }
+    case SM16716: {
+      return new SM16716Controller<DATA_PIN, CLOCK_PIN, RGB>();
+    }
+    case P9813: {
+      return new P9813Controller<DATA_PIN, CLOCK_PIN, RGB>();
+    }
+    case DOTSTAR:
+    case APA102: {
+      return new APA102Controller<DATA_PIN, CLOCK_PIN, RGB>();
+    }
+    case SK9822: {
+      return new SK9822Controller<DATA_PIN, CLOCK_PIN, RGB>();
+    }
+  }
+}
+
+#ifdef FASTLED_HAS_CLOCKLESS
+template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN> static CLEDController *create() {
+  return new CHIPSET<DATA_PIN, RGB>();
+}
+#endif
+
+#ifdef FASTLED_HAS_BLOCKLESS
+template<EBlockChipsets CHIPSET, int NUM_LANES> static CLEDController *create() {
+  switch (CHIPSET) {
+#ifdef PORTA_FIRST_PIN
+    case WS2811_PORTA:
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640)>();
+    case WS2811_400_PORTA:
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900)>();
+    case WS2813_PORTA:
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB, 0, false,
+                                                300>();
+    case TM1803_PORTA:
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB>();
+    case UCS1903_PORTA:
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB>();
+#endif
+  }
+}
+#endif
+}  // namespace CLEDControllerFactory
+
+}  // namespace fastled_bus
+}  // namespace esphome
+
+#endif

--- a/esphome/components/fastled_bus/cled_controller_factory.h
+++ b/esphome/components/fastled_bus/cled_controller_factory.h
@@ -19,96 +19,70 @@ namespace esphome {
 namespace fastled_bus {
 
 namespace CLEDControllerFactory {
-template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, uint32_t SPI_DATA_RATE>
+template<ESPIChipsets CHIPSET, EOrder RGB_Order, uint8_t DATA_PIN, uint8_t CLOCK_PIN, uint32_t SPI_DATA_RATE>
 static CLEDController *create() {
   switch (CHIPSET) {
     case LPD8806: {
-      return new LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+      return new LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_Order, SPI_DATA_RATE>();
     }
     case WS2801: {
-      return new WS2801Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+      return new WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_Order, SPI_DATA_RATE>();
     }
     case WS2803: {
-      return new WS2803Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+      return new WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_Order, SPI_DATA_RATE>();
     }
     case SM16716: {
-      return new SM16716Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+      return new SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_Order, SPI_DATA_RATE>();
     }
     case P9813: {
-      return new P9813Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+      return new P9813Controller<DATA_PIN, CLOCK_PIN, RGB_Order, SPI_DATA_RATE>();
     }
     case DOTSTAR:
     case APA102: {
-      return new APA102Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+      return new APA102Controller<DATA_PIN, CLOCK_PIN, RGB_Order, SPI_DATA_RATE>();
     }
     case SK9822: {
-      return new SK9822Controller<DATA_PIN, CLOCK_PIN, RGB, SPI_DATA_RATE>();
+      return new SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_Order, SPI_DATA_RATE>();
     }
   }
 }
 
-template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> static CLEDController *create() {
+template<ESPIChipsets CHIPSET, EOrder RGB_Order, uint8_t DATA_PIN, uint8_t CLOCK_PIN> static CLEDController *create() {
   switch (CHIPSET) {
     case LPD8806: {
-      return new LPD8806Controller<DATA_PIN, CLOCK_PIN>();
+      return new LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_Order>();
     }
     case WS2801: {
-      return new WS2801Controller<DATA_PIN, CLOCK_PIN>();
+      return new WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_Order>();
     }
     case WS2803: {
-      return new WS2803Controller<DATA_PIN, CLOCK_PIN>();
+      return new WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_Order>();
     }
     case SM16716: {
-      return new SM16716Controller<DATA_PIN, CLOCK_PIN>();
+      return new SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_Order>();
     }
     case P9813: {
-      return new P9813Controller<DATA_PIN, CLOCK_PIN>();
+      return new P9813Controller<DATA_PIN, CLOCK_PIN, RGB_Order>();
     }
     case DOTSTAR:
     case APA102: {
-      return new APA102Controller<DATA_PIN, CLOCK_PIN>();
+      return new APA102Controller<DATA_PIN, CLOCK_PIN, RGB_Order>();
     }
     case SK9822: {
-      return new SK9822Controller<DATA_PIN, CLOCK_PIN>();
-    }
-  }
-}
-
-template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> static CLEDController *create(int num_leds) {
-  switch (CHIPSET) {
-    case LPD8806: {
-      return new LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB>();
-    }
-    case WS2801: {
-      return new WS2801Controller<DATA_PIN, CLOCK_PIN, RGB>();
-    }
-    case WS2803: {
-      return new WS2803Controller<DATA_PIN, CLOCK_PIN, RGB>();
-    }
-    case SM16716: {
-      return new SM16716Controller<DATA_PIN, CLOCK_PIN, RGB>();
-    }
-    case P9813: {
-      return new P9813Controller<DATA_PIN, CLOCK_PIN, RGB>();
-    }
-    case DOTSTAR:
-    case APA102: {
-      return new APA102Controller<DATA_PIN, CLOCK_PIN, RGB>();
-    }
-    case SK9822: {
-      return new SK9822Controller<DATA_PIN, CLOCK_PIN, RGB>();
+      return new SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_Order>();
     }
   }
 }
 
 #ifdef FASTLED_HAS_CLOCKLESS
-template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN> static CLEDController *create() {
-  return new CHIPSET<DATA_PIN, RGB>();
+template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, EOrder RGB_Order, uint8_t DATA_PIN>
+static CLEDController *create() {
+  return new CHIPSET<DATA_PIN, RGB_Order>();
 }
 #endif
 
 #ifdef FASTLED_HAS_BLOCKLESS
-template<EBlockChipsets CHIPSET, int NUM_LANES> static CLEDController *create() {
+template<EBlockChipsets CHIPSET, EOrder RGB_Order, int NUM_LANES> static CLEDController *create() {
   switch (CHIPSET) {
 #ifdef PORTA_FIRST_PIN
     case WS2811_PORTA:
@@ -116,12 +90,12 @@ template<EBlockChipsets CHIPSET, int NUM_LANES> static CLEDController *create() 
     case WS2811_400_PORTA:
       return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900)>();
     case WS2813_PORTA:
-      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB, 0, false,
-                                                300>();
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_Order, 0,
+                                                false, 300>();
     case TM1803_PORTA:
-      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB>();
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_Order>();
     case UCS1903_PORTA:
-      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB>();
+      return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_Order>();
 #endif
   }
 }

--- a/esphome/components/fastled_bus/fastled_bus.cpp
+++ b/esphome/components/fastled_bus/fastled_bus.cpp
@@ -1,0 +1,38 @@
+#include "fastled_bus.h"
+
+namespace esphome {
+namespace fastled_bus {
+
+void FastLEDBus::setup() {
+  this->dump_config();
+  for (int i = 0; i < this->num_chips_ * this->chip_channels_; i++) {
+    this->chips()[i] = 0;
+  }
+  this->controller_->init();
+  this->controller_->setLeds((CRGB *) this->chips(), this->num_chips_);
+  if (!this->max_refresh_rate_.has_value()) {
+    this->set_max_refresh_rate(this->controller_->getMaxRefreshRate());
+  }
+  this->schedule_refresh();
+}
+
+void FastLEDBus::dump_config() {
+  ESP_LOGCONFIG("fastled:bus:", "FastLED bus:%d:%p", this->num_chips_, this->controller_);
+}
+
+void FastLEDBus::loop() {
+  if (!this->do_refresh_) {
+    return;
+  }
+  // protect from refreshing too often
+  uint32_t now = micros();
+  if (*this->max_refresh_rate_ != 0 && (now - this->last_refresh_) < *this->max_refresh_rate_) {
+    return;
+  }
+  this->last_refresh_ = now;
+  this->controller_->showLeds();
+  this->do_refresh_ = false;
+}
+
+}  // namespace fastled_bus
+}  // namespace esphome

--- a/esphome/components/fastled_bus/fastled_bus.cpp
+++ b/esphome/components/fastled_bus/fastled_bus.cpp
@@ -6,10 +6,10 @@ namespace fastled_bus {
 void FastLEDBus::setup() {
   this->dump_config();
   for (int i = 0; i < this->num_chips_ * this->chip_channels_; i++) {
-    this->chips()[i] = 0;
+    this->channels_[i] = 0;
   }
   this->controller_->init();
-  this->controller_->setLeds((CRGB *) this->chips(), this->num_chips_);
+  this->controller_->setLeds((CRGB *) this->channels_, this->num_chips_);
   if (!this->max_refresh_rate_.has_value()) {
     this->set_max_refresh_rate(this->controller_->getMaxRefreshRate());
   }

--- a/esphome/components/fastled_bus/fastled_bus.h
+++ b/esphome/components/fastled_bus/fastled_bus.h
@@ -30,7 +30,7 @@ class FastLEDBus : public Component {
   CLEDController *controller_{nullptr};
   const char *tag_;
   uint8_t *chips_;
-  const uint8_t *effect_data_;
+  uint8_t *effect_data_;
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};
   boolean do_refresh_{false};
@@ -41,7 +41,7 @@ class FastLEDBus : public Component {
 
   uint8_t *chips() { return this->chips_; }
 
-  const uint8_t *effect_data() { return this->effect_data_; }
+  uint8_t *effect_data() { return this->effect_data_; }
 
   void setup() override;
   void dump_config() override;

--- a/esphome/components/fastled_bus/fastled_bus.h
+++ b/esphome/components/fastled_bus/fastled_bus.h
@@ -42,6 +42,7 @@ class FastLEDBus : public Component {
   uint8_t *chips() { return this->chips_; }
 
   uint8_t *effect_data() { return this->effect_data_; }
+  CLEDController *controller() { return this->controller_; }
 
   void setup() override;
   void dump_config() override;

--- a/esphome/components/fastled_bus/fastled_bus.h
+++ b/esphome/components/fastled_bus/fastled_bus.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#ifdef USE_ARDUINO
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+#define FASTLED_ESP8266_RAW_PIN_ORDER
+#define FASTLED_ESP32_RAW_PIN_ORDER
+#define FASTLED_RMT_BUILTIN_DRIVER true
+
+// Avoid annoying compiler messages
+#define FASTLED_INTERNAL
+#include "FastLED.h"
+
+namespace esphome {
+namespace fastled_bus {
+
+class FastLEDBus : public Component {
+ public:
+  FastLEDBus(uint8_t chip_channels, uint16_t num_chips)
+      : tag_("FastLEDBus"),
+        chips_(new uint8_t[num_chips * chip_channels]),
+        effect_data_(new uint8_t[num_chips]),
+        chip_channels_(chip_channels),
+        num_chips_(num_chips) {}
+
+ protected:
+  CLEDController *controller_{nullptr};
+  const char *tag_;
+  uint8_t *chips_;
+  const uint8_t *effect_data_;
+  uint32_t last_refresh_{0};
+  optional<uint32_t> max_refresh_rate_{};
+  boolean do_refresh_{false};
+
+ public:
+  const uint8_t chip_channels_;
+  const uint16_t num_chips_;
+
+  uint8_t *chips() { return this->chips_; }
+
+  const uint8_t *effect_data() { return this->effect_data_; }
+
+  void setup() override;
+  void dump_config() override;
+
+  /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
+  void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
+
+  void schedule_refresh() { this->do_refresh_ = true; }
+  void loop() override;
+  void set_controller(CLEDController *controller) { this->controller_ = controller; }
+};
+
+}  // namespace fastled_bus
+}  // namespace esphome
+
+#endif

--- a/esphome/components/fastled_bus/fastled_bus.h
+++ b/esphome/components/fastled_bus/fastled_bus.h
@@ -21,7 +21,7 @@ class FastLEDBus : public Component {
  public:
   FastLEDBus(uint8_t chip_channels, uint16_t num_chips)
       : tag_("FastLEDBus"),
-        chips_(new uint8_t[num_chips * chip_channels]),
+        channels_(new uint8_t[num_chips * chip_channels]),
         effect_data_(new uint8_t[num_chips]),
         chip_channels_(chip_channels),
         num_chips_(num_chips) {}
@@ -29,7 +29,7 @@ class FastLEDBus : public Component {
  protected:
   CLEDController *controller_{nullptr};
   const char *tag_;
-  uint8_t *chips_;
+  uint8_t *channels_;
   uint8_t *effect_data_;
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};
@@ -39,7 +39,7 @@ class FastLEDBus : public Component {
   const uint8_t chip_channels_;
   const uint16_t num_chips_;
 
-  uint8_t *chips() { return this->chips_; }
+  uint8_t *channels() { return this->channels_; }
 
   uint8_t *effect_data() { return this->effect_data_; }
   CLEDController *controller() { return this->controller_; }

--- a/esphome/components/fastled_bus/fastled_bus_output.cpp
+++ b/esphome/components/fastled_bus/fastled_bus_output.cpp
@@ -4,7 +4,7 @@ namespace esphome {
 namespace fastled_bus {
 
 void setup_mapping(Mapping &map) {
-  if (map.num_chips_ + map.ofs_ >= map.bus_->num_chips_) {
+  if (map.num_chips_ + map.ofs_ > map.bus_->num_chips_) {
     ESP_LOGE("fastled:bus:output", "Number of chips (%d) + offset (%d) > (%d)", map.num_chips_, map.ofs_,
              map.bus_->num_chips_);
     return;

--- a/esphome/components/fastled_bus/fastled_bus_output.cpp
+++ b/esphome/components/fastled_bus/fastled_bus_output.cpp
@@ -15,18 +15,25 @@ void setup_mapping(Mapping &map) {
 
 void write_mapping(Mapping &map, float state) {
   auto *chips = &(map.bus_->chips()[map.ofs_ * map.bus_->chip_channels_]);
+  // ESP_LOGCONFIG("fastled:bus:write_mapping", "Writing FastLEDBusOutput...[%d:%d:%d:%d]:%p:[%d:%d]:%p", map.num_chips_, map.ofs_,
+  //               map.channel_offset_, map.repeat_distance_, map.bus_->chips(), map.bus_->chip_channels_, map.bus_->num_chips_,
+  //               chips);
   auto val = uint8_t(state * 255);
+  auto schedule_refresh = false;
   for (uint16_t i = (uint16_t)(map.channel_offset_ / map.bus_->chip_channels_);
        i < map.num_chips_ * map.bus_->chip_channels_;
        i += (uint16_t)(map.repeat_distance_)) {
-    chips[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
+    // chips[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
+    schedule_refresh = true;
     // ESP_LOGCONFIG("fastled:bus:write_mapping", "%d:%x:controller:%p:%p:%p:%d:%d:%d:%d",
     // i, val,
     // map.bus_->controller(), chips, map.bus_->chips(),
     // map.ofs_, map.bus_->chip_channels_, map.num_chips_,
     // map.repeat_distance_);
   }
-  map.bus_->schedule_refresh();
+  if (schedule_refresh) {
+    map.bus_->schedule_refresh();
+  }
 }
 
 }  // namespace fastled_bus

--- a/esphome/components/fastled_bus/fastled_bus_output.cpp
+++ b/esphome/components/fastled_bus/fastled_bus_output.cpp
@@ -1,0 +1,28 @@
+#include "fastled_bus_output.h"
+
+namespace esphome {
+namespace fastled_bus {
+
+void Output::setup() {
+  if (this->num_chips_ + this->ofs_ >= this->bus_->num_chips_) {
+    ESP_LOGE("fastled:bus:output", "Number of chips (%d) + offset (%d) > (%d)", this->num_chips_, this->ofs_,
+             this->bus_->num_chips_);
+    return;
+  }
+  ESP_LOGCONFIG("fastled:bus:output", "Setting up FastLEDBusOutput...[%d:%d:%d:%d]", this->num_chips_, this->ofs_,
+                this->channel_offset_, this->repeat_distance_);
+}
+
+void Output::write_state(float state) {
+  uint8_t *chips = &this->bus_->chips()[this->ofs_ * this->bus_->chip_channels_];
+  auto val = uint8_t(state * 255);
+  for (uint16_t i = (uint16_t)(this->channel_offset_ / this->bus_->chip_channels_);
+       i < this->num_chips_ * this->bus_->chip_channels_;
+       i += (uint16_t)(this->repeat_distance_ / this->bus_->chip_channels_)) {
+    chips[i + (this->channel_offset_ % this->bus_->chip_channels_)] = val;
+  }
+  this->bus_->schedule_refresh();
+};
+
+}  // namespace fastled_bus
+}  // namespace esphome

--- a/esphome/components/fastled_bus/fastled_bus_output.cpp
+++ b/esphome/components/fastled_bus/fastled_bus_output.cpp
@@ -5,12 +5,12 @@ namespace fastled_bus {
 
 void setup_mapping(Mapping &map) {
   if (map.num_chips_ + map.ofs_ > map.bus_->num_chips_) {
-    ESP_LOGE("fastled:bus:output", "Number of chips (%d) + offset (%d) > (%d)", map.num_chips_, map.ofs_,
+    ESP_LOGE("fastled:bus:setup_mapping", "Number of chips (%d) + offset (%d) > (%d)", map.num_chips_, map.ofs_,
              map.bus_->num_chips_);
     return;
   }
-  ESP_LOGCONFIG("fastled:bus:output", "Setting up FastLEDBusOutput...[%d:%d:%d:%d]", map.num_chips_, map.ofs_,
-                map.channel_offset_, map.repeat_distance_);
+  // ESP_LOGCONFIG("fastled:bus:setup_mapping", "Setting up FastLEDBusOutput...[%d:%d:%d:%d]", map.num_chips_, map.ofs_,
+  //               map.channel_offset_, map.repeat_distance_);
 }
 
 void write_mapping(Mapping &map, float state) {
@@ -18,8 +18,13 @@ void write_mapping(Mapping &map, float state) {
   auto val = uint8_t(state * 255);
   for (uint16_t i = (uint16_t)(map.channel_offset_ / map.bus_->chip_channels_);
        i < map.num_chips_ * map.bus_->chip_channels_;
-       i += (uint16_t)(map.repeat_distance_ / map.bus_->chip_channels_)) {
+       i += (uint16_t)(map.repeat_distance_)) {
     chips[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
+    // ESP_LOGCONFIG("fastled:bus:write_mapping", "%d:%x:controller:%p:%p:%p:%d:%d:%d:%d",
+    // i, val,
+    // map.bus_->controller(), chips, map.bus_->chips(),
+    // map.ofs_, map.bus_->chip_channels_, map.num_chips_,
+    // map.repeat_distance_);
   }
   map.bus_->schedule_refresh();
 }

--- a/esphome/components/fastled_bus/fastled_bus_output.cpp
+++ b/esphome/components/fastled_bus/fastled_bus_output.cpp
@@ -14,7 +14,7 @@ void setup_mapping(Mapping &map) {
 }
 
 void write_mapping(Mapping &map, float state) {
-  auto *chips = &(map.bus_->chips()[map.ofs_ * map.bus_->chip_channels_]);
+  auto *channels = &(map.bus_->channels()[map.ofs_ * map.bus_->chip_channels_]);
   // ESP_LOGCONFIG("fastled:bus:write_mapping", "Writing FastLEDBusOutput...[%d:%d:%d:%d]:%p:[%d:%d]:%p",
   // map.num_chips_, map.ofs_,
   //               map.channel_offset_, map.repeat_distance_, map.bus_->chips(), map.bus_->chip_channels_,
@@ -23,7 +23,7 @@ void write_mapping(Mapping &map, float state) {
   auto schedule_refresh = false;
   for (uint16_t i = (uint16_t)(map.channel_offset_ / map.bus_->chip_channels_);
        i < map.num_chips_ * map.bus_->chip_channels_; i += (uint16_t)(map.repeat_distance_)) {
-    chips[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
+    channels[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
     schedule_refresh = true;
     // ESP_LOGCONFIG("fastled:bus:write_mapping", "%d:%x:controller:%p:%p:%p:%d:%d:%d:%d",
     // i, val,

--- a/esphome/components/fastled_bus/fastled_bus_output.cpp
+++ b/esphome/components/fastled_bus/fastled_bus_output.cpp
@@ -15,15 +15,15 @@ void setup_mapping(Mapping &map) {
 
 void write_mapping(Mapping &map, float state) {
   auto *chips = &(map.bus_->chips()[map.ofs_ * map.bus_->chip_channels_]);
-  // ESP_LOGCONFIG("fastled:bus:write_mapping", "Writing FastLEDBusOutput...[%d:%d:%d:%d]:%p:[%d:%d]:%p", map.num_chips_, map.ofs_,
-  //               map.channel_offset_, map.repeat_distance_, map.bus_->chips(), map.bus_->chip_channels_, map.bus_->num_chips_,
-  //               chips);
+  // ESP_LOGCONFIG("fastled:bus:write_mapping", "Writing FastLEDBusOutput...[%d:%d:%d:%d]:%p:[%d:%d]:%p",
+  // map.num_chips_, map.ofs_,
+  //               map.channel_offset_, map.repeat_distance_, map.bus_->chips(), map.bus_->chip_channels_,
+  //               map.bus_->num_chips_, chips);
   auto val = uint8_t(state * 255);
   auto schedule_refresh = false;
   for (uint16_t i = (uint16_t)(map.channel_offset_ / map.bus_->chip_channels_);
-       i < map.num_chips_ * map.bus_->chip_channels_;
-       i += (uint16_t)(map.repeat_distance_)) {
-    // chips[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
+       i < map.num_chips_ * map.bus_->chip_channels_; i += (uint16_t)(map.repeat_distance_)) {
+    chips[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
     schedule_refresh = true;
     // ESP_LOGCONFIG("fastled:bus:write_mapping", "%d:%x:controller:%p:%p:%p:%d:%d:%d:%d",
     // i, val,

--- a/esphome/components/fastled_bus/fastled_bus_output.cpp
+++ b/esphome/components/fastled_bus/fastled_bus_output.cpp
@@ -3,38 +3,26 @@
 namespace esphome {
 namespace fastled_bus {
 
-static void setup_mapping(Mapping *map) {
-  if (map->num_chips_ + map->ofs_ >= map->bus_->num_chips_) {
-    ESP_LOGE("fastled:bus:output", "Number of chips (%d) + offset (%d) > (%d)", map->num_chips_, map->ofs_,
-             map->bus_->num_chips_);
+void setup_mapping(Mapping &map) {
+  if (map.num_chips_ + map.ofs_ >= map.bus_->num_chips_) {
+    ESP_LOGE("fastled:bus:output", "Number of chips (%d) + offset (%d) > (%d)", map.num_chips_, map.ofs_,
+             map.bus_->num_chips_);
     return;
   }
-  ESP_LOGCONFIG("fastled:bus:output", "Setting up FastLEDBusOutput...[%d:%d:%d:%d]", map->num_chips_, map->ofs_,
-                map->channel_offset_, map->repeat_distance_);
+  ESP_LOGCONFIG("fastled:bus:output", "Setting up FastLEDBusOutput...[%d:%d:%d:%d]", map.num_chips_, map.ofs_,
+                map.channel_offset_, map.repeat_distance_);
 }
 
-void Output::setup() {
-  for (uint8_t i = 0; i < this->len_; i++) {
-    setup_mapping(&this->mappings_[i]);
-  }
-}
-
-static void write_mapping(Mapping *map, float state) {
-  auto *chips = &(map->bus_->chips()[map->ofs_ * map->bus_->chip_channels_]);
+void write_mapping(Mapping &map, float state) {
+  auto *chips = &(map.bus_->chips()[map.ofs_ * map.bus_->chip_channels_]);
   auto val = uint8_t(state * 255);
-  for (uint16_t i = (uint16_t)(map->channel_offset_ / map->bus_->chip_channels_);
-       i < map->num_chips_ * map->bus_->chip_channels_;
-       i += (uint16_t)(map->repeat_distance_ / map->bus_->chip_channels_)) {
-    chips[i + (map->channel_offset_ % map->bus_->chip_channels_)] = val;
+  for (uint16_t i = (uint16_t)(map.channel_offset_ / map.bus_->chip_channels_);
+       i < map.num_chips_ * map.bus_->chip_channels_;
+       i += (uint16_t)(map.repeat_distance_ / map.bus_->chip_channels_)) {
+    chips[i + (map.channel_offset_ % map.bus_->chip_channels_)] = val;
   }
-  map->bus_->schedule_refresh();
+  map.bus_->schedule_refresh();
 }
-
-void Output::write_state(float state) {
-  for (uint8_t i = 0; i < this->len_; i++) {
-    write_mapping(&this->mappings_[i], state);
-  }
-};
 
 }  // namespace fastled_bus
 }  // namespace esphome

--- a/esphome/components/fastled_bus/fastled_bus_output.h
+++ b/esphome/components/fastled_bus/fastled_bus_output.h
@@ -45,7 +45,7 @@ template<std::size_t S> class MappingsBuilder {
     current->channel_offset_ = channel_offset;
     current->repeat_distance_ = repeat_distance;
     if (repeat_distance == 0) {
-      current->repeat_distance_ = 1;
+      current->repeat_distance_ = bus->chip_channels_;
     }
     return *this;
   }

--- a/esphome/components/fastled_bus/fastled_bus_output.h
+++ b/esphome/components/fastled_bus/fastled_bus_output.h
@@ -19,13 +19,13 @@
 namespace esphome {
 namespace fastled_bus {
 
-typedef struct sMapping {
+using Mapping = struct SMapping {
   FastLEDBus *bus_;
   uint16_t num_chips_;
   uint16_t ofs_;
   uint8_t channel_offset_;
   uint16_t repeat_distance_;
-} Mapping;
+};
 
 template<std::size_t S> class MappingsBuilder {
  private:
@@ -33,7 +33,8 @@ template<std::size_t S> class MappingsBuilder {
   uint8_t index_{0};
 
  public:
-  typedef Mapping Mappings[S];
+  // typedef Mapping Mappings[S];
+  using Mappings = Mapping[S];
 
   MappingsBuilder &add_mapping(FastLEDBus *const bus, const uint16_t num_chips, const uint16_t ofs,
                                const uint8_t channel_offset, const uint16_t repeat_distance) {
@@ -48,10 +49,10 @@ template<std::size_t S> class MappingsBuilder {
     }
     return *this;
   }
-  MappingsBuilder<S>::Mappings &done() { return this->mappings_; }
+  Mappings &done() { return this->mappings_; }
 };
 
-template<std::size_t S> MappingsBuilder<S> &MappingsBuilderCreate() { return *(new MappingsBuilder<S>()); }
+template<std::size_t S> MappingsBuilder<S> &mappings_builder_create() { return *(new MappingsBuilder<S>()); }
 
 void setup_mapping(Mapping &map);
 void write_mapping(Mapping &map, float state);

--- a/esphome/components/fastled_bus/fastled_bus_output.h
+++ b/esphome/components/fastled_bus/fastled_bus_output.h
@@ -19,27 +19,61 @@
 namespace esphome {
 namespace fastled_bus {
 
-using Mapping = struct {
-  FastLEDBus *const bus_;
-  const uint16_t num_chips_;
-  const uint16_t ofs_;
-  const uint8_t channel_offset_;
-  const uint16_t repeat_distance_;
+typedef struct sMapping {
+  FastLEDBus *bus_;
+  uint16_t num_chips_;
+  uint16_t ofs_;
+  uint8_t channel_offset_;
+  uint16_t repeat_distance_;
+} Mapping;
+
+template<std::size_t S> class MappingsBuilder {
+ private:
+  Mapping mappings_[S]{};
+  uint8_t index_{0};
+
+ public:
+  typedef Mapping Mappings[S];
+
+  MappingsBuilder &add_mapping(FastLEDBus *const bus, const uint16_t num_chips, const uint16_t ofs,
+                               const uint8_t channel_offset, const uint16_t repeat_distance) {
+    auto current = this->mappings_[this->index_++];
+    current.bus_ = bus;
+    current.num_chips_ = num_chips;
+    current.ofs_ = ofs;
+    current.channel_offset_ = channel_offset;
+    current.repeat_distance_ = repeat_distance;
+    return *this;
+  }
+  MappingsBuilder<S>::Mappings &done() { return this->mappings_; }
 };
 
-class Output : public esphome::output::FloatOutput, public Component {
+template<std::size_t S> MappingsBuilder<S> &MappingsBuilderCreate() { return *(new MappingsBuilder<S>()); }
+
+void setup_mapping(Mapping &map);
+void write_mapping(Mapping &map, float state);
+
+template<std::size_t S> class Output : public esphome::output::FloatOutput, public Component {
  protected:
-  const uint8_t len_;
-  Mapping *const mappings_;
+  const Mapping (&mappings_)[S];
 
  public:
   // repeated_distance must be big to stop the set loop
-  Output(uint8_t len, Mapping *const mappings) : len_(len), mappings_{mappings} {}
+  Output(const Mapping (&mappings)[S]) : mappings_{mappings} {}
 
-  void setup() override;
+  void setup() override {
+    for (auto mapping : this->mappings_) {
+      setup_mapping(mapping);
+    }
+  }
+
   void dump_config() override {}
 
-  void write_state(float state) override;
+  void write_state(float state) override {
+    for (auto mapping : this->mappings_) {
+      write_mapping(mapping, state);
+    }
+  }
 };
 
 }  // namespace fastled_bus

--- a/esphome/components/fastled_bus/fastled_bus_output.h
+++ b/esphome/components/fastled_bus/fastled_bus_output.h
@@ -43,6 +43,9 @@ template<std::size_t S> class MappingsBuilder {
     current->ofs_ = ofs;
     current->channel_offset_ = channel_offset;
     current->repeat_distance_ = repeat_distance;
+    if (repeat_distance == 0) {
+      current->repeat_distance_ = 1;
+    }
     return *this;
   }
   MappingsBuilder<S>::Mappings &done() { return this->mappings_; }

--- a/esphome/components/fastled_bus/fastled_bus_output.h
+++ b/esphome/components/fastled_bus/fastled_bus_output.h
@@ -29,7 +29,7 @@ typedef struct sMapping {
 
 template<std::size_t S> class MappingsBuilder {
  private:
-  Mapping mappings_[S]{};
+  Mapping mappings_[S];
   uint8_t index_{0};
 
  public:
@@ -37,12 +37,12 @@ template<std::size_t S> class MappingsBuilder {
 
   MappingsBuilder &add_mapping(FastLEDBus *const bus, const uint16_t num_chips, const uint16_t ofs,
                                const uint8_t channel_offset, const uint16_t repeat_distance) {
-    auto current = this->mappings_[this->index_++];
-    current.bus_ = bus;
-    current.num_chips_ = num_chips;
-    current.ofs_ = ofs;
-    current.channel_offset_ = channel_offset;
-    current.repeat_distance_ = repeat_distance;
+    auto *current = &(this->mappings_[this->index_++]);
+    current->bus_ = bus;
+    current->num_chips_ = num_chips;
+    current->ofs_ = ofs;
+    current->channel_offset_ = channel_offset;
+    current->repeat_distance_ = repeat_distance;
     return *this;
   }
   MappingsBuilder<S>::Mappings &done() { return this->mappings_; }

--- a/esphome/components/fastled_bus/fastled_bus_output.h
+++ b/esphome/components/fastled_bus/fastled_bus_output.h
@@ -19,24 +19,22 @@
 namespace esphome {
 namespace fastled_bus {
 
-class Output : public esphome::output::FloatOutput, public Component {
- protected:
+using Mapping = struct {
+  FastLEDBus *const bus_;
   const uint16_t num_chips_;
   const uint16_t ofs_;
   const uint8_t channel_offset_;
-  uint16_t repeat_distance_{0};
-  FastLEDBus *bus_{nullptr};
+  const uint16_t repeat_distance_;
+};
+
+class Output : public esphome::output::FloatOutput, public Component {
+ protected:
+  const uint8_t len_;
+  Mapping *const mappings_;
 
  public:
   // repeated_distance must be big to stop the set loop
-  Output(uint16_t num_chips, uint16_t ofs, uint8_t channel_offset)
-      : num_chips_(num_chips), ofs_(ofs), channel_offset_(channel_offset) {}
-
-  void set_bus(FastLEDBus *bus) {
-    this->bus_ = bus;
-    this->repeat_distance_ = this->bus_->chip_channels_ * this->bus_->num_chips_;
-  }
-  void set_repeat_distance(uint16_t repeat_distance) { this->repeat_distance_ = repeat_distance; }
+  Output(uint8_t len, Mapping *const mappings) : len_(len), mappings_{mappings} {}
 
   void setup() override;
   void dump_config() override {}

--- a/esphome/components/fastled_bus/fastled_bus_output.h
+++ b/esphome/components/fastled_bus/fastled_bus_output.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifdef USE_ARDUINO
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "esphome/components/output/float_output.h"
+
+#define FASTLED_ESP8266_RAW_PIN_ORDER
+#define FASTLED_ESP32_RAW_PIN_ORDER
+#define FASTLED_RMT_BUILTIN_DRIVER true
+
+// Avoid annoying compiler messages
+#define FASTLED_INTERNAL
+
+#include "fastled_bus.h"
+
+namespace esphome {
+namespace fastled_bus {
+
+class Output : public esphome::output::FloatOutput, public Component {
+ protected:
+  const uint16_t num_chips_;
+  const uint16_t ofs_;
+  const uint8_t channel_offset_;
+  uint16_t repeat_distance_{0};
+  FastLEDBus *bus_{nullptr};
+
+ public:
+  // repeated_distance must be big to stop the set loop
+  Output(uint16_t num_chips, uint16_t ofs, uint8_t channel_offset)
+      : num_chips_(num_chips), ofs_(ofs), channel_offset_(channel_offset) {}
+
+  void set_bus(FastLEDBus *bus) {
+    this->bus_ = bus;
+    this->repeat_distance_ = this->bus_->chip_channels_ * this->bus_->num_chips_;
+  }
+  void set_repeat_distance(uint16_t repeat_distance) { this->repeat_distance_ = repeat_distance; }
+
+  void setup() override;
+  void dump_config() override {}
+
+  void write_state(float state) override;
+};
+
+}  // namespace fastled_bus
+}  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/fastled_bus/output.py
+++ b/esphome/components/fastled_bus/output.py
@@ -44,8 +44,8 @@ async def to_code(config):
             crd = channel[CONF_REPEAT_DISTANCE]
         out = out.add_mapping(
             bus,
-            channel[CONF_OFFSET],
             channel[CONF_NUM_CHIPS],
+            channel[CONF_OFFSET],
             channel[CONF_CHANNEL_OFFSET],
             crd,
         )

--- a/esphome/components/fastled_bus/output.py
+++ b/esphome/components/fastled_bus/output.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 async def to_code(config):
     channels = list(config[CONF_CHANNELS])
     template_len = cg.TemplateArguments(cg.RawExpression(f"{len(channels)}"))
-    out = bus_ns.MappingsBuilderCreate(template_len)
+    out = bus_ns.mappings_builder_create(template_len)
 
     for channel in channels:
         bus = await cg.get_variable(channel[CONF_BUS])

--- a/esphome/components/fastled_bus/output.py
+++ b/esphome/components/fastled_bus/output.py
@@ -2,8 +2,14 @@ import copy
 import esphome.config_validation as cv
 from esphome.components import output
 import esphome.codegen as cg
-from esphome.const import CONF_CHANNELS, CONF_ID, CONF_NUM_CHIPS, CONF_OFFSET
-from . import CONF_BUS, CONF_REPEAT_DISTANCE, CONF_CHANNEL_OFFSET, bus_ns
+from esphome.const import CONF_CHANNELS, CONF_ID, CONF_NUM_CHIPS
+from . import (
+    CONF_BUS,
+    CONF_REPEAT_DISTANCE,
+    CONF_CHANNEL_OFFSET,
+    CONF_CHIP_OFFSET,
+    bus_ns,
+)
 
 # MULTI_CONF = True
 
@@ -21,7 +27,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
             cv.Schema(
                 {
                     cv.Required(CONF_BUS): cv.use_id(CONF_BUS),
-                    cv.Required(CONF_OFFSET): cv.positive_int,
+                    cv.Required(CONF_CHIP_OFFSET): cv.positive_int,
                     cv.Required(CONF_NUM_CHIPS): cv.positive_not_null_int,
                     cv.Required(CONF_CHANNEL_OFFSET): cv.positive_int,
                     cv.Optional(CONF_REPEAT_DISTANCE): cv.positive_not_null_int,
@@ -45,28 +51,10 @@ async def to_code(config):
         out = out.add_mapping(
             bus,
             channel[CONF_NUM_CHIPS],
-            channel[CONF_OFFSET],
+            channel[CONF_CHIP_OFFSET],
             channel[CONF_CHANNEL_OFFSET],
             crd,
         )
-        # out.append(
-        #     cg.StructInitializer(
-        #         Mapping,
-        #         ("bus_", bus),
-        #         ("num_chips_", channel[CONF_OFFSET]),
-        #         ("ofs_", channel[CONF_NUM_CHIPS]),
-        #         ("channel_offset_", channel[CONF_CHANNEL_OFFSET]),
-        #         ("repeat_distance_", crd),
-        #     )
-        # )
-    # cg.add(
-    #     cg.AssignmentExpression(
-    #         Mapping,
-    #         "",
-    #         f"_{config[CONF_ID]}[{len(out)}]",
-    #         cg.ArrayInitializer(*out, multiline=True),
-    #     )
-    # )
 
     # very ugly things to add template parameters to type declaration.
 
@@ -79,19 +67,5 @@ async def to_code(config):
         out.done(),
     )
 
-    # var = cg.new_Pvariable(
-    #     config[CONF_ID], cg.RawExpression(f"_{config[CONF_ID]}")
-    # )
-    # out = f"({Mapping}[{len(channels)}]){{\n"
-    # comma = ""
-    # for channel in channels:
-    #     bus = await cg.get_variable(channel[CONF_BUS])
-    #     crd = 0
-    #     if CONF_REPEAT_DISTANCE in channel:
-    #         crd = channel[CONF_REPEAT_DISTANCE]
-    #     out += f'{comma}{{ {bus}, {channel[CONF_NUM_CHIPS]}, {channel[CONF_OFFSET]}, {channel[CONF_CHANNEL_OFFSET]}, {crd} }}'
-    #     comma = ",\n"
-    # out += "\n}"
-    # var = cg.new_Pvariable(config[CONF_ID], len(out), cg.RawExpression(out))
     await cg.register_component(var, config)
     await output.register_output(var, config)

--- a/esphome/components/fastled_bus/output.py
+++ b/esphome/components/fastled_bus/output.py
@@ -1,0 +1,33 @@
+import esphome.config_validation as cv
+from esphome.components import output
+import esphome.codegen as cg
+from esphome.const import CONF_ID, CONF_NUM_CHIPS, CONF_OFFSET
+from . import CONF_BUS, CONF_REPEAT_DISTANCE, CONF_CHANNEL_OFFSET, bus_ns
+
+clazz_output = bus_ns.class_("Output", output.FloatOutput, cg.Component)
+
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(clazz_output),
+        cv.Required(CONF_BUS): cv.use_id(CONF_BUS),
+        cv.Required(CONF_OFFSET): cv.positive_int,
+        cv.Required(CONF_NUM_CHIPS): cv.positive_not_null_int,
+        cv.Required(CONF_CHANNEL_OFFSET): cv.positive_int,
+        cv.Optional(CONF_REPEAT_DISTANCE): cv.positive_not_null_int,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        config[CONF_NUM_CHIPS],
+        config[CONF_OFFSET],
+        config[CONF_CHANNEL_OFFSET],
+    )
+    bus = await cg.get_variable(config[CONF_BUS])
+    if CONF_REPEAT_DISTANCE in config:
+        cg.add(var.set_repeat_distance(config[CONF_REPEAT_DISTANCE]))
+    cg.add(var.set_bus(bus))
+    await cg.register_component(var, config)
+    await output.register_output(var, config)

--- a/esphome/components/fastled_bus_clockless/__init__.py
+++ b/esphome/components/fastled_bus_clockless/__init__.py
@@ -2,7 +2,8 @@ from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import fastled_bus
-import esphome.components.fastled_clockless.light as fastled_clockless_light
+from esphome.components import fastled_base
+# import esphome.components.fastled_base.light as fastled_clockless_light
 from esphome.const import CONF_CHIPSET, CONF_ID, CONF_NUM_CHIPS, CONF_PIN
 
 CODEOWNERS = ["@mabels"]
@@ -13,7 +14,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(CONF_ID): fastled_bus.FastledBusId,
             cv.Required(CONF_CHIPSET): cv.one_of(
-                *fastled_clockless_light.CHIPSETS, upper=True
+                *fastled_base.CLOCKLESS_CHIPSETS, upper=True
             ),
             cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
         }

--- a/esphome/components/fastled_bus_clockless/__init__.py
+++ b/esphome/components/fastled_bus_clockless/__init__.py
@@ -3,7 +3,6 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import fastled_bus
 from esphome.components import fastled_base
-# import esphome.components.fastled_base.light as fastled_clockless_light
 from esphome.const import CONF_CHIPSET, CONF_ID, CONF_NUM_CHIPS, CONF_PIN
 
 CODEOWNERS = ["@mabels"]
@@ -32,6 +31,8 @@ async def to_code(config):
     fastled_bus.new_fastled_bus(var, config)
 
     template_args = cg.TemplateArguments(
-        cg.RawExpression(config[CONF_CHIPSET]), fastled_bus.rgb_order(config), config[CONF_PIN]
+        cg.RawExpression(config[CONF_CHIPSET]),
+        fastled_bus.rgb_order(config),
+        config[CONF_PIN],
     )
     cg.add(var.set_controller(fastled_bus.CLEDControllerFactory.create(template_args)))

--- a/esphome/components/fastled_bus_clockless/__init__.py
+++ b/esphome/components/fastled_bus_clockless/__init__.py
@@ -1,0 +1,42 @@
+from esphome import pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import fastled_bus
+import esphome.components.fastled_clockless.light as fastled_clockless_light
+from esphome.const import CONF_CHIPSET, CONF_ID, CONF_NUM_CHIPS, CONF_PIN
+
+CODEOWNERS = ["@mabels"]
+MULTI_CONF = True
+
+CONFIG_SCHEMA = cv.All(
+    fastled_bus.CONFIG_BUS_SCHEMA.extend(
+        {
+            cv.GenerateID(CONF_ID): cv.declare_id(fastled_bus.FastLEDBus),
+            cv.Required(CONF_CHIPSET): cv.one_of(
+                *fastled_clockless_light.CHIPSETS, upper=True
+            ),
+            cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
+        }
+    ),
+    fastled_bus.REQUIRED_FRAMEWORK,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID], config[fastled_bus.CONF_CHIP_CHANNELS], config[CONF_NUM_CHIPS]
+    )
+    await cg.register_component(var, config)
+
+    fastled_bus.new_fastled_bus(var, config)
+
+    template_args = cg.TemplateArguments(
+        cg.RawExpression(config[CONF_CHIPSET]), config[CONF_PIN]
+    )
+    cg.add(
+        var.set_controller(
+            cg.RawExpression(
+                f"fastled_bus::CLEDControllerFactory::create{template_args}()"
+            )
+        )
+    )

--- a/esphome/components/fastled_bus_clockless/__init__.py
+++ b/esphome/components/fastled_bus_clockless/__init__.py
@@ -33,10 +33,4 @@ async def to_code(config):
     template_args = cg.TemplateArguments(
         cg.RawExpression(config[CONF_CHIPSET]), config[CONF_PIN]
     )
-    cg.add(
-        var.set_controller(
-            cg.RawExpression(
-                f"fastled_bus::CLEDControllerFactory::create{template_args}()"
-            )
-        )
-    )
+    cg.add(var.set_controller(fastled_bus.CLEDControllerFactory.create(template_args)))

--- a/esphome/components/fastled_bus_clockless/__init__.py
+++ b/esphome/components/fastled_bus_clockless/__init__.py
@@ -11,7 +11,7 @@ MULTI_CONF = True
 CONFIG_SCHEMA = cv.All(
     fastled_bus.CONFIG_BUS_SCHEMA.extend(
         {
-            cv.GenerateID(CONF_ID): cv.declare_id(fastled_bus.FastLEDBus),
+            cv.GenerateID(CONF_ID): fastled_bus.FastledBusId,
             cv.Required(CONF_CHIPSET): cv.one_of(
                 *fastled_clockless_light.CHIPSETS, upper=True
             ),
@@ -31,6 +31,6 @@ async def to_code(config):
     fastled_bus.new_fastled_bus(var, config)
 
     template_args = cg.TemplateArguments(
-        cg.RawExpression(config[CONF_CHIPSET]), config[CONF_PIN]
+        cg.RawExpression(config[CONF_CHIPSET]), fastled_bus.rgb_order(config), config[CONF_PIN]
     )
     cg.add(var.set_controller(fastled_bus.CLEDControllerFactory.create(template_args)))

--- a/esphome/components/fastled_bus_spi/__init__.py
+++ b/esphome/components/fastled_bus_spi/__init__.py
@@ -33,9 +33,7 @@ CONFIG_SCHEMA = cv.All(
     fastled_bus.CONFIG_BUS_SCHEMA.extend(
         {
             cv.GenerateID(CONF_ID): fastled_bus.FastledBusId,
-            cv.Required(CONF_CHIPSET): cv.one_of(
-                *CHIPSETS, upper=True
-            ),
+            cv.Required(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
             cv.Required(CONF_DATA_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_DATA_RATE): cv.frequency,

--- a/esphome/components/fastled_bus_spi/__init__.py
+++ b/esphome/components/fastled_bus_spi/__init__.py
@@ -3,7 +3,6 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import fastled_bus
 from esphome.components.fastled_bus import CONF_CHIP_CHANNELS
-import esphome.components.fastled_spi.light as fastled_spi_light
 from esphome.const import (
     CONF_CHIPSET,
     CONF_CLOCK_PIN,
@@ -18,13 +17,24 @@ AUTO_LOAD = ["fastled_bus"]
 CODEOWNERS = ["@mabels"]
 MULTI_CONF = True
 
+CHIPSETS = [
+    "LPD8806",
+    "WS2801",
+    "WS2803",
+    "SM16716",
+    "P9813",
+    "APA102",
+    "SK9822",
+    "DOTSTAR",
+]
+
 
 CONFIG_SCHEMA = cv.All(
     fastled_bus.CONFIG_BUS_SCHEMA.extend(
         {
             cv.GenerateID(CONF_ID): fastled_bus.FastledBusId,
             cv.Required(CONF_CHIPSET): cv.one_of(
-                *fastled_spi_light.CHIPSETS, upper=True
+                *CHIPSETS, upper=True
             ),
             cv.Required(CONF_DATA_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,

--- a/esphome/components/fastled_bus_spi/__init__.py
+++ b/esphome/components/fastled_bus_spi/__init__.py
@@ -56,10 +56,4 @@ async def to_code(config):
         data_rate,
     )
     fastled_bus.new_fastled_bus(var, config)
-    cg.add(
-        var.set_controller(
-            cg.RawExpression(
-                f"fastled_bus::CLEDControllerFactory::create{template_args}()"
-            )
-        )
-    )
+    cg.add(var.set_controller(fastled_bus.CLEDControllerFactory.create(template_args)))

--- a/esphome/components/fastled_bus_spi/__init__.py
+++ b/esphome/components/fastled_bus_spi/__init__.py
@@ -1,0 +1,65 @@
+from esphome import pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import fastled_bus
+from esphome.components.fastled_bus import CONF_CHIP_CHANNELS
+import esphome.components.fastled_spi.light as fastled_spi_light
+from esphome.const import (
+    CONF_CHIPSET,
+    CONF_CLOCK_PIN,
+    CONF_DATA_PIN,
+    CONF_DATA_RATE,
+    CONF_ID,
+    CONF_NUM_CHIPS,
+)
+
+# AUTO_LOAD = ["fastled_bus"]
+AUTO_LOAD = ["fastled_bus"]
+CODEOWNERS = ["@mabels"]
+MULTI_CONF = True
+
+CONFIG_SCHEMA = cv.All(
+    fastled_bus.CONFIG_BUS_SCHEMA.extend(
+        {
+            cv.GenerateID(CONF_ID): cv.declare_id(fastled_bus.FastLEDBus),
+            cv.Required(CONF_CHIPSET): cv.one_of(
+                *fastled_spi_light.CHIPSETS, upper=True
+            ),
+            cv.Required(CONF_DATA_PIN): pins.internal_gpio_output_pin_number,
+            cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
+            cv.Optional(CONF_DATA_RATE): cv.frequency,
+        }
+    ),
+    fastled_bus.REQUIRED_FRAMEWORK,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID], config[CONF_CHIP_CHANNELS], config[CONF_NUM_CHIPS]
+    )
+    await cg.register_component(var, config)
+
+    data_rate = None
+    if CONF_DATA_RATE in config:
+        data_rate_khz = int(config[CONF_DATA_RATE] / 1000)
+        if data_rate_khz < 1000:
+            data_rate = cg.RawExpression(f"DATA_RATE_KHZ({data_rate_khz})")
+        else:
+            data_rate_mhz = int(data_rate_khz / 1000)
+            data_rate = cg.RawExpression(f"DATA_RATE_MHZ({data_rate_mhz})")
+
+    template_args = cg.TemplateArguments(
+        cg.RawExpression(config[CONF_CHIPSET]),
+        config[CONF_DATA_PIN],
+        config[CONF_CLOCK_PIN],
+        data_rate,
+    )
+    fastled_bus.new_fastled_bus(var, config)
+    cg.add(
+        var.set_controller(
+            cg.RawExpression(
+                f"fastled_bus::CLEDControllerFactory::create{template_args}()"
+            )
+        )
+    )

--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -1,8 +1,12 @@
+import copy
 import esphome.codegen as cg
+from esphome.components import fastled_bus
+from esphome.components.fastled_bus import CONF_BUS, CONF_CHIP_CHANNELS, FastledBusId
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.components import fastled_base
-from esphome.const import CONF_CHIPSET, CONF_NUM_LEDS, CONF_PIN, CONF_RGB_ORDER
+from esphome.components import fastled_base, fastled_bus_clockless
+from esphome.const import CONF_CHIPSET, CONF_ID, CONF_NUM_CHIPS, CONF_NUM_LEDS, CONF_PIN, CONF_RGB_ORDER
+from esphome.loader import get_component
 
 AUTO_LOAD = ["fastled_base"]
 
@@ -38,8 +42,13 @@ CHIPSETS = [
 def _validate(value):
     if value[CONF_CHIPSET] == "NEOPIXEL" and CONF_RGB_ORDER in value:
         raise cv.Invalid("NEOPIXEL doesn't support RGB order")
+        out = value.copy()
+    # if not CONF_BUS in value:
+    #     # fastled_component = get_component("fastled_bus_clockless")
+    #     # busConfig = cv.Schema(fastled_bus_clockless.CONFIG_SCHEMA)
+    #     print("Adding bus config")
+    #     value[CONF_BUS] = f"{value[CONF_ID]}_clockless_bus"
     return value
-
 
 CONFIG_SCHEMA = cv.All(
     fastled_base.BASE_SCHEMA.extend(
@@ -57,14 +66,28 @@ CONFIG_SCHEMA = cv.All(
     ),
 )
 
-
 async def to_code(config):
     var = await fastled_base.new_fastled_light(config)
+    if not CONF_BUS in config:
+        template_args = cg.TemplateArguments(
+            cg.RawExpression(config[CONF_CHIPSET]),
+            fastled_bus.rgb_order(config),
+            config[CONF_PIN],
+        )
 
-    rgb_order = None
-    if CONF_RGB_ORDER in config:
-        rgb_order = cg.RawExpression(config[CONF_RGB_ORDER])
-    template_args = cg.TemplateArguments(
-        cg.RawExpression(config[CONF_CHIPSET]), config[CONF_PIN], rgb_order
-    )
-    cg.add(var.add_leds(template_args, config[CONF_NUM_LEDS]))
+        bus = cg.RawExpression(f'''[]() {{
+    auto bus = new fastled_bus::FastLEDBus(3, {config[CONF_NUM_LEDS]});
+    bus->set_controller(fastled_bus::CLEDControllerFactory::create{template_args}());
+    return bus;
+}}()''')
+    else:
+        print("BUS--->" + str(config[CONF_BUS]))
+        bus = await cg.get_variable(config[CONF_BUS])
+
+
+    # template_args = cg.TemplateArguments(
+    #     cg.RawExpression(config[CONF_CHIPSET]), config[CONF_PIN], rgb_order
+    # )
+    # cg.add(var.set_bus(bus))
+    # cg.add(var.add_leds(template_args, config[CONF_NUM_LEDS]))
+    cg.add(var.set_bus(bus))

--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -1,19 +1,22 @@
-import copy
 import esphome.codegen as cg
 from esphome.components import fastled_bus
-from esphome.components.fastled_bus import CONF_BUS, CONF_CHIP_CHANNELS, FastledBusId
+from esphome.components.fastled_bus import CONF_BUS
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.components import fastled_base, fastled_bus_clockless
-from esphome.const import CONF_CHIPSET, CONF_ID, CONF_NUM_CHIPS, CONF_NUM_LEDS, CONF_PIN, CONF_RGB_ORDER
-from esphome.loader import get_component
+from esphome.components import fastled_base
+from esphome.const import (
+    CONF_CHIPSET,
+    CONF_NUM_LEDS,
+    CONF_PIN,
+    CONF_RGB_ORDER,
+)
 
 AUTO_LOAD = ["fastled_base", "fastled_bus", "output"]
+
 
 def _validate(value):
     if value[CONF_CHIPSET] == "NEOPIXEL" and CONF_RGB_ORDER in value:
         raise cv.Invalid("NEOPIXEL doesn't support RGB order")
-        out = value.copy()
     # if not CONF_BUS in value:
     #     # fastled_component = get_component("fastled_bus_clockless")
     #     # busConfig = cv.Schema(fastled_bus_clockless.CONFIG_SCHEMA)
@@ -21,10 +24,13 @@ def _validate(value):
     #     value[CONF_BUS] = f"{value[CONF_ID]}_clockless_bus"
     return value
 
+
 CONFIG_SCHEMA = cv.All(
     fastled_base.BASE_SCHEMA.extend(
         {
-            cv.Required(CONF_CHIPSET): cv.one_of(*fastled_base.CLOCKLESS_CHIPSETS, upper=True),
+            cv.Required(CONF_CHIPSET): cv.one_of(
+                *fastled_base.CLOCKLESS_CHIPSETS, upper=True
+            ),
             cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
         }
     ),
@@ -37,24 +43,26 @@ CONFIG_SCHEMA = cv.All(
     ),
 )
 
+
 async def to_code(config):
     var = await fastled_base.new_fastled_light(config)
-    if not CONF_BUS in config:
+    if CONF_BUS not in config:
         template_args = cg.TemplateArguments(
             cg.RawExpression(config[CONF_CHIPSET]),
             fastled_bus.rgb_order(config),
             config[CONF_PIN],
         )
 
-        bus = cg.RawExpression(f'''[]() {{
+        bus = cg.RawExpression(
+            f"""[]() {{
     auto bus = new fastled_bus::FastLEDBus(3, {config[CONF_NUM_LEDS]});
     bus->set_controller(fastled_bus::CLEDControllerFactory::create{template_args}());
     return bus;
-}}()''')
+}}()"""
+        )
     else:
         # print("BUS--->" + str(config[CONF_BUS]))
         bus = await cg.get_variable(config[CONF_BUS])
-
 
     # template_args = cg.TemplateArguments(
     #     cg.RawExpression(config[CONF_CHIPSET]), config[CONF_PIN], rgb_order

--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -8,36 +8,7 @@ from esphome.components import fastled_base, fastled_bus_clockless
 from esphome.const import CONF_CHIPSET, CONF_ID, CONF_NUM_CHIPS, CONF_NUM_LEDS, CONF_PIN, CONF_RGB_ORDER
 from esphome.loader import get_component
 
-AUTO_LOAD = ["fastled_base"]
-
-CHIPSETS = [
-    "NEOPIXEL",
-    "TM1829",
-    "TM1809",
-    "TM1804",
-    "TM1803",
-    "UCS1903",
-    "UCS1903B",
-    "UCS1904",
-    "UCS2903",
-    "WS2812",
-    "WS2852",
-    "WS2812B",
-    "SK6812",
-    "SK6822",
-    "APA106",
-    "PL9823",
-    "WS2811",
-    "WS2813",
-    "APA104",
-    "WS2811_400",
-    "GW6205",
-    "GW6205_400",
-    "LPD1886",
-    "LPD1886_8BIT",
-    "SM16703",
-]
-
+AUTO_LOAD = ["fastled_base", "fastled_bus", "output"]
 
 def _validate(value):
     if value[CONF_CHIPSET] == "NEOPIXEL" and CONF_RGB_ORDER in value:
@@ -53,7 +24,7 @@ def _validate(value):
 CONFIG_SCHEMA = cv.All(
     fastled_base.BASE_SCHEMA.extend(
         {
-            cv.Required(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
+            cv.Required(CONF_CHIPSET): cv.one_of(*fastled_base.CLOCKLESS_CHIPSETS, upper=True),
             cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
         }
     ),
@@ -81,7 +52,7 @@ async def to_code(config):
     return bus;
 }}()''')
     else:
-        print("BUS--->" + str(config[CONF_BUS]))
+        # print("BUS--->" + str(config[CONF_BUS]))
         bus = await cg.get_variable(config[CONF_BUS])
 
 

--- a/esphome/components/fastled_spi/light.py
+++ b/esphome/components/fastled_spi/light.py
@@ -17,34 +17,23 @@ from esphome.const import (
 
 AUTO_LOAD = ["fastled_base"]
 
-CHIPSETS = [
-    "LPD8806",
-    "WS2801",
-    "WS2803",
-    "SM16716",
-    "P9813",
-    "APA102",
-    "SK9822",
-    "DOTSTAR",
-]
-
-
 def _validate(value):
-    # if not CONF_BUS in value:
-    # fastled_component = get_component("fastled_bus_clockless")
-    # busConfig = cv.Schema(fastled_bus_clockless.CONFIG_SCHEMA)
-    # print("Adding bus config")
-    # value[CONF_BUS] = f"{value[CONF_ID]}_spi_bus"
+    if not CONF_BUS in value:
+      if not (CONF_CHIPSET in value and CONF_DATA_PIN in value and CONF_CLOCK_PIN in value and CONF_NUM_LEDS in value):
+        raise cv.Invalid(
+            f"{CONF_CHIPSET},{CONF_DATA_PIN},{CONF_CLOCK_PIN},{CONF_NUM_LEDS} are required when {CONF_BUS} is not set"
+        )
     return value
 
 
 CONFIG_SCHEMA = cv.All(
     fastled_base.BASE_SCHEMA.extend(
         {
-            cv.Required(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
-            cv.Required(CONF_DATA_PIN): pins.internal_gpio_output_pin_number,
-            cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
+            cv.Optional(CONF_CHIPSET): cv.one_of(*fastled_bus_spi.CHIPSETS, upper=True),
+            cv.Optional(CONF_DATA_PIN): pins.internal_gpio_output_pin_number,
+            cv.Optional(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_DATA_RATE): cv.frequency,
+            cv.Optional(CONF_BUS): cv.use_id(fastled_bus.FastLEDBus),
         }
     ),
     _validate,
@@ -59,34 +48,33 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     var = await fastled_base.new_fastled_light(config)
-    if not CONF_BUS in config:
-        data_rate = None
 
-        if CONF_DATA_RATE in config:
-            data_rate_khz = int(config[CONF_DATA_RATE] / 1000)
+
+    if not CONF_BUS in config:
+      data_rate = None
+      if CONF_DATA_RATE in config:
+        data_rate_khz = int(config[CONF_DATA_RATE] / 1000)
         if data_rate_khz < 1000:
             data_rate = cg.RawExpression(f"DATA_RATE_KHZ({data_rate_khz})")
         else:
             data_rate_mhz = int(data_rate_khz / 1000)
             data_rate = cg.RawExpression(f"DATA_RATE_MHZ({data_rate_mhz})")
 
-        template_args = cg.TemplateArguments(
+      template_args = cg.TemplateArguments(
             cg.RawExpression(config[CONF_CHIPSET]),
             fastled_bus.rgb_order(config),
             config[CONF_DATA_PIN],
             config[CONF_CLOCK_PIN],
             data_rate,
-        )
-        bus = cg.RawExpression(
-            f"""[]() {{
+          )
+      bus = cg.RawExpression(f"""[]() {{
     auto bus = new fastled_bus::FastLEDBus(3, {config[CONF_NUM_LEDS]});
     bus->set_controller(fastled_bus::CLEDControllerFactory::create{template_args}());
     return bus;
 }}()"""
-        )
+      )
     else:
-        print("BUS--->" + str(config[CONF_BUS]))
-        bus = await cg.get_variable(config[CONF_BUS])
+      bus = await cg.get_variable(config[CONF_BUS])
 
     cg.add(var.set_bus(bus))
     # cg.add(var.add_leds(template_args, config[CONF_NUM_LEDS]))

--- a/esphome/components/fastled_spi/light.py
+++ b/esphome/components/fastled_spi/light.py
@@ -1,12 +1,16 @@
 import esphome.codegen as cg
+from esphome.components import fastled_bus
+from esphome.components.fastled_bus import CONF_BUS, CONF_CHIP_CHANNELS
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.components import fastled_base
+from esphome.components import fastled_base, fastled_bus_spi
 from esphome.const import (
     CONF_CHIPSET,
     CONF_CLOCK_PIN,
     CONF_DATA_PIN,
     CONF_DATA_RATE,
+    CONF_ID,
+    CONF_NUM_CHIPS,
     CONF_NUM_LEDS,
     CONF_RGB_ORDER,
 )
@@ -24,6 +28,16 @@ CHIPSETS = [
     "DOTSTAR",
 ]
 
+
+def _validate(value):
+    # if not CONF_BUS in value:
+    # fastled_component = get_component("fastled_bus_clockless")
+    # busConfig = cv.Schema(fastled_bus_clockless.CONFIG_SCHEMA)
+    # print("Adding bus config")
+    # value[CONF_BUS] = f"{value[CONF_ID]}_spi_bus"
+    return value
+
+
 CONFIG_SCHEMA = cv.All(
     fastled_base.BASE_SCHEMA.extend(
         {
@@ -33,6 +47,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DATA_RATE): cv.frequency,
         }
     ),
+    _validate,
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 7, 4),
         esp32_arduino=cv.Version(99, 0, 0),
@@ -44,24 +59,34 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     var = await fastled_base.new_fastled_light(config)
+    if not CONF_BUS in config:
+        data_rate = None
 
-    rgb_order = cg.RawExpression(
-        config[CONF_RGB_ORDER] if CONF_RGB_ORDER in config else "RGB"
-    )
-    data_rate = None
-
-    if CONF_DATA_RATE in config:
-        data_rate_khz = int(config[CONF_DATA_RATE] / 1000)
+        if CONF_DATA_RATE in config:
+            data_rate_khz = int(config[CONF_DATA_RATE] / 1000)
         if data_rate_khz < 1000:
             data_rate = cg.RawExpression(f"DATA_RATE_KHZ({data_rate_khz})")
         else:
             data_rate_mhz = int(data_rate_khz / 1000)
             data_rate = cg.RawExpression(f"DATA_RATE_MHZ({data_rate_mhz})")
-    template_args = cg.TemplateArguments(
-        cg.RawExpression(config[CONF_CHIPSET]),
-        config[CONF_DATA_PIN],
-        config[CONF_CLOCK_PIN],
-        rgb_order,
-        data_rate,
-    )
-    cg.add(var.add_leds(template_args, config[CONF_NUM_LEDS]))
+
+        template_args = cg.TemplateArguments(
+            cg.RawExpression(config[CONF_CHIPSET]),
+            fastled_bus.rgb_order(config),
+            config[CONF_DATA_PIN],
+            config[CONF_CLOCK_PIN],
+            data_rate,
+        )
+        bus = cg.RawExpression(
+            f"""[]() {{
+    auto bus = new fastled_bus::FastLEDBus(3, {config[CONF_NUM_LEDS]});
+    bus->set_controller(fastled_bus::CLEDControllerFactory::create{template_args}());
+    return bus;
+}}()"""
+        )
+    else:
+        print("BUS--->" + str(config[CONF_BUS]))
+        bus = await cg.get_variable(config[CONF_BUS])
+
+    cg.add(var.set_bus(bus))
+    # cg.add(var.add_leds(template_args, config[CONF_NUM_LEDS]))

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -547,6 +547,7 @@ class IDPassValidationStep(ConfigValidationStep):
         # Resolve default ids after manual IDs
         for id, _ in result.declare_ids:
             id.resolve([v[0].id for v in result.declare_ids])
+            print("Resolved ID:", id, id.type)
             if isinstance(id.type, MockObjClass) and id.type.inherits_from(Component):
                 CORE.component_ids.add(id.id)
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -547,7 +547,6 @@ class IDPassValidationStep(ConfigValidationStep):
         # Resolve default ids after manual IDs
         for id, _ in result.declare_ids:
             id.resolve([v[0].id for v in result.declare_ids])
-            print("Resolved ID:", id, id.type)
             if isinstance(id.type, MockObjClass) and id.type.inherits_from(Component):
                 CORE.component_ids.add(id.id)
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1757,17 +1757,17 @@ output:
     id: output_componentr_spi
     channels:
     - bus: fastled_busSpi
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 0
       repeat_distance: 6
     - bus: fastled_busCl
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 0
       repeat_distance: 6
     - bus: fastled_busSpi
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 0
       repeat_distance: 9
@@ -1775,35 +1775,35 @@ output:
     id: output_componentc_spi
     channels:
     - bus: fastled_busSpi
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 1
   - platform: fastled_bus
     id: output_componentw_spi
     channels:
     - bus: fastled_busSpi
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 2
   - platform: fastled_bus
     id: output_componentb_spi
     channels:
     - bus: fastled_busSpi
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 3
   - platform: fastled_bus
     id: output_componentg_spi
     channels:
     - bus: fastled_busSpi
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 5
   - platform: fastled_bus
     id: output_componentr_cl
     channels:
     - bus: fastled_busCl
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 0
       repeat_distance: 6
@@ -1811,14 +1811,14 @@ output:
     id: output_componentg_cl
     channels:
     - bus: fastled_busCl
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 1
   - platform: fastled_bus
     id: output_componentb_cl
     channels:
       bus: fastled_busCl
-      offset: 0
+      chip_offset: 0
       num_chips: 2
       channel_offset: 2
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1755,55 +1755,71 @@ output:
     initial_value: 0.5
   - platform: fastled_bus
     id: output_componentr_spi
-    bus: fastled_busSpi
-    offset: 0
-    num_chips: 2
-    channel_offset: 0
-    repeat_distance: 6
+    channels:
+    - bus: fastled_busSpi
+      offset: 0
+      num_chips: 2
+      channel_offset: 0
+      repeat_distance: 6
+    - bus: fastled_busCl
+      offset: 0
+      num_chips: 2
+      channel_offset: 0
+      repeat_distance: 6
+    - bus: fastled_busSpi
+      offset: 0
+      num_chips: 2
+      channel_offset: 0
+      repeat_distance: 9
   - platform: fastled_bus
     id: output_componentc_spi
-    bus: fastled_busSpi
-    offset: 0
-    num_chips: 2
-    channel_offset: 1
+    channels:
+    - bus: fastled_busSpi
+      offset: 0
+      num_chips: 2
+      channel_offset: 1
   - platform: fastled_bus
     id: output_componentw_spi
-    bus: fastled_busSpi
-    offset: 0
-    num_chips: 2
-    channel_offset: 2
+    channels:
+    - bus: fastled_busSpi
+      offset: 0
+      num_chips: 2
+      channel_offset: 2
   - platform: fastled_bus
     id: output_componentb_spi
-    bus: fastled_busSpi
-    offset: 0
-    num_chips: 2
-    channel_offset: 3
+    channels:
+    - bus: fastled_busSpi
+      offset: 0
+      num_chips: 2
+      channel_offset: 3
   - platform: fastled_bus
-    bus: fastled_busSpi
     id: output_componentg_spi
-    offset: 0
-    num_chips: 2
-    channel_offset: 5
+    channels:
+    - bus: fastled_busSpi
+      offset: 0
+      num_chips: 2
+      channel_offset: 5
   - platform: fastled_bus
     id: output_componentr_cl
-    bus: fastled_busCl
-    offset: 0
-    num_chips: 2
-    channel_offset: 0
-    repeat_distance: 6
+    channels:
+    - bus: fastled_busCl
+      offset: 0
+      num_chips: 2
+      channel_offset: 0
+      repeat_distance: 6
   - platform: fastled_bus
     id: output_componentg_cl
-    bus: fastled_busCl
-    offset: 0
-    num_chips: 2
-    channel_offset: 1
+    channels:
+    - bus: fastled_busCl
+      offset: 0
+      num_chips: 2
+      channel_offset: 1
   - platform: fastled_bus
     id: output_componentb_cl
     bus: fastled_busCl
     offset: 0
     num_chips: 2
     channel_offset: 2
->>>>>>> d9a55640 (Add FastLED Bus enables multichip lights with channel-mapping)
 
 e131:
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -317,6 +317,20 @@ mcp23s17:
     cs_pin: GPIO12
     deviceaddress: 1
 
+fastled_bus_spi:
+    - id: fastled_busSpi
+      chipset: P9813
+      data_pin: GPIO0
+      clock_pin: GPIO3
+      num_chips: 2
+
+fastled_bus_clockless:
+    - id: fastled_busCl
+      chipset: SK6812
+      pin: GPIO18
+      chip_channels: 4
+      num_chips: 2
+
 sensor:
   - platform: ble_client
     type: characteristic
@@ -1739,6 +1753,57 @@ output:
     inc_pin: GPIO26
     ud_pin: GPIO27
     initial_value: 0.5
+  - platform: fastled_bus
+    id: output_componentr_spi
+    bus: fastled_busSpi
+    offset: 0
+    num_chips: 2
+    channel_offset: 0
+    repeat_distance: 6
+  - platform: fastled_bus
+    id: output_componentc_spi
+    bus: fastled_busSpi
+    offset: 0
+    num_chips: 2
+    channel_offset: 1
+  - platform: fastled_bus
+    id: output_componentw_spi
+    bus: fastled_busSpi
+    offset: 0
+    num_chips: 2
+    channel_offset: 2
+  - platform: fastled_bus
+    id: output_componentb_spi
+    bus: fastled_busSpi
+    offset: 0
+    num_chips: 2
+    channel_offset: 3
+  - platform: fastled_bus
+    bus: fastled_busSpi
+    id: output_componentg_spi
+    offset: 0
+    num_chips: 2
+    channel_offset: 5
+  - platform: fastled_bus
+    id: output_componentr_cl
+    bus: fastled_busCl
+    offset: 0
+    num_chips: 2
+    channel_offset: 0
+    repeat_distance: 6
+  - platform: fastled_bus
+    id: output_componentg_cl
+    bus: fastled_busCl
+    offset: 0
+    num_chips: 2
+    channel_offset: 1
+  - platform: fastled_bus
+    id: output_componentb_cl
+    bus: fastled_busCl
+    offset: 0
+    num_chips: 2
+    channel_offset: 2
+>>>>>>> d9a55640 (Add FastLED Bus enables multichip lights with channel-mapping)
 
 e131:
 
@@ -1949,6 +2014,30 @@ light:
         from: 20
         to: 25
       - single_light_id: ${roomname}_lights
+
+  - platform: shelly_dimmer
+    name: "Shelly Dimmer Light"
+    power:
+      name: "Shelly Dimmer Power"
+    voltage:
+      name: "Shelly Dimmer Voltage"
+    current:
+      name: "Shelly Dimmer Current"
+    max_brightness: 500
+    firmware: "51.6"
+    uart_id: uart0
+  - platform: rgbww
+    name: "Livingroom Lights SPI"
+    red: output_componentr_spi
+    green: output_componentg_spi
+    blue: output_componentb_spi
+    cold_white: output_componentc_spi
+    warm_white: output_componentw_spi
+  - platform: rgb
+    name: "Livingroom Lights CL"
+    red: output_componentr_cl
+    green: output_componentg_cl
+    blue: output_componentb_cl
 
 remote_transmitter:
   - pin: 32

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1816,10 +1816,11 @@ output:
       channel_offset: 1
   - platform: fastled_bus
     id: output_componentb_cl
-    bus: fastled_busCl
-    offset: 0
-    num_chips: 2
-    channel_offset: 2
+    channels:
+      bus: fastled_busCl
+      offset: 0
+      num_chips: 2
+      channel_offset: 2
 
 e131:
 
@@ -2031,17 +2032,6 @@ light:
         to: 25
       - single_light_id: ${roomname}_lights
 
-  - platform: shelly_dimmer
-    name: "Shelly Dimmer Light"
-    power:
-      name: "Shelly Dimmer Power"
-    voltage:
-      name: "Shelly Dimmer Voltage"
-    current:
-      name: "Shelly Dimmer Current"
-    max_brightness: 500
-    firmware: "51.6"
-    uart_id: uart0
   - platform: rgbww
     name: "Livingroom Lights SPI"
     red: output_componentr_spi

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -71,6 +71,19 @@ mcp3008:
   - id: mcp3008_hub
     cs_pin: GPIO12
 
+fastled_bus_spi:
+    - id: fastled_busSpi
+      chipset: P9813
+      data_pin: GPIO0
+      clock_pin: GPIO3
+      num_chips: 2
+
+fastled_bus_clockless:
+    - id: fastled_busCl
+      chipset: WS2811
+      pin: GPIO18
+      num_chips: 2
+
 output:
   - platform: ac_dimmer
     id: dimmer1

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -86,6 +86,19 @@ dac7678:
   id: dac7678_hub1
   internal_reference: true
 
+fastled_bus_spi:
+    - id: fastled_busSpi
+      chipset: P9813
+      data_pin: GPIO0
+      clock_pin: GPIO3
+      num_chips: 2
+
+fastled_bus_clockless:
+    - id: fastled_busCl
+      chipset: WS2811
+      pin: GPIO18
+      num_chips: 2
+
 sensor:
   - platform: homeassistant
     entity_id: sensor.hello_world


### PR DESCRIPTION
# What does this implement/fix?

It adds the feature to split a FastLED Bus into multiple lights. I build it to enable P9813 chips to controll self build RGBWW lights.

look in esphome/components/fastled_bus/__init__.py there is a configuration example.

I'm need to the project and not figured out how to write the documentation and tests. I
would appreciate some pointers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

I will look into it soon.


## Test Environment

- [ X] ESP32
- [ X] ESP32 IDF
- [ X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# fastled_bus_spi:
#     - id: bla
#       chipset: P9813
#       data_pin: D1
#       clock_pin: D2
#       num_chips: 2

# output:
#   - platform: fastled_bus
#     id: output_componentr
#     bus: bla
#     offset: 0
#     num_chips: 2
#     byte_offset: 0
#     byte_distance: 6
#   - platform: fastled_bus
#     id: output_componentc
#     bus: bla
#     offset: 0
#     num_chips: 2
#     byte_offset: 1
#     byte_distance: 6
#   - platform: fastled_bus
#     id: output_componentw
#     bus: bla
#     offset: 0
#     num_chips: 2
#     byte_offset: 2
#     byte_distance: 6
#   - platform: fastled_bus
#     id: output_componentb
#     bus: bla
#     offset: 0
#     num_chips: 2
#     byte_offset: 3
#     byte_distance: 6
#   - platform: fastled_bus
#     bus: bla
#     id: output_componentg
#     offset: 0
#     num_chips: 2
#     byte_offset: 5
#     byte_distance: 6

# light:
#   - platform: rgbww
#     name: "Livingroom Lights"
#     red: output_componentr
#     green: output_componentg
#     blue: output_componentb
#     cold_white: output_componentc
#     warm_white: output_componentw

```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
