### PR TITLE
Captive portal show nearby WiFi with no ssid configured

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -73,8 +73,11 @@ void WiFiComponent::setup() {
       ESP_LOGV(TAG, "Setting Output Power Option failed!");
     }
 #ifdef USE_CAPTIVE_PORTAL
-    if (captive_portal::global_captive_portal != nullptr)
+    if (captive_portal::global_captive_portal != nullptr) {
+      this->wifi_sta_pre_setup_();
+      this->start_scanning();
       captive_portal::global_captive_portal->start();
+    }
 #endif
   }
 #ifdef USE_IMPROV


### PR DESCRIPTION
# What does this implement/fix?

Fix starts wifi scanning even if STA is not configured in case captive portal is enabled. Scanning results are used by the captive portal to show WiFi networks nearby.

I'm not sure in the correctness of this fix and probably there were good reasons not to initiate scanning in case of AP only. Moreover in verbose mode after scanning is started and before STA is configured I started to see messages like these repeating every loop iteration:
```
[V][component:199]: Component mdns took a long time for an operation (0.05 s).
[V][component:200]: Components should block for at most 20-30ms.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3527
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
wifi:
  ap: {} # This spawns an AP with the device name and mac address with no password.

mdns:
  disabled: false

captive_portal:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
