### PR TITLE
Extend ST7789V component to support additional displays

### DIFF
--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -15,6 +15,7 @@ from esphome.const import (
 )
 from . import st7789v_ns
 
+CONF_EIGHTBITCOLOR = "eightbitcolor"
 CONF_OFFSET_HEIGHT = "offset_height"
 CONF_OFFSET_WIDTH = "offset_width"
 
@@ -68,6 +69,7 @@ async def to_code(config):
         )
         cg.add(var.set_writer(lambda_))
 
+    cg.add(var.set_eightbitcolor(config[CONF_EIGHTBITCOLOR]))
     cg.add(var.set_height(config[CONF_HEIGHT]))
     cg.add(var.set_width(config[CONF_WIDTH]))
     cg.add(var.set_offset_height(config[CONF_OFFSET_HEIGHT]))

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -36,6 +36,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_EIGHTBITCOLOR, default=False): cv.boolean,
             cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
             cv.Optional(CONF_HEIGHT, default=240): cv.int_,
             cv.Optional(CONF_WIDTH, default=135): cv.int_,
@@ -75,4 +76,4 @@ async def to_code(config):
     cg.add(var.set_offset_height(config[CONF_OFFSET_HEIGHT]))
     cg.add(var.set_offset_width(config[CONF_OFFSET_WIDTH]))
 
-    yield display.register_display(var, config)
+    await display.register_display(var, config)

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -49,7 +49,8 @@ def validate_st7789v(config):
         raise cv.Invalid(
             f'{CONF_HEIGHT}, {CONF_WIDTH}, {CONF_OFFSET_HEIGHT} and {CONF_OFFSET_WIDTH} must be specified when {CONF_MODEL} is "CUSTOM"'
         )
-    elif config[CONF_MODEL].upper() != "CUSTOM" and (
+
+    if config[CONF_MODEL].upper() != "CUSTOM" and (
         CONF_HEIGHT in config
         or CONF_WIDTH in config
         or CONF_OFFSET_HEIGHT in config

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -7,11 +7,16 @@ from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_CS_PIN,
     CONF_DC_PIN,
+    CONF_HEIGHT,
     CONF_ID,
     CONF_LAMBDA,
     CONF_RESET_PIN,
+    CONF_WIDTH,
 )
 from . import st7789v_ns
+
+CONF_OFFSET_HEIGHT = "offset_height"
+CONF_OFFSET_WIDTH = "offset_width"
 
 CODEOWNERS = ["@kbx81"]
 
@@ -31,6 +36,10 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
+            cv.Optional(CONF_HEIGHT, default=240): cv.int_,
+            cv.Optional(CONF_WIDTH, default=135): cv.int_,
+            cv.Optional(CONF_OFFSET_HEIGHT, default=52): cv.int_,
+            cv.Optional(CONF_OFFSET_WIDTH, default=40): cv.int_,
         }
     )
     .extend(cv.polling_component_schema("5s"))
@@ -59,4 +68,9 @@ async def to_code(config):
         )
         cg.add(var.set_writer(lambda_))
 
-    await display.register_display(var, config)
+    cg.add(var.set_height(config[CONF_HEIGHT]))
+    cg.add(var.set_width(config[CONF_WIDTH]))
+    cg.add(var.set_offset_height(config[CONF_OFFSET_HEIGHT]))
+    cg.add(var.set_offset_width(config[CONF_OFFSET_WIDTH]))
+
+    yield display.register_display(var, config)

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -4,12 +4,12 @@ from esphome import pins
 from esphome.components import display, spi
 from esphome.const import (
     CONF_BACKLIGHT_PIN,
-    CONF_BRIGHTNESS,
     CONF_CS_PIN,
     CONF_DC_PIN,
     CONF_HEIGHT,
     CONF_ID,
     CONF_LAMBDA,
+    CONF_MODEL,
     CONF_RESET_PIN,
     CONF_WIDTH,
 )
@@ -27,32 +27,77 @@ ST7789V = st7789v_ns.class_(
     "ST7789V", cg.PollingComponent, spi.SPIDevice, display.DisplayBuffer
 )
 ST7789VRef = ST7789V.operator("ref")
+ST7789VModel = st7789v_ns.enum("ST7789VModel")
 
-CONFIG_SCHEMA = (
+MODELS = {
+    "TTGO_TDISPLAY_135X240": ST7789VModel.ST7789V_MODEL_TTGO_TDISPLAY_135_240,
+    "ADAFRUIT_FUNHOUSE_240X240": ST7789VModel.ST7789V_MODEL_ADAFRUIT_FUNHOUSE_240_240,
+    "ADAFRUIT_RR_280X240": ST7789VModel.ST7789V_MODEL_ADAFRUIT_RR_280_240,
+    "CUSTOM": ST7789VModel.ST7789V_MODEL_CUSTOM,
+}
+
+ST7789V_MODEL = cv.enum(MODELS, upper=True, space="_")
+
+
+def validate_st7789v(config):
+    if config[CONF_MODEL].upper() == "CUSTOM" and (
+        CONF_HEIGHT not in config
+        or CONF_WIDTH not in config
+        or CONF_OFFSET_HEIGHT not in config
+        or CONF_OFFSET_WIDTH not in config
+    ):
+        raise cv.Invalid(
+            f'{CONF_HEIGHT}, {CONF_WIDTH}, {CONF_OFFSET_HEIGHT} and {CONF_OFFSET_WIDTH} must be specified when {CONF_MODEL} is "CUSTOM"'
+        )
+    elif config[CONF_MODEL].upper() != "CUSTOM" and (
+        CONF_HEIGHT in config
+        or CONF_WIDTH in config
+        or CONF_OFFSET_HEIGHT in config
+        or CONF_OFFSET_WIDTH in config
+    ):
+        raise cv.Invalid(
+            f'Do not specify {CONF_HEIGHT}, {CONF_WIDTH}, {CONF_OFFSET_HEIGHT} or {CONF_OFFSET_WIDTH} when using {CONF_MODEL} that is not "CUSTOM"'
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(ST7789V),
+            cv.Required(CONF_MODEL): ST7789V_MODEL,
             cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_EIGHTBITCOLOR, default=False): cv.boolean,
-            cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
-            cv.Optional(CONF_HEIGHT, default=240): cv.int_,
-            cv.Optional(CONF_WIDTH, default=135): cv.int_,
-            cv.Optional(CONF_OFFSET_HEIGHT, default=52): cv.int_,
-            cv.Optional(CONF_OFFSET_WIDTH, default=40): cv.int_,
+            cv.Optional(CONF_HEIGHT): cv.int_,
+            cv.Optional(CONF_WIDTH): cv.int_,
+            cv.Optional(CONF_OFFSET_HEIGHT): cv.int_,
+            cv.Optional(CONF_OFFSET_WIDTH): cv.int_,
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(spi.spi_device_schema())
+    .extend(spi.spi_device_schema()),
+    validate_st7789v,
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+    await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+
+    cg.add(var.set_model(config[CONF_MODEL]))
+
+    if config[CONF_MODEL].upper() == "CUSTOM":
+        cg.add(var.set_height(config[CONF_HEIGHT]))
+        cg.add(var.set_width(config[CONF_WIDTH]))
+        cg.add(var.set_offset_height(config[CONF_OFFSET_HEIGHT]))
+        cg.add(var.set_offset_width(config[CONF_OFFSET_WIDTH]))
+
+    cg.add(var.set_eightbitcolor(config[CONF_EIGHTBITCOLOR]))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))
@@ -69,11 +114,3 @@ async def to_code(config):
             config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
-
-    cg.add(var.set_eightbitcolor(config[CONF_EIGHTBITCOLOR]))
-    cg.add(var.set_height(config[CONF_HEIGHT]))
-    cg.add(var.set_width(config[CONF_WIDTH]))
-    cg.add(var.set_offset_height(config[CONF_OFFSET_HEIGHT]))
-    cg.add(var.set_offset_width(config[CONF_OFFSET_WIDTH]))
-
-    await display.register_display(var, config)

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -156,7 +156,19 @@ void ST7789V::write_display_data() {
   this->write_byte(ST7789_RAMWR);
   this->dc_pin_->digital_write(true);
 
-  this->write_array(this->buffer_, this->get_buffer_length_());
+  if (this->eightbitcolor_) {
+    for (int line = 0; line < this->get_buffer_length_(); line = line + this->get_width_internal()) {
+      for (int index = 0; index < this->get_width_internal(); ++index) {
+        auto color = Color(this->buffer_[index + line], Color::ColorOrder::COLOR_ORDER_RGB,
+                           Color::ColorBitness::COLOR_BITNESS_332, true)
+                         .to_565();
+        this->write_byte((color >> 8) & 0xff);
+        this->write_byte(color & 0xff);
+      }
+    }
+  } else {
+    this->write_array(this->buffer_, this->get_buffer_length_());
+  }
 
   this->disable();
 }
@@ -224,6 +236,9 @@ int ST7789V::get_height_internal() { return this->height_; }
 int ST7789V::get_width_internal() { return this->width_; }
 
 size_t ST7789V::get_buffer_length_() {
+  if (this->eightbitcolor_) {
+    return size_t(this->get_width_internal()) * size_t(this->get_height_internal());
+  }
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) * 2;
 }
 
@@ -259,11 +274,16 @@ void HOT ST7789V::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
 
-  auto color565 = display::ColorUtil::color_to_565(color);
-
-  uint32_t pos = (x + y * this->get_width_internal()) * 2;
-  this->buffer_[pos++] = (color565 >> 8) & 0xff;
-  this->buffer_[pos] = color565 & 0xff;
+  if (this->eightbitcolor_) {
+    const uint32_t color332 = color.to_332();
+    uint32_t pos = (x + y * this->get_width_internal());
+    this->buffer_[pos] = color332;
+  } else {
+    const uint32_t color565 = color.to_565();
+    uint32_t pos = (x + y * this->get_width_internal()) * 2;
+    this->buffer_[pos++] = (color565 >> 8) & 0xff;
+    this->buffer_[pos] = color565 & 0xff;
+  }
 }
 
 }  // namespace st7789v

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -219,13 +219,9 @@ void ST7789V::write_color_(uint16_t color, uint16_t size) {
   return write_array(byte, size * 2);
 }
 
-int ST7789V::get_height_internal() {
-  return this->height_;
-}
+int ST7789V::get_height_internal() { return this->height_; }
 
-int ST7789V::get_width_internal() {
-  return this->width_;
-}
+int ST7789V::get_width_internal() { return this->width_; }
 
 size_t ST7789V::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) * 2;

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -134,10 +134,10 @@ void ST7789V::update() {
 void ST7789V::loop() {}
 
 void ST7789V::write_display_data() {
-  uint16_t x1 = 52;   // _offsetx
-  uint16_t x2 = 186;  // _offsetx
-  uint16_t y1 = 40;   // _offsety
-  uint16_t y2 = 279;  // _offsety
+  uint16_t x1 = this->offset_height_;
+  uint16_t x2 = x1 + get_height_internal() - 1;
+  uint16_t y1 = this->offset_width_;
+  uint16_t y2 = y1 + get_width_internal() - 1;
 
   this->enable();
 
@@ -220,11 +220,11 @@ void ST7789V::write_color_(uint16_t color, uint16_t size) {
 }
 
 int ST7789V::get_height_internal() {
-  return 240;  // 320;
+  return this->height_;
 }
 
 int ST7789V::get_width_internal() {
-  return 135;  // 240;
+  return this->width_;
 }
 
 size_t ST7789V::get_buffer_length_() {
@@ -265,7 +265,7 @@ void HOT ST7789V::draw_absolute_pixel_internal(int x, int y, Color color) {
 
   auto color565 = display::ColorUtil::color_to_565(color);
 
-  uint16_t pos = (x + y * this->get_width_internal()) * 2;
+  uint32_t pos = (x + y * this->get_width_internal()) * 2;
   this->buffer_[pos++] = (color565 >> 8) & 0xff;
   this->buffer_[pos] = color565 & 0xff;
 }

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -126,9 +126,7 @@ void ST7789V::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  if (this->backlight_pin_ != nullptr) {
-    LOG_PIN("  B/L Pin: ", this->backlight_pin_);
-  }
+  LOG_PIN("  B/L Pin: ", this->backlight_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -139,7 +139,7 @@ class ST7789V : public PollingComponent,
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *backlight_pin_{nullptr};
 
-  boolean eightbitcolor_ = false;
+  bool eightbitcolor_ = false;
   uint16_t height_{240};
   uint16_t width_{135};
   uint16_t offset_height_{52};

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -116,6 +116,11 @@ class ST7789V : public PollingComponent,
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_backlight_pin(GPIOPin *backlight_pin) { this->backlight_pin_ = backlight_pin; }
 
+  void set_height(uint32_t height) { this->height_ = height; }
+  void set_width(uint16_t width) { this->width_ = width; }
+  void set_offset_height(uint32_t offset_height) { this->offset_height_ = offset_height; }
+  void set_offset_width(uint16_t offset_width) { this->offset_width_ = offset_width; }
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   void setup() override;
@@ -132,6 +137,11 @@ class ST7789V : public PollingComponent,
   GPIOPin *dc_pin_;
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *backlight_pin_{nullptr};
+
+  uint16_t height_{240};
+  uint16_t width_{135};
+  uint16_t offset_height_{52};
+  uint16_t offset_width_{40};
 
   void init_reset_();
   void backlight_(bool onoff);

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -7,8 +7,12 @@
 namespace esphome {
 namespace st7789v {
 
-static const uint8_t BLACK = 0;
-static const uint8_t WHITE = 1;
+enum ST7789VModel {
+  ST7789V_MODEL_TTGO_TDISPLAY_135_240,
+  ST7789V_MODEL_ADAFRUIT_FUNHOUSE_240_240,
+  ST7789V_MODEL_ADAFRUIT_RR_280_240,
+  ST7789V_MODEL_CUSTOM
+};
 
 static const uint8_t ST7789_NOP = 0x00;        // No Operation
 static const uint8_t ST7789_SWRESET = 0x01;    // Software Reset
@@ -110,8 +114,9 @@ static const uint8_t ST7789_MADCTL_COLOR_ORDER = ST7789_MADCTL_BGR;
 class ST7789V : public PollingComponent,
                 public display::DisplayBuffer,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
-                                      spi::DATA_RATE_8MHZ> {
+                                      spi::DATA_RATE_10MHZ> {
  public:
+  void set_model(ST7789VModel model);
   void set_dc_pin(GPIOPin *dc_pin) { this->dc_pin_ = dc_pin; }
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_backlight_pin(GPIOPin *backlight_pin) { this->backlight_pin_ = backlight_pin; }
@@ -128,22 +133,22 @@ class ST7789V : public PollingComponent,
   void dump_config() override;
   float get_setup_priority() const override;
   void update() override;
-  void loop() override;
 
   void write_display_data();
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
 
  protected:
-  GPIOPin *dc_pin_;
+  ST7789VModel model_{ST7789V_MODEL_TTGO_TDISPLAY_135_240};
+  GPIOPin *dc_pin_{nullptr};
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *backlight_pin_{nullptr};
 
-  bool eightbitcolor_ = false;
-  uint16_t height_{240};
-  uint16_t width_{135};
-  uint16_t offset_height_{52};
-  uint16_t offset_width_{40};
+  bool eightbitcolor_{false};
+  uint16_t height_{0};
+  uint16_t width_{0};
+  uint16_t offset_height_{0};
+  uint16_t offset_width_{0};
 
   void init_reset_();
   void backlight_(bool onoff);
@@ -152,13 +157,15 @@ class ST7789V : public PollingComponent,
   void write_addr_(uint16_t addr1, uint16_t addr2);
   void write_color_(uint16_t color, uint16_t size);
 
-  int get_height_internal() override;
-  int get_width_internal() override;
+  int get_height_internal() override { return this->height_; }
+  int get_width_internal() override { return this->width_; }
   size_t get_buffer_length_();
 
   void draw_filled_rect_(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
+
+  const char *model_str_();
 };
 
 }  // namespace st7789v

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -116,6 +116,7 @@ class ST7789V : public PollingComponent,
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_backlight_pin(GPIOPin *backlight_pin) { this->backlight_pin_ = backlight_pin; }
 
+  void set_eightbitcolor(bool eightbitcolor) { this->eightbitcolor_ = eightbitcolor; }
   void set_height(uint32_t height) { this->height_ = height; }
   void set_width(uint16_t width) { this->width_ = width; }
   void set_offset_height(uint32_t offset_height) { this->offset_height_ = offset_height; }
@@ -138,6 +139,7 @@ class ST7789V : public PollingComponent,
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *backlight_pin_{nullptr};
 
+  boolean eightbitcolor_ = false;
   uint16_t height_{240};
   uint16_t width_{135};
   uint16_t offset_height_{52};

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2366,6 +2366,7 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: st7789v
+    model: TTGO TDisplay 135x240
     cs_pin: GPIO5
     dc_pin: GPIO16
     reset_pin: GPIO23


### PR DESCRIPTION
# What does this implement/fix?

Adds support to the ST7789V component for `Adafruit Funhouse 240x240`, `Adafruit RR 280x240` and "custom" displays.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2195

## Notes on Breaking Change

For those already using the component on the TTGO T-Display module, simply add:

```yaml
    model: TTGO TDisplay 135x240
```

...to your display configuration to continue using the module as before.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
