### PR TITLE
Fix time/automation (cron) wdt crash when time jumps ahead too much

### DIFF
--- a/esphome/components/time/automation.cpp
+++ b/esphome/components/time/automation.cpp
@@ -31,6 +31,13 @@ void CronTrigger::loop() {
       return;
     }
 
+    if (time > *this->last_check_ && time.timestamp - this->last_check_->timestamp > 900) {
+      // We went ahead in time (a lot), probably caused by time synchronization
+      ESP_LOGW(TAG, "Time has jumped ahead!");
+      this->last_check_ = time;
+      return;
+    }
+
     while (true) {
       this->last_check_->increment_second();
       if (*this->last_check_ >= time)

--- a/esphome/components/time/automation.cpp
+++ b/esphome/components/time/automation.cpp
@@ -6,6 +6,8 @@ namespace esphome {
 namespace time {
 
 static const char *const TAG = "automation";
+static const int MAX_TIMESTAMP_DRIFT = 900;  // how far can the clock drift before we consider
+                                             // there has been a drastic time synchronization
 
 void CronTrigger::add_second(uint8_t second) { this->seconds_[second] = true; }
 void CronTrigger::add_minute(uint8_t minute) { this->minutes_[minute] = true; }
@@ -23,15 +25,13 @@ void CronTrigger::loop() {
     return;
 
   if (this->last_check_.has_value()) {
-    if (*this->last_check_ > time && this->last_check_->timestamp - time.timestamp > 900) {
+    if (*this->last_check_ > time && this->last_check_->timestamp - time.timestamp > MAX_TIMESTAMP_DRIFT) {
       // We went back in time (a lot), probably caused by time synchronization
       ESP_LOGW(TAG, "Time has jumped back!");
     } else if (*this->last_check_ >= time) {
       // already handled this one
       return;
-    }
-
-    if (time > *this->last_check_ && time.timestamp - this->last_check_->timestamp > 900) {
+    } else if (time > *this->last_check_ && time.timestamp - this->last_check_->timestamp > MAX_TIMESTAMP_DRIFT) {
       // We went ahead in time (a lot), probably caused by time synchronization
       ESP_LOGW(TAG, "Time has jumped ahead!");
       this->last_check_ = time;


### PR DESCRIPTION
# What does this implement/fix?

When time synchronization takes place and the clocks have drifted apart too ahead of time, a wdt crash happens due to a very long loop in `void CronTrigger::loop()`, The below loop iterates for every second of difference to trigger automations:

```cpp
    while (true) {
      this->last_check_->increment_second();
      if (*this->last_check_ >= time)
        break;

      if (this->matches(*this->last_check_))
        this->trigger();
    }
```
 
This fix detects jumps in time that are too big (in the same way a jump could happen backwards) and avoids entering a potentially too long loop.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

