### PR TITLE
Remove floating point calculation from ac_dimmer ISR

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -203,7 +203,7 @@ void AcDimmer::setup() {
 #endif
 }
 void AcDimmer::write_state(float state) {
-  state = acos(1 - (2 * state)) / 3.14159;  // RMS power compensation
+  state = std::acos(1 - (2 * state)) / 3.14159;  // RMS power compensation
   auto new_value = static_cast<uint16_t>(roundf(state * 65535));
   if (new_value != 0 && this->store_.value == 0)
     this->store_.init_cycle = this->init_with_half_cycle_;

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -122,7 +122,7 @@ void IRAM_ATTR HOT AcDimmerDataStore::gpio_intr() {
       // also take into account min_power
       auto min_us = this->cycle_time_us * this->min_power / 1000;
       this->enable_time_us = std::max((uint32_t) 1, ((65535 - this->value) * (this->cycle_time_us - min_us)) / 65535);
-      
+
       if (this->method == DIM_METHOD_LEADING_PULSE) {
         // Minimum pulse time should be enough for the triac to trigger when it is close to the ZC zone
         // this is for brightness near 99%

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -203,7 +203,7 @@ void AcDimmer::setup() {
 #endif
 }
 void AcDimmer::write_state(float state) {
-  state = acos(1 - (2 * state)) / 3.14159; // RMS power compensation
+  state = acos(1 - (2 * state)) / 3.14159;  // RMS power compensation
   auto new_value = static_cast<uint16_t>(roundf(state * 65535));
   if (new_value != 0 && this->store_.value == 0)
     this->store_.init_cycle = this->init_with_half_cycle_;

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -121,11 +121,8 @@ void IRAM_ATTR HOT AcDimmerDataStore::gpio_intr() {
       // calculate time until enable in µs: (1.0-value)*cycle_time, but with integer arithmetic
       // also take into account min_power
       auto min_us = this->cycle_time_us * this->min_power / 1000;
-      // calculate required value to provide a true RMS voltage output
-      this->enable_time_us =
-          std::max((uint32_t) 1, (uint32_t)((65535 - (acos(1 - (2 * this->value / 65535.0)) / 3.14159 * 65535)) *
-                                            (this->cycle_time_us - min_us)) /
-                                     65535);
+      this->enable_time_us = std::max((uint32_t) 1, ((65535 - this->value) * (this->cycle_time_us - min_us)) / 65535);
+      
       if (this->method == DIM_METHOD_LEADING_PULSE) {
         // Minimum pulse time should be enough for the triac to trigger when it is close to the ZC zone
         // this is for brightness near 99%
@@ -206,6 +203,7 @@ void AcDimmer::setup() {
 #endif
 }
 void AcDimmer::write_state(float state) {
+  state = acos(1 - (2 * state)) / 3.14159; // RMS power compensation
   auto new_value = static_cast<uint16_t>(roundf(state * 65535));
   if (new_value != 0 && this->store_.value == 0)
     this->store_.init_cycle = this->init_with_half_cycle_;


### PR DESCRIPTION
# What does this implement/fix?

PR<https://github.com/esphome/esphome/pull/3494> added code to linearize the RMS power output of the ac_dimmer relative to the output state. Doing so introduced an acos into the ISR, which most of the time works, but some race condition exists that causes this call to throw an exception when doing stuff like OTA, setting a new value in home assistant, or sometimes it just keeps working (depending on what version of ESPHome you're running and your luck).

The RMS power linearization only needs to be computed when a new state is written, as it doesn't vary cycle to cycle. This PR moves the acos function outside the ISR into the write_state function where it shouldn't cause problems. 

The original PR was considered breaking because it might change how gamma is perceived on some lights. The linearization previously applied only to leading dimmers, while now it applies to both, so it might change how gamma is perceived on trailing dimmers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [3509](https://github.com/esphome/issues/issues/3509)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: ac_dimmer
    id: dimmer1
    gate_pin: 
      number: GPIO13
      inverted: true
    zero_cross_pin: GPIO12
    min_power: 0.2
    zero_means_zero: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - n/a Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
