### PR TITLE
Don't publish values if no data collected.

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -149,9 +149,31 @@ void CSE7766Component::parse_data_() {
   }
 }
 void CSE7766Component::update() {
-  float voltage = this->voltage_counts_ > 0 ? this->voltage_acc_ / this->voltage_counts_ : 0.0f;
-  float current = this->current_counts_ > 0 ? this->current_acc_ / this->current_counts_ : 0.0f;
-  float power = this->power_counts_ > 0 ? this->power_acc_ / this->power_counts_ : 0.0f;
+  float voltage = 0.0f, current = 0.0f, power = 0.0f;
+
+  if (this->voltage_counts_ > 0) {
+    voltage = this->voltage_acc_ / this->voltage_counts_;
+    if (this->voltage_sensor_ != nullptr)
+      this->voltage_sensor_->publish_state(voltage);
+  } else {
+    ESP_LOGV(TAG, "No voltage data");
+  }
+
+  if (this->current_counts_ > 0) {
+    current = this->current_acc_ / this->current_counts_;
+    if (this->current_sensor_ != nullptr)
+      this->current_sensor_->publish_state(current);
+  } else {
+    ESP_LOGV(TAG, "No current data");
+  }
+
+  if (this->current_counts_ > 0) {
+    power = this->power_acc_ / this->power_counts_;
+    if (this->power_sensor_ != nullptr)
+      this->power_sensor_->publish_state(power);
+  } else {
+    ESP_LOGV(TAG, "No power data");
+  }
 
   ESP_LOGV(TAG, "Got voltage_acc=%.2f current_acc=%.2f power_acc=%.2f", this->voltage_acc_, this->current_acc_,
            this->power_acc_);
@@ -159,12 +181,6 @@ void CSE7766Component::update() {
            this->power_counts_);
   ESP_LOGD(TAG, "Got voltage=%.1fV current=%.1fA power=%.1fW", voltage, current, power);
 
-  if (this->voltage_sensor_ != nullptr)
-    this->voltage_sensor_->publish_state(voltage);
-  if (this->current_sensor_ != nullptr)
-    this->current_sensor_->publish_state(current);
-  if (this->power_sensor_ != nullptr)
-    this->power_sensor_->publish_state(power);
   if (this->energy_sensor_ != nullptr)
     this->energy_sensor_->publish_state(this->energy_total_);
 


### PR DESCRIPTION
# What does this implement/fix?

The component publishes values even if there was no data collected during the interval.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3468

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
