### PR TITLE
Various ili9341 fixes

### DIFF
--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -89,12 +89,12 @@ void ILI9341Display::display_() {
   uint32_t start_pos = ((this->y_low_ * this->width_) + x_low_);
 
   // check if something was displayed
-  if ((this->x_high_ < this->x_low_ ) || (this->y_high_ < this->y_low_ )) return; // NOLINT
+  if ((this->x_high_ < this->x_low_ ) || (this->y_high_ < this->y_low_ )) {return;}
 
   set_addr_window_(this->x_low_, this->y_low_, w, h);
 
   ESP_LOGD("ILI9341", "Start ILI9341Display::display_(xl:%d, xh:%d, yl:%d, yh:%d, w:%d, h:%d, start_pos:%d)",
-           this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos );
+           this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos);
 
   this->start_data_();
   for (uint16_t row = 0; row < h; row++) {
@@ -132,7 +132,7 @@ void ILI9341Display::fill(Color color) {
 void ILI9341Display::fill_internal_(uint8_t color) {
   memset(transfer_buffer_, color, sizeof(transfer_buffer_));
 
-  uint32_t rem = (this->get_buffer_length_()*2);
+  uint32_t rem = (this->get_buffer_length_() * 2);
 
   this->set_addr_window_(0, 0, this->get_width_internal(), this->get_height_internal());
   this->start_data_();
@@ -149,7 +149,7 @@ void ILI9341Display::fill_internal_(uint8_t color) {
 }
 
 void ILI9341Display::rotate_my_(uint8_t m) {
-  uint8_t rotation = m & 3; // can't be higher than 3
+  uint8_t rotation = m & 3;  // can't be higher than 3
   switch (rotation) {
     case 0:
       m = (MADCTL_MX | MADCTL_BGR);
@@ -192,7 +192,7 @@ void HOT ILI9341Display::draw_absolute_pixel_internal(int x, int y, Color color)
 
   if (buffer_[pos] != new_color) {
     buffer_[pos] = new_color;
-  // low and high watermark may speed up drawing from buffer
+    // low and high watermark may speed up drawing from buffer
     this->x_low_ = (x < this->x_low_) ? x : this->x_low_;
     this->y_low_ = (y < this->y_low_) ? y : this->y_low_;
     this->x_high_ = (x > this->x_high_) ? x : this->x_high_;

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -89,7 +89,7 @@ void ILI9341Display::display_() {
   uint32_t start_pos = ((this->y_low_ * this->width_) + x_low_);
 
   // check if something was displayed
-  if ((this->x_high_ < this->x_low_) || (this->y_high_ < this->y_low_ )) {
+  if ((this->x_high_ < this->x_low_) || (this->y_high_ < this->y_low_)) {
     return;
   }
 

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -96,7 +96,7 @@ void ILI9341Display::display_() {
   set_addr_window_(this->x_low_, this->y_low_, w, h);
 
   ESP_LOGVV("ILI9341", "Start ILI9341Display::display_(xl:%d, xh:%d, yl:%d, yh:%d, w:%d, h:%d, start_pos:%d)",
-           this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos);
+            this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos);
 
   this->start_data_();
   for (uint16_t row = 0; row < h; row++) {
@@ -113,7 +113,7 @@ void ILI9341Display::display_() {
     App.feed_wdt();
   }
   this->end_data_();
- 
+
   // invalidate watermarks
   this->x_low_ = this->width_;
   this->y_low_ = this->height_;

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -89,7 +89,9 @@ void ILI9341Display::display_() {
   uint32_t start_pos = ((this->y_low_ * this->width_) + x_low_);
 
   // check if something was displayed
-  if ((this->x_high_ < this->x_low_ ) || (this->y_high_ < this->y_low_ )) {return;}
+  if ((this->x_high_ < this->x_low_) || (this->y_high_ < this->y_low_ )) {
+    return;
+  }
 
   set_addr_window_(this->x_low_, this->y_low_, w, h);
 

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -28,11 +28,9 @@ void ILI9341Display::setup_pins_() {
 
 void ILI9341Display::dump_config() {
   LOG_DISPLAY("", "ili9341", this);
-  //ESP_LOGCONFIG(TAG, "  Width: %d, Height: %d,  Rotation: %d", this->width_, this->height_, this->rotation_); // already shown in the line above.
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
- // LOG_PIN("  Backlight Pin: ", this->led_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
 
@@ -90,11 +88,13 @@ void ILI9341Display::display_() {
   uint16_t h = this->y_high_ - this->y_low_ + 1;
   uint32_t start_pos = ((this->y_low_ * this->width_) + x_low_);
 
-  if ((this->x_high_ < this->x_low_ ) || (this->y_high_ < this->y_low_ )) return; // check i something was displayed
+  // check if something was displayed
+  if ((this->x_high_ < this->x_low_ ) || (this->y_high_ < this->y_low_ )) return; // NOLINT
 
   set_addr_window_(this->x_low_, this->y_low_, w, h);
 
-  ESP_LOGD("ILI9341", "Start ILI9341Display::display_(xl:%d, xh:%d, yl:%d, yh:%d, w:%d, h:%d, start_pos:%d)",this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos );
+  ESP_LOGD("ILI9341", "Start ILI9341Display::display_(xl:%d, xh:%d, yl:%d, yh:%d, w:%d, h:%d, start_pos:%d)",
+           this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos );
 
   this->start_data_();
   for (uint16_t row = 0; row < h; row++) {
@@ -149,28 +149,28 @@ void ILI9341Display::fill_internal_(uint8_t color) {
 }
 
 void ILI9341Display::rotate_my_(uint8_t m) {
-  uint8_t rotation = m && 3; // can't be higher than 3
+  uint8_t rotation = m & 3; // can't be higher than 3
   switch (rotation) {
-  case 0:
-    m = (MADCTL_MX | MADCTL_BGR);
-   // _width = ILI9341_TFTWIDTH;
-   // _height = ILI9341_TFTHEIGHT;
-    break;
-  case 1:
-    m = (MADCTL_MV | MADCTL_BGR);
-    //_width = ILI9341_TFTHEIGHT;
-    //_height = ILI9341_TFTWIDTH;
-    break;
-  case 2:
-    m = (MADCTL_MY | MADCTL_BGR);
-    //_width = ILI9341_TFTWIDTH;
-    //_height = ILI9341_TFTHEIGHT;
-    break;
-  case 3:
-    m = (MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR);
-    //_width = ILI9341_TFTHEIGHT;
-    //_height = ILI9341_TFTWIDTH;
-    break;
+    case 0:
+      m = (MADCTL_MX | MADCTL_BGR);
+      // _width = ILI9341_TFTWIDTH;
+      // _height = ILI9341_TFTHEIGHT;
+      break;
+    case 1:
+      m = (MADCTL_MV | MADCTL_BGR);
+      // _width = ILI9341_TFTHEIGHT;
+      // _height = ILI9341_TFTWIDTH;
+      break;
+    case 2:
+      m = (MADCTL_MY | MADCTL_BGR);
+      // _width = ILI9341_TFTWIDTH;
+      // _height = ILI9341_TFTHEIGHT;
+      break;
+    case 3:
+      m = (MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR);
+      // _width = ILI9341_TFTHEIGHT;
+      // _height = ILI9341_TFTWIDTH;
+      break;
   }
 
   this->command(ILI9341_MADCTL);
@@ -190,11 +190,11 @@ void HOT ILI9341Display::draw_absolute_pixel_internal(int x, int y, Color color)
     new_color = display::ColorUtil::color_to_index8_palette888(color, this->palette_);
   }
 
-  if (buffer_[pos] != new_color) { //
+  if (buffer_[pos] != new_color) {
     buffer_[pos] = new_color;
   // low and high watermark may speed up drawing from buffer
-    this->x_low_  = (x < this->x_low_)  ? x : this->x_low_;
-    this->y_low_  = (y < this->y_low_)  ? y : this->y_low_;
+    this->x_low_ = (x < this->x_low_) ? x : this->x_low_;
+    this->y_low_ = (y < this->y_low_) ? y : this->y_low_;
     this->x_high_ = (x > this->x_high_) ? x : this->x_high_;
     this->y_high_ = (y > this->y_high_) ? y : this->y_high_;
   }

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -10,7 +10,6 @@ namespace ili9341 {
 static const char *const TAG = "ili9341";
 
 void ILI9341Display::setup_pins_() {
-  this->init_internal_(this->get_buffer_length_());
   this->dc_pin_->setup();  // OUTPUT
   this->dc_pin_->digital_write(false);
   if (this->reset_pin_ != nullptr) {
@@ -34,7 +33,8 @@ void ILI9341Display::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-float ILI9341Display::get_setup_priority() const { return setup_priority::PROCESSOR; }
+float ILI9341Display::get_setup_priority() const { return setup_priority::HARDWARE; }
+
 void ILI9341Display::command(uint8_t value) {
   this->start_command_();
   this->write_byte(value);
@@ -95,7 +95,7 @@ void ILI9341Display::display_() {
 
   set_addr_window_(this->x_low_, this->y_low_, w, h);
 
-  ESP_LOGD("ILI9341", "Start ILI9341Display::display_(xl:%d, xh:%d, yl:%d, yh:%d, w:%d, h:%d, start_pos:%d)",
+  ESP_LOGVV("ILI9341", "Start ILI9341Display::display_(xl:%d, xh:%d, yl:%d, yh:%d, w:%d, h:%d, start_pos:%d)",
            this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos);
 
   this->start_data_();
@@ -113,8 +113,7 @@ void ILI9341Display::display_() {
     App.feed_wdt();
   }
   this->end_data_();
-  ESP_LOGD("ILI9341", "Finish ILI9341Display::display_()");
-
+ 
   // invalidate watermarks
   this->x_low_ = this->width_;
   this->y_low_ = this->height_;
@@ -284,7 +283,6 @@ void ILI9341M5Stack::initialize() {
   this->width_ = 320;
   this->height_ = 240;
   this->invert_display_(true);
-  this->fill_internal_(0x00);
 }
 
 //   24_TFT display
@@ -292,7 +290,6 @@ void ILI9341TFT24::initialize() {
   this->init_lcd_(INITCMD_TFT);
   this->width_ = 240;
   this->height_ = 320;
-  this->fill_internal_(0x00);
 }
 
 //   24_TFT rotated display
@@ -300,7 +297,6 @@ void ILI9341TFT24R::initialize() {
   this->init_lcd_(INITCMD_TFT);
   this->width_ = 320;
   this->height_ = 240;
-  this->fill_internal_(0x00);
 }
 
 }  // namespace ili9341

--- a/esphome/components/ili9341/ili9341_display.cpp
+++ b/esphome/components/ili9341/ili9341_display.cpp
@@ -28,11 +28,11 @@ void ILI9341Display::setup_pins_() {
 
 void ILI9341Display::dump_config() {
   LOG_DISPLAY("", "ili9341", this);
-  ESP_LOGCONFIG(TAG, "  Width: %d, Height: %d,  Rotation: %d", this->width_, this->height_, this->rotation_);
+  //ESP_LOGCONFIG(TAG, "  Width: %d, Height: %d,  Rotation: %d", this->width_, this->height_, this->rotation_); // already shown in the line above.
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
-  LOG_PIN("  Backlight Pin: ", this->led_pin_);
+ // LOG_PIN("  Backlight Pin: ", this->led_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
 
@@ -88,10 +88,15 @@ void ILI9341Display::display_() {
   // we will only update the changed window to the display
   uint16_t w = this->x_high_ - this->x_low_ + 1;
   uint16_t h = this->y_high_ - this->y_low_ + 1;
+  uint32_t start_pos = ((this->y_low_ * this->width_) + x_low_);
+
+  if ((this->x_high_ < this->x_low_ ) || (this->y_high_ < this->y_low_ )) return; // check i something was displayed
 
   set_addr_window_(this->x_low_, this->y_low_, w, h);
+
+  ESP_LOGD("ILI9341", "Start ILI9341Display::display_(xl:%d, xh:%d, yl:%d, yh:%d, w:%d, h:%d, start_pos:%d)",this->x_low_, this->x_high_, this->y_low_, this->y_high_, w, h, start_pos );
+
   this->start_data_();
-  uint32_t start_pos = ((this->y_low_ * this->width_) + x_low_);
   for (uint16_t row = 0; row < h; row++) {
     uint32_t pos = start_pos + (row * width_);
     uint32_t rem = w;
@@ -101,9 +106,12 @@ void ILI9341Display::display_() {
       this->write_array(transfer_buffer_, 2 * sz);
       pos += sz;
       rem -= sz;
+      App.feed_wdt();
     }
+    App.feed_wdt();
   }
   this->end_data_();
+  ESP_LOGD("ILI9341", "Finish ILI9341Display::display_()");
 
   // invalidate watermarks
   this->x_low_ = this->width_;
@@ -121,20 +129,10 @@ void ILI9341Display::fill(Color color) {
   this->y_high_ = this->get_height_internal() - 1;
 }
 
-void ILI9341Display::fill_internal_(Color color) {
-  if (color.raw_32 == Color::BLACK.raw_32) {
-    memset(transfer_buffer_, 0, sizeof(transfer_buffer_));
-  } else {
-    uint8_t *dst = transfer_buffer_;
-    auto color565 = display::ColorUtil::color_to_565(color);
+void ILI9341Display::fill_internal_(uint8_t color) {
+  memset(transfer_buffer_, color, sizeof(transfer_buffer_));
 
-    while (dst < transfer_buffer_ + sizeof(transfer_buffer_)) {
-      *dst++ = (uint8_t)(color565 >> 8);
-      *dst++ = (uint8_t) color565;
-    }
-  }
-
-  uint32_t rem = this->get_width_internal() * this->get_height_internal();
+  uint32_t rem = (this->get_buffer_length_()*2);
 
   this->set_addr_window_(0, 0, this->get_width_internal(), this->get_height_internal());
   this->start_data_();
@@ -147,26 +145,58 @@ void ILI9341Display::fill_internal_(Color color) {
 
   this->end_data_();
 
-  memset(buffer_, 0, (this->get_width_internal()) * (this->get_height_internal()));
+  memset(buffer_, color, this->get_buffer_length_());
+}
+
+void ILI9341Display::rotate_my_(uint8_t m) {
+  uint8_t rotation = m && 3; // can't be higher than 3
+  switch (rotation) {
+  case 0:
+    m = (MADCTL_MX | MADCTL_BGR);
+   // _width = ILI9341_TFTWIDTH;
+   // _height = ILI9341_TFTHEIGHT;
+    break;
+  case 1:
+    m = (MADCTL_MV | MADCTL_BGR);
+    //_width = ILI9341_TFTHEIGHT;
+    //_height = ILI9341_TFTWIDTH;
+    break;
+  case 2:
+    m = (MADCTL_MY | MADCTL_BGR);
+    //_width = ILI9341_TFTWIDTH;
+    //_height = ILI9341_TFTHEIGHT;
+    break;
+  case 3:
+    m = (MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR);
+    //_width = ILI9341_TFTHEIGHT;
+    //_height = ILI9341_TFTWIDTH;
+    break;
+  }
+
+  this->command(ILI9341_MADCTL);
+  this->data(m);
 }
 
 void HOT ILI9341Display::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
 
-  // low and high watermark may speed up drawing from buffer
-  this->x_low_ = (x < this->x_low_) ? x : this->x_low_;
-  this->y_low_ = (y < this->y_low_) ? y : this->y_low_;
-  this->x_high_ = (x > this->x_high_) ? x : this->x_high_;
-  this->y_high_ = (y > this->y_high_) ? y : this->y_high_;
-
   uint32_t pos = (y * width_) + x;
+  uint8_t new_color;
+
   if (this->buffer_color_mode_ == BITS_8) {
-    uint8_t color332 = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
-    buffer_[pos] = color332;
+    new_color = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
   } else {  // if (this->buffer_color_mode_ == BITS_8_INDEXED) {
-    uint8_t index = display::ColorUtil::color_to_index8_palette888(color, this->palette_);
-    buffer_[pos] = index;
+    new_color = display::ColorUtil::color_to_index8_palette888(color, this->palette_);
+  }
+
+  if (buffer_[pos] != new_color) { //
+    buffer_[pos] = new_color;
+  // low and high watermark may speed up drawing from buffer
+    this->x_low_  = (x < this->x_low_)  ? x : this->x_low_;
+    this->y_low_  = (y < this->y_low_)  ? y : this->y_low_;
+    this->x_high_ = (x > this->x_high_) ? x : this->x_high_;
+    this->y_high_ = (y > this->y_high_) ? y : this->y_high_;
   }
 }
 
@@ -252,7 +282,7 @@ void ILI9341M5Stack::initialize() {
   this->width_ = 320;
   this->height_ = 240;
   this->invert_display_(true);
-  this->fill_internal_(Color::BLACK);
+  this->fill_internal_(0x00);
 }
 
 //   24_TFT display
@@ -260,7 +290,7 @@ void ILI9341TFT24::initialize() {
   this->init_lcd_(INITCMD_TFT);
   this->width_ = 240;
   this->height_ = 320;
-  this->fill_internal_(Color::BLACK);
+  this->fill_internal_(0x00);
 }
 
 //   24_TFT rotated display
@@ -268,7 +298,7 @@ void ILI9341TFT24R::initialize() {
   this->init_lcd_(INITCMD_TFT);
   this->width_ = 320;
   this->height_ = 240;
-  this->fill_internal_(Color::BLACK);
+  this->fill_internal_(0x00);
 }
 
 }  // namespace ili9341

--- a/esphome/components/ili9341/ili9341_display.h
+++ b/esphome/components/ili9341/ili9341_display.h
@@ -5,6 +5,7 @@
 #include "esphome/components/display/display_buffer.h"
 #include "ili9341_defines.h"
 #include "ili9341_init.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace ili9341 {
@@ -45,8 +46,17 @@ class ILI9341Display : public PollingComponent,
 
   void dump_config() override;
   void setup() override {
+
     this->setup_pins_();
     this->initialize();
+
+    this->x_low_ = this->width_;
+    this->y_low_ = this->height_;
+    this->x_high_ = 0;
+    this->y_high_ = 0;
+
+    this->init_internal_(this->get_buffer_length_());
+    this->fill_internal_(0x00);
   }
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }

--- a/esphome/components/ili9341/ili9341_display.h
+++ b/esphome/components/ili9341/ili9341_display.h
@@ -46,7 +46,6 @@ class ILI9341Display : public PollingComponent,
 
   void dump_config() override;
   void setup() override {
-
     this->setup_pins_();
     this->initialize();
 

--- a/esphome/components/ili9341/ili9341_display.h
+++ b/esphome/components/ili9341/ili9341_display.h
@@ -59,8 +59,9 @@ class ILI9341Display : public PollingComponent,
   void set_addr_window_(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   void invert_display_(bool invert);
   void reset_();
-  void fill_internal_(Color color);
+  void fill_internal_(uint8_t color);
   void display_();
+  void rotate_my_(uint8_t m);
 
   ILI9341Model model_;
   int16_t width_{320};   ///< Display width as modified by current rotation


### PR DESCRIPTION
- display_() crashed when noting needed to be displayed.
- simplyfied the fill_internal_() and fill buffer_ and screen same color
- the update area is now only being updated when the pixel changed
- fixed initiation clear screen where only half the screen was cleared

# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
