### PR TITLE
Added support for setting the current animation frame

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -591,6 +591,12 @@ void Animation::prev_frame() {
   }
 }
 
+void Animation::set_frame(int frame) {
+  if (frame < this->current_frame_) {
+    this->current_frame_ = frame;
+  }
+}
+
 DisplayPage::DisplayPage(display_writer_t writer) : writer_(std::move(writer)) {}
 void DisplayPage::show() { this->parent_->show_page(this); }
 void DisplayPage::show_next() { this->next_->show(); }

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -595,7 +595,7 @@ void Animation::set_frame(int frame) {
   unsigned abs_frame = abs(frame);
 
   if (abs_frame < this->animation_frame_count_) {
-    if (frame > 0) {
+    if (frame >= 0) {
       this->current_frame_ = frame;
     } else {
       this->current_frame_ = this->animation_frame_count_ - abs_frame;

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -595,7 +595,7 @@ void Animation::set_frame(int frame) {
   unsigned abs_frame = abs(frame);
 
   if (abs_frame < this->animation_frame_count_) {
-    if (frame) {
+    if (frame > 0) {
       this->current_frame_ = frame;
     } else {
       this->current_frame_ = this->animation_frame_count_ - abs_frame;

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -592,11 +592,13 @@ void Animation::prev_frame() {
 }
 
 void Animation::set_frame(int frame) {
-  if (abs(frame) < this->animation_frame_count_) {
+  unsigned abs_frame = abs(frame);
+
+  if (abs_frame < this->animation_frame_count_) {
     if (frame) {
       this->current_frame_ = frame;
     } else {
-      this->current_frame_ = this->animation_frame_count_ - frame;
+      this->current_frame_ = this->animation_frame_count_ - abs_frame;
     }
   }
 }

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -592,8 +592,12 @@ void Animation::prev_frame() {
 }
 
 void Animation::set_frame(int frame) {
-  if (frame < this->animation_frame_count_) {
-    this->current_frame_ = frame;
+  if (abs(frame) < this->animation_frame_count_) {
+    if (frame) {
+      this->current_frame_ = frame;
+    } else {
+      this->current_frame_ = this->animation_frame_count_ - frame;
+    }
   }
 }
 

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -592,7 +592,7 @@ void Animation::prev_frame() {
 }
 
 void Animation::set_frame(int frame) {
-  if (frame < this->current_frame_) {
+  if (frame < this->animation_frame_count_) {
     this->current_frame_ = frame;
   }
 }

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -490,6 +490,7 @@ class Animation : public Image {
   int get_current_frame() const;
   void next_frame();
   void prev_frame();
+  void set_frame(int frame);
 
  protected:
   int current_frame_;

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -490,6 +490,11 @@ class Animation : public Image {
   int get_current_frame() const;
   void next_frame();
   void prev_frame();
+
+  /** Selects a specific frame within the animation.
+   *
+   * @param frame If possitive, advance to the frame. If negative, recede to that frame from the end frame.
+   */
   void set_frame(int frame);
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

This allows users of the `Display` component to select an explicit animation frame, in addition to the existing `next_frame` and `prev_frame`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2214

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
lambda: |-
  id(animated_git).set_frame(5);
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
