### PR TITLE
add preset option to restore user set temperatures

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -71,6 +71,7 @@ from esphome.const import (
 CONF_PRESET_CHANGE = "preset_change"
 CONF_DEFAULT_PRESET = "default_preset"
 CONF_ON_BOOT_RESTORE_FROM = "on_boot_restore_from"
+CONF_PRESET_TEMP_RESTORE = "preset_temp_restore"
 
 CODEOWNERS = ["@kbx81"]
 
@@ -114,6 +115,7 @@ PRESET_CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_SWING_MODE): cv.templatable(
             climate.validate_climate_swing_mode
         ),
+        cv.Optional(CONF_PRESET_TEMP_RESTORE, default=False): cv.boolean,
     }
 )
 
@@ -904,6 +906,13 @@ async def to_code(config):
                 cg.add(
                     preset_target_variable.set_swing_mode(
                         preset_config[CONF_SWING_MODE]
+                    )
+                )
+
+            if CONF_PRESET_TEMP_RESTORE in preset_config:
+                cg.add(
+                    preset_target_variable.set_preset_temp_restore(
+                        preset_config[CONF_PRESET_TEMP_RESTORE]
                     )
                 )
 

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1020,18 +1020,48 @@ void ThermostatClimate::change_custom_preset_(const std::string &custom_preset) 
 
 bool ThermostatClimate::change_preset_internal_(const ThermostatClimateTargetTempConfig &config) {
   bool something_changed = false;
+  ThermostatClimateTargetTempConfig *current_config = nullptr;
 
-  if (this->supports_two_points_) {
-    if (this->target_temperature_low != config.default_temperature_low) {
-      this->target_temperature_low = config.default_temperature_low;
-      something_changed = true;
+  if (this->preset.has_value()) {
+    climate::ClimatePreset preset = this->preset.value();
+    ThermostatClimateTargetTempConfig &current_preset_config = this->preset_config_.find(preset)->second;
+    current_config = &current_preset_config;
+  }
+
+  if (this->custom_preset.has_value()) {
+    const std::string &custom_preset = this->custom_preset.value();
+    ThermostatClimateTargetTempConfig &current_custom_preset_config =
+        this->custom_preset_config_.find(custom_preset)->second;
+    current_config = &current_custom_preset_config;
+  }
+
+  if (current_config != nullptr && current_config->preset_temp_restore_) {
+    if (supports_two_points_) {
+      current_config->stored_temperature_low = this->target_temperature_low;
+      current_config->stored_temperature_high = this->target_temperature_high;
+    } else {
+      current_config->stored_temperature = this->target_temperature;
     }
-    if (this->target_temperature_high != config.default_temperature_high) {
-      this->target_temperature_high = config.default_temperature_high;
+  }
+
+  if (config.preset_temp_restore_) {
+    if (this->supports_two_points_) {
+      this->target_temperature_low =
+          std::isnan(config.stored_temperature_low) ? config.default_temperature_low : config.stored_temperature_low;
+      this->target_temperature_high =
+          std::isnan(config.stored_temperature_high) ? config.default_temperature_high : config.stored_temperature_high;
+      something_changed = true;
+    } else {
+      this->target_temperature =
+          std::isnan(config.stored_temperature) ? config.default_temperature : config.stored_temperature;
       something_changed = true;
     }
   } else {
-    if (this->target_temperature != config.default_temperature) {
+    if (this->supports_two_points_) {
+      this->target_temperature_low = config.default_temperature_low;
+      this->target_temperature_high = config.default_temperature_high;
+      something_changed = true;
+    } else {
       this->target_temperature = config.default_temperature;
       something_changed = true;
     }

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -39,10 +39,14 @@ struct ThermostatClimateTargetTempConfig {
   void set_fan_mode(climate::ClimateFanMode fan_mode) { this->fan_mode_ = fan_mode; }
   void set_swing_mode(climate::ClimateSwingMode swing_mode) { this->swing_mode_ = swing_mode; }
   void set_mode(climate::ClimateMode mode) { this->mode_ = mode; }
+  void set_preset_temp_restore(bool preset_temp_restore) { this->preset_temp_restore_ = preset_temp_restore; }
 
   float default_temperature{NAN};
   float default_temperature_low{NAN};
   float default_temperature_high{NAN};
+  float stored_temperature{NAN};
+  float stored_temperature_low{NAN};
+  float stored_temperature_high{NAN};
   float cool_deadband_{NAN};
   float cool_overrun_{NAN};
   float heat_deadband_{NAN};
@@ -50,6 +54,7 @@ struct ThermostatClimateTargetTempConfig {
   optional<climate::ClimateFanMode> fan_mode_{};
   optional<climate::ClimateSwingMode> swing_mode_{};
   optional<climate::ClimateMode> mode_{};
+  bool preset_temp_restore_;
 };
 
 class ThermostatClimate : public climate::Climate, public Component {


### PR DESCRIPTION
# What does this implement/fix?

This adds an option to presets to store the user set temperature and restore them when re-activating the preset. Default is false, so this breaks nothing.
This is just a draft! No idea if naming is ok, no idea if the spot where I do that is ok, this should just be a start for a discussion for the related feature request.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1787

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
- platform: thermostat
    [...]
    preset:
      - name: home
        default_target_temperature_low: 19 °C
        preset_temp_restore: true
      - name: away
        default_target_temperature_low: 17 °C
        preset_temp_restore: true
    [...]
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
