### PR TITLE
Rework NaN handling in sensor filters

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -212,18 +212,16 @@ optional<float> SlidingWindowMovingAverageFilter::new_value(float value) {
 ExponentialMovingAverageFilter::ExponentialMovingAverageFilter(float alpha, size_t send_every, size_t send_first_at)
     : send_every_(send_every), send_at_(send_every - send_first_at), alpha_(alpha) {}
 optional<float> ExponentialMovingAverageFilter::new_value(float value) {
-  if (std::isnan(value)) {
-    return value;
+  if (!std::isnan(value)) {
+    if (this->first_value_) {
+      this->accumulator_ = value;
+      this->first_value_ = false;
+    } else {
+      this->accumulator_ = (this->alpha_ * value) + (1.0f - this->alpha_) * this->accumulator_;
+    }
   }
 
-  if (this->first_value_) {
-    this->accumulator_ = value;
-    this->first_value_ = false;
-  } else {
-    this->accumulator_ = (this->alpha_ * value) + (1.0f - this->alpha_) * this->accumulator_;
-  }
-
-  const float average = this->accumulator_;
+  const float average = std::isnan(value) ? value : this->accumulator_;
   ESP_LOGVV(TAG, "ExponentialMovingAverageFilter(%p)::new_value(%f) -> %f", this, value, average);
 
   if (++this->send_at_ >= this->send_every_) {

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -131,18 +131,11 @@ optional<float> MinFilter::new_value(float value) {
   if (++this->send_at_ >= this->send_every_) {
     this->send_at_ = 0;
 
-    // Copy queue without NaN values
-    std::deque<float> min_queue;
+    float min = NAN;
     for (auto v : this->queue_) {
       if (!std::isnan(v)) {
-        min_queue.push_back(v);
+        min = std::isnan(min) ? v : std::min(min, v);
       }
-    }
-
-    float min = NAN;
-    if (!min_queue.empty()) {
-      std::deque<float>::iterator it = std::min_element(min_queue.begin(), min_queue.end());
-      min = *it;
     }
 
     ESP_LOGVV(TAG, "MinFilter(%p)::new_value(%f) SENDING", this, min);
@@ -166,18 +159,11 @@ optional<float> MaxFilter::new_value(float value) {
   if (++this->send_at_ >= this->send_every_) {
     this->send_at_ = 0;
 
-    // Copy queue without NaN values
-    std::deque<float> max_queue;
+    float max = NAN;
     for (auto v : this->queue_) {
       if (!std::isnan(v)) {
-        max_queue.push_back(v);
+        max = std::isnan(max) ? v : std::max(max, v);
       }
-    }
-
-    float max = NAN;
-    if (!max_queue.empty()) {
-      std::deque<float>::iterator it = std::max_element(max_queue.begin(), max_queue.end());
-      max = *it;
     }
 
     ESP_LOGVV(TAG, "MaxFilter(%p)::new_value(%f) SENDING", this, max);

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -331,8 +331,13 @@ optional<float> ThrottleFilter::new_value(float value) {
 // DeltaFilter
 DeltaFilter::DeltaFilter(float min_delta) : min_delta_(min_delta), last_value_(NAN) {}
 optional<float> DeltaFilter::new_value(float value) {
-  if (std::isnan(value))
-    return {};
+  if (std::isnan(value)) {
+    if (std::isnan(this->last_value_)) {
+      return {};
+    } else {
+      return this->last_value_ = value;
+    }
+  }
   if (std::isnan(this->last_value_)) {
     return this->last_value_ = value;
   }

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -49,7 +49,7 @@ optional<float> MedianFilter::new_value(float value) {
     float median = NAN;
     if (!this->queue_.empty()) {
       // Copy queue without NaN values
-      std::deque<float> median_queue;
+      std::vector<float> median_queue;
       for (auto v : this->queue_) {
         if (!std::isnan(v)) {
           median_queue.push_back(v);
@@ -93,7 +93,7 @@ optional<float> QuantileFilter::new_value(float value) {
     float result = NAN;
     if (!this->queue_.empty()) {
       // Copy queue without NaN values
-      std::deque<float> quantile_queue;
+      std::vector<float> quantile_queue;
       for (auto v : this->queue_) {
         if (!std::isnan(v)) {
           quantile_queue.push_back(v);

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -226,16 +226,18 @@ optional<float> SlidingWindowMovingAverageFilter::new_value(float value) {
 ExponentialMovingAverageFilter::ExponentialMovingAverageFilter(float alpha, size_t send_every, size_t send_first_at)
     : send_every_(send_every), send_at_(send_every - send_first_at), alpha_(alpha) {}
 optional<float> ExponentialMovingAverageFilter::new_value(float value) {
-  if (!std::isnan(value)) {
-    if (this->first_value_) {
-      this->accumulator_ = value;
-    } else {
-      this->accumulator_ = (this->alpha_ * value) + (1.0f - this->alpha_) * this->accumulator_;
-    }
-    this->first_value_ = false;
+  if (std::isnan(value)) {
+    return value;
   }
 
-  float average = this->accumulator_;
+  if (this->first_value_) {
+    this->accumulator_ = value;
+    this->first_value_ = false;
+  } else {
+    this->accumulator_ = (this->alpha_ * value) + (1.0f - this->alpha_) * this->accumulator_;
+  }
+
+  const float average = this->accumulator_;
   ESP_LOGVV(TAG, "ExponentialMovingAverageFilter(%p)::new_value(%f) -> %f", this, value, average);
 
   if (++this->send_at_ >= this->send_every_) {

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -68,7 +68,7 @@ optional<float> MedianFilter::new_value(float value) {
       }
     }
 
-    ESP_LOGVV(TAG, "MedianFilter(%p)::new_value(%f) SENDING", this, median);
+    ESP_LOGVV(TAG, "MedianFilter(%p)::new_value(%f) SENDING %f", this, value, median);
     return median;
   }
   return {};
@@ -110,7 +110,7 @@ optional<float> QuantileFilter::new_value(float value) {
       }
     }
 
-    ESP_LOGVV(TAG, "QuantileFilter(%p)::new_value(%f) SENDING", this, result);
+    ESP_LOGVV(TAG, "QuantileFilter(%p)::new_value(%f) SENDING %f", this, value, result);
     return result;
   }
   return {};
@@ -138,7 +138,7 @@ optional<float> MinFilter::new_value(float value) {
       }
     }
 
-    ESP_LOGVV(TAG, "MinFilter(%p)::new_value(%f) SENDING", this, min);
+    ESP_LOGVV(TAG, "MinFilter(%p)::new_value(%f) SENDING %f", this, value, min);
     return min;
   }
   return {};
@@ -166,7 +166,7 @@ optional<float> MaxFilter::new_value(float value) {
       }
     }
 
-    ESP_LOGVV(TAG, "MaxFilter(%p)::new_value(%f) SENDING", this, max);
+    ESP_LOGVV(TAG, "MaxFilter(%p)::new_value(%f) SENDING %f", this, value, max);
     return max;
   }
   return {};
@@ -202,7 +202,7 @@ optional<float> SlidingWindowMovingAverageFilter::new_value(float value) {
       average = sum / valid_count;
     }
 
-    ESP_LOGVV(TAG, "SlidingWindowMovingAverageFilter(%p)::new_value(%f) SENDING", this, value);
+    ESP_LOGVV(TAG, "SlidingWindowMovingAverageFilter(%p)::new_value(%f) SENDING %f", this, value, average);
     return average;
   }
   return {};
@@ -227,7 +227,7 @@ optional<float> ExponentialMovingAverageFilter::new_value(float value) {
   ESP_LOGVV(TAG, "ExponentialMovingAverageFilter(%p)::new_value(%f) -> %f", this, value, average);
 
   if (++this->send_at_ >= this->send_every_) {
-    ESP_LOGVV(TAG, "ExponentialMovingAverageFilter(%p)::new_value(%f) SENDING", this, value);
+    ESP_LOGVV(TAG, "ExponentialMovingAverageFilter(%p)::new_value(%f) SENDING %f", this, value, average);
     this->send_at_ = 0;
     return average;
   }

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -180,7 +180,6 @@ class SlidingWindowMovingAverageFilter : public Filter {
   void set_window_size(size_t window_size);
 
  protected:
-  float sum_{0.0};
   std::deque<float> queue_;
   size_t send_every_;
   size_t send_at_;

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -202,7 +202,7 @@ class ExponentialMovingAverageFilter : public Filter {
 
  protected:
   bool first_value_{true};
-  float accumulator_{0.0f};
+  float accumulator_{NAN};
   size_t send_every_;
   size_t send_at_;
   float alpha_;


### PR DESCRIPTION
# What does this implement/fix?

tl;dr all sensor filters now handle NaN in a reasonable manner

While most filters would handle NaN (unknown) values correctly, the following would silently drop NaN values, preventing anything using the sensor from being informed of a problem: [`quantile`](https://esphome.io/components/sensor/index.html#quantile), [`median`](https://esphome.io/components/sensor/index.html#median), [`min`](https://esphome.io/components/sensor/index.html#min), [`max`](https://esphome.io/components/sensor/index.html#max), [`sliding_window_moving_average`](https://esphome.io/components/sensor/index.html#sliding-window-moving-average), [`exponential_moving_average`](https://esphome.io/components/sensor/index.html#exponential-moving-average), [`delta`](https://esphome.io/components/sensor/index.html#delta)

This could have physical consequences, e.g. imagine a temperature sensor controlling a heater in a fish tank where the sensor fails while the heater is on. The heater would never turn off, because the temperature output would never update or become unavailable.

~~I don't think this is a breaking change because the new behavior appears to be the expected behavior (see the related issues below). For those that want NaN to be dropped, adding a `filter_out: NaN` before other filter(s) will drop it while being explicitly clear about the intention. I suspect most people are already doing this if they want it.~~
The change in sensor behavior is significant enough this is a breaking change (see comments below). 

I didn't add myself as a codeowner but can if desired.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

### Breaking Change

[Sensor Filters](https://esphome.io/components/sensor/index.html#sensor-filters) now all handle NaN (unknown) values. If you used one of the following filters, this is a breaking change: [`quantile`](https://esphome.io/components/sensor/index.html#quantile), [`median`](https://esphome.io/components/sensor/index.html#median), [`min`](https://esphome.io/components/sensor/index.html#min), [`max`](https://esphome.io/components/sensor/index.html#max), [`sliding_window_moving_average`](https://esphome.io/components/sensor/index.html#sliding-window-moving-average), [`exponential_moving_average`](https://esphome.io/components/sensor/index.html#exponential-moving-average), [`delta`](https://esphome.io/components/sensor/index.html#delta)

To restore the previous behavior, add `filter_out: NaN` **before** the sensor filter. This will explicitly drop incoming NaN (unknown) values, making it clear what is happening and that it is desired.

**Related issue or feature (if applicable):** fixes esphome/issues#3140, fixes esphome/issues#3338, esphome/issues#3378, 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A but I can make one if anyone feels the documentation needs clarification on NaN handling.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yamlfilter_out: NAN
sensor:
  - platform: max31865
    name: "Air Temperature"
    cs_pin: GPIO15
    reference_resistance: 4.3 kΩ
    rtd_nominal_resistance: 1 kΩ
    rtd_wires: 3
    update_interval: 5s
    filters:
      # I verified the correct behavior of the fixed code on the following (one at a time)
      # - quantile
      # - median
      # - min
      # - max
      - sliding_window_moving_average:
          window_size: 5
          send_every: 3
      # - exponential_moving_average
      # - delta: 1.0
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
