### PR TITLE
Makes ble_client.ble_write's action value templatable

### DIFF
--- a/esphome/components/ble_client/automation.cpp
+++ b/esphome/components/ble_client/automation.cpp
@@ -10,7 +10,7 @@ namespace esphome {
 namespace ble_client {
 static const char *const TAG = "ble_client.automation";
 
-void BLEWriterClientNode::write() {
+void BLEWriterClientNode::write(const std::vector<uint8_t> &value) {
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "Cannot write to BLE characteristic - not connected");
     return;
@@ -29,9 +29,10 @@ void BLEWriterClientNode::write() {
     ESP_LOGE(TAG, "Characteristic %s does not allow writing", this->char_uuid_.to_string().c_str());
     return;
   }
-  ESP_LOGVV(TAG, "Will write %d bytes: %s", this->value_.size(), format_hex_pretty(this->value_).c_str());
-  esp_err_t err = esp_ble_gattc_write_char(this->parent()->gattc_if, this->parent()->conn_id, this->ble_char_handle_,
-                                           value_.size(), value_.data(), write_type, ESP_GATT_AUTH_REQ_NONE);
+  ESP_LOGVV(TAG, "Will write %d bytes: %s", value.size(), format_hex_pretty(value).c_str());
+  esp_err_t err =
+      esp_ble_gattc_write_char(this->parent()->gattc_if, this->parent()->conn_id, this->ble_char_handle_, value.size(),
+                               const_cast<uint8_t *>(value.data()), write_type, ESP_GATT_AUTH_REQ_NONE);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Error writing to characteristic: %s!", esp_err_to_name(err));
   }

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -77,8 +77,8 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
     has_simple_value_ = false;
   }
 
-  void set_value_simple(std::vector<uint8_t> value) {
-    this->value_simple_ = std::move(value);
+  void set_value_simple(const std::vector<uint8_t> &value) {
+    this->value_simple_ = value;
     has_simple_value_ = true;
   }
 

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -42,10 +42,8 @@ class BLEWriterClientNode : public BLEClientNode {
     ble_client_ = ble_client;
   }
 
-  void set_value(std::vector<uint8_t> value) { value_ = std::move(value); }
-
-  // Attempts to write the contents of value_ to char_uuid_.
-  void write();
+  // Attempts to write the contents of value to char_uuid_.
+  void write(const std::vector<uint8_t> &value);
 
   void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
 
@@ -60,14 +58,34 @@ class BLEWriterClientNode : public BLEClientNode {
   esp_gatt_char_prop_t char_props_;
   espbt::ESPBTUUID service_uuid_;
   espbt::ESPBTUUID char_uuid_;
-  std::vector<uint8_t> value_;
 };
 
 template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, public BLEWriterClientNode {
  public:
   BLEClientWriteAction(BLEClient *ble_client) : BLEWriterClientNode(ble_client) {}
 
-  void play(Ts... x) override { return write(); }
+  void play(Ts... x) override {
+    if (has_simple_value_) {
+      return write(this->value_simple_);
+    } else {
+      return write(this->value_template_(x...));
+    }
+  }
+
+  void set_value_template(std::function<std::vector<uint8_t>(Ts...)> func) {
+    this->value_template_ = std::move(func);
+    has_simple_value_ = false;
+  }
+
+  void set_value_simple(std::vector<uint8_t> value) {
+    this->value_simple_ = std::move(value);
+    has_simple_value_ = true;
+  }
+
+ private:
+  bool has_simple_value_ = true;
+  std::vector<uint8_t> value_simple_;
+  std::function<std::vector<uint8_t>(Ts...)> value_template_{};
 };
 
 }  // namespace ble_client

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -615,3 +615,9 @@ switch:
           service_uuid: F61E3BE9-2826-A81B-970A-4D4DECFABBAE
           characteristic_uuid: 6490FAFE-0734-732C-8705-91B653A081FC
           value: [0x01, 0xab, 0xff]
+      - ble_client.ble_write:
+          id: airthings01
+          service_uuid: F61E3BE9-2826-A81B-970A-4D4DECFABBAE
+          characteristic_uuid: 6490FAFE-0734-732C-8705-91B653A081FC
+          value: !lambda |-
+            return {0x13, 0x37};


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the ability to template values with the `ble_client.write_action` introduced in #3398. One of the use case is setting the position of SwitchBot covers. See the example YAML below. Other use cases are: dimming lights, controlling actuators over BLE.

Note that while the Switchbot example works, it will drain the battery of the SwitchBot. For a better experience, on-demand BLE connection is needed. This featured ("delayed BLE actions") is tracked in #3434.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2225

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: esphome-templatable-ble-client

esp32:
  board: esp32dev

esp32_ble_tracker:

ble_client:
  - id: switchbot_ble_client
    mac_address: F1:E0:37:0D:EE:B5

cover:
    position_action:
      - ble_client.ble_write:
          id: switchbot_ble_client
          service_uuid: cba20d00-224d-11e6-9fb8-0002a5d5c51b
          characteristic_uuid: cba20002-224d-11e6-9fb8-0002a5d5c51b
          value: !lambda |-
            uint8_t byte_position = 100  * (1.0f - pos);
            ESP_LOGW("POS: ", "pos: %f, byte_position: %d", pos, byte_position);
            return {0x57, 0x0F, 0x45, 0x01, 0x05, 0xFF, byte_position};
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
