### PR TITLE
Update modbus_controller.cpp

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -236,7 +236,7 @@ size_t ModbusController::create_register_ranges_() {
       }
     }
 
-    if (curr->start_address == r.start_address) {
+    if (curr->start_address == r.start_address && curr->register_type == r.register_type) {
       // use the lowest non zero value for the whole range
       // Because zero is the default value for skip_updates it is excluded from getting the min value.
       if (curr->skip_updates != 0) {


### PR DESCRIPTION
# What does this implement/fix?
Fix issue when there several types of modbus sensor types in config (i.e. read, discrete_input) and each type of registers starts from modbus address 0x00

i.e
Discrete inputs register type (Funcion 0x02):
Sensor 1 - address 0x00
Sensor 2 - address 0x01
Sensor 3 - address 0x02

Read register type (Function 0x04):
Sensor 4 - address 0x00
Sensor 5 - address 0x01
Sensor 6 - address 0x02

existing code will skip Sensor 4 from ranges creation, this will never be polled

Quick description and explanation of changes
Change to modbuscontroller.cpp  ModbusController::create_register_ranges_() 

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ x] ESP32
- [ ] ESP32 IDF
- [ x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
