### PR TITLE
toshiba: expose some fan modes for the generic impl

### DIFF
--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -180,8 +180,29 @@ void ToshibaClimate::transmit_generic_() {
     default:
       mode = TOSHIBA_MODE_AUTO;
   }
+  uint8_t fan = TOSHIBA_FAN_SPEED_AUTO;
+  if (this->mode != climate::CLIMATE_MODE_OFF) {
+    switch (this->fan_mode.value()) {
+      case climate::CLIMATE_FAN_LOW:
+        fan = TOSHIBA_FAN_SPEED_1;
+        break;
 
-  message[6] |= mode | TOSHIBA_FAN_SPEED_AUTO;
+      case climate::CLIMATE_FAN_MEDIUM:
+        fan = TOSHIBA_FAN_SPEED_3;
+        break;
+
+      case climate::CLIMATE_FAN_HIGH:
+        fan = TOSHIBA_FAN_SPEED_5;
+        break;
+
+      case climate::CLIMATE_FAN_AUTO:
+      default:
+        fan = TOSHIBA_FAN_SPEED_AUTO;
+        break;
+    }
+  }
+
+  message[6] = mode | fan;
 
   // Zero
   message[7] = 0x00;
@@ -531,7 +552,7 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
           this->mode = climate::CLIMATE_MODE_HEAT_COOL;
           break;
 
-        // case RAC_PT1411HWRU_MODE_OFF:
+          // case RAC_PT1411HWRU_MODE_OFF:
         case RAC_PT1411HWRU_MODE_COOL:
           if (((message[4] >> 4) == RAC_PT1411HWRU_TEMPERATURE_FAN_ONLY) && (message[2] == RAC_PT1411HWRU_FAN_OFF)) {
             this->mode = climate::CLIMATE_MODE_OFF;
@@ -540,7 +561,7 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
           }
           break;
 
-        // case RAC_PT1411HWRU_MODE_DRY:
+          // case RAC_PT1411HWRU_MODE_DRY:
         case RAC_PT1411HWRU_MODE_FAN:
           if ((message[4] >> 4) == RAC_PT1411HWRU_TEMPERATURE_FAN_ONLY) {
             this->mode = climate::CLIMATE_MODE_FAN_ONLY;
@@ -595,7 +616,7 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
         }
       }
       break;
-    // "Comfort Sense" temperature packet
+      // "Comfort Sense" temperature packet
     case RAC_PT1411HWRU_CS_HEADER:
       // "Comfort Sense" feature notes
       // IR Code: 0xBA45 xxXX yyYY
@@ -612,7 +633,7 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->current_temperature = message[2] & ~(RAC_PT1411HWRU_CS_ENABLED | RAC_PT1411HWRU_CS_DATA);
       }
       break;
-    // Swing mode
+      // Swing mode
     case RAC_PT1411HWRU_SWING_HEADER:
       if (message[4] == RAC_PT1411HWRU_SWING_VERTICAL[4]) {
         this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
@@ -620,7 +641,7 @@ bool ToshibaClimate::on_receive(remote_base::RemoteReceiveData data) {
         this->swing_mode = climate::CLIMATE_SWING_OFF;
       }
       break;
-    // Generic (old) Toshiba packet
+      // Generic (old) Toshiba packet
     default:
       uint8_t checksum = 0;
       // Add back the length of the header (we pruned it above)

--- a/esphome/components/toshiba/toshiba.h
+++ b/esphome/components/toshiba/toshiba.h
@@ -53,10 +53,8 @@ class ToshibaClimate : public climate_ir::ClimateIR {
     return ((this->model_ == MODEL_RAC_PT1411HWRU_C) || (this->model_ == MODEL_RAC_PT1411HWRU_F));
   }
   std::set<climate::ClimateFanMode> toshiba_fan_modes_() {
-    return (this->model_ == MODEL_GENERIC)
-               ? std::set<climate::ClimateFanMode>{}
-               : std::set<climate::ClimateFanMode>{climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
-                                                   climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH};
+    return std::set<climate::ClimateFanMode>{climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
+                                             climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH};
   }
   std::set<climate::ClimateSwingMode> toshiba_swing_modes_() {
     return (this->model_ == MODEL_GENERIC)


### PR DESCRIPTION
# What does this implement/fix?

I needed to be able to change the fan mode on my Toshiba AC RAS-M16SKV-E. As it's a pretty old model and fan mode is a universal (?) feature, I assumed that I could implement that in the generic model. It seems that someone knew the protocol as the value code where already there, as toshiba generic.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml, just the normal toshiba config
remote_transmitter:
  pin: GPIO10
  carrier_duty_percent: 50%

climate:
  - platform: toshiba
    name: "Office AC"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
