### PR TITLE
Add Daikin preset modes

### DIFF
--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -16,6 +16,8 @@ void DaikinClimate::transmit_state() {
   uint16_t fan_speed = this->fan_speed_();
   remote_state[24] = fan_speed >> 8;
   remote_state[25] = fan_speed & 0xff;
+  remote_state[29] = this->powerful_quiet_preset_();
+  remote_state[32] = this->eco_preset_();
 
   // Calculate checksum
   for (int i = 16; i < 34; i++) {
@@ -108,6 +110,8 @@ uint16_t DaikinClimate::fan_speed_() const {
       fan_speed = DAIKIN_FAN_5 << 8;
       break;
     case climate::CLIMATE_FAN_AUTO:
+      fan_speed = DAIKIN_FAN_AUTO << 8;
+      break;
     default:
       fan_speed = DAIKIN_FAN_AUTO << 8;
   }
@@ -140,6 +144,32 @@ uint8_t DaikinClimate::temperature_() const {
       uint8_t temperature = (uint8_t) roundf(clamp<float>(this->target_temperature, DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX));
       return temperature << 1;
   }
+}
+
+uint8_t DaikinClimate::powerful_quiet_preset_() const {
+  uint8_t powerful_quiet_preset = DAIKIN_PRESET_OFF;
+  if (this->preset.has_value()) {
+    if (this->preset == climate::CLIMATE_PRESET_BOOST) {
+      powerful_quiet_preset = DAIKIN_PRESET_POWERFUL_ON;
+    } else if (this->preset == climate::CLIMATE_PRESET_SLEEP) {
+      powerful_quiet_preset = DAIKIN_PRESET_QUIET_ON;
+    }
+  }
+  return powerful_quiet_preset;
+}
+
+uint8_t DaikinClimate::eco_preset_() const {
+  uint8_t eco_preset = DAIKIN_PRESET_OFF;
+  if (this->preset.has_value()) {
+    if (this->preset == climate::CLIMATE_PRESET_ECO) {
+      eco_preset = DAIKIN_PRESET_ECONO_ON;
+    } else if (this->preset == climate::CLIMATE_PRESET_COMFORT) {
+      eco_preset = DAIKIN_PRESET_COMFORT_ON;
+    } else if (this->preset == climate::CLIMATE_PRESET_ACTIVITY) {
+      eco_preset = DAIKIN_PRESET_SENSOR_ON;
+    }
+  }
+  return eco_preset;
 }
 
 bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
@@ -190,9 +220,9 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
   }
   switch (fan_mode & 0xF0) {
     case DAIKIN_FAN_1:
-    case DAIKIN_FAN_2:
       this->fan_mode = climate::CLIMATE_FAN_LOW;
       break;
+    case DAIKIN_FAN_2:
     case DAIKIN_FAN_3:
       this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
       break;
@@ -207,6 +237,31 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
       this->fan_mode = climate::CLIMATE_FAN_QUIET;
       break;
   }
+
+  this->preset = climate::CLIMATE_PRESET_NONE;
+  uint8_t powerful_quiet_preset = frame[13];
+  uint8_t eco_preset = frame[16];
+
+  switch (powerful_quiet_preset) {
+    case DAIKIN_PRESET_POWERFUL_ON:
+      this->preset = climate::CLIMATE_PRESET_BOOST;
+      break;
+    case DAIKIN_PRESET_QUIET_ON:
+      this->preset = climate::CLIMATE_PRESET_SLEEP;
+      break;
+  }
+  switch (eco_preset) {
+    case DAIKIN_PRESET_COMFORT_ON:
+      this->preset = climate::CLIMATE_PRESET_COMFORT;
+      break;
+    case DAIKIN_PRESET_ECONO_ON:
+      this->preset = climate::CLIMATE_PRESET_ECO;
+      break;
+    case DAIKIN_PRESET_SENSOR_ON:
+      this->preset = climate::CLIMATE_PRESET_ACTIVITY;
+      break;
+  }
+
   this->publish_state();
   return true;
 }

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -28,6 +28,15 @@ const uint8_t DAIKIN_FAN_3 = 0x50;
 const uint8_t DAIKIN_FAN_4 = 0x60;
 const uint8_t DAIKIN_FAN_5 = 0x70;
 
+const uint8_t DAIKIN_PRESET_OFF = 0x00;
+// Powerful/Quiet Presets
+const uint8_t DAIKIN_PRESET_POWERFUL_ON = 0x01;
+const uint8_t DAIKIN_PRESET_QUIET_ON = 0x20;
+// Comfort/Econo/Sensor Presets
+const uint8_t DAIKIN_PRESET_COMFORT_ON = 0x02;
+const uint8_t DAIKIN_PRESET_ECONO_ON = 0x04;
+const uint8_t DAIKIN_PRESET_SENSOR_ON = 0x08;
+
 // IR Transmission
 const uint32_t DAIKIN_IR_FREQUENCY = 38000;
 const uint32_t DAIKIN_HEADER_MARK = 3360;
@@ -43,11 +52,14 @@ const uint8_t DAIKIN_STATE_FRAME_SIZE = 19;
 class DaikinClimate : public climate_ir::ClimateIR {
  public:
   DaikinClimate()
-      : climate_ir::ClimateIR(DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,
-                              {climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
-                               climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
-                              {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
-                               climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH}) {}
+      : climate_ir::ClimateIR(
+            DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,
+            {climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
+             climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
+            {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL,
+             climate::CLIMATE_SWING_BOTH},
+            {climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_COMFORT,
+             climate::CLIMATE_PRESET_SLEEP, climate::CLIMATE_PRESET_ACTIVITY, climate::CLIMATE_PRESET_NONE}) {}
 
  protected:
   // Transmit via IR the state of this climate controller.
@@ -55,6 +67,8 @@ class DaikinClimate : public climate_ir::ClimateIR {
   uint8_t operation_mode_() const;
   uint16_t fan_speed_() const;
   uint8_t temperature_() const;
+  uint8_t powerful_quiet_preset_() const;
+  uint8_t eco_preset_() const;
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool parse_state_frame_(const uint8_t frame[]);


### PR DESCRIPTION
# What does this implement/fix?

Adds support for Daikin preset modes, and adds support for 0.5 degree temperature increments. 
 - Quiet (Sleep)
 - Powerful (Boost)
 - Comfort 
 - Sensor (Activity)
 - Eco

Additionally fixes a bug where Low fan speed was mapped to Quiet in one direction and Low in the other direction. 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1248 , https://github.com/esphome/feature-requests/issues/1413 & https://github.com/esphome/feature-requests/issues/859

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
climate:
  - platform: daikin
    name: "Daikin AC"
    visual:
      temperature_step: 0.5 °C

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
