### PR TITLE
fix never calling preset change trigger

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -974,8 +974,11 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
   auto config = this->preset_config_.find(preset);
 
   if (config != this->preset_config_.end()) {
+    ESP_LOGI(TAG, "Preset %s requested", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
     if (this->change_preset_internal_(config->second)) {
-      ESP_LOGI(TAG, "Applied preset %s", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
+      ESP_LOGI(TAG, "Preset %s applied", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
+    } else {
+      ESP_LOGI(TAG, "No changes required to apply preset %s", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
     }
     this->custom_preset.reset();
     this->preset = preset;
@@ -988,8 +991,11 @@ void ThermostatClimate::change_custom_preset_(const std::string &custom_preset) 
   auto config = this->custom_preset_config_.find(custom_preset);
 
   if (config != this->custom_preset_config_.end()) {
+    ESP_LOGI(TAG, "Custom preset %s requested", custom_preset.c_str());
     if (this->change_preset_internal_(config->second)) {
-      ESP_LOGI(TAG, "Applied custom preset %s", custom_preset.c_str());
+      ESP_LOGI(TAG, "Custom preset %s applied", custom_preset.c_str());
+    } else {
+      ESP_LOGI(TAG, "No changes required to apply custom preset %s", custom_preset.c_str());
     }
     this->preset.reset();
     this->custom_preset = custom_preset;

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1024,11 +1024,9 @@ void ThermostatClimate::change_preset_internal_(const ThermostatClimateTargetTem
   }
 
   // Fire any preset changed trigger if defined
-  if (this->preset != preset) {
-    Trigger<> *trig = this->preset_change_trigger_;
-    assert(trig != nullptr);
-    trig->trigger();
-  }
+  Trigger<> *trig = this->preset_change_trigger_;
+  assert(trig != nullptr);
+  trig->trigger();
 
   this->refresh();
 }

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -168,7 +168,8 @@ class ThermostatClimate : public climate::Climate, public Component {
 
   /// Applies the temperature, mode, fan, and swing modes of the provided config.
   /// This is agnostic of custom vs built in preset
-  void change_preset_internal_(const ThermostatClimateTargetTempConfig &config);
+  /// Returns true if something was changed
+  bool change_preset_internal_(const ThermostatClimateTargetTempConfig &config);
 
   /// Return the traits of this controller.
   climate::ClimateTraits traits() override;


### PR DESCRIPTION
# What does this implement/fix?

Thermostat never calling change preset trigger, see fixed issue

Note to reviewer: I assume `change_preset_internal_` is only called when preset changes, seems to work ok with quick tests.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3615

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
