### PR TITLE
ibeacon support for the ble_rssi sensor

### DIFF
--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -12,20 +12,32 @@ namespace ble_rssi {
 class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   void set_address(uint64_t address) {
-    this->by_address_ = true;
+    this->match_by_ = MATCH_BY_MAC_ADDRESS;
     this->address_ = address;
   }
   void set_service_uuid16(uint16_t uuid) {
-    this->by_address_ = false;
+    this->match_by_ = MATCH_BY_SERVICE_UUID;
     this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_uint16(uuid);
   }
   void set_service_uuid32(uint32_t uuid) {
-    this->by_address_ = false;
+    this->match_by_ = MATCH_BY_SERVICE_UUID;
     this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_uint32(uuid);
   }
   void set_service_uuid128(uint8_t *uuid) {
-    this->by_address_ = false;
+    this->match_by_ = MATCH_BY_SERVICE_UUID;
     this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(uuid);
+  }
+  void set_ibeacon_uuid(uint8_t *uuid) {
+    this->match_by_ = MATCH_BY_IBEACON_UUID;
+    this->ibeacon_uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(uuid);
+  }
+  void set_ibeacon_major(uint16_t major) {
+    this->check_ibeacon_major_ = true;
+    this->ibeacon_major_ = major;
+  }
+  void set_ibeacon_minor(uint16_t minor) {
+    this->check_ibeacon_minor_ = true;
+    this->ibeacon_minor_ = minor;
   }
   void on_scan_end() override {
     if (!this->found_)
@@ -33,20 +45,45 @@ class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDevi
     this->found_ = false;
   }
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
-    if (this->by_address_) {
-      if (device.address_uint64() == this->address_) {
-        this->publish_state(device.get_rssi());
-        this->found_ = true;
-        return true;
-      }
-    } else {
-      for (auto uuid : device.get_service_uuids()) {
-        if (this->uuid_ == uuid) {
+    switch (this->match_by_) {
+      case MATCH_BY_MAC_ADDRESS:
+        if (device.address_uint64() == this->address_) {
           this->publish_state(device.get_rssi());
           this->found_ = true;
           return true;
         }
-      }
+        break;
+      case MATCH_BY_SERVICE_UUID:
+        for (auto uuid : device.get_service_uuids()) {
+          if (this->uuid_ == uuid) {
+            this->publish_state(device.get_rssi());
+            this->found_ = true;
+            return true;
+          }
+        }
+        break;
+      case MATCH_BY_IBEACON_UUID:
+        if (!device.get_ibeacon().has_value()) {
+          return false;
+        }
+
+        auto ibeacon = device.get_ibeacon().value();
+
+        if (this->ibeacon_uuid_ != ibeacon.get_uuid()) {
+          return false;
+        }
+
+        if (this->check_ibeacon_major_ && this->ibeacon_major_ != ibeacon.get_major()) {
+          return false;
+        }
+
+        if (this->check_ibeacon_minor_ && this->ibeacon_minor_ != ibeacon.get_minor()) {
+          return false;
+        }
+
+        this->publish_state(device.get_rssi());
+        this->found_ = true;
+        return true;
     }
     return false;
   }
@@ -54,10 +91,20 @@ class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDevi
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
+  enum MatchType { MATCH_BY_MAC_ADDRESS, MATCH_BY_SERVICE_UUID, MATCH_BY_IBEACON_UUID };
+  MatchType match_by_;
+
   bool found_{false};
-  bool by_address_{false};
+
   uint64_t address_;
+
   esp32_ble_tracker::ESPBTUUID uuid_;
+
+  esp32_ble_tracker::ESPBTUUID ibeacon_uuid_;
+  uint16_t ibeacon_major_;
+  bool check_ibeacon_major_;
+  uint16_t ibeacon_minor_;
+  bool check_ibeacon_minor_;
 };
 
 }  // namespace ble_rssi

--- a/esphome/components/ble_rssi/sensor.py
+++ b/esphome/components/ble_rssi/sensor.py
@@ -2,6 +2,9 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, esp32_ble_tracker
 from esphome.const import (
+    CONF_IBEACON_MAJOR,
+    CONF_IBEACON_MINOR,
+    CONF_IBEACON_UUID,
     CONF_SERVICE_UUID,
     CONF_MAC_ADDRESS,
     DEVICE_CLASS_SIGNAL_STRENGTH,
@@ -16,6 +19,15 @@ BLERSSISensor = ble_rssi_ns.class_(
     "BLERSSISensor", sensor.Sensor, cg.Component, esp32_ble_tracker.ESPBTDeviceListener
 )
 
+
+def _validate(config):
+    if CONF_IBEACON_MAJOR in config and CONF_IBEACON_UUID not in config:
+        raise cv.Invalid("iBeacon major identifier requires iBeacon UUID")
+    if CONF_IBEACON_MINOR in config and CONF_IBEACON_UUID not in config:
+        raise cv.Invalid("iBeacon minor identifier requires iBeacon UUID")
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(
         BLERSSISensor,
@@ -28,11 +40,15 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
+            cv.Optional(CONF_IBEACON_MAJOR): cv.uint16_t,
+            cv.Optional(CONF_IBEACON_MINOR): cv.uint16_t,
+            cv.Optional(CONF_IBEACON_UUID): cv.uuid,
         }
     )
     .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA),
-    cv.has_exactly_one_key(CONF_MAC_ADDRESS, CONF_SERVICE_UUID),
+    cv.has_exactly_one_key(CONF_MAC_ADDRESS, CONF_SERVICE_UUID, CONF_IBEACON_UUID),
+    _validate,
 )
 
 
@@ -60,3 +76,13 @@ async def to_code(config):
         elif len(config[CONF_SERVICE_UUID]) == len(esp32_ble_tracker.bt_uuid128_format):
             uuid128 = esp32_ble_tracker.as_reversed_hex_array(config[CONF_SERVICE_UUID])
             cg.add(var.set_service_uuid128(uuid128))
+
+    if CONF_IBEACON_UUID in config:
+        ibeacon_uuid = esp32_ble_tracker.as_hex_array(str(config[CONF_IBEACON_UUID]))
+        cg.add(var.set_ibeacon_uuid(ibeacon_uuid))
+
+        if CONF_IBEACON_MAJOR in config:
+            cg.add(var.set_ibeacon_major(config[CONF_IBEACON_MAJOR]))
+
+        if CONF_IBEACON_MINOR in config:
+            cg.add(var.set_ibeacon_minor(config[CONF_IBEACON_MINOR]))

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -96,6 +96,9 @@ sensor:
   - platform: ble_rssi
     service_uuid: '11223344-5566-7788-99aa-bbccddeeff00'
     name: 'BLE Test Service 128'
+  - platform: ble_rssi
+    service_uuid: '11223344-5566-7788-99aa-bbccddeeff00'
+    name: 'BLE Test iBeacon UUID'
   - platform: b_parasite
     mac_address: F0:CA:F0:CA:01:01
     humidity:


### PR DESCRIPTION
# What does this implement/fix?

The PR adds support to the ble_rssi sensor to track iBeacon devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2248

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esp32_ble_tracker:

sensor:
  - platform: ble_rssi
    ibeacon_uuid: '80dc42c2-90d9-49ef-84b9-cf6c00c37665'
    name: "iBeacon RSSI"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
