### PR TITLE
Added ethernet_info platform from text_sensor

### DIFF
--- a/esphome/components/ethernet_info/__init__.py
+++ b/esphome/components/ethernet_info/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@gtjadsonsantos"]

--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.cpp
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.cpp
@@ -1,0 +1,12 @@
+#include "ethernet_info_text_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ethernet_info {
+
+static const char *const TAG = "ethernet_info";
+
+void IPAddressEthernetInfo::dump_config() { LOG_TEXT_SENSOR("", "EthernetInfo IPAddress", this); }
+
+}  // namespace ethernet_info
+}  // namespace esphome

--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.h
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.h
@@ -7,19 +7,18 @@
 namespace esphome {
 namespace ethernet_info {
 
-class IPAddressWiFiInfo : public PollingComponent, public text_sensor::TextSensor {
+class IPAddressEthernetInfo : public PollingComponent, public text_sensor::TextSensor {
  public:
   void update() override {
-    
-      tcpip_adapter_ip_info_t tcpip;
 
-      tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &tcpip);
-    
-      ip = IPAddress(tcpip.ip.addr);
+    tcpip_adapter_ip_info_t tcpip;
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &tcpip);
+
+    auto ip = tcpip.ip.addr;
 
     if (ip != this->last_ip_) {
       this->last_ip_ = ip;
-      this->publish_state(ip.str());
+      this->publish_state(network::IPAddress(ip).str().c_str());
     }
 
   }

--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.h
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/ethernet/ethernet_component.h"
+
+namespace esphome {
+namespace ethernet_info {
+
+class IPAddressWiFiInfo : public PollingComponent, public text_sensor::TextSensor {
+ public:
+  void update() override {
+    
+      tcpip_adapter_ip_info_t tcpip;
+
+      tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &tcpip);
+    
+      ip = IPAddress(tcpip.ip.addr);
+
+    if (ip != this->last_ip_) {
+      this->last_ip_ = ip;
+      this->publish_state(ip.str());
+    }
+
+  }
+
+  float get_setup_priority() const override { return setup_priority::ETHERNET; }
+  std::string unique_id() override { return get_mac_address() + "-ethernetinfo"; }
+  void dump_config() override;
+
+ protected:
+  network::IPAddress last_ip_;
+};
+
+}  // namespace ethernet_info
+}  // namespace esphome

--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.h
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.h
@@ -12,9 +12,7 @@ class IPAddressEthernetInfo : public PollingComponent, public text_sensor::TextS
   void update() override {
     tcpip_adapter_ip_info_t tcpip;
     tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &tcpip);
-
     auto ip = tcpip.ip.addr;
-
     if (ip != this->last_ip_) {
       this->last_ip_ = ip;
       this->publish_state(network::IPAddress(ip).str().c_str());

--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.h
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.h
@@ -10,7 +10,6 @@ namespace ethernet_info {
 class IPAddressEthernetInfo : public PollingComponent, public text_sensor::TextSensor {
  public:
   void update() override {
-
     tcpip_adapter_ip_info_t tcpip;
     tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &tcpip);
 
@@ -20,7 +19,6 @@ class IPAddressEthernetInfo : public PollingComponent, public text_sensor::TextS
       this->last_ip_ = ip;
       this->publish_state(network::IPAddress(ip).str().c_str());
     }
-
   }
 
   float get_setup_priority() const override { return setup_priority::ETHERNET; }

--- a/esphome/components/ethernet_info/text_sensor.py
+++ b/esphome/components/ethernet_info/text_sensor.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+from esphome.const import (
+    CONF_IP_ADDRESS,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+
+DEPENDENCIES = ["ethernet"]
+
+ethernet_info_ns = cg.esphome_ns.namespace("ethernet_info")
+
+IPAddressEsthernetInfo = ethernet_info_ns.class_(
+    "IPAddressEthernetInfo", text_sensor.TextSensor, cg.PollingComponent
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_IP_ADDRESS): text_sensor.text_sensor_schema(
+            IPAddressEsthernetInfo, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+        ).extend(cv.polling_component_schema("1s"))
+    }
+)
+
+
+async def setup_conf(config, key):
+    if key in config:
+        conf = config[key]
+        var = await text_sensor.new_text_sensor(conf)
+        await cg.register_component(var, conf)
+
+
+async def to_code(config):
+    await setup_conf(config, CONF_IP_ADDRESS)

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -20,6 +20,7 @@ const float PROCESSOR = 400.0;
 const float BLUETOOTH = 350.0f;
 const float AFTER_BLUETOOTH = 300.0f;
 const float WIFI = 250.0f;
+const float ETHERNET = 250.0f;
 const float BEFORE_CONNECTION = 220.0f;
 const float AFTER_WIFI = 200.0f;
 const float AFTER_CONNECTION = 100.0f;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -29,6 +29,7 @@ extern const float PROCESSOR;
 extern const float BLUETOOTH;
 extern const float AFTER_BLUETOOTH;
 extern const float WIFI;
+extern const float ETHERNET;
 /// For components that should be initialized after WiFi and before API is connected.
 extern const float BEFORE_CONNECTION;
 /// For components that should be initialized after WiFi is connected.

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -531,6 +531,9 @@ text_sensor:
   - platform: copy
     source_id: inverter0_device_mode
     name: Inverter Text Sensor Copy
+  - platform: ethernet_info
+    ip_address:
+      name: IP Address
 
 output:
   - platform: pipsolar


### PR DESCRIPTION
# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
text_sensor:
  - platform: ethernet_info
    ip_address:
      name: IP Address
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
