### PR TITLE
split pronto codes if they are too long

### DIFF
--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -227,7 +227,18 @@ optional<ProntoData> ProntoProtocol::decode(RemoteReceiveData src) {
   return out;
 }
 
-void ProntoProtocol::dump(const ProntoData &data) { ESP_LOGD(TAG, "Received Pronto: data=%s", data.data.c_str()); }
+void ProntoProtocol::dump(const ProntoData &data) {
+  std::string first, rest;
+  if (data.data.size() < 230) {
+    first = data.data;
+  } else {
+    first = data.data.substr(0, 229);
+    rest = data.data.substr(230);
+  }
+  ESP_LOGD(TAG, "Received Pronto: data=%s", first.c_str());
+  if (!rest.empty())
+    ESP_LOGD(TAG, "%s", rest.c_str());
+}
 
 }  // namespace remote_base
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?
If the pronto code is too long for a log message, it will split it into a second line.

Quick description and explanation of changes

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
