### PR TITLE
Pass optional args to 'new_Pvariable' when creating new entities

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -483,8 +483,8 @@ async def register_binary_sensor(var, config):
     await setup_binary_sensor_core_(var, config)
 
 
-async def new_binary_sensor(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+async def new_binary_sensor(config, *args):
+    var = cg.new_Pvariable(config[CONF_ID], *args)
     await register_binary_sensor(var, config)
     return var
 

--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -102,8 +102,8 @@ async def register_button(var, config):
     await setup_button_core_(var, config)
 
 
-async def new_button(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+async def new_button(config, *args):
+    var = cg.new_Pvariable(config[CONF_ID], *args)
     await register_button(var, config)
     return var
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -614,8 +614,8 @@ async def register_sensor(var, config):
     await setup_sensor_core_(var, config)
 
 
-async def new_sensor(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+async def new_sensor(config, *args):
+    var = cg.new_Pvariable(config[CONF_ID], *args)
     await register_sensor(var, config)
     return var
 

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -189,8 +189,8 @@ async def register_text_sensor(var, config):
     await setup_text_sensor_core_(var, config)
 
 
-async def new_text_sensor(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+async def new_text_sensor(config, *args):
+    var = cg.new_Pvariable(config[CONF_ID], *args)
     await register_text_sensor(var, config)
     return var
 


### PR DESCRIPTION

To enable passing arguments to entity constructors when calling e.g. `sensor.new_sensor`, `button.new_button` etc. pass optional `*args` to `cg.new_Pvariable`.

# What does this implement/fix?
Make it easier for components to pass arguments to constructors of new sensors.

No impact on end users.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
