### PR TITLE
Add support for ZHLT01 heatpump IR protocol

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -58,6 +58,7 @@ PROTOCOLS = {
     "sharp": Protocol.PROTOCOL_SHARP,
     "toshiba_daiseikai": Protocol.PROTOCOL_TOSHIBA_DAISEIKAI,
     "toshiba": Protocol.PROTOCOL_TOSHIBA,
+    "zhlt01": Protocol.PROTOCOL_ZHLT01,
 }
 
 CONF_HORIZONTAL_DEFAULT = "horizontal_default"

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -53,6 +53,7 @@ const std::map<Protocol, std::function<HeatpumpIR *()>> PROTOCOL_CONSTRUCTOR_MAP
     {PROTOCOL_SHARP, []() { return new SharpHeatpumpIR(); }},                                // NOLINT
     {PROTOCOL_TOSHIBA_DAISEIKAI, []() { return new ToshibaDaiseikaiHeatpumpIR(); }},         // NOLINT
     {PROTOCOL_TOSHIBA, []() { return new ToshibaHeatpumpIR(); }},                            // NOLINT
+    {PROTOCOL_ZHLT01, []() { return new ZHLT01HeatpumpIR(); }},                              // NOLINT
 };
 
 void HeatpumpIRClimate::setup() {

--- a/esphome/components/heatpumpir/heatpumpir.h
+++ b/esphome/components/heatpumpir/heatpumpir.h
@@ -53,6 +53,7 @@ enum Protocol {
   PROTOCOL_SHARP,
   PROTOCOL_TOSHIBA_DAISEIKAI,
   PROTOCOL_TOSHIBA,
+  PROTOCOL_ZHLT01,
 };
 
 // Simple enum to represent horizontal directios


### PR DESCRIPTION
# What does this implement/fix?

Added support for the ZHLT01 protocol using the existing HeatPumpIR component.

This protocol supports AC brands: Eurom, Chigo, Tristar, Tecnomaster, Elgin, Geant, Tekno, Topair, Proma, Sumikura, JBS, Turbo Air, Nakatomy, Celestial Air, Ager, Blueway, Airlux
Refer to https://github.com/ToniA/arduino-heatpumpir for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2199

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
