### PR TITLE
Ruuvi BLE: Fix NA handling of fields

### DIFF
--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -64,9 +64,9 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       result.acceleration_y = data[8] == 0x80 && data[9] == 0x00 ? NAN : acceleration_y;
       result.acceleration_z = data[10] == 0x80 && data[11] == 0x00 ? NAN : acceleration_z;
       result.acceleration = std::isnan(*result.acceleration_x) || std::isnan(*result.acceleration_y) || std::isnan(*result.acceleration_z)
-	                        ? NAN
-	                        : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
-	                                acceleration_z * acceleration_z);
+                          ? NAN
+                          : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
+                                  acceleration_z * acceleration_z);
       result.battery_voltage = (power_info >> 5) == 0x7FF ? NAN : battery_voltage;
       result.tx_power = (power_info & 0x1F) == 0x1F ? NAN : tx_power;
       result.movement_counter = data[14] == 0xFF ? NAN : movement_counter;

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -54,8 +54,8 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       const float battery_voltage = ((power_info >> 5) + 1600.0f) / 1000.0f;
       const float tx_power = ((power_info & 0x1F) * 2.0f) - 40.0f;
 
-      const float movement_counter = data[14] == 0xFF ? NAN : float(data[14]);
-      const float measurement_sequence_number = data[15] == 0xFF && data[16] == 0xFF ? NAN : float(uint16_t(data[15] << 8) | uint16_t(data[16]));
+      const float movement_counter = float(data[14]);
+      const float measurement_sequence_number = float(uint16_t(data[15] << 8) | uint16_t(data[16]));
 
       result.temperature = data[0] == 0x80 && data[1] == 0x00 ? NAN : temperature;
       result.humidity = data[2] == 0xFF && data[3] == 0xFF ? NAN : humidity;
@@ -69,8 +69,8 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
 	                                acceleration_z * acceleration_z);
       result.battery_voltage = (power_info >> 5) == 0x7FF ? NAN : battery_voltage;
       result.tx_power = (power_info & 0x1F) == 0x1F ? NAN : tx_power;
-      result.movement_counter = movement_counter;
-      result.measurement_sequence_number = measurement_sequence_number;
+      result.movement_counter = data[14] == 0xFF ? NAN : movement_counter;
+      result.measurement_sequence_number = data[15] == 0xFF && data[16] == 0xFF ? NAN : measurement_sequence_number;
 
       return true;
     }

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -54,19 +54,19 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       const float battery_voltage = ((power_info >> 5) + 1600.0f) / 1000.0f;
       const float tx_power = ((power_info & 0x1F) * 2.0f) - 40.0f;
 
-      const float movement_counter = float(data[14]);
-      const float measurement_sequence_number = float(uint16_t(data[15] << 8) | uint16_t(data[16]));
+      const float movement_counter = data[14] == 0xFF ? NAN : float(data[14]);
+      const float measurement_sequence_number = data[15] == 0xFF && data[16] == 0xFF ? NAN : float(uint16_t(data[15] << 8) | uint16_t(data[16]));
 
-      result.temperature = data[0] == 0x7F && data[1] == 0xFF ? NAN : temperature;
+      result.temperature = data[0] == 0x80 && data[1] == 0x00 ? NAN : temperature;
       result.humidity = data[2] == 0xFF && data[3] == 0xFF ? NAN : humidity;
       result.pressure = data[4] == 0xFF && data[5] == 0xFF ? NAN : pressure;
-      result.acceleration_x = data[6] == 0xFF && data[7] == 0xFF ? NAN : acceleration_x;
-      result.acceleration_y = data[8] == 0xFF && data[9] == 0xFF ? NAN : acceleration_y;
-      result.acceleration_z = data[10] == 0xFF && data[11] == 0xFF ? NAN : acceleration_z;
-      result.acceleration = result.acceleration_x == NAN || result.acceleration_y == NAN || result.acceleration_z == NAN
-                                ? NAN
-                                : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
-                                        acceleration_z * acceleration_z);
+      result.acceleration_x = data[6] == 0x80 && data[7] == 0x00 ? NAN : acceleration_x;
+      result.acceleration_y = data[8] == 0x80 && data[9] == 0x00 ? NAN : acceleration_y;
+      result.acceleration_z = data[10] == 0x80 && data[11] == 0x00 ? NAN : acceleration_z;
+      result.acceleration = isnan(*result.acceleration_x) || isnan(*result.acceleration_y) || isnan(*result.acceleration_z) == NAN
+	                        ? NAN
+	                        : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
+	                                acceleration_z * acceleration_z);
       result.battery_voltage = (power_info >> 5) == 0x7FF ? NAN : battery_voltage;
       result.tx_power = (power_info & 0x1F) == 0x1F ? NAN : tx_power;
       result.movement_counter = movement_counter;

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -63,7 +63,7 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       result.acceleration_x = data[6] == 0x80 && data[7] == 0x00 ? NAN : acceleration_x;
       result.acceleration_y = data[8] == 0x80 && data[9] == 0x00 ? NAN : acceleration_y;
       result.acceleration_z = data[10] == 0x80 && data[11] == 0x00 ? NAN : acceleration_z;
-      result.acceleration = isnan(*result.acceleration_x) || isnan(*result.acceleration_y) || isnan(*result.acceleration_z) == NAN
+      result.acceleration = isnan(*result.acceleration_x) || isnan(*result.acceleration_y) || isnan(*result.acceleration_z)
 	                        ? NAN
 	                        : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
 	                                acceleration_z * acceleration_z);

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -63,7 +63,7 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       result.acceleration_x = data[6] == 0x80 && data[7] == 0x00 ? NAN : acceleration_x;
       result.acceleration_y = data[8] == 0x80 && data[9] == 0x00 ? NAN : acceleration_y;
       result.acceleration_z = data[10] == 0x80 && data[11] == 0x00 ? NAN : acceleration_z;
-      result.acceleration = isnan(*result.acceleration_x) || isnan(*result.acceleration_y) || isnan(*result.acceleration_z)
+      result.acceleration = std::isnan(*result.acceleration_x) || std::isnan(*result.acceleration_y) || std::isnan(*result.acceleration_z)
 	                        ? NAN
 	                        : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
 	                                acceleration_z * acceleration_z);

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -63,10 +63,11 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       result.acceleration_x = data[6] == 0x80 && data[7] == 0x00 ? NAN : acceleration_x;
       result.acceleration_y = data[8] == 0x80 && data[9] == 0x00 ? NAN : acceleration_y;
       result.acceleration_z = data[10] == 0x80 && data[11] == 0x00 ? NAN : acceleration_z;
-      result.acceleration = std::isnan(*result.acceleration_x) || std::isnan(*result.acceleration_y) || std::isnan(*result.acceleration_z)
-                          ? NAN
-                          : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
-                                  acceleration_z * acceleration_z);
+      result.acceleration =
+          std::isnan(*result.acceleration_x) || std::isnan(*result.acceleration_y) || std::isnan(*result.acceleration_z)
+              ? NAN
+              : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
+                      acceleration_z * acceleration_z);
       result.battery_voltage = (power_info >> 5) == 0x7FF ? NAN : battery_voltage;
       result.tx_power = (power_info & 0x1F) == 0x1F ? NAN : tx_power;
       result.movement_counter = data[14] == 0xFF ? NAN : movement_counter;


### PR DESCRIPTION
# What does this implement/fix?

With Ruuvi BLE advertisements: Fixes NA value handling of signed fields (temperature, acceleration). Added NA value handling of `movement_counter` and `measurement_sequence_number`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3489

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [ ] The code change is tested and works locally.
  -- not feasible to test locally (NA values are rare in practice). Need guidance or testers to check that valid values are still parsed correctly.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  -- not applicable? Or is it possible to introduce c++ unit tests there?

If user exposed functionality or configuration variables are added/changed: Not applicable, no changes like that.
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
