### PR TITLE
2022.9.0b2

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -121,11 +121,8 @@ void IRAM_ATTR HOT AcDimmerDataStore::gpio_intr() {
       // calculate time until enable in µs: (1.0-value)*cycle_time, but with integer arithmetic
       // also take into account min_power
       auto min_us = this->cycle_time_us * this->min_power / 1000;
-      // calculate required value to provide a true RMS voltage output
-      this->enable_time_us =
-          std::max((uint32_t) 1, (uint32_t)((65535 - (acos(1 - (2 * this->value / 65535.0)) / 3.14159 * 65535)) *
-                                            (this->cycle_time_us - min_us)) /
-                                     65535);
+      this->enable_time_us = std::max((uint32_t) 1, ((65535 - this->value) * (this->cycle_time_us - min_us)) / 65535);
+
       if (this->method == DIM_METHOD_LEADING_PULSE) {
         // Minimum pulse time should be enough for the triac to trigger when it is close to the ZC zone
         // this is for brightness near 99%
@@ -206,6 +203,7 @@ void AcDimmer::setup() {
 #endif
 }
 void AcDimmer::write_state(float state) {
+  state = std::acos(1 - (2 * state)) / 3.14159;  // RMS power compensation
   auto new_value = static_cast<uint16_t>(roundf(state * 65535));
   if (new_value != 0 && this->store_.value == 0)
     this->store_.init_cycle = this->init_with_half_cycle_;

--- a/esphome/components/ade7953/ade7953.h
+++ b/esphome/components/ade7953/ade7953.h
@@ -82,7 +82,7 @@ class ADE7953 : public i2c::I2CDevice, public PollingComponent {
     return i2c::ERROR_OK;
   }
 
-  InternalGPIOPin *irq_pin_ = nullptr;
+  InternalGPIOPin *irq_pin_{nullptr};
   bool is_setup_{false};
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_a_sensor_{nullptr};

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -18,8 +18,8 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
 
  protected:
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *humidity_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
 }  // namespace aht10

--- a/esphome/components/am2320/am2320.h
+++ b/esphome/components/am2320/am2320.h
@@ -21,8 +21,8 @@ class AM2320Component : public PollingComponent, public i2c::I2CDevice {
   bool read_data_(uint8_t *data);
   bool read_bytes_(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion = 0);
 
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *humidity_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
 }  // namespace am2320

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -116,9 +116,9 @@ class APINoiseFrameHelper : public APIFrameHelper {
   std::vector<uint8_t> prologue_;
 
   std::shared_ptr<APINoiseContext> ctx_;
-  NoiseHandshakeState *handshake_ = nullptr;
-  NoiseCipherState *send_cipher_ = nullptr;
-  NoiseCipherState *recv_cipher_ = nullptr;
+  NoiseHandshakeState *handshake_{nullptr};
+  NoiseCipherState *send_cipher_{nullptr};
+  NoiseCipherState *recv_cipher_{nullptr};
   NoiseProtocolId nid_;
 
   enum class State {

--- a/esphome/components/as3935/as3935.h
+++ b/esphome/components/as3935/as3935.h
@@ -92,9 +92,9 @@ class AS3935Component : public Component {
 
   virtual void write_register(uint8_t reg, uint8_t mask, uint8_t bits, uint8_t start_position) = 0;
 
-  sensor::Sensor *distance_sensor_;
-  sensor::Sensor *energy_sensor_;
-  binary_sensor::BinarySensor *thunder_alert_binary_sensor_;
+  sensor::Sensor *distance_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
+  binary_sensor::BinarySensor *thunder_alert_binary_sensor_{nullptr};
   GPIOPin *irq_pin_;
 
   bool indoor_;

--- a/esphome/components/bl0939/bl0939.h
+++ b/esphome/components/bl0939/bl0939.h
@@ -75,16 +75,16 @@ class BL0939 : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  sensor::Sensor *voltage_sensor_;
-  sensor::Sensor *current_sensor_1_;
-  sensor::Sensor *current_sensor_2_;
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_1_{nullptr};
+  sensor::Sensor *current_sensor_2_{nullptr};
   // NB This may be negative as the circuits is seemingly able to measure
   // power in both directions
-  sensor::Sensor *power_sensor_1_;
-  sensor::Sensor *power_sensor_2_;
-  sensor::Sensor *energy_sensor_1_;
-  sensor::Sensor *energy_sensor_2_;
-  sensor::Sensor *energy_sensor_sum_;
+  sensor::Sensor *power_sensor_1_{nullptr};
+  sensor::Sensor *power_sensor_2_{nullptr};
+  sensor::Sensor *energy_sensor_1_{nullptr};
+  sensor::Sensor *energy_sensor_2_{nullptr};
+  sensor::Sensor *energy_sensor_sum_{nullptr};
 
   // Divide by this to turn into Watt
   float power_reference_ = BL0939_PREF;

--- a/esphome/components/bl0940/bl0940.h
+++ b/esphome/components/bl0940/bl0940.h
@@ -75,14 +75,14 @@ class BL0940 : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  sensor::Sensor *voltage_sensor_;
-  sensor::Sensor *current_sensor_;
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
   // NB This may be negative as the circuits is seemingly able to measure
   // power in both directions
-  sensor::Sensor *power_sensor_;
-  sensor::Sensor *energy_sensor_;
-  sensor::Sensor *internal_temperature_sensor_;
-  sensor::Sensor *external_temperature_sensor_;
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
+  sensor::Sensor *internal_temperature_sensor_{nullptr};
+  sensor::Sensor *external_temperature_sensor_{nullptr};
 
   // Max difference between two measurements of the temperature. Used to avoid noise.
   float max_temperature_diff_{0};

--- a/esphome/components/bl0942/bl0942.h
+++ b/esphome/components/bl0942/bl0942.h
@@ -43,13 +43,13 @@ class BL0942 : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  sensor::Sensor *voltage_sensor_;
-  sensor::Sensor *current_sensor_;
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
   // NB This may be negative as the circuits is seemingly able to measure
   // power in both directions
-  sensor::Sensor *power_sensor_;
-  sensor::Sensor *energy_sensor_;
-  sensor::Sensor *frequency_sensor_;
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
+  sensor::Sensor *frequency_sensor_{nullptr};
 
   // Divide by this to turn into Watt
   float power_reference_ = BL0942_PREF;

--- a/esphome/components/bme280/bme280.h
+++ b/esphome/components/bme280/bme280.h
@@ -96,9 +96,9 @@ class BME280Component : public PollingComponent, public i2c::I2CDevice {
   BME280Oversampling pressure_oversampling_{BME280_OVERSAMPLING_16X};
   BME280Oversampling humidity_oversampling_{BME280_OVERSAMPLING_16X};
   BME280IIRFilter iir_filter_{BME280_IIR_FILTER_OFF};
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
-  sensor::Sensor *humidity_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,

--- a/esphome/components/bme680/bme680.h
+++ b/esphome/components/bme680/bme680.h
@@ -129,10 +129,10 @@ class BME680Component : public PollingComponent, public i2c::I2CDevice {
   uint16_t heater_temperature_{320};
   uint16_t heater_duration_{150};
 
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
-  sensor::Sensor *humidity_sensor_;
-  sensor::Sensor *gas_resistance_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
+  sensor::Sensor *gas_resistance_sensor_{nullptr};
 };
 
 }  // namespace bme680

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -100,15 +100,15 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   SampleRate pressure_sample_rate_{SAMPLE_RATE_DEFAULT};
   SampleRate humidity_sample_rate_{SAMPLE_RATE_DEFAULT};
 
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
-  sensor::Sensor *humidity_sensor_;
-  sensor::Sensor *gas_resistance_sensor_;
-  sensor::Sensor *iaq_sensor_;
-  text_sensor::TextSensor *iaq_accuracy_text_sensor_;
-  sensor::Sensor *iaq_accuracy_sensor_;
-  sensor::Sensor *co2_equivalent_sensor_;
-  sensor::Sensor *breath_voc_equivalent_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
+  sensor::Sensor *gas_resistance_sensor_{nullptr};
+  sensor::Sensor *iaq_sensor_{nullptr};
+  text_sensor::TextSensor *iaq_accuracy_text_sensor_{nullptr};
+  sensor::Sensor *iaq_accuracy_sensor_{nullptr};
+  sensor::Sensor *co2_equivalent_sensor_{nullptr};
+  sensor::Sensor *breath_voc_equivalent_sensor_{nullptr};
 };
 #endif
 }  // namespace bme680_bsec

--- a/esphome/components/bmp280/bmp280.h
+++ b/esphome/components/bmp280/bmp280.h
@@ -81,8 +81,8 @@ class BMP280Component : public PollingComponent, public i2c::I2CDevice {
   BMP280Oversampling temperature_oversampling_{BMP280_OVERSAMPLING_16X};
   BMP280Oversampling pressure_oversampling_{BMP280_OVERSAMPLING_16X};
   BMP280IIRFilter iir_filter_{BMP280_IIR_FILTER_OFF};
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,

--- a/esphome/components/bmp3xx/bmp3xx.h
+++ b/esphome/components/bmp3xx/bmp3xx.h
@@ -125,8 +125,8 @@ class BMP3XXComponent : public PollingComponent, public i2c::I2CDevice {
   Oversampling pressure_oversampling_{OVERSAMPLING_X16};
   IIRFilter iir_filter_{IIR_FILTER_OFF};
   OperationMode operation_mode_{FORCED_MODE};
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
   enum ErrorCode {
     NONE = 0,
     ERROR_COMMUNICATION_FAILED,

--- a/esphome/components/dht12/dht12.h
+++ b/esphome/components/dht12/dht12.h
@@ -20,8 +20,8 @@ class DHT12Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   bool read_data_(uint8_t *data);
 
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *humidity_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
 }  // namespace dht12

--- a/esphome/components/dps310/dps310.h
+++ b/esphome/components/dps310/dps310.h
@@ -53,8 +53,8 @@ class DPS310Component : public PollingComponent, public i2c::I2CDevice {
   void calculate_values_(int32_t raw_temperature, int32_t raw_pressure);
   static int32_t twos_complement(int32_t val, uint8_t bits);
 
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
   int32_t raw_pressure_, raw_temperature_, c00_, c10_;
   int16_t c0_, c1_, c01_, c11_, c20_, c21_, c30_;
   uint8_t prod_rev_id_;

--- a/esphome/components/ens210/ens210.h
+++ b/esphome/components/ens210/ens210.h
@@ -31,8 +31,8 @@ class ENS210Component : public PollingComponent, public i2c::I2CDevice {
   bool set_low_power_(bool enable);
   void extract_measurement_(uint32_t val, int *data, int *status);
 
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *humidity_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
 }  // namespace ens210

--- a/esphome/components/hdc1080/hdc1080.h
+++ b/esphome/components/hdc1080/hdc1080.h
@@ -21,8 +21,8 @@ class HDC1080Component : public PollingComponent, public i2c::I2CDevice {
   float get_setup_priority() const override;
 
  protected:
-  sensor::Sensor *temperature_;
-  sensor::Sensor *humidity_;
+  sensor::Sensor *temperature_{nullptr};
+  sensor::Sensor *humidity_{nullptr};
 };
 
 }  // namespace hdc1080

--- a/esphome/components/hmc5883l/hmc5883l.h
+++ b/esphome/components/hmc5883l/hmc5883l.h
@@ -54,10 +54,10 @@ class HMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
   HMC5883LOversampling oversampling_{HMC5883L_OVERSAMPLING_1};
   HMC5883LDatarate datarate_{HMC5883L_DATARATE_15_0_HZ};
   HMC5883LRange range_{HMC5883L_RANGE_130_UT};
-  sensor::Sensor *x_sensor_;
-  sensor::Sensor *y_sensor_;
-  sensor::Sensor *z_sensor_;
-  sensor::Sensor *heading_sensor_;
+  sensor::Sensor *x_sensor_{nullptr};
+  sensor::Sensor *y_sensor_{nullptr};
+  sensor::Sensor *z_sensor_{nullptr};
+  sensor::Sensor *heading_sensor_{nullptr};
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,

--- a/esphome/components/honeywellabp/honeywellabp.h
+++ b/esphome/components/honeywellabp/honeywellabp.h
@@ -29,8 +29,8 @@ class HONEYWELLABPSensor : public PollingComponent,
   uint8_t status_ = 0;         // byte to hold status information.
   int pressure_count_ = 0;     // hold raw pressure data (14 - bit, 0 - 16384)
   int temperature_count_ = 0;  // hold raw temperature data (11 - bit, 0 - 2048)
-  sensor::Sensor *pressure_sensor_;
-  sensor::Sensor *temperature_sensor_;
+  sensor::Sensor *pressure_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
   uint8_t readsensor_();
   uint8_t readstatus_();
   int rawpressure_();

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -58,9 +58,9 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
 
   sensor::Sensor *sensors_[NUM_SENSORS] = {nullptr};
 #ifdef USE_BINARY_SENSOR
-  binary_sensor::BinarySensor *too_cold_sensor_ = nullptr;
-  binary_sensor::BinarySensor *lens_bad_sensor_ = nullptr;
-  binary_sensor::BinarySensor *em_sat_sensor_ = nullptr;
+  binary_sensor::BinarySensor *too_cold_sensor_{nullptr};
+  binary_sensor::BinarySensor *lens_bad_sensor_{nullptr};
+  binary_sensor::BinarySensor *em_sat_sensor_{nullptr};
 #endif
 
   int16_t boot_count_ = 0;

--- a/esphome/components/mlx90393/sensor_mlx90393.h
+++ b/esphome/components/mlx90393/sensor_mlx90393.h
@@ -52,7 +52,7 @@ class MLX90393Cls : public PollingComponent, public i2c::I2CDevice, public MLX90
   uint8_t temperature_oversampling_ = 0;
   uint8_t filter_;
   uint8_t resolutions_[3] = {0};
-  GPIOPin *drdy_pin_ = nullptr;
+  GPIOPin *drdy_pin_{nullptr};
 };
 
 }  // namespace mlx90393

--- a/esphome/components/ms5611/ms5611.h
+++ b/esphome/components/ms5611/ms5611.h
@@ -22,8 +22,8 @@ class MS5611Component : public PollingComponent, public i2c::I2CDevice {
   void read_pressure_(uint32_t raw_temperature);
   void calculate_values_(uint32_t raw_temperature, uint32_t raw_pressure);
 
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
   uint16_t prom_[6];
 };
 

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -59,8 +59,8 @@ class PIDClimate : public climate::Climate, public Component {
 
   /// The sensor used for getting the current temperature
   sensor::Sensor *sensor_;
-  output::FloatOutput *cool_output_ = nullptr;
-  output::FloatOutput *heat_output_ = nullptr;
+  output::FloatOutput *cool_output_{nullptr};
+  output::FloatOutput *heat_output_{nullptr};
   PIDController controller_;
   /// Output value as reported by the PID controller, for PIDClimateSensor
   float output_value_;

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -81,7 +81,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   PulseCounterStorageBase &storage_;
   uint32_t last_time_{0};
   uint32_t current_total_{0};
-  sensor::Sensor *total_sensor_;
+  sensor::Sensor *total_sensor_{nullptr};
 };
 
 }  // namespace pulse_counter

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -31,11 +31,11 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
  protected:
   static void gpio_intr(PulseMeterSensor *sensor);
 
-  InternalGPIOPin *pin_ = nullptr;
+  InternalGPIOPin *pin_{nullptr};
   ISRInternalGPIOPin isr_pin_;
   uint32_t filter_us_ = 0;
   uint32_t timeout_us_ = 1000000UL * 60UL * 5UL;
-  sensor::Sensor *total_sensor_ = nullptr;
+  sensor::Sensor *total_sensor_{nullptr};
   InternalFilterMode filter_mode_{FILTER_EDGE};
 
   Deduplicator<uint32_t> pulse_width_dedupe_;

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.h
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.h
@@ -114,7 +114,7 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
   void delayed_disconnect_();
 #ifdef USE_TIME
   void sync_time_();
-  time::RealTimeClock *time_ = nullptr;
+  time::RealTimeClock *time_{nullptr};
 #endif
   uint16_t char_handle_ = 0;
   bool connection_established_ = false;

--- a/esphome/components/pzem004t/pzem004t.h
+++ b/esphome/components/pzem004t/pzem004t.h
@@ -23,10 +23,10 @@ class PZEM004T : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  sensor::Sensor *voltage_sensor_;
-  sensor::Sensor *current_sensor_;
-  sensor::Sensor *power_sensor_;
-  sensor::Sensor *energy_sensor_;
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
 
   enum PZEM004TReadState {
     SET_ADDRESS = 0xB4,

--- a/esphome/components/pzemac/pzemac.h
+++ b/esphome/components/pzemac/pzemac.h
@@ -27,12 +27,12 @@ class PZEMAC : public PollingComponent, public modbus::ModbusDevice {
 
  protected:
   template<typename... Ts> friend class ResetEnergyAction;
-  sensor::Sensor *voltage_sensor_;
-  sensor::Sensor *current_sensor_;
-  sensor::Sensor *power_sensor_;
-  sensor::Sensor *energy_sensor_;
-  sensor::Sensor *frequency_sensor_;
-  sensor::Sensor *power_factor_sensor_;
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
+  sensor::Sensor *frequency_sensor_{nullptr};
+  sensor::Sensor *power_factor_sensor_{nullptr};
 
   void reset_energy_();
 };

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -22,11 +22,11 @@ class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
   void dump_config() override;
 
  protected:
-  sensor::Sensor *voltage_sensor_;
-  sensor::Sensor *current_sensor_;
-  sensor::Sensor *power_sensor_;
-  sensor::Sensor *frequency_sensor_;
-  sensor::Sensor *power_factor_sensor_;
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *frequency_sensor_{nullptr};
+  sensor::Sensor *power_factor_sensor_{nullptr};
 };
 
 }  // namespace pzemdc

--- a/esphome/components/qmc5883l/qmc5883l.h
+++ b/esphome/components/qmc5883l/qmc5883l.h
@@ -45,10 +45,10 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
   QMC5883LDatarate datarate_{QMC5883L_DATARATE_10_HZ};
   QMC5883LRange range_{QMC5883L_RANGE_200_UT};
   QMC5883LOversampling oversampling_{QMC5883L_SAMPLING_512};
-  sensor::Sensor *x_sensor_;
-  sensor::Sensor *y_sensor_;
-  sensor::Sensor *z_sensor_;
-  sensor::Sensor *heading_sensor_;
+  sensor::Sensor *x_sensor_{nullptr};
+  sensor::Sensor *y_sensor_{nullptr};
+  sensor::Sensor *z_sensor_{nullptr};
+  sensor::Sensor *heading_sensor_{nullptr};
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,

--- a/esphome/components/qmp6988/qmp6988.h
+++ b/esphome/components/qmp6988/qmp6988.h
@@ -91,8 +91,8 @@ class QMP6988Component : public PollingComponent, public i2c::I2CDevice {
 
  protected:
   qmp6988_data_t qmp6988_data_;
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *pressure_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
 
   QMP6988Oversampling temperature_oversampling_{QMP6988_OVERSAMPLING_16X};
   QMP6988Oversampling pressure_oversampling_{QMP6988_OVERSAMPLING_16X};

--- a/esphome/components/sht3xd/sht3xd.h
+++ b/esphome/components/sht3xd/sht3xd.h
@@ -19,8 +19,8 @@ class SHT3XDComponent : public PollingComponent, public sensirion_common::Sensir
   void update() override;
 
  protected:
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *humidity_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
 }  // namespace sht3xd

--- a/esphome/components/shtcx/shtcx.h
+++ b/esphome/components/shtcx/shtcx.h
@@ -26,8 +26,8 @@ class SHTCXComponent : public PollingComponent, public sensirion_common::Sensiri
  protected:
   SHTCXType type_;
   uint16_t sensor_id_;
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *humidity_sensor_;
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
 }  // namespace shtcx

--- a/esphome/components/sim800l/__init__.py
+++ b/esphome/components/sim800l/__init__.py
@@ -18,15 +18,42 @@ Sim800LReceivedMessageTrigger = sim800l_ns.class_(
     "Sim800LReceivedMessageTrigger",
     automation.Trigger.template(cg.std_string, cg.std_string),
 )
+Sim800LIncomingCallTrigger = sim800l_ns.class_(
+    "Sim800LIncomingCallTrigger",
+    automation.Trigger.template(cg.std_string),
+)
+Sim800LCallConnectedTrigger = sim800l_ns.class_(
+    "Sim800LCallConnectedTrigger",
+    automation.Trigger.template(),
+)
+Sim800LCallDisconnectedTrigger = sim800l_ns.class_(
+    "Sim800LCallDisconnectedTrigger",
+    automation.Trigger.template(),
+)
+
+Sim800LReceivedUssdTrigger = sim800l_ns.class_(
+    "Sim800LReceivedUssdTrigger",
+    automation.Trigger.template(cg.std_string),
+)
 
 # Actions
 Sim800LSendSmsAction = sim800l_ns.class_("Sim800LSendSmsAction", automation.Action)
+Sim800LSendUssdAction = sim800l_ns.class_("Sim800LSendUssdAction", automation.Action)
 Sim800LDialAction = sim800l_ns.class_("Sim800LDialAction", automation.Action)
+Sim800LConnectAction = sim800l_ns.class_("Sim800LConnectAction", automation.Action)
+Sim800LDisconnectAction = sim800l_ns.class_(
+    "Sim800LDisconnectAction", automation.Action
+)
 
 CONF_SIM800L_ID = "sim800l_id"
 CONF_ON_SMS_RECEIVED = "on_sms_received"
+CONF_ON_USSD_RECEIVED = "on_ussd_received"
+CONF_ON_INCOMING_CALL = "on_incoming_call"
+CONF_ON_CALL_CONNECTED = "on_call_connected"
+CONF_ON_CALL_DISCONNECTED = "on_call_disconnected"
 CONF_RECIPIENT = "recipient"
 CONF_MESSAGE = "message"
+CONF_USSD = "ussd"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -36,6 +63,34 @@ CONFIG_SCHEMA = cv.All(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
                         Sim800LReceivedMessageTrigger
+                    ),
+                }
+            ),
+            cv.Optional(CONF_ON_INCOMING_CALL): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        Sim800LIncomingCallTrigger
+                    ),
+                }
+            ),
+            cv.Optional(CONF_ON_CALL_CONNECTED): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        Sim800LCallConnectedTrigger
+                    ),
+                }
+            ),
+            cv.Optional(CONF_ON_CALL_DISCONNECTED): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        Sim800LCallDisconnectedTrigger
+                    ),
+                }
+            ),
+            cv.Optional(CONF_ON_USSD_RECEIVED): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        Sim800LReceivedUssdTrigger
                     ),
                 }
             ),
@@ -59,6 +114,19 @@ async def to_code(config):
         await automation.build_automation(
             trigger, [(cg.std_string, "message"), (cg.std_string, "sender")], conf
         )
+    for conf in config.get(CONF_ON_INCOMING_CALL, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(cg.std_string, "caller_id")], conf)
+    for conf in config.get(CONF_ON_CALL_CONNECTED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_CALL_DISCONNECTED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+
+    for conf in config.get(CONF_ON_USSD_RECEIVED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(cg.std_string, "ussd")], conf)
 
 
 SIM800L_SEND_SMS_SCHEMA = cv.Schema(
@@ -97,4 +165,45 @@ async def sim800l_dial_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_RECIPIENT], args, cg.std_string)
     cg.add(var.set_recipient(template_))
+    return var
+
+
+@automation.register_action(
+    "sim800l.connect",
+    Sim800LConnectAction,
+    cv.Schema({cv.GenerateID(): cv.use_id(Sim800LComponent)}),
+)
+async def sim800l_connect_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    return var
+
+
+SIM800L_SEND_USSD_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(Sim800LComponent),
+        cv.Required(CONF_USSD): cv.templatable(cv.string_strict),
+    }
+)
+
+
+@automation.register_action(
+    "sim800l.send_ussd", Sim800LSendUssdAction, SIM800L_SEND_USSD_SCHEMA
+)
+async def sim800l_send_ussd_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_USSD], args, cg.std_string)
+    cg.add(var.set_ussd(template_))
+    return var
+
+
+@automation.register_action(
+    "sim800l.disconnect",
+    Sim800LDisconnectAction,
+    cv.Schema({cv.GenerateID(): cv.use_id(Sim800LComponent)}),
+)
+async def sim800l_disconnect_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
     return var

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -16,20 +16,38 @@ void Sim800LComponent::update() {
     this->write(26);
   }
 
+  if (this->expect_ack_)
+    return;
+
   if (state_ == STATE_INIT) {
     if (this->registered_ && this->send_pending_) {
       this->send_cmd_("AT+CSCS=\"GSM\"");
-      this->state_ = STATE_SENDINGSMS1;
+      this->state_ = STATE_SENDING_SMS_1;
     } else if (this->registered_ && this->dial_pending_) {
       this->send_cmd_("AT+CSCS=\"GSM\"");
       this->state_ = STATE_DIALING1;
+    } else if (this->registered_ && this->connect_pending_) {
+      this->connect_pending_ = false;
+      ESP_LOGI(TAG, "Connecting...");
+      this->send_cmd_("ATA");
+      this->state_ = STATE_ATA_SENT;
+    } else if (this->registered_ && this->send_ussd_pending_) {
+      this->send_cmd_("AT+CSCS=\"GSM\"");
+      this->state_ = STATE_SEND_USSD1;
+    } else if (this->registered_ && this->disconnect_pending_) {
+      this->disconnect_pending_ = false;
+      ESP_LOGI(TAG, "Disconnecting...");
+      this->send_cmd_("ATH");
+    } else if (this->registered_ && this->call_state_ != 6) {
+      send_cmd_("AT+CLCC");
+      this->state_ = STATE_CHECK_CALL;
+      return;
     } else {
       this->send_cmd_("AT");
-      this->state_ = STATE_CHECK_AT;
+      this->state_ = STATE_SETUP_CMGF;
     }
     this->expect_ack_ = true;
-  }
-  if (state_ == STATE_RECEIVEDSMS) {
+  } else if (state_ == STATE_RECEIVED_SMS) {
     // Serial Buffer should have flushed.
     // Send cmd to delete received sms
     char delete_cmd[20];
@@ -49,16 +67,29 @@ void Sim800LComponent::send_cmd_(const std::string &message) {
 }
 
 void Sim800LComponent::parse_cmd_(std::string message) {
-  ESP_LOGV(TAG, "R: %s - %d", message.c_str(), this->state_);
-
   if (message.empty())
     return;
 
+  ESP_LOGV(TAG, "R: %s - %d", message.c_str(), this->state_);
+
+  if (this->state_ != STATE_RECEIVE_SMS) {
+    if (message == "RING") {
+      // Incoming call...
+      this->state_ = STATE_PARSE_CLIP;
+      this->expect_ack_ = false;
+    } else if (message == "NO CARRIER") {
+      if (this->call_state_ != 6) {
+        this->call_state_ = 6;
+        this->call_disconnected_callback_.call();
+      }
+    }
+  }
+
+  bool ok = message == "OK";
   if (this->expect_ack_) {
-    bool ok = message == "OK";
     this->expect_ack_ = false;
     if (!ok) {
-      if (this->state_ == STATE_CHECK_AT && message == "AT") {
+      if (this->state_ == STATE_SETUP_CMGF && message == "AT") {
         // Expected ack but AT echo received
         this->state_ = STATE_DISABLE_ECHO;
         this->expect_ack_ = true;
@@ -68,6 +99,10 @@ void Sim800LComponent::parse_cmd_(std::string message) {
         return;
       }
     }
+  } else if (ok && (this->state_ != STATE_PARSE_SMS_RESPONSE && this->state_ != STATE_CHECK_CALL &&
+                    this->state_ != STATE_RECEIVE_SMS && this->state_ != STATE_DIALING2)) {
+    ESP_LOGW(TAG, "Received unexpected OK. Ignoring");
+    return;
   }
 
   switch (this->state_) {
@@ -75,30 +110,88 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       // While we were waiting for update to check for messages, this notifies a message
       // is available.
       bool message_available = message.compare(0, 6, "+CMTI:") == 0;
-      if (!message_available)
+      if (!message_available) {
+        if (message == "RING") {
+          // Incoming call...
+          this->state_ = STATE_PARSE_CLIP;
+        } else if (message == "NO CARRIER") {
+          if (this->call_state_ != 6) {
+            this->call_state_ = 6;
+            this->call_disconnected_callback_.call();
+          }
+        } else if (message.compare(0, 6, "+CUSD:") == 0) {
+          // Incoming USSD MESSAGE
+          this->state_ = STATE_CHECK_USSD;
+        }
         break;
+      }
+
       // Else fall thru ...
     }
     case STATE_CHECK_SMS:
       send_cmd_("AT+CMGL=\"ALL\"");
-      this->state_ = STATE_PARSE_SMS;
+      this->state_ = STATE_PARSE_SMS_RESPONSE;
       this->parse_index_ = 0;
       break;
     case STATE_DISABLE_ECHO:
       send_cmd_("ATE0");
-      this->state_ = STATE_CHECK_AT;
+      this->state_ = STATE_SETUP_CMGF;
       this->expect_ack_ = true;
       break;
-    case STATE_CHECK_AT:
+    case STATE_SETUP_CMGF:
       send_cmd_("AT+CMGF=1");
+      this->state_ = STATE_SETUP_CLIP;
+      this->expect_ack_ = true;
+      break;
+    case STATE_SETUP_CLIP:
+      send_cmd_("AT+CLIP=1");
       this->state_ = STATE_CREG;
       this->expect_ack_ = true;
       break;
+    case STATE_SETUP_USSD:
+      send_cmd_("AT+CUSD=1");
+      this->state_ = STATE_CREG;
+      this->expect_ack_ = true;
+      break;
+    case STATE_SEND_USSD1:
+      this->send_cmd_("AT+CUSD=1, \"" + this->ussd_ + "\"");
+      this->state_ = STATE_SEND_USSD2;
+      break;
+    case STATE_SEND_USSD2:
+      ESP_LOGD(TAG, "SendUssd2: '%s'", message.c_str());
+      if (message == "OK") {
+        // Dialing
+        ESP_LOGD(TAG, "Dialing ussd code: '%s' done.", this->ussd_.c_str());
+        this->state_ = STATE_CHECK_USSD;
+        this->send_ussd_pending_ = false;
+      } else {
+        this->set_registered_(false);
+        this->state_ = STATE_INIT;
+        this->send_cmd_("AT+CMEE=2");
+        this->write(26);
+      }
+      break;
+    case STATE_CHECK_USSD:
+      ESP_LOGD(TAG, "Check ussd code: '%s'", message.c_str());
+      if (message.compare(0, 6, "+CUSD:") == 0) {
+        this->state_ = STATE_RECEIVED_USSD;
+        this->ussd_ = "";
+        size_t start = 10;
+        size_t end = message.find_last_of(',');
+        if (end > start) {
+          this->ussd_ = message.substr(start + 1, end - start - 2);
+          this->ussd_received_callback_.call(this->ussd_);
+        }
+      }
+      // Otherwise we receive another OK, we do nothing just wait polling to continuously check for SMS
+      if (message == "OK")
+        this->state_ = STATE_INIT;
+      break;
     case STATE_CREG:
       send_cmd_("AT+CREG?");
-      this->state_ = STATE_CREGWAIT;
+      this->state_ = STATE_CREG_WAIT;
       break;
-    case STATE_CREGWAIT: {
+    case STATE_CREG_WAIT: {
       // Response: "+CREG: 0,1" -- the one there means registered ok
       //           "+CREG: -,-" means not registered ok
       bool registered = message.compare(0, 6, "+CREG:") == 0 && (message[9] == '1' || message[9] == '5');
@@ -112,10 +205,10 @@ void Sim800LComponent::parse_cmd_(std::string message) {
         if (message[7] == '0') {  // Network registration is disable, enable it
           send_cmd_("AT+CREG=1");
           this->expect_ack_ = true;
-          this->state_ = STATE_CHECK_AT;
+          this->state_ = STATE_SETUP_CMGF;
         } else {
           // Keep waiting registration
-          this->state_ = STATE_CREG;
+          this->state_ = STATE_INIT;
         }
       }
       set_registered_(registered);
@@ -145,9 +238,6 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       this->expect_ack_ = true;
       this->state_ = STATE_CHECK_SMS;
       break;
-    case STATE_PARSE_SMS:
-      this->state_ = STATE_PARSE_SMS_RESPONSE;
-      break;
     case STATE_PARSE_SMS_RESPONSE:
       if (message.compare(0, 6, "+CMGL:") == 0 && this->parse_index_ == 0) {
         size_t start = 7;
@@ -158,10 +248,11 @@ void Sim800LComponent::parse_cmd_(std::string message) {
           if (item == 1) {  // Slot Index
             this->parse_index_ = parse_number<uint8_t>(message.substr(start, end - start)).value_or(0);
           }
-          // item 2 = STATUS, usually "REC UNERAD"
+          // item 2 = STATUS, usually "REC UNREAD"
           if (item == 3) {  // recipient
             // Add 1 and remove 2 from substring to get rid of "quotes"
             this->sender_ = message.substr(start + 1, end - start - 2);
+            this->message_.clear();
             break;
           }
           // item 4 = ""
@@ -174,42 +265,83 @@ void Sim800LComponent::parse_cmd_(std::string message) {
           ESP_LOGD(TAG, "Invalid message %d %s", this->state_, message.c_str());
           return;
         }
-        this->state_ = STATE_RECEIVESMS;
+        this->state_ = STATE_RECEIVE_SMS;
       }
-      // Otherwise we receive another OK, we do nothing just wait polling to continuously check for SMS
-      if (message == "OK")
-        this->state_ = STATE_INIT;
+      // Otherwise we receive another OK
+      if (ok) {
+        send_cmd_("AT+CLCC");
+        this->state_ = STATE_CHECK_CALL;
+      }
       break;
-    case STATE_RECEIVESMS:
+    case STATE_CHECK_CALL:
+      if (message.compare(0, 6, "+CLCC:") == 0 && this->parse_index_ == 0) {
+        this->expect_ack_ = true;
+        size_t start = 7;
+        size_t end = message.find(',', start);
+        uint8_t item = 0;
+        while (end != start) {
+          item++;
+          // item 1 call index for +CHLD
+          // item 2 dir 0 Mobile originated; 1 Mobile terminated
+          if (item == 3) {  // stat
+            uint8_t current_call_state = parse_number<uint8_t>(message.substr(start, end - start)).value_or(6);
+            if (current_call_state != this->call_state_) {
+              ESP_LOGD(TAG, "Call state is now: %d", current_call_state);
+              if (current_call_state == 0)
+                this->call_connected_callback_.call();
+            }
+            this->call_state_ = current_call_state;
+            break;
+          }
+          // item 4 = ""
+          // item 5 = Received timestamp
+          start = end + 1;
+          end = message.find(',', start);
+        }
+
+        if (item < 2) {
+          ESP_LOGD(TAG, "Invalid message %d %s", this->state_, message.c_str());
+          return;
+        }
+      } else if (ok) {
+        if (this->call_state_ != 6) {
+          // no call in progress
+          this->call_state_ = 6;  // Disconnect
+          this->call_disconnected_callback_.call();
+        }
+      }
+      this->state_ = STATE_INIT;
+      break;
+    case STATE_RECEIVE_SMS:
       /* Our recipient is set and the message body is in message
         kick ESPHome callback now
       */
-      ESP_LOGD(TAG, "Received SMS from: %s", this->sender_.c_str());
-      ESP_LOGD(TAG, "%s", message.c_str());
-      this->callback_.call(message, this->sender_);
-      /* If the message is multiline, next lines will contain message data.
-         If there were other messages in the list, next line will be +CMGL: ...
-         At the end of the list the new line and the OK should be received.
-         To keep this simple just first line of message if considered, then
-         the next state will swallow all received data and in next poll event
-         this message index is marked for deletion.
-      */
-      this->state_ = STATE_RECEIVEDSMS;
+      if (ok || message.compare(0, 6, "+CMGL:") == 0) {
+        ESP_LOGD(TAG, "Received SMS from: %s", this->sender_.c_str());
+        ESP_LOGD(TAG, "%s", this->message_.c_str());
+        this->sms_received_callback_.call(this->message_, this->sender_);
+        this->state_ = STATE_RECEIVED_SMS;
+      } else {
+        if (this->message_.length() > 0)
+          this->message_ += "\n";
+        this->message_ += message;
+      }
       break;
-    case STATE_RECEIVEDSMS:
+    case STATE_RECEIVED_SMS:
+    case STATE_RECEIVED_USSD:
       // Let the buffer flush. Next poll will request to delete the parsed index message.
       break;
-    case STATE_SENDINGSMS1:
+    case STATE_SENDING_SMS_1:
       this->send_cmd_("AT+CMGS=\"" + this->recipient_ + "\"");
-      this->state_ = STATE_SENDINGSMS2;
+      this->state_ = STATE_SENDING_SMS_2;
       break;
-    case STATE_SENDINGSMS2:
+    case STATE_SENDING_SMS_2:
       if (message == ">") {
         // Send sms body
-        ESP_LOGD(TAG, "Sending message: '%s'", this->outgoing_message_.c_str());
+        ESP_LOGI(TAG, "Sending to %s message: '%s'", this->recipient_.c_str(), this->outgoing_message_.c_str());
         this->write_str(this->outgoing_message_.c_str());
         this->write(26);
-        this->state_ = STATE_SENDINGSMS3;
+        this->state_ = STATE_SENDING_SMS_3;
       } else {
         set_registered_(false);
         this->state_ = STATE_INIT;
@@ -217,7 +349,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
         this->write(26);
       }
       break;
-    case STATE_SENDINGSMS3:
+    case STATE_SENDING_SMS_3:
       if (message.compare(0, 6, "+CMGS:") == 0) {
         ESP_LOGD(TAG, "SMS Sent OK: %s", message.c_str());
         this->send_pending_ = false;
@@ -230,23 +362,55 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       this->state_ = STATE_DIALING2;
       break;
     case STATE_DIALING2:
-      if (message == "OK") {
-        // Dialing
-        ESP_LOGD(TAG, "Dialing: '%s'", this->recipient_.c_str());
-        this->state_ = STATE_INIT;
+      if (ok) {
+        ESP_LOGI(TAG, "Dialing: '%s'", this->recipient_.c_str());
         this->dial_pending_ = false;
       } else {
         this->set_registered_(false);
-        this->state_ = STATE_INIT;
         this->send_cmd_("AT+CMEE=2");
         this->write(26);
       }
+      this->state_ = STATE_INIT;
+      break;
+    case STATE_PARSE_CLIP:
+      if (message.compare(0, 6, "+CLIP:") == 0) {
+        std::string caller_id;
+        size_t start = 7;
+        size_t end = message.find(',', start);
+        uint8_t item = 0;
+        while (end != start) {
+          item++;
+          if (item == 1) {  // Slot Index
+            // Add 1 and remove 2 from substring to get rid of "quotes"
+            caller_id = message.substr(start + 1, end - start - 2);
+            break;
+          }
+          // item 4 = ""
+          // item 5 = Received timestamp
+          start = end + 1;
+          end = message.find(',', start);
+        }
+        if (this->call_state_ != 4) {
+          this->call_state_ = 4;
+          ESP_LOGI(TAG, "Incoming call from %s", caller_id.c_str());
+          incoming_call_callback_.call(caller_id);
+        }
+        this->state_ = STATE_INIT;
+      }
+      break;
+    case STATE_ATA_SENT:
+      ESP_LOGI(TAG, "Call connected");
+      if (this->call_state_ != 0) {
+        this->call_state_ = 0;
+        this->call_connected_callback_.call();
+      }
+      this->state_ = STATE_INIT;
       break;
     default:
-      ESP_LOGD(TAG, "Unhandled: %s - %d", message.c_str(), this->state_);
+      ESP_LOGW(TAG, "Unhandled: %s - %d", message.c_str(), this->state_);
       break;
   }
-}
+}  // namespace sim800l
 
 void Sim800LComponent::loop() {
   // Read message
@@ -265,7 +429,7 @@ void Sim800LComponent::loop() {
       byte = '?';  // need to be valid utf8 string for log functions.
     this->read_buffer_[this->read_pos_] = byte;
 
-    if (this->state_ == STATE_SENDINGSMS2 && this->read_pos_ == 0 && byte == '>')
+    if (this->state_ == STATE_SENDING_SMS_2 && this->read_pos_ == 0 && byte == '>')
       this->read_buffer_[++this->read_pos_] = ASCII_LF;
 
     if (this->read_buffer_[this->read_pos_] == ASCII_LF) {
@@ -276,13 +440,23 @@ void Sim800LComponent::loop() {
       this->read_pos_++;
     }
   }
+  if (state_ == STATE_INIT && this->registered_ &&
+      (this->call_state_ != 6  // A call is in progress
+       || this->send_pending_ || this->dial_pending_ || this->connect_pending_ || this->disconnect_pending_)) {
+    this->update();
+  }
 }
 
 void Sim800LComponent::send_sms(const std::string &recipient, const std::string &message) {
-  ESP_LOGD(TAG, "Sending to %s: %s", recipient.c_str(), message.c_str());
   this->recipient_ = recipient;
   this->outgoing_message_ = message;
   this->send_pending_ = true;
+}
+
+void Sim800LComponent::send_ussd(const std::string &ussd_code) {
+  ESP_LOGD(TAG, "Sending USSD code: %s", ussd_code.c_str());
+  this->ussd_ = ussd_code;
+  this->send_ussd_pending_ = true;
   this->update();
 }
 void Sim800LComponent::dump_config() {
@@ -295,11 +469,11 @@ void Sim800LComponent::dump_config() {
 #endif
 }
 void Sim800LComponent::dial(const std::string &recipient) {
-  ESP_LOGD(TAG, "Dialing %s", recipient.c_str());
   this->recipient_ = recipient;
   this->dial_pending_ = true;
-  this->update();
 }
+void Sim800LComponent::connect() { this->connect_pending_ = true; }
+void Sim800LComponent::disconnect() { this->disconnect_pending_ = true; }
 
 void Sim800LComponent::set_registered_(bool registered) {
   this->registered_ = registered;

--- a/esphome/components/tsl2591/tsl2591.h
+++ b/esphome/components/tsl2591/tsl2591.h
@@ -245,10 +245,10 @@ class TSL2591Component : public PollingComponent, public i2c::I2CDevice {
 
  protected:
   const char *name_;
-  sensor::Sensor *full_spectrum_sensor_;
-  sensor::Sensor *infrared_sensor_;
-  sensor::Sensor *visible_sensor_;
-  sensor::Sensor *calculated_lux_sensor_;
+  sensor::Sensor *full_spectrum_sensor_{nullptr};
+  sensor::Sensor *infrared_sensor_{nullptr};
+  sensor::Sensor *visible_sensor_{nullptr};
+  sensor::Sensor *calculated_lux_sensor_{nullptr};
   TSL2591IntegrationTime integration_time_;
   TSL2591ComponentGain component_gain_;
   TSL2591Gain gain_;

--- a/esphome/components/tx20/tx20.h
+++ b/esphome/components/tx20/tx20.h
@@ -43,8 +43,8 @@ class Tx20Component : public Component {
 
   std::string wind_cardinal_direction_;
   InternalGPIOPin *pin_;
-  sensor::Sensor *wind_speed_sensor_;
-  sensor::Sensor *wind_direction_degrees_sensor_;
+  sensor::Sensor *wind_speed_sensor_{nullptr};
+  sensor::Sensor *wind_direction_degrees_sensor_{nullptr};
   Tx20ComponentStore store_;
 };
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2022.9.0b1"
+__version__ = "2022.9.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -176,7 +176,7 @@ template<typename... Ts> class Action {
     return this->next_->is_running();
   }
 
-  Action<Ts...> *next_ = nullptr;
+  Action<Ts...> *next_{nullptr};
 
   /// The number of instances of this sequence in the list of actions
   /// that is currently being executed.

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -254,7 +254,7 @@ class Component {
 
   uint32_t component_state_{0x0000};  ///< State of this component.
   float setup_priority_override_{NAN};
-  const char *component_source_ = nullptr;
+  const char *component_source_{nullptr};
 };
 
 /** This class simplifies creating components that periodically check a state.

--- a/esphome/core/gpio.h
+++ b/esphome/core/gpio.h
@@ -73,7 +73,7 @@ class ISRInternalGPIOPin {
   void pin_mode(gpio::Flags flags);
 
  protected:
-  void *arg_ = nullptr;
+  void *arg_{nullptr};
 };
 
 class InternalGPIOPin : public GPIOPin {


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"In theory, theory and practice are the same. In practice, they’re not."_

~ Yogi Berra
- null initialize total sensor for pulse counter [esphome#3803](https://github.com/esphome/esphome/pull/3803)
- Sim800l add calls, multiline sms and ussd [esphome#3630](https://github.com/esphome/esphome/pull/3630)
- Unify 'nullptr' initalization of class members; [esphome#3805](https://github.com/esphome/esphome/pull/3805)
- Initialize all child sensors to nullptr [esphome#3808](https://github.com/esphome/esphome/pull/3808)
- Remove floating point calculation from ac_dimmer ISR [esphome#3770](https://github.com/esphome/esphome/pull/3770)
