### PR TITLE
Add the same docker tags as used in HA

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -88,10 +88,12 @@ def main():
                 sys.exit(1)
 
     # detect channel from tag
-    match = re.match(r'^\d+\.\d+(?:\.\d+)?(b\d+)?$', args.tag)
+    match = re.match(r"^(\d+\.\d+)(?:\.\d+)?(b\d+)?$", args.tag)
+    major_minor_version = None
     if match is None:
         channel = CHANNEL_DEV
-    elif match.group(1) is None:
+    elif match.group(2) is None:
+        major_minor_version = match.group(1)
         channel = CHANNEL_RELEASE
     else:
         channel = CHANNEL_BETA
@@ -105,6 +107,11 @@ def main():
         # Additionally push to beta
         tags_to_push.append("beta")
         tags_to_push.append("latest")
+
+        # Compatibility with HA tags
+        if major_minor_version:
+            tags_to_push.append("stable")
+            tags_to_push.append(major_minor_version)
 
     if args.command == "build":
         # 1. pull cache image


### PR DESCRIPTION
# What does this implement/fix?

This change adds `YEAR.MONTH` tags for the esphome's docker container.

Home Assistant provides the following docker tags for each stable release:

- stable
- latest
- `YEAR.MONTH`

Every patch release (`YEAR.MONTH.patch`) has the same base set of tags. This way, a user
can set up a container using, for example, tag `2022.8` and update it automatically without the fear
of any unexpected breaking changes.

I'll update the docs if you decide to approve this PR (I'm bad with the documentation, so don't want to do it for something that won't be merged, sorry about this 😅).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/feature-requests#1614

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2260

## Test Environment

N/A

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).