### PR TITLE
Ignore NaN states in the integration component

### DIFF
--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -23,6 +23,8 @@ void IntegrationSensor::setup() {
 }
 void IntegrationSensor::dump_config() { LOG_SENSOR("", "Integration Sensor", this); }
 void IntegrationSensor::process_sensor_value_(float value) {
+  if (std::isnan(value))
+    return;
   const uint32_t now = millis();
   const double old_value = this->last_value_;
   const double new_value = value;


### PR DESCRIPTION
# What does this implement/fix?

Ignore NaN's in the integration component. This is inline with other similar components (e.g. total_daily_energy). No other obvious case found where NaN handling is missing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3531

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
- platform: homeassistant
    id: mains_voltage
    entity_id: sensor.pzem_004t_v3_voltage
    internal: true
    filters:
      - delta: 0.01 # Prevent repetitive actions using the same value

#   ^^^^^^^^^ Output of this can be NaN

  - platform: template
    update_interval: 1s
    internal: true
    name: ${friendly_devicename} Power
    id: floor_power
    state_class: measurement
    device_class: power
    accuracy_decimals: 0
    unit_of_measurement: "W"
    icon: "mdi:flash"
    lambda: |-
      return id(heater).state * powf(id(mains_voltage).state, 2.0f) / ${floor_resistance};
    filters:
      - delta: 0.01 # Prevent repetitive actions using the same value

  - platform: integration
    name: ${friendly_devicename} Energy
    sensor: floor_power
    time_unit: h
    restore: true
    accuracy_decimals: 3
    unit_of_measurement: "kWh"
    icon: "mdi:flash"
    device_class: energy
    state_class: total_increasing
    filters:
      - multiply: 0.001 # Wh to kWh
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
