### PR TITLE
Support for HIGH_SPEED and HIGH_ACCURACY for VL53L0X

### DIFF
--- a/esphome/components/vl53l0x/sensor.py
+++ b/esphome/components/vl53l0x/sensor.py
@@ -26,7 +26,7 @@ MeasurementMode = vl53l0x_ns.enum("MeasurementMode")
 MEASUREMENT_MODES = {
     "HIGH_SPEED": MeasurementMode.HIGH_SPEED,
     "HIGH_ACCURACY": MeasurementMode.HIGH_ACCURACY,
-    "STANDARD": MeasurementMode.STANDARD
+    "STANDARD": MeasurementMode.STANDARD,
 }
 
 
@@ -64,7 +64,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ENABLE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_MEASUREMENT_MODE, default="STANDARD"): cv.enum(
                 MEASUREMENT_MODES, upper=True
-            )
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))

--- a/esphome/components/vl53l0x/sensor.py
+++ b/esphome/components/vl53l0x/sensor.py
@@ -20,6 +20,14 @@ VL53L0XSensor = vl53l0x_ns.class_(
 
 CONF_SIGNAL_RATE_LIMIT = "signal_rate_limit"
 CONF_LONG_RANGE = "long_range"
+CONF_MEASUREMENT_MODE = "measurement_mode"
+
+MeasurementMode = vl53l0x_ns.enum("MeasurementMode")
+MEASUREMENT_MODES = {
+    "HIGH_SPEED": MeasurementMode.HIGH_SPEED,
+    "HIGH_ACCURACY": MeasurementMode.HIGH_ACCURACY,
+    "STANDARD": MeasurementMode.STANDARD
+}
 
 
 def check_keys(obj):
@@ -54,6 +62,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_LONG_RANGE, default=False): cv.boolean,
             cv.Optional(CONF_TIMEOUT, default="10ms"): check_timeout,
             cv.Optional(CONF_ENABLE_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_MEASUREMENT_MODE, default="STANDARD"): cv.enum(
+                MEASUREMENT_MODES, upper=True
+            )
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -68,6 +79,7 @@ async def to_code(config):
     cg.add(var.set_signal_rate_limit(config[CONF_SIGNAL_RATE_LIMIT]))
     cg.add(var.set_long_range(config[CONF_LONG_RANGE]))
     cg.add(var.set_timeout_us(config[CONF_TIMEOUT]))
+    cg.add(var.set_measurement_mode(config[CONF_MEASUREMENT_MODE]))
 
     if CONF_ENABLE_PIN in config:
         enable = await cg.gpio_pin_expression(config[CONF_ENABLE_PIN])

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -230,7 +230,15 @@ void VL53L0XSensor::setup() {
   reg(0x84) &= ~0x10;
   reg(0x0B) = 0x01;
 
-  measurement_timing_budget_us_ = get_measurement_timing_budget_();
+  // Timing budgets taken from upstream:
+  // https://github.com/pololu/vl53l0x-arduino/blob/master/examples/Single/Single.ino
+  if (measurement_mode_ == HIGH_ACCURACY) { 
+    measurement_timing_budget_us_ = 200000;
+  } else if (measurement_mode_ == HIGH_SPEED) {
+    measurement_timing_budget_us_ = 20000;
+  } else {
+    measurement_timing_budget_us_ = get_measurement_timing_budget_();
+  }
   reg(0x01) = 0xE8;
   set_measurement_timing_budget_(measurement_timing_budget_us_);
   reg(0x01) = 0x01;

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -232,7 +232,7 @@ void VL53L0XSensor::setup() {
 
   // Timing budgets taken from upstream:
   // https://github.com/pololu/vl53l0x-arduino/blob/master/examples/Single/Single.ino
-  if (measurement_mode_ == HIGH_ACCURACY) { 
+  if (measurement_mode_ == HIGH_ACCURACY) {
     measurement_timing_budget_us_ = 200000;
   } else if (measurement_mode_ == HIGH_SPEED) {
     measurement_timing_budget_us_ = 20000;

--- a/esphome/components/vl53l0x/vl53l0x_sensor.h
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.h
@@ -23,6 +23,8 @@ struct SequenceStepTimeouts {
 
 enum VcselPeriodType { VCSEL_PERIOD_PRE_RANGE, VCSEL_PERIOD_FINAL_RANGE };
 
+enum MeasurementMode { STANDARD, HIGH_SPEED, HIGH_ACCURACY };
+
 class VL53L0XSensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
   VL53L0XSensor();
@@ -39,6 +41,7 @@ class VL53L0XSensor : public sensor::Sensor, public PollingComponent, public i2c
   void set_long_range(bool long_range) { long_range_ = long_range; }
   void set_timeout_us(uint32_t timeout_us) { this->timeout_us_ = timeout_us; }
   void set_enable_pin(GPIOPin *enable) { this->enable_pin_ = enable; }
+  void set_measurement_mode(MeasurementMode measurement_mode) { measurement_mode_ = measurement_mode; }
 
  protected:
   uint32_t get_measurement_timing_budget_();
@@ -66,6 +69,7 @@ class VL53L0XSensor : public sensor::Sensor, public PollingComponent, public i2c
 
   uint16_t timeout_start_us_;
   uint16_t timeout_us_{};
+  MeasurementMode measurement_mode_;
 
   static std::list<VL53L0XSensor *> vl53_sensors;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
   static bool enable_pin_setup_complete;           // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
Example in the upstream driver library: https://github.com/pololu/vl53l0x-arduino/blob/master/examples/Single/Single.ino

# What does this implement/fix?

Implements HIGH_ACCURACY and HIGH_SPEED optional measurement modes for VL53L0X TOF sensor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: vl53l0x
    name: "VL53L0x Distance"
    address: 0x29
    update_interval: 10min
    long_range: false
    unit_of_measurement: "m"
    accuracy_decimals: 3
    measurement_mode: high_accuracy

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

*** I'm not actually sure what to do here. I was following https://github.com/esphome/esphome/pull/1055, and the tests added there apply.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
