### PR TITLE
Fixes BLE remote address type when connecting

### DIFF
--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -54,6 +54,7 @@ bool BLEClient::parse_device(const espbt::ESPBTDevice &device) {
   this->remote_bda[3] = (addr >> 16) & 0xFF;
   this->remote_bda[4] = (addr >> 8) & 0xFF;
   this->remote_bda[5] = (addr >> 0) & 0xFF;
+  this->remote_addr_type = device.get_address_type();
   return true;
 }
 
@@ -83,7 +84,7 @@ void BLEClient::set_enabled(bool enabled) {
 
 void BLEClient::connect() {
   ESP_LOGI(TAG, "Attempting BLE connection to %s", this->address_str().c_str());
-  auto ret = esp_ble_gattc_open(this->gattc_if, this->remote_bda, BLE_ADDR_TYPE_PUBLIC, true);
+  auto ret = esp_ble_gattc_open(this->gattc_if, this->remote_bda, this->remote_addr_type, true);
   if (ret) {
     ESP_LOGW(TAG, "esp_ble_gattc_open error, address=%s status=%d", this->address_str().c_str(), ret);
     this->set_states_(espbt::ClientState::IDLE);

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -115,6 +115,7 @@ class BLEClient : public espbt::ESPBTClient, public Component {
 
   int gattc_if;
   esp_bd_addr_t remote_bda;
+  esp_ble_addr_type_t remote_addr_type;
   uint16_t conn_id;
   uint64_t address;
   bool enabled;


### PR DESCRIPTION
# What does this implement/fix?

ESPHome running on esp32-c3 fails to connect to some BLE devices. A simple example is the [nrf_blinky](https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/master/libraries/Bluefruit52Lib/examples/Peripheral/nrf_blinky/nrf_blinky.ino) running on an nRF52840. While the `dev` branch running on the usual `esp32` connects without issues, the same code running on the `esp32-c3` fails with the following error:
```
[20:53:30][I][ble_client:085]: Attempting BLE connection to f5:30:30:a4:51:fc
...
[20:54:00][D][esp-idf:000]: W (31108) BT_APPL: gattc_conn_cb: if=3 st=0 id=3 rsn=0x100
[20:54:00][W][ble_client:118]: connect to f5:30:30:a4:51:fc failed, status=133
```
After comparing the ESPHome BLE connection procedure with the [BLE_Client.cpp](https://github.com/espressif/arduino-esp32/blob/7856de7a57420e494176c16c5138174fe2c1dad0/libraries/BLE/src/BLEClient.cpp#L130) from [arduino-esp32](https://github.com/espressif/arduino-esp32) (which does work and connect while running on the `esp32-c3`), one of the differences is that we always use `BLE_ADDR_TYPE_PUBLIC` as the address type in the `esp_ble_gattc_open` call.

Updating it to use the actual scanned address type fixed the issue on the `esp32-c3`, while the `esp32` kept working as before. My guess is that the BLE stack in the `esp32-c3` is more strict about this argument.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [X] ESP32-C3 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
For ESP32-C3:
```yaml
esphome:
  name: ble-client-test
  platformio_options:
    board_build.flash_mode: dio

esp32:
   board: esp32-c3-devkitm-1
  framework:
    type: esp-idf
    sdkconfig_options:
      CONFIG_BT_BLE_42_FEATURES_SUPPORTED: y
      CONFIG_BT_BLE_50_FEATURES_SUPPORTED: y

esp32_ble_tracker:

ble_client:
  - id: test_ble_client
    mac_address: F5:30:30:A4:51:FC
```
For ESP32:
```yaml
esphome:
  name: ble-client-test

esp32:
  board: esp32dev
  framework:
    type: esp-idf

esp32_ble_tracker:

ble_client:
  - id: test_ble_client
    mac_address: F5:30:30:A4:51:FC
```
## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
