### PR TITLE
Add display GPIO setup instruction for Aliexpress display

### DIFF
--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -76,6 +76,8 @@ void SSD1327::setup() {
   this->command(0x55);
   this->command(SSD1327_SETVCOMHVOLTAGE);  // Set High Voltage Level of COM Pin
   this->command(0x1C);
+  this->command(SSD1327_SETGPIO);  // Switch voltage converter on (for Aliexpress display)
+  this->command(0x03);
   this->command(SSD1327_NORMALDISPLAY);  // set display mode
   set_brightness(this->brightness_);
   this->fill(Color::BLACK);  // clear display - ensures we do not see garbage at power-on


### PR DESCRIPTION
# What does this implement/fix?

Sets a couple of the display driver's GPIO pins to high enabling some voltage converter someone put on a display Aliexpress is selling.

I've confirmed that this change does not impact the display from Waveshare on which the component was originally developed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** something that came up on discord

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
