### PR TITLE
Pulse_counter: Restore total pulse count from flash

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/preferences.h"
 
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
 #include <driver/pcnt.h>
@@ -55,6 +56,9 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   void set_filter_us(uint32_t filter) { storage_.filter_us = filter; }
   void set_total_sensor(sensor::Sensor *total_sensor) { total_sensor_ = total_sensor; }
 
+  void set_restore_value(bool restore_value) { this->restore_total_value_ = restore_value; }
+  void set_min_save_interval(uint32_t min_interval) { this->min_save_interval_ = min_interval; }
+
   /// Unit of measurement is "pulses/min".
   void setup() override;
   void update() override;
@@ -66,7 +70,11 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   PulseCounterStorage storage_;
   uint32_t last_time_{0};
   uint32_t current_total_{0};
+  uint32_t last_save_{0};
+  uint32_t min_save_interval_{0};
+  bool restore_total_value_ = false;
   sensor::Sensor *total_sensor_;
+  ESPPreferenceObject pref_;
 };
 
 }  // namespace pulse_counter

--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_FALLING_EDGE,
     CONF_INTERNAL_FILTER,
     CONF_PIN,
+    CONF_RESTORE_VALUE,
     CONF_RISING_EDGE,
     CONF_NUMBER,
     CONF_TOTAL,
@@ -27,6 +28,8 @@ COUNT_MODES = {
 }
 
 COUNT_MODE_SCHEMA = cv.enum(COUNT_MODES, upper=True)
+
+CONF_MIN_SAVE_INTERVAL = "min_save_interval"
 
 PulseCounterSensor = pulse_counter_ns.class_(
     "PulseCounterSensor", sensor.Sensor, cg.PollingComponent
@@ -95,6 +98,13 @@ CONFIG_SCHEMA = (
                 icon=ICON_PULSE,
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_TOTAL_INCREASING,
+            ).extend(
+                {
+                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+                    cv.Optional(
+                        CONF_MIN_SAVE_INTERVAL, default="0s"
+                    ): cv.positive_time_period_milliseconds,
+                }
             ),
         }
     )
@@ -114,5 +124,9 @@ async def to_code(config):
     cg.add(var.set_filter_us(config[CONF_INTERNAL_FILTER]))
 
     if CONF_TOTAL in config:
+        restore = config[CONF_TOTAL][CONF_RESTORE_VALUE]
+        min_save_interval = config[CONF_TOTAL][CONF_MIN_SAVE_INTERVAL]
         sens = await sensor.new_sensor(config[CONF_TOTAL])
+        cg.add(var.set_restore_value(restore))
+        cg.add(var.set_min_save_interval(min_save_interval))
         cg.add(var.set_total_sensor(sens))

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/preferences.h"
+
 #include "esphome/core/helpers.h"
 
 namespace esphome {
@@ -21,6 +23,9 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   void set_timeout_us(uint32_t timeout) { this->timeout_us_ = timeout; }
   void set_total_sensor(sensor::Sensor *sensor) { this->total_sensor_ = sensor; }
 
+  void set_restore_value(bool restore_value) { this->restore_total_value_ = restore_value; }
+  void set_min_save_interval(uint32_t min_interval) { this->min_save_interval_ = min_interval; }
+
   void set_total_pulses(uint32_t pulses);
 
   void setup() override;
@@ -35,7 +40,11 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   ISRInternalGPIOPin isr_pin_;
   uint32_t filter_us_ = 0;
   uint32_t timeout_us_ = 1000000UL * 60UL * 5UL;
+  uint32_t last_save_{0};
+  uint32_t min_save_interval_{0};
+  bool restore_total_value_ = false;
   sensor::Sensor *total_sensor_ = nullptr;
+  ESPPreferenceObject pref_;
   InternalFilterMode filter_mode_{FILTER_EDGE};
 
   Deduplicator<uint32_t> pulse_width_dedupe_;

--- a/esphome/components/pulse_meter/sensor.py
+++ b/esphome/components/pulse_meter/sensor.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_INTERNAL_FILTER_MODE,
     CONF_PIN,
     CONF_NUMBER,
+    CONF_RESTORE_VALUE,
     CONF_TIMEOUT,
     CONF_TOTAL,
     CONF_VALUE,
@@ -20,6 +21,8 @@ from esphome.const import (
 from esphome.core import CORE
 
 CODEOWNERS = ["@stevebaxter", "@cstaahl"]
+
+CONF_MIN_SAVE_INTERVAL = "min_save_interval"
 
 pulse_meter_ns = cg.esphome_ns.namespace("pulse_meter")
 
@@ -73,6 +76,13 @@ CONFIG_SCHEMA = sensor.sensor_schema(
             icon=ICON_PULSE,
             accuracy_decimals=0,
             state_class=STATE_CLASS_TOTAL_INCREASING,
+        ).extend(
+            {
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+                cv.Optional(
+                    CONF_MIN_SAVE_INTERVAL, default="0s"
+                ): cv.positive_time_period_milliseconds,
+            }
         ),
         cv.Optional(CONF_INTERNAL_FILTER_MODE, default="EDGE"): cv.enum(
             FILTER_MODES, upper=True
@@ -92,7 +102,11 @@ async def to_code(config):
     cg.add(var.set_filter_mode(config[CONF_INTERNAL_FILTER_MODE]))
 
     if CONF_TOTAL in config:
+        restore = config[CONF_TOTAL][CONF_RESTORE_VALUE]
+        min_save_interval = config[CONF_TOTAL][CONF_MIN_SAVE_INTERVAL]
         sens = await sensor.new_sensor(config[CONF_TOTAL])
+        cg.add(var.set_restore_value(restore))
+        cg.add(var.set_min_save_interval(min_save_interval))
         cg.add(var.set_total_sensor(sens))
 
 


### PR DESCRIPTION
# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

  # Example configuration entry
  sensor:
    - platform: pulse_meter
      pin: 12
      unit_of_measurement: 'kW'
      name: 'Electricity Usage'
      internal_filter: 100ms
      accuracy_decimals: 3
      filters:
        - multiply: 0.06
      total:
        name: "Electricity Total"
        unit_of_measurement: "kWh"
        accuracy_decimals: 3
        restore_value: True  # <<-- New functionality
        min_save_interval: 5min  # <<-- New functionality
        filters:
          - multiply: 0.001
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
