### PR TITLE
Esp32 pulsecounter optional pcnt

### DIFF
--- a/esphome/components/hlw8012/hlw8012.h
+++ b/esphome/components/hlw8012/hlw8012.h
@@ -16,8 +16,17 @@ enum HLW8012SensorModels {
   HLW8012_SENSOR_MODEL_BL0937
 };
 
+#ifdef HAS_PCNT
+#define USE_PCNT true
+#else
+#define USE_PCNT false
+#endif
+
 class HLW8012Component : public PollingComponent {
  public:
+  HLW8012Component()
+      : cf_store_(*pulse_counter::get_storage(USE_PCNT)), cf1_store_(*pulse_counter::get_storage(USE_PCNT)) {}
+
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
@@ -49,9 +58,9 @@ class HLW8012Component : public PollingComponent {
   uint64_t cf_total_pulses_{0};
   GPIOPin *sel_pin_;
   InternalGPIOPin *cf_pin_;
-  pulse_counter::PulseCounterStorage cf_store_;
+  pulse_counter::PulseCounterStorageBase &cf_store_;
   InternalGPIOPin *cf1_pin_;
-  pulse_counter::PulseCounterStorage cf1_store_;
+  pulse_counter::PulseCounterStorageBase &cf1_store_;
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -9,12 +9,12 @@ static const char *const TAG = "pulse_counter";
 const char *const EDGE_MODE_TO_STRING[] = {"DISABLE", "INCREMENT", "DECREMENT"};
 
 #ifdef HAS_PCNT
-PulseCounterStorage_Base *getStorage(bool hw_pcnt) {
-  return (hw_pcnt ? (PulseCounterStorage_Base *) (new HwPulseCounterStorage)
-                  : (PulseCounterStorage_Base *) (new BasicPulseCounterStorage));
+PulseCounterStorageBase *get_storage(bool hw_pcnt) {
+  return (hw_pcnt ? (PulseCounterStorageBase *) (new HwPulseCounterStorage)
+                  : (PulseCounterStorageBase *) (new BasicPulseCounterStorage));
 }
 #else
-PulseCounterStorage_Base *getStorage(bool) { return new BasicPulseCounterStorage; }
+PulseCounterStorageBase *get_storage(bool) { return new BasicPulseCounterStorage; }
 #endif
 
 void IRAM_ATTR BasicPulseCounterStorage::gpio_intr(BasicPulseCounterStorage *arg) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -8,6 +8,15 @@ static const char *const TAG = "pulse_counter";
 
 const char *const EDGE_MODE_TO_STRING[] = {"DISABLE", "INCREMENT", "DECREMENT"};
 
+#ifdef HAS_PCNT
+PulseCounterStorage_Base *getStorage(bool hw_pcnt) {
+  return (hw_pcnt ? (PulseCounterStorage_Base *) (new HwPulseCounterStorage)
+                  : (PulseCounterStorage_Base *) (new BasicPulseCounterStorage));
+}
+#else
+PulseCounterStorage_Base *getStorage(bool) { return new BasicPulseCounterStorage; }
+#endif
+
 void IRAM_ATTR BasicPulseCounterStorage::gpio_intr(BasicPulseCounterStorage *arg) {
   const uint32_t now = micros();
   const bool discard = now - arg->last_pulse < arg->filter_us;

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -8,8 +8,7 @@ static const char *const TAG = "pulse_counter";
 
 const char *const EDGE_MODE_TO_STRING[] = {"DISABLE", "INCREMENT", "DECREMENT"};
 
-#ifndef HAS_PCNT
-void IRAM_ATTR PulseCounterStorage::gpio_intr(PulseCounterStorage *arg) {
+void IRAM_ATTR BasicPulseCounterStorage::gpio_intr(BasicPulseCounterStorage *arg) {
   const uint32_t now = micros();
   const bool discard = now - arg->last_pulse < arg->filter_us;
   arg->last_pulse = now;
@@ -28,23 +27,22 @@ void IRAM_ATTR PulseCounterStorage::gpio_intr(PulseCounterStorage *arg) {
       break;
   }
 }
-bool PulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
+bool BasicPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   this->pin = pin;
   this->pin->setup();
   this->isr_pin = this->pin->to_isr();
-  this->pin->attach_interrupt(PulseCounterStorage::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
+  this->pin->attach_interrupt(BasicPulseCounterStorage::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
   return true;
 }
-pulse_counter_t PulseCounterStorage::read_raw_value() {
+pulse_counter_t BasicPulseCounterStorage::read_raw_value() {
   pulse_counter_t counter = this->counter;
   pulse_counter_t ret = counter - this->last_value;
   this->last_value = counter;
   return ret;
 }
-#endif
 
 #ifdef HAS_PCNT
-bool PulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
+bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   static pcnt_unit_t next_pcnt_unit = PCNT_UNIT_0;
   this->pin = pin;
   this->pin->setup();
@@ -127,7 +125,7 @@ bool PulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
   return true;
 }
-pulse_counter_t PulseCounterStorage::read_raw_value() {
+pulse_counter_t HwPulseCounterStorage::read_raw_value() {
   pulse_counter_t counter;
   pcnt_get_counter_value(this->pcnt_unit, &counter);
   pulse_counter_t ret = counter - this->last_value;

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -56,11 +56,11 @@ struct HwPulseCounterStorage : public PulseCounterStorage_Base {
 };
 #endif
 
+PulseCounterStorage_Base *getStorage(bool hw_pcnt);
+
 class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
  public:
-  explicit PulseCounterSensor(bool hw_pcnt = false)
-      : storage_(*(hw_pcnt ? (PulseCounterStorage_Base *) (new HwPulseCounterStorage)
-                           : (PulseCounterStorage_Base *) (new BasicPulseCounterStorage))) {}
+  explicit PulseCounterSensor(bool hw_pcnt = false) : storage_(*getStorage(hw_pcnt)) {}
 
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void set_rising_edge_mode(PulseCounterCountMode mode) { storage_.rising_edge_mode = mode; }

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -24,7 +24,7 @@ using pulse_counter_t = int16_t;
 using pulse_counter_t = int32_t;
 #endif
 
-struct PulseCounterStorage_Base {
+struct PulseCounterStorageBase {
   virtual bool pulse_counter_setup(InternalGPIOPin *pin) = 0;
   virtual pulse_counter_t read_raw_value() = 0;
 
@@ -35,7 +35,7 @@ struct PulseCounterStorage_Base {
   pulse_counter_t last_value{0};
 };
 
-struct BasicPulseCounterStorage : public PulseCounterStorage_Base {
+struct BasicPulseCounterStorage : public PulseCounterStorageBase {
   static void gpio_intr(BasicPulseCounterStorage *arg);
 
   bool pulse_counter_setup(InternalGPIOPin *pin) override;
@@ -48,7 +48,7 @@ struct BasicPulseCounterStorage : public PulseCounterStorage_Base {
 };
 
 #ifdef HAS_PCNT
-struct HwPulseCounterStorage : public PulseCounterStorage_Base {
+struct HwPulseCounterStorage : public PulseCounterStorageBase {
   bool pulse_counter_setup(InternalGPIOPin *pin) override;
   pulse_counter_t read_raw_value() override;
 
@@ -56,11 +56,11 @@ struct HwPulseCounterStorage : public PulseCounterStorage_Base {
 };
 #endif
 
-PulseCounterStorage_Base *getStorage(bool hw_pcnt);
+PulseCounterStorageBase *get_storage(bool hw_pcnt = false);
 
 class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
  public:
-  explicit PulseCounterSensor(bool hw_pcnt = false) : storage_(*getStorage(hw_pcnt)) {}
+  explicit PulseCounterSensor(bool hw_pcnt = false) : storage_(*get_storage(hw_pcnt)) {}
 
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void set_rising_edge_mode(PulseCounterCountMode mode) { storage_.rising_edge_mode = mode; }
@@ -78,7 +78,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
 
  protected:
   InternalGPIOPin *pin_;
-  PulseCounterStorage_Base &storage_;
+  PulseCounterStorageBase &storage_;
   uint32_t last_time_{0};
   uint32_t current_total_{0};
   sensor::Sensor *total_sensor_;

--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -106,7 +106,7 @@ CONFIG_SCHEMA = cv.All(
                 ),
                 validate_count_mode,
             ),
-            cv.Optional(CONF_USE_PCNT, default=CORE.is_esp32): cv.boolean,
+            cv.SplitDefault(CONF_USE_PCNT, esp32=True, esp8266=False): cv.boolean,
             cv.Optional(
                 CONF_INTERNAL_FILTER, default="13us"
             ): cv.positive_time_period_microseconds,


### PR DESCRIPTION
# What does this implement/fix?

Make use of hardware `pcnt` optional for pulsecounter sensors on ESP32.

Requires PR #3690, to pass selection argument to the sensor constructor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2212

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

esp32:
  board: wemos_d1_mini32
  framework:
    type: arduino
    version: latest

sensor:
  - platform: pulse_counter
    pin:
      number: D3
    name: "Pulse Counter"
    update_interval: 5min
    accuracy_decimals: 3
    use_pcnt: false
    internal_filter: 500ms

  - platform: pulse_counter
    pin:
      number: D6
    name: "PCNT Pulse Counter"
    update_interval: 5min
    accuracy_decimals: 3
    use_pcnt: true
    internal_filter: 13us
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
