### PR TITLE
Allow ble tracker to subscribe to ota start and stop the scanning

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -239,6 +239,8 @@ async def to_code(config):
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
 
+    cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts
+
 
 ESP32_BLE_START_SCAN_ACTION_SCHEMA = cv.Schema(
     {

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -78,6 +78,7 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_port(config[CONF_PORT]))
+    cg.add_define("USE_OTA")
     if CONF_PASSWORD in config:
         cg.add(var.set_auth_password(config[CONF_PASSWORD]))
         cg.add_define("USE_OTA_PASSWORD")

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -21,6 +21,8 @@ static const char *const TAG = "ota";
 
 static const uint8_t OTA_VERSION_1_0 = 1;
 
+OTAComponent *global_ota_component = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 std::unique_ptr<OTABackend> make_ota_backend() {
 #ifdef USE_ARDUINO
 #ifdef USE_ESP8266
@@ -34,6 +36,8 @@ std::unique_ptr<OTABackend> make_ota_backend() {
   return make_unique<IDFOTABackend>();
 #endif  // USE_ESP_IDF
 }
+
+OTAComponent::OTAComponent() { global_ota_component = this; }
 
 void OTAComponent::setup() {
   server_ = socket::socket_ip(SOCK_STREAM, 0);

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -41,6 +41,7 @@ enum OTAState { OTA_COMPLETED = 0, OTA_STARTED, OTA_IN_PROGRESS, OTA_ERROR };
 /// OTAComponent provides a simple way to integrate Over-the-Air updates into your app using ArduinoOTA.
 class OTAComponent : public Component {
  public:
+  OTAComponent();
 #ifdef USE_OTA_PASSWORD
   void set_auth_password(const std::string &password) { password_ = password; }
 #endif  // USE_OTA_PASSWORD
@@ -102,6 +103,8 @@ class OTAComponent : public Component {
   CallbackManager<void(OTAState, float, uint8_t)> state_callback_{};
 #endif
 };
+
+extern OTAComponent *global_ota_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace ota
 }  // namespace esphome

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -32,6 +32,7 @@
 #define USE_MEDIA_PLAYER
 #define USE_MQTT
 #define USE_NUMBER
+#define USE_OTA
 #define USE_OTA_PASSWORD
 #define USE_OTA_STATE_CALLBACK
 #define USE_POWER_SUPPLY


### PR DESCRIPTION
# What does this implement/fix?

BLE often conflicts with the OTA updates, both trying to allocate the same block of memory at the same time due to BLE working in a separate RTOS task.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
