### PR TITLE
List webserver service on MDNS if enabled.

### DIFF
--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -68,6 +68,16 @@ void MDNSComponent::compile_records_() {
   }
 #endif
 
+#ifdef USE_WEBSERVER
+  {
+    MDNSService service{};
+    service.service_type = "_http";
+    service.proto = "_tcp";
+    service.port = USE_WEBSERVER_PORT;
+    this->services_.push_back(service);
+  }
+#endif
+
   if (this->services_.empty()) {
     // Publish "http" service if not using native API
     // This is just to have *some* mDNS service so that .local resolution works


### PR DESCRIPTION
# What does this implement/fix?

Lists the (port 80) webservice if enabled as and MDNS service for the sake of correctness.
Fixes some query patterns where a webpage is not opened as there is no service exposed on port 80 according to the query results.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
