### PR TITLE
Add pin aliases for upesy boards

### DIFF
--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -984,6 +984,9 @@ ESP32_BOARD_PINS = {
         "D13": 2,
     },
     "xinabox_cw02": {"LED": 27},
+    "upesy_wroom": {"LED": 2},
+    "upesy_wroom_lp": {},
+    "upesy_wrover": {"LED": 2},
 }
 
 """
@@ -1180,4 +1183,7 @@ BOARD_TO_VARIANT = {
     "wipy3": VARIANT_ESP32,
     "wt32-eth01": VARIANT_ESP32,
     "xinabox_cw02": VARIANT_ESP32,
+    "upesy_wroom": VARIANT_ESP32,
+    "upesy_wroom_lp": VARIANT_ESP32,
+    "upesy_wrover": VARIANT_ESP32,
 }

--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -985,7 +985,6 @@ ESP32_BOARD_PINS = {
     },
     "xinabox_cw02": {"LED": 27},
     "upesy_wroom": {"LED": 2},
-    "upesy_wroom_lp": {},
     "upesy_wrover": {"LED": 2},
 }
 
@@ -1183,7 +1182,4 @@ BOARD_TO_VARIANT = {
     "wipy3": VARIANT_ESP32,
     "wt32-eth01": VARIANT_ESP32,
     "xinabox_cw02": VARIANT_ESP32,
-    "upesy_wroom": VARIANT_ESP32,
-    "upesy_wroom_lp": VARIANT_ESP32,
-    "upesy_wrover": VARIANT_ESP32,
 }


### PR DESCRIPTION
# What does this implement/fix?

Adds uPesy ESP32 boards with pin aliases. [Available on PIO ](https://docs.platformio.org/en/latest/boards/espressif32/upesy_wrover.html)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esp32:
  board: upesy_wroom
  framework:
    type: esp32
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
