### PR TITLE
Let favicon be cached

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -947,9 +947,14 @@ def make_app(debug=get_bool_env(ENV_DEV)):
 
     class StaticFileHandler(tornado.web.StaticFileHandler):
         def set_extra_headers(self, path):
-            self.set_header(
-                "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"
-            )
+            if "favicon.ico" in path:
+                self.set_header(
+                    "Cache-Control", "max-age=84600, public"
+                )
+            else:
+                self.set_header(
+                    "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"
+                )
 
     app_settings = {
         "debug": debug,

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -948,9 +948,7 @@ def make_app(debug=get_bool_env(ENV_DEV)):
     class StaticFileHandler(tornado.web.StaticFileHandler):
         def set_extra_headers(self, path):
             if "favicon.ico" in path:
-                self.set_header(
-                    "Cache-Control", "max-age=84600, public"
-                )
+                self.set_header("Cache-Control", "max-age=84600, public")
             else:
                 self.set_header(
                     "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"


### PR DESCRIPTION
# What does this implement/fix?

Caching of static assets was disabled (for good reasons) in #2025. However, it also broke caching of the favicon, which means that e.g. bookmarks in Firefox will not get any favicon.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
