### PR TITLE
Update Ethernet component to Arduino 2.0.3 and platform version 5.1.1

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -27,11 +27,16 @@ CONF_MDIO_PIN = "mdio_pin"
 CONF_CLK_MODE = "clk_mode"
 CONF_POWER_PIN = "power_pin"
 
-EthernetType = ethernet_ns.enum("EthernetType")
+EthernetType = cg.global_ns.enum("eth_phy_type_t")
 ETHERNET_TYPES = {
-    "LAN8720": EthernetType.ETHERNET_TYPE_LAN8720,
-    "TLK110": EthernetType.ETHERNET_TYPE_TLK110,
-    "IP101": EthernetType.ETHERNET_TYPE_IP101,
+    "LAN8720": EthernetType.ETH_PHY_LAN8720,
+    "TLK110": EthernetType.ETH_PHY_TLK110,
+    "IP101": EthernetType.ETH_PHY_IP101,
+    "RTL8201": EthernetType.ETH_PHY_RTL8201,
+    "DP83848": EthernetType.ETH_PHY_DP83848,
+    "DM9051": EthernetType.ETH_PHY_DM9051,
+    "KSZ8041": EthernetType.ETH_PHY_KSZ8041,
+    "KSZ8081": EthernetType.ETH_PHY_KSZ8081,
 }
 
 eth_clock_mode_t = cg.global_ns.enum("eth_clock_mode_t")
@@ -127,3 +132,4 @@ async def to_code(config):
 
     if CORE.is_esp32:
         cg.add_library("WiFi", None)
+        cg.add_library("Ethernet", None)

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -6,19 +6,10 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/network/ip_address.h"
 
-#include "esp_eth.h"
-#include <esp_wifi.h>
-#include <WiFiType.h>
-#include <WiFi.h>
+#include "ETH.h"
 
 namespace esphome {
 namespace ethernet {
-
-enum EthernetType {
-  ETHERNET_TYPE_LAN8720 = 0,
-  ETHERNET_TYPE_TLK110,
-  ETHERNET_TYPE_IP101,
-};
 
 struct ManualIP {
   network::IPAddress static_ip;
@@ -48,7 +39,7 @@ class EthernetComponent : public Component {
   void set_power_pin(GPIOPin *power_pin);
   void set_mdc_pin(uint8_t mdc_pin);
   void set_mdio_pin(uint8_t mdio_pin);
-  void set_type(EthernetType type);
+  void set_type(eth_phy_type_t type);
   void set_clk_mode(eth_clock_mode_t clk_mode);
   void set_manual_ip(const ManualIP &manual_ip);
 
@@ -57,19 +48,16 @@ class EthernetComponent : public Component {
   void set_use_address(const std::string &use_address);
 
  protected:
-  void on_wifi_event_(system_event_id_t event, system_event_info_t info);
+  static void on_wifi_event_(WiFiEvent_t event);
   void start_connect_();
   void dump_connect_params_();
-
-  static void eth_phy_config_gpio();
-  static void eth_phy_power_enable(bool enable);
 
   std::string use_address_;
   uint8_t phy_addr_{0};
   GPIOPin *power_pin_{nullptr};
   uint8_t mdc_pin_{23};
   uint8_t mdio_pin_{18};
-  EthernetType type_{ETHERNET_TYPE_LAN8720};
+  eth_phy_type_t type_{ETH_PHY_LAN8720};
   eth_clock_mode_t clk_mode_{ETH_CLOCK_GPIO0_IN};
   optional<ManualIP> manual_ip_{};
 
@@ -77,8 +65,6 @@ class EthernetComponent : public Component {
   bool connected_{false};
   EthernetComponentState state_{EthernetComponentState::STOPPED};
   uint32_t connect_begin_;
-  eth_config_t eth_config_;
-  eth_phy_power_enable_func orig_power_enable_fun_;
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/platformio.ini
+++ b/platformio.ini
@@ -112,7 +112,8 @@ lib_deps =
     ; order matters with lib-deps; some of the libs in common:arduino.lib_deps
     ; don't declare built-in libraries as dependencies, so they have to be declared first
     FS                              ; web_server_base (Arduino built-in)
-    WiFi                            ; wifi,web_server_base,ethernet (Arduino built-in)
+    WiFi                            ; wifi,web_server_base
+    Ethernet
     Update                          ; ota,web_server_base (Arduino built-in)
     ${common:arduino.lib_deps}
     esphome/AsyncTCP-esphome@1.2.2  ; async_tcp


### PR DESCRIPTION
I'm opening this PR to put the update of the Ethernet component to Arduino 2.0.x in the spotlight. This is still incomplete, but the (possibly) hardest part is done: getting DHCP and ping to work.

Thanks to @xorbit for his help debugging.

TODO:
- Replace the content of `ethernet_component.cpp` functions and methods that are now covered by the Arduino Framework version 2.0.x by calls to the latter
- Replace deprecated struct `IPAddress` with the new Arduino class of the same name both in Ethernet and WiFi libraries
- (Optional) add platform version checks if using Arduino < v2.0.3 (esp-idf < v4.4) for PHYs that were introduced in esp-idf v4.4

# What does this implement/fix?

Adds support to various Ethernet PHYs by updating the underlying Arduino framework to version 2.0.3 and platform version to 5.1.1

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1462 and supports https://github.com/esphome/esphome/pull/3564

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Tested on Espoir and wESP32
esphome:
  name: esptest

esp32:
  board: esp32dev
  framework: 
    type: arduino
    version: 2.0.4
    platform_version: 5.1.1
    
ethernet:
  type: KSZ8081
  mdc_pin: GPIO32
  mdio_pin: GPIO33
  clk_mode: GPIO0_IN
  phy_addr: 0

# Enable logging
logger:
  level: VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
