### PR TITLE
hydreon_rgxx: Support lens_bad, em_sat and temperature

### DIFF
--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -166,7 +166,7 @@ void HydreonRGxxComponent::process_line_() {
     ESP_LOGW(TAG, "Received LensBad!");
     this->lens_bad_ = true;
   }
-  if (this->buffer_.find("EmSat") != std::string::npos) {
+  if (this->buffer_.find("EmSat") != std::string::npos ) {
     ESP_LOGW(TAG, "Received EmSat!");
     this->em_sat_ = true;
   }
@@ -224,7 +224,7 @@ void HydreonRGxxComponent::process_line_() {
       ESP_LOGD(TAG, "Received %s: %f", PROTOCOL_NAMES[i], this->sensors_[i]->get_raw_state());
       this->sensors_received_ |= (1 << i);
     }
-  } else if(this->buffer_starts_with_("Event")){
+  } else if (this->buffer_starts_with_("Event")) {
     ESP_LOGI(TAG, "Received 'Event'");
   } else {
     ESP_LOGI(TAG, "Got unknown line: %s", this->buffer_.c_str());

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -236,8 +236,8 @@ void HydreonRGxxComponent::process_line_() {
       this->write_str("T\n");
     }
   } else {
-    for (int i = 0; i < HYDREON_RGXX_IGNORE_LIST_LEN; i++) {
-      if (this->buffer_starts_with_(IGNORE_STRINGS[i])) {
+    for (auto ignore : IGNORE_STRINGS) {
+      if (this->buffer_starts_with_(ignore)) {
         ESP_LOGI(TAG, "Ignoring %s", this->buffer_.substr(0, this->buffer_.size() - 2).c_str());
         return;
       }

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -9,6 +9,7 @@ static const int MAX_DATA_LENGTH_BYTES = 80;
 static const uint8_t ASCII_LF = 0x0A;
 #define HYDREON_RGXX_COMMA ,
 static const char *const PROTOCOL_NAMES[] = {HYDREON_RGXX_PROTOCOL_LIST(, HYDREON_RGXX_COMMA)};
+static const char *const IGNORE_STRINGS[] = {HYDREON_RGXX_IGNORE_LIST(, HYDREON_RGXX_COMMA)};
 
 void HydreonRGxxComponent::dump_config() {
   this->check_uart_settings(9600, 1, esphome::uart::UART_CONFIG_PARITY_NONE, 8);
@@ -34,33 +35,37 @@ void HydreonRGxxComponent::setup() {
   this->schedule_reboot_();
 }
 
-bool HydreonRGxxComponent::sensor_missing_() {
+int HydreonRGxxComponent::num_sensors_missing_() {
   if (this->sensors_received_ == -1) {
-    // no request sent yet, don't check
-    return false;
-  } else {
-    if (this->sensors_received_ == 0) {
-      ESP_LOGW(TAG, "No data at all");
-      return true;
-    }
-    for (int i = 0; i < NUM_SENSORS; i++) {
-      if (this->sensors_[i] == nullptr) {
-        continue;
-      }
-      if ((this->sensors_received_ >> i & 1) == 0) {
-        ESP_LOGW(TAG, "Missing %s", PROTOCOL_NAMES[i]);
-        return true;
-      }
-    }
-    return false;
+    return -1;
   }
+  int ret = NUM_SENSORS;
+  for (int i = 0; i < NUM_SENSORS; i++) {
+    if (this->sensors_[i] == nullptr) {
+      ret -= 1;
+      continue;
+    }
+    if ((this->sensors_received_ >> i & 1) != 0) {
+      ret -= 1;
+    }
+  }
+  return ret;
 }
 
 void HydreonRGxxComponent::update() {
   if (this->boot_count_ > 0) {
-    if (this->sensor_missing_()) {
+    if (this->num_sensors_missing_() > 0) {
+      for (int i = 0; i < NUM_SENSORS; i++) {
+        if (this->sensors_[i] == nullptr) {
+          continue;
+        }
+        if ((this->sensors_received_ >> i & 1) == 0) {
+          ESP_LOGW(TAG, "Missing %s", PROTOCOL_NAMES[i]);
+        }
+      }
+
       this->no_response_count_++;
-      ESP_LOGE(TAG, "data missing %d times", this->no_response_count_);
+      ESP_LOGE(TAG, "missing %d sensors; %d times in a row", this->num_sensors_missing_(), this->no_response_count_);
       if (this->no_response_count_ > 15) {
         ESP_LOGE(TAG, "asking sensor to reboot");
         for (auto &sensor : this->sensors_) {
@@ -75,9 +80,6 @@ void HydreonRGxxComponent::update() {
       this->no_response_count_ = 0;
     }
     this->write_str("R\n");
-    if (this->request_temperature_) {
-      this->write_str("T\n");
-    }
 #ifdef USE_BINARY_SENSOR
     if (this->too_cold_sensor_ != nullptr) {
       this->too_cold_sensor_->publish_state(this->too_cold_);
@@ -86,7 +88,7 @@ void HydreonRGxxComponent::update() {
       this->lens_bad_sensor_->publish_state(this->lens_bad_);
     }
     if (this->em_sat_sensor_ != nullptr) {
-      this->em_sat_sensor_->publish_state(this->em_sat_sensor_);
+      this->em_sat_sensor_->publish_state(this->em_sat_);
     }
 #endif
     this->too_cold_ = false;
@@ -157,9 +159,15 @@ void HydreonRGxxComponent::process_line_() {
     ESP_LOGI(TAG, "Comment: %s", this->buffer_.substr(0, this->buffer_.size() - 2).c_str());
     return;
   }
-  if (this->buffer_.find('\n') <= 1) {
+  std::string::size_type newlineposn = this->buffer_.find('\n');
+  if (newlineposn <= 1) {
     // allow both \r\n and \n
     ESP_LOGD(TAG, "Received empty line");
+    return;
+  }
+  if (newlineposn <= 2) {
+    // single character lines, such as acknowledgements
+    ESP_LOGD(TAG, "Received ack: %s", this->buffer_.substr(0, this->buffer_.size() - 2).c_str());
     return;
   }
   if (this->buffer_.find("LensBad") != std::string::npos) {
@@ -224,9 +232,16 @@ void HydreonRGxxComponent::process_line_() {
       ESP_LOGD(TAG, "Received %s: %f", PROTOCOL_NAMES[i], this->sensors_[i]->get_raw_state());
       this->sensors_received_ |= (1 << i);
     }
-  } else if (this->buffer_starts_with_("Event")) {
-    ESP_LOGI(TAG, "Received 'Event'");
+    if (this->request_temperature_ && this->num_sensors_missing_() == 1) {
+      this->write_str("T\n");
+    }
   } else {
+    for (int i = 0; i < HYDREON_RGXX_IGNORE_LIST_LEN; i++) {
+      if (this->buffer_starts_with_(IGNORE_STRINGS[i])) {
+        ESP_LOGI(TAG, "Ignoring %s", this->buffer_.substr(0, this->buffer_.size() - 2).c_str());
+        return;
+      }
+    }
     ESP_LOGI(TAG, "Got unknown line: %s", this->buffer_.c_str());
   }
 }

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -157,16 +157,16 @@ void HydreonRGxxComponent::process_line_() {
     ESP_LOGI(TAG, "Comment: %s", this->buffer_.substr(0, this->buffer_.size() - 2).c_str());
     return;
   }
-  if (this->buffer_.find("\n") <= 1) {
-    //allow both \r\n and \n
+  if (this->buffer_.find('\n') <= 1) {
+    // allow both \r\n and \n
     ESP_LOGD(TAG, "Received empty line");
     return;
   }
-  if (this->buffer_.find("LensBad") != std::string::npos ) {
+  if (this->buffer_.find("LensBad") != std::string::npos) {
     ESP_LOGW(TAG, "Received LensBad!");
     this->lens_bad_ = true;
   }
-  if (this->buffer_.find("EmSat") != std::string::npos ) {
+  if (this->buffer_.find("EmSat") != std::string::npos) {
     ESP_LOGW(TAG, "Received EmSat!");
     this->em_sat_ = true;
   }

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -236,7 +236,7 @@ void HydreonRGxxComponent::process_line_() {
       this->write_str("T\n");
     }
   } else {
-    for (auto ignore : IGNORE_STRINGS) {
+    for (const auto *ignore : IGNORE_STRINGS) {
       if (this->buffer_starts_with_(ignore)) {
         ESP_LOGI(TAG, "Ignoring %s", this->buffer_.substr(0, this->buffer_.size() - 2).c_str());
         return;

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -26,6 +26,9 @@ static const uint8_t NUM_SENSORS = 1;
 #define HYDREON_RGXX_PROTOCOL_LIST(F, SEP) F("")
 #endif
 
+#define HYDREON_RGXX_IGNORE_LIST_LEN 3
+#define HYDREON_RGXX_IGNORE_LIST(F, SEP) F("Emitters") SEP F("Event") SEP F("Reset")
+
 class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
  public:
   void set_sensor(sensor::Sensor *sensor, int index) { this->sensors_[index] = sensor; }
@@ -52,7 +55,7 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
   void schedule_reboot_();
   bool buffer_starts_with_(const std::string &prefix);
   bool buffer_starts_with_(const char *prefix);
-  bool sensor_missing_();
+  int num_sensors_missing_();
 
   sensor::Sensor *sensors_[NUM_SENSORS] = {nullptr};
 #ifdef USE_BINARY_SENSOR

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -31,8 +31,11 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
   void set_sensor(sensor::Sensor *sensor, int index) { this->sensors_[index] = sensor; }
 #ifdef USE_BINARY_SENSOR
   void set_too_cold_sensor(binary_sensor::BinarySensor *sensor) { this->too_cold_sensor_ = sensor; }
+  void set_lens_bad_sensor(binary_sensor::BinarySensor *sensor) { this->lens_bad_sensor_ = sensor; }
+  void set_em_sat_sensor(binary_sensor::BinarySensor *sensor) { this->em_sat_sensor_ = sensor; }
 #endif
   void set_model(RGModel model) { model_ = model; }
+  void set_request_temperature(bool b) { request_temperature_ = b; }
 
   /// Schedule data readings.
   void update() override;
@@ -54,6 +57,8 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *sensors_[NUM_SENSORS] = {nullptr};
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *too_cold_sensor_ = nullptr;
+  binary_sensor::BinarySensor *lens_bad_sensor_ = nullptr;
+  binary_sensor::BinarySensor *em_sat_sensor_   = nullptr;
 #endif
 
   int16_t boot_count_ = 0;
@@ -62,6 +67,9 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
   RGModel model_ = RG9;
   int sw_version_ = 0;
   bool too_cold_ = false;
+  bool lens_bad_ = false;
+  bool em_sat_ = false;
+  bool request_temperature_ = false;
 
   // bit field showing which sensors we have received data for
   int sensors_received_ = -1;

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -58,7 +58,7 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *too_cold_sensor_ = nullptr;
   binary_sensor::BinarySensor *lens_bad_sensor_ = nullptr;
-  binary_sensor::BinarySensor *em_sat_sensor_   = nullptr;
+  binary_sensor::BinarySensor *em_sat_sensor_ = nullptr;
 #endif
 
   int16_t boot_count_ = 0;

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -26,7 +26,6 @@ static const uint8_t NUM_SENSORS = 1;
 #define HYDREON_RGXX_PROTOCOL_LIST(F, SEP) F("")
 #endif
 
-#define HYDREON_RGXX_IGNORE_LIST_LEN 3
 #define HYDREON_RGXX_IGNORE_LIST(F, SEP) F("Emitters") SEP F("Event") SEP F("Reset")
 
 class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {

--- a/esphome/components/hydreon_rgxx/sensor.py
+++ b/esphome/components/hydreon_rgxx/sensor.py
@@ -36,7 +36,7 @@ SUPPORTED_SENSORS = {
     CONF_TOTAL_ACC: ["RG_15"],
     CONF_R_INT: ["RG_15"],
     CONF_MOISTURE: ["RG_9"],
-    CONF_TEMPERATURE: ["RG_15"],
+    CONF_TEMPERATURE: ["RG_9"],
 }
 PROTOCOL_NAMES = {
     CONF_MOISTURE: "R",
@@ -119,7 +119,7 @@ async def to_code(config):
     cg.add_define(
         "HYDREON_RGXX_PROTOCOL_LIST(F, sep)",
         cg.RawExpression(
-            " sep ".join([f'F("{name}")' for name in PROTOCOL_NAMES.values()])
+            " sep ".join([f'F("{name} ")' for name in PROTOCOL_NAMES.values()])
         ),
     )
     cg.add_define("HYDREON_RGXX_NUM_SENSORS", len(PROTOCOL_NAMES))

--- a/esphome/components/hydreon_rgxx/sensor.py
+++ b/esphome/components/hydreon_rgxx/sensor.py
@@ -5,8 +5,11 @@ from esphome.const import (
     CONF_ID,
     CONF_MODEL,
     CONF_MOISTURE,
+    CONF_TEMPERATURE,
     DEVICE_CLASS_HUMIDITY,
     STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    ICON_THERMOMETER,
 )
 
 from . import RGModel, HydreonRGxxComponent
@@ -33,6 +36,7 @@ SUPPORTED_SENSORS = {
     CONF_TOTAL_ACC: ["RG_15"],
     CONF_R_INT: ["RG_15"],
     CONF_MOISTURE: ["RG_9"],
+    CONF_TEMPERATURE: ["RG_15"],
 }
 PROTOCOL_NAMES = {
     CONF_MOISTURE: "R",
@@ -40,6 +44,7 @@ PROTOCOL_NAMES = {
     CONF_R_INT: "RInt",
     CONF_EVENT_ACC: "EventAcc",
     CONF_TOTAL_ACC: "TotalAcc",
+    CONF_TEMPERATURE: "t",
 }
 
 
@@ -92,6 +97,12 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=0,
+                icon=ICON_THERMOMETER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -117,3 +128,5 @@ async def to_code(config):
         if conf in config:
             sens = await sensor.new_sensor(config[conf])
             cg.add(var.set_sensor(sens, i))
+
+    cg.add(var.set_request_temperature(CONF_TEMPERATURE in config))

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -849,6 +849,10 @@ binary_sensor:
     hydreon_rgxx_id: "hydreon_rg9"
     too_cold:
       name: "rg9_toocold"
+    em_sat:
+      name: "rg9_emsat"
+    lens_bad:
+      name: "rg9_lens_bad"
   - platform: template
     id: 'pzemac_reset_energy'
     on_press:


### PR DESCRIPTION
# What does this implement/fix?

Add support for `temperature` sensor for RG9.
Add support for `lens_bad` and `em_sat` binary sensors for RG15 and RG9.

Ignores some lines that were previously reported as unknown.
This includes acknowledgements,  `Event`, `Emitter` and empty lines.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3248

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2188

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: hydreontest
  platform: ESP8266
  board: nodemcuv2


uart:
  rx_pin: GPIO4
  tx_pin: GPIO5
  baud_rate: 9600

binary_sensor:
   - platform: hydreon_rgxx
    too_cold:
      name: "too_cold"
    lens_bad:
      name: "lens_bad"
    em_sat:
      name: "em_sat"

sensor:
  - platform: hydreon_rgxx
    model: "RG_9"
    temperature:
      name: "rain sensor temp"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
