### PR TITLE
Only trigger ble_client on_connect after discovering services

### DIFF
--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -15,10 +15,10 @@ class BLEClientConnectTrigger : public Trigger<>, public BLEClientNode {
   void loop() override {}
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override {
-    if (event == ESP_GATTC_OPEN_EVT && param->open.status == ESP_GATT_OK)
-      this->trigger();
-    if (event == ESP_GATTC_SEARCH_CMPL_EVT)
+    if (event == ESP_GATTC_SEARCH_CMPL_EVT) {
       this->node_state = espbt::ClientState::ESTABLISHED;
+      this->trigger();
+    }
   }
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Triggers on_connect only after discovering services and characteristics. Triggering prematurely means that
some automations against the device will fail as services that may be written to have not yet been
discovered by the stack.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues/issues/3494

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
ble_client:
  - mac_address: 02:5D:FB:D0:5B:2E
    id: art_left
    on_connect:
     then:
      - binary_sensor.template.publish:
          id: am43_left_connected
          state: ON
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
