### PR TITLE
Update inkbird_ibsth1_mini.cpp

### DIFF
--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -55,7 +55,7 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
     ESP_LOGVV(TAG, "parse_device(): manufacturer data element length is expected to be of length 7");
     return false;
   }
-  if (mnf_data.data[6] != 8) {
+  if ((mnf_data.data[6] != 8) && (mnf_data.data[6] != 6)) {
     ESP_LOGVV(TAG, "parse_device(): unexpected data");
     return false;
   }


### PR DESCRIPTION
Fix handling of newer devices.

# What does this implement/fix?

One byte appears to have changed in the data for the TH1 plus and TH2.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
fixes https://github.com/esphome/feature-requests/issues/1586
fixes https://github.com/esphome/feature-requests/issues/1808

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
