### PR TITLE
Thermostat remove deprecated config

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -461,9 +461,12 @@ def validate_thermostat(config):
             raise cv.Invalid(
                 f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
             )
-    
+
     # If restoring default preset on boot is true then ensure we have a default preset
-    if CONF_RESTORE_DEFAULT_PRESET_ON_BOOT in config and config[CONF_RESTORE_DEFAULT_PRESET_ON_BOOT] is True:
+    if (
+        CONF_RESTORE_DEFAULT_PRESET_ON_BOOT in config
+        and config[CONF_RESTORE_DEFAULT_PRESET_ON_BOOT] is True
+    ):
         if CONF_DEFAULT_PRESET not in config:
             raise cv.Invalid(
                 f"{CONF_DEFAULT_PRESET} must be defined to use {CONF_RESTORE_DEFAULT_PRESET_ON_BOOT}"
@@ -911,9 +914,13 @@ async def to_code(config):
             cg.add(var.set_default_preset(climate_preset))
         else:
             cg.add(var.set_default_preset(default_preset_name))
-    
+
     if CONF_RESTORE_DEFAULT_PRESET_ON_BOOT in config:
-        cg.add(var.set_restore_default_preset_on_boot(config[CONF_RESTORE_DEFAULT_PRESET_ON_BOOT]))
+        cg.add(
+            var.set_restore_default_preset_on_boot(
+                config[CONF_RESTORE_DEFAULT_PRESET_ON_BOOT]
+            )
+        )
 
     if CONF_PRESET_CHANGE in config:
         await automation.build_automation(

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -70,7 +70,7 @@ from esphome.const import (
 
 CONF_PRESET_CHANGE = "preset_change"
 CONF_DEFAULT_PRESET = "default_preset"
-CONF_RESTORE_DEFAULT_PRESET_ON_BOOT = "restore_default_preset_on_boot"
+CONF_STARTUP_BEHAVIOR = "startup_behavior"
 
 CODEOWNERS = ["@kbx81"]
 
@@ -82,6 +82,13 @@ ThermostatClimate = thermostat_ns.class_(
 ThermostatClimateTargetTempConfig = thermostat_ns.struct(
     "ThermostatClimateTargetTempConfig"
 )
+StartupBehavior = thermostat_ns.enum("StartupBehavior")
+STARTUP_BEHAVIOR = {
+    "RESTORE_FROM_MEMORY": StartupBehavior.RESTORE_FROM_MEMORY,
+    "APPLY_DEFAULT_PRESET": StartupBehavior.APPLY_DEFAULT_PRESET,
+}
+validate_startup_behavior = cv.enum(STARTUP_BEHAVIOR, upper=True)
+
 ClimateMode = climate_ns.enum("ClimateMode")
 CLIMATE_MODES = {
     "OFF": ClimateMode.CLIMATE_MODE_OFF,
@@ -464,12 +471,12 @@ def validate_thermostat(config):
 
     # If restoring default preset on boot is true then ensure we have a default preset
     if (
-        CONF_RESTORE_DEFAULT_PRESET_ON_BOOT in config
-        and config[CONF_RESTORE_DEFAULT_PRESET_ON_BOOT] is True
+        CONF_STARTUP_BEHAVIOR in config
+        and config[CONF_STARTUP_BEHAVIOR] is StartupBehavior.APPLY_DEFAULT_PRESET
     ):
         if CONF_DEFAULT_PRESET not in config:
             raise cv.Invalid(
-                f"{CONF_DEFAULT_PRESET} must be defined to use {CONF_RESTORE_DEFAULT_PRESET_ON_BOOT}"
+                f"{CONF_DEFAULT_PRESET} must be defined to use {CONF_STARTUP_BEHAVIOR} in APPLY_DEFAULT_PRESET mode"
             )
 
     if config[CONF_FAN_WITH_COOLING] is True and CONF_FAN_ONLY_ACTION not in config:
@@ -610,7 +617,7 @@ CONFIG_SCHEMA = cv.All(
                 }
             ),
             cv.Optional(CONF_PRESET): cv.ensure_list(PRESET_CONFIG_SCHEMA),
-            cv.Optional(CONF_RESTORE_DEFAULT_PRESET_ON_BOOT, default=False): cv.boolean,
+            cv.Optional(CONF_STARTUP_BEHAVIOR): validate_startup_behavior,
             cv.Optional(CONF_PRESET_CHANGE): automation.validate_automation(
                 single=True
             ),
@@ -915,12 +922,8 @@ async def to_code(config):
         else:
             cg.add(var.set_default_preset(default_preset_name))
 
-    if CONF_RESTORE_DEFAULT_PRESET_ON_BOOT in config:
-        cg.add(
-            var.set_restore_default_preset_on_boot(
-                config[CONF_RESTORE_DEFAULT_PRESET_ON_BOOT]
-            )
-        )
+    if CONF_STARTUP_BEHAVIOR in config:
+        cg.add(var.set_startup_behavior(config[CONF_STARTUP_BEHAVIOR]))
 
     if CONF_PRESET_CHANGE in config:
         await automation.build_automation(

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -446,7 +446,14 @@ def validate_thermostat(config):
             )
         else:
             presets = config[CONF_PRESET]
-            if default_preset not in presets:
+            found_preset = False
+
+            for preset in presets:
+                if preset[CONF_NAME] == default_preset:
+                    found_preset = True
+                    break
+            
+            if found_preset == False:
                 raise cv.Invalid(
                     f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
                 )

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -70,7 +70,7 @@ from esphome.const import (
 
 CONF_PRESET_CHANGE = "preset_change"
 CONF_DEFAULT_PRESET = "default_preset"
-CONF_STARTUP_BEHAVIOR = "startup_behavior"
+CONF_ON_BOOT_RESTORE_FROM = "on_boot_restore_from"
 
 CODEOWNERS = ["@kbx81"]
 
@@ -82,12 +82,12 @@ ThermostatClimate = thermostat_ns.class_(
 ThermostatClimateTargetTempConfig = thermostat_ns.struct(
     "ThermostatClimateTargetTempConfig"
 )
-StartupBehavior = thermostat_ns.enum("StartupBehavior")
-STARTUP_BEHAVIOR = {
-    "RESTORE_FROM_MEMORY": StartupBehavior.RESTORE_FROM_MEMORY,
-    "APPLY_DEFAULT_PRESET": StartupBehavior.APPLY_DEFAULT_PRESET,
+OnBootRestoreFrom = thermostat_ns.enum("OnBootRestoreFrom")
+ON_BOOT_RESTORE_FROM = {
+    "MEMORY": OnBootRestoreFrom.MEMORY,
+    "DEFAULT_PRESET": OnBootRestoreFrom.DEFAULT_PRESET,
 }
-validate_startup_behavior = cv.enum(STARTUP_BEHAVIOR, upper=True)
+validate_on_boot_restore_from = cv.enum(ON_BOOT_RESTORE_FROM, upper=True)
 
 ClimateMode = climate_ns.enum("ClimateMode")
 CLIMATE_MODES = {
@@ -471,12 +471,12 @@ def validate_thermostat(config):
 
     # If restoring default preset on boot is true then ensure we have a default preset
     if (
-        CONF_STARTUP_BEHAVIOR in config
-        and config[CONF_STARTUP_BEHAVIOR] is StartupBehavior.APPLY_DEFAULT_PRESET
+        CONF_ON_BOOT_RESTORE_FROM in config
+        and config[CONF_ON_BOOT_RESTORE_FROM] is OnBootRestoreFrom.DEFAULT_PRESET
     ):
         if CONF_DEFAULT_PRESET not in config:
             raise cv.Invalid(
-                f"{CONF_DEFAULT_PRESET} must be defined to use {CONF_STARTUP_BEHAVIOR} in APPLY_DEFAULT_PRESET mode"
+                f"{CONF_DEFAULT_PRESET} must be defined to use {CONF_ON_BOOT_RESTORE_FROM} in DEFAULT_PRESET mode"
             )
 
     if config[CONF_FAN_WITH_COOLING] is True and CONF_FAN_ONLY_ACTION not in config:
@@ -617,7 +617,7 @@ CONFIG_SCHEMA = cv.All(
                 }
             ),
             cv.Optional(CONF_PRESET): cv.ensure_list(PRESET_CONFIG_SCHEMA),
-            cv.Optional(CONF_STARTUP_BEHAVIOR): validate_startup_behavior,
+            cv.Optional(CONF_ON_BOOT_RESTORE_FROM): validate_on_boot_restore_from,
             cv.Optional(CONF_PRESET_CHANGE): automation.validate_automation(
                 single=True
             ),
@@ -922,8 +922,8 @@ async def to_code(config):
         else:
             cg.add(var.set_default_preset(default_preset_name))
 
-    if CONF_STARTUP_BEHAVIOR in config:
-        cg.add(var.set_startup_behavior(config[CONF_STARTUP_BEHAVIOR]))
+    if CONF_ON_BOOT_RESTORE_FROM in config:
+        cg.add(var.set_on_boot_restore_from(config[CONF_ON_BOOT_RESTORE_FROM]))
 
     if CONF_PRESET_CHANGE in config:
         await automation.build_automation(

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -135,12 +135,12 @@ def validate_temperature_preset(preset, root_config, name, requirements):
 
 
 def generate_comparable_preset(config, name):
-    comparable_preset = f"{CONF_PRESET}:\n" f"-  {CONF_NAME}: {name}\n"
+    comparable_preset = f"{CONF_PRESET}:\n" f"  -  {CONF_NAME}: {name}\n"
 
     if CONF_DEFAULT_TARGET_TEMPERATURE_LOW in config:
-        comparable_preset += f"  {CONF_DEFAULT_TARGET_TEMPERATURE_LOW}: {config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]}\n"
+        comparable_preset += f"     {CONF_DEFAULT_TARGET_TEMPERATURE_LOW}: {config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]}\n"
     if CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in config:
-        comparable_preset += f"  {CONF_DEFAULT_TARGET_TEMPERATURE_HIGH}: {config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH]}\n"
+        comparable_preset += f"     {CONF_DEFAULT_TARGET_TEMPERATURE_HIGH}: {config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH]}\n"
 
     return comparable_preset
 
@@ -302,14 +302,14 @@ def validate_thermostat(config):
         comparable_preset = generate_comparable_preset(config, "Your new preset")
 
         raise cv.Invalid(
-            f"{CONF_DEFAULT_TARGET_TEMPERATURE_LOW} is no longer valid. Please switch to using a preset for an equivalent experience. Equivalent configuration;\n\n"
+            f"{CONF_DEFAULT_TARGET_TEMPERATURE_LOW} is no longer valid. Please switch to using a preset for an equivalent experience.\nEquivalent configuration:\n\n"
             f"{comparable_preset}"
         )
     if CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in config:
         comparable_preset = generate_comparable_preset(config, "Your new preset")
 
         raise cv.Invalid(
-            f"{CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} is no longer valid. Please switch to using a preset for an equivalent experience. Equivalent configuration;\n\n"
+            f"{CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} is no longer valid. Please switch to using a preset for an equivalent experience.\nEquivalent configuration:\n\n"
             f"{comparable_preset}"
         )
 
@@ -320,7 +320,7 @@ def validate_thermostat(config):
         raise cv.Invalid(
             f"{CONF_AWAY_CONFIG} is no longer valid. Please switch to using a preset named "
             "Away"
-            " for an equivalent experience. Equivalent configuration;\n\n"
+            " for an equivalent experience.\nEquivalent configuration:\n\n"
             f"{comparable_preset}"
         )
 

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -618,6 +618,8 @@ async def to_code(config):
         CONF_COOL_ACTION in config
         or (config[CONF_FAN_ONLY_COOLING] and CONF_FAN_ONLY_ACTION in config)
     )
+    if two_points_available:
+        cg.add(var.set_supports_two_points(True))
 
     sens = await cg.get_variable(config[CONF_SENSOR])
     cg.add(
@@ -844,8 +846,8 @@ async def to_code(config):
         )
 
     if CONF_PRESET in config:
+        presetcount = 0
         for preset_config in config[CONF_PRESET]:
-
             name = preset_config[CONF_NAME]
             standard_preset = None
             if name.upper() in climate.CLIMATE_PRESETS:

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -125,11 +125,9 @@ def validate_temperature_preset(preset, root_config, name, requirements):
                     f"{config_temp} is defined in {name} config with no {req_action}"
                 )
 
+
 def generate_comparable_preset(config, name):
-    comparable_preset = (
-    f"{CONF_PRESET}:\n"
-    f"  {CONF_NAME}: {name}\n"
-    )
+    comparable_preset = f"{CONF_PRESET}:\n" f"  {CONF_NAME}: {name}\n"
 
     if CONF_DEFAULT_TARGET_TEMPERATURE_LOW in config:
         comparable_preset += f"  {CONF_DEFAULT_TARGET_TEMPERATURE_LOW}: {config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]}\n"
@@ -137,6 +135,7 @@ def generate_comparable_preset(config, name):
         comparable_preset += f"  {CONF_DEFAULT_TARGET_TEMPERATURE_HIGH}: {config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH]}\n"
 
     return comparable_preset
+
 
 def validate_thermostat(config):
     # verify corresponding action(s) exist(s) for any defined climate mode or action
@@ -310,10 +309,13 @@ def validate_thermostat(config):
     if CONF_AWAY_CONFIG in config:
         comparable_preset = generate_comparable_preset(config[CONF_AWAY_CONFIG], "Away")
 
-        raise cv.Invalid(f"{CONF_AWAY_CONFIG} is no longer valid. Please switch to using a preset named ""Away"" for an equivalent experience. Equivalent configuration;\n\n"
-        f"{comparable_preset}"
+        raise cv.Invalid(
+            f"{CONF_AWAY_CONFIG} is no longer valid. Please switch to using a preset named "
+            "Away"
+            " for an equivalent experience. Equivalent configuration;\n\n"
+            f"{comparable_preset}"
         )
-    
+
     # Validate temperature requirements for presets
     if CONF_PRESET in config:
         for preset_config in config[CONF_PRESET]:
@@ -323,7 +325,9 @@ def validate_thermostat(config):
 
     # Warn about using the removed CONF_DEFAULT_MODE and advise users
     if CONF_DEFAULT_MODE in config and config[CONF_DEFAULT_MODE] is not None:
-        raise cv.Invalid(f"{CONF_DEFAULT_MODE} is no longer valid. Please switch to using presets and specify a {CONF_DEFAULT_PRESET}.")
+        raise cv.Invalid(
+            f"{CONF_DEFAULT_MODE} is no longer valid. Please switch to using presets and specify a {CONF_DEFAULT_PRESET}."
+        )
 
     default_mode = config[CONF_DEFAULT_MODE]
     requirements = {
@@ -435,7 +439,6 @@ def validate_thermostat(config):
                         f"{CONF_SWING_MODE} is set to {swing_mode} for {preset_config[CONF_NAME]} but {req} is not present in the configuration"
                     )
 
-
     # If a default preset is requested then ensure that preset is defined
     if CONF_DEFAULT_PRESET in config:
         default_preset = config[CONF_DEFAULT_PRESET]
@@ -444,19 +447,19 @@ def validate_thermostat(config):
             raise cv.Invalid(
                 f"{CONF_DEFAULT_PRESET} is specified but no presets are defined"
             )
-        else:
-            presets = config[CONF_PRESET]
-            found_preset = False
 
-            for preset in presets:
-                if preset[CONF_NAME] == default_preset:
-                    found_preset = True
-                    break
-            
-            if found_preset == False:
-                raise cv.Invalid(
-                    f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
-                )
+        presets = config[CONF_PRESET]
+        found_preset = False
+
+        for preset in presets:
+            if preset[CONF_NAME] == default_preset:
+                found_preset = True
+                break
+
+        if found_preset is False:
+            raise cv.Invalid(
+                f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
+            )
 
     if config[CONF_FAN_WITH_COOLING] is True and CONF_FAN_ONLY_ACTION not in config:
         raise cv.Invalid(

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -697,7 +697,6 @@ async def to_code(config):
     cg.add(var.set_supports_fan_with_heating(config[CONF_FAN_WITH_HEATING]))
 
     cg.add(var.set_use_startup_delay(config[CONF_STARTUP_DELAY]))
-    cg.add(var.set_preset_config(ClimatePreset.CLIMATE_PRESET_HOME, normal_config))
 
     await automation.build_automation(
         var.get_idle_action_trigger(), [], config[CONF_IDLE_ACTION]

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -127,7 +127,7 @@ def validate_temperature_preset(preset, root_config, name, requirements):
 
 
 def generate_comparable_preset(config, name):
-    comparable_preset = f"{CONF_PRESET}:\n" f"  {CONF_NAME}: {name}\n"
+    comparable_preset = f"{CONF_PRESET}:\n" f"-  {CONF_NAME}: {name}\n"
 
     if CONF_DEFAULT_TARGET_TEMPERATURE_LOW in config:
         comparable_preset += f"  {CONF_DEFAULT_TARGET_TEMPERATURE_LOW}: {config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]}\n"

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -889,6 +889,16 @@ async def to_code(config):
             else:
                 cg.add(var.set_custom_preset_config(name, preset_target_variable))
 
+    if CONF_DEFAULT_PRESET in config:
+        default_preset_name = config[CONF_DEFAULT_PRESET]
+
+        # if the name is a built in preset use the appropriate naming format
+        if default_preset_name.upper() in climate.CLIMATE_PRESETS:
+            climate_preset = climate.CLIMATE_PRESETS[default_preset_name.upper()]
+            cg.add(var.set_default_preset(climate_preset))
+        else:
+            cg.add(var.set_default_preset(default_preset_name))
+
     if CONF_PRESET_CHANGE in config:
         await automation.build_automation(
             var.get_preset_change_trigger(), [], config[CONF_PRESET_CHANGE]

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -849,7 +849,6 @@ async def to_code(config):
         )
 
     if CONF_PRESET in config:
-        presetcount = 0
         for preset_config in config[CONF_PRESET]:
             name = preset_config[CONF_NAME]
             standard_preset = None

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -29,7 +29,7 @@ void ThermostatClimate::setup() {
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->to_call(this).perform();
-  } 
+  }
 
   // Specifically set the default state outside of restored state
   if (this->default_preset_ != climate::ClimatePreset::CLIMATE_PRESET_NONE) {
@@ -927,8 +927,7 @@ bool ThermostatClimate::supplemental_heating_required_() {
           (this->supplemental_action_ == climate::CLIMATE_ACTION_HEATING));
 }
 
-void ThermostatClimate::dump_preset_config_(const std::string &preset,
-                                            const ThermostatClimateTargetTempConfig &config,
+void ThermostatClimate::dump_preset_config_(const std::string &preset, const ThermostatClimateTargetTempConfig &config,
                                             bool is_default_preset) {
   const auto *preset_name = preset.c_str();
 
@@ -1072,9 +1071,7 @@ void ThermostatClimate::set_default_preset(const std::string &custom_preset) {
   this->default_custom_preset_ = custom_preset;
 }
 
-void ThermostatClimate::set_default_preset(climate::ClimatePreset preset) {
-  this->default_preset_ = preset;
-}
+void ThermostatClimate::set_default_preset(climate::ClimatePreset preset) { this->default_preset_ = preset; }
 
 void ThermostatClimate::set_set_point_minimum_differential(float differential) {
   this->set_point_minimum_differential_ = differential;

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -25,7 +25,7 @@ void ThermostatClimate::setup() {
     this->publish_state();
   });
   this->current_temperature = this->sensor_->state;
-  
+
   auto use_default_preset = true;
 
   if (!this->restore_default_preset_on_boot_) {

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -29,10 +29,7 @@ void ThermostatClimate::setup() {
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->to_call(this).perform();
-  }
-
-  // Specifically set the default state outside of restored state
-  if (this->default_preset_ != climate::ClimatePreset::CLIMATE_PRESET_NONE) {
+  } else if (this->default_preset_ != climate::ClimatePreset::CLIMATE_PRESET_NONE) {
     this->change_preset_(this->default_preset_);
   } else if (!this->default_custom_preset_.empty()) {
     this->change_custom_preset_(this->default_custom_preset_);

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -28,7 +28,7 @@ void ThermostatClimate::setup() {
 
   auto use_default_preset = true;
 
-  if (this->startup_behavior_ == thermostat::StartupBehavior::RESTORE_FROM_MEMORY) {
+  if (this->on_boot_restore_from_ == thermostat::OnBootRestoreFrom::MEMORY) {
     // restore all climate data, if possible
     auto restore = this->restore_state_();
     if (restore.has_value()) {
@@ -1081,8 +1081,8 @@ void ThermostatClimate::set_default_preset(const std::string &custom_preset) {
 
 void ThermostatClimate::set_default_preset(climate::ClimatePreset preset) { this->default_preset_ = preset; }
 
-void ThermostatClimate::set_startup_behavior(thermostat::StartupBehavior startup_behavior) {
-  this->startup_behavior_ = startup_behavior;
+void ThermostatClimate::set_on_boot_restore_from(thermostat::OnBootRestoreFrom on_boot_restore_from) {
+  this->on_boot_restore_from_ = on_boot_restore_from;
 }
 void ThermostatClimate::set_set_point_minimum_differential(float differential) {
   this->set_point_minimum_differential_ = differential;

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -29,11 +29,15 @@ void ThermostatClimate::setup() {
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->to_call(this).perform();
-  } else {
-    // restore from defaults, change_away handles temps for us
-    this->mode = this->default_mode_;
-    this->change_preset_(climate::CLIMATE_PRESET_HOME);
+  } 
+
+  // Specifically set the default state outside of restored state
+  if (this->default_preset_ != climate::ClimatePreset::CLIMATE_PRESET_NONE) {
+    this->change_preset_(this->default_preset_);
+  } else if (!this->default_custom_preset_.empty()) {
+    this->change_custom_preset_(this->default_custom_preset_);
   }
+
   // refresh the climate action based on the restored settings, we'll publish_state() later
   this->switch_to_action_(this->compute_action_(), false);
   this->switch_to_supplemental_action_(this->compute_supplemental_action_());
@@ -924,8 +928,11 @@ bool ThermostatClimate::supplemental_heating_required_() {
 }
 
 void ThermostatClimate::dump_preset_config_(const std::string &preset,
-                                            const ThermostatClimateTargetTempConfig &config) {
+                                            const ThermostatClimateTargetTempConfig &config,
+                                            bool is_default_preset) {
   const auto *preset_name = preset.c_str();
+
+  ESP_LOGCONFIG(TAG, "      %s Is Default: %s", preset_name, YESNO(is_default_preset));
 
   if (this->supports_heat_) {
     if (this->supports_two_points_) {
@@ -1061,7 +1068,14 @@ ThermostatClimate::ThermostatClimate()
       temperature_change_trigger_(new Trigger<>()),
       preset_change_trigger_(new Trigger<>()) {}
 
-void ThermostatClimate::set_default_mode(climate::ClimateMode default_mode) { this->default_mode_ = default_mode; }
+void ThermostatClimate::set_default_preset(const std::string &custom_preset) {
+  this->default_custom_preset_ = custom_preset;
+}
+
+void ThermostatClimate::set_default_preset(climate::ClimatePreset preset) {
+  this->default_preset_ = preset;
+}
+
 void ThermostatClimate::set_set_point_minimum_differential(float differential) {
   this->set_point_minimum_differential_ = differential;
 }
@@ -1284,7 +1298,7 @@ void ThermostatClimate::dump_config() {
     const auto *preset_name = LOG_STR_ARG(climate::climate_preset_to_string(it.first));
 
     ESP_LOGCONFIG(TAG, "    Supports %s: %s", preset_name, YESNO(true));
-    this->dump_preset_config_(preset_name, it.second);
+    this->dump_preset_config_(preset_name, it.second, it.first == this->default_preset_);
   }
 
   ESP_LOGCONFIG(TAG, "  Supported CUSTOM PRESETS: ");
@@ -1292,7 +1306,7 @@ void ThermostatClimate::dump_config() {
     const auto *preset_name = it.first.c_str();
 
     ESP_LOGCONFIG(TAG, "    Supports %s: %s", preset_name, YESNO(true));
-    this->dump_preset_config_(preset_name, it.second);
+    this->dump_preset_config_(preset_name, it.second, it.first == this->default_custom_preset_);
   }
 }
 

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1235,8 +1235,9 @@ Trigger<> *ThermostatClimate::get_preset_change_trigger() const { return this->p
 void ThermostatClimate::dump_config() {
   LOG_CLIMATE("", "Thermostat", this);
 
-  if (this->supports_two_points_)
+  if (this->supports_two_points_) {
     ESP_LOGCONFIG(TAG, "  Minimum Set Point Differential: %.1f°C", this->set_point_minimum_differential_);
+  }
   ESP_LOGCONFIG(TAG, "  Start-up Delay Enabled: %s", YESNO(this->use_startup_delay_));
   if (this->supports_cool_) {
     ESP_LOGCONFIG(TAG, "  Cooling Parameters:");
@@ -1316,6 +1317,8 @@ void ThermostatClimate::dump_config() {
     ESP_LOGCONFIG(TAG, "    Supports %s: %s", preset_name, YESNO(true));
     this->dump_preset_config_(preset_name, it.second, it.first == this->default_custom_preset_);
   }
+  ESP_LOGCONFIG(TAG, "  On boot, restore from: %s",
+                this->on_boot_restore_from_ == thermostat::DEFAULT_PRESET ? "DEFAULT_PRESET" : "MEMORY");
 }
 
 ThermostatClimateTargetTempConfig::ThermostatClimateTargetTempConfig() = default;

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -28,7 +28,7 @@ void ThermostatClimate::setup() {
 
   auto use_default_preset = true;
 
-  if (!this->restore_default_preset_on_boot_) {
+  if (this->startup_behavior_ == thermostat::StartupBehavior::RESTORE_FROM_MEMORY) {
     // restore all climate data, if possible
     auto restore = this->restore_state_();
     if (restore.has_value()) {
@@ -1081,8 +1081,8 @@ void ThermostatClimate::set_default_preset(const std::string &custom_preset) {
 
 void ThermostatClimate::set_default_preset(climate::ClimatePreset preset) { this->default_preset_ = preset; }
 
-void ThermostatClimate::set_restore_default_preset_on_boot(bool restore_preset) {
-  this->restore_default_preset_on_boot_ = restore_preset;
+void ThermostatClimate::set_startup_behavior(thermostat::StartupBehavior startup_behavior) {
+  this->startup_behavior_ = startup_behavior;
 }
 void ThermostatClimate::set_set_point_minimum_differential(float differential) {
   this->set_point_minimum_differential_ = differential;

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -57,7 +57,8 @@ class ThermostatClimate : public climate::Climate, public Component {
   void setup() override;
   void dump_config() override;
 
-  void set_default_mode(climate::ClimateMode default_mode);
+  void set_default_preset(const std::string &name);
+  void set_default_preset(climate::ClimatePreset preset);
   void set_set_point_minimum_differential(float differential);
   void set_cool_deadband(float deadband);
   void set_cool_overrun(float overrun);
@@ -225,7 +226,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   bool supplemental_cooling_required_();
   bool supplemental_heating_required_();
 
-  void dump_preset_config_(const std::string &preset_name, const ThermostatClimateTargetTempConfig &config);
+  void dump_preset_config_(const std::string &preset_name, const ThermostatClimateTargetTempConfig &config, bool is_default_preset);
 
   /// The sensor used for getting the current temperature
   sensor::Sensor *sensor_{nullptr};
@@ -397,7 +398,6 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// These are used to determine when a trigger/action needs to be called
   climate::ClimateAction supplemental_action_{climate::CLIMATE_ACTION_OFF};
   climate::ClimateFanMode prev_fan_mode_{climate::CLIMATE_FAN_ON};
-  climate::ClimateMode default_mode_{climate::CLIMATE_MODE_OFF};
   climate::ClimateMode prev_mode_{climate::CLIMATE_MODE_OFF};
   climate::ClimateSwingMode prev_swing_mode_{climate::CLIMATE_SWING_OFF};
 
@@ -441,6 +441,11 @@ class ThermostatClimate : public climate::Climate, public Component {
   std::map<climate::ClimatePreset, ThermostatClimateTargetTempConfig> preset_config_{};
   /// The set of custom preset configurations this thermostat supports (eg. "My Custom Preset")
   std::map<std::string, ThermostatClimateTargetTempConfig> custom_preset_config_{};
+
+  /// Default standard preset to use on start up
+  climate::ClimatePreset default_preset_{};
+  /// Default custom preset to use on start up
+  std::string default_custom_preset_{};
 };
 
 }  // namespace thermostat

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -450,7 +450,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   std::string default_custom_preset_{};
 
   /// If true then the default preset is always used when false prior state will attempt to be restored
-  bool restore_default_preset_on_boot_ {false};
+  bool restore_default_preset_on_boot_{false};
 };
 
 }  // namespace thermostat

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -22,7 +22,7 @@ enum ThermostatClimateTimerIndex : size_t {
   TIMER_IDLE_ON = 9,
 };
 
-enum StartupBehavior : size_t { RESTORE_FROM_MEMORY = 0, APPLY_DEFAULT_PRESET = 1 };
+enum OnBootRestoreFrom : size_t { MEMORY = 0, DEFAULT_PRESET = 1 };
 struct ThermostatClimateTimer {
   const std::string name;
   bool active;
@@ -60,7 +60,7 @@ class ThermostatClimate : public climate::Climate, public Component {
 
   void set_default_preset(const std::string &custom_preset);
   void set_default_preset(climate::ClimatePreset preset);
-  void set_startup_behavior(thermostat::StartupBehavior startup_behavior);
+  void set_on_boot_restore_from(thermostat::OnBootRestoreFrom on_boot_restore_from);
   void set_set_point_minimum_differential(float differential);
   void set_cool_deadband(float deadband);
   void set_cool_overrun(float overrun);
@@ -450,9 +450,9 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// Default custom preset to use on start up
   std::string default_custom_preset_{};
 
-  /// If set to APPLY_DEFAULT_PRESET then the default preset is always used. When RESTORE_FROM_MEMORY prior
+  /// If set to DEFAULT_PRESET then the default preset is always used. When MEMORY prior
   /// state will attempt to be restored if possible
-  thermostat::StartupBehavior startup_behavior_{thermostat::StartupBehavior::RESTORE_FROM_MEMORY};
+  thermostat::OnBootRestoreFrom on_boot_restore_from_{thermostat::OnBootRestoreFrom::MEMORY};
 };
 
 }  // namespace thermostat

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -57,7 +57,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   void setup() override;
   void dump_config() override;
 
-  void set_default_preset(const std::string &name);
+  void set_default_preset(const std::string &custom_preset);
   void set_default_preset(climate::ClimatePreset preset);
   void set_set_point_minimum_differential(float differential);
   void set_cool_deadband(float deadband);
@@ -226,7 +226,8 @@ class ThermostatClimate : public climate::Climate, public Component {
   bool supplemental_cooling_required_();
   bool supplemental_heating_required_();
 
-  void dump_preset_config_(const std::string &preset_name, const ThermostatClimateTargetTempConfig &config, bool is_default_preset);
+  void dump_preset_config_(const std::string &preset_name, const ThermostatClimateTargetTempConfig &config,
+                           bool is_default_preset);
 
   /// The sensor used for getting the current temperature
   sensor::Sensor *sensor_{nullptr};

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -59,6 +59,7 @@ class ThermostatClimate : public climate::Climate, public Component {
 
   void set_default_preset(const std::string &custom_preset);
   void set_default_preset(climate::ClimatePreset preset);
+  void set_restore_default_preset_on_boot(bool restore_preset);
   void set_set_point_minimum_differential(float differential);
   void set_cool_deadband(float deadband);
   void set_cool_overrun(float overrun);
@@ -447,6 +448,9 @@ class ThermostatClimate : public climate::Climate, public Component {
   climate::ClimatePreset default_preset_{};
   /// Default custom preset to use on start up
   std::string default_custom_preset_{};
+
+  /// If true then the default preset is always used when false prior state will attempt to be restored
+  bool restore_default_preset_on_boot_ {false};
 };
 
 }  // namespace thermostat

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -22,11 +22,7 @@ enum ThermostatClimateTimerIndex : size_t {
   TIMER_IDLE_ON = 9,
 };
 
-enum StartupBehavior : size_t {
-  RESTORE_FROM_MEMORY = 0,
-  APPLY_DEFAULT_PRESET = 1
-};
-
+enum StartupBehavior : size_t { RESTORE_FROM_MEMORY = 0, APPLY_DEFAULT_PRESET = 1 };
 struct ThermostatClimateTimer {
   const std::string name;
   bool active;
@@ -454,7 +450,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// Default custom preset to use on start up
   std::string default_custom_preset_{};
 
-  /// If set to APPLY_DEFAULT_PRESET then the default preset is always used. When RESTORE_FROM_MEMORY prior 
+  /// If set to APPLY_DEFAULT_PRESET then the default preset is always used. When RESTORE_FROM_MEMORY prior
   /// state will attempt to be restored if possible
   thermostat::StartupBehavior startup_behavior_{thermostat::StartupBehavior::RESTORE_FROM_MEMORY};
 };

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -22,6 +22,11 @@ enum ThermostatClimateTimerIndex : size_t {
   TIMER_IDLE_ON = 9,
 };
 
+enum StartupBehavior : size_t {
+  RESTORE_FROM_MEMORY = 0,
+  APPLY_DEFAULT_PRESET = 1
+};
+
 struct ThermostatClimateTimer {
   const std::string name;
   bool active;
@@ -59,7 +64,7 @@ class ThermostatClimate : public climate::Climate, public Component {
 
   void set_default_preset(const std::string &custom_preset);
   void set_default_preset(climate::ClimatePreset preset);
-  void set_restore_default_preset_on_boot(bool restore_preset);
+  void set_startup_behavior(thermostat::StartupBehavior startup_behavior);
   void set_set_point_minimum_differential(float differential);
   void set_cool_deadband(float deadband);
   void set_cool_overrun(float overrun);
@@ -449,8 +454,9 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// Default custom preset to use on start up
   std::string default_custom_preset_{};
 
-  /// If true then the default preset is always used when false prior state will attempt to be restored
-  bool restore_default_preset_on_boot_{false};
+  /// If set to APPLY_DEFAULT_PRESET then the default preset is always used. When RESTORE_FROM_MEMORY prior 
+  /// state will attempt to be restored if possible
+  thermostat::StartupBehavior startup_behavior_{thermostat::StartupBehavior::RESTORE_FROM_MEMORY};
 };
 
 }  // namespace thermostat

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1021,8 +1021,13 @@ climate:
   - platform: thermostat
     name: Thermostat Climate
     sensor: ha_hello_world
-    default_target_temperature_low: 18°C
-    default_target_temperature_high: 24°C
+    preset:
+    - name: Default Preset
+      default_target_temperature_low: 18°C
+      default_target_temperature_high: 24°C
+    - name: Away
+      default_target_temperature_low: 16°C
+      default_target_temperature_high: 20°C
     idle_action:
       - switch.turn_on: gpio_switch1
     cool_action:
@@ -1097,9 +1102,6 @@ climate:
     fan_only_cooling: true
     fan_with_cooling: true
     fan_with_heating: true
-    away_config:
-      default_target_temperature_low: 16°C
-      default_target_temperature_high: 20°C
   - platform: pid
     id: pid_climate
     name: 'PID Climate Controller'


### PR DESCRIPTION
# What does this implement/fix?

Following on from #3298 this PR moves any deprecated configuration from raise an error with descriptive messaging on how to convert between the old configuration and the new configuration. The intent is to have this merged, released, and then the following release remove all the deprecated configuration handling code.

Secondly, as part of this, it introduces `default_preset` as the successor for `default_mode`. This will change the preset on start up. This effectively allows the control of not just default modes, but default temperatures, swing modes, and fan modes on the thermostat.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2292

## Breaking change notes

`default_mode` has been replaced with `default_preset`. See [the docs](https://next.esphome.io/components/climate/thermostat.html#default-preset) for more detail.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example legacy yaml
climate:
  - platform: thermostat
    name: My Thermostat
    default_mode: Off
    away_config:
        default_target_temperature_low: 16
        default_target_temperature_high: 30
    default_target_temperature_low: 20
    default_target_temperature_high: 24
```

```yaml
# Example new yaml
climate:
  - platform: thermostat
    name: My Thermostat
    default_preset: Startup Preset
    startup_behavior: APPLY_DEFAULT_PRESET
    preset:
      - name: Away
        default_target_temperature_low: 16
        default_target_temperature_high: 30
      - name: Home
        default_target_temperature_low: 20
        default_target_temperature_high: 24
      - name: Startup Preset
        mode: off
        default_target_temperature_low: 20
        default_target_temperature_high: 24
    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

TBD