### PR TITLE
Adding support for configuring timing budget

### DIFF
--- a/esphome/components/vl53l0x/sensor.py
+++ b/esphome/components/vl53l0x/sensor.py
@@ -20,6 +20,7 @@ VL53L0XSensor = vl53l0x_ns.class_(
 
 CONF_SIGNAL_RATE_LIMIT = "signal_rate_limit"
 CONF_LONG_RANGE = "long_range"
+CONF_TIMING_BUDGET = "timing_budget"
 
 
 def check_keys(obj):
@@ -54,6 +55,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_LONG_RANGE, default=False): cv.boolean,
             cv.Optional(CONF_TIMEOUT, default="10ms"): check_timeout,
             cv.Optional(CONF_ENABLE_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_TIMING_BUDGET): cv.int_range(
+                min=17000, max=4294967295, min_included=True, max_included=True
+            )
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -72,5 +76,8 @@ async def to_code(config):
     if CONF_ENABLE_PIN in config:
         enable = await cg.gpio_pin_expression(config[CONF_ENABLE_PIN])
         cg.add(var.set_enable_pin(enable))
+
+    if CONF_TIMING_BUDGET in config:
+        cg.add(var.set_timing_budget(config[CONF_TIMING_BUDGET]))
 
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/vl53l0x/sensor.py
+++ b/esphome/components/vl53l0x/sensor.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ENABLE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_TIMING_BUDGET): cv.int_range(
                 min=17000, max=4294967295, min_included=True, max_included=True
-            )
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -27,6 +27,9 @@ void VL53L0XSensor::dump_config() {
   if (this->enable_pin_ != nullptr) {
     LOG_PIN("  Enable Pin: ", this->enable_pin_);
   }
+  if (this->timing_budget_) {
+    ESP_LOGCONFIG(TAG, "  Timing Budget %u%s ", this->timing_budget_, "us");
+  }
   ESP_LOGCONFIG(TAG, "  Timeout: %u%s", this->timeout_us_, this->timeout_us_ > 0 ? "us" : " (no timeout)");
 }
 
@@ -230,7 +233,12 @@ void VL53L0XSensor::setup() {
   reg(0x84) &= ~0x10;
   reg(0x0B) = 0x01;
 
-  measurement_timing_budget_us_ = get_measurement_timing_budget_();
+  if (timing_budget_) {
+    measurement_timing_budget_us_ = timing_budget_;
+  } else {
+    measurement_timing_budget_us_ = get_measurement_timing_budget_();
+  }
+  
   reg(0x01) = 0xE8;
   set_measurement_timing_budget_(measurement_timing_budget_us_);
   reg(0x01) = 0x01;

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -238,7 +238,7 @@ void VL53L0XSensor::setup() {
   } else {
     measurement_timing_budget_us_ = get_measurement_timing_budget_();
   }
-  
+
   reg(0x01) = 0xE8;
   set_measurement_timing_budget_(measurement_timing_budget_us_);
   reg(0x01) = 0x01;

--- a/esphome/components/vl53l0x/vl53l0x_sensor.h
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.h
@@ -39,6 +39,7 @@ class VL53L0XSensor : public sensor::Sensor, public PollingComponent, public i2c
   void set_long_range(bool long_range) { long_range_ = long_range; }
   void set_timeout_us(uint32_t timeout_us) { this->timeout_us_ = timeout_us; }
   void set_enable_pin(GPIOPin *enable) { this->enable_pin_ = enable; }
+  void set_timing_budget(uint32_t timing_budget) { timing_budget_ = timing_budget; }
 
  protected:
   uint32_t get_measurement_timing_budget_();
@@ -66,6 +67,7 @@ class VL53L0XSensor : public sensor::Sensor, public PollingComponent, public i2c
 
   uint16_t timeout_start_us_;
   uint16_t timeout_us_{};
+  uint32_t timing_budget_{};
 
   static std::list<VL53L0XSensor *> vl53_sensors;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
   static bool enable_pin_setup_complete;           // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

Adding the ability to configure the timing budget used by the vl53l0x sensor. The larger the timing budget, the more accurate the reading. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2237

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: vl53l0x
    name: "VL53L0x Distance"
    address: 0x29
    update_interval: 1min
    long_range: false
    unit_of_measurement: "m"
    accuracy_decimals: 3
    timing_budget: 200000
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
