### PR TITLE
Add min_value and max_value in filters for sensors

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -295,9 +295,11 @@ async def multiply_filter_to_code(config, filter_id):
 async def filter_out_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id, config)
 
+
 @FILTER_REGISTRY.register("min_value", FilterMinValue, cv.float_)
 async def filter_min_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id, config)
+
 
 @FILTER_REGISTRY.register("max_value", FilterMaxValue, cv.float_)
 async def filter_max_filter_to_code(config, filter_id):

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -170,6 +170,8 @@ LambdaFilter = sensor_ns.class_("LambdaFilter", Filter)
 OffsetFilter = sensor_ns.class_("OffsetFilter", Filter)
 MultiplyFilter = sensor_ns.class_("MultiplyFilter", Filter)
 FilterOutValueFilter = sensor_ns.class_("FilterOutValueFilter", Filter)
+FilterMinValue = sensor_ns.class_("FilterMinValue", Filter)
+FilterMaxValue = sensor_ns.class_("FilterMaxValue", Filter)
 ThrottleFilter = sensor_ns.class_("ThrottleFilter", Filter)
 DebounceFilter = sensor_ns.class_("DebounceFilter", Filter, cg.Component)
 HeartbeatFilter = sensor_ns.class_("HeartbeatFilter", Filter, cg.Component)
@@ -291,6 +293,14 @@ async def multiply_filter_to_code(config, filter_id):
 
 @FILTER_REGISTRY.register("filter_out", FilterOutValueFilter, cv.float_)
 async def filter_out_filter_to_code(config, filter_id):
+    return cg.new_Pvariable(filter_id, config)
+
+@FILTER_REGISTRY.register("min_value", FilterMinValue, cv.float_)
+async def filter_min_filter_to_code(config, filter_id):
+    return cg.new_Pvariable(filter_id, config)
+
+@FILTER_REGISTRY.register("max_value", FilterMaxValue, cv.float_)
+async def filter_max_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id, config)
 
 

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -275,7 +275,7 @@ optional<float> MultiplyFilter::new_value(float value) { return value * this->mu
 FilterMinValue::FilterMinValue(float minvalue) : minvalue_(minvalue) {}
 
 optional<float> FilterMinValue::new_value(float value) {
-  if(value < this->minvalue_) { 
+  if (value < this->minvalue_) { 
     return this->minvalue_; 
   }
   return value;
@@ -285,7 +285,7 @@ optional<float> FilterMinValue::new_value(float value) {
 FilterMaxValue::FilterMaxValue(float maxvalue) : maxvalue_(maxvalue) {}
 
 optional<float> FilterMaxValue::new_value(float value) {
-  if(value > this->maxvalue_) {
+  if (value > this->maxvalue_) {
     return this->maxvalue_;
   }
   return value;

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -275,7 +275,9 @@ optional<float> MultiplyFilter::new_value(float value) { return value * this->mu
 FilterMinValue::FilterMinValue(float minvalue) : minvalue_(minvalue) {}
 
 optional<float> FilterMinValue::new_value(float value) {
-  if(value < this->minvalue_) return this->minvalue_;
+  if(value < this->minvalue_) { 
+    return this->minvalue_; 
+  }
   return value;
 }
 
@@ -283,7 +285,9 @@ optional<float> FilterMinValue::new_value(float value) {
 FilterMaxValue::FilterMaxValue(float maxvalue) : maxvalue_(maxvalue) {}
 
 optional<float> FilterMaxValue::new_value(float value) {
-  if(value > this->maxvalue_) return this->maxvalue_;
+  if(value > this->maxvalue_) {
+    return this->maxvalue_;
+  }
   return value;
 }
 

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -275,8 +275,8 @@ optional<float> MultiplyFilter::new_value(float value) { return value * this->mu
 FilterMinValue::FilterMinValue(float minvalue) : minvalue_(minvalue) {}
 
 optional<float> FilterMinValue::new_value(float value) {
-  if (value < this->minvalue_) { 
-    return this->minvalue_; 
+  if (value < this->minvalue_) {
+    return this->minvalue_;
   }
   return value;
 }

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -271,6 +271,22 @@ MultiplyFilter::MultiplyFilter(float multiplier) : multiplier_(multiplier) {}
 
 optional<float> MultiplyFilter::new_value(float value) { return value * this->multiplier_; }
 
+// MinValueFilter
+FilterMinValue::FilterMinValue(float minvalue) : minvalue_(minvalue) {}
+
+optional<float> FilterMinValue::new_value(float value) {
+  if(value < this->minvalue_) return this->minvalue_;
+  return value;
+}
+
+// MaxValueFilter
+FilterMaxValue::FilterMaxValue(float maxvalue) : maxvalue_(maxvalue) {}
+
+optional<float> FilterMaxValue::new_value(float value) {
+  if(value > this->maxvalue_) return this->maxvalue_;
+  return value;
+}
+
 // FilterOutValueFilter
 FilterOutValueFilter::FilterOutValueFilter(float value_to_filter_out) : value_to_filter_out_(value_to_filter_out) {}
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -275,7 +275,6 @@ class MultiplyFilter : public Filter {
   float multiplier_;
 };
 
-
 /// Minimum Value
 class FilterMinValue : public Filter {
  public:

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -129,8 +129,6 @@ class MinFilter : public Filter {
   size_t window_size_;
 };
 
-
-
 /** Simple max filter.
  *
  * Takes the max of the last <send_every> values and pushes it out every <send_every>.

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -129,6 +129,8 @@ class MinFilter : public Filter {
   size_t window_size_;
 };
 
+
+
 /** Simple max filter.
  *
  * Takes the max of the last <send_every> values and pushes it out every <send_every>.
@@ -271,6 +273,29 @@ class MultiplyFilter : public Filter {
 
  protected:
   float multiplier_;
+};
+
+
+/// Minimum Value
+class FilterMinValue : public Filter {
+ public:
+  explicit FilterMinValue(float minvalue);
+
+  optional<float> new_value(float value) override;
+
+ protected:
+  float minvalue_;
+};
+
+/// Maximum Value
+class FilterMaxValue : public Filter {
+ public:
+  explicit FilterMaxValue(float maxvalue);
+
+  optional<float> new_value(float value) override;
+
+ protected:
+  float maxvalue_;
 };
 
 /// A simple filter that only forwards the filter chain if it doesn't receive `value_to_filter_out`.


### PR DESCRIPTION
# What does this implement/fix?

A threshold value for the maximum and minimum values has been added to the filter for sensors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#1581](https://github.com/esphome/feature-requests/issues/1581)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2156

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
