### PR TITLE
FIX: Modbus queue deduplicator deleting custom commands

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -108,8 +108,7 @@ void ModbusController::queue_command(const ModbusCommandItem &command) {
   // check if this command is already qeued.
   // not very effective but the queue is never really large
   for (auto &item : command_queue_) {
-    if (item->register_address == command.register_address && item->register_count == command.register_count &&
-        item->register_type == command.register_type && item->function_code == command.function_code) {
+    if (item->is_equal(command)) {
       ESP_LOGW(TAG, "Duplicate modbus command found: type=0x%x address=%u count=%u",
                static_cast<uint8_t>(command.register_type), command.register_address, command.register_count);
       // update the payload of the queued command
@@ -487,6 +486,15 @@ bool ModbusCommandItem::send() {
   ESP_LOGV(TAG, "Command sent %d 0x%X %d", uint8_t(this->function_code), this->register_address, this->register_count);
   send_countdown--;
   return true;
+}
+
+bool ModbusCommandItem::is_equal(const ModbusCommandItem &other) {
+  // for custom commands we have to check for identical payloads, since
+  // address/count/type fields will be set to zero
+  return this->function_code == ModbusFunctionCode::CUSTOM
+             ? this->payload == other.payload
+             : other.register_address == this->register_address && other.register_count == this->register_count &&
+                   other.register_type == this->register_type && other.function_code == this->function_code;
 }
 
 void number_to_payload(std::vector<uint16_t> &data, int64_t value, SensorValueType value_type) {

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -395,6 +395,8 @@ class ModbusCommandItem {
       ModbusController *modbusdevice, const std::vector<uint16_t> &values,
       std::function<void(ModbusRegisterType register_type, uint16_t start_address, const std::vector<uint8_t> &data)>
           &&handler = nullptr);
+
+  bool is_equal(const ModbusCommandItem &other);
 };
 
 /** Modbus controller class.


### PR DESCRIPTION
# What does this implement/fix?

When a custom Modbus command is in the queue and another (possibly unrelated) custom command comes in, the first one is incorrectly replaced with the incoming one, due to the way commands are compared. Custom commands have their address/type, etc, fields set to zero, so they looked identical to the queue deduplicator in `ModbusController::queue_command()` and thus custom commands were dropped mistakenly.

This PR fixes this issue by comparing custom commands by the payload.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
