### PR TITLE
add a fallback for missing VSPI on ESP32-C3 etc.

### DIFF
--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -15,6 +15,18 @@
 namespace esphome {
 namespace spi {
 
+#ifdef USE_ESP32
+#if !defined(VSPI)
+#ifdef VSPI_HOST
+#define VSPI VSPI_HOST
+#elif defined(SPI2_HOST)
+#define VSPI SPI2_HOST
+#else
+#define VSPI 2
+#endif
+#endif
+#endif
+
 /// The bit-order for SPI devices. This defines how the data read from and written to the device is interpreted.
 enum SPIBitOrder {
   /// The least significant bit is transmitted/received first.

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -16,15 +16,15 @@ namespace esphome {
 namespace spi {
 
 #ifdef USE_ESP32
-//#if !defined(VSPI)
-//#ifdef VSPI_HOST
-//#define VSPI VSPI_HOST
-//#elif defined(SPI2_HOST)
-//#define VSPI SPI2_HOST
-//#else
+#if !defined(VSPI)
+#ifdef VSPI_HOST
+#define VSPI VSPI_HOST
+#elif defined(SPI3_HOST)
+#define VSPI SPI3_HOST
+#else
 #define VSPI 3
-//#endif
-//#endif
+#endif
+#endif
 #endif
 
 /// The bit-order for SPI devices. This defines how the data read from and written to the device is interpreted.

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -16,15 +16,15 @@ namespace esphome {
 namespace spi {
 
 #ifdef USE_ESP32
-#if !defined(VSPI)
-#ifdef VSPI_HOST
-#define VSPI VSPI_HOST
-#elif defined(SPI2_HOST)
-#define VSPI SPI2_HOST
-#else
-#define VSPI 2
-#endif
-#endif
+//#if !defined(VSPI)
+//#ifdef VSPI_HOST
+//#define VSPI VSPI_HOST
+//#elif defined(SPI2_HOST)
+//#define VSPI SPI2_HOST
+//#else
+#define VSPI 3
+//#endif
+//#endif
 #endif
 
 /// The bit-order for SPI devices. This defines how the data read from and written to the device is interpreted.


### PR DESCRIPTION
# What does this implement/fix?

On the ESP32-C3 etc. the define VSPI is missing, this PR adds a fallback by setting VSPI when it is missing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
