### PR TITLE
Allow use of all pins in ESP32 Pico

### DIFF
--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -26,8 +26,10 @@ def esp32_validate_gpio_pin(value):
     if value < 0 or value > 39:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-39)")
     if value in _ESP_SDIO_PINS:
-        raise cv.Invalid(
-            f"This pin cannot be used on ESP32s and is already used by the flash interface (function: {_ESP_SDIO_PINS[value]})"
+        _LOGGER.warning(
+            "Pin %s might already be used by the "
+            "flash interface (function: %s).",
+            value, _ESP_SDIO_PINS[value]
         )
     if 9 <= value <= 10:
         _LOGGER.warning(

--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -27,8 +27,7 @@ def esp32_validate_gpio_pin(value):
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-39)")
     if value in _ESP_SDIO_PINS:
         _LOGGER.warning(
-            "Pin %s might already be used by the "
-            "flash interface (function: %s).",
+            "Pin %s might already be used by the flash interface (function: %s).",
             value,
             _ESP_SDIO_PINS[value],
         )

--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -29,7 +29,8 @@ def esp32_validate_gpio_pin(value):
         _LOGGER.warning(
             "Pin %s might already be used by the "
             "flash interface (function: %s).",
-            value, _ESP_SDIO_PINS[value]
+            value,
+            _ESP_SDIO_PINS[value],
         )
     if 9 <= value <= 10:
         _LOGGER.warning(


### PR DESCRIPTION
# What does this implement/fix?

ESP32 Pico (e.g. Adafruit QT Py ESP32 Pico) uses pins that are blocked for usage in the yaml validation

This will show warning, not error, when using pins that may be already in use.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
switch:
  - platform: gpio
    name: "NeoPixel Power"
    internal: true
    pin: 8
    restore_mode: ALWAYS_O
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
