### PR TITLE
Fix default unit for ble_rssi sensor

### DIFF
--- a/esphome/components/ble_rssi/sensor.py
+++ b/esphome/components/ble_rssi/sensor.py
@@ -9,7 +9,7 @@ from esphome.const import (
     CONF_MAC_ADDRESS,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     STATE_CLASS_MEASUREMENT,
-    UNIT_DECIBEL,
+    UNIT_DECIBEL_MILLIWATT,
 )
 
 DEPENDENCIES = ["esp32_ble_tracker"]
@@ -31,7 +31,7 @@ def _validate(config):
 CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(
         BLERSSISensor,
-        unit_of_measurement=UNIT_DECIBEL,
+        unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
         accuracy_decimals=0,
         device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
         state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
# What does this implement/fix?

Changes unit for `ble_rssi` sensor from `dB` to `dBm`.
Found conflicting measurments while working on #3860, where sticking to the [espressif docs](https://docs.espressif.com/projects/esp-idf/en/v4.2/esp32/api-reference/bluetooth/esp_gap_ble.html?highlight=dbm#_CPPv4N22esp_ble_gap_cb_param_t28ble_read_rssi_cmpl_evt_param4rssiE) the unit used is `dBm`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
