### PR TITLE
Jablotron JA-121T Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
             file: tests/test6.yaml
             name: Test tests/test6.yaml
             pio_cache_key: test6
+          - id: test
+            file: tests/test7.yaml
+            name: Test tests/test7.yaml
+            pio_cache_key: test7
           - id: pytest
             name: Run pytest
           - id: clang-format

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -112,6 +112,7 @@ esphome/components/interval/* @esphome/core
 esphome/components/jablotron/* @juliekoubova
 esphome/components/jablotron_info/* @juliekoubova
 esphome/components/jablotron_peripheral/* @juliekoubova
+esphome/components/jablotron_pg/* @juliekoubova
 esphome/components/jablotron_section/* @juliekoubova
 esphome/components/jablotron_section_flag/* @juliekoubova
 esphome/components/json/* @OttoWinter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -109,6 +109,11 @@ esphome/components/inkbird_ibsth1_mini/* @fkirill
 esphome/components/inkplate6/* @jesserockz
 esphome/components/integration/* @OttoWinter
 esphome/components/interval/* @esphome/core
+esphome/components/jablotron/* @juliekoubova
+esphome/components/jablotron_info/* @juliekoubova
+esphome/components/jablotron_peripheral/* @juliekoubova
+esphome/components/jablotron_section/* @juliekoubova
+esphome/components/jablotron_section_flag/* @juliekoubova
 esphome/components/json/* @OttoWinter
 esphome/components/kalman_combinator/* @Cat-Ion
 esphome/components/lcd_menu/* @numo68

--- a/esphome/components/jablotron/__init__.py
+++ b/esphome/components/jablotron/__init__.py
@@ -1,0 +1,63 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import uart
+from esphome.const import CONF_FLOW_CONTROL_PIN, CONF_ID, CONF_INDEX
+
+CODEOWNERS = ["@juliekoubova"]
+DEPENDENCIES = ["uart"]
+
+CONF_ACCESS_CODE = "access_code"
+CONF_JABLOTRON_ID = "jablotron_id"
+
+jablotron_ns = cg.esphome_ns.namespace("jablotron")
+JablotronComponent = jablotron_ns.class_(
+    "JablotronComponent", cg.PollingComponent, uart.UARTDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(JablotronComponent),
+            cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_ACCESS_CODE): cv.string,
+        }
+    )
+    .extend(cv.polling_component_schema("1s"))
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+JABLOTRON_DEVICE_SCHEMA = cv.Schema(
+    {cv.GenerateID(CONF_JABLOTRON_ID): cv.use_id(JablotronComponent)}
+)
+
+ACCESS_CODE_SCHEMA = cv.Schema({cv.Optional(CONF_ACCESS_CODE): cv.string})
+
+INDEX_SCHEMA = cv.Schema({cv.Required(CONF_INDEX): cv.int_range(min=0)})
+
+
+async def register_jablotron_device(var, config):
+    parent = await cg.get_variable(config[CONF_JABLOTRON_ID])
+    cg.add(var.set_parent_jablotron(parent))
+
+
+def set_access_code(var, config):
+    if CONF_ACCESS_CODE in config:
+        cg.add(var.set_access_code(config[CONF_ACCESS_CODE]))
+
+
+def set_index(var, config):
+    cg.add(var.set_index(config[CONF_INDEX]))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    if CONF_FLOW_CONTROL_PIN in config:
+        flow_control_pin = await cg.gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
+        cg.add(var.set_flow_control_pin(flow_control_pin))
+
+    set_access_code(var, config)
+
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/esphome/components/jablotron/jablotron_component.cpp
+++ b/esphome/components/jablotron/jablotron_component.cpp
@@ -47,19 +47,19 @@ void JablotronComponent::queue_peripheral_request_() {
 
 void JablotronComponent::queue_pg_request_() {
   if (!this->pgs_.empty()) {
-    this->queue_request("PGSTATE" + this->get_index_string(this->pgs_));
+    this->queue_request("PGSTATE" + this->get_index_string_(this->pgs_));
   }
 }
 
 void JablotronComponent::queue_section_request_() {
   if (!this->sections_.empty()) {
-    this->queue_request("STATE" + this->get_index_string(this->sections_));
+    this->queue_request("STATE" + this->get_index_string_(this->sections_));
   }
 }
 
 void JablotronComponent::queue_section_flag_request_() {
   if (!this->section_flags_.empty()) {
-    this->queue_request("FLAGS" + this->get_index_string(this->section_flags_));
+    this->queue_request("FLAGS" + this->get_index_string_(this->section_flags_));
   }
 }
 

--- a/esphome/components/jablotron/jablotron_component.cpp
+++ b/esphome/components/jablotron/jablotron_component.cpp
@@ -1,0 +1,145 @@
+#include "jablotron_component.h"
+#include "response_handler.h"
+
+namespace esphome {
+namespace jablotron {
+
+static const char *const TAG = "jablotron";
+
+JablotronComponent::JablotronComponent()
+    : PollingComponent(60000),
+      pgstate_handler_{pgs_},
+      prfstate_handler_{peripherals_},
+      state_handler_{sections_},
+      ver_handler_{infos_},
+      section_flag_handler_{section_flags_} {}
+
+void JablotronComponent::setup() {
+  UARTLineDevice::setup();
+  this->queue_request("VER");
+}
+
+void JablotronComponent::update() { this->pending_update_ = true; }
+
+void JablotronComponent::loop() {
+  auto lines = this->read_lines();
+  for (const auto &line : lines) {
+    auto *handler = this->handle_response_(line);
+    if (handler == nullptr) {
+      ESP_LOGE(TAG, "Unknown message: '%s'", line.c_str());
+    } else if (handler->is_last_response()) {
+      this->response_awaiter_.response_received();
+    }
+  }
+
+  if (!this->available() && this->line_buffer_empty() && !this->response_awaiter_.is_waiting_for_response()) {
+    this->send_queued_request_();
+  }
+}
+
+void JablotronComponent::set_access_code(std::string access_code) { this->access_code_ = std::move(access_code); }
+
+void JablotronComponent::queue_peripheral_request_() {
+  if (!this->peripherals_.empty()) {
+    this->queue_request("PRFSTATE");
+  }
+}
+
+void JablotronComponent::queue_pg_request_() {
+  if (!this->pgs_.empty()) {
+    this->queue_request("PGSTATE" + this->get_index_string(this->pgs_));
+  }
+}
+
+void JablotronComponent::queue_section_request_() {
+  if (!this->sections_.empty()) {
+    this->queue_request("STATE" + this->get_index_string(this->sections_));
+  }
+}
+
+void JablotronComponent::queue_section_flag_request_() {
+  if (!this->section_flags_.empty()) {
+    this->queue_request("FLAGS" + this->get_index_string(this->section_flags_));
+  }
+}
+
+void JablotronComponent::send_queued_request_() {
+  if (this->request_queue_.empty() && this->pending_update_) {
+    this->queue_peripheral_request_();
+    this->queue_section_request_();
+    this->queue_section_flag_request_();
+    this->queue_pg_request_();
+    this->pending_update_ = false;
+  }
+  if (!this->request_queue_.empty()) {
+    auto request = std::move(this->request_queue_.front());
+    this->request_queue_.pop_front();
+    this->send_request_(request);
+    this->response_awaiter_.request_sent();
+  }
+}
+
+void JablotronComponent::queue_request(std::string request) {
+  ESP_LOGI(TAG, "Queueing request '%s'", request.c_str());
+  this->request_queue_.emplace_back(std::move(request));
+}
+
+void JablotronComponent::queue_request_access_code(std::string request, const std::string &access_code) {
+  const std::string &actual_access_code = access_code.empty() ? this->access_code_ : access_code;
+  ESP_LOGI(TAG, "Queueing request '" LOG_SECRET("%s") " %s'", actual_access_code.c_str(), request.c_str());
+  this->request_queue_.emplace_back(actual_access_code + ' ' + std::move(request));
+}
+
+void JablotronComponent::send_request_(const std::string &request) {
+  ESP_LOGD(TAG, "Sending request '%s'", request.c_str());
+  this->write_line(request);
+}
+
+void JablotronComponent::register_section(SectionDevice *device) {
+  ESP_LOGI(TAG, "Registering section index=%u", device->get_index());
+  this->sections_.push_back(device);
+}
+
+void JablotronComponent::register_section_flag(SectionFlagDevice *device) {
+  ESP_LOGI(TAG, "Registering section flag flag=%u index=%u", static_cast<uint32_t>(device->get_flag()),
+           device->get_index());
+  this->section_flags_.push_back(device);
+}
+
+void JablotronComponent::register_peripheral(PeripheralDevice *device) {
+  ESP_LOGI(TAG, "Registering peripheral index=%u", device->get_index());
+  this->peripherals_.push_back(device);
+}
+
+void JablotronComponent::register_pg(PGDevice *device) {
+  ESP_LOGI(TAG, "Registering PG index=%u", device->get_index());
+  this->pgs_.push_back(device);
+}
+
+void JablotronComponent::register_info(InfoDevice *device) {
+  ESP_LOGI(TAG, "Registering info");
+  this->infos_.push_back(device);
+}
+
+ResponseHandler *JablotronComponent::handle_response_(StringView response) {
+  if (pgstate_handler_.invoke(response)) {
+    return &pgstate_handler_;
+  } else if (prfstate_handler_.invoke(response)) {
+    return &prfstate_handler_;
+  } else if (state_handler_.invoke(response)) {
+    return &state_handler_;
+  } else if (ok_handler_.invoke(response)) {
+    return &ok_handler_;
+  } else if (ver_handler_.invoke(response)) {
+    return &ver_handler_;
+  } else if (error_handler_.invoke(response)) {
+    return &error_handler_;
+  } else if (section_flag_handler_.invoke(response)) {
+    return &section_flag_handler_;
+  } else {
+    return nullptr;
+  }
+}
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/jablotron_component.h
+++ b/esphome/components/jablotron/jablotron_component.h
@@ -1,0 +1,81 @@
+#pragma once
+#include <deque>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+#include "jablotron_device.h"
+#include "response_awaiter.h"
+#include "response_handler.h"
+#include "uart_line_device.h"
+#include "string_view.h"
+
+namespace esphome {
+namespace jablotron {
+
+class JablotronComponent : public UARTLineDevice, public PollingComponent {
+ public:
+  JablotronComponent();
+
+  void setup() override;
+  void loop() override;
+  void update() override;
+
+  void queue_request(std::string request);
+  void queue_request_access_code(std::string request, const std::string &access_code);
+
+  void register_info(InfoDevice *device);
+  void register_peripheral(PeripheralDevice *device);
+  void register_pg(PGDevice *device);
+  void register_section(SectionDevice *device);
+  void register_section_flag(SectionFlagDevice *device);
+
+  void set_access_code(std::string access_code);
+
+ private:
+  ResponseHandler *handle_response_(StringView response);
+
+  void queue_peripheral_request_();
+  void queue_pg_request_();
+  void queue_section_request_();
+  void queue_section_flag_request_();
+
+  void send_queued_request_();
+  void send_request_(const std::string &request);
+
+  template<typename T> std::string get_index_string(const std::vector<T *> &items) {
+    std::set<int32_t> indices;
+    std::transform(std::begin(items), std::end(items), std::inserter(indices, indices.begin()),
+                   [](const T *item) { return item->get_index(); });
+    std::stringstream stream;
+    for (int32_t index : indices) {
+      stream << ' ' << index;
+    }
+    return stream.str();
+  }
+
+  std::string access_code_;
+
+  InfoDeviceVector infos_;
+  PeripheralDeviceVector peripherals_;
+  PGDeviceVector pgs_;
+  SectionDeviceVector sections_;
+  SectionFlagDeviceVector section_flags_;
+  std::deque<std::string> request_queue_;
+
+  ResponseAwaiter response_awaiter_;
+  bool pending_update_ = false;
+
+  ResponseHandlerError error_handler_;
+  ResponseHandlerOK ok_handler_;
+  ResponseHandlerPGState pgstate_handler_;
+  ResponseHandlerPrfState prfstate_handler_;
+  ResponseHandlerState state_handler_;
+  ResponseHandlerVer ver_handler_;
+  ResponseHandlerSectionFlag section_flag_handler_;
+};
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/jablotron_component.h
+++ b/esphome/components/jablotron/jablotron_component.h
@@ -45,7 +45,7 @@ class JablotronComponent : public UARTLineDevice, public PollingComponent {
   void send_queued_request_();
   void send_request_(const std::string &request);
 
-  template<typename T> std::string get_index_string(const std::vector<T *> &items) {
+  template<typename T> std::string get_index_string_(const std::vector<T *> &items) {
     std::set<int32_t> indices;
     std::transform(std::begin(items), std::end(items), std::inserter(indices, indices.begin()),
                    [](const T *item) { return item->get_index(); });

--- a/esphome/components/jablotron/jablotron_device.cpp
+++ b/esphome/components/jablotron/jablotron_device.cpp
@@ -29,8 +29,9 @@ const std::string &IndexedDevice::get_index_string() const {
 }
 
 void IndexedDevice::set_index(int value) {
+  using namespace std;
   this->index_ = value;
-  this->index_str_ = std::to_string(value);
+  this->index_str_ = to_string(value);
 }
 
 SectionFlag SectionFlagDevice::get_flag() const { return this->flag_; }

--- a/esphome/components/jablotron/jablotron_device.cpp
+++ b/esphome/components/jablotron/jablotron_device.cpp
@@ -1,0 +1,42 @@
+#include "jablotron_device.h"
+#include "jablotron_component.h"
+
+namespace esphome {
+namespace jablotron {
+
+static const char TAG[] = "jablotron";
+
+const std::string &JablotronDevice::get_access_code() const { return this->access_code_; }
+void JablotronDevice::set_access_code(std::string access_code) { this->access_code_ = std::move(access_code); }
+
+void JablotronDevice::set_parent_jablotron(JablotronComponent *parent) {
+  if (this->parent_ != parent) {
+    this->parent_ = parent;
+    if (parent != nullptr) {
+      this->register_parent(*parent);
+    }
+  }
+}
+
+JablotronComponent *JablotronDevice::get_parent_jablotron() const { return this->parent_; }
+
+const std::string &IndexedDevice::get_index_string() const {
+  if (this->index_str_.empty()) {
+    ESP_LOGE(TAG, "Index not set");
+  }
+  return this->index_str_;
+}
+
+void IndexedDevice::set_index(int value) {
+  this->index_ = value;
+  this->index_str_ = std::to_string(value);
+}
+
+SectionFlag SectionFlagDevice::get_flag() const { return this->flag_; }
+
+void SectionFlagDevice::set_flag(SectionFlag value) { this->flag_ = value; }
+
+void SectionFlagDevice::set_flag(int value) { this->set_flag(static_cast<SectionFlag>(value)); }
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/jablotron_device.cpp
+++ b/esphome/components/jablotron/jablotron_device.cpp
@@ -29,7 +29,7 @@ const std::string &IndexedDevice::get_index_string() const {
 
 void IndexedDevice::set_index(int value) {
   this->index_ = value;
-  this->index_str_ = std::to_string(value);
+  this->index_str_ = to_string(value);
 }
 
 SectionFlag SectionFlagDevice::get_flag() const { return this->flag_; }

--- a/esphome/components/jablotron/jablotron_device.cpp
+++ b/esphome/components/jablotron/jablotron_device.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include "jablotron_device.h"
 #include "jablotron_component.h"
 
@@ -29,7 +30,7 @@ const std::string &IndexedDevice::get_index_string() const {
 
 void IndexedDevice::set_index(int value) {
   this->index_ = value;
-  this->index_str_ = to_string(value);
+  this->index_str_ = std::to_string(value);
 }
 
 SectionFlag SectionFlagDevice::get_flag() const { return this->flag_; }

--- a/esphome/components/jablotron/jablotron_device.h
+++ b/esphome/components/jablotron/jablotron_device.h
@@ -1,0 +1,86 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "string_view.h"
+
+namespace esphome {
+namespace jablotron {
+
+class JablotronComponent;
+
+class JablotronDevice {
+ public:
+  virtual ~JablotronDevice() = default;
+  void set_access_code(std::string);
+  void set_parent_jablotron(JablotronComponent *parent);
+
+  const std::string &get_access_code() const;
+  JablotronComponent *get_parent_jablotron() const;
+
+ protected:
+  virtual void register_parent(JablotronComponent &parent) {}
+
+ private:
+  std::string access_code_;
+  JablotronComponent *parent_ = nullptr;
+};
+
+class IndexedDevice {
+ public:
+  virtual ~IndexedDevice() = default;
+
+  int get_index() const { return this->index_; }
+  const std::string &get_index_string() const;
+  void set_index(int value);
+
+ private:
+  int index_ = -1;
+  std::string index_str_;
+};
+
+template<typename T = StringView> class SensorDevice {
+ public:
+  virtual ~SensorDevice() = default;
+  virtual void set_state(T value) = 0;
+};
+
+template<typename T = StringView>
+class IndexedSensorDevice : public JablotronDevice, public IndexedDevice, public SensorDevice<T> {};
+
+enum class SectionFlag {
+  NONE = 0,
+  INTERNAL_WARNING = 1,
+  EXTERNAL_WARNING = 2,
+  FIRE_ALARM = 3,
+  INTRUDER_ALARM = 4,
+  PANIC_ALARM = 5,
+  ENTRY = 6,
+  EXIT = 7
+};
+
+class SectionFlagDevice : public IndexedSensorDevice<bool> {
+ public:
+  SectionFlag get_flag() const;
+  void set_flag(SectionFlag value);
+  void set_flag(int value);
+
+ private:
+  SectionFlag flag_ = SectionFlag::NONE;
+};
+
+class InfoDevice : public JablotronDevice, public SensorDevice<StringView> {};
+
+using PeripheralDevice = IndexedSensorDevice<bool>;
+using PeripheralDeviceVector = std::vector<PeripheralDevice *>;
+
+using SectionDevice = IndexedSensorDevice<StringView>;
+using SectionDeviceVector = std::vector<SectionDevice *>;
+
+using PGDevice = IndexedSensorDevice<bool>;
+using PGDeviceVector = std::vector<PGDevice *>;
+
+using InfoDeviceVector = std::vector<InfoDevice *>;
+using SectionFlagDeviceVector = std::vector<SectionFlagDevice *>;
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/jablotron_device.h
+++ b/esphome/components/jablotron/jablotron_device.h
@@ -11,7 +11,7 @@ class JablotronComponent;
 class JablotronDevice {
  public:
   virtual ~JablotronDevice() = default;
-  void set_access_code(std::string);
+  void set_access_code(std::string access_code);
   void set_parent_jablotron(JablotronComponent *parent);
 
   const std::string &get_access_code() const;

--- a/esphome/components/jablotron/response_awaiter.cpp
+++ b/esphome/components/jablotron/response_awaiter.cpp
@@ -1,0 +1,21 @@
+#include "response_awaiter.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace jablotron {
+
+ResponseAwaiter::ResponseAwaiter(uint32_t send_wait_time) : send_wait_time_{send_wait_time} {}
+
+bool ResponseAwaiter::is_waiting_for_response() const {
+  return is_waiting_for_response_ && (millis() - this->last_send_time_) < this->send_wait_time_;
+}
+
+void ResponseAwaiter::request_sent() {
+  this->is_waiting_for_response_ = true;
+  this->last_send_time_ = millis();
+}
+
+void ResponseAwaiter::response_received() { this->is_waiting_for_response_ = false; }
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/response_awaiter.h
+++ b/esphome/components/jablotron/response_awaiter.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+
+namespace esphome {
+namespace jablotron {
+
+class ResponseAwaiter {
+ public:
+  explicit ResponseAwaiter(uint32_t send_wait_time = 2000);
+
+  bool is_waiting_for_response() const;
+  void request_sent();
+  void response_received();
+
+ private:
+  bool is_waiting_for_response_ = false;
+  uint32_t last_send_time_ = 0;
+  const uint32_t send_wait_time_;
+};
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/response_handler.cpp
+++ b/esphome/components/jablotron/response_handler.cpp
@@ -1,0 +1,167 @@
+#include "response_handler.h"
+#include "string_view.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace jablotron {
+
+static constexpr const char TAG[] = "jablotron";
+
+bool ResponseHandler::is_last_response() const { return this->is_last_response_; }
+void ResponseHandler::set_is_last_response_(bool value) { this->is_last_response_ = value; }
+
+ResponseHandlerError::ResponseHandlerError() { this->set_is_last_response_(true); }
+bool ResponseHandlerError::invoke(StringView response) const {
+  if (response == "ERROR") {
+    ESP_LOGE(TAG, "Received ERROR");
+    return true;
+  }
+  if (try_remove_prefix_and_space(response, "ERROR:")) {
+    ESP_LOGE(TAG, "Received ERROR: '%s'", response.data());
+    return true;
+  }
+  return false;
+}
+
+ResponseHandlerOK::ResponseHandlerOK() { this->set_is_last_response_(true); }
+bool ResponseHandlerOK::invoke(StringView response) const { return response == "OK"; }
+
+ResponseHandlerPGState::ResponseHandlerPGState(const PGDeviceVector &devices) : devices_{devices} {
+  this->set_is_last_response_(false);
+}
+
+bool ResponseHandlerPGState::invoke(StringView response) const {
+  if (response == "PGSTATE:") {
+    return true;
+  }
+  if (!try_remove_prefix_and_space(response, "PG")) {
+    return false;
+  }
+
+  int index;
+  if (!try_remove_integer_and_space(response, index)) {
+    ESP_LOGE(TAG, "ResponseHandlerPGState: PG has no index: '%s'", response.data());
+    return false;
+  }
+
+  bool state;
+  if (response == "ON") {
+    state = true;
+  } else if (response == "OFF") {
+    state = false;
+  } else {
+    ESP_LOGE(TAG, "ResponseHandlerPGState: Unknown PG state: '%s'", response.data());
+    return false;
+  }
+
+  for (auto *device : this->devices_) {
+    if (device->get_index() == index) {
+      device->set_state(state);
+    }
+  }
+  return true;
+}
+
+ResponseHandlerPrfState::ResponseHandlerPrfState(const PeripheralDeviceVector &devices) : devices_{devices} {
+  this->set_is_last_response_(true);
+}
+
+bool ResponseHandlerPrfState::invoke(StringView response) const {
+  if (!try_remove_prefix(response, "PRFSTATE ")) {
+    return false;
+  }
+  for (auto *device : this->devices_) {
+    auto state = get_bit_in_hex_string(response, device->get_index());
+    device->set_state(state);
+  }
+  return true;
+}
+
+ResponseHandlerState::ResponseHandlerState(const SectionDeviceVector &devices) : devices_{devices} {
+  this->set_is_last_response_(false);
+}
+
+bool ResponseHandlerState::invoke(StringView response) const {
+  if (response == "STATE:") {
+    return true;
+  }
+  if (!try_remove_prefix(response, "STATE ")) {
+    return false;
+  }
+  int index;
+  if (!try_remove_integer_and_space(response, index)) {
+    ESP_LOGE(TAG, "ResponseHandlerState: STATE has no index: '%s'", response.data());
+    return false;
+  }
+  for (auto *device : this->devices_) {
+    if (device->get_index() == index) {
+      device->set_state(response);
+    }
+  }
+  return true;
+}
+
+ResponseHandlerVer::ResponseHandlerVer(const InfoDeviceVector &devices) : devices_{devices} {
+  this->set_is_last_response_(true);
+}
+
+bool ResponseHandlerVer::invoke(StringView response) const {
+  if (!response.starts_with("JA-121T,")) {
+    return false;
+  }
+  for (auto *device : this->devices_) {
+    device->set_state(response);
+  }
+  return true;
+}
+
+ResponseHandlerSectionFlag::ResponseHandlerSectionFlag(const SectionFlagDeviceVector &devices) : devices_{devices} {
+  this->set_is_last_response_(false);
+}
+
+bool ResponseHandlerSectionFlag::invoke(StringView response) const {
+  SectionFlag flag = SectionFlag::NONE;
+  if (try_remove_prefix(response, "EXTERNAL_WARNING ")) {
+    flag = SectionFlag::EXTERNAL_WARNING;
+  } else if (try_remove_prefix(response, "INTERNAL_WARNING ")) {
+    flag = SectionFlag::INTERNAL_WARNING;
+  } else if (try_remove_prefix(response, "FIRE_ALARM ")) {
+    flag = SectionFlag::FIRE_ALARM;
+  } else if (try_remove_prefix(response, "INTRUDER_ALARM ")) {
+    flag = SectionFlag::INTRUDER_ALARM;
+  } else if (try_remove_prefix(response, "PANIC_ALARM ")) {
+    flag = SectionFlag::PANIC_ALARM;
+  } else if (try_remove_prefix(response, "ENTRY ")) {
+    flag = SectionFlag::ENTRY;
+  } else if (try_remove_prefix(response, "EXIT ")) {
+    flag = SectionFlag::EXIT;
+  } else {
+    return false;
+  }
+
+  int index;
+  if (!try_remove_integer_and_space(response, index)) {
+    ESP_LOGE(TAG, "ResponseHandlerSectionFlag: section flag has no index: '%s'", response.data());
+    return false;
+  }
+
+  bool state;
+  if (response == "ON") {
+    state = true;
+  } else if (response == "OFF") {
+    state = false;
+  } else {
+    ESP_LOGE(TAG, "ResponseHandlerSectionFlag: unknown flag state: '%s'", response.data());
+    return false;
+  }
+
+  for (auto *device : this->devices_) {
+    if (device->get_index() == index && device->get_flag() == flag) {
+      device->set_state(state);
+    }
+  }
+  return true;
+}
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/response_handler.h
+++ b/esphome/components/jablotron/response_handler.h
@@ -1,0 +1,80 @@
+#pragma once
+#include "jablotron_device.h"
+#include "string_view.h"
+
+namespace esphome {
+namespace jablotron {
+
+class ResponseHandler {
+ public:
+  virtual ~ResponseHandler() = default;
+  virtual bool invoke(StringView response) const = 0;
+
+  bool is_last_response() const;
+
+ protected:
+  void set_is_last_response_(bool value);
+
+ private:
+  bool is_last_response_ = false;
+};
+
+class ResponseHandlerError : public ResponseHandler {
+ public:
+  ResponseHandlerError();
+  bool invoke(StringView response) const final;
+};
+
+class ResponseHandlerOK : public ResponseHandler {
+ public:
+  ResponseHandlerOK();
+  bool invoke(StringView response) const final;
+};
+
+class ResponseHandlerPGState final : public ResponseHandler {
+ public:
+  explicit ResponseHandlerPGState(const PGDeviceVector &devices);
+  bool invoke(StringView response) const final;
+
+ private:
+  const PeripheralDeviceVector &devices_;
+};
+
+class ResponseHandlerPrfState final : public ResponseHandler {
+ public:
+  explicit ResponseHandlerPrfState(const PeripheralDeviceVector &devices);
+  bool invoke(StringView response) const final;
+
+ private:
+  const PeripheralDeviceVector &devices_;
+};
+
+class ResponseHandlerState final : public ResponseHandler {
+ public:
+  explicit ResponseHandlerState(const SectionDeviceVector &devices);
+  bool invoke(StringView response) const final;
+
+ private:
+  const SectionDeviceVector &devices_;
+};
+
+class ResponseHandlerVer final : public ResponseHandler {
+ public:
+  explicit ResponseHandlerVer(const InfoDeviceVector &devices);
+  bool invoke(StringView response) const final;
+
+ private:
+  const InfoDeviceVector &devices_;
+};
+
+class ResponseHandlerSectionFlag final : public ResponseHandler {
+ public:
+  explicit ResponseHandlerSectionFlag(const SectionFlagDeviceVector &devices);
+  bool invoke(StringView response) const final;
+
+ private:
+  const SectionFlagDeviceVector &devices_;
+};
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/string_view.cpp
+++ b/esphome/components/jablotron/string_view.cpp
@@ -1,0 +1,147 @@
+#include "string_view.h"
+#include "esphome/core/log.h"
+#include <cstring>
+#include <cstdlib>
+
+namespace esphome {
+namespace jablotron {
+
+namespace {
+
+const char *const TAG = "jablotron";
+
+uint8_t parse_hex_nibble(char hex) {
+  if (hex >= '0' && hex <= '9') {
+    return hex - '0';
+  } else if (hex >= 'A' && hex <= 'F') {
+    return hex - 'A' + 10;
+  } else {
+    ESP_LOGE(TAG, "parse_hex_nibble: char=%c not 0-9A-F", hex);
+    return 0;
+  }
+}
+
+uint8_t parse_hex_byte(char high, char low) { return (parse_hex_nibble(high) << 4) | (parse_hex_nibble(low)); }
+
+}  // namespace
+
+StringView::StringView() : data_{nullptr}, size_{0} {}
+StringView::StringView(const char *begin) : data_{begin}, size_{std::strlen(begin)} {}
+
+StringView::StringView(const char *begin, size_t size) : data_{begin}, size_{size} {}
+
+StringView::StringView(const std::string &str) : data_{str.data()}, size_{str.size()} {}
+
+const char *StringView::data() const noexcept { return this->data_; }
+bool StringView::empty() const noexcept { return this->size_ == 0; }
+StringView::size_type StringView::size() const noexcept { return this->size_; }
+StringView::operator std::string() const { return std::string{this->data_, this->size_}; }
+
+bool StringView::starts_with(StringView s) const { return this->substr(0, s.size()) == s; }
+
+void StringView::remove_prefix(size_type n) {
+  if (n > this->size_) {
+    this->data_ = nullptr;
+    this->size_ = 0;
+  } else {
+    this->data_ += n;
+    this->size_ -= n;
+  }
+}
+
+StringView StringView::substr(size_type pos, size_type count) const {
+  if (pos > this->size_) {
+    return StringView{};
+  }
+  auto rcount = std::min(this->size_ - pos, count);
+  return StringView{this->data_ + pos, rcount};
+}
+
+const char &StringView::operator[](size_type index) const { return this->data_[index]; }
+
+bool StringView::operator==(const StringView &other) const noexcept {
+  return this->size_ == other.size_ && (this->size_ == 0 || std::strncmp(this->data_, other.data_, this->size_) == 0);
+}
+
+bool StringView::operator!=(const StringView &other) const noexcept { return !(*this == other); }
+
+bool StringView::operator==(const std::string &other) const noexcept { return *this == StringView{other}; }
+bool StringView::operator!=(const std::string &other) const noexcept { return *this != StringView{other}; }
+
+bool StringView::operator==(const char *other) const noexcept { return *this == StringView{other}; }
+bool StringView::operator!=(const char *other) const noexcept { return *this != StringView{other}; }
+
+bool operator==(const std::string &string, const StringView &view) noexcept { return view == string; }
+bool operator!=(const std::string &string, const StringView &view) noexcept { return view != string; }
+
+bool get_bit_in_hex_string(StringView str, size_t index) {
+  if (index >= str.size()) {
+    ESP_LOGE(TAG, "get_bit_in_hex_string: index=%zu out of string bounds", index);
+    return false;
+  }
+
+  auto div = std::div(index, 8);
+  size_t high_nibble_index = 2 * div.quot;
+  size_t low_nibble_index = 2 * div.quot + 1;
+  size_t bit_index = div.rem;
+
+  if (low_nibble_index >= str.size()) {
+    ESP_LOGE(TAG, "get_bit_in_hex_string: string length not even");
+    return false;
+  }
+
+  uint8_t byte = parse_hex_byte(str[high_nibble_index], str[low_nibble_index]);
+  uint8_t bit_mask = 1 << bit_index;
+  return byte & bit_mask;
+}
+
+bool starts_with(StringView str, StringView prefix) {
+  if (prefix.empty()) {
+    return false;
+  }
+  return str.substr(0, prefix.size()) == prefix;
+}
+
+bool try_remove_prefix(StringView &str, StringView prefix) {
+  if (starts_with(str, prefix)) {
+    str.remove_prefix(prefix.size());
+    return true;
+  }
+  return false;
+}
+
+bool try_remove_prefix(StringView &str, const std::string &prefix) {
+  return try_remove_prefix(str, StringView{prefix});
+}
+
+bool try_remove_prefix(StringView &str, const char *prefix) { return try_remove_prefix(str, StringView{prefix}); }
+
+bool try_remove_prefix_and_space(StringView &str, StringView prefix) {
+  if (starts_with(str, prefix) && str[prefix.size()] == ' ') {
+    str.remove_prefix(prefix.size() + 1);
+    return true;
+  }
+  return false;
+}
+
+bool try_remove_prefix_and_space(StringView &str, const std::string &prefix) {
+  return try_remove_prefix_and_space(str, StringView{prefix});
+}
+
+bool try_remove_prefix_and_space(StringView &str, const char *prefix) {
+  return try_remove_prefix_and_space(str, StringView{prefix});
+}
+
+bool try_remove_integer_and_space(StringView &str, int &result) {
+  const char *begin = str.data();
+  char *integer_end = nullptr;
+  result = static_cast<int>(std::strtol(begin, &integer_end, 10));
+  if (integer_end == begin || *integer_end != ' ') {
+    return false;
+  }
+  str = StringView{integer_end + 1};
+  return true;
+}
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/string_view.h
+++ b/esphome/components/jablotron/string_view.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <stdexcept>
+#include <cstring>
+#include <string>
+#include <limits>
+
+namespace esphome {
+namespace jablotron {
+
+class StringView {
+ public:
+  using size_type = std::size_t;
+
+  StringView();
+  StringView(const char *begin);
+  StringView(const char *begin, size_type size);
+  StringView(const std::string &str);
+
+  const char *data() const noexcept;
+  bool empty() const noexcept;
+  size_type size() const noexcept;
+  operator std::string() const;
+
+  bool starts_with(StringView s) const;
+  void remove_prefix(size_type n);
+  StringView substr(size_type pos = 0, size_type count = NPOS) const;
+
+  const char &operator[](size_type index) const;
+
+  bool operator==(const StringView &other) const noexcept;
+
+  bool operator!=(const StringView &other) const noexcept;
+
+  bool operator==(const std::string &other) const noexcept;
+  bool operator!=(const std::string &other) const noexcept;
+
+  bool operator==(const char *other) const noexcept;
+  bool operator!=(const char *other) const noexcept;
+
+  static constexpr size_type NPOS = std::numeric_limits<size_t>::max();
+
+ private:
+  const char *data_;
+  size_type size_;
+};
+
+bool operator==(const std::string &string, const StringView &view) noexcept;
+bool operator!=(const std::string &string, const StringView &view) noexcept;
+
+bool get_bit_in_hex_string(StringView str, size_t index);
+bool starts_with(StringView str, StringView prefix);
+
+bool try_remove_prefix(StringView &str, StringView prefix);
+bool try_remove_prefix(StringView &str, const std::string &prefix);
+bool try_remove_prefix(StringView &str, const char *prefix);
+
+bool try_remove_prefix_and_space(StringView &str, StringView prefix);
+bool try_remove_prefix_and_space(StringView &str, const std::string &prefix);
+bool try_remove_prefix_and_space(StringView &str, const char *prefix);
+
+bool try_remove_integer_and_space(StringView &str, int &result);
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/uart_line_device.cpp
+++ b/esphome/components/jablotron/uart_line_device.cpp
@@ -1,0 +1,58 @@
+#include "uart_line_device.h"
+
+namespace esphome {
+namespace jablotron {
+
+static const char *const TAG = "uart_line";
+
+bool UARTLineDevice::line_buffer_empty() const { return this->line_.empty(); }
+
+void UARTLineDevice::setup() {
+  if (this->flow_control_pin_ != nullptr) {
+    this->flow_control_pin_->setup();
+  }
+}
+
+void UARTLineDevice::set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
+
+std::vector<std::string> UARTLineDevice::read_lines() {
+  std::vector<std::string> lines;
+
+  while (this->available()) {
+    uint8_t byte;
+    if (!this->read_byte(&byte)) {
+      break;
+    }
+    if (byte == '\n') {
+      continue;
+    } else if (byte == '\r') {
+      if (!this->line_.empty()) {
+        ESP_LOGD(TAG, "read line '%s'", this->line_.c_str());
+        lines.push_back(this->line_);
+        this->line_.clear();
+      }
+    } else {
+      this->line_.push_back(byte);
+    }
+  }
+
+  return lines;
+}
+
+void UARTLineDevice::write_line(std::string str) {
+  str += "\r\n";
+
+  if (this->flow_control_pin_ != nullptr) {
+    this->flow_control_pin_->digital_write(true);
+  }
+
+  this->write_array(reinterpret_cast<const uint8_t *>(str.data()), str.size());
+  this->flush();
+
+  if (this->flow_control_pin_ != nullptr) {
+    this->flow_control_pin_->digital_write(false);
+  }
+}
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron/uart_line_device.h
+++ b/esphome/components/jablotron/uart_line_device.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace jablotron {
+
+class UARTLineDevice : public uart::UARTDevice {
+ public:
+  bool line_buffer_empty() const;
+  void set_flow_control_pin(GPIOPin *flow_control_pin);
+  void setup();
+  std::vector<std::string> read_lines();
+  void write_line(std::string str);
+
+ private:
+  std::string line_;
+  GPIOPin *flow_control_pin_ = nullptr;
+};
+
+}  // namespace jablotron
+}  // namespace esphome

--- a/esphome/components/jablotron_info/__init__.py
+++ b/esphome/components/jablotron_info/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@juliekoubova"]

--- a/esphome/components/jablotron_info/info_sensor.cpp
+++ b/esphome/components/jablotron_info/info_sensor.cpp
@@ -1,0 +1,15 @@
+#include "info_sensor.h"
+#include "../jablotron/jablotron_component.h"
+#include "../jablotron/string_view.h"
+
+namespace esphome {
+namespace jablotron_info {
+
+using namespace jablotron;
+
+void InfoSensor::register_parent(JablotronComponent &parent) { parent.register_info(this); }
+
+void InfoSensor::set_state(StringView value) { this->publish_state(value); }
+
+}  // namespace jablotron_info
+}  // namespace esphome

--- a/esphome/components/jablotron_info/info_sensor.h
+++ b/esphome/components/jablotron_info/info_sensor.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/jablotron/jablotron_device.h"
+
+namespace esphome {
+namespace jablotron_info {
+
+class InfoSensor : public text_sensor::TextSensor, public jablotron::InfoDevice {
+ public:
+  void set_state(jablotron::StringView value) override;
+
+ protected:
+  void register_parent(jablotron::JablotronComponent &parent) override;
+};
+
+}  // namespace jablotron_info
+}  // namespace esphome

--- a/esphome/components/jablotron_info/text_sensor.py
+++ b/esphome/components/jablotron_info/text_sensor.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.components.jablotron import (
+    register_jablotron_device,
+    JABLOTRON_DEVICE_SCHEMA,
+)
+
+DEPENDENCIES = ["jablotron", "text_sensor"]
+
+jablotron_info_ns = cg.esphome_ns.namespace("jablotron_info")
+InfoSensor = jablotron_info_ns.class_("InfoSensor", text_sensor.TextSensor)
+
+CONFIG_SCHEMA = text_sensor.text_sensor_schema(
+    InfoSensor, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+).extend(JABLOTRON_DEVICE_SCHEMA)
+
+
+async def to_code(config):
+    sensor = cg.new_Pvariable(config[CONF_ID])
+    await register_jablotron_device(sensor, config)
+    await text_sensor.register_text_sensor(sensor, config)

--- a/esphome/components/jablotron_peripheral/__init__.py
+++ b/esphome/components/jablotron_peripheral/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@juliekoubova"]

--- a/esphome/components/jablotron_peripheral/binary_sensor.py
+++ b/esphome/components/jablotron_peripheral/binary_sensor.py
@@ -1,0 +1,26 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+from esphome.components.jablotron import (
+    CONF_INDEX,
+    INDEX_SCHEMA,
+    JABLOTRON_DEVICE_SCHEMA,
+    register_jablotron_device,
+)
+
+jablotron_peripheral_ns = cg.esphome_ns.namespace("jablotron_peripheral")
+PeripheralSensor = jablotron_peripheral_ns.class_(
+    "PeripheralSensor", binary_sensor.BinarySensor
+)
+
+DEPENDENCIES = ["jablotron"]
+CONFIG_SCHEMA = (
+    binary_sensor.binary_sensor_schema(PeripheralSensor)
+    .extend(JABLOTRON_DEVICE_SCHEMA)
+    .extend(INDEX_SCHEMA)
+)
+
+
+async def to_code(config):
+    sensor = await binary_sensor.new_binary_sensor(config)
+    cg.add(sensor.set_index(config[CONF_INDEX]))
+    await register_jablotron_device(sensor, config)

--- a/esphome/components/jablotron_peripheral/peripheral_sensor.cpp
+++ b/esphome/components/jablotron_peripheral/peripheral_sensor.cpp
@@ -1,0 +1,19 @@
+#include "peripheral_sensor.h"
+#include "../jablotron/jablotron_component.h"
+
+namespace esphome {
+namespace jablotron_peripheral {
+
+using namespace jablotron;
+
+void PeripheralSensor::register_parent(JablotronComponent &parent) { parent.register_peripheral(this); }
+
+void PeripheralSensor::set_state(bool value) {
+  if (this->last_value_ != value) {
+    this->publish_state(value);
+    this->last_value_ = value;
+  }
+}
+
+}  // namespace jablotron_peripheral
+}  // namespace esphome

--- a/esphome/components/jablotron_peripheral/peripheral_sensor.h
+++ b/esphome/components/jablotron_peripheral/peripheral_sensor.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "../jablotron/jablotron_device.h"
+
+namespace esphome {
+namespace jablotron_peripheral {
+
+class PeripheralSensor : public binary_sensor::BinarySensor, public jablotron::PeripheralDevice {
+ public:
+  void register_parent(jablotron::JablotronComponent &parent) override;
+  void set_state(bool value) override;
+
+ private:
+  int last_value_ = -1;
+};
+
+}  // namespace jablotron_peripheral
+}  // namespace esphome

--- a/esphome/components/jablotron_pg/__init__.py
+++ b/esphome/components/jablotron_pg/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@juliekoubova"]

--- a/esphome/components/jablotron_pg/switch/__init__.py
+++ b/esphome/components/jablotron_pg/switch/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+from esphome.components.jablotron import (
+    ACCESS_CODE_SCHEMA,
+    INDEX_SCHEMA,
+    JABLOTRON_DEVICE_SCHEMA,
+    set_access_code,
+    set_index,
+    register_jablotron_device,
+)
+
+jablotron_pg_ns = cg.esphome_ns.namespace("jablotron_pg")
+PGSwitch = jablotron_pg_ns.class_("PGSwitch", switch.Switch)
+
+DEPENDENCIES = ["jablotron", "switch"]
+CONFIG_SCHEMA = (
+    switch.SWITCH_SCHEMA.extend(JABLOTRON_DEVICE_SCHEMA)
+    .extend(ACCESS_CODE_SCHEMA)
+    .extend(INDEX_SCHEMA)
+    .extend({cv.GenerateID(): cv.declare_id(PGSwitch)})
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[cv.CONF_ID])
+    await switch.register_switch(var, config)
+    set_access_code(var, config)
+    set_index(var, config)
+    await register_jablotron_device(var, config)

--- a/esphome/components/jablotron_pg/switch/pg_switch.cpp
+++ b/esphome/components/jablotron_pg/switch/pg_switch.cpp
@@ -1,0 +1,16 @@
+#include "pg_switch.h"
+#include "esphome/components/jablotron/jablotron_component.h"
+
+namespace esphome::jablotron_pg {
+
+void PGSwitch::register_parent(jablotron::JablotronComponent &parent) { parent.register_pg(this); }
+
+void PGSwitch::write_state(bool state) {
+  std::string command = state ? "PGON " : "PGOFF ";
+  command += this->get_index_string();
+  this->get_parent_jablotron()->queue_request_access_code(std::move(command), this->get_access_code());
+}
+
+void PGSwitch::set_state(bool state) { this->publish_state(state); }
+
+}  // namespace esphome::jablotron_pg

--- a/esphome/components/jablotron_pg/switch/pg_switch.cpp
+++ b/esphome/components/jablotron_pg/switch/pg_switch.cpp
@@ -1,7 +1,8 @@
 #include "pg_switch.h"
 #include "esphome/components/jablotron/jablotron_component.h"
 
-namespace esphome::jablotron_pg {
+namespace esphome {
+namespace jablotron_pg {
 
 void PGSwitch::register_parent(jablotron::JablotronComponent &parent) { parent.register_pg(this); }
 
@@ -13,4 +14,5 @@ void PGSwitch::write_state(bool state) {
 
 void PGSwitch::set_state(bool state) { this->publish_state(state); }
 
-}  // namespace esphome::jablotron_pg
+}  // namespace jablotron_pg
+}  // namespace esphome

--- a/esphome/components/jablotron_pg/switch/pg_switch.h
+++ b/esphome/components/jablotron_pg/switch/pg_switch.h
@@ -2,7 +2,8 @@
 #include "esphome/components/jablotron/jablotron_device.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome::jablotron_pg {
+namespace esphome {
+namespace jablotron_pg {
 
 class PGSwitch : public jablotron::PGDevice, public switch_::Switch {
  public:
@@ -11,4 +12,5 @@ class PGSwitch : public jablotron::PGDevice, public switch_::Switch {
   void set_state(bool state) override;
 };
 
-}  // namespace esphome::jablotron_pg
+}  // namespace jablotron_pg
+}  // namespace esphome

--- a/esphome/components/jablotron_pg/switch/pg_switch.h
+++ b/esphome/components/jablotron_pg/switch/pg_switch.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "esphome/components/jablotron/jablotron_device.h"
+#include "esphome/components/switch/switch.h"
+
+namespace esphome::jablotron_pg {
+
+class PGSwitch : public jablotron::PGDevice, public switch_::Switch {
+ public:
+  void write_state(bool state) override;
+  void register_parent(jablotron::JablotronComponent &parent) override;
+  void set_state(bool state) override;
+};
+
+}  // namespace esphome::jablotron_pg

--- a/esphome/components/jablotron_section/__init__.py
+++ b/esphome/components/jablotron_section/__init__.py
@@ -1,0 +1,4 @@
+import esphome.codegen as cg
+
+CODEOWNERS = ["@juliekoubova"]
+jablotron_section_ns = cg.esphome_ns.namespace("jablotron_section")

--- a/esphome/components/jablotron_section/select/__init__.py
+++ b/esphome/components/jablotron_section/select/__init__.py
@@ -1,0 +1,29 @@
+import esphome.config_validation as cv
+from esphome.components import select
+from esphome.components.jablotron import (
+    ACCESS_CODE_SCHEMA,
+    INDEX_SCHEMA,
+    JABLOTRON_DEVICE_SCHEMA,
+    set_access_code,
+    set_index,
+    register_jablotron_device,
+)
+from esphome.components.jablotron_section import jablotron_section_ns
+
+SectionSelect = jablotron_section_ns.class_("SectionSelect", select.Select)
+
+AUTO_LOAD = ["select"]
+DEPENDENCIES = ["jablotron"]
+CONFIG_SCHEMA = (
+    select.SELECT_SCHEMA.extend(JABLOTRON_DEVICE_SCHEMA)
+    .extend(INDEX_SCHEMA)
+    .extend(ACCESS_CODE_SCHEMA)
+    .extend({cv.GenerateID(): cv.declare_id(SectionSelect)})
+)
+
+
+async def to_code(config):
+    sel = await select.new_select(config, options=["READY", "ARMED_PART", "ARMED"])
+    set_index(sel, config)
+    set_access_code(sel, config)
+    await register_jablotron_device(sel, config)

--- a/esphome/components/jablotron_section/select/__init__.py
+++ b/esphome/components/jablotron_section/select/__init__.py
@@ -8,7 +8,7 @@ from esphome.components.jablotron import (
     set_index,
     register_jablotron_device,
 )
-from esphome.components.jablotron_section import jablotron_section_ns
+from .. import jablotron_section_ns
 
 SectionSelect = jablotron_section_ns.class_("SectionSelect", select.Select)
 

--- a/esphome/components/jablotron_section/select/section_select.cpp
+++ b/esphome/components/jablotron_section/select/section_select.cpp
@@ -1,0 +1,36 @@
+#include "section_select.h"
+#include "esphome/components/jablotron/jablotron_component.h"
+
+namespace esphome::jablotron_section {
+
+constexpr const char ARMED[] = "ARMED";
+constexpr const char ARMED_PART[] = "ARMED_PART";
+constexpr const char READY[] = "READY";
+
+constexpr const char TAG[] = "jablotron_section";
+
+void SectionSelect::control(std::string const &value) {
+  std::string request;
+  if (value == ARMED) {
+    request = "SET " + this->get_index_string();
+  } else if (value == ARMED_PART) {
+    request = "SETP " + this->get_index_string();
+  } else if (value == READY) {
+    request = "UNSET " + this->get_index_string();
+  } else {
+    ESP_LOGE(TAG, "Invalid section state: '%s'", value.c_str());
+    return;
+  }
+  this->get_parent_jablotron()->queue_request_access_code(std::move(request), this->get_access_code());
+}
+
+void SectionSelect::register_parent(jablotron::JablotronComponent &parent) { parent.register_section(this); }
+
+void SectionSelect::set_state(jablotron::StringView value) {
+  if (this->last_value_ != value) {
+    this->last_value_ = std::string{value};
+    this->publish_state(this->last_value_);
+  }
+}
+
+}  // namespace esphome::jablotron_section

--- a/esphome/components/jablotron_section/select/section_select.cpp
+++ b/esphome/components/jablotron_section/select/section_select.cpp
@@ -1,7 +1,8 @@
 #include "section_select.h"
 #include "esphome/components/jablotron/jablotron_component.h"
 
-namespace esphome::jablotron_section {
+namespace esphome {
+namespace jablotron_section {
 
 constexpr const char ARMED[] = "ARMED";
 constexpr const char ARMED_PART[] = "ARMED_PART";
@@ -33,4 +34,5 @@ void SectionSelect::set_state(jablotron::StringView value) {
   }
 }
 
-}  // namespace esphome::jablotron_section
+}  // namespace jablotron_section
+}  // namespace esphome

--- a/esphome/components/jablotron_section/select/section_select.h
+++ b/esphome/components/jablotron_section/select/section_select.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "esphome/components/jablotron/jablotron_device.h"
+#include "esphome/components/jablotron/string_view.h"
+#include "esphome/components/select/select.h"
+
+namespace esphome {
+namespace jablotron_section {
+
+class SectionSelect : public select::Select, public jablotron::SectionDevice {
+ public:
+  void control(const std::string &value) override;
+  void register_parent(jablotron::JablotronComponent &parent) override;
+  void set_state(jablotron::StringView state) override;
+
+ private:
+  std::string last_value_;
+};
+
+}  // namespace jablotron_section
+}  // namespace esphome

--- a/esphome/components/jablotron_section/select/section_select.h
+++ b/esphome/components/jablotron_section/select/section_select.h
@@ -10,7 +10,7 @@ class SectionSelect : public select::Select, public jablotron::SectionDevice {
  public:
   void control(const std::string &value) override;
   void register_parent(jablotron::JablotronComponent &parent) override;
-  void set_state(jablotron::StringView state) override;
+  void set_state(jablotron::StringView value) override;
 
  private:
   std::string last_value_;

--- a/esphome/components/jablotron_section/text_sensor/__init__.py
+++ b/esphome/components/jablotron_section/text_sensor/__init__.py
@@ -7,7 +7,7 @@ from esphome.components.jablotron import (
     JABLOTRON_DEVICE_SCHEMA,
     register_jablotron_device,
 )
-from esphome.components.jablotron_section import jablotron_section_ns
+from .. import jablotron_section_ns
 
 SectionSensor = jablotron_section_ns.class_("SectionSensor", text_sensor.TextSensor)
 

--- a/esphome/components/jablotron_section/text_sensor/__init__.py
+++ b/esphome/components/jablotron_section/text_sensor/__init__.py
@@ -1,0 +1,26 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+from esphome.const import CONF_ID
+from esphome.components.jablotron import (
+    CONF_INDEX,
+    INDEX_SCHEMA,
+    JABLOTRON_DEVICE_SCHEMA,
+    register_jablotron_device,
+)
+from esphome.components.jablotron_section import jablotron_section_ns
+
+SectionSensor = jablotron_section_ns.class_("SectionSensor", text_sensor.TextSensor)
+
+DEPENDENCIES = ["jablotron"]
+CONFIG_SCHEMA = (
+    text_sensor.text_sensor_schema(SectionSensor)
+    .extend(JABLOTRON_DEVICE_SCHEMA)
+    .extend(INDEX_SCHEMA)
+)
+
+
+async def to_code(config):
+    sensor = cg.new_Pvariable(config[CONF_ID])
+    cg.add(sensor.set_index(config[CONF_INDEX]))
+    await register_jablotron_device(sensor, config)
+    await text_sensor.register_text_sensor(sensor, config)

--- a/esphome/components/jablotron_section/text_sensor/section_sensor.cpp
+++ b/esphome/components/jablotron_section/text_sensor/section_sensor.cpp
@@ -1,0 +1,23 @@
+#include "section_sensor.h"
+#include "esphome/core/log.h"
+#include "esphome/components/jablotron/string_view.h"
+#include "esphome/components/jablotron/jablotron_component.h"
+
+namespace esphome {
+namespace jablotron_section {
+
+using namespace jablotron;
+
+static const char *const TAG = "jablotron_section";
+
+void SectionSensor::register_parent(JablotronComponent &parent) { parent.register_section(this); }
+
+void SectionSensor::set_state(StringView value) {
+  if (value != this->last_value_) {
+    this->last_value_ = std::string{value};
+    this->publish_state(this->last_value_);
+  }
+}
+
+}  // namespace jablotron_section
+}  // namespace esphome

--- a/esphome/components/jablotron_section/text_sensor/section_sensor.h
+++ b/esphome/components/jablotron_section/text_sensor/section_sensor.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/jablotron/jablotron_device.h"
+#include "esphome/components/jablotron/string_view.h"
+
+namespace esphome {
+namespace jablotron_section {
+
+class SectionSensor : public text_sensor::TextSensor, public jablotron::SectionDevice {
+ public:
+  void set_state(jablotron::StringView value) override;
+
+ protected:
+  void register_parent(jablotron::JablotronComponent &parent) override;
+
+ private:
+  std::string last_value_;
+};
+
+}  // namespace jablotron_section
+}  // namespace esphome

--- a/esphome/components/jablotron_section_flag/__init__.py
+++ b/esphome/components/jablotron_section_flag/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@juliekoubova"]

--- a/esphome/components/jablotron_section_flag/binary_sensor.py
+++ b/esphome/components/jablotron_section_flag/binary_sensor.py
@@ -1,0 +1,40 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.components.jablotron import (
+    CONF_INDEX,
+    INDEX_SCHEMA,
+    JABLOTRON_DEVICE_SCHEMA,
+    register_jablotron_device,
+)
+
+jablotron_section_flag_ns = cg.esphome_ns.namespace("jablotron_section_flag")
+SectionFlagSensor = jablotron_section_flag_ns.class_(
+    "SectionFlagSensor", binary_sensor.BinarySensor
+)
+
+CONF_FLAG = "flag"
+SECTION_FLAGS = {
+    "INTERNAL_WARNING": 1,
+    "EXTERNAL_WARNING": 2,
+    "FIRE_ALARM": 3,
+    "INTRUDER_ALARM": 4,
+    "PANIC_ALARM": 5,
+    "ENTRY": 6,
+    "EXIT": 7,
+}
+
+DEPENDENCIES = ["jablotron", "binary_sensor"]
+CONFIG_SCHEMA = (
+    binary_sensor.binary_sensor_schema(SectionFlagSensor)
+    .extend(JABLOTRON_DEVICE_SCHEMA)
+    .extend(INDEX_SCHEMA)
+    .extend(cv.Schema({cv.Required(CONF_FLAG): cv.enum(SECTION_FLAGS, upper=True)}))
+)
+
+
+async def to_code(config):
+    sensor = await binary_sensor.new_binary_sensor(config)
+    cg.add(sensor.set_index(config[CONF_INDEX]))
+    cg.add(sensor.set_flag(config[CONF_FLAG]))
+    await register_jablotron_device(sensor, config)

--- a/esphome/components/jablotron_section_flag/section_flag_sensor.cpp
+++ b/esphome/components/jablotron_section_flag/section_flag_sensor.cpp
@@ -1,0 +1,17 @@
+#include "section_flag_sensor.h"
+#include "../jablotron/jablotron_component.h"
+
+namespace esphome {
+namespace jablotron_section_flag {
+
+void SectionFlagSensor::register_parent(jablotron::JablotronComponent &parent) { parent.register_section_flag(this); }
+
+void SectionFlagSensor::set_state(bool value) {
+  if (this->last_value_ != value) {
+    this->publish_state(value);
+    this->last_value_ = value;
+  }
+}
+
+}  // namespace jablotron_section_flag
+}  // namespace esphome

--- a/esphome/components/jablotron_section_flag/section_flag_sensor.h
+++ b/esphome/components/jablotron_section_flag/section_flag_sensor.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "../jablotron/jablotron_device.h"
+
+namespace esphome {
+namespace jablotron_section_flag {
+
+class SectionFlagSensor : public binary_sensor::BinarySensor, public jablotron::SectionFlagDevice {
+ public:
+  void register_parent(jablotron::JablotronComponent &parent) override;
+  void set_state(bool value) override;
+
+ private:
+  int last_value_ = -1;
+};
+
+}  // namespace jablotron_section_flag
+}  // namespace esphome

--- a/script/test
+++ b/script/test
@@ -11,3 +11,5 @@ esphome compile tests/test2.yaml
 esphome compile tests/test3.yaml
 esphome compile tests/test4.yaml
 esphome compile tests/test5.yaml
+esphome compile tests/test6.yaml
+esphome compile tests/test7.yaml

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,3 +25,4 @@ Current test_.yaml file contents.
 | test4.yaml | ESP32 | ethernet | None
 | test5.yaml | ESP32 | wifi | ble_server
 | test6.yaml | RP2040 | wifi | N/A
+| test7.yaml | ESP8266 | wifi | N/A

--- a/tests/component_tests/jablotron/test_jablotron.py
+++ b/tests/component_tests/jablotron/test_jablotron.py
@@ -1,0 +1,59 @@
+"""Tests for the jablotron component."""
+
+
+def test_jablotron_esp8266(generate_main):
+    """
+    When the index and flag of sensor is set in the yaml file, it should be registered in main
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main(
+        "tests/component_tests/jablotron/test_jablotron_esp8266.yaml"
+    )
+
+    # Then
+    assert 'jablotron_jablotroncomponent->set_access_code("1234");' in main_cpp
+    assert "entry_delay->set_index(1);" in main_cpp
+    assert "entry_delay->set_flag(6);" in main_cpp
+    assert (
+        "entry_delay->set_parent_jablotron(jablotron_jablotroncomponent);" in main_cpp
+    )
+
+
+def test_jablotron_esp32(generate_main):
+    """
+    When the entity category of sensor is set in the yaml file, it should be registered in main
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main(
+        "tests/component_tests/jablotron/test_jablotron_esp32.yaml"
+    )
+
+    # Then
+    assert 'jablo->set_access_code("1234");' in main_cpp
+    assert "jablo_info = new jablotron_info::InfoSensor();" in main_cpp
+    assert "jablo_info->set_parent_jablotron(jablo);" in main_cpp
+    assert 'jablo_info->set_name("Jablotron Info");' in main_cpp
+    assert "jablo_info->set_entity_category(::ENTITY_CATEGORY_DIAGNOSTIC);" in main_cpp
+
+
+def test_jablotron_esp32idf(generate_main):
+    """
+    When the device_class of sensor is set in the yaml file, it should be registered in main
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main(
+        "tests/component_tests/jablotron/test_jablotron_esp32idf.yaml"
+    )
+
+    # Then
+    assert 'entry_motion->set_name("Entryway motion");' in main_cpp
+    assert "entry_motion->set_disabled_by_default(false);" in main_cpp
+    assert 'entry_motion->set_device_class("motion");' in main_cpp
+    assert "entry_motion->set_index(2);" in main_cpp
+    assert "entry_motion->set_parent_jablotron(jablo);" in main_cpp

--- a/tests/component_tests/jablotron/test_jablotron.py
+++ b/tests/component_tests/jablotron/test_jablotron.py
@@ -38,6 +38,8 @@ def test_jablotron_esp32(generate_main):
     assert "jablo_info->set_parent_jablotron(jablo);" in main_cpp
     assert 'jablo_info->set_name("Jablotron Info");' in main_cpp
     assert "jablo_info->set_entity_category(::ENTITY_CATEGORY_DIAGNOSTIC);" in main_cpp
+    assert "jablo_select = new jablotron_section::SectionSelect();" in main_cpp
+    assert "jablo_select->set_parent_jablotron(jablo);" in main_cpp
 
 
 def test_jablotron_esp32idf(generate_main):
@@ -57,3 +59,5 @@ def test_jablotron_esp32idf(generate_main):
     assert 'entry_motion->set_device_class("motion");' in main_cpp
     assert "entry_motion->set_index(2);" in main_cpp
     assert "entry_motion->set_parent_jablotron(jablo);" in main_cpp
+    assert "jablo_pg->set_index(15);" in main_cpp
+    assert "jablo_pg->set_parent_jablotron(jablo);" in main_cpp

--- a/tests/component_tests/jablotron/test_jablotron_esp32.yaml
+++ b/tests/component_tests/jablotron/test_jablotron_esp32.yaml
@@ -1,0 +1,35 @@
+esphome: { name: test }
+esp32: { board: lolin_d32 }
+
+uart:
+  id: uart_bus
+  tx_pin: TX
+  rx_pin: RX
+  baud_rate: 9600
+
+jablotron:
+  access_code: 1234
+  flow_control_pin: GPIO14
+  id: jablo
+
+binary_sensor:
+  - platform: jablotron_peripheral
+    index: 2
+    id: entry_motion
+    name: Entryway motion
+    device_class: motion
+
+  - platform: jablotron_section_flag
+    id: entry_delay
+    index: 1
+    flag: ENTRY
+    name: "Alarm entry delay"
+
+text_sensor:
+  - platform: jablotron_info
+    id: jablo_info
+    name: "Jablotron Info"
+  - id: entry_alarm
+    platform: jablotron_section
+    index: 1
+    name: Entry alarm

--- a/tests/component_tests/jablotron/test_jablotron_esp32.yaml
+++ b/tests/component_tests/jablotron/test_jablotron_esp32.yaml
@@ -33,3 +33,14 @@ text_sensor:
     platform: jablotron_section
     index: 1
     name: Entry alarm
+
+select:
+  - platform: jablotron_section
+    id: jablo_select
+    access_code: 1*2345
+    index: 3
+
+switch:
+  - id: jablo_pg
+    platform: jablotron_pg
+    index: 15

--- a/tests/component_tests/jablotron/test_jablotron_esp32idf.yaml
+++ b/tests/component_tests/jablotron/test_jablotron_esp32idf.yaml
@@ -33,3 +33,14 @@ text_sensor:
     platform: jablotron_section
     index: 1
     name: Entry alarm
+
+select:
+  - platform: jablotron_section
+    id: jablo_select
+    access_code: 1*2345
+    index: 3
+
+switch:
+  - id: jablo_pg
+    platform: jablotron_pg
+    index: 15

--- a/tests/component_tests/jablotron/test_jablotron_esp32idf.yaml
+++ b/tests/component_tests/jablotron/test_jablotron_esp32idf.yaml
@@ -1,0 +1,35 @@
+esphome:
+  name: test
+
+esp32:
+  board: lolin_d32
+  framework: { type: esp-idf }
+
+uart:
+  id: uart_bus
+  tx_pin: TX
+  rx_pin: RX
+  baud_rate: 9600
+
+jablotron: { id: jablo }
+binary_sensor:
+  - platform: jablotron_peripheral
+    index: 2
+    id: entry_motion
+    name: Entryway motion
+    device_class: motion
+
+  - platform: jablotron_section_flag
+    id: entry_delay
+    index: 1
+    flag: ENTRY
+    name: "Alarm entry delay"
+
+text_sensor:
+  - id: jablo_info
+    platform: jablotron_info
+    name: "Jablotron Info"
+  - id: entry_alarm
+    platform: jablotron_section
+    index: 1
+    name: Entry alarm

--- a/tests/component_tests/jablotron/test_jablotron_esp8266.yaml
+++ b/tests/component_tests/jablotron/test_jablotron_esp8266.yaml
@@ -1,0 +1,34 @@
+esphome: { name: test }
+esp8266: { board: d1_mini }
+
+uart:
+  id: uart_bus
+  tx_pin: D1
+  rx_pin: D2
+  baud_rate: 9600
+
+jablotron:
+  access_code: 1234
+  flow_control_pin: D4
+
+binary_sensor:
+  - platform: jablotron_peripheral
+    index: 2
+    id: entry_motion
+    name: Entryway motion
+    device_class: motion
+
+  - platform: jablotron_section_flag
+    id: entry_delay
+    index: 1
+    flag: ENTRY
+    name: "Alarm entry delay"
+
+text_sensor:
+  - id: jablo_info
+    platform: jablotron_info
+    name: "Jablotron Info"
+  - id: entry_alarm
+    platform: jablotron_section
+    index: 1
+    name: Entry alarm

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -38,6 +38,10 @@ uart:
     rx_pin: 16
     baud_rate: 19200
 
+jablotron:
+  access_code: 1234
+  uart_id: uart2
+
 i2c:
   frequency: 100khz
 
@@ -77,7 +81,7 @@ binary_sensor:
     id: modbus_binsensortest
     register_type: read
     address: 0x3200
-    bitmask: 0x80  # (bit 8)
+    bitmask: 0x80 # (bit 8)
     lambda: "return x;"
 
   - platform: tm1638
@@ -162,14 +166,23 @@ binary_sensor:
       then:
         - output.turn_off: Led7
 
-
-
-
   - platform: ezo_pmp
     pump_state:
       name: "Pump State"
     is_paused:
       name: "Is Paused"
+
+  - platform: jablotron_section_flag
+    id: entry_delay
+    index: 1
+    flag: ENTRY
+    name: "Alarm entry delay"
+
+  - platform: jablotron_peripheral
+    index: 2
+    id: entry_motion
+    name: Entryway motion
+    device_class: motion
 
 tlc5947:
   data_pin: GPIO12
@@ -512,6 +525,15 @@ display:
       it.print("81818181");
 
 text_sensor:
+  - id: jablo_info
+    platform: jablotron_info
+    name: "Jablotron Info"
+
+  - id: entry_alarm
+    platform: jablotron_section
+    index: 1
+    name: Entry alarm
+
   - platform: ezo_pmp
     dosing_mode:
       name: Dosing Mode

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -352,6 +352,10 @@ select:
       "Two": 2
       "Three": 3
 
+  - platform: jablotron_section
+    name: Alarm Section
+    index: 12
+
 sensor:
   - platform: selec_meter
     total_active_energy:
@@ -512,6 +516,11 @@ switch:
     id: Led3
     led: 3
     name: TM1638Led3
+
+  - platform: jablotron_pg
+    index: 4
+    access_code: 3*210
+    name: Jablotron PG
 
 display:
   - platform: tm1638

--- a/tests/test7.yaml
+++ b/tests/test7.yaml
@@ -109,13 +109,13 @@ text_sensor:
     name: Entry alarm
 
 switch:
-  - id: pg
+  - id: jablo_pg
     platform: jablotron_pg
     index: 1
     name: Windows open
     access_code: 1*2345
 
 select:
-  - id: sel
+  - id: jablo_sel
     platform: jablotron_section
     index: 1

--- a/tests/test7.yaml
+++ b/tests/test7.yaml
@@ -1,0 +1,121 @@
+---
+esphome:
+  name: $device_name
+  comment: $device_comment
+  build_path: build/test7
+  on_boot:
+    - if:
+        condition:
+          - api.connected
+          - wifi.connected
+        then:
+          - logger.log: Have time
+  includes:
+    # - custom.h
+
+esp8266:
+  board: d1_mini
+  early_pin_init: true
+
+substitutions:
+  device_name: test7
+  device_comment: test3 device
+  min_sub: "0.03"
+  max_sub: "12.0%"
+
+api:
+  port: 8000
+  password: pwd
+  reboot_timeout: 0min
+  encryption:
+    key: bOFFzzvfpg5DB94DuBGLXD/hMnhpDKgP9UQyBulwWVU=
+
+wifi:
+  ssid: "MySSID"
+  password: "password1"
+
+uart:
+  - id: uart1
+    tx_pin:
+      number: GPIO1
+      inverted: true
+    rx_pin: GPIO3
+    baud_rate: 115200
+  - id: uart2
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
+  - id: uart3
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 4800
+  - id: uart4
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
+  - id: uart5
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
+  - id: uart6
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
+  - id: uart7
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 38400
+  - id: uart8
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 4800
+    parity: NONE
+    stop_bits: 2
+    # Specifically added for testing debug with no options at all.
+    debug:
+  - id: uart9
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
+  - id: uart10
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
+
+jablotron:
+  uart_id: uart9
+  flow_control_pin: D4
+  access_code: 5*6789
+
+binary_sensor:
+  - platform: jablotron_peripheral
+    index: 2
+    id: entry_motion
+    name: Entryway motion
+    device_class: motion
+  - platform: jablotron_section_flag
+    id: entry_delay
+    index: 1
+    flag: ENTRY
+    name: "Alarm entry delay"
+
+text_sensor:
+  - id: jablo_info
+    platform: jablotron_info
+    name: "Jablotron Info"
+  - id: entry_alarm
+    platform: jablotron_section
+    index: 1
+    name: Entry alarm
+
+switch:
+  - id: pg
+    platform: jablotron_pg
+    index: 1
+    name: Windows open
+    access_code: 1*2345
+
+select:
+  - id: sel
+    platform: jablotron_section
+    index: 1


### PR DESCRIPTION
Hey everyone, this might be too niche for general consumption, but since I wrote it and it seems to work, I figured why not send a PR. Please let me know if you're interested & please review the code thoroughly, I haven't written anything for an embedded device before, and I haven't really used ESPHome before, so there might be questionable design choices that don't really mesh with how things are supposed to be done around here.

Jablotron is a brand of home security systems. They offer a component (JA-121T) that provides UART access to the system. This integration adds sensors to expose motion detectors, door sensors, and report state (armed, leaving, entering, etc.) of individual sections in the system.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2395

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml

uart:
  id: uart_bus
  tx_pin: D1
  rx_pin: D2
  baud_rate: 9600

jablotron:
  flow_control_pin: D4
    
binary_sensor:
  - { platform: jablotron_peripheral, index: 1,   name: 'Gallery motion', device_class: motion }
  - { platform: jablotron_peripheral, index: 2,   name: 'Entryway motion', device_class: motion }
  - { platform: jablotron_peripheral, index: 16,  name: 'Dining room motion', device_class: motion }
  - { platform: jablotron_peripheral, index: 17,  name: 'Front door', device_class: door }
  - { platform: jablotron_section_flag, index: 1, flag: ENTRY, name: 'Alarm entry delay' }
    
text_sensor:
  - { platform: jablotron_info, name: 'Jablotron Info' }
  - { platform: jablotron_section, index: 1, name: 'Alarm' }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
