### PR TITLE
Add stop action for ble scanning

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -51,6 +51,9 @@ BLEEndOfScanTrigger = esp32_ble_tracker_ns.class_(
 ESP32BLEStartScanAction = esp32_ble_tracker_ns.class_(
     "ESP32BLEStartScanAction", automation.Action
 )
+ESP32BLEStopScanAction = esp32_ble_tracker_ns.class_(
+    "ESP32BLEStopScanAction", automation.Action
+)
 
 
 def validate_scan_parameters(config):
@@ -256,6 +259,28 @@ async def esp32_ble_tracker_start_scan_action_to_code(
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     cg.add(var.set_continuous(config[CONF_CONTINUOUS]))
+    return var
+
+
+ESP32_BLE_STOP_SCAN_ACTION_SCHEMA = automation.maybe_simple_id(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(ESP32BLETracker),
+        }
+    )
+)
+
+
+@automation.register_action(
+    "esp32_ble_tracker.stop_scan",
+    ESP32BLEStopScanAction,
+    ESP32_BLE_STOP_SCAN_ACTION_SCHEMA,
+)
+async def esp32_ble_tracker_stop_scan_action_to_code(
+    config, action_id, template_arg, args
+):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
     return var
 
 

--- a/esphome/components/esp32_ble_tracker/automation.h
+++ b/esphome/components/esp32_ble_tracker/automation.h
@@ -84,6 +84,24 @@ class BLEEndOfScanTrigger : public Trigger<>, public ESPBTDeviceListener {
   void on_scan_end() override { this->trigger(); }
 };
 
+template<typename... Ts> class ESP32BLEStartScanAction : public Action<Ts...> {
+ public:
+  ESP32BLEStartScanAction(ESP32BLETracker *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(bool, continuous)
+  void play(Ts... x) override {
+    this->parent_->set_scan_continuous(this->continuous_.value(x...));
+    this->parent_->start_scan();
+  }
+
+ protected:
+  ESP32BLETracker *parent_;
+};
+
+template<typename... Ts> class ESP32BLEStopScanAction : public Action<Ts...>, public Parented<ESP32BLETracker> {
+ public:
+  void play(Ts... x) override { this->parent_->stop_scan(); }
+};
+
 }  // namespace esp32_ble_tracker
 }  // namespace esphome
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -156,6 +156,13 @@ void ESP32BLETracker::start_scan() {
   }
 }
 
+void ESP32BLETracker::stop_scan() {
+  ESP_LOGD(TAG, "Stopping scan.");
+  this->scan_continuous_ = false;
+  esp_ble_gap_stop_scanning();
+  this->cancel_timeout("scan");
+}
+
 bool ESP32BLETracker::ble_setup() {
   // Initialize non-volatile storage for the bluetooth controller
   esp_err_t err = nvs_flash_init();

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -191,6 +191,7 @@ class ESP32BLETracker : public Component {
   void print_bt_device_info(const ESPBTDevice &device);
 
   void start_scan();
+  void stop_scan();
 
  protected:
   /// The FreeRTOS task managing the bluetooth interface.
@@ -242,19 +243,6 @@ class ESP32BLETracker : public Component {
 
 // NOLINTNEXTLINE
 extern ESP32BLETracker *global_esp32_ble_tracker;
-
-template<typename... Ts> class ESP32BLEStartScanAction : public Action<Ts...> {
- public:
-  ESP32BLEStartScanAction(ESP32BLETracker *parent) : parent_(parent) {}
-  TEMPLATABLE_VALUE(bool, continuous)
-  void play(Ts... x) override {
-    this->parent_->set_scan_continuous(this->continuous_.value(x...));
-    this->parent_->start_scan();
-  }
-
- protected:
-  ESP32BLETracker *parent_;
-};
 
 }  // namespace esp32_ble_tracker
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Adds an action to the `esp32_ble_tracker` to stop the scanning.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2295

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
