### PR TITLE
Adding option to report signal strength on pvvx_mithermometer

### DIFF
--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
@@ -43,6 +43,8 @@ bool PVVXMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
       this->battery_level_->publish_state(*res->battery_level);
     if (res->battery_voltage.has_value() && this->battery_voltage_ != nullptr)
       this->battery_voltage_->publish_state(*res->battery_voltage);
+    if (this->signal_strength_ != nullptr)
+      this->signal_strength_->publish_state(device.get_rssi());
     success = true;
   }
 

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -28,6 +28,7 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
   void set_battery_voltage(sensor::Sensor *battery_voltage) { battery_voltage_ = battery_voltage; }
+  void set_signal_strength(sensor::Sensor *signal_strength) { signal_strength_ = signal_strength; }
 
  protected:
   uint64_t address_;
@@ -35,6 +36,7 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
   sensor::Sensor *humidity_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
   sensor::Sensor *battery_voltage_{nullptr};
+  sensor::Sensor *signal_strength_{nullptr};
 
   optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);

--- a/esphome/components/pvvx_mithermometer/sensor.py
+++ b/esphome/components/pvvx_mithermometer/sensor.py
@@ -6,15 +6,18 @@ from esphome.const import (
     CONF_BATTERY_VOLTAGE,
     CONF_MAC_ADDRESS,
     CONF_HUMIDITY,
+    CONF_SIGNAL_STRENGTH,
     CONF_TEMPERATURE,
     CONF_ID,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLTAGE,
     ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
+    UNIT_DECIBEL_MILLIWATT,
     UNIT_PERCENT,
     UNIT_VOLT,
 )
@@ -59,6 +62,13 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
+            cv.Optional(CONF_SIGNAL_STRENGTH): sensor.sensor_schema(
+                unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
         }
     )
     .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
@@ -85,3 +95,6 @@ async def to_code(config):
     if CONF_BATTERY_VOLTAGE in config:
         sens = await sensor.new_sensor(config[CONF_BATTERY_VOLTAGE])
         cg.add(var.set_battery_voltage(sens))
+    if CONF_SIGNAL_STRENGTH in config:
+        sens = await sensor.new_sensor(config[CONF_SIGNAL_STRENGTH])
+        cg.add(var.set_signal_strength(sens))


### PR DESCRIPTION
# What does this implement/fix?

The code adds a signal strength sensor for the pvvx_mithermometer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Same type of change as #3000 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2211

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
    sensor:
      - platform: pvvx_mithermometer
        mac_address: "A4:C1:38:B1:CD:7F"
        signal_strength:
          name: "PVVX Signal"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
