### PR TITLE
Fix Nextion send_command_ race condition

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -35,6 +35,7 @@ bool Nextion::send_command_(const std::string &command) {
   this->write_str(command.c_str());
   const uint8_t to_send[3] = {0xFF, 0xFF, 0xFF};
   this->write_array(to_send, sizeof(to_send));
+  delay(3);
   return true;
 }
 

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -838,7 +838,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
 
   std::string command_data_;
   bool is_connected_ = false;
-  uint32_t startup_override_ms_ = 8000;
+  uint32_t startup_override_ms_ = 1500;
   uint32_t max_q_age_ms_ = 8000;
   uint32_t started_ms_ = 0;
   bool sent_setup_commands_ = false;


### PR DESCRIPTION
# What does this implement/fix?

Given some specific set of circumstances, there appears to be a race condition that will occur which prevents communication with Nextion displays. I still don't understand exactly _why_ it occurs but _I think_ it is somehow related to the component's accessing of the display's associated (software-)UART and/or its buffer.

I don't like this fix...but it does seem to alleviate the issue as best I can tell and it's pretty trivial in terms of practical impact. I _think_ the issue has something to do with the soft UART needing to pick up the buffer contents before control is returned to the main loop...but this is largely speculation...

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
 - fixes https://github.com/esphome/issues/issues/3225
 - fixes https://github.com/esphome/issues/issues/3335

The behavior described in the above issues are what prompted me to even begin to look into this.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266 (D1 Mini)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). **N/A**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). **N/A**