### PR TITLE
First release of component for reading Easymeter Q3DA smartmeter data…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -161,6 +161,7 @@ esphome/components/preferences/* @esphome/core
 esphome/components/psram/* @esphome/core
 esphome/components/pulse_meter/* @cstaahl @stevebaxter
 esphome/components/pvvx_mithermometer/* @pasiz
+esphome/components/q3da/* @vogt31337
 esphome/components/qmp6988/* @andrewpc
 esphome/components/qr_code/* @wjtje
 esphome/components/radon_eye_ble/* @jeffeb3

--- a/esphome/components/q3da/__init__.py
+++ b/esphome/components/q3da/__init__.py
@@ -1,0 +1,38 @@
+import re
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@vogt31337"]
+
+DEPENDENCIES = ["uart"]
+
+q3da_ns = cg.esphome_ns.namespace("q3da")
+Q3DA = q3da_ns.class_("q3da", cg.Component, uart.UARTDevice)
+MULTI_CONF = True
+
+CONF_Q3DA_ID = "q3da_id"
+CONF_OBIS_CODE = "obis_code"
+CONF_SERVER_ID = "server_id"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(Q3DA),
+    }
+).extend(uart.UART_DEVICE_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+
+def obis_code(value):
+    value = cv.string(value)
+    match = re.match(r"^\d{1,3}-\d{1,3}:\d{1,3}\.\d{1,3}\.\d{1,3}$", value)
+    if match is None:
+        raise cv.Invalid(f"{value} is not a valid OBIS code")
+    return value

--- a/esphome/components/q3da/constants.h
+++ b/esphome/components/q3da/constants.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+
+namespace esphome {
+  namespace q3da {
+    const uint8_t START_MASK = 47; // = / Start mark of a new telegram
+    const uint8_t END_MASK = 33; // = ! End mark of a new telegram
+  }  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/constants.h
+++ b/esphome/components/q3da/constants.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 
 namespace esphome {
-  namespace q3da {
-    const uint8_t START_MASK = 47; // = / Start mark of a new telegram
-    const uint8_t END_MASK = 33; // = ! End mark of a new telegram
-  }  // namespace q3da
+namespace q3da {
+const uint8_t START_MASK = 47; // = / Start mark of a new telegram
+const uint8_t END_MASK = 33; // = ! End mark of a new telegram
+}  // namespace q3da
 }  // namespace esphome

--- a/esphome/components/q3da/q3da.cpp
+++ b/esphome/components/q3da/q3da.cpp
@@ -1,0 +1,106 @@
+#include "q3da.h"
+#include "esphome/core/log.h"
+#include "q3da_parser.h"
+
+namespace esphome {
+namespace q3da {
+
+static const char *const TAG = "q3da";
+
+const char START_BYTES_DETECTED = 1;
+const char END_BYTES_DETECTED = 2;
+
+Q3DAListener::Q3DAListener(std::string server_id, std::string obis_code)
+    : server_id(std::move(server_id)), obis_code(std::move(obis_code)) {}
+
+char q3da::check_start_end_bytes_(uint8_t byte) {
+  if (byte == START_MASK)
+    return START_BYTES_DETECTED;
+  if (byte == END_MASK)
+    return END_BYTES_DETECTED;
+  return 0;
+}
+
+void q3da::loop() {
+  while (available()) {
+    const char c = read();
+
+    if (this->record_)
+      this->q3da_data_.emplace_back(c);
+
+    switch (this->check_start_end_bytes_(c)) {
+      case START_BYTES_DETECTED: {
+        this->record_ = true;
+        this->q3da_data_.clear();
+        break;
+      };
+      case END_BYTES_DETECTED: {
+        if (this->record_) {
+          this->record_ = false;
+
+          if (!check_q3da_data(this->q3da_data_))
+            break;
+
+          // remove footer bytes
+          //this->q3da_data_.resize(this->q3da_data_.size() - 2);
+          this->process_q3da_telegram_(this->q3da_data_);
+        }
+        break;
+      };
+    };
+  }
+}
+
+void q3da::process_q3da_telegram_(const bytes &q3da_data) {
+  //ESP_LOGV(TAG, "Received a telegram: %d", q3da_data.size());
+  Q3DATelegram q3da_file = Q3DATelegram(q3da_data);
+  std::vector<ObisInfo> obis_info = q3da_file.get_obis_info();
+  this->publish_obis_info_(obis_info);
+
+  this->log_obis_info_(obis_info);
+}
+
+void q3da::log_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {
+  ESP_LOGD(TAG, "OBIS info:");
+  for (auto const &obis_info : obis_info_vec) {
+    std::string info;
+    info += "  (" + bytes_repr(obis_info.server_id) + ") ";
+    info += obis_info.code_repr();
+    //info += " [0x" + bytes_repr(obis_info.value) + "]";
+    ESP_LOGD(TAG, "%s", info.c_str());
+  }
+}
+
+void q3da::publish_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {
+  for (auto const &obis_info : obis_info_vec) {
+    this->publish_value_(obis_info);
+  }
+}
+
+void q3da::publish_value_(const ObisInfo &obis_info) {
+  for (auto const &q3da_listener : q3da_listeners_) {
+    //if ((!q3da_listener->server_id.empty()) && (bytes_repr(obis_info.server_id) != q3da_listener->server_id))
+    //  continue;
+    if (obis_info.code_repr() != q3da_listener->obis_code)
+      continue;
+    q3da_listener->publish_val(obis_info);
+  }
+}
+
+void q3da::dump_config() { ESP_LOGCONFIG(TAG, "Q3DA:"); }
+
+void q3da::register_q3da_listener(Q3DAListener *listener) { q3da_listeners_.emplace_back(listener); }
+
+bool check_q3da_data(const bytes &buffer) {
+  if (buffer.size() < 2) {
+    ESP_LOGW(TAG, "Too less Q3DA data received.");
+    return false;
+  }
+
+  // Todo: do more fancy checking.
+
+  return true;
+}
+
+}  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/q3da.cpp
+++ b/esphome/components/q3da/q3da.cpp
@@ -42,7 +42,7 @@ void q3da::loop() {
             break;
 
           // remove footer bytes
-          //this->q3da_data_.resize(this->q3da_data_.size() - 2);
+          // this->q3da_data_.resize(this->q3da_data_.size() - 2);
           this->process_q3da_telegram_(this->q3da_data_);
         }
         break;
@@ -52,7 +52,7 @@ void q3da::loop() {
 }
 
 void q3da::process_q3da_telegram_(const bytes &q3da_data) {
-  //ESP_LOGV(TAG, "Received a telegram: %d", q3da_data.size());
+  // ESP_LOGV(TAG, "Received a telegram: %d", q3da_data.size());
   Q3DATelegram q3da_file = Q3DATelegram(q3da_data);
   std::vector<ObisInfo> obis_info = q3da_file.get_obis_info();
   this->publish_obis_info_(obis_info);
@@ -66,7 +66,7 @@ void q3da::log_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {
     std::string info;
     info += "  (" + bytes_repr(obis_info.server_id) + ") ";
     info += obis_info.code_repr();
-    //info += " [0x" + bytes_repr(obis_info.value) + "]";
+    // info += " [0x" + bytes_repr(obis_info.value) + "]";
     ESP_LOGD(TAG, "%s", info.c_str());
   }
 }
@@ -79,7 +79,7 @@ void q3da::publish_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {
 
 void q3da::publish_value_(const ObisInfo &obis_info) {
   for (auto const &q3da_listener : q3da_listeners_) {
-    //if ((!q3da_listener->server_id.empty()) && (bytes_repr(obis_info.server_id) != q3da_listener->server_id))
+    // if ((!q3da_listener->server_id.empty()) && (bytes_repr(obis_info.server_id) != q3da_listener->server_id))
     //  continue;
     if (obis_info.code_repr() != q3da_listener->obis_code)
       continue;

--- a/esphome/components/q3da/q3da.h
+++ b/esphome/components/q3da/q3da.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+#include "q3da_parser.h"
+
+namespace esphome {
+namespace q3da {
+
+class Q3DAListener {
+ public:
+  std::string server_id;
+  std::string obis_code;
+  Q3DAListener(std::string server_id, std::string obis_code);
+  virtual void publish_val(const ObisInfo &obis_info){};
+};
+
+class q3da : public Component, public uart::UARTDevice {
+ public:
+  void register_q3da_listener(Q3DAListener *listener);
+  void loop() override;
+  void dump_config() override;
+  std::vector<Q3DAListener *> q3da_listeners_{};
+
+ protected:
+  void process_q3da_telegram_(const bytes &q3da_data);
+  void log_obis_info_(const std::vector<ObisInfo> &obis_info_vec);
+  void publish_obis_info_(const std::vector<ObisInfo> &obis_info_vec);
+  char check_start_end_bytes_(uint8_t byte);
+  void publish_value_(const ObisInfo &obis_info);
+
+  // Serial parser
+  bool record_ = false;
+  bytes q3da_data_;
+};
+
+bool check_q3da_data(const bytes &buffer);
+}  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/q3da_parser.cpp
+++ b/esphome/components/q3da/q3da_parser.cpp
@@ -8,62 +8,62 @@ namespace q3da {
 
 static const char *const TAG = "q3da";
 
-ObisInfo::ObisInfo(bytes server_id, char* str) { //: server_id(std::move(server_id)) {
-  //char* str = (char*)data.c_str();        // convert to c_str
-  
+ObisInfo::ObisInfo(bytes server_id, char* str) {
+  // char* str = (char*)data.c_str();        // convert to c_str
+
   this->server_id = server_id;
 
-  char* first  = strtok(str, "(");        // split into first half (before '(')
-  char* second = strtok(NULL, "(");       // and second half
+  char* first  = strtok(str, "(");   // split into first half (before '(')
+  char* second = strtok(NULL, "(");  // and second half
 
   char *token     = strtok(first, "-");
-  this->medium    = (uint8_t)atoi(token); // Value Group A: Electricity = 1, Gas = 7, ...
+  this->medium    = (uint8_t)atoi(token);  // Value Group A: Electricity = 1, Gas = 7, ...
   token     = strtok(NULL, "-");
 
   token     = strtok(token, ":");
-  this->channels  = (uint8_t)atoi(token); // Value Group B: internal or external
+  this->channels  = (uint8_t)atoi(token);  // Value Group B: internal or external
   token     = strtok(NULL, ":");
 
   token     = strtok(token, ".");
-  this->unit      = (uint8_t)atoi(token); // Value Group C: Active, Reactive, ...
+  this->unit      = (uint8_t)atoi(token);  // Value Group C: Active, Reactive, ...
   token     = strtok(NULL, ".");
-  this->type      = (uint8_t)atoi(token); // Value Group D: Kind of measurement: Max, current, ...
+  this->type      = (uint8_t)atoi(token);  // Value Group D: Kind of measurement: Max, current, ...
   token     = strtok(NULL, ".");
 
   token     = strtok(token, "*");
-  this->tariff    = (uint8_t)atoi(token); // Value Group E: Kind of tariff: Total, Tarif1, Tarif2, ...
+  this->tariff    = (uint8_t)atoi(token);  // Value Group E: Kind of tariff: Total, Tarif1, Tarif2, ...
   token     = strtok(NULL, "*");
-  this->scaler    = (uint8_t)atoi(token); // Value Group F: 00..99, 255 = ignored?
+  this->scaler    = (uint8_t)atoi(token);  // Value Group F: 00..99, 255 = ignored?
 
   int star = strchr(second, '*')-second+1;
-  //ESP_LOGV(TAG, "%s", second);
+  // ESP_LOGV(TAG, "%s", second);
 
-  if (star > 0) {         // we have found a '*' = 42, so a float is in the rest
+  if (star > 0) {  // we have found a '*' = 42, so a float is in the rest
     token  = strtok(second, "*");
-    this->value = (float)atof(token);     // Actual Value for example 1234.5
+    this->value = (float)atof(token);  // Actual Value for example 1234.5
     second = strtok(NULL, "*");
   } else {
     this->value = 0.0/0.0;
   }
 
-/*  ESP_LOGV(TAG, "%s", second);
+  /*  ESP_LOGV(TAG, "%s", second);
   token     = strtok(second, ")");
   strcpy(this->symbol, token); // Copy the rest of the data and without the last ')'*/
 }
 
-Q3DATelegram::Q3DATelegram(const bytes buffer) {//: buffer_(std::move(buffer)) {
+Q3DATelegram::Q3DATelegram(const bytes buffer) {
   std::string data;
   data.assign(buffer.begin(), buffer.end());
-  char* str = (char*)data.c_str();
+  char* str = (char *) data.c_str();
 
   this->messages.clear();
 
-  std::vector<char*> tokens;
+  std::vector<char *> tokens;
   tokens.clear();
 
   // First line is the type / name of the smartmeter
-  char* token = strtok(str, "\r\n");
-  token++;  
+  char *token = strtok(str, "\r\n");
+  token++;
 
   bytes server_id;
   for (int i = 0; i < strlen(token); i++) {
@@ -72,18 +72,16 @@ Q3DATelegram::Q3DATelegram(const bytes buffer) {//: buffer_(std::move(buffer)) {
 
   while (token != NULL) {
     token = strtok(NULL, "\r\n");
-    
     if (token != NULL && token[0] != END_MASK) {
-      //this->messages.emplace_back(obis);
+      // this->messages.emplace_back(obis);
       tokens.push_back(token);
     }
   }
 
   for (auto & token: tokens) {
-      this->messages.emplace_back(ObisInfo(server_id, token));
+    this->messages.emplace_back(ObisInfo(server_id, token));
   }
-  //ESP_LOGV(TAG, "Found %d msg", this->messages.size());
-
+  // ESP_LOGV(TAG, "Found %d msg", this->messages.size());
 }
 
 std::string bytes_repr(const bytes &buffer) {
@@ -94,9 +92,7 @@ std::string bytes_repr(const bytes &buffer) {
   return repr;
 }
 
-std::vector<ObisInfo> Q3DATelegram::get_obis_info() {
-  return this->messages;
-}
+std::vector<ObisInfo> Q3DATelegram::get_obis_info() { return this->messages; }
 
 std::string ObisInfo::code_repr() const {
   return str_sprintf("%d-%d:%d.%d.%d", this->medium, this->channels, this->unit, this->type, this->tariff);

--- a/esphome/components/q3da/q3da_parser.cpp
+++ b/esphome/components/q3da/q3da_parser.cpp
@@ -1,0 +1,106 @@
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "constants.h"
+#include "q3da_parser.h"
+
+namespace esphome {
+namespace q3da {
+
+static const char *const TAG = "q3da";
+
+ObisInfo::ObisInfo(bytes server_id, char* str) { //: server_id(std::move(server_id)) {
+  //char* str = (char*)data.c_str();        // convert to c_str
+  
+  this->server_id = server_id;
+
+  char* first  = strtok(str, "(");        // split into first half (before '(')
+  char* second = strtok(NULL, "(");       // and second half
+
+  char *token     = strtok(first, "-");
+  this->medium    = (uint8_t)atoi(token); // Value Group A: Electricity = 1, Gas = 7, ...
+  token     = strtok(NULL, "-");
+
+  token     = strtok(token, ":");
+  this->channels  = (uint8_t)atoi(token); // Value Group B: internal or external
+  token     = strtok(NULL, ":");
+
+  token     = strtok(token, ".");
+  this->unit      = (uint8_t)atoi(token); // Value Group C: Active, Reactive, ...
+  token     = strtok(NULL, ".");
+  this->type      = (uint8_t)atoi(token); // Value Group D: Kind of measurement: Max, current, ...
+  token     = strtok(NULL, ".");
+
+  token     = strtok(token, "*");
+  this->tariff    = (uint8_t)atoi(token); // Value Group E: Kind of tariff: Total, Tarif1, Tarif2, ...
+  token     = strtok(NULL, "*");
+  this->scaler    = (uint8_t)atoi(token); // Value Group F: 00..99, 255 = ignored?
+
+  int star = strchr(second, '*')-second+1;
+  //ESP_LOGV(TAG, "%s", second);
+
+  if (star > 0) {         // we have found a '*' = 42, so a float is in the rest
+    token  = strtok(second, "*");
+    this->value = (float)atof(token);     // Actual Value for example 1234.5
+    second = strtok(NULL, "*");
+  } else {
+    this->value = 0.0/0.0;
+  }
+
+/*  ESP_LOGV(TAG, "%s", second);
+  token     = strtok(second, ")");
+  strcpy(this->symbol, token); // Copy the rest of the data and without the last ')'*/
+}
+
+Q3DATelegram::Q3DATelegram(const bytes buffer) {//: buffer_(std::move(buffer)) {
+  std::string data;
+  data.assign(buffer.begin(), buffer.end());
+  char* str = (char*)data.c_str();
+
+  this->messages.clear();
+
+  std::vector<char*> tokens;
+  tokens.clear();
+
+  // First line is the type / name of the smartmeter
+  char* token = strtok(str, "\r\n");
+  token++;  
+
+  bytes server_id;
+  for (int i = 0; i < strlen(token); i++) {
+    server_id.push_back(token[i]);
+  }
+
+  while (token != NULL) {
+    token = strtok(NULL, "\r\n");
+    
+    if (token != NULL && token[0] != END_MASK) {
+      //this->messages.emplace_back(obis);
+      tokens.push_back(token);
+    }
+  }
+
+  for (auto & token: tokens) {
+      this->messages.emplace_back(ObisInfo(server_id, token));
+  }
+  //ESP_LOGV(TAG, "Found %d msg", this->messages.size());
+
+}
+
+std::string bytes_repr(const bytes &buffer) {
+  std::string repr;
+  for (auto const value : buffer) {
+    repr += str_sprintf("%02x", value & 0xff);
+  }
+  return repr;
+}
+
+std::vector<ObisInfo> Q3DATelegram::get_obis_info() {
+  return this->messages;
+}
+
+std::string ObisInfo::code_repr() const {
+  return str_sprintf("%d-%d:%d.%d.%d", this->medium, this->channels, this->unit, this->type, this->tariff);
+}
+
+}  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/q3da_parser.h
+++ b/esphome/components/q3da/q3da_parser.h
@@ -19,17 +19,17 @@ class Q3DANode {
 };
 
 class ObisInfo {
-  public:
+ public:
   ObisInfo(bytes server_id, char* token);
   bytes server_id;
-  uint8_t medium;   // Value Group A: Electricity = 1, Gas = 7, ...
-  uint8_t channels; // Value Group B: internal or external
-  uint8_t unit;     // Value Group C: Active, Reactive, ...
-  uint8_t type;     // Value Group D: Kind of measurement: Max, current, ...
-  uint8_t tariff;   // Value Group E: Kind of tariff: Total, Tarif1, Tarif2, ...
-  uint8_t scaler;   // Value Group F: 00..99, 255 = ignored?
-  float value;      // Actual Value for example 1234.5
-  char* symbol;     // Either represents a unit (e.g. W or kWh) or textual data.
+  uint8_t medium;    // Value Group A: Electricity = 1, Gas = 7, ...
+  uint8_t channels;  // Value Group B: internal or external
+  uint8_t unit;      // Value Group C: Active, Reactive, ...
+  uint8_t type;      // Value Group D: Kind of measurement: Max, current, ...
+  uint8_t tariff;    // Value Group E: Kind of tariff: Total, Tarif1, Tarif2, ...
+  uint8_t scaler;    // Value Group F: 00..99, 255 = ignored?
+  float value;       // Actual Value for example 1234.5
+  char* symbol;      // Either represents a unit (e.g. W or kWh) or textual data.
   std::string code_repr() const;
 };
 
@@ -37,6 +37,7 @@ class Q3DATelegram {
  public:
   Q3DATelegram(const bytes buffer);
   std::vector<ObisInfo> get_obis_info();
+  
  protected:
   std::vector<ObisInfo> messages;
   const bytes buffer_;
@@ -44,5 +45,5 @@ class Q3DATelegram {
 
 std::string bytes_repr(const bytes &buffer);
 
-}  // namespace sml
+}  // namespace q3da
 }  // namespace esphome

--- a/esphome/components/q3da/q3da_parser.h
+++ b/esphome/components/q3da/q3da_parser.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "constants.h"
+
+namespace esphome {
+namespace q3da {
+
+using bytes = std::vector<uint8_t>;
+
+class Q3DANode {
+ public:
+  uint8_t type;
+  bytes value_bytes;
+  std::vector<Q3DANode> nodes;
+};
+
+class ObisInfo {
+  public:
+  ObisInfo(bytes server_id, char* token);
+  bytes server_id;
+  uint8_t medium;   // Value Group A: Electricity = 1, Gas = 7, ...
+  uint8_t channels; // Value Group B: internal or external
+  uint8_t unit;     // Value Group C: Active, Reactive, ...
+  uint8_t type;     // Value Group D: Kind of measurement: Max, current, ...
+  uint8_t tariff;   // Value Group E: Kind of tariff: Total, Tarif1, Tarif2, ...
+  uint8_t scaler;   // Value Group F: 00..99, 255 = ignored?
+  float value;      // Actual Value for example 1234.5
+  char* symbol;     // Either represents a unit (e.g. W or kWh) or textual data.
+  std::string code_repr() const;
+};
+
+class Q3DATelegram {
+ public:
+  Q3DATelegram(const bytes buffer);
+  std::vector<ObisInfo> get_obis_info();
+ protected:
+  std::vector<ObisInfo> messages;
+  const bytes buffer_;
+};
+
+std::string bytes_repr(const bytes &buffer);
+
+}  // namespace sml
+}  // namespace esphome

--- a/esphome/components/q3da/sensor/__init__.py
+++ b/esphome/components/q3da/sensor/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import CONF_ID
+
+from .. import CONF_OBIS_CODE, CONF_SERVER_ID, CONF_Q3DA_ID, Q3DA, obis_code, q3da_ns
+
+AUTO_LOAD = ["q3da"]
+
+Q3DASensor = q3da_ns.class_("Q3DASensor", sensor.Sensor, cg.Component)
+
+
+CONFIG_SCHEMA = sensor.sensor_schema().extend(
+    {
+        cv.GenerateID(): cv.declare_id(Q3DASensor),
+        cv.GenerateID(CONF_Q3DA_ID): cv.use_id(Q3DA),
+        cv.Required(CONF_OBIS_CODE): obis_code,
+        cv.Optional(CONF_SERVER_ID, default=""): cv.string,
+    }
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID], config[CONF_SERVER_ID], config[CONF_OBIS_CODE]
+    )
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)
+    q3da = await cg.get_variable(config[CONF_Q3DA_ID])
+    cg.add(q3da.register_q3da_listener(var))

--- a/esphome/components/q3da/sensor/q3da_sensor.cpp
+++ b/esphome/components/q3da/sensor/q3da_sensor.cpp
@@ -1,0 +1,47 @@
+#include "esphome/core/log.h"
+#include "q3da_sensor.h"
+#include "../q3da_parser.h"
+
+namespace esphome {
+namespace q3da {
+
+static const char *const TAG = "q3da_sensor";
+
+Q3DASensor::Q3DASensor(std::string server_id, std::string obis_code)
+    : Q3DAListener(std::move(server_id), std::move(obis_code)) {}
+
+void Q3DASensor::publish_val(const ObisInfo &obis_info) {
+  //if (obis_info.value != obis_info.value) {
+  //  publish_state(obis_info.symbol);
+  //} else {
+  publish_state(obis_info.value);
+  //}
+  
+  /*switch (obis_info.value_type) {
+    case Q3DA_INT: {
+      publish_state(bytes_to_int(obis_info.value));
+      break;
+    }
+    case Q3DA_BOOL:
+    case Q3DA_UINT: {
+      publish_state(bytes_to_uint(obis_info.value));
+      break;
+    }
+    case Q3DA_OCTET: {
+      ESP_LOGW(TAG, "No number conversion for (%s) %s. Consider using Q3DA TextSensor instead.",
+               bytes_repr(obis_info.server_id).c_str(), obis_info.code_repr().c_str());
+      break;
+    }
+  }*/
+}
+
+void Q3DASensor::dump_config() {
+  LOG_SENSOR("", "Q3DA", this);
+  if (!this->server_id.empty()) {
+    ESP_LOGCONFIG(TAG, "  Server ID: %s", this->server_id.c_str());
+  }
+  ESP_LOGCONFIG(TAG, "  OBIS Code: %s", this->obis_code.c_str());
+}
+
+}  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/sensor/q3da_sensor.cpp
+++ b/esphome/components/q3da/sensor/q3da_sensor.cpp
@@ -11,28 +11,7 @@ Q3DASensor::Q3DASensor(std::string server_id, std::string obis_code)
     : Q3DAListener(std::move(server_id), std::move(obis_code)) {}
 
 void Q3DASensor::publish_val(const ObisInfo &obis_info) {
-  //if (obis_info.value != obis_info.value) {
-  //  publish_state(obis_info.symbol);
-  //} else {
   publish_state(obis_info.value);
-  //}
-  
-  /*switch (obis_info.value_type) {
-    case Q3DA_INT: {
-      publish_state(bytes_to_int(obis_info.value));
-      break;
-    }
-    case Q3DA_BOOL:
-    case Q3DA_UINT: {
-      publish_state(bytes_to_uint(obis_info.value));
-      break;
-    }
-    case Q3DA_OCTET: {
-      ESP_LOGW(TAG, "No number conversion for (%s) %s. Consider using Q3DA TextSensor instead.",
-               bytes_repr(obis_info.server_id).c_str(), obis_info.code_repr().c_str());
-      break;
-    }
-  }*/
 }
 
 void Q3DASensor::dump_config() {

--- a/esphome/components/q3da/sensor/q3da_sensor.h
+++ b/esphome/components/q3da/sensor/q3da_sensor.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "esphome/components/q3da/q3da.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome {
+namespace q3da {
+
+class Q3DASensor : public Q3DAListener, public sensor::Sensor, public Component {
+ public:
+  Q3DASensor(std::string server_id, std::string obis_code);
+  void publish_val(const ObisInfo &obis_info) override;
+  void dump_config() override;
+};
+
+}  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/text_sensor/__init__.py
+++ b/esphome/components/q3da/text_sensor/__init__.py
@@ -1,0 +1,43 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+from esphome.const import CONF_FORMAT, CONF_ID
+
+from .. import CONF_OBIS_CODE, CONF_SERVER_ID, CONF_Q3DA_ID, Q3DA, obis_code, q3da_ns
+
+AUTO_LOAD = ["q3da"]
+
+Q3DAType = q3da_ns.enum("Q3DAType")
+Q3DA_TYPES = {
+    "text": Q3DAType.Q3DA_OCTET,
+    "bool": Q3DAType.Q3DA_BOOL,
+    "int": Q3DAType.Q3DA_INT,
+    "uint": Q3DAType.Q3DA_UINT,
+    "hex": Q3DAType.Q3DA_HEX,
+    "": Q3DAType.Q3DA_UNDEFINED,
+}
+
+Q3DATextSensor = q3da_ns.class_("Q3DATextSensor", text_sensor.TextSensor, cg.Component)
+
+CONFIG_SCHEMA = text_sensor.TEXT_SENSOR_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(Q3DATextSensor),
+        cv.GenerateID(CONF_Q3DA_ID): cv.use_id(Q3DA),
+        cv.Required(CONF_OBIS_CODE): obis_code,
+        cv.Optional(CONF_SERVER_ID, default=""): cv.string,
+        cv.Optional(CONF_FORMAT, default=""): cv.enum(Q3DA_TYPES, lower=True),
+    }
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        config[CONF_SERVER_ID],
+        config[CONF_OBIS_CODE],
+        config[CONF_FORMAT],
+    )
+    await cg.register_component(var, config)
+    await text_sensor.register_text_sensor(var, config)
+    q3da = await cg.get_variable(config[CONF_Q3DA_ID])
+    cg.add(q3da.register_sml_listener(var))

--- a/esphome/components/q3da/text_sensor/q3da_text_sensor.cpp
+++ b/esphome/components/q3da/text_sensor/q3da_text_sensor.cpp
@@ -8,7 +8,7 @@ namespace q3da {
 
 static const char *const TAG = "q3da_text_sensor";
 
-Q3DATextSensor::Q3DATextSensor(std::string server_id, std::string obis_code, Q3DAType format)
+Q3DATextSensor::Q3DATextSensor(std::string server_id, std::string obis_code)
     : Q3DAListener(std::move(server_id), std::move(obis_code)), format_(format) {}
 
 void Q3DATextSensor::publish_val(const ObisInfo &obis_info) {

--- a/esphome/components/q3da/text_sensor/q3da_text_sensor.cpp
+++ b/esphome/components/q3da/text_sensor/q3da_text_sensor.cpp
@@ -1,0 +1,60 @@
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "q3da_text_sensor.h"
+#include "../q3da_parser.h"
+
+namespace esphome {
+namespace q3da {
+
+static const char *const TAG = "q3da_text_sensor";
+
+Q3DATextSensor::Q3DATextSensor(std::string server_id, std::string obis_code, Q3DAType format)
+    : Q3DAListener(std::move(server_id), std::move(obis_code)), format_(format) {}
+
+void Q3DATextSensor::publish_val(const ObisInfo &obis_info) {
+  if (obis_info.value != obis_info.value) {
+    publish_state(obis_info.symbol);
+  } else {
+    publish_state(obis_info.value);
+  }
+
+  /*uint8_t value_type;
+  if (this->format_ == Q3DA_UNDEFINED) {
+    value_type = obis_info.value_type;
+  } else {
+    value_type = this->format_;
+  }
+
+  switch (value_type) {
+    case Q3DA_HEX: {
+      publish_state("0x" + bytes_repr(obis_info.value));
+      break;
+    }
+    case Q3DA_INT: {
+      publish_state(to_string(bytes_to_int(obis_info.value)));
+      break;
+    }
+    case Q3DA_BOOL:
+      publish_state(bytes_to_uint(obis_info.value) ? "True" : "False");
+      break;
+    case Q3DA_UINT: {
+      publish_state(to_string(bytes_to_uint(obis_info.value)));
+      break;
+    }
+    case Q3DA_OCTET: {
+      publish_state(std::string(obis_info.value.begin(), obis_info.value.end()));
+      break;
+    }
+  }*/
+}
+
+void Q3DATextSensor::dump_config() {
+  LOG_TEXT_SENSOR("", "Q3DA", this);
+  if (!this->server_id.empty()) {
+    ESP_LOGCONFIG(TAG, "  Server ID: %s", this->server_id.c_str());
+  }
+  ESP_LOGCONFIG(TAG, "  OBIS Code: %s", this->obis_code.c_str());
+}
+
+}  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/text_sensor/q3da_text_sensor.h
+++ b/esphome/components/q3da/text_sensor/q3da_text_sensor.h
@@ -17,5 +17,5 @@ class Q3DATextSensor : public Q3DAListener, public text_sensor::TextSensor, publ
   Q3DAType format_;
 };
 
-}  // namespace sml
+}  // namespace q3da
 }  // namespace esphome

--- a/esphome/components/q3da/text_sensor/q3da_text_sensor.h
+++ b/esphome/components/q3da/text_sensor/q3da_text_sensor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esphome/components/q3da/q3da.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "../constants.h"
+
+namespace esphome {
+namespace q3da {
+
+class Q3DATextSensor : public Q3DAListener, public text_sensor::TextSensor, public Component {
+ public:
+  Q3DATextSensor(std::string server_id, std::string obis_code, Q3DAType format);
+  void publish_val(const ObisInfo &obis_info) override;
+  void dump_config() override;
+
+ protected:
+  Q3DAType format_;
+};
+
+}  // namespace sml
+}  // namespace esphome

--- a/esphome/components/q3da/text_sensor/sml_text_sensor.cpp
+++ b/esphome/components/q3da/text_sensor/sml_text_sensor.cpp
@@ -1,0 +1,54 @@
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "q3da_text_sensor.h"
+#include "../q3da_parser.h"
+
+namespace esphome {
+namespace q3da {
+
+static const char *const TAG = "q3da_text_sensor";
+
+Q3DATextSensor::Q3DATextSensor(std::string server_id, std::string obis_code, Q3DAType format)
+    : Q3DAListener(std::move(server_id), std::move(obis_code)), format_(format) {}
+
+void Q3DATextSensor::publish_val(const ObisInfo &obis_info) {
+  uint8_t value_type;
+  if (this->format_ == Q3DA_UNDEFINED) {
+    value_type = obis_info.value_type;
+  } else {
+    value_type = this->format_;
+  }
+
+  switch (value_type) {
+    case Q3DA_HEX: {
+      publish_state("0x" + bytes_repr(obis_info.value));
+      break;
+    }
+    case Q3DA_INT: {
+      publish_state(to_string(bytes_to_int(obis_info.value)));
+      break;
+    }
+    case Q3DA_BOOL:
+      publish_state(bytes_to_uint(obis_info.value) ? "True" : "False");
+      break;
+    case Q3DA_UINT: {
+      publish_state(to_string(bytes_to_uint(obis_info.value)));
+      break;
+    }
+    case Q3DA_OCTET: {
+      publish_state(std::string(obis_info.value.begin(), obis_info.value.end()));
+      break;
+    }
+  }
+}
+
+void Q3DATextSensor::dump_config() {
+  LOG_TEXT_SENSOR("", "Q3DA", this);
+  if (!this->server_id.empty()) {
+    ESP_LOGCONFIG(TAG, "  Server ID: %s", this->server_id.c_str());
+  }
+  ESP_LOGCONFIG(TAG, "  OBIS Code: %s", this->obis_code.c_str());
+}
+
+}  // namespace q3da
+}  // namespace esphome

--- a/esphome/components/q3da/text_sensor/sml_text_sensor.h
+++ b/esphome/components/q3da/text_sensor/sml_text_sensor.h
@@ -17,5 +17,5 @@ class Q3DATextSensor : public Q3DAListener, public text_sensor::TextSensor, publ
   Q3DAType format_;
 };
 
-}  // namespace sml
+}  // namespace q3da
 }  // namespace esphome

--- a/esphome/components/q3da/text_sensor/sml_text_sensor.h
+++ b/esphome/components/q3da/text_sensor/sml_text_sensor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esphome/components/q3da/q3da.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "../constants.h"
+
+namespace esphome {
+namespace q3da {
+
+class Q3DATextSensor : public Q3DAListener, public text_sensor::TextSensor, public Component {
+ public:
+  Q3DATextSensor(std::string server_id, std::string obis_code, Q3DAType format);
+  void publish_val(const ObisInfo &obis_info) override;
+  void dump_config() override;
+
+ protected:
+  Q3DAType format_;
+};
+
+}  // namespace sml
+}  // namespace esphome


### PR DESCRIPTION
… via IR Interface.

# What does this implement/fix?

A new component to read data from an Easymeter Q3DA. The normal SML interface doesn't work since the data is send in ascii and not in a stuffed binary format. Also the data only uses a subset of the OBIS data standard, looking like they've only implemented the bare minimum in the Q3DA. 
Therefore I wrote this new component based on the former SML component. It is tested with my meters and the provided example config. My C++ skills are not the highest therefore improvements are welcome.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

None.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

Not now, but I'll set out to write some documentation.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
uart:
  id: uart_bus
  rx_pin: GPIO3
  baud_rate: 9600
  data_bits: 7
  parity: EVEN
  stop_bits: 1
  
q3da:
  id: mysml
  uart_id: uart_bus

sensor:
  - platform: q3da
    name: "Total energy"
    q3da_id: mysml
    obis_code: "1-0:1.8.0"
    unit_of_measurement: kWh
    accuracy_decimals: 1
    device_class: energy
    state_class: total_increasing
  - platform: q3da
    name: "Current power draw"
    q3da_id: mysml
    obis_code: "1-0:1.7.0"
    unit_of_measurement: W
    accuracy_decimals: 2
    device_class: energy
    state_class: measurement

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
