### PR TITLE
FIX: NVS preferences being written even if unchanged

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -154,7 +154,7 @@ class ESP32Preferences : public ESPPreferences {
       ESP_LOGV(TAG, "nvs_get_blob('%s'): %s - the key might not be set yet", to_save.key.c_str(), esp_err_to_name(err));
       return true;
     }
-    stored_data.data.reserve(actual_len);
+    stored_data.data.resize(actual_len);
     err = nvs_get_blob(nvs_handle, to_save.key.c_str(), stored_data.data.data(), &actual_len);
     if (err != 0) {
       ESP_LOGV(TAG, "nvs_get_blob('%s') failed: %s", to_save.key.c_str(), esp_err_to_name(err));


### PR DESCRIPTION
# What does this implement/fix?

PR #3479 attempts to avoid saving preferences to NVS if the data present in the preferences has not changed. However, due to a bug, this was not actually working and therefore NVS was being overwritten every time, resulting in flash wear.

In particular, this line of code is the culprit:

```cpp
bool is_changed() {
// ...
stored_data.data.reserve(actual_len);
```
`std::vector::reserve()` does not do what it looks like. It preallocates memory but does not actually mark the array as that size: the vector remains empty. As a result, the vector comparison at the end of the function always returns `true`, since an empty vector will always be different than whatever information is to be saved.

The intended behavior is provided by `vector::resize()`. This expands the array so data can be loaded into it.

The PR also adds debug preference saving counters to allow for easily debugging issues around preferences, and for example visualize if too many preferences are being saved (i.e., the user may have set too many components with a restore state)


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes <link to issue>
#3479

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
