### PR TITLE
Keeloq

### DIFF
--- a/esphome/components/hcs301/__init__.py
+++ b/esphome/components/hcs301/__init__.py
@@ -1,0 +1,33 @@
+from esphome import pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_CLOCK_PIN,
+)
+
+hcs301_ns = cg.esphome_ns.namespace("hcs301")
+HCS301 = hcs301_ns.class_("HCS301", cg.Component)
+
+CONF_POWER_PIN = "power_pin"
+CONF_PWM_PIN = "pwm_pin"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(HCS301),
+        cv.Required(CONF_POWER_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_PWM_PIN): pins.internal_gpio_output_pin_schema,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    pin_power = await cg.gpio_pin_expression(config[CONF_POWER_PIN])
+    cg.add(var.set_power_pin(pin_power))
+    pin_clock = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
+    cg.add(var.set_clock_pin(pin_clock))
+    pin_pwm = await cg.gpio_pin_expression(config[CONF_PWM_PIN])
+    cg.add(var.set_pwm_pin(pin_pwm))

--- a/esphome/components/hcs301/hcs301.cpp
+++ b/esphome/components/hcs301/hcs301.cpp
@@ -1,0 +1,185 @@
+#include "esphome/core/log.h"
+#include "hcs301.h"
+
+namespace esphome {
+namespace hcs301 {
+
+static const char *TAG = "hcs301";
+
+// This is how many words the EEPROM has (12x 16 bit addresses)
+#define EEPROM_SIZE 12
+
+void HCS301::setup() {
+  if (this->power_pin_ != nullptr) {
+    this->power_pin_->setup();
+    this->power_pin_->digital_write(false);
+  }
+  if (this->clock_pin_ != nullptr) {
+    this->clock_pin_->setup();
+    this->clock_pin_->digital_write(false);
+  }
+  if (this->pwm_pin_ != nullptr) {
+    this->pwm_pin_->setup();
+    this->pwm_pin_->digital_write(false);
+  }
+}
+
+void HCS301::loop() {}
+
+void HCS301::dump_config(){
+    ESP_LOGCONFIG(TAG, "HCS301");
+    LOG_PIN("  Power Pin: ", this->power_pin_);
+    LOG_PIN("  Clock Pin: ", this->clock_pin_);
+    LOG_PIN("  PWM Pin: ", this->pwm_pin_);
+}
+
+bool HCS301::program(uint32_t serial, uint16_t sequence, uint64_t key) {
+    uint16_t eeprom_buffer[EEPROM_SIZE]; // Buffer for EEPROM Data
+    uint16_t vbuffer[EEPROM_SIZE]; // Data for verification received from device
+    
+    uint32_t seed = 0x0; // we don't handle "Secure Learn" yet
+
+    HCSConfig config;
+    config.voltage_low = (hcs301_voltage_ == HCS301_Voltage::Vcc_9_12);
+
+    // prepare the EEPROM data
+    config_eeprom_buffer_(eeprom_buffer, key, sequence, serial, seed, config);
+    // write to the HCS301
+    write_eeprom_buffer(eeprom_buffer, vbuffer);
+    // check the EEPROM readback
+    uint8_t success = 0xFF;
+    for (int i = 0; i < EEPROM_SIZE; i++){
+        ESP_LOGD(TAG, "Verify word %d, expect %04X, got %04X", i, eeprom_buffer[i], vbuffer[i]);
+        if (eeprom_buffer[i] != vbuffer[i]) {
+            success = i;
+            break;
+        }
+    }
+    if (success != 0xFF) {
+        ESP_LOGD(TAG, "Failed to program HCS301, EEPROM verification failed at word %d", success);
+        return false;
+    }
+    return true;
+}
+
+// FIXME: This should really be exposed as a Switch
+void HCS301::transmitS2() {
+    ESP_LOGD(TAG, "Triggering Transmit");
+    pwm_pin_->pin_mode(INPUT);
+    power_pin_->digital_write(true);
+    clock_pin_->digital_write(true);
+    delay(15);
+    clock_pin_->digital_write(false);
+//    power_pin_->digital_write(false);
+    ESP_LOGD(TAG, "Done");
+}
+
+void HCS301::config_eeprom_buffer_(uint16_t *eeprom_buffer, uint64_t key, uint16_t sync, uint32_t serial, uint32_t seed, struct HCSConfig hcsconfig) {
+  // Configure the secret key:
+  // Split the key up into 4 separate words inside the eeprom buffer
+  // This is accomplished by bitmasking the 64 bit key provided as an argument
+  eeprom_buffer[0] = (key & 0x000000000000ffff);          // KEY_0
+  eeprom_buffer[1] = (key & 0x00000000ffff0000) >> 16;    // KEY_1
+  eeprom_buffer[2] = (key & 0x0000ffff00000000) >> 32;    // KEY_2
+  eeprom_buffer[3] = (key & 0xffff000000000000) >> 48;    // KEY_3
+  eeprom_buffer[4] = sync;                                // SYNC
+  eeprom_buffer[5] = 0x0000;                              // RESERVED
+
+  // In the HCS301 serial numbers only use the first 28 bits. If anything is set with those first 4 bits, its an invalid serial number
+  // That being said, the bits are just ignored...
+  if (serial & 0xF0000000) {
+    ESP_LOGD(TAG, "Invalid serial number, bits 29+ set: %08X", serial);
+  }
+
+  // Take the serial number and split into 2 words by bitmask and shift.
+  eeprom_buffer[6] = (serial & 0x0000ffff);               // SERIAL_0
+  eeprom_buffer[7] = (serial & 0x0fff0000) >> 16;         // SERIAL_1 / Auto Shutoff (MSb)
+
+  // If AUTO_SHUTOFF is true, set the most significant bit (31) of the serial number.
+  // We can simply add 0x8000 to the since it will be set to zero because of the bitmask above
+  if (hcsconfig.auto_shutoff == 1) {
+    eeprom_buffer[7] |= 0x8000;
+  }
+
+  // Split the seed into 2 words
+  eeprom_buffer[8] = (seed & 0x0000ffff);                 // SEED_0
+  eeprom_buffer[9] = (seed & 0xffff0000) >> 16;           // SEED_1
+  eeprom_buffer[10] = 0x0000;                             // RESERVED
+  
+  // Setup the config.
+  uint16_t config = 0;
+  config |= hcsconfig.overflow_0 << 10;
+  config |= hcsconfig.overflow_1 << 11;
+  config |= hcsconfig.voltage_low << 12;
+  config |= hcsconfig.bsl0 << 13;
+  config |= hcsconfig.bsl1 << 14;
+
+  // Take the first 10 bit of the serial number to set the discrimination bits per the datasheet:
+  config |= (serial & 0x03ff);
+
+  eeprom_buffer[11] = config;    // CONFIG
+}
+
+void HCS301::write_eeprom_buffer(uint16_t *eeprom_buffer, uint16_t *vbuffer) {
+  // Set PWM to output mode
+  this->pwm_pin_->pin_mode(OUTPUT);
+  // Default the pwm to low
+  this->pwm_pin_->digital_write(false);
+  // Enable programming mode for the HCS301
+  // S2[CLK_PIN] High for 3.5MS
+  this->clock_pin_->digital_write(true);
+  this->power_pin_->digital_write(true);
+  // TPS for 3.5ms-4.5ms
+  delayMicroseconds(3500);
+  this->pwm_pin_->digital_write(true);
+  // TPH1 for minimum of 3.5ms
+  delayMicroseconds(3500);
+  this->pwm_pin_->digital_write(false);
+  // TPH2 for 50us
+  delayMicroseconds(50);
+  this->clock_pin_->digital_write(false);
+  // TPBW for 4.0ms
+  delay(4);
+  for (int line_number = 0; line_number < EEPROM_SIZE; line_number++) {
+    this->pwm_pin_->pin_mode(OUTPUT);
+    for (int i = 0; i <= 15; i++) {
+      bool val;
+      // Shift the buffer line_number i bits to the right, then bitmask with 0x01 to get a 0 or 1 (LOW/HIGH) and output directly to the PWM pin.
+      val = ((eeprom_buffer[line_number] >> i) & 0x01) == 0x01;
+      this->pwm_pin_->digital_write(val);
+      this->clock_pin_->digital_write(true);
+      delayMicroseconds(35);
+      this->clock_pin_->digital_write(false);
+      delayMicroseconds(35);
+    }
+    this->clock_pin_->digital_write(false);
+    this->pwm_pin_->digital_write(false);
+    // Set PWM to input mode so we can get the ack 
+    // FIXME: No check for ack?
+    this->pwm_pin_->pin_mode(INPUT);
+    // TWC for 50ms
+    delay(50);
+  }
+  // Verify Cycle.
+  this->clock_pin_->digital_write(false);
+  this->pwm_pin_->digital_write(false);
+  for (int line_number = 0; line_number < EEPROM_SIZE; line_number++) {
+    uint16_t val = 0x0000;
+    for (int i = 0; i < 16 ; i++) {
+      this->clock_pin_->digital_write(true);
+      delayMicroseconds(35);
+      // Read from LSB first...
+      val |= this->pwm_pin_->digital_read() << i;
+      this->clock_pin_->digital_write(false);
+      delayMicroseconds(35);
+    }
+    // Write the entire word to the vbuffer
+    vbuffer[line_number] = val;
+  }
+  // Turn off the HCS301
+  delay(200);
+  this->power_pin_->digital_write(false);
+}
+
+}  // namespace empty_component
+}  // namespace esphome

--- a/esphome/components/hcs301/hcs301.cpp
+++ b/esphome/components/hcs301/hcs301.cpp
@@ -7,7 +7,7 @@ namespace hcs301 {
 static const char *TAG = "hcs301";
 
 // This is how many words the EEPROM has (12x 16 bit addresses)
-#define EEPROM_SIZE 12
+static const uint8_t EEPROM_SIZE = 12;
 
 void HCS301::setup() {
   if (this->power_pin_ != nullptr) {
@@ -158,7 +158,7 @@ void HCS301::write_eeprom_buffer(uint16_t *eeprom_buffer, uint16_t *vbuffer) {
     // FIXME: No check for ack?
     this->pwm_pin_->pin_mode(INPUT);
     // TWC for 50ms
-    delay(50);
+    delay(50); // NOLINT
   }
   // Verify Cycle.
   this->clock_pin_->digital_write(false);
@@ -177,9 +177,10 @@ void HCS301::write_eeprom_buffer(uint16_t *eeprom_buffer, uint16_t *vbuffer) {
     vbuffer[line_number] = val;
   }
   // Turn off the HCS301
-  delay(200);
+  delay(200); // NOLINT
   this->power_pin_->digital_write(false);
 }
 
 }  // namespace empty_component
 }  // namespace esphome
+

--- a/esphome/components/hcs301/hcs301.cpp
+++ b/esphome/components/hcs301/hcs301.cpp
@@ -65,7 +65,7 @@ bool HCS301::program(uint32_t serial, uint16_t sequence, uint64_t key) {
 // FIXME: This should really be exposed as a Switch
 void HCS301::transmitS2() {
     ESP_LOGD(TAG, "Triggering Transmit");
-    pwm_pin_->pin_mode(INPUT);
+    pwm_pin_->pin_mode(gpio::FLAG_INPUT);
     power_pin_->digital_write(true);
     clock_pin_->digital_write(true);
     delay(15);
@@ -122,7 +122,7 @@ void HCS301::config_eeprom_buffer_(uint16_t *eeprom_buffer, uint64_t key, uint16
 
 void HCS301::write_eeprom_buffer(uint16_t *eeprom_buffer, uint16_t *vbuffer) {
   // Set PWM to output mode
-  this->pwm_pin_->pin_mode(OUTPUT);
+  this->pwm_pin_->pin_mode(gpio::FLAG_OUTPUT);
   // Default the pwm to low
   this->pwm_pin_->digital_write(false);
   // Enable programming mode for the HCS301
@@ -141,7 +141,7 @@ void HCS301::write_eeprom_buffer(uint16_t *eeprom_buffer, uint16_t *vbuffer) {
   // TPBW for 4.0ms
   delay(4);
   for (int line_number = 0; line_number < EEPROM_SIZE; line_number++) {
-    this->pwm_pin_->pin_mode(OUTPUT);
+    this->pwm_pin_->pin_mode(gpio::FLAG_OUTPUT);
     for (int i = 0; i <= 15; i++) {
       bool val;
       // Shift the buffer line_number i bits to the right, then bitmask with 0x01 to get a 0 or 1 (LOW/HIGH) and output directly to the PWM pin.
@@ -156,7 +156,7 @@ void HCS301::write_eeprom_buffer(uint16_t *eeprom_buffer, uint16_t *vbuffer) {
     this->pwm_pin_->digital_write(false);
     // Set PWM to input mode so we can get the ack 
     // FIXME: No check for ack?
-    this->pwm_pin_->pin_mode(INPUT);
+    this->pwm_pin_->pin_mode(gpio::FLAG_INPUT);
     // TWC for 50ms
     delay(50); // NOLINT
   }

--- a/esphome/components/hcs301/hcs301.h
+++ b/esphome/components/hcs301/hcs301.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace hcs301 {
+
+// Configuration Struct
+struct HCSConfig {
+  bool auto_shutoff = true;
+  bool bsl0 = false;
+  bool bsl1 = false;
+  bool voltage_low = false;
+  bool overflow_0 = false;
+  bool overflow_1 = false;
+  bool envelope_encryption = false;
+};
+
+enum class HCS301_Voltage {
+  Vcc_9_12,
+  Vcc_6,
+};
+
+class HCS301 : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void set_power_pin(GPIOPin *power_pin) { this->power_pin_ = power_pin; };
+  void set_clock_pin(GPIOPin *clock_pin) { this->clock_pin_ = clock_pin; };
+  void set_pwm_pin(GPIOPin *pwm_pin) { this->pwm_pin_ = pwm_pin; };
+  void set_hcs301_voltage(const HCS301_Voltage voltage) { this->hcs301_voltage_ = voltage; }
+  bool program(uint32_t serial, uint16_t sequence, uint64_t key);
+  void transmitS2();
+
+ protected:
+  void config_eeprom_buffer_(uint16_t *eeprom_buffer, uint64_t key, uint16_t sync, uint32_t serial, uint32_t seed, struct HCSConfig config);
+  void write_eeprom_buffer(uint16_t *eeprom_buffer, uint16_t *vbuffer);
+
+  GPIOPin *power_pin_{nullptr}; 
+  GPIOPin *clock_pin_{nullptr}; 
+  GPIOPin *pwm_pin_{nullptr};
+  HCS301_Voltage hcs301_voltage_;
+};
+
+
+}  // namespace hcs301
+}  // namespace esphome

--- a/esphome/components/hcs301/hcs301.h
+++ b/esphome/components/hcs301/hcs301.h
@@ -47,3 +47,4 @@ class HCS301 : public Component {
 
 }  // namespace hcs301
 }  // namespace esphome
+

--- a/esphome/components/hcs301/hcs301.h
+++ b/esphome/components/hcs301/hcs301.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/hal.h"
 #include "esphome/core/component.h"
 
 namespace esphome {

--- a/esphome/components/keeloq_normal_crypter/__init__.py
+++ b/esphome/components/keeloq_normal_crypter/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+keeloq_normal_crypter_ns = cg.esphome_ns.namespace("keeloq_normal_crypter")
+KeeloqNormalCrypter = keeloq_normal_crypter_ns.class_(
+    "KeeloqNormalCrypter", cg.Component
+)
+
+CONF_MANUFACTURER_KEY = "manufacturer_key"
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(KeeloqNormalCrypter),
+        cv.Optional(CONF_MANUFACTURER_KEY, default=0): cv.hex_uint64_t,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    cg.add(var.set_manufacturer_key(config[CONF_MANUFACTURER_KEY]))

--- a/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.cpp
+++ b/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.cpp
@@ -1,0 +1,103 @@
+#include "esphome/core/log.h"
+#include "keeloq_normal_crypter.h"
+
+namespace esphome {
+namespace keeloq_normal_crypter {
+
+static const char *TAG = "keeloq_normal_crypter";
+
+void KeeloqNormalCrypter::setup() {}
+
+void KeeloqNormalCrypter::loop() {}
+
+bool KeeloqNormalCrypter::decrypt(remote_base::KeeloqData &data){
+    return this->decrypt(data, this->normal_keygen(data.serial));
+}
+
+bool KeeloqNormalCrypter::encrypt(remote_base::KeeloqData &data){
+    if(!mkey_)
+        return false;
+    this->encrypt(data, this->normal_keygen(data.serial));
+    return true;
+}
+
+void KeeloqNormalCrypter::dump_config(){
+    ESP_LOGCONFIG(TAG, "Keeloq Normal Crypter: key %s", this->mkey_ == 0 ? "not set": "set");
+}
+
+
+#define KeeLoq_NLF              0x3A5C742E
+#define bit_is_set(x,n)                (((x)>>(n))&1)
+#define g5(x,a,b,c,d,e) (bit_is_set(x,a)+bit_is_set(x,b)*2+bit_is_set(x,c)*4+bit_is_set(x,d)*8+bit_is_set(x,e)*16)
+
+uint32_t keeloq_encrypt(const uint32_t data, const uint64_t key) {
+  uint32_t x = data, r;
+
+  for (r = 0; r < 528; r++) {
+    x = (x>>1)^((bit_is_set(x,0)^bit_is_set(x,16)^(uint32_t)bit_is_set(key,r&63)^bit_is_set(KeeLoq_NLF,g5(x,1,9,20,26,31)))<<31);
+  }
+
+  return x;
+}
+
+uint32_t keeloq_decrypt(const uint32_t data, const uint64_t key) {
+  uint32_t x = data, r;
+
+  for (r = 0; r < 528; r++) {
+    x = (x<<1)^bit_is_set(x,31)^bit_is_set(x,15)^(uint32_t)bit_is_set(key,(15-r)&63)^bit_is_set(KeeLoq_NLF,g5(x,0,8,19,25,30));
+  }
+
+  return x;
+}
+
+uint64_t KeeloqNormalCrypter::normal_keygen(uint32_t serial) {
+  static uint64_t key;
+  static uint32_t cached = 0;
+
+  // make sure the function code is masked out
+  serial &= 0x0fffffff;
+
+  if (serial == cached)
+    return key;
+
+  key = keeloq_decrypt(serial | 0x60000000, mkey_);
+  key = key << 32 | keeloq_decrypt(serial | 0x20000000, mkey_);
+
+  cached = serial;
+
+  return key;
+}
+
+bool KeeloqNormalCrypter::decrypt(remote_base::KeeloqData &data, uint64_t key) {
+  uint32_t clear = keeloq_decrypt(data.encrypted, key);
+  uint16_t sync = clear & 0xFFFF;
+  uint16_t chk = clear >> 16;
+
+  // compare low 10 bits of Serial Number
+  if ((chk & 0x3FF) != (data.serial & 0x3FF)) {
+    ESP_LOGD(TAG, "Failed to verify discrimination bits, expected %04X, got %04X", data.serial & 0x3FF, chk & 0x3FF);
+    return false;
+  }
+
+  // verify button code
+  if (((chk >> 12) & 0x0F) != data.button) {
+    ESP_LOGD(TAG, "Failed to verify button, expected %04X, got %04X", data.button, (chk >> 12) & 0x0F);
+    return false;
+  }
+
+  data.sync = sync;
+  ESP_LOGV(TAG, "Decrypted: Serial %07X Sync: %04X", data.serial, data.sync);
+  return true;
+}
+
+void KeeloqNormalCrypter::encrypt(remote_base::KeeloqData &data, uint64_t key) {
+  uint16_t chk = ((data.button & 0xF) << 12) | (data.serial & 0x3FF);
+  uint32_t clear = (chk << 16) | data.sync;
+  data.encrypted = keeloq_encrypt(clear, key);
+
+  ESP_LOGD(TAG, "Encrypt: Serial %07X Clear: %08X Encrypted: %08X", data.serial, clear, data.encrypted);
+}
+
+
+}  // namespace keeloq_normal_crypter
+}  // namespace esphome

--- a/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.cpp
+++ b/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.cpp
@@ -101,3 +101,4 @@ void KeeloqNormalCrypter::encrypt(remote_base::KeeloqData &data, uint64_t key) {
 
 }  // namespace keeloq_normal_crypter
 }  // namespace esphome
+

--- a/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.h
+++ b/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/remote_base/remote_base.h"
+#include "esphome/components/remote_base/keeloq_protocol.h"
+
+namespace esphome {
+namespace keeloq_normal_crypter {
+
+class KeeloqNormalCrypter : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  void set_manufacturer_key(const uint64_t key) { this->mkey_ = key; }
+  // Decrypts and validates the decrypted data against the serial number
+  bool decrypt(remote_base::KeeloqData &data);
+  bool encrypt(remote_base::KeeloqData &data);
+  bool decrypt(remote_base::KeeloqData &data, uint64_t key);
+  void encrypt(remote_base::KeeloqData &data, uint64_t key);
+  uint64_t normal_keygen(uint32_t serial);
+
+ protected:
+  uint64_t mkey_{0};
+};
+
+
+}  // namespace empty_component
+}  // namespace esphome

--- a/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.h
+++ b/esphome/components/keeloq_normal_crypter/keeloq_normal_crypter.h
@@ -27,3 +27,4 @@ class KeeloqNormalCrypter : public Component {
 
 }  // namespace empty_component
 }  // namespace esphome
+

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -356,8 +356,6 @@ async def jvc_action(var, config, args):
 CONF_ENCRYPTED = "encrypted"
 CONF_SERIAL = "serial"
 CONF_BUTTON = "button"
-CONF_LOW = "low"
-CONF_REPEAT = "repeat"
 CONF_MANUFACTURER_KEY = "manufacturer_key"
 (
     KeeloqData,
@@ -371,8 +369,6 @@ KEELOQ_SCHEMA = cv.Schema(
         cv.Optional(CONF_ENCRYPTED, default=0): cv.hex_uint32_t,
         cv.Required(CONF_SERIAL): cv.hex_uint32_t,
         cv.Required(CONF_BUTTON): cv.hex_uint8_t,
-        cv.Optional(CONF_LOW, default=False): cv.boolean,
-        cv.Optional(CONF_REPEAT, default=False): cv.boolean,
     }
 )
 
@@ -383,11 +379,8 @@ def keeloq_binary_sensor(var, config):
         var.set_data(
             cg.StructInitializer(
                 KeeloqData,
-                ("encrypted", config[CONF_ENCRYPTED]),
                 ("serial", config[CONF_SERIAL]),
                 ("button", config[CONF_BUTTON]),
-                ("low", config[CONF_LOW]),
-                ("repeat", config[CONF_REPEAT]),
             )
         )
     )
@@ -411,10 +404,6 @@ async def keeloq_action(var, config, args):
     cg.add(var.set_serial(template_))
     template_ = await cg.templatable(config[CONF_BUTTON], args, cg.uint8)
     cg.add(var.set_button(template_))
-    template_ = await cg.templatable(config[CONF_LOW], args, cg.bool)
-    cg.add(var.set_low(template_))
-    template_ = await cg.templatable(config[CONF_REPEAT], args, cg.uint8)
-    cg.add(var.set_repeat(template_))
 
 
 # LG

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -352,6 +352,71 @@ async def jvc_action(var, config, args):
     cg.add(var.set_data(template_))
 
 
+# Keeloq
+CONF_ENCRYPTED = "encrypted"
+CONF_SERIAL = "serial"
+CONF_BUTTON = "button"
+CONF_LOW = "low"
+CONF_REPEAT = "repeat"
+CONF_MANUFACTURER_KEY = "manufacturer_key"
+(
+    KeeloqData,
+    KeeloqBinarySensor,
+    KeeloqTrigger,
+    KeeloqAction,
+    KeeloqDumper,
+) = declare_protocol("Keeloq")
+KEELOQ_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_ENCRYPTED, default=0): cv.hex_uint32_t,
+        cv.Required(CONF_SERIAL): cv.hex_uint32_t,
+        cv.Required(CONF_BUTTON): cv.hex_uint8_t,
+        cv.Optional(CONF_LOW, default=False): cv.boolean,
+        cv.Optional(CONF_REPEAT, default=False): cv.boolean,
+    }
+)
+
+
+@register_binary_sensor("keeloq", KeeloqBinarySensor, KEELOQ_SCHEMA)
+def keeloq_binary_sensor(var, config):
+    cg.add(
+        var.set_data(
+            cg.StructInitializer(
+                KeeloqData,
+                ("encrypted", config[CONF_ENCRYPTED]),
+                ("serial", config[CONF_SERIAL]),
+                ("button", config[CONF_BUTTON]),
+                ("low", config[CONF_LOW]),
+                ("repeat", config[CONF_REPEAT]),
+            )
+        )
+    )
+
+
+@register_trigger("keeloq", KeeloqTrigger, KeeloqData)
+def keeloq_trigger(var, config):
+    pass
+
+
+@register_dumper("keeloq", KeeloqDumper)
+def keeloq_dumper(var, config):
+    pass
+
+
+@register_action("keeloq", KeeloqAction, KEELOQ_SCHEMA)
+async def keeloq_action(var, config, args):
+    template_ = await cg.templatable(config[CONF_ENCRYPTED], args, cg.uint32)
+    cg.add(var.set_encrypted(template_))
+    template_ = await cg.templatable(config[CONF_SERIAL], args, cg.uint32)
+    cg.add(var.set_serial(template_))
+    template_ = await cg.templatable(config[CONF_BUTTON], args, cg.uint8)
+    cg.add(var.set_button(template_))
+    template_ = await cg.templatable(config[CONF_LOW], args, cg.bool)
+    cg.add(var.set_low(template_))
+    template_ = await cg.templatable(config[CONF_REPEAT], args, cg.uint8)
+    cg.add(var.set_repeat(template_))
+
+
 # LG
 LGData, LGBinarySensor, LGTrigger, LGAction, LGDumper = declare_protocol("LG")
 LG_SCHEMA = cv.Schema(

--- a/esphome/components/remote_base/keeloq_protocol.cpp
+++ b/esphome/components/remote_base/keeloq_protocol.cpp
@@ -1,0 +1,110 @@
+#include "keeloq_protocol.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace remote_base {
+
+static const char *TAG = "remote.keeloq";
+
+static const uint8_t NBITS = 156;
+
+static const uint32_t PREAMBLE_HIGH_US = 425;
+static const uint32_t PREAMBLE_LOW_US = 325;
+static const uint32_t HEADER_LOW_US = 2700;
+
+void KeeloqProtocol::encode(RemoteTransmitData *dst, const KeeloqData &data) {
+	// not implemented
+}
+
+optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
+  KeeloqData out;
+
+  // check if we have enough bits
+  if (src.size() != NBITS) {
+    if (src.size() != 199)
+      ESP_LOGV(TAG, "Received %d bits", src.size());
+    return {};
+  }
+
+  // check if header matches
+  for (uint8_t i = 0; i < 11; i++) {
+    if (!src.expect_item(PREAMBLE_HIGH_US, PREAMBLE_LOW_US)) {
+      ESP_LOGD(TAG, "Preamble failure on bit %d, got (%d,%d)", i, src.peek(), src.peek(1));
+      return {};
+	  }
+  }
+
+  if (!src.expect_mark(PREAMBLE_HIGH_US)) {
+    ESP_LOGD(TAG, "Preamble failure, mark %d", src.peek());
+    return {};
+  }
+  // te is the elemental period, derived from the actual 
+  // HEADER_LOW period, divided by 10
+  uint32_t te = 380;
+  if (src.peek_space_at_least(HEADER_LOW_US)) {
+    int32_t header_low = src.peek();
+    te = (-header_low) / 10;
+  	src.advance();
+  } else {
+    ESP_LOGD(TAG, "Header failure: %d", src.peek());
+    return {};
+  }
+
+  out.encrypted = 0;
+  // get the first 32 encrypted bits
+  for (uint8_t i = 0; i < 32; i++) {
+    if (src.expect_item(te, 2 * te)) {
+      out.encrypted |= (1UL << i);
+    } else if (!src.expect_item(2 * te, te)) {
+      ESP_LOGD(TAG, "Failure reading encrypted bit %d, got (%d,%d)", i, src.peek(), src.peek(1));
+      return {};
+    }
+  }
+
+  out.serial = 0;
+  // get the serial number bits
+  for (uint8_t i = 0; i < 28; i++) {
+    if (src.expect_item(te, 2 * te)) {
+      out.serial |= (1UL << i);
+    } else if (!src.expect_item(2 * te, te)) {
+      ESP_LOGD(TAG, "Failure reading serial bit %d, got (%d,%d)", i, src.peek(), src.peek(1));
+      return {};
+    }
+  }
+
+  out.button = 0;
+  // get the button bits
+  for (uint8_t i = 0; i < 4; i++) {
+    if (src.expect_item(te, 2 * te)) {
+      out.button |= (1UL << i);
+    } else if (!src.expect_item(2 * te, te)) {
+      ESP_LOGD(TAG, "Failure reading button bit %d, got (%d,%d)", i, src.peek(), src.peek(1));
+      return {};
+    }
+  }
+
+  if (src.expect_item(te, 2 * te)) {
+    out.low = 1;
+  } else if (!src.expect_item(2 * te, te)) {
+    ESP_LOGD(TAG, "Failure reading low voltage bit, got (%d,%d)", src.peek(), src.peek(1));
+    return {};
+  }
+
+  // the space for the last bit merges with the space for the trailer
+  // so we just check the mark
+  if (src.expect_mark(te)) {
+    out.repeat = 1;
+  } else if (!src.expect_mark(2 * te)) {
+    ESP_LOGD(TAG, "Failure reading repeat bit, got (%d)", src.peek());
+    return {};
+  }
+
+  return out;
+}
+void KeeloqProtocol::dump(const KeeloqData &data) {
+  ESP_LOGD(TAG, "Received Keeloq: serial=%07X, encrypted=%08X, button=%01X%s%s", data.serial, data.encrypted, data.button, data.low ? " LOW": "", data.repeat? " REPEAT" : "");
+
+}
+
+}  // namespace remote_base
+}  // namespace esphome

--- a/esphome/components/remote_base/keeloq_protocol.cpp
+++ b/esphome/components/remote_base/keeloq_protocol.cpp
@@ -13,7 +13,7 @@ static const uint32_t PREAMBLE_LOW_US = 325;
 static const uint32_t HEADER_LOW_US = 2700;
 
 void KeeloqProtocol::encode(RemoteTransmitData *dst, const KeeloqData &data) {
-	// not implemented
+    // not implemented
 }
 
 optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
@@ -31,7 +31,7 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
     if (!src.expect_item(PREAMBLE_HIGH_US, PREAMBLE_LOW_US)) {
       ESP_LOGD(TAG, "Preamble failure on bit %d, got (%d,%d)", i, src.peek(), src.peek(1));
       return {};
-	  }
+    }
   }
 
   if (!src.expect_mark(PREAMBLE_HIGH_US)) {
@@ -44,7 +44,7 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
   if (src.peek_space_at_least(HEADER_LOW_US)) {
     int32_t header_low = src.peek();
     te = (-header_low) / 10;
-  	src.advance();
+    src.advance();
   } else {
     ESP_LOGD(TAG, "Header failure: %d", src.peek());
     return {};

--- a/esphome/components/remote_base/keeloq_protocol.h
+++ b/esphome/components/remote_base/keeloq_protocol.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "remote_base.h"
+
+namespace esphome {
+namespace remote_base {
+
+struct KeeloqData {
+	uint32_t encrypted;
+	uint32_t serial;
+	uint8_t button;
+	bool low;
+	bool repeat;
+  uint16_t sync = 0;
+
+  bool operator==(const KeeloqData &rhs) const { return serial == rhs.serial && button == rhs.button; }
+};
+
+class KeeloqProtocol : public RemoteProtocol<KeeloqData> {
+ public:
+  void encode(RemoteTransmitData *dst, const KeeloqData &data) override;
+  optional<KeeloqData> decode(RemoteReceiveData src) override;
+  void dump(const KeeloqData &data) override;
+};
+
+DECLARE_REMOTE_PROTOCOL(Keeloq)
+
+template<typename... Ts> class KeeloqAction : public RemoteTransmitterActionBase<Ts...> {
+ public:
+  TEMPLATABLE_VALUE(uint32_t, encrypted)
+  TEMPLATABLE_VALUE(uint32_t, serial)
+  TEMPLATABLE_VALUE(uint8_t, button)
+  TEMPLATABLE_VALUE(bool, low)
+  TEMPLATABLE_VALUE(bool, repeat)
+//  TEMPLATABLE_VALUE(uint16_t, sync)
+
+  void encode(RemoteTransmitData *dst, Ts... x) override {
+    KeeloqData data{};
+    data.encrypted = this->encrypted_.value(x...);
+    data.serial = this->serial_.value(x...);
+    data.button = this->button_.value(x...);
+    data.low = this->low_.value(x...);
+    data.repeat = this->repeat_.value(x...);
+//    data.sync = this->sync_.value(x...);
+    KeeloqProtocol().encode(dst, data);
+  }
+};
+
+}  // namespace remote_base
+}  // namespace esphome

--- a/esphome/components/remote_base/keeloq_protocol.h
+++ b/esphome/components/remote_base/keeloq_protocol.h
@@ -7,14 +7,14 @@ namespace esphome {
 namespace remote_base {
 
 struct KeeloqData {
-	uint32_t encrypted;
-	uint32_t serial;
-	uint8_t button;
-	bool low;
-	bool repeat;
-  uint16_t sync = 0;
+    uint32_t encrypted;
+    uint32_t serial;
+    uint8_t button;
+    bool low;
+    bool repeat;
+    uint16_t sync = 0;
 
-  bool operator==(const KeeloqData &rhs) const { return serial == rhs.serial && button == rhs.button; }
+    bool operator==(const KeeloqData &rhs) const { return serial == rhs.serial && button == rhs.button; }
 };
 
 class KeeloqProtocol : public RemoteProtocol<KeeloqData> {


### PR DESCRIPTION
# What does this implement/fix?

This adds an implementation of a decoder for the Keeloq protocol

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [X] STM32 (Only hardware I have that has a radio at 403.92MHz)

NB: This decoder is carrier frequency independent, and should work just fine at 433.92MHz too!

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
keeloq_normal_crypter:
  id: keeloq_crypter
  # e.g. keeloq_manufacturer_key: 0x0123456789abcdef
  manufacturer_key: !secret keeloq_manufacturer_key

text_sensor:
  - platform: template
    name: "Keeloq Remote"
    id: keeloq_remote

remote_receiver:
  id: receiver
  pin:
    number: PA_3
    mode: INPUT
  buffer_size: 200
  tolerance: 30%
#  dump: keeloq
  on_keeloq:
    then:
      - lambda: |-
          char buff[20];
          if (id(keeloq_crypter).decrypt(x)) {
            snprintf(buff, sizeof(buff), "%07x:%1x:%04X:%c:%c",
                     x.serial, x.button, x.sync, x.low ? 'L' : 'N', x.repeat ? 'R' : 'F');
          } else {
            snprintf(buff, sizeof(buff), "%07x:%1x::%c:%c",
                     x.serial, x.button, x.low ? 'L' : 'N', x.repeat ? 'R' : 'F');
          }
          std::string buffAsStdStr = buff;
          id(keeloq_remote).publish_state(buff);

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
