### PR TITLE
Fix-esphome-validation-line-number

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -172,7 +172,9 @@ class Config(OrderedDict, fv.FinalValidateConfig):
         for item_index in path:
             try:
                 if item_index in data:
-                    doc_range = [x for x in data.keys() if x == item_index][0].esp_range
+                    key_data = [x for x in data.keys() if x == item_index][0]
+                    if isinstance(key_data, ESPHomeDataBase):
+                        doc_range = key_data.esp_range
                 data = data[item_index]
             except (KeyError, IndexError, TypeError, AttributeError):
                 return doc_range

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -281,7 +281,7 @@ class ConfigValidationStep(abc.ABC):
 class LoadValidationStep(ConfigValidationStep):
     """Load step, this step is called once for each domain config fragment.
 
-    Responsibilties:
+    Responsibilities:
     - Load component code
     - Ensure all AUTO_LOADs are added
     - Set output paths of result

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -165,17 +165,19 @@ class Config(OrderedDict, fv.FinalValidateConfig):
                 return err
         return None
 
-    def get_deepest_document_range_for_path(self, path):
-        # type: (ConfigPath) -> Optional[ESPHomeDataBase]
+    def get_deepest_document_range_for_path(self, path, get_key=False):
+        # type: (ConfigPath, bool) -> Optional[ESPHomeDataBase]
         data = self
         doc_range = None
-        for item_index in path:
+        for index, path_item in enumerate(path):
             try:
-                if item_index in data:
-                    key_data = [x for x in data.keys() if x == item_index][0]
+                if path_item in data:
+                    key_data = [x for x in data.keys() if x == path_item][0]
                     if isinstance(key_data, ESPHomeDataBase):
                         doc_range = key_data.esp_range
-                data = data[item_index]
+                        if get_key and index == len(path) - 1:
+                            return doc_range
+                data = data[path_item]
             except (KeyError, IndexError, TypeError, AttributeError):
                 return doc_range
             if isinstance(data, core.ID):
@@ -739,6 +741,10 @@ def validate_config(config, command_line_substitutions) -> Config:
         if key in config:
             result.add_validation_step(LoadValidationStep(key, config[key]))
     result.run_validation_steps()
+
+    if result.errors:
+        # do not try to validate further as we don't know what the target is
+        return result
 
     for domain, conf in config.items():
         result.add_validation_step(LoadValidationStep(domain, conf))

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -179,7 +179,11 @@ def preload_core_config(config, result):
     ]
 
     if not has_oldstyle and not newstyle_found:
-        raise cv.Invalid("Platform missing for core options!", [CONF_ESPHOME])
+        raise cv.Invalid(
+            "Platform missing. You must include one of the available platform keys: "
+            + ", ".join(TARGET_PLATFORMS),
+            [CONF_ESPHOME],
+        )
     if has_oldstyle and newstyle_found:
         raise cv.Invalid(
             f"Please remove the `platform` key from the [esphome] block. You're already using the new style with the [{conf[CONF_PLATFORM]}] block",

--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -12,7 +12,9 @@ from typing import Optional
 
 def _get_invalid_range(res, invalid):
     # type: (Config, cv.Invalid) -> Optional[DocumentRange]
-    return res.get_deepest_document_range_for_path(invalid.path)
+    return res.get_deepest_document_range_for_path(
+        invalid.path, invalid.error_message == "extra keys not allowed"
+    )
 
 
 def _dump_range(range):


### PR DESCRIPTION
# What does this implement/fix?

These are small improvements on where in the yaml file the error is happening, specially handles better the case of errors in the `esphome:` key and also in platforms: `esp8266:`, `esp32:`  it even handles a case where esphome will crash validating some yaml files.

A few of this are needed after idf support was added and core config got handled differently.

There is still lots of room for improving this but I would start adding test cases to support the changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
