### PR TITLE
SM2135 Add optional current configuration, avoid communication failures.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -232,7 +232,7 @@ esphome/components/shutdown/* @esphome/core @jsuanet
 esphome/components/sigma_delta_output/* @Cat-Ion
 esphome/components/sim800l/* @glmnet
 esphome/components/sm10bit_base/* @Cossid
-esphome/components/sm2135/* @BoukeHaarsma23
+esphome/components/sm2135/* @BoukeHaarsma23 @matika77
 esphome/components/sm2235/* @Cossid
 esphome/components/sm2335/* @Cossid
 esphome/components/sml/* @alengwenus

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -232,7 +232,7 @@ esphome/components/shutdown/* @esphome/core @jsuanet
 esphome/components/sigma_delta_output/* @Cat-Ion
 esphome/components/sim800l/* @glmnet
 esphome/components/sm10bit_base/* @Cossid
-esphome/components/sm2135/* @BoukeHaarsma23 @matika77 @dd32
+esphome/components/sm2135/* @BoukeHaarsma23 @dd32 @matika77
 esphome/components/sm2235/* @Cossid
 esphome/components/sm2335/* @Cossid
 esphome/components/sml/* @alengwenus

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -232,7 +232,7 @@ esphome/components/shutdown/* @esphome/core @jsuanet
 esphome/components/sigma_delta_output/* @Cat-Ion
 esphome/components/sim800l/* @glmnet
 esphome/components/sm10bit_base/* @Cossid
-esphome/components/sm2135/* @BoukeHaarsma23 @matika77
+esphome/components/sm2135/* @BoukeHaarsma23 @matika77 @dd32
 esphome/components/sm2235/* @Cossid
 esphome/components/sm2335/* @Cossid
 esphome/components/sml/* @alengwenus

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -44,4 +44,3 @@ async def to_code(config):
 
     cg.add(var.set_rgb_current(config[CONF_RGB_CURRENT]))
     cg.add(var.set_cw_current(config[CONF_CW_CURRENT]))
-

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -16,13 +16,9 @@ SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 CONF_RGB_CURRENT = "rgb_current"
 CONF_CW_CURRENT = "cw_current"
 
-DRIVE_STRENGTHS_CW = {
-10,15,20,25,30,40,45,50,55,60
-}
+DRIVE_STRENGTHS_CW = {10, 15, 20, 25, 30, 40, 45, 50, 55, 60}
 
-DRIVE_STRENGTHS_RGB = {
-10,15,20,25,30,40,45
-}
+DRIVE_STRENGTHS_RGB = {10, 15, 20, 25, 30, 40, 45}
 
 
 MULTI_CONF = True
@@ -32,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_RGB_CURRENT): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
-        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True)
+        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -48,3 +44,4 @@ async def to_code(config):
 
     cg.add(var.set_rgb_current(config[CONF_RGB_CURRENT]))
     cg.add(var.set_cw_current(config[CONF_CW_CURRENT]))
+

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RGB_CURRENT, default=20): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
-        cv.Optional(CONF_CW_CURRENT, default=30): cv.one_of(*DRIVE_STRENGTHS_CW, int=True),
+        cv.Optional(CONF_CW_CURRENT, default=10): cv.one_of(*DRIVE_STRENGTHS_CW, int=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -8,7 +8,7 @@ from esphome.const import (
 )
 
 AUTO_LOAD = ["output"]
-CODEOWNERS = ["@BoukeHaarsma23"]
+CODEOWNERS = ["@BoukeHaarsma23","@matika77","@dd32"]
 
 sm2135_ns = cg.esphome_ns.namespace("sm2135")
 SM2135 = sm2135_ns.class_("SM2135", cg.Component)

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -16,9 +16,9 @@ SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 CONF_RGB_CURRENT = "rgb_current"
 CONF_CW_CURRENT = "cw_current"
 
-DRIVE_STRENGTHS_CW = {10, 15, 20, 25, 30, 40, 45, 50, 55, 60}
+DRIVE_STRENGTHS_CW = {10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60}
 
-DRIVE_STRENGTHS_RGB = {10, 15, 20, 25, 30, 40, 45}
+DRIVE_STRENGTHS_RGB = {10, 15, 20, 25, 30, 35, 40, 45}
 
 
 MULTI_CONF = True

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -27,8 +27,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(SM2135),
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
-        cv.Required(CONF_RGB_CURRENT): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
-        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True),
+        cv.Optional(CONF_RGB_CURRENT, default=20): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
+        cv.Optional(CONF_CW_CURRENT, default=30): cv.one_of(*DRIVE_STRENGTHS_CW, int=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -13,12 +13,26 @@ CODEOWNERS = ["@BoukeHaarsma23"]
 sm2135_ns = cg.esphome_ns.namespace("sm2135")
 SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 
+CONF_RGB_CURRENT = "rgb_current"
+CONF_CW_CURRENT = "cw_current"
+
+DRIVE_STRENGTHS_CW = {
+10,15,20,25,30,40,45,50,55,60
+}
+
+DRIVE_STRENGTHS_RGB = {
+10,15,20,25,30,40,45
+}
+
+
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(SM2135),
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_RGB_CURRENT): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
+        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True)
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -31,3 +45,6 @@ async def to_code(config):
     cg.add(var.set_data_pin(data))
     clock = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
     cg.add(var.set_clock_pin(clock))
+
+    cg.add(var.set_rgb_current(config[CONF_RGB_CURRENT]))
+    cg.add(var.set_cw_current(config[CONF_CW_CURRENT]))

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -8,7 +8,7 @@ from esphome.const import (
 )
 
 AUTO_LOAD = ["output"]
-CODEOWNERS = ["@BoukeHaarsma23","@matika77","@dd32"]
+CODEOWNERS = ["@BoukeHaarsma23", "@matika77", "@dd32"]
 
 sm2135_ns = cg.esphome_ns.namespace("sm2135")
 SM2135 = sm2135_ns.class_("SM2135", cg.Component)
@@ -27,8 +27,12 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(SM2135),
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_RGB_CURRENT, default=20): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
-        cv.Optional(CONF_CW_CURRENT, default=10): cv.one_of(*DRIVE_STRENGTHS_CW, int=True),
+        cv.Optional(CONF_RGB_CURRENT, default=20): cv.one_of(
+            *DRIVE_STRENGTHS_RGB, int=True
+        ),
+        cv.Optional(CONF_CW_CURRENT, default=10): cv.one_of(
+            *DRIVE_STRENGTHS_CW, int=True
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -16,9 +16,29 @@ SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 CONF_RGB_CURRENT = "rgb_current"
 CONF_CW_CURRENT = "cw_current"
 
-DRIVE_STRENGTHS_CW = {10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60}
-
-DRIVE_STRENGTHS_RGB = {10, 15, 20, 25, 30, 35, 40, 45}
+DRIVE_STRENGTHS_CW = {
+    "10mA": 10,
+    "15mA": 15,
+    "20mA": 20,
+    "25mA": 25,
+    "30mA": 30,
+    "35mA": 35,
+    "40mA": 40,
+    "45mA": 45,
+    "50mA": 50,
+    "55mA": 55,
+    "60mA": 60,
+}
+DRIVE_STRENGTHS_RGB = {
+    "10mA": 10,
+    "15mA": 15,
+    "20mA": 20,
+    "25mA": 25,
+    "30mA": 30,
+    "35mA": 35,
+    "40mA": 40,
+    "45mA": 45,
+}
 
 
 MULTI_CONF = True
@@ -27,12 +47,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(SM2135),
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_RGB_CURRENT, default=20): cv.one_of(
-            *DRIVE_STRENGTHS_RGB, int=True
-        ),
-        cv.Optional(CONF_CW_CURRENT, default=10): cv.one_of(
-            *DRIVE_STRENGTHS_CW, int=True
-        ),
+        cv.Optional(CONF_RGB_CURRENT, "20mA"): cv.enum(DRIVE_STRENGTHS_RGB),
+        cv.Optional(CONF_CW_CURRENT, "10mA"): cv.enum(DRIVE_STRENGTHS_CW),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -16,28 +16,30 @@ SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 CONF_RGB_CURRENT = "rgb_current"
 CONF_CW_CURRENT = "cw_current"
 
+SM2135Current = sm2135_ns.enum("SM2135Current")
+
 DRIVE_STRENGTHS_CW = {
-    "10mA": 10,
-    "15mA": 15,
-    "20mA": 20,
-    "25mA": 25,
-    "30mA": 30,
-    "35mA": 35,
-    "40mA": 40,
-    "45mA": 45,
-    "50mA": 50,
-    "55mA": 55,
-    "60mA": 60,
+    "10mA": SM2135Current.SM2135_CURRENT_10MA,
+    "15mA": SM2135Current.SM2135_CURRENT_15MA,
+    "20mA": SM2135Current.SM2135_CURRENT_20MA,
+    "25mA": SM2135Current.SM2135_CURRENT_25MA,
+    "30mA": SM2135Current.SM2135_CURRENT_30MA,
+    "35mA": SM2135Current.SM2135_CURRENT_35MA,
+    "40mA": SM2135Current.SM2135_CURRENT_40MA,
+    "45mA": SM2135Current.SM2135_CURRENT_45MA,
+    "50mA": SM2135Current.SM2135_CURRENT_50MA,
+    "55mA": SM2135Current.SM2135_CURRENT_55MA,
+    "60mA": SM2135Current.SM2135_CURRENT_60MA,
 }
 DRIVE_STRENGTHS_RGB = {
-    "10mA": 10,
-    "15mA": 15,
-    "20mA": 20,
-    "25mA": 25,
-    "30mA": 30,
-    "35mA": 35,
-    "40mA": 40,
-    "45mA": 45,
+    "10mA": SM2135Current.SM2135_CURRENT_10MA,
+    "15mA": SM2135Current.SM2135_CURRENT_15MA,
+    "20mA": SM2135Current.SM2135_CURRENT_20MA,
+    "25mA": SM2135Current.SM2135_CURRENT_25MA,
+    "30mA": SM2135Current.SM2135_CURRENT_30MA,
+    "35mA": SM2135Current.SM2135_CURRENT_35MA,
+    "40mA": SM2135Current.SM2135_CURRENT_40MA,
+    "45mA": SM2135Current.SM2135_CURRENT_45MA,
 }
 
 

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -19,7 +19,6 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
-
 static const uint8_t SM2135_10MA = 0x00;
 static const uint8_t SM2135_15MA = 0x01;
 static const uint8_t SM2135_20MA = 0x02;
@@ -31,7 +30,6 @@ static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
 static const uint8_t SM2135_50MA = 0x08;
 static const uint8_t SM2135_55MA = 0x09;
 static const uint8_t SM2135_60MA = 0x0A;
-
 
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
@@ -59,7 +57,7 @@ void SM2135::loop() {
   if (!this->update_)
     return;
 
-  Sm2135Start_();
+  sm2135_start_();
   write_byte_(SM2135_ADDR_MC);
   write_byte_(current_mask_);
 
@@ -67,9 +65,9 @@ void SM2135::loop() {
     // No color so must be Cold/Warm
 
     write_byte_(SM2135_CW);
-    Sm2135Stop_();
+    sm2135_stop_();
     delay(1);
-    Sm2135Start_();
+    sm2135_start_();
     write_byte_(SM2135_ADDR_C);
     write_byte_(this->pwm_amounts_[4]);  // Warm
     write_byte_(this->pwm_amounts_[3]);  // Cold
@@ -82,11 +80,10 @@ void SM2135::loop() {
     write_byte_(this->pwm_amounts_[2]);  // Blue
   }
 
-  Sm2135Stop_();
+  sm2135_stop_();
 
   this->update_ = false;
 }
-
 
 }  // namespace sm2135
 }  // namespace esphome

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -6,31 +6,6 @@
 namespace esphome {
 namespace sm2135 {
 
-static const char *const TAG = "sm2135";
-
-static const uint8_t SM2135_ADDR_MC = 0xC0;  // Max current register
-static const uint8_t SM2135_ADDR_CH = 0xC1;  // RGB or CW channel select register
-static const uint8_t SM2135_ADDR_R = 0xC2;   // Red color
-static const uint8_t SM2135_ADDR_G = 0xC3;   // Green color
-static const uint8_t SM2135_ADDR_B = 0xC4;   // Blue color
-static const uint8_t SM2135_ADDR_C = 0xC5;   // Cold
-static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
-
-static const uint8_t SM2135_RGB = 0x00;  // RGB channel
-static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
-
-static const uint8_t SM2135_10MA = 0x00;
-static const uint8_t SM2135_15MA = 0x01;
-static const uint8_t SM2135_20MA = 0x02;
-static const uint8_t SM2135_25MA = 0x03;
-static const uint8_t SM2135_30MA = 0x04;
-static const uint8_t SM2135_35MA = 0x05;
-static const uint8_t SM2135_40MA = 0x06;
-static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
-static const uint8_t SM2135_50MA = 0x08;
-static const uint8_t SM2135_55MA = 0x09;
-static const uint8_t SM2135_60MA = 0x0A;
-
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
   this->data_pin_->setup();

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -19,11 +19,12 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
+
 static const uint8_t SM2135_10MA = 0x00;
 static const uint8_t SM2135_15MA = 0x01;
-static const uint8_t SM2135_20MA = 0x02;  // RGB max current (Chip default)
+static const uint8_t SM2135_20MA = 0x02;
 static const uint8_t SM2135_25MA = 0x03;
-static const uint8_t SM2135_30MA = 0x04;  // CW max current (Chip default)
+static const uint8_t SM2135_30MA = 0x04;
 static const uint8_t SM2135_35MA = 0x05;
 static const uint8_t SM2135_40MA = 0x06;
 static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
@@ -31,51 +32,61 @@ static const uint8_t SM2135_50MA = 0x08;
 static const uint8_t SM2135_55MA = 0x09;
 static const uint8_t SM2135_60MA = 0x0A;
 
-static const uint8_t SM2135_CURRENT = (SM2135_20MA << 4) | SM2135_10MA;
 
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
   this->data_pin_->setup();
-  this->data_pin_->digital_write(true);
+  this->data_pin_->digital_write(false);
+  this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
   this->clock_pin_->setup();
-  this->clock_pin_->digital_write(true);
+  this->clock_pin_->digital_write(false);
+  this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+
+  this->data_pin_->pin_mode(gpio::FLAG_PULLUP);
+  this->clock_pin_->pin_mode(gpio::FLAG_PULLUP);
+
   this->pwm_amounts_.resize(5, 0);
 }
 void SM2135::dump_config() {
   ESP_LOGCONFIG(TAG, "SM2135:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
+  ESP_LOGCONFIG(TAG, "  CW Current: %d", this->cw_current_);
+  ESP_LOGCONFIG(TAG, "  RGB Current: %d", this->rgb_current_);
 }
 
 void SM2135::loop() {
   if (!this->update_)
     return;
 
-  uint8_t data[6];
+  Sm2135Start_();
+  write_byte_(SM2135_ADDR_MC);
+  write_byte_(current_mask_);
+
   if (this->update_channel_ == 3 || this->update_channel_ == 4) {
     // No color so must be Cold/Warm
-    data[0] = SM2135_ADDR_MC;
-    data[1] = SM2135_CURRENT;
-    data[2] = SM2135_CW;
-    this->write_buffer_(data, 3);
+
+    write_byte_(SM2135_CW);
+    Sm2135Stop_();
     delay(1);
-    data[0] = SM2135_ADDR_C;
-    data[1] = this->pwm_amounts_[4];  // Warm
-    data[2] = this->pwm_amounts_[3];  // Cold
-    this->write_buffer_(data, 3);
+    Sm2135Start_();
+    write_byte_(SM2135_ADDR_C);
+    write_byte_(this->pwm_amounts_[4]);  // Warm
+    write_byte_(this->pwm_amounts_[3]);  // Cold
   } else {
     // Color
-    data[0] = SM2135_ADDR_MC;
-    data[1] = SM2135_CURRENT;
-    data[2] = SM2135_RGB;
-    data[3] = this->pwm_amounts_[1];  // Green
-    data[4] = this->pwm_amounts_[0];  // Red
-    data[5] = this->pwm_amounts_[2];  // Blue
-    this->write_buffer_(data, 6);
+
+    write_byte_(SM2135_RGB);
+    write_byte_(this->pwm_amounts_[1]);  // Green
+    write_byte_(this->pwm_amounts_[0]);  // Red
+    write_byte_(this->pwm_amounts_[2]);  // Blue
   }
+
+  Sm2135Stop_();
 
   this->update_ = false;
 }
+
 
 }  // namespace sm2135
 }  // namespace esphome

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -10,16 +10,14 @@ static const char *const TAG = "sm2135";
 
 static const uint8_t SM2135_ADDR_MC = 0xC0;  // Max current register
 static const uint8_t SM2135_ADDR_CH = 0xC1;  // RGB or CW channel select register
+static const uint8_t SM2135_ADDR_R = 0xC2;   // Red color
+static const uint8_t SM2135_ADDR_G = 0xC3;   // Green color
+static const uint8_t SM2135_ADDR_B = 0xC4;   // Blue color
+static const uint8_t SM2135_ADDR_C = 0xC5;   // Cold
+static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 
-// NOTE: This is the default chip byte order of colors, but SM2135::loop() uses a different order.
-static const uint8_t SM2135_ADDR_R = 0xC2;  // Red color
-static const uint8_t SM2135_ADDR_G = 0xC3;  // Green color
-static const uint8_t SM2135_ADDR_B = 0xC4;  // Blue color
-static const uint8_t SM2135_ADDR_C = 0xC5;  // Cold
-static const uint8_t SM2135_ADDR_W = 0xC6;  // Warm
-
-static const uint8_t SM2135_RGB = 0x00;     // RGB channel
-static const uint8_t SM2135_CW = 0x80;      // CW channel (Chip default)
+static const uint8_t SM2135_RGB = 0x00;      // RGB channel
+static const uint8_t SM2135_CW = 0x80;       // CW channel (Chip default)
 
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -6,6 +6,21 @@
 namespace esphome {
 namespace sm2135 {
 
+static const char *const TAG = "sm2135";
+
+static const uint8_t SM2135_ADDR_MC = 0xC0;  // Max current register
+static const uint8_t SM2135_ADDR_CH = 0xC1;  // RGB or CW channel select register
+
+// NOTE: This is the default chip byte order of colors, but SM2135::loop() uses a different order.
+static const uint8_t SM2135_ADDR_R = 0xC2;  // Red color
+static const uint8_t SM2135_ADDR_G = 0xC3;  // Green color
+static const uint8_t SM2135_ADDR_B = 0xC4;  // Blue color
+static const uint8_t SM2135_ADDR_C = 0xC5;  // Cold
+static const uint8_t SM2135_ADDR_W = 0xC6;  // Warm
+
+static const uint8_t SM2135_RGB = 0x00;     // RGB channel
+static const uint8_t SM2135_CW = 0x80;      // CW channel (Chip default)
+
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
   this->data_pin_->setup();
@@ -25,87 +40,105 @@ void SM2135::dump_config() {
   ESP_LOGCONFIG(TAG, "SM2135:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  CW Current: %d", this->cw_current_);
-  ESP_LOGCONFIG(TAG, "  RGB Current: %d", this->rgb_current_);
+  ESP_LOGCONFIG(TAG, "  CW Current: %dmA", 10 + (this->cw_current_ * 5));
+  ESP_LOGCONFIG(TAG, "  RGB Current: %dmA", 10 + (this->rgb_current_ * 5));
 }
 
 void SM2135::write_byte_(uint8_t data) {
   for (uint8_t mask = 0x80; mask; mask >>= 1) {
     if (mask & data) {
-      sm2135_set_high_(this->data_pin_);
+      this->sm2135_set_high_(this->data_pin_);
     } else {
-      sm2135_set_low_(this->data_pin_);
+      this->sm2135_set_low_(this->data_pin_);
     }
 
-    sm2135_set_high_(clock_pin_);
-    delayMicroseconds(sm2135_delay_);
-    sm2135_set_low_(clock_pin_);
+    this->sm2135_set_high_(this->clock_pin_);
+    delayMicroseconds(4);
+    this->sm2135_set_low_(clock_pin_);
   }
 
-  sm2135_set_high_(this->data_pin_);
-  sm2135_set_high_(this->clock_pin_);
-  delayMicroseconds(sm2135_delay_ / 2);
-  sm2135_set_low_(this->clock_pin_);
-  delayMicroseconds(sm2135_delay_ / 2);
-  sm2135_set_low_(this->data_pin_);
+  this->sm2135_set_high_(this->data_pin_);
+  this->sm2135_set_high_(this->clock_pin_);
+  delayMicroseconds(2);
+  this->sm2135_set_low_(this->clock_pin_);
+  delayMicroseconds(2);
+  this->sm2135_set_low_(this->data_pin_);
 }
 
 void SM2135::sm2135_start_() {
-  sm2135_set_low_(this->data_pin_);
-  delayMicroseconds(sm2135_delay_);
-  sm2135_set_low_(this->clock_pin_);
+  this->sm2135_set_low_(this->data_pin_);
+  delayMicroseconds(4);
+  this->sm2135_set_low_(this->clock_pin_);
 }
 
 void SM2135::sm2135_stop_() {
-  sm2135_set_low_(this->data_pin_);
-  delayMicroseconds(sm2135_delay_);
-  sm2135_set_high_(this->clock_pin_);
-  delayMicroseconds(sm2135_delay_);
-  sm2135_set_high_(this->data_pin_);
-  delayMicroseconds(sm2135_delay_);
+  this->sm2135_set_low_(this->data_pin_);
+  delayMicroseconds(4);
+  this->sm2135_set_high_(this->clock_pin_);
+  delayMicroseconds(4);
+  this->sm2135_set_high_(this->data_pin_);
+  delayMicroseconds(4);
 }
 
 void SM2135::write_buffer_(uint8_t *buffer, uint8_t size) {
-  sm2135_start_();
+  this->sm2135_start_();
 
   this->data_pin_->digital_write(false);
   for (uint32_t i = 0; i < size; i++) {
     this->write_byte_(buffer[i]);
   }
 
-  sm2135_stop_();
+  this->sm2135_stop_();
 }
 
 void SM2135::loop() {
   if (!this->update_)
     return;
 
-  sm2135_start_();
-  write_byte_(SM2135_ADDR_MC);
-  write_byte_(current_mask_);
+  this->sm2135_start_();
+  this->write_byte_(SM2135_ADDR_MC);
+  this->write_byte_(current_mask_);
 
   if (this->update_channel_ == 3 || this->update_channel_ == 4) {
     // No color so must be Cold/Warm
 
-    write_byte_(SM2135_CW);
-    sm2135_stop_();
+    this->write_byte_(SM2135_CW);
+    this->sm2135_stop_();
     delay(1);
-    sm2135_start_();
-    write_byte_(SM2135_ADDR_C);
-    write_byte_(this->pwm_amounts_[4]);  // Warm
-    write_byte_(this->pwm_amounts_[3]);  // Cold
+    this->sm2135_start_();
+    this->write_byte_(SM2135_ADDR_C);
+    this->write_byte_(this->pwm_amounts_[4]);  // Warm
+    this->write_byte_(this->pwm_amounts_[3]);  // Cold
   } else {
     // Color
 
-    write_byte_(SM2135_RGB);
-    write_byte_(this->pwm_amounts_[1]);  // Green
-    write_byte_(this->pwm_amounts_[0]);  // Red
-    write_byte_(this->pwm_amounts_[2]);  // Blue
+    this->write_byte_(SM2135_RGB);
+    this->write_byte_(this->pwm_amounts_[1]);  // Green
+    this->write_byte_(this->pwm_amounts_[0]);  // Red
+    this->write_byte_(this->pwm_amounts_[2]);  // Blue
   }
 
-  sm2135_stop_();
+  this->sm2135_stop_();
 
   this->update_ = false;
+}
+
+void SM2135::set_channel_value_(uint8_t channel, uint8_t value) {
+  if (this->pwm_amounts_[channel] != value) {
+    this->update_ = true;
+    this->update_channel_ = channel;
+  }
+  this->pwm_amounts_[channel] = value;
+}
+
+void SM2135::sm2135_set_low_(GPIOPin *pin) {
+  pin->digital_write(false);
+  pin->pin_mode(gpio::FLAG_OUTPUT);
+}
+
+void SM2135::sm2135_set_high_(GPIOPin *pin) {
+  pin->digital_write(true);
+  pin->pin_mode(gpio::FLAG_PULLUP);
 }
 
 }  // namespace sm2135

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -16,8 +16,8 @@ static const uint8_t SM2135_ADDR_B = 0xC4;   // Blue color
 static const uint8_t SM2135_ADDR_C = 0xC5;   // Cold
 static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 
-static const uint8_t SM2135_RGB = 0x00;      // RGB channel
-static const uint8_t SM2135_CW = 0x80;       // CW channel (Chip default)
+static const uint8_t SM2135_RGB = 0x00;  // RGB channel
+static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -20,12 +20,60 @@ void SM2135::setup() {
 
   this->pwm_amounts_.resize(5, 0);
 }
+
 void SM2135::dump_config() {
   ESP_LOGCONFIG(TAG, "SM2135:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
   ESP_LOGCONFIG(TAG, "  CW Current: %d", this->cw_current_);
   ESP_LOGCONFIG(TAG, "  RGB Current: %d", this->rgb_current_);
+}
+
+void SM2135::write_byte_(uint8_t data) {
+  for (uint8_t mask = 0x80; mask; mask >>= 1) {
+    if (mask & data) {
+      sm2135_set_high_(this->data_pin_);
+    } else {
+      sm2135_set_low_(this->data_pin_);
+    }
+
+    sm2135_set_high_(clock_pin_);
+    delayMicroseconds(sm2135_delay_);
+    sm2135_set_low_(clock_pin_);
+  }
+
+  sm2135_set_high_(this->data_pin_);
+  sm2135_set_high_(this->clock_pin_);
+  delayMicroseconds(sm2135_delay_ / 2);
+  sm2135_set_low_(this->clock_pin_);
+  delayMicroseconds(sm2135_delay_ / 2);
+  sm2135_set_low_(this->data_pin_);
+}
+
+void SM2135::sm2135_start_() {
+  sm2135_set_low_(this->data_pin_);
+  delayMicroseconds(sm2135_delay_);
+  sm2135_set_low_(this->clock_pin_);
+}
+
+void SM2135::sm2135_stop_() {
+  sm2135_set_low_(this->data_pin_);
+  delayMicroseconds(sm2135_delay_);
+  sm2135_set_high_(this->clock_pin_);
+  delayMicroseconds(sm2135_delay_);
+  sm2135_set_high_(this->data_pin_);
+  delayMicroseconds(sm2135_delay_);
+}
+
+void SM2135::write_buffer_(uint8_t *buffer, uint8_t size) {
+  sm2135_start_();
+
+  this->data_pin_->digital_write(false);
+  for (uint32_t i = 0; i < size; i++) {
+    this->write_byte_(buffer[i]);
+  }
+
+  sm2135_stop_();
 }
 
 void SM2135::loop() {

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -4,6 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/output/float_output.h"
 #include <vector>
+#include <map>
 
 namespace esphome {
 namespace sm2135 {
@@ -23,17 +24,21 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
-static const uint8_t SM2135_10MA = 0x00;
-static const uint8_t SM2135_15MA = 0x01;
-static const uint8_t SM2135_20MA = 0x02;
-static const uint8_t SM2135_25MA = 0x03;
-static const uint8_t SM2135_30MA = 0x04;
-static const uint8_t SM2135_35MA = 0x05;
-static const uint8_t SM2135_40MA = 0x06;
-static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
-static const uint8_t SM2135_50MA = 0x08;
-static const uint8_t SM2135_55MA = 0x09;
-static const uint8_t SM2135_60MA = 0x0A;
+static const std::map<uint8_t,uint8_t> SM2135_CURRENT = {
+  { 10, 0x00 },
+  { 15, 0x01 },
+  { 20, 0x02 },
+  { 25, 0x03 },
+  { 30, 0x04 },
+  { 35, 0x05 },
+  { 40, 0x06 },
+  { 45, 0x07 },  // Max value for RGB
+  { 50, 0x08 },
+  { 55, 0x09 },
+  { 60, 0x0A },
+};
+
+#define SM2135_CURRENT_LOOKUP(ma) ( SM2135_CURRENT.find(ma)->second )
 
 class SM2135 : public Component {
  public:
@@ -44,12 +49,12 @@ class SM2135 : public Component {
 
   void set_rgb_current(uint8_t rgb_current) {
     rgb_current_ = rgb_current;
-    current_mask_ = (convert_ma_to_bitmask_(rgb_current_) << 4) | convert_ma_to_bitmask_(cw_current_);
+    current_mask_ = (SM2135_CURRENT_LOOKUP(rgb_current_) << 4) | SM2135_CURRENT_LOOKUP(cw_current_);
   }
 
   void set_cw_current(uint8_t cw_current) {
     cw_current_ = cw_current;
-    current_mask_ = (convert_ma_to_bitmask_(rgb_current_) << 4) | convert_ma_to_bitmask_(cw_current_);
+    current_mask_ = (SM2135_CURRENT_LOOKUP(rgb_current_) << 4) | SM2135_CURRENT_LOOKUP(cw_current_);
   }
 
   void setup() override;
@@ -143,8 +148,6 @@ class SM2135 : public Component {
 
     sm2135_stop_();
   }
-
-  uint8_t convert_ma_to_bitmask_(uint8_t ma) { return (ma - 10) / 5; }
 
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -12,6 +12,8 @@ static const char *const TAG = "sm2135";
 
 static const uint8_t SM2135_ADDR_MC = 0xC0;  // Max current register
 static const uint8_t SM2135_ADDR_CH = 0xC1;  // RGB or CW channel select register
+
+// NOTE: This is the default chip byte order of colors, but SM2135::loop() uses a different order.
 static const uint8_t SM2135_ADDR_R = 0xC2;   // Red color
 static const uint8_t SM2135_ADDR_G = 0xC3;   // Green color
 static const uint8_t SM2135_ADDR_B = 0xC4;   // Blue color

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -8,6 +8,31 @@
 namespace esphome {
 namespace sm2135 {
 
+static const char *const TAG = "sm2135";
+
+static const uint8_t SM2135_ADDR_MC = 0xC0;  // Max current register
+static const uint8_t SM2135_ADDR_CH = 0xC1;  // RGB or CW channel select register
+static const uint8_t SM2135_ADDR_R = 0xC2;   // Red color
+static const uint8_t SM2135_ADDR_G = 0xC3;   // Green color
+static const uint8_t SM2135_ADDR_B = 0xC4;   // Blue color
+static const uint8_t SM2135_ADDR_C = 0xC5;   // Cold
+static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
+
+static const uint8_t SM2135_RGB = 0x00;  // RGB channel
+static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
+
+static const uint8_t SM2135_10MA = 0x00;
+static const uint8_t SM2135_15MA = 0x01;
+static const uint8_t SM2135_20MA = 0x02;
+static const uint8_t SM2135_25MA = 0x03;
+static const uint8_t SM2135_30MA = 0x04;
+static const uint8_t SM2135_35MA = 0x05;
+static const uint8_t SM2135_40MA = 0x06;
+static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
+static const uint8_t SM2135_50MA = 0x08;
+static const uint8_t SM2135_55MA = 0x09;
+static const uint8_t SM2135_60MA = 0x0A;
+
 class SM2135 : public Component {
  public:
   class Channel;

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -67,13 +67,13 @@ class SM2135 : public Component {
 
   void sm2135_set_high_(GPIOPin *pin) { pin->pin_mode(gpio::FLAG_PULLUP); }
 
-  void sm2135_start_(void) {
+  void sm2135_start_() {
     sm2135_set_low_(this->data_pin_);
     delayMicroseconds(s_m2135_delay_);
     sm2135_set_low_(this->clock_pin_);
   }
 
-  void sm2135_stop_(void) {
+  void sm2135_stop_() {
     sm2135_set_low_(this->data_pin_);
     delayMicroseconds(s_m2135_delay_);
     sm2135_set_high_(this->clock_pin_);

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -65,7 +65,10 @@ class SM2135 : public Component {
     pin->pin_mode(gpio::FLAG_OUTPUT);
   }
 
-  void sm2135_set_high_(GPIOPin *pin) { pin->pin_mode(gpio::FLAG_PULLUP); }
+  void sm2135_set_high_(GPIOPin *pin) {
+    pin->digital_write(true);
+    pin->pin_mode(gpio::FLAG_PULLUP);
+  }
 
   void sm2135_start_() {
     sm2135_set_low_(this->data_pin_);

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -15,6 +15,18 @@ class SM2135 : public Component {
   void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }
   void set_clock_pin(GPIOPin *clock_pin) { clock_pin_ = clock_pin; }
 
+  void set_rgb_current(uint8 rgb_current) {
+   rgb_current_ = rgb_current;
+   current_mask_ = (convert_ma_to_bitmask(rgb_current_) << 4) | \
+     convert_ma_to_bitmask(cw_current_);
+  }
+
+  void set_cw_current(uint8 cw_current) {
+   cw_current_ = cw_current;
+   current_mask_ = (convert_ma_to_bitmask(rgb_current_) << 4) | \
+     convert_ma_to_bitmask(cw_current_);
+  }
+
   void setup() override;
 
   void dump_config() override;
@@ -40,6 +52,9 @@ class SM2135 : public Component {
   };
 
  protected:
+
+  const uint8_t SM2135_DELAY = 4;
+
   void set_channel_value_(uint8_t channel, uint8_t value) {
     if (this->pwm_amounts_[channel] != value) {
       this->update_ = true;
@@ -47,36 +62,76 @@ class SM2135 : public Component {
     }
     this->pwm_amounts_[channel] = value;
   }
-  void write_bit_(bool value) {
-    this->clock_pin_->digital_write(false);
-    this->data_pin_->digital_write(value);
-    this->clock_pin_->digital_write(true);
+
+  void Sm2135SetLow_(GPIOPin *pin) {
+    pin->digital_write(false);
+    pin->pin_mode(gpio::FLAG_OUTPUT);
+  }
+
+  void Sm2135SetHigh_(GPIOPin *pin) {
+      pin->pin_mode(gpio::FLAG_PULLUP);
+  }
+
+  void Sm2135Start_(void) {
+    Sm2135SetLow_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetLow_(this->clock_pin_);
+  }
+
+  void Sm2135Stop_(void) {
+    Sm2135SetLow_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetHigh_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetHigh_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
   }
 
   void write_byte_(uint8_t data) {
     for (uint8_t mask = 0x80; mask; mask >>= 1) {
-      this->write_bit_(data & mask);
+      if(mask & data) {
+        Sm2135SetHigh_(this->data_pin_);
+      } else {
+        Sm2135SetLow_(this->data_pin_);
+      }
+
+      Sm2135SetHigh_(clock_pin_);
+      delayMicroseconds(SM2135_DELAY);
+      Sm2135SetLow_(clock_pin_);
     }
-    this->clock_pin_->digital_write(false);
-    this->data_pin_->digital_write(true);
-    this->clock_pin_->digital_write(true);
+
+    Sm2135SetHigh_(this->data_pin_);
+    Sm2135SetHigh_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY / 2);
+    Sm2135SetLow_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY / 2);
+    Sm2135SetLow_(this->data_pin_);
   }
 
   void write_buffer_(uint8_t *buffer, uint8_t size) {
+    Sm2135Start_();
+
     this->data_pin_->digital_write(false);
     for (uint32_t i = 0; i < size; i++) {
       this->write_byte_(buffer[i]);
     }
-    this->clock_pin_->digital_write(false);
-    this->clock_pin_->digital_write(true);
-    this->data_pin_->digital_write(true);
+
+    Sm2135Stop_();
+  }
+
+  uint8_t convert_ma_to_bitmask(uint8_t ma) {
+    return (ma-10) / 5;
   }
 
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;
+  uint8 current_mask_;
+  uint8 rgb_current_;
+  uint8 cw_current_;
   uint8_t update_channel_;
   std::vector<uint8_t> pwm_amounts_;
   bool update_{true};
+
 };
 
 }  // namespace sm2135

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -94,52 +94,10 @@ class SM2135 : public Component {
     pin->pin_mode(gpio::FLAG_PULLUP);
   }
 
-  void sm2135_start_() {
-    sm2135_set_low_(this->data_pin_);
-    delayMicroseconds(sm2135_delay_);
-    sm2135_set_low_(this->clock_pin_);
-  }
-
-  void sm2135_stop_() {
-    sm2135_set_low_(this->data_pin_);
-    delayMicroseconds(sm2135_delay_);
-    sm2135_set_high_(this->clock_pin_);
-    delayMicroseconds(sm2135_delay_);
-    sm2135_set_high_(this->data_pin_);
-    delayMicroseconds(sm2135_delay_);
-  }
-
-  void write_byte_(uint8_t data) {
-    for (uint8_t mask = 0x80; mask; mask >>= 1) {
-      if (mask & data) {
-        sm2135_set_high_(this->data_pin_);
-      } else {
-        sm2135_set_low_(this->data_pin_);
-      }
-
-      sm2135_set_high_(clock_pin_);
-      delayMicroseconds(sm2135_delay_);
-      sm2135_set_low_(clock_pin_);
-    }
-
-    sm2135_set_high_(this->data_pin_);
-    sm2135_set_high_(this->clock_pin_);
-    delayMicroseconds(sm2135_delay_ / 2);
-    sm2135_set_low_(this->clock_pin_);
-    delayMicroseconds(sm2135_delay_ / 2);
-    sm2135_set_low_(this->data_pin_);
-  }
-
-  void write_buffer_(uint8_t *buffer, uint8_t size) {
-    sm2135_start_();
-
-    this->data_pin_->digital_write(false);
-    for (uint32_t i = 0; i < size; i++) {
-      this->write_byte_(buffer[i]);
-    }
-
-    sm2135_stop_();
-  }
+  void sm2135_start_();
+  void sm2135_stop_();
+  void write_byte_(uint8_t data);
+  void write_buffer_(uint8_t *buffer, uint8_t size);
 
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -74,7 +74,7 @@ class SM2135 : public Component {
   };
 
  protected:
-  const uint8_t s_m2135_delay_ = 4;
+  const uint8_t sm2135_delay_ = 4;
 
   void set_channel_value_(uint8_t channel, uint8_t value) {
     if (this->pwm_amounts_[channel] != value) {
@@ -96,17 +96,17 @@ class SM2135 : public Component {
 
   void sm2135_start_() {
     sm2135_set_low_(this->data_pin_);
-    delayMicroseconds(s_m2135_delay_);
+    delayMicroseconds(sm2135_delay_);
     sm2135_set_low_(this->clock_pin_);
   }
 
   void sm2135_stop_() {
     sm2135_set_low_(this->data_pin_);
-    delayMicroseconds(s_m2135_delay_);
+    delayMicroseconds(sm2135_delay_);
     sm2135_set_high_(this->clock_pin_);
-    delayMicroseconds(s_m2135_delay_);
+    delayMicroseconds(sm2135_delay_);
     sm2135_set_high_(this->data_pin_);
-    delayMicroseconds(s_m2135_delay_);
+    delayMicroseconds(sm2135_delay_);
   }
 
   void write_byte_(uint8_t data) {
@@ -118,15 +118,15 @@ class SM2135 : public Component {
       }
 
       sm2135_set_high_(clock_pin_);
-      delayMicroseconds(s_m2135_delay_);
+      delayMicroseconds(sm2135_delay_);
       sm2135_set_low_(clock_pin_);
     }
 
     sm2135_set_high_(this->data_pin_);
     sm2135_set_high_(this->clock_pin_);
-    delayMicroseconds(s_m2135_delay_ / 2);
+    delayMicroseconds(sm2135_delay_ / 2);
     sm2135_set_low_(this->clock_pin_);
-    delayMicroseconds(s_m2135_delay_ / 2);
+    delayMicroseconds(sm2135_delay_ / 2);
     sm2135_set_low_(this->data_pin_);
   }
 

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -24,19 +24,11 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
-static const std::map<uint8_t,uint8_t> SM2135_CURRENT = {
-  { 10, 0x00 },
-  { 15, 0x01 },
-  { 20, 0x02 },
-  { 25, 0x03 },
-  { 30, 0x04 },
-  { 35, 0x05 },
-  { 40, 0x06 },
-  { 45, 0x07 },  // Max value for RGB
-  { 50, 0x08 },
-  { 55, 0x09 },
-  { 60, 0x0A },
-};
+static const std::map<uint8_t, uint8_t> SM2135_CURRENT = {
+    {10, 0x00}, {15, 0x01}, {20, 0x02}, {25, 0x03},
+    {30, 0x04}, {35, 0x05}, {40, 0x06}, {45, 0x07},  // Max value for RGB
+    {50, 0x08}, {55, 0x09}, {60, 0x0A},
+ };
 
 #define SM2135_CURRENT_LOOKUP(ma) ( SM2135_CURRENT.find(ma)->second )
 

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -1,10 +1,9 @@
 #pragma once
 
+#include <vector>
+#include "esphome/components/output/float_output.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
-#include "esphome/components/output/float_output.h"
-#include <vector>
-#include <map>
 
 namespace esphome {
 namespace sm2135 {

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -15,11 +15,11 @@ static const uint8_t SM2135_ADDR_MC = 0xC0;  // Max current register
 static const uint8_t SM2135_ADDR_CH = 0xC1;  // RGB or CW channel select register
 
 // NOTE: This is the default chip byte order of colors, but SM2135::loop() uses a different order.
-static const uint8_t SM2135_ADDR_R = 0xC2;   // Red color
-static const uint8_t SM2135_ADDR_G = 0xC3;   // Green color
-static const uint8_t SM2135_ADDR_B = 0xC4;   // Blue color
-static const uint8_t SM2135_ADDR_C = 0xC5;   // Cold
-static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
+static const uint8_t SM2135_ADDR_R = 0xC2;  // Red color
+static const uint8_t SM2135_ADDR_G = 0xC3;  // Green color
+static const uint8_t SM2135_ADDR_B = 0xC4;  // Blue color
+static const uint8_t SM2135_ADDR_C = 0xC5;  // Cold
+static const uint8_t SM2135_ADDR_W = 0xC6;  // Warm
 
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
@@ -28,9 +28,9 @@ static const std::map<uint8_t, uint8_t> SM2135_CURRENT = {
     {10, 0x00}, {15, 0x01}, {20, 0x02}, {25, 0x03},
     {30, 0x04}, {35, 0x05}, {40, 0x06}, {45, 0x07},  // Max value for RGB
     {50, 0x08}, {55, 0x09}, {60, 0x0A},
- };
+};
 
-#define SM2135_CURRENT_LOOKUP(ma) ( SM2135_CURRENT.find(ma)->second )
+#define SM2135_CURRENT_LOOKUP(ma) (SM2135_CURRENT.find(ma)->second)
 
 class SM2135 : public Component {
  public:

--- a/tests/test3.1.yaml
+++ b/tests/test3.1.yaml
@@ -300,6 +300,8 @@ text_sensor:
 sm2135:
   data_pin: GPIO12
   clock_pin: GPIO14
+  rgb_current: 20mA
+  cw_current: 60mA
 
 switch:
   - platform: template

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -806,12 +806,6 @@ script:
     then:
       - lambda: 'ESP_LOGD("main", "Hello World!");'
 
-sm2135:
-  data_pin: GPIO12
-  clock_pin: GPIO14
-  rgb_current: 20mA
-  cw_current: 60mA
-
 switch:
   - platform: gpio
     id: gpio_switch1

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -809,8 +809,8 @@ script:
 sm2135:
   data_pin: GPIO12
   clock_pin: GPIO14
-  rgb_current: 20
-  cw_current: 60
+  rgb_current: 20mA
+  cw_current: 60mA
 
 switch:
   - platform: gpio

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -822,6 +822,7 @@ switch:
     name: R0 Switch
     component_name: page0.r0
 
+
 climate:
   - platform: bang_bang
     name: Bang Bang Climate
@@ -1104,6 +1105,7 @@ rf_bridge:
         code: "ABC123"
     - rf_bridge.send_raw:
         raw: "AAA5070008001000ABC12355"
+
 
 display:
   - platform: nextion

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -806,6 +806,12 @@ script:
     then:
       - lambda: 'ESP_LOGD("main", "Hello World!");'
 
+sm2135:
+  data_pin: GPIO12
+  clock_pin: GPIO14
+  rgb_current: 20
+  cw_current: 60
+
 switch:
   - platform: gpio
     id: gpio_switch1
@@ -821,7 +827,6 @@ switch:
     id: r0
     name: R0 Switch
     component_name: page0.r0
-
 
 climate:
   - platform: bang_bang
@@ -1105,7 +1110,6 @@ rf_bridge:
         code: "ABC123"
     - rf_bridge.send_raw:
         raw: "AAA5070008001000ABC12355"
-
 
 display:
   - platform: nextion


### PR DESCRIPTION
# What does this implement/fix?

Rebased https://github.com/esphome/esphome/pull/3621

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/3506>, fixes <https://github.com/esphome/issues/issues/2546>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2331

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
