### PR TITLE
mcp23017: read output latch registers during setup

### DIFF
--- a/esphome/components/mcp23008/mcp23008.cpp
+++ b/esphome/components/mcp23008/mcp23008.cpp
@@ -14,6 +14,9 @@ void MCP23008::setup() {
     return;
   }
 
+  // Read current output register state
+  this->read_reg(mcp23x08_base::MCP23X08_OLAT, &this->olat_);
+
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
     this->write_reg(mcp23x08_base::MCP23X08_IOCON, 0x04);

--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -15,6 +15,10 @@ void MCP23016::setup() {
     return;
   }
 
+  // Read current output register state
+  this->read_reg_(MCP23016_OLAT0, &this->olat_0_);
+  this->read_reg_(MCP23016_OLAT1, &this->olat_1_);
+
   // all pins input
   this->write_reg_(MCP23016_IODIR0, 0xFF);
   this->write_reg_(MCP23016_IODIR1, 0xFF);

--- a/esphome/components/mcp23017/mcp23017.cpp
+++ b/esphome/components/mcp23017/mcp23017.cpp
@@ -14,6 +14,10 @@ void MCP23017::setup() {
     return;
   }
 
+  // Read current output register state
+  this->read_reg(mcp23x17_base::MCP23X17_OLATA, &this->olat_a_);
+  this->read_reg(mcp23x17_base::MCP23X17_OLATB, &this->olat_b_);
+
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
     this->write_reg(mcp23x17_base::MCP23X17_IOCONA, 0x04);

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -23,6 +23,9 @@ void MCP23S08::setup() {
   this->transfer_byte(0b00011000);  // Enable HAEN pins for addressing
   this->disable();
 
+  // Read current output register state
+  this->read_reg(mcp23x08_base::MCP23X08_OLAT, &this->olat_);
+
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
     this->write_reg(mcp23x08_base::MCP23X08_IOCON, 0x04);

--- a/esphome/components/mcp23s17/mcp23s17.cpp
+++ b/esphome/components/mcp23s17/mcp23s17.cpp
@@ -23,6 +23,10 @@ void MCP23S17::setup() {
   this->transfer_byte(0b00011000);  // Enable HAEN pins for addressing
   this->disable();
 
+  // Read current output register state
+  this->read_reg(mcp23x17_base::MCP23X17_OLATA, &this->olat_a_);
+  this->read_reg(mcp23x17_base::MCP23X17_OLATB, &this->olat_b_);
+
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
     this->write_reg(mcp23x17_base::MCP23X17_IOCONA, 0x04);


### PR DESCRIPTION
# What does this implement/fix?

During setup of the MCP23017 (and probably other MCP23xxx variants), the current code assumes that the output register state is 0x00. If active-high relays are connected to a board, the relays click briefly during a **reboot** of the ESP because the assumed register state does not match the current state (if the MCP is not reset along with the ESP).
The click is entirely prevented if the current output register state is read during setup, so that the cached values match the output latch register states.

Note: I assume that a similar fix is required for the other MCP23xxx variants, but I do not have any of these variants.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
