### PR TITLE
[BME280] raise standby time

### DIFF
--- a/esphome/components/bme280/bme280.cpp
+++ b/esphome/components/bme280/bme280.cpp
@@ -163,7 +163,7 @@ void BME280Component::setup() {
     return;
   }
   config_register &= ~0b11111100;
-  config_register |= 0b000 << 5;  // 0.5 ms standby time
+  config_register |= 0b101 << 5;  // 1000 ms standby time
   config_register |= (this->iir_filter_ & 0b111) << 2;
   if (!this->write_byte(BME280_REGISTER_CONFIG, config_register)) {
     this->mark_failed();


### PR DESCRIPTION
Raise standby period between measurements from 0.5ms to 1000ms. This will get it more in line with the recommended settings from the datasheet and most importantly keep the sensor from heating itself, skewing the temperature readings.

Fixes: https://github.com/esphome/feature-requests/issues/1593

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1593

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).