### PR TITLE
Fixed ESP32-S3 adc initialization.

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -62,8 +62,8 @@ void ADCSensor::setup() {
     }
   }
 
-  // adc_gpio_init doesn't exist on ESP32-S2, ESP32-C3 or ESP32-H2
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2) && !defined(USE_ESP32_VARIANT_ESP32S2)
+  // adc_gpio_init doesn't exist on ESP32-S2, ESP32-S3, ESP32-C3 or ESP32-H2
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2) && !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32S3)
   adc_gpio_init(ADC_UNIT_1, (adc_channel_t) channel_);
 #endif
 #endif  // USE_ESP32

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -63,7 +63,8 @@ void ADCSensor::setup() {
   }
 
   // adc_gpio_init doesn't exist on ESP32-S2, ESP32-S3, ESP32-C3 or ESP32-H2
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2) && !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32S3)
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32H2) && \
+    !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32S3)
   adc_gpio_init(ADC_UNIT_1, (adc_channel_t) channel_);
 #endif
 #endif  // USE_ESP32


### PR DESCRIPTION
The ESP32-S3 also does not have the `adc_gpio_init` function. Tested on a custom ESP32-S3 development board and not having the check given in this PR prevents any project using ADC from compiling.

# What does this implement/fix?

ADC initialization on ESP32-S3 platforms.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (using a custom board based on ESP32S3-Wroom-1-N4
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: foobar
  platformio_options:
    board_build.flash_mode: dio
    board_build.f_flash: 80000000L
    board_build.flash_size: 4MB

esp32:
  board: esp32dev
  variant: esp32s3
  framework:
    type: esp-idf
    platform_version: 4.3.0
    version: latest

sensor:
  - platform: adc
    pin: GPIO8
    name: "Battery Level"
    attenuation: 11db # 0 mV ~ 3100 mV on ADC pin
    update_interval: 60s
    filters:
      - multiply: 2.0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
