### PR TITLE
Allow preserving WiFi credentials entered with captive_portal

### DIFF
--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -59,4 +59,4 @@ async def to_code(config):
         cg.add_library("DNSServer", None)
 
     if config.get(CONF_KEEP_USER_CREDENTIALS, False):
-        cg.add_define("USE_WIFI_USER_CREDENTIALS")
+        cg.add_define("USE_CAPTIVE_PORTAL_KEEP_USER_CREDENTIALS")

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -1,8 +1,9 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+import esphome.final_validate as fv
 from esphome.components import web_server_base
 from esphome.components.web_server_base import CONF_WEB_SERVER_BASE_ID
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_NETWORKS, CONF_PASSWORD, CONF_SSID, CONF_WIFI
 from esphome.core import coroutine_with_priority, CORE
 
 AUTO_LOAD = ["web_server_base"]
@@ -12,6 +13,7 @@ CODEOWNERS = ["@OttoWinter"]
 captive_portal_ns = cg.esphome_ns.namespace("captive_portal")
 CaptivePortal = captive_portal_ns.class_("CaptivePortal", cg.Component)
 
+CONF_KEEP_USER_CREDENTIALS = "keep_user_credentials"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -19,10 +21,27 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(CONF_WEB_SERVER_BASE_ID): cv.use_id(
                 web_server_base.WebServerBase
             ),
+            cv.Optional(CONF_KEEP_USER_CREDENTIALS, default=False): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
 )
+
+
+def validate_wifi(config):
+    wifi_conf = fv.full_config.get()[CONF_WIFI]
+    if config.get(CONF_KEEP_USER_CREDENTIALS, False) and (
+        CONF_SSID in wifi_conf
+        or CONF_PASSWORD in wifi_conf
+        or CONF_NETWORKS in wifi_conf
+    ):
+        raise cv.Invalid(
+            f"WiFi credentials cannot be used together with {CONF_KEEP_USER_CREDENTIALS}"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = validate_wifi
 
 
 @coroutine_with_priority(64.0)
@@ -38,3 +57,6 @@ async def to_code(config):
         cg.add_library("WiFi", None)
     if CORE.is_esp8266:
         cg.add_library("DNSServer", None)
+
+    if config.get(CONF_KEEP_USER_CREDENTIALS, False):
+        cg.add_define("USE_WIFI_USER_CREDENTIALS")

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -200,13 +200,6 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 
 
 def _validate(config):
-    if config.get(CONF_KEEP_USER_CREDENTIALS, False) and (
-        CONF_SSID in config or CONF_PASSWORD in config or CONF_NETWORKS in config
-    ):
-        raise cv.Invalid(
-            f"WiFi credentials cannot be used together with {CONF_KEEP_USER_CREDENTIALS}"
-        )
-
     if CONF_PASSWORD in config and CONF_SSID not in config:
         raise cv.Invalid("Cannot have WiFi password without SSID!")
 
@@ -259,7 +252,6 @@ def _validate(config):
 
 
 CONF_OUTPUT_POWER = "output_power"
-CONF_KEEP_USER_CREDENTIALS = "keep_user_credentials"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -279,7 +271,6 @@ CONFIG_SCHEMA = cv.All(
             ): cv.enum(WIFI_POWER_SAVE_MODES, upper=True),
             cv.Optional(CONF_FAST_CONNECT, default=False): cv.boolean,
             cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
-            cv.Optional(CONF_KEEP_USER_CREDENTIALS, default=False): cv.boolean,
             cv.SplitDefault(CONF_OUTPUT_POWER, esp8266=20.0): cv.All(
                 cv.decibel, cv.float_range(min=8.5, max=20.5)
             ),
@@ -384,9 +375,6 @@ async def to_code(config):
     cg.add(var.set_fast_connect(config[CONF_FAST_CONNECT]))
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
-
-    if config.get(CONF_KEEP_USER_CREDENTIALS, False):
-        cg.add_define("USE_WIFI_USER_CREDENTIALS")
 
     if CORE.is_esp8266:
         cg.add_library("ESP8266WiFi", None)

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -200,6 +200,13 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 
 
 def _validate(config):
+    if config.get(CONF_KEEP_USER_CREDENTIALS, False) and (
+        CONF_SSID in config or CONF_PASSWORD in config or CONF_NETWORKS in config
+    ):
+        raise cv.Invalid(
+            f"WiFi credentials cannot be used together with {CONF_KEEP_USER_CREDENTIALS}"
+        )
+
     if CONF_PASSWORD in config and CONF_SSID not in config:
         raise cv.Invalid("Cannot have WiFi password without SSID!")
 
@@ -378,7 +385,7 @@ async def to_code(config):
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
 
-    if CONF_KEEP_USER_CREDENTIALS in config:
+    if config.get(CONF_KEEP_USER_CREDENTIALS, False):
         cg.add_define("USE_WIFI_USER_CREDENTIALS")
 
     if CORE.is_esp8266:

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -252,7 +252,7 @@ def _validate(config):
 
 
 CONF_OUTPUT_POWER = "output_power"
-CONF_KEEP_CREDENTIALS = "keep_user_credentials"
+CONF_KEEP_USER_CREDENTIALS = "keep_user_credentials"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -272,7 +272,7 @@ CONFIG_SCHEMA = cv.All(
             ): cv.enum(WIFI_POWER_SAVE_MODES, upper=True),
             cv.Optional(CONF_FAST_CONNECT, default=False): cv.boolean,
             cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
-            cv.Optional(CONF_KEEP_CREDENTIALS, default=False): cv.boolean,
+            cv.Optional(CONF_KEEP_USER_CREDENTIALS, default=False): cv.boolean,
             cv.SplitDefault(CONF_OUTPUT_POWER, esp8266=20.0): cv.All(
                 cv.decibel, cv.float_range(min=8.5, max=20.5)
             ),
@@ -378,7 +378,7 @@ async def to_code(config):
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
 
-    if CONF_KEEP_CREDENTIALS in config:
+    if CONF_KEEP_USER_CREDENTIALS in config:
         cg.add_define("USE_WIFI_USER_CREDENTIALS")
 
     if CORE.is_esp8266:

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -252,6 +252,7 @@ def _validate(config):
 
 
 CONF_OUTPUT_POWER = "output_power"
+CONF_KEEP_CREDENTIALS = "keep_user_credentials"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -271,6 +272,7 @@ CONFIG_SCHEMA = cv.All(
             ): cv.enum(WIFI_POWER_SAVE_MODES, upper=True),
             cv.Optional(CONF_FAST_CONNECT, default=False): cv.boolean,
             cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
+            cv.Optional(CONF_KEEP_CREDENTIALS, default=False): cv.boolean,
             cv.SplitDefault(CONF_OUTPUT_POWER, esp8266=20.0): cv.All(
                 cv.decibel, cv.float_range(min=8.5, max=20.5)
             ),
@@ -375,6 +377,9 @@ async def to_code(config):
     cg.add(var.set_fast_connect(config[CONF_FAST_CONNECT]))
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
+
+    if CONF_KEEP_CREDENTIALS in config:
+        cg.add_define("USE_WIFI_USER_CREDENTIALS")
 
     if CORE.is_esp8266:
         cg.add_library("ESP8266WiFi", None)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -38,7 +38,7 @@ void WiFiComponent::setup() {
   this->last_connected_ = millis();
   this->wifi_pre_setup_();
 
-#ifndef USE_WIFI_USER_CREDENTIALS
+#ifndef USE_CAPTIVE_PORTAL_KEEP_USER_CREDENTIALS
   uint32_t hash = fnv1_hash(App.get_compilation_time());
 #else
   uint32_t hash = 88491487UL;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -38,7 +38,11 @@ void WiFiComponent::setup() {
   this->last_connected_ = millis();
   this->wifi_pre_setup_();
 
+#ifndef USE_WIFI_USER_CREDENTIALS
   uint32_t hash = fnv1_hash(App.get_compilation_time());
+#else
+  uint32_t hash = 88491487UL;
+#endif
   this->pref_ = global_preferences->make_preference<wifi::SavedWifiSettings>(hash, true);
 
   SavedWifiSettings save{};


### PR DESCRIPTION
# What does this implement/fix?

This PR allows the user to preserve the WiFi credentials, that were entered using `captive_portal`, over subsequent OTA updates. I think this may be a useful feature, given that guides like `Sharing ESPHome devices` exist, and the recent addition of a "factory reset" component. When using `keep_user_credentials`, the user can freely reconfigure a device to a different network in a [WiFiManager](https://github.com/tzapu/WiFiManager)-like manner, whether it's a DIY, tuya-converted, or vendor-supplied ESPHome device.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2301

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] LibreTuya port

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
wifi:
  keep_user_credentials: true
  # ssid: "my_ssid_unused"
  # password: "1234"
  ap:
    password: "ESPHome123"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
