### PR TITLE
Allow GPIO20 for ESP32

### DIFF
--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -42,7 +42,7 @@ def esp32_validate_gpio_pin(value):
             "See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins",
             value,
         )
-    if value in (20, 24, 28, 29, 30, 31):
+    if value in (24, 28, 29, 30, 31):
         # These pins are not exposed in GPIO mux (reason unknown)
         # but they're missing from IO_MUX list in datasheet
         raise cv.Invalid(f"The pin GPIO{value} is not usable on ESP32s.")


### PR DESCRIPTION
As they are now used in some boards like adafruit_feather_esp32_v2

# What does this implement/fix?

Relax ESP32 validation rules to allow GPIO20.
Fixes https://github.com/esphome/issues/issues/3417

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
i2c:
  - id: stemma
    sda: 22
    scl: 20
    scan: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
