### PR TITLE
add log messages for bad pronto codes

### DIFF
--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -106,6 +106,7 @@ void ProntoProtocol::send_pronto_(RemoteTransmitData *dst, const std::vector<uin
   ESP_LOGD(TAG, "Send Pronto: intros=%d", intros);
   ESP_LOGD(TAG, "Send Pronto: repeats=%d", repeats);
   if (NUMBERS_IN_PREAMBLE + intros + repeats != data.size()) {  // inconsistent sizes
+    ESP_LOGE(TAG, "Inconsistent data, not sending");
     return;
   }
 

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -113,6 +113,10 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     this->rmt_temp_.push_back(rmt_item);
   }
 
+  if ((this->rmt_temp_.data() == nullptr) || (this->rmt_temp_.size() == 0)) {
+    ESP_LOGE(TAG, "Empty data");
+    return;
+  }
   for (uint32_t i = 0; i < send_times; i++) {
     esp_err_t error = rmt_write_items(this->channel_, this->rmt_temp_.data(), this->rmt_temp_.size(), true);
     if (error != ESP_OK) {

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -113,7 +113,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     this->rmt_temp_.push_back(rmt_item);
   }
 
-  if ((this->rmt_temp_.data() == nullptr) || (this->rmt_temp_.size() == 0)) {
+  if ((this->rmt_temp_.data() == nullptr) || this->rmt_temp_.empty()) {
     ESP_LOGE(TAG, "Empty data");
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

A bad pronto code causes an abort in the decode, but the transmission can't be aborted, so the transmitter has empty data to send.  This causes a hard to understand error from the low-level framework.  This PR adds log messages and avoids the bad send.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3275

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
