### PR TITLE
add simple function to gradient the color

### DIFF
--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -141,6 +141,10 @@ struct Color {
   }
   Color fade_to_white(uint8_t amnt) { return Color(255, 255, 255, 255) - (*this * amnt); }
   Color fade_to_black(uint8_t amnt) { return *this * amnt; }
+  
+  Color gradient(const Color &to_color, uint8_t amnt) {
+    return (*this * amnt) + (to_color * (255 - amnt));
+  }
   Color lighten(uint8_t delta) { return *this + delta; }
   Color darken(uint8_t delta) { return *this - delta; }
 

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -141,10 +141,7 @@ struct Color {
   }
   Color fade_to_white(uint8_t amnt) { return Color(255, 255, 255, 255) - (*this * amnt); }
   Color fade_to_black(uint8_t amnt) { return *this * amnt; }
-  
-  Color gradient(const Color &to_color, uint8_t amnt) {
-    return (*this * amnt) + (to_color * (255 - amnt));
-  }
+  Color gradient(const Color &to_color, uint8_t amnt) { return (*this * amnt) + (to_color * (255 - amnt)); }
   Color lighten(uint8_t delta) { return *this + delta; }
   Color darken(uint8_t delta) { return *this - delta; }
 


### PR DESCRIPTION
# What does this implement/fix?

Allow a color to blend into an other color

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
 

```yaml
display:
  - id: my_display
    platform: ili9341
    model: TFT 2.4
    cs_pin: 5
    dc_pin: 16
    rotation: 90

    lambda: |-
      Color xyz = id(my_blue).grandient(id(my_red),200);
      it.filled_rectangle(110, 28, 99, 99, xyz);


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
