### PR TITLE
Unify 'nullptr' initalization of class members;

### DIFF
--- a/esphome/components/ade7953/ade7953.h
+++ b/esphome/components/ade7953/ade7953.h
@@ -82,7 +82,7 @@ class ADE7953 : public i2c::I2CDevice, public PollingComponent {
     return i2c::ERROR_OK;
   }
 
-  InternalGPIOPin *irq_pin_ = nullptr;
+  InternalGPIOPin *irq_pin_{nullptr};
   bool is_setup_{false};
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_a_sensor_{nullptr};

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -116,9 +116,9 @@ class APINoiseFrameHelper : public APIFrameHelper {
   std::vector<uint8_t> prologue_;
 
   std::shared_ptr<APINoiseContext> ctx_;
-  NoiseHandshakeState *handshake_ = nullptr;
-  NoiseCipherState *send_cipher_ = nullptr;
-  NoiseCipherState *recv_cipher_ = nullptr;
+  NoiseHandshakeState *handshake_{nullptr};
+  NoiseCipherState *send_cipher_{nullptr};
+  NoiseCipherState *recv_cipher_{nullptr};
   NoiseProtocolId nid_;
 
   enum class State {

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -58,9 +58,9 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
 
   sensor::Sensor *sensors_[NUM_SENSORS] = {nullptr};
 #ifdef USE_BINARY_SENSOR
-  binary_sensor::BinarySensor *too_cold_sensor_ = nullptr;
-  binary_sensor::BinarySensor *lens_bad_sensor_ = nullptr;
-  binary_sensor::BinarySensor *em_sat_sensor_ = nullptr;
+  binary_sensor::BinarySensor *too_cold_sensor_{nullptr};
+  binary_sensor::BinarySensor *lens_bad_sensor_{nullptr};
+  binary_sensor::BinarySensor *em_sat_sensor_{nullptr};
 #endif
 
   int16_t boot_count_ = 0;

--- a/esphome/components/mlx90393/sensor_mlx90393.h
+++ b/esphome/components/mlx90393/sensor_mlx90393.h
@@ -52,7 +52,7 @@ class MLX90393Cls : public PollingComponent, public i2c::I2CDevice, public MLX90
   uint8_t temperature_oversampling_ = 0;
   uint8_t filter_;
   uint8_t resolutions_[3] = {0};
-  GPIOPin *drdy_pin_ = nullptr;
+  GPIOPin *drdy_pin_{nullptr};
 };
 
 }  // namespace mlx90393

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -59,8 +59,8 @@ class PIDClimate : public climate::Climate, public Component {
 
   /// The sensor used for getting the current temperature
   sensor::Sensor *sensor_;
-  output::FloatOutput *cool_output_ = nullptr;
-  output::FloatOutput *heat_output_ = nullptr;
+  output::FloatOutput *cool_output_{nullptr};
+  output::FloatOutput *heat_output_{nullptr};
   PIDController controller_;
   /// Output value as reported by the PID controller, for PIDClimateSensor
   float output_value_;

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -31,11 +31,11 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
  protected:
   static void gpio_intr(PulseMeterSensor *sensor);
 
-  InternalGPIOPin *pin_ = nullptr;
+  InternalGPIOPin *pin_{nullptr};
   ISRInternalGPIOPin isr_pin_;
   uint32_t filter_us_ = 0;
   uint32_t timeout_us_ = 1000000UL * 60UL * 5UL;
-  sensor::Sensor *total_sensor_ = nullptr;
+  sensor::Sensor *total_sensor_{nullptr};
   InternalFilterMode filter_mode_{FILTER_EDGE};
 
   Deduplicator<uint32_t> pulse_width_dedupe_;

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.h
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.h
@@ -114,7 +114,7 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
   void delayed_disconnect_();
 #ifdef USE_TIME
   void sync_time_();
-  time::RealTimeClock *time_ = nullptr;
+  time::RealTimeClock *time_{nullptr};
 #endif
   uint16_t char_handle_ = 0;
   bool connection_established_ = false;

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -176,7 +176,7 @@ template<typename... Ts> class Action {
     return this->next_->is_running();
   }
 
-  Action<Ts...> *next_ = nullptr;
+  Action<Ts...> *next_{nullptr};
 
   /// The number of instances of this sequence in the list of actions
   /// that is currently being executed.

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -254,7 +254,7 @@ class Component {
 
   uint32_t component_state_{0x0000};  ///< State of this component.
   float setup_priority_override_{NAN};
-  const char *component_source_ = nullptr;
+  const char *component_source_{nullptr};
 };
 
 /** This class simplifies creating components that periodically check a state.

--- a/esphome/core/gpio.h
+++ b/esphome/core/gpio.h
@@ -73,7 +73,7 @@ class ISRInternalGPIOPin {
   void pin_mode(gpio::Flags flags);
 
  protected:
-  void *arg_ = nullptr;
+  void *arg_{nullptr};
 };
 
 class InternalGPIOPin : public GPIOPin {


### PR DESCRIPTION
# What does this implement/fix?

Changes all ` ... = nullptr;` pointer class member initializations to `{nullptr};` styling.
The vast majority of occurences already used the latter syntax, this modifies the missing few to adhere to the same standard.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: styling

**Related issue or feature (if applicable):** as mentioned in #3803

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
