### PR TITLE
Add final validate for i2c with mix/max frequency

### DIFF
--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+import esphome.final_validate as fv
 from esphome import pins
 from esphome.const import (
     CONF_FREQUENCY,
@@ -110,3 +111,31 @@ async def register_i2c_device(var, config):
     parent = await cg.get_variable(config[CONF_I2C_ID])
     cg.add(var.set_i2c_bus(parent))
     cg.add(var.set_i2c_address(config[CONF_ADDRESS]))
+
+
+def final_validate_device_schema(
+    name: str, *, min_frequency: cv.frequency = None, max_frequency: cv.frequency = None
+):
+    hub_schema = {}
+    if min_frequency is not None:
+        hub_schema[cv.Required(CONF_FREQUENCY)] = cv.All(
+            cv.Range(
+                min=cv.frequency(min_frequency),
+                min_included=True,
+                msg=f"Component {name} requires a minimum frequency of {min_frequency} for the I2C bus",
+            ),
+        )
+
+    if max_frequency is not None:
+        hub_schema[cv.Required(CONF_FREQUENCY)] = cv.All(
+            cv.Range(
+                max=cv.frequency(max_frequency),
+                max_included=True,
+                msg=f"Component {name} cannot be used with a frequency of over {max_frequency} for the I2C bus",
+            ),
+        )
+
+    return cv.Schema(
+        {cv.Required(CONF_I2C_ID): fv.id_declaration_match_schema(hub_schema)},
+        extra=cv.ALLOW_EXTRA,
+    )

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -118,21 +118,17 @@ def final_validate_device_schema(
 ):
     hub_schema = {}
     if min_frequency is not None:
-        hub_schema[cv.Required(CONF_FREQUENCY)] = cv.All(
-            cv.Range(
-                min=cv.frequency(min_frequency),
-                min_included=True,
-                msg=f"Component {name} requires a minimum frequency of {min_frequency} for the I2C bus",
-            ),
+        hub_schema[cv.Required(CONF_FREQUENCY)] = cv.Range(
+            min=cv.frequency(min_frequency),
+            min_included=True,
+            msg=f"Component {name} requires a minimum frequency of {min_frequency} for the I2C bus",
         )
 
     if max_frequency is not None:
-        hub_schema[cv.Required(CONF_FREQUENCY)] = cv.All(
-            cv.Range(
-                max=cv.frequency(max_frequency),
-                max_included=True,
-                msg=f"Component {name} cannot be used with a frequency of over {max_frequency} for the I2C bus",
-            ),
+        hub_schema[cv.Required(CONF_FREQUENCY)] = cv.Range(
+            max=cv.frequency(max_frequency),
+            max_included=True,
+            msg=f"Component {name} cannot be used with a frequency of over {max_frequency} for the I2C bus",
         )
 
     return cv.Schema(


### PR DESCRIPTION
# What does this implement/fix?

Changes pulled from #3700 by @MrEditor97

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
