### PR TITLE
null initialize total sensor for pulse counter

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -81,7 +81,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   PulseCounterStorageBase &storage_;
   uint32_t last_time_{0};
   uint32_t current_total_{0};
-  sensor::Sensor *total_sensor_ = nullptr;
+  sensor::Sensor *total_sensor_{nullptr};
 };
 
 }  // namespace pulse_counter

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -81,7 +81,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   PulseCounterStorageBase &storage_;
   uint32_t last_time_{0};
   uint32_t current_total_{0};
-  sensor::Sensor *total_sensor_;
+  sensor::Sensor *total_sensor_ = nullptr;
 };
 
 }  // namespace pulse_counter


### PR DESCRIPTION
# What does this implement/fix?

Fixes issue found by @glmnet, mis-reported in #3691, but actually related to #3640.
When the total count sensor is not used in the `pulse_counter`, it was not default null initialized. This fixes that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  -

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: pulse_counter
    pin: GPIO34
    id: engine_rpm_instant
    update_interval: 300ms
    count_mode:
      falling_edge: INCREMENT
      rising_edge: DISABLE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
