### PR TITLE
Proxy friendly host url resolution for `use_address` with path.

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from typing import Union
 import tempfile
+from urllib.parse import urlparse
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,7 +135,8 @@ def resolve_ip_address(host):
             errs.append(str(err))
 
     try:
-        return socket.gethostbyname(host)
+        host_url = host if (urlparse(host).scheme != "") else "http://" + host
+        return socket.gethostbyname(urlparse(host_url).hostname)
     except OSError as err:
         errs.append(str(err))
         raise EsphomeError(f"Error resolving IP address: {', '.join(errs)}") from err


### PR DESCRIPTION
# What does this implement/fix?

Uses propper url parsing for host resolution to allow proxied devices that require path-prefix.

Related to:
- esphome/esphome-webserver#9
- esphome/issues#3462

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** (mostly) fixes esphome/issues#3462

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

wifi:
  ssid: !secret WiFi_ssid
  password: !secret WiFi_password
  use_address: local.my.domain/devices/plug1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
