### PR TITLE
Add Rx buffer flush to get rid of CRC errors

### DIFF
--- a/esphome/components/teleinfo/teleinfo.cpp
+++ b/esphome/components/teleinfo/teleinfo.cpp
@@ -70,6 +70,10 @@ void TeleInfo::setup() { state_ = OFF; }
 void TeleInfo::update() {
   if (state_ == OFF) {
     buf_index_ = 0;
+	// Flush Rx buffer at update. Ensure to start on a new Teleinfo frame
+	while (available() > 0) {
+       read();
+    }
     state_ = ON;
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Due to persistent CRC errors even with correct reception confirmed (am I the only one in this case? ), i've investigate teleinfo.cpp code. To get rid of CRC errors I have to :
- increase "real" uart Rx buffer size in esphome yaml file (rx_buffer_size: 2048 for me, default size of 256 bytes is too small versus standard mode and its 865 bytes at 9600 bits/s)
- Add a Rx buffer flush in update() function of teleinfo.cpp in order to ensure that a unique full frame will be read

Since these modifications no more CRC errors observed over a month of continuous working.

## Types of changes

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

```yaml
# Example config.yaml

uart:
  id: uart_bus
  rx_pin:
    number: GPIO16
  #tx_pin: GPIO1
  baud_rate: 9600
  parity: EVEN
  data_bits: 7
  rx_buffer_size: 2048
  #debug:
    #direction: RX
    #dummy_receiver: false
    #after:
      #delimiter: "\n"
    #sequence:
      #- lambda: UARTDebug::log_string(direction, bytes);


teleinfo:
  id: myteleinfo
  update_interval: 10s
  historical_mode: false

## Checklist:
  - [X ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
