### PR TITLE
Add adc128s102 sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,7 @@ esphome/core/* @esphome/core
 # Integrations
 esphome/components/ac_dimmer/* @glmnet
 esphome/components/adc/* @esphome/core
+esphome/components/adc128s102/* @DeerMaximum
 esphome/components/addressable_light/* @justfalter
 esphome/components/airthings_ble/* @jeromelaban
 esphome/components/airthings_wave_mini/* @ncareau

--- a/esphome/components/adc128s102/__init__.py
+++ b/esphome/components/adc128s102/__init__.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import spi
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["spi"]
+MULTI_CONF = True
+CODEOWNERS = ["@DeerMaximum"]
+
+adc128s102_ns = cg.esphome_ns.namespace("adc128s102")
+ADC128S102 = adc128s102_ns.class_("ADC128S102", cg.Component, spi.SPIDevice)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(ADC128S102),
+    }
+).extend(spi.spi_device_schema(cs_pin_required=True))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await spi.register_spi_device(var, config)

--- a/esphome/components/adc128s102/adc128s102.cpp
+++ b/esphome/components/adc128s102/adc128s102.cpp
@@ -1,0 +1,35 @@
+#include "adc128s102.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace adc128s102{
+
+static const char *const TAG = "adc128s102";
+
+float ADC128S102::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+void ADC128S102::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up adc128s102");
+  this->spi_setup();
+}
+
+void ADC128S102::dump_config() {
+  ESP_LOGCONFIG(TAG, "ADC128S102:");
+  LOG_PIN("  CS Pin:", this->cs_);
+}
+
+uint16_t ADC128S102::read_data(uint8_t channel){
+  byte control = channel << 3;
+
+  this->enable();
+  uint8_t adc_primary_byte = this->transfer_byte(control);
+  uint8_t adc_secondary_byte = this->transfer_byte(0x00);
+  this->disable();
+
+  uint16_t digital_value = adc_primary_byte << 8 | adc_secondary_byte;
+
+  return digital_value;
+}
+
+}
+}

--- a/esphome/components/adc128s102/adc128s102.cpp
+++ b/esphome/components/adc128s102/adc128s102.cpp
@@ -19,7 +19,7 @@ void ADC128S102::dump_config() {
 }
 
 uint16_t ADC128S102::read_data(uint8_t channel){
-  byte control = channel << 3;
+  uint8_t control = channel << 3;
 
   this->enable();
   uint8_t adc_primary_byte = this->transfer_byte(control);

--- a/esphome/components/adc128s102/adc128s102.cpp
+++ b/esphome/components/adc128s102/adc128s102.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace adc128s102{
+namespace adc128s102 {
 
 static const char *const TAG = "adc128s102";
 
@@ -18,7 +18,7 @@ void ADC128S102::dump_config() {
   LOG_PIN("  CS Pin:", this->cs_);
 }
 
-uint16_t ADC128S102::read_data(uint8_t channel){
+uint16_t ADC128S102::read_data(uint8_t channel) {
   uint8_t control = channel << 3;
 
   this->enable();
@@ -31,5 +31,5 @@ uint16_t ADC128S102::read_data(uint8_t channel){
   return digital_value;
 }
 
-}
-}
+}  // namespace adc128s102
+}  // namespace esphome

--- a/esphome/components/adc128s102/adc128s102.h
+++ b/esphome/components/adc128s102/adc128s102.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome {
+namespace adc128s102{
+
+class ADC128S102 : public Component,
+                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                                      spi::DATA_RATE_10MHZ>{
+
+public:
+ ADC128S102() = default;
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  uint16_t read_data(uint8_t channel);
+
+};
+
+
+}
+}

--- a/esphome/components/adc128s102/adc128s102.h
+++ b/esphome/components/adc128s102/adc128s102.h
@@ -5,22 +5,19 @@
 #include "esphome/components/spi/spi.h"
 
 namespace esphome {
-namespace adc128s102{
+namespace adc128s102 {
 
 class ADC128S102 : public Component,
-                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
-                                      spi::DATA_RATE_10MHZ>{
-
-public:
- ADC128S102() = default;
+                   public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                                         spi::DATA_RATE_10MHZ> {
+ public:
+  ADC128S102() = default;
 
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
   uint16_t read_data(uint8_t channel);
-
 };
 
-
-}
-}
+}  // namespace adc128s102
+}  // namespace esphome

--- a/esphome/components/adc128s102/sensor/__init__.py
+++ b/esphome/components/adc128s102/sensor/__init__.py
@@ -1,0 +1,35 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, voltage_sampler
+from esphome.const import CONF_ID, CONF_CHANNEL
+
+from .. import adc128s102_ns, ADC128S102
+
+AUTO_LOAD = ["voltage_sampler"]
+DEPENDENCIES = ["adc128s102"]
+
+ADC128S102Sensor = adc128s102_ns.class_(
+    "ADC128S102Sensor",
+    sensor.Sensor,
+    cg.PollingComponent,
+    voltage_sampler.VoltageSampler,
+)
+CONF_ADC128S102_ID = "adc128s102_id"
+
+CONFIG_SCHEMA = sensor.SENSOR_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(ADC128S102Sensor),
+        cv.GenerateID(CONF_ADC128S102_ID): cv.use_id(ADC128S102),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=7),
+    }
+).extend(cv.polling_component_schema("60s"))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        config[CONF_CHANNEL],
+    )
+    await cg.register_parented(var, config[CONF_ADC128S102_ID])
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
@@ -1,0 +1,25 @@
+#include "adc128s102_sensor.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace adc128s102{
+
+static const char *const TAG = "adc128s102.sensor";
+
+ADC128S102Sensor::ADC128S102Sensor(uint8_t channel) : channel_(channel) {}
+
+float ADC128S102Sensor::get_setup_priority() const { return setup_priority::DATA; }
+
+void ADC128S102Sensor::dump_config() {
+  LOG_SENSOR("", "ADC128S102 Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Pin: %u", this->channel_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+float ADC128S102Sensor::sample() { return this->parent_->read_data(this->channel_); }
+void ADC128S102Sensor::update() { this->publish_state(this->sample()); }
+
+
+}
+}

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
@@ -3,7 +3,7 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace adc128s102{
+namespace adc128s102 {
 
 static const char *const TAG = "adc128s102.sensor";
 
@@ -20,6 +20,5 @@ void ADC128S102Sensor::dump_config() {
 float ADC128S102Sensor::sample() { return this->parent_->read_data(this->channel_); }
 void ADC128S102Sensor::update() { this->publish_state(this->sample()); }
 
-
-}
-}
+}  // namespace adc128s102
+}  // namespace esphome

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.h
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.h
@@ -8,15 +8,13 @@
 #include "../adc128s102.h"
 
 namespace esphome {
-namespace adc128s102{
-
+namespace adc128s102 {
 
 class ADC128S102Sensor : public PollingComponent,
-                      public Parented<ADC128S102>,
-                      public sensor::Sensor,
-                      public voltage_sampler::VoltageSampler{
-
-public:
+                         public Parented<ADC128S102>,
+                         public sensor::Sensor,
+                         public voltage_sampler::VoltageSampler {
+ public:
   ADC128S102Sensor(uint8_t channel);
 
   void update() override;
@@ -24,8 +22,8 @@ public:
   float get_setup_priority() const override;
   float sample() override;
 
-protected:
+ protected:
   uint8_t channel_;
 };
-}
-}
+}  // namespace adc128s102
+}  // namespace esphome

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.h
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/voltage_sampler/voltage_sampler.h"
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+
+#include "../adc128s102.h"
+
+namespace esphome {
+namespace adc128s102{
+
+
+class ADC128S102Sensor : public PollingComponent,
+                      public Parented<ADC128S102>,
+                      public sensor::Sensor,
+                      public voltage_sampler::VoltageSampler{
+
+public:
+  ADC128S102Sensor(uint8_t channel);
+
+  void update() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  float sample() override;
+
+protected:
+  uint8_t channel_;
+};
+}
+}

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -789,6 +789,11 @@ sensor:
     voltage:
       name: Voltage
     update_interval: 60s
+
+  - platform: adc128s102
+    id: adc128s102_channel_0
+    channel: 0
+
 time:
   - platform: homeassistant
 
@@ -1538,3 +1543,6 @@ cd74hc4067:
   pin_s1: GPIO13
   pin_s2: GPIO14
   pin_s3: GPIO15
+
+adc128s102:
+  cs_pin: GPIO12


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the ADC128S102 8-channel 12-bit A/D converter to the components

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2308

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration entry
adc128s102:
  cs_pin: D8
  id: my_adc

sensor:
  - platform: adc128s102           # Attached to pin 0 of the ADC128S102.
    update_interval: 1s
    adc128s102_id: my_mcp
    id: freezer_temp_source
    channel: 0                     # ADC128S102 channel

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
