### PR TITLE
Add priority to on_shutdown trigger

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -93,7 +93,12 @@ class StartupTrigger : public Trigger<>, public Component {
 
 class ShutdownTrigger : public Trigger<>, public Component {
  public:
+  explicit ShutdownTrigger(float setup_priority) : setup_priority_(setup_priority) {}
   void on_shutdown() override { this->trigger(); }
+  float get_setup_priority() const override { return this->setup_priority_; }
+
+ protected:
+  float setup_priority_;
 };
 
 class LoopTrigger : public Trigger<>, public Component {

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -117,6 +117,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_SHUTDOWN): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ShutdownTrigger),
+                    cv.Optional(CONF_PRIORITY, default=600.0): cv.float_,
                 }
             ),
             cv.Optional(CONF_ON_LOOP): automation.validate_automation(
@@ -291,7 +292,7 @@ async def _add_automations(config):
         await automation.build_automation(trigger, [], conf)
 
     for conf in config.get(CONF_ON_SHUTDOWN, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], conf.get(CONF_PRIORITY))
         await cg.register_component(trigger, conf)
         await automation.build_automation(trigger, [], conf)
 


### PR DESCRIPTION
# What does this implement/fix?
Adds priority to the shutdown trigger. As cals made in these triggers may depend on resources that could already be torn down based on their priority, we need the option to define the shutdown order for these triggers as well.

My usecase; storing a a value to a `RestoringGlobalsComponent`, the storage bits of which are torn down at the same time (priority level) as when `on_shutdown` triggers are executed. I.e. for this to work correctly the priority of the `on_shutdown` trigger should be slightly increased to assure it's shutdown trigger is handled before that of the component it relies on.

Extension of #3585

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2189

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:

  on_shutdown:
    # Priority 800, same as preferences component!...
    priority: 750
    then:
      - lambda: |-
          id(global_pulse_count) = id(water_pulse_total)->get_state();

esp8266:
  board: d1_mini
  restore_from_flash: true

globals:
  - id: global_pulse_count
    type: uint32_t
    restore_value: true
    initial_value: "0"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
