### PR TITLE
Added reset_() to 7P5InBV2 init to fix deep sleep

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -938,6 +938,8 @@ void WaveshareEPaper5P8In::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 void WaveshareEPaper7P5InBV2::initialize() {
+  this->reset_();
+  
   // COMMAND POWER SETTING
   this->command(0x01);
   this->data(0x07);


### PR DESCRIPTION
After entering deep sleep, the Waveshare 7.5 B V3 (B/W/R) display would not update again until the ESP32 was power cycled or new firmware was installed. This was resolved initially by using `7.50inV2alt` instead of `7.50in-bV2`, but that introduced other unwanted display artifacts and other issues. Notably, the `7.50inV2alt` configuration resets the display at the start of init.

Adding this reset here seems to resolve issues after deep sleep, and matches the Waveshare e-Paper sample code found at https://github.com/waveshare/e-Paper/blob/master/Arduino/epd7in5b_V2/epd7in5b_V2.cpp .

# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
