### PR TITLE
Advanced pio options

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -701,12 +701,18 @@ class EsphomeCore:
         _LOGGER.debug("Adding define: %s", define)
         return define
 
-    def add_platformio_option(self, key: str, value: Union[str, List[str]]) -> None:
+    def add_platformio_option(
+        self,
+        key: str,
+        value: Union[str, List[str]],
+        force_override: Optional[bool] = None,
+    ) -> None:
         new_val = value
-        old_val = self.platformio_options.get(key)
-        if isinstance(old_val, list):
-            assert isinstance(value, list)
-            new_val = old_val + value
+        if not force_override:
+            old_val = self.platformio_options.get(key)
+            if isinstance(old_val, list):
+                assert isinstance(value, list)
+                new_val = old_val + value
         self.platformio_options[key] = new_val
 
     def _get_variable_generator(self, id):

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -590,7 +590,9 @@ def add_define(name: str, value: SafeExpType = None):
         CORE.add_define(Define(name, safe_exp(value)))
 
 
-def add_platformio_option(key: str, value: Union[str, List[str]], force_override: Optional[bool] = None):
+def add_platformio_option(
+    key: str, value: Union[str, List[str]], force_override: Optional[bool] = None
+):
     CORE.add_platformio_option(key, value, force_override)
 
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -590,8 +590,8 @@ def add_define(name: str, value: SafeExpType = None):
         CORE.add_define(Define(name, safe_exp(value)))
 
 
-def add_platformio_option(key: str, value: Union[str, List[str]]):
-    CORE.add_platformio_option(key, value)
+def add_platformio_option(key: str, value: Union[str, List[str]], force_override: Optional[bool] = None):
+    CORE.add_platformio_option(key, value, force_override)
 
 
 async def get_variable(id_: ID) -> "MockObj":

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -11,6 +11,9 @@ esphome:
   board: nodemcu-32s
   platformio_options:
     board_build.partitions: huge_app.csv
+    platform_packages:
+      value: ""
+      override: true
   on_boot:
     priority: 150.0
     then:
@@ -565,14 +568,14 @@ sensor:
     temperature:
       name: "Living Room Temperature 5"
     humidity:
-      name: 'Living Room Humidity 5'
+      name: "Living Room Humidity 5"
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: hdc1080
     temperature:
-      name: 'Living Room Temperature 6'
+      name: "Living Room Temperature 6"
     humidity:
-      name: 'Living Room Humidity 5'
+      name: "Living Room Humidity 5"
     update_interval: 15s
     i2c_id: i2c_bus
   - platform: hlw8012
@@ -2091,7 +2094,44 @@ switch:
     turn_on_action:
       remote_transmitter.transmit_aeha:
         address: 0x8008
-        data: [0x00, 0x02, 0xFD, 0xFF, 0x00, 0x33, 0xCC, 0x49, 0xB6, 0xC8, 0x37, 0x16, 0xE9, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0xCA, 0x35, 0x8F, 0x70, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF]
+        data:
+          [
+            0x00,
+            0x02,
+            0xFD,
+            0xFF,
+            0x00,
+            0x33,
+            0xCC,
+            0x49,
+            0xB6,
+            0xC8,
+            0x37,
+            0x16,
+            0xE9,
+            0x00,
+            0xFF,
+            0x00,
+            0xFF,
+            0x00,
+            0xFF,
+            0x00,
+            0xFF,
+            0x00,
+            0xFF,
+            0xCA,
+            0x35,
+            0x8F,
+            0x70,
+            0x00,
+            0xFF,
+            0x00,
+            0xFF,
+            0x00,
+            0xFF,
+            0x00,
+            0xFF,
+          ]
   - platform: template
     name: Living Room Lights
     id: livingroom_lights

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -513,6 +513,16 @@ class TestEsphomeCore:
 
         assert t == other
 
+    def test_platformio_options(self, target):
+        target.add_platformio_option("list", ["value1"])
+        target.add_platformio_option("list", ["value2"])
+
+        assert target.platformio_options["list"] == ["value1", "value2"]
+
+        target.add_platformio_option("list", "only1", True)
+
+        assert target.platformio_options["list"] == "only1"
+
     def test_address__none(self, target):
         target.config = {}
         assert target.address is None
@@ -530,14 +540,35 @@ class TestEsphomeCore:
 
         assert target.address == "4.3.2.1"
 
+    def test_is_esp8266(self, target):
+        target.data[const.KEY_CORE] = {const.KEY_TARGET_PLATFORM: "esp8266"}
+
+        assert target.is_esp32 is False
+        assert target.is_esp8266 is True
+
     def test_is_esp32(self, target):
         target.data[const.KEY_CORE] = {const.KEY_TARGET_PLATFORM: "esp32"}
 
         assert target.is_esp32 is True
         assert target.is_esp8266 is False
 
-    def test_is_esp8266(self, target):
-        target.data[const.KEY_CORE] = {const.KEY_TARGET_PLATFORM: "esp8266"}
 
-        assert target.is_esp32 is False
-        assert target.is_esp8266 is True
+#   def test_is_esp32_arduino(self, target):
+#       target.data[const.KEY_CORE] = {const.KEY_TARGET_FRAMEWORK: "arduino"}
+#
+#       assert target.using_arduino is True
+#       assert target.using_esp_idf is False
+#
+#   def test_is_esp32_espidf(self, target):
+#       target.data[const.KEY_CORE] = {const.KEY_TARGET_FRAMEWORK: "esp-idf"}
+#
+#       assert target.using_arduino is False
+#       assert target.using_esp_idf is True
+#
+#   def test_is_esp32_arduino_espidf(self, target):
+#       target.data[const.KEY_CORE] = {
+#           const.KEY_TARGET_FRAMEWORK: ["arduino", "esp-idf"]
+#       }
+#
+#       assert target.using_arduino is True
+#       assert target.using_esp_idf is True


### PR DESCRIPTION
# What does this implement/fix?

For some more advanced use-cases one might need more control over the entries of the `platformio.ini` file.
This PR allows users to (force) override an entry in this file. Original syntax remains unchanged, but to override the value in `platformio.ini` an optional boolean is added. See example below.

This added functionality makes development of code that requires features from newer than recommended framework or platform a whole lot easier. Especially when relying on other platform / framework sources.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2261

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test1
  platformio_options:
    # Regular line
    board_build.partitions: huge_app.csv
    # Forced empty by override:
    platform_packages:
      value: ""
      override: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
