### PR TITLE
Add dynamic filtering to bluetooth_proxy

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1128,14 +1128,14 @@ message BluetoothLEAdvertisementResponse {
   repeated BluetoothServiceData manufacturer_data = 6;
 }
 
-message BluetoothListAddressesRequest {
+message BluetoothAddressIgnoreListRequest {
   option (id) = 68;
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_BLUETOOTH_PROXY";
   // Empty
 }
 
-message BluetoothListAddressesResponse {
+message BluetoothAddressIgnoreListResponse {
   option (id) = 69;
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_BLUETOOTH_PROXY";

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1127,3 +1127,18 @@ message BluetoothLEAdvertisementResponse {
   repeated BluetoothServiceData service_data = 5;
   repeated BluetoothServiceData manufacturer_data = 6;
 }
+
+message BluetoothListAddressesRequest {
+  option (id) = 68;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+  // Empty
+}
+
+message BluetoothListAddressesResponse {
+  option (id) = 69;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  repeated uint64 addresses = 1;
+}

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -104,6 +104,12 @@ class APIConnection : public APIServerConnection {
       return false;
     return this->send_bluetooth_le_advertisement_response(call);
   }
+  bool request_bluetooth_address_list() {
+    return this->send_bluetooth_list_addresses_request(BluetoothListAddressesRequest());
+  }
+  void on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &msg) override {
+    this->parent_->on_bluetooth_list_addresses_response(msg);
+  }
 #endif
 #ifdef USE_HOMEASSISTANT_TIME
   void send_time_request() {
@@ -190,7 +196,7 @@ class APIConnection : public APIServerConnection {
   uint32_t last_traffic_;
   bool sent_ping_{false};
   bool service_call_subscription_{false};
-  bool bluetooth_le_advertisement_subscription_{true};
+  bool bluetooth_le_advertisement_subscription_{false};
   bool next_close_ = false;
   APIServer *parent_;
   InitialStateIterator initial_state_iterator_;

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -104,11 +104,11 @@ class APIConnection : public APIServerConnection {
       return false;
     return this->send_bluetooth_le_advertisement_response(call);
   }
-  bool request_bluetooth_address_list() {
-    return this->send_bluetooth_list_addresses_request(BluetoothListAddressesRequest());
+  bool request_bluetooth_address_ignore_list() {
+    return this->send_bluetooth_address_ignore_list_request(BluetoothAddressIgnoreListRequest());
   }
-  void on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &msg) override {
-    this->parent_->on_bluetooth_list_addresses_response(msg);
+  void on_bluetooth_address_ignore_list_response(const BluetoothAddressIgnoreListResponse &msg) override {
+    this->parent_->on_bluetooth_address_ignore_list_response(msg);
   }
 #endif
 #ifdef USE_HOMEASSISTANT_TIME

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -5000,11 +5000,13 @@ void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void BluetoothListAddressesRequest::encode(ProtoWriteBuffer buffer) const {}
+void BluetoothAddressIgnoreListRequest::encode(ProtoWriteBuffer buffer) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
-void BluetoothListAddressesRequest::dump_to(std::string &out) const { out.append("BluetoothListAddressesRequest {}"); }
+void BluetoothAddressIgnoreListRequest::dump_to(std::string &out) const {
+  out.append("BluetoothAddressIgnoreListRequest {}");
+}
 #endif
-bool BluetoothListAddressesResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothAddressIgnoreListResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
       this->addresses.push_back(value.as_uint64());
@@ -5014,15 +5016,15 @@ bool BluetoothListAddressesResponse::decode_varint(uint32_t field_id, ProtoVarIn
       return false;
   }
 }
-void BluetoothListAddressesResponse::encode(ProtoWriteBuffer buffer) const {
+void BluetoothAddressIgnoreListResponse::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->addresses) {
     buffer.encode_uint64(1, it, true);
   }
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
-void BluetoothListAddressesResponse::dump_to(std::string &out) const {
+void BluetoothAddressIgnoreListResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
-  out.append("BluetoothListAddressesResponse {\n");
+  out.append("BluetoothAddressIgnoreListResponse {\n");
   for (const auto &it : this->addresses) {
     out.append("  addresses: ");
     sprintf(buffer, "%llu", it);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -5000,6 +5000,38 @@ void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+void BluetoothListAddressesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothListAddressesRequest::dump_to(std::string &out) const { out.append("BluetoothListAddressesRequest {}"); }
+#endif
+bool BluetoothListAddressesResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->addresses.push_back(value.as_uint64());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothListAddressesResponse::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->addresses) {
+    buffer.encode_uint64(1, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothListAddressesResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothListAddressesResponse {\n");
+  for (const auto &it : this->addresses) {
+    out.append("  addresses: ");
+    sprintf(buffer, "%llu", it);
+    out.append(buffer);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1254,7 +1254,7 @@ class BluetoothLEAdvertisementResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothListAddressesRequest : public ProtoMessage {
+class BluetoothAddressIgnoreListRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1263,7 +1263,7 @@ class BluetoothListAddressesRequest : public ProtoMessage {
 
  protected:
 };
-class BluetoothListAddressesResponse : public ProtoMessage {
+class BluetoothAddressIgnoreListResponse : public ProtoMessage {
  public:
   std::vector<uint64_t> addresses{};
   void encode(ProtoWriteBuffer buffer) const override;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1254,6 +1254,26 @@ class BluetoothLEAdvertisementResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+class BluetoothListAddressesRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class BluetoothListAddressesResponse : public ProtoMessage {
+ public:
+  std::vector<uint64_t> addresses{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -185,7 +185,8 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
 #endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
+    const SubscribeHomeAssistantStateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
 #endif
@@ -705,7 +706,8 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(
+    const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;
@@ -727,7 +729,8 @@ void APIServerConnection::on_subscribe_home_assistant_states_request(const Subsc
   }
   this->subscribe_home_assistant_states(msg);
 }
-void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
+void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
+    const SubscribeBluetoothLEAdvertisementsRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -185,8 +185,7 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
 #endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
-    const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
 #endif
@@ -335,6 +334,16 @@ bool APIServerConnectionBase::send_bluetooth_le_advertisement_response(const Blu
 #endif
   return this->send_message_<BluetoothLEAdvertisementResponse>(msg, 67);
 }
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_list_addresses_request(const BluetoothListAddressesRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_list_addresses_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothListAddressesRequest>(msg, 68);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
 #endif
 bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
   switch (msg_type) {
@@ -612,6 +621,17 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       this->on_subscribe_bluetooth_le_advertisements_request(msg);
       break;
     }
+    case 69: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothListAddressesResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_list_addresses_response: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_list_addresses_response(msg);
+#endif
+      break;
+    }
     default:
       return false;
   }
@@ -685,8 +705,7 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(
-    const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;
@@ -708,8 +727,7 @@ void APIServerConnection::on_subscribe_home_assistant_states_request(const Subsc
   }
   this->subscribe_home_assistant_states(msg);
 }
-void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
-    const SubscribeBluetoothLEAdvertisementsRequest &msg) {
+void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -336,11 +336,11 @@ bool APIServerConnectionBase::send_bluetooth_le_advertisement_response(const Blu
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-bool APIServerConnectionBase::send_bluetooth_list_addresses_request(const BluetoothListAddressesRequest &msg) {
+bool APIServerConnectionBase::send_bluetooth_address_ignore_list_request(const BluetoothAddressIgnoreListRequest &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  ESP_LOGVV(TAG, "send_bluetooth_list_addresses_request: %s", msg.dump().c_str());
+  ESP_LOGVV(TAG, "send_bluetooth_address_ignore_list_request: %s", msg.dump().c_str());
 #endif
-  return this->send_message_<BluetoothListAddressesRequest>(msg, 68);
+  return this->send_message_<BluetoothAddressIgnoreListRequest>(msg, 68);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -623,12 +623,12 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
     }
     case 69: {
 #ifdef USE_BLUETOOTH_PROXY
-      BluetoothListAddressesResponse msg;
+      BluetoothAddressIgnoreListResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_list_addresses_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_address_ignore_list_response: %s", msg.dump().c_str());
 #endif
-      this->on_bluetooth_list_addresses_response(msg);
+      this->on_bluetooth_address_ignore_list_response(msg);
 #endif
       break;
     }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -159,10 +159,10 @@ class APIServerConnectionBase : public ProtoService {
   bool send_bluetooth_le_advertisement_response(const BluetoothLEAdvertisementResponse &msg);
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  bool send_bluetooth_list_addresses_request(const BluetoothListAddressesRequest &msg);
+  bool send_bluetooth_address_ignore_list_request(const BluetoothAddressIgnoreListRequest &msg);
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  virtual void on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &value){};
+  virtual void on_bluetooth_address_ignore_list_response(const BluetoothAddressIgnoreListResponse &value){};
 #endif
  protected:
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -154,10 +154,15 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_MEDIA_PLAYER
   virtual void on_media_player_command_request(const MediaPlayerCommandRequest &value){};
 #endif
-  virtual void on_subscribe_bluetooth_le_advertisements_request(
-      const SubscribeBluetoothLEAdvertisementsRequest &value){};
+  virtual void on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &value){};
 #ifdef USE_BLUETOOTH_PROXY
   bool send_bluetooth_le_advertisement_response(const BluetoothLEAdvertisementResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_list_addresses_request(const BluetoothListAddressesRequest &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &value){};
 #endif
  protected:
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -154,7 +154,8 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_MEDIA_PLAYER
   virtual void on_media_player_command_request(const MediaPlayerCommandRequest &value){};
 #endif
-  virtual void on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &value){};
+  virtual void on_subscribe_bluetooth_le_advertisements_request(
+      const SubscribeBluetoothLEAdvertisementsRequest &value){};
 #ifdef USE_BLUETOOTH_PROXY
   bool send_bluetooth_le_advertisement_response(const BluetoothLEAdvertisementResponse &msg);
 #endif

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -297,6 +297,18 @@ void APIServer::send_bluetooth_le_advertisement(const BluetoothLEAdvertisementRe
     client->send_bluetooth_le_advertisement(call);
   }
 }
+
+void APIServer::request_bluetooth_address_list(std::function<void(const std::vector<uint64_t> &)> &&callback) {
+  this->bluetooth_address_list_callback_ = std::move(callback);
+  for (auto &client : this->clients_) {
+    client->request_bluetooth_address_list();
+  }
+}
+void APIServer::on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &msg) {
+  if (this->bluetooth_address_list_callback_ != nullptr) {
+    this->bluetooth_address_list_callback_(msg.addresses);
+  }
+}
 #endif
 APIServer::APIServer() { global_api_server = this; }
 void APIServer::subscribe_home_assistant_state(std::string entity_id, optional<std::string> attribute,

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -298,15 +298,15 @@ void APIServer::send_bluetooth_le_advertisement(const BluetoothLEAdvertisementRe
   }
 }
 
-void APIServer::request_bluetooth_address_list(std::function<void(const std::vector<uint64_t> &)> &&callback) {
-  this->bluetooth_address_list_callback_ = std::move(callback);
+void APIServer::request_bluetooth_address_ignore_list(std::function<void(const std::vector<uint64_t> &)> &&callback) {
+  this->bluetooth_address_ignore_list_callback_ = std::move(callback);
   for (auto &client : this->clients_) {
-    client->request_bluetooth_address_list();
+    client->request_bluetooth_address_ignore_list();
   }
 }
-void APIServer::on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &msg) {
-  if (this->bluetooth_address_list_callback_ != nullptr) {
-    this->bluetooth_address_list_callback_(msg.addresses);
+void APIServer::on_bluetooth_address_ignore_list_response(const BluetoothAddressIgnoreListResponse &msg) {
+  if (this->bluetooth_address_ignore_list_callback_ != nullptr) {
+    this->bluetooth_address_ignore_list_callback_(msg.addresses);
   }
 }
 #endif

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -75,6 +75,8 @@ class APIServer : public Component, public Controller {
   void send_homeassistant_service_call(const HomeassistantServiceResponse &call);
 #ifdef USE_BLUETOOTH_PROXY
   void send_bluetooth_le_advertisement(const BluetoothLEAdvertisementResponse &call);
+  void request_bluetooth_address_list(std::function<void(const std::vector<uint64_t> &)> &&callback);
+  void on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &msg);
 #endif
   void register_user_service(UserServiceDescriptor *descriptor) { this->user_services_.push_back(descriptor); }
 #ifdef USE_HOMEASSISTANT_TIME
@@ -107,6 +109,10 @@ class APIServer : public Component, public Controller {
 #ifdef USE_API_NOISE
   std::shared_ptr<APINoiseContext> noise_ctx_ = std::make_shared<APINoiseContext>();
 #endif  // USE_API_NOISE
+
+#ifdef USE_BLUETOOTH_PROXY
+  std::function<void(const std::vector<uint64_t> &)> bluetooth_address_list_callback_;
+#endif
 };
 
 extern APIServer *global_api_server;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -75,8 +75,8 @@ class APIServer : public Component, public Controller {
   void send_homeassistant_service_call(const HomeassistantServiceResponse &call);
 #ifdef USE_BLUETOOTH_PROXY
   void send_bluetooth_le_advertisement(const BluetoothLEAdvertisementResponse &call);
-  void request_bluetooth_address_list(std::function<void(const std::vector<uint64_t> &)> &&callback);
-  void on_bluetooth_list_addresses_response(const BluetoothListAddressesResponse &msg);
+  void request_bluetooth_address_ignore_list(std::function<void(const std::vector<uint64_t> &)> &&callback);
+  void on_bluetooth_address_ignore_list_response(const BluetoothAddressIgnoreListResponse &msg);
 #endif
   void register_user_service(UserServiceDescriptor *descriptor) { this->user_services_.push_back(descriptor); }
 #ifdef USE_HOMEASSISTANT_TIME
@@ -111,7 +111,7 @@ class APIServer : public Component, public Controller {
 #endif  // USE_API_NOISE
 
 #ifdef USE_BLUETOOTH_PROXY
-  std::function<void(const std::vector<uint64_t> &)> bluetooth_address_list_callback_;
+  std::function<void(const std::vector<uint64_t> &)> bluetooth_address_ignore_list_callback_;
 #endif
 };
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -13,7 +13,42 @@ namespace bluetooth_proxy {
 
 static const char *const TAG = "bluetooth_proxy";
 
+void BluetoothProxy::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up Bluetooth Proxy...");
+#ifdef USE_API
+  api::global_api_server->request_bluetooth_address_list([this](const std::vector<uint64_t> &addresses) {
+    for (const auto &address : addresses) {
+#ifdef ESPHOME_LOG_HAS_VERBOSE
+      esp_bd_addr_t addr;
+      addr[0] = (address >> 40) & 0xFF;
+      addr[1] = (address >> 32) & 0xFF;
+      addr[2] = (address >> 24) & 0xFF;
+      addr[3] = (address >> 16) & 0xFF;
+      addr[4] = (address >> 8) & 0xFF;
+      addr[5] = (address >> 0) & 0xFF;
+
+      ESP_LOGV(TAG, "Adding %02X:%02X:%02X:%02X:%02X:%02X to whitelist", addr[0], addr[1], addr[2], addr[3], addr[4],
+               addr[5]);
+#endif
+      this->whitelist_[address] = -1;
+    }
+  });
+#endif
+}
+
 bool BluetoothProxy::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+  uint64_t addr64 = device.address_uint64();
+  if (this->whitelist_.size() > 0) {
+    if (this->whitelist_.find(addr64) == this->whitelist_.end()) {
+      this->whitelist_[addr64] = 0;
+    }
+    int8_t v = this->whitelist_[addr64];
+    if (v >= 3) {
+      return false;
+    } else if (v != -1) {
+      this->whitelist_[addr64] = v + 1;
+    }
+  }
   ESP_LOGV(TAG, "Proxying packet from %s - %s. RSSI: %d dB", device.get_name().c_str(), device.address_str().c_str(),
            device.get_rssi());
   this->send_api_packet_(device);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -40,7 +40,7 @@ void BluetoothProxy::setup() {
 
 bool BluetoothProxy::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   uint64_t addr64 = device.address_uint64();
-  if (this->ignore_list_.size() > 0) {
+  if (!this->ignore_list_.empty()) {
     if (std::find(this->ignore_list_.begin(), this->ignore_list_.end(), addr64) != this->ignore_list_.end()) {
       ESP_LOGV(TAG, "Ignoring packet from %s - %s. RSSI: %d dB", device.get_name().c_str(),
                device.address_str().c_str(), device.get_rssi());

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -23,7 +23,7 @@ class BluetoothProxy : public Component, public esp32_ble_tracker::ESPBTDeviceLi
  protected:
   void send_api_packet_(const esp32_ble_tracker::ESPBTDevice &device);
 
-  std::map<uint64_t, int8_t> whitelist_;
+  std::vector<uint64_t> ignore_list_;
 };
 
 }  // namespace bluetooth_proxy

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -3,6 +3,7 @@
 #ifdef USE_ESP32
 
 #include <map>
+#include <vector>
 
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/core/automation.h"
@@ -13,11 +14,16 @@ namespace bluetooth_proxy {
 
 class BluetoothProxy : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
+  void setup() override;
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
 
+  float get_setup_priority() const override { return setup_priority::AFTER_CONNECTION; }
+
  protected:
   void send_api_packet_(const esp32_ble_tracker::ESPBTDevice &device);
+
+  std::map<uint64_t, int8_t> whitelist_;
 };
 
 }  // namespace bluetooth_proxy


### PR DESCRIPTION
# What does this implement/fix?

This allows Home Assistant (or other client) to send a list of addresses for the Bluetooth Proxy to filter on. It will also temporarily send 3 packets from unknown devices for discovery purposes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
