### PR TITLE
Add dps310 sensor support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,6 +59,7 @@ esphome/components/debug/* @OttoWinter
 esphome/components/delonghi/* @grob6000
 esphome/components/dfplayer/* @glmnet
 esphome/components/dht/* @OttoWinter
+esphome/components/dps310/* @kbx81
 esphome/components/ds1307/* @badbadc0ffee
 esphome/components/dsmr/* @glmnet @zuidwijk
 esphome/components/ektf2232/* @jesserockz

--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -102,6 +102,7 @@ float DPS310Component::get_setup_priority() const { return setup_priority::DATA;
 
 void DPS310Component::update() {
   if (!this->update_in_progress_) {
+    this->update_in_progress_ = true;
     this->read_();
   }
 }

--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -78,16 +78,11 @@ void DPS310Component::setup() {
       (((uint32_t) coef_data_raw[5] & 0x0F) << 16) | ((uint32_t) coef_data_raw[6] << 8) | (uint32_t) coef_data_raw[7];
   this->c10_ = DPS310Component::twos_complement(c10_, 20);
 
-  this->c01_ =
-      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[8] << 8) | (uint16_t) coef_data_raw[9]), 16);
-  this->c11_ =
-      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[10] << 8) | (uint16_t) coef_data_raw[11]), 16);
-  this->c20_ =
-      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[12] << 8) | (uint16_t) coef_data_raw[13]), 16);
-  this->c21_ =
-      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[14] << 8) | (uint16_t) coef_data_raw[15]), 16);
-  this->c30_ =
-      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[16] << 8) | (uint16_t) coef_data_raw[17]), 16);
+  this->c01_ = (int16_t)((uint16_t) coef_data_raw[8] << 8) | (uint16_t) coef_data_raw[9]);
+  this->c11_ = (int16_t)((uint16_t) coef_data_raw[10] << 8) | (uint16_t) coef_data_raw[11]);
+  this->c20_ = (int16_t)((uint16_t) coef_data_raw[12] << 8) | (uint16_t) coef_data_raw[13]);
+  this->c21_ = (int16_t)((uint16_t) coef_data_raw[14] << 8) | (uint16_t) coef_data_raw[15]);
+  this->c30_ = (int16_t)((uint16_t) coef_data_raw[16] << 8) | (uint16_t) coef_data_raw[17]);
 }
 
 void DPS310Component::dump_config() {

--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -8,7 +8,7 @@ namespace dps310 {
 static const char *const TAG = "dps310";
 
 void DPS310Component::setup() {
-  uint8_t coef_data_raw[DPS310_INIT_TIMEOUT];
+  uint8_t coef_data_raw[DPS310_NUM_COEF_REGS];
   auto timer = DPS310_INIT_TIMEOUT;
   uint8_t reg = 0;
 
@@ -78,11 +78,11 @@ void DPS310Component::setup() {
       (((uint32_t) coef_data_raw[5] & 0x0F) << 16) | ((uint32_t) coef_data_raw[6] << 8) | (uint32_t) coef_data_raw[7];
   this->c10_ = DPS310Component::twos_complement(c10_, 20);
 
-  this->c01_ = (int16_t)((uint16_t) coef_data_raw[8] << 8) | (uint16_t) coef_data_raw[9]);
-  this->c11_ = (int16_t)((uint16_t) coef_data_raw[10] << 8) | (uint16_t) coef_data_raw[11]);
-  this->c20_ = (int16_t)((uint16_t) coef_data_raw[12] << 8) | (uint16_t) coef_data_raw[13]);
-  this->c21_ = (int16_t)((uint16_t) coef_data_raw[14] << 8) | (uint16_t) coef_data_raw[15]);
-  this->c30_ = (int16_t)((uint16_t) coef_data_raw[16] << 8) | (uint16_t) coef_data_raw[17]);
+  this->c01_ = (int16_t) (((uint16_t) coef_data_raw[8] << 8) | (uint16_t) coef_data_raw[9]);
+  this->c11_ = (int16_t) (((uint16_t) coef_data_raw[10] << 8) | (uint16_t) coef_data_raw[11]);
+  this->c20_ = (int16_t) (((uint16_t) coef_data_raw[12] << 8) | (uint16_t) coef_data_raw[13]);
+  this->c21_ = (int16_t) (((uint16_t) coef_data_raw[14] << 8) | (uint16_t) coef_data_raw[15]);
+  this->c30_ = (int16_t) (((uint16_t) coef_data_raw[16] << 8) | (uint16_t) coef_data_raw[17]);
 }
 
 void DPS310Component::dump_config() {

--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -78,11 +78,11 @@ void DPS310Component::setup() {
       (((uint32_t) coef_data_raw[5] & 0x0F) << 16) | ((uint32_t) coef_data_raw[6] << 8) | (uint32_t) coef_data_raw[7];
   this->c10_ = DPS310Component::twos_complement(c10_, 20);
 
-  this->c01_ = (int16_t) (((uint16_t) coef_data_raw[8] << 8) | (uint16_t) coef_data_raw[9]);
-  this->c11_ = (int16_t) (((uint16_t) coef_data_raw[10] << 8) | (uint16_t) coef_data_raw[11]);
-  this->c20_ = (int16_t) (((uint16_t) coef_data_raw[12] << 8) | (uint16_t) coef_data_raw[13]);
-  this->c21_ = (int16_t) (((uint16_t) coef_data_raw[14] << 8) | (uint16_t) coef_data_raw[15]);
-  this->c30_ = (int16_t) (((uint16_t) coef_data_raw[16] << 8) | (uint16_t) coef_data_raw[17]);
+  this->c01_ = int16_t(((uint16_t) coef_data_raw[8] << 8) | (uint16_t) coef_data_raw[9]);
+  this->c11_ = int16_t(((uint16_t) coef_data_raw[10] << 8) | (uint16_t) coef_data_raw[11]);
+  this->c20_ = int16_t(((uint16_t) coef_data_raw[12] << 8) | (uint16_t) coef_data_raw[13]);
+  this->c21_ = int16_t(((uint16_t) coef_data_raw[14] << 8) | (uint16_t) coef_data_raw[15]);
+  this->c30_ = int16_t(((uint16_t) coef_data_raw[16] << 8) | (uint16_t) coef_data_raw[17]);
 }
 
 void DPS310Component::dump_config() {

--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -1,0 +1,193 @@
+#include "dps310.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace dps310 {
+
+static const char *const TAG = "dps310";
+
+void DPS310Component::setup() {
+  uint8_t coef_data_raw[DPS310_INIT_TIMEOUT];
+  auto timer = DPS310_INIT_TIMEOUT;
+  uint8_t reg = 0;
+
+  ESP_LOGCONFIG(TAG, "Setting up DPS310...");
+  // first, reset the sensor
+  if (!this->write_byte(DPS310_REG_RESET, DPS310_CMD_RESET)) {
+    this->mark_failed();
+    return;
+  }
+  delay(10);
+  // wait for the sensor and its coefficients to be ready
+  while (timer-- && (!(reg & DPS310_BIT_SENSOR_RDY) || !(reg & DPS310_BIT_COEF_RDY))) {
+    reg = this->read_byte(DPS310_REG_MEAS_CFG).value_or(0);
+    delay(5);
+  }
+
+  if (!(reg & DPS310_BIT_SENSOR_RDY) || !(reg & DPS310_BIT_COEF_RDY)) {  // the flags were not set in time
+    this->mark_failed();
+    return;
+  }
+  // read device ID
+  if (!this->read_byte(DPS310_REG_PROD_REV_ID, &this->prod_rev_id_)) {
+    this->mark_failed();
+    return;
+  }
+  // read in coefficients used to calculate the compensated pressure and temperature values
+  if (!this->read_bytes(DPS310_REG_COEF, coef_data_raw, DPS310_NUM_COEF_REGS)) {
+    this->mark_failed();
+    return;
+  }
+  // read in coefficients source register, too -- we need this a few lines down
+  if (!this->read_byte(DPS310_REG_TMP_COEF_SRC, &reg)) {
+    this->mark_failed();
+    return;
+  }
+  // set up operational stuff
+  if (!this->write_byte(DPS310_REG_PRS_CFG, DPS310_VAL_PRS_CFG)) {
+    this->mark_failed();
+    return;
+  }
+  if (!this->write_byte(DPS310_REG_TMP_CFG, DPS310_VAL_TMP_CFG | (reg & DPS310_BIT_TMP_COEF_SRC))) {
+    this->mark_failed();
+    return;
+  }
+  if (!this->write_byte(DPS310_REG_CFG, DPS310_VAL_REG_CFG)) {
+    this->mark_failed();
+    return;
+  }
+  if (!this->write_byte(DPS310_REG_MEAS_CFG, 0x07)) {  // enable background mode
+    this->mark_failed();
+    return;
+  }
+
+  this->c0_ =  // we only ever use c0/2, so just divide by 2 here to save time later
+      DPS310Component::twos_complement(
+          int16_t(((uint16_t) coef_data_raw[0] << 4) | (((uint16_t) coef_data_raw[1] >> 4) & 0x0F)), 12) /
+      2;
+
+  this->c1_ =
+      DPS310Component::twos_complement(int16_t((((uint16_t) coef_data_raw[1] & 0x0F) << 8) | coef_data_raw[2]), 12);
+
+  this->c00_ = ((uint32_t) coef_data_raw[3] << 12) | ((uint32_t) coef_data_raw[4] << 4) |
+               (((uint32_t) coef_data_raw[5] >> 4) & 0x0F);
+  this->c00_ = DPS310Component::twos_complement(c00_, 20);
+
+  this->c10_ =
+      (((uint32_t) coef_data_raw[5] & 0x0F) << 16) | ((uint32_t) coef_data_raw[6] << 8) | (uint32_t) coef_data_raw[7];
+  this->c10_ = DPS310Component::twos_complement(c10_, 20);
+
+  this->c01_ =
+      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[8] << 8) | (uint16_t) coef_data_raw[9]), 16);
+  this->c11_ =
+      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[10] << 8) | (uint16_t) coef_data_raw[11]), 16);
+  this->c20_ =
+      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[12] << 8) | (uint16_t) coef_data_raw[13]), 16);
+  this->c21_ =
+      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[14] << 8) | (uint16_t) coef_data_raw[15]), 16);
+  this->c30_ =
+      DPS310Component::twos_complement(int16_t(((uint16_t) coef_data_raw[16] << 8) | (uint16_t) coef_data_raw[17]), 16);
+}
+
+void DPS310Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "DPS310:");
+  ESP_LOGCONFIG(TAG, "  Product ID: %u", this->prod_rev_id_ & 0x0F);
+  ESP_LOGCONFIG(TAG, "  Revision ID: %u", (this->prod_rev_id_ >> 4) & 0x0F);
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with DPS310 failed!");
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
+}
+
+float DPS310Component::get_setup_priority() const { return setup_priority::DATA; }
+
+void DPS310Component::update() {
+  if (!this->update_in_progress_) {
+    this->read_();
+  }
+}
+
+void DPS310Component::read_() {
+  uint8_t reg = 0;
+  if (!this->read_byte(DPS310_REG_MEAS_CFG, &reg)) {
+    this->status_set_warning();
+    return;
+  }
+
+  if ((!this->got_pres_) && (reg & DPS310_BIT_PRS_RDY)) {
+    this->read_pressure_();
+  }
+
+  if ((!this->got_temp_) && (reg & DPS310_BIT_TMP_RDY)) {
+    this->read_temperature_();
+  }
+
+  if (this->got_pres_ && this->got_temp_) {
+    this->calculate_values_(this->raw_temperature_, this->raw_pressure_);
+    this->got_pres_ = false;
+    this->got_temp_ = false;
+    this->update_in_progress_ = false;
+    this->status_clear_warning();
+  } else {
+    auto f = std::bind(&DPS310Component::read_, this);
+    this->set_timeout("dps310", 10, f);
+  }
+}
+
+void DPS310Component::read_pressure_() {
+  uint8_t bytes[3];
+  if (!this->read_bytes(DPS310_REG_PRS_B2, bytes, 3)) {
+    this->status_set_warning();
+    return;
+  }
+  this->got_pres_ = true;
+  this->raw_pressure_ = DPS310Component::twos_complement(
+      int32_t((uint32_t(bytes[0]) << 16) | (uint32_t(bytes[1]) << 8) | (uint32_t(bytes[2]))), 24);
+}
+
+void DPS310Component::read_temperature_() {
+  uint8_t bytes[3];
+  if (!this->read_bytes(DPS310_REG_TMP_B2, bytes, 3)) {
+    this->status_set_warning();
+    return;
+  }
+  this->got_temp_ = true;
+  this->raw_temperature_ = DPS310Component::twos_complement(
+      int32_t((uint32_t(bytes[0]) << 16) | (uint32_t(bytes[1]) << 8) | (uint32_t(bytes[2]))), 24);
+}
+
+// Calculations are taken from the datasheet which can be found here:
+// https://www.infineon.com/dgdl/Infineon-DPS310-DataSheet-v01_02-EN.pdf?fileId=5546d462576f34750157750826c42242
+// Sections "How to Calculate Compensated Pressure Values" and "How to Calculate Compensated Temperature Values"
+// Variable names below match variable names from the datasheet but lowercased
+void DPS310Component::calculate_values_(int32_t raw_temperature, int32_t raw_pressure) {
+  const float t_raw_sc = (float) raw_temperature / DPS310_SCALE_FACTOR;
+  const float p_raw_sc = (float) raw_pressure / DPS310_SCALE_FACTOR;
+
+  const float temperature = t_raw_sc * this->c1_ + this->c0_;  // c0/2 done earlier!
+
+  const float pressure = (this->c00_ + p_raw_sc * (this->c10_ + p_raw_sc * (this->c20_ + p_raw_sc * this->c30_)) +
+                          t_raw_sc * this->c01_ + t_raw_sc * p_raw_sc * (this->c11_ + p_raw_sc * this->c21_)) /
+                         100;  // divide by 100 for hPa
+
+  if (this->temperature_sensor_ != nullptr) {
+    this->temperature_sensor_->publish_state(temperature);
+  }
+  if (this->pressure_sensor_ != nullptr) {
+    this->pressure_sensor_->publish_state(pressure);
+  }
+}
+
+int32_t DPS310Component::twos_complement(int32_t val, uint8_t bits) {
+  if (val & ((uint32_t) 1 << (bits - 1))) {
+    val -= (uint32_t) 1 << bits;
+  }
+  return val;
+}
+
+}  // namespace dps310
+}  // namespace esphome

--- a/esphome/components/dps310/dps310.h
+++ b/esphome/components/dps310/dps310.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace dps310 {
+
+static const uint8_t DPS310_REG_PRS_B2 = 0x00;        // Highest byte of pressure data
+static const uint8_t DPS310_REG_TMP_B2 = 0x03;        // Highest byte of temperature data
+static const uint8_t DPS310_REG_PRS_CFG = 0x06;       // Pressure configuration
+static const uint8_t DPS310_REG_TMP_CFG = 0x07;       // Temperature configuration
+static const uint8_t DPS310_REG_MEAS_CFG = 0x08;      // Sensor configuration
+static const uint8_t DPS310_REG_CFG = 0x09;           // Interrupt/FIFO configuration
+static const uint8_t DPS310_REG_RESET = 0x0C;         // Soft reset
+static const uint8_t DPS310_REG_PROD_REV_ID = 0x0D;   // Register that contains the part ID
+static const uint8_t DPS310_REG_COEF = 0x10;          // Top of calibration coefficient data space
+static const uint8_t DPS310_REG_TMP_COEF_SRC = 0x28;  // Temperature calibration src
+
+static const uint8_t DPS310_BIT_PRS_RDY = 0x10;       // Pressure measurement is ready
+static const uint8_t DPS310_BIT_TMP_RDY = 0x20;       // Temperature measurement is ready
+static const uint8_t DPS310_BIT_SENSOR_RDY = 0x40;    // Sensor initialization complete when bit is set
+static const uint8_t DPS310_BIT_COEF_RDY = 0x80;      // Coefficients are available when bit is set
+static const uint8_t DPS310_BIT_TMP_COEF_SRC = 0x80;  // Temperature measurement source (0 = ASIC, 1 = MEMS element)
+static const uint8_t DPS310_BIT_REQ_PRES = 0x01;      // Set this bit to request pressure reading
+static const uint8_t DPS310_BIT_REQ_TEMP = 0x02;      // Set this bit to request temperature reading
+
+static const uint8_t DPS310_CMD_RESET = 0x89;  // What to write to reset the device
+
+static const uint8_t DPS310_VAL_PRS_CFG = 0x01;  // Value written to DPS310_REG_PRS_CFG at startup
+static const uint8_t DPS310_VAL_TMP_CFG = 0x01;  // Value written to DPS310_REG_TMP_CFG at startup
+static const uint8_t DPS310_VAL_REG_CFG = 0x00;  // Value written to DPS310_REG_CFG at startup
+
+static const uint8_t DPS310_INIT_TIMEOUT = 20;       // How long to wait for DPS310 start-up to complete
+static const uint8_t DPS310_NUM_COEF_REGS = 18;      // Number of coefficients we need to read from the device
+static const int32_t DPS310_SCALE_FACTOR = 1572864;  // Measurement compensation scale factor
+
+class DPS310Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  void update() override;
+
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
+
+ protected:
+  void read_();
+  void read_pressure_();
+  void read_temperature_();
+  void calculate_values_(int32_t raw_temperature, int32_t raw_pressure);
+  static int32_t twos_complement(int32_t val, uint8_t bits);
+
+  sensor::Sensor *temperature_sensor_;
+  sensor::Sensor *pressure_sensor_;
+  int32_t raw_pressure_, raw_temperature_, c00_, c10_;
+  int16_t c0_, c1_, c01_, c11_, c20_, c21_, c30_;
+  uint8_t prod_rev_id_;
+  bool got_pres_, got_temp_, update_in_progress_;
+};
+
+}  // namespace dps310
+}  // namespace esphome

--- a/esphome/components/dps310/sensor.py
+++ b/esphome/components/dps310/sensor.py
@@ -1,0 +1,62 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    ICON_GAUGE,
+    ICON_THERMOMETER,
+    UNIT_HECTOPASCAL,
+)
+
+CODEOWNERS = ["@kbx81"]
+
+DEPENDENCIES = ["i2c"]
+
+dps310_ns = cg.esphome_ns.namespace("dps310")
+DPS310Component = dps310_ns.class_(
+    "DPS310Component", cg.PollingComponent, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DPS310Component),
+            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Required(CONF_PRESSURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_HECTOPASCAL,
+                icon=ICON_GAUGE,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_PRESSURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x77))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature_sensor(sens))
+
+    if CONF_PRESSURE in config:
+        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+        cg.add(var.set_pressure_sensor(sens))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -768,6 +768,14 @@ sensor:
     temperature:
       name: "MPU6886 Temperature"
     i2c_id: i2c_bus
+  - platform: dps310
+    temperature:
+      name: "DPS310 Temperature"
+    pressure:
+      name: "DPS310 Pressure"
+    address: 0x77
+    update_interval: 15s
+    i2c_id: i2c_bus
   - platform: ms5611
     temperature:
       name: "Outside Temperature"


### PR DESCRIPTION
# What does this implement/fix?

I'm continuing to add support for components I found on my [Adafruit FunHouse](https://www.adafruit.com/product/4985).

This one adds support for the `DPS310` pressure and temperature sensor via I2C.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2218

## Test Environment

- [x] ESP32-S2
- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
sensor:
  - platform: dps310
    temperature:
      id: funhouse_dps310_temperature
      name: FunHouse DPS310 Temperature
    pressure:
      id: funhouse_dps310_pressure
      name: FunHouse DPS310 Pressure
    update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs)