### PR TITLE
fix sx1509 use of pullup and pulldown

### DIFF
--- a/esphome/components/sx1509/__init__.py
+++ b/esphome/components/sx1509/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_MODE,
     CONF_INVERTED,
     CONF_OUTPUT,
+    CONF_PULLDOWN,
     CONF_PULLUP,
 )
 
@@ -74,6 +75,10 @@ def validate_mode(value):
         raise cv.Invalid("Mode must be either input or output")
     if value[CONF_PULLUP] and not value[CONF_INPUT]:
         raise cv.Invalid("Pullup only available with input")
+    if value[CONF_PULLDOWN] and not value[CONF_INPUT]:
+        raise cv.Invalid("Pulldown only available with input")
+    if value[CONF_PULLUP] and value[CONF_PULLDOWN]:
+        raise cv.Invalid("Can only have one of pullup or pulldown")
     return value
 
 
@@ -87,6 +92,7 @@ SX1509_PIN_SCHEMA = cv.All(
             {
                 cv.Optional(CONF_INPUT, default=False): cv.boolean,
                 cv.Optional(CONF_PULLUP, default=False): cv.boolean,
+                cv.Optional(CONF_PULLDOWN, default=False): cv.boolean,
                 cv.Optional(CONF_OUTPUT, default=False): cv.boolean,
             },
             validate_mode,

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -70,26 +70,6 @@ void SX1509Component::digital_write(uint8_t pin, bool bit_value) {
       temp_reg_data &= ~(1 << pin);
     }
     this->write_byte_16(REG_DATA_B, temp_reg_data);
-  } else {
-    // Otherwise the pin is an input, pull-up/down
-    uint16_t temp_pullup = 0;
-    this->read_byte_16(REG_PULL_UP_B, &temp_pullup);
-    uint16_t temp_pull_down = 0;
-    this->read_byte_16(REG_PULL_DOWN_B, &temp_pull_down);
-
-    if (bit_value) {
-      // if HIGH, do pull-up, disable pull-down
-      temp_pullup |= (1 << pin);
-      temp_pull_down &= ~(1 << pin);
-      this->write_byte_16(REG_PULL_UP_B, temp_pullup);
-      this->write_byte_16(REG_PULL_DOWN_B, temp_pull_down);
-    } else {
-      // If LOW do pull-down, disable pull-up
-      temp_pull_down |= (1 << pin);
-      temp_pullup &= ~(1 << pin);
-      this->write_byte_16(REG_PULL_UP_B, temp_pullup);
-      this->write_byte_16(REG_PULL_DOWN_B, temp_pull_down);
-    }
   }
 }
 
@@ -99,11 +79,28 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->ddr_mask_ &= ~(1 << pin);
   } else {
     this->ddr_mask_ |= (1 << pin);
+
+    uint16_t temp_pullup;
+    this->read_byte_16(REG_PULL_UP_B, &temp_pullup);
+    uint16_t temp_pulldown;
+    this->read_byte_16(REG_PULL_DOWN_B, &temp_pulldown);
+
+    if (flags & gpio::FLAG_PULLUP) {
+      temp_pullup |= (1 << pin);
+    } else {
+      temp_pullup &= ~(1 << pin);
+    }
+
+    if (flags & gpio::FLAG_PULLDOWN) {
+      temp_pulldown |= (1 << pin);
+    } else {
+      temp_pulldown &= ~(1 << pin);
+    }
+
+    this->write_byte_16(REG_PULL_UP_B, temp_pullup);
+    this->write_byte_16(REG_PULL_DOWN_B, temp_pulldown);
   }
   this->write_byte_16(REG_DIR_B, this->ddr_mask_);
-
-  if (flags & gpio::FLAG_PULLUP)
-    digital_write(pin, true);
 }
 
 void SX1509Component::setup_led_driver(uint8_t pin) {
@@ -113,10 +110,6 @@ void SX1509Component::setup_led_driver(uint8_t pin) {
   this->read_byte_16(REG_INPUT_DISABLE_B, &temp_word);
   temp_word |= (1 << pin);
   this->write_byte_16(REG_INPUT_DISABLE_B, temp_word);
-
-  this->read_byte_16(REG_PULL_UP_B, &temp_word);
-  temp_word &= ~(1 << pin);
-  this->write_byte_16(REG_PULL_UP_B, temp_word);
 
   this->ddr_mask_ &= ~(1 << pin);  // 0=output
   this->write_byte_16(REG_DIR_B, this->ddr_mask_);


### PR DESCRIPTION
# What does this implement/fix?

The original code forced the use of either pullup or pulldown.  This makes it work properly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3365

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
