### PR TITLE
add Outlaw 990 component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -157,6 +157,7 @@ esphome/components/nextion/text_sensor/* @senexcrenshaw
 esphome/components/nfc/* @jesserockz
 esphome/components/number/* @esphome/core
 esphome/components/ota/* @esphome/core
+esphome/components/outlaw_990/* @tangentaudio
 esphome/components/output/* @esphome/core
 esphome/components/pid/* @OttoWinter
 esphome/components/pipsolar/* @andreashergert1984

--- a/esphome/components/outlaw_990/__init__.py
+++ b/esphome/components/outlaw_990/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ['uart']
+AUTO_LOAD = ["binary_sensor"]
+MULTI_CONF = True
+
+CONF_OUTLAW_990_ID = "outlaw_990_id"
+
+outlaw_990_ns = cg.esphome_ns.namespace('outlaw_990')
+Outlaw990 = outlaw_990_ns.class_('Outlaw990', cg.PollingComponent, uart.UARTDevice)
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(Outlaw990)
+}).extend(cv.polling_component_schema("1000ms")).extend(uart.UART_DEVICE_SCHEMA)
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield uart.register_uart_device(var, config)

--- a/esphome/components/outlaw_990/__init__.py
+++ b/esphome/components/outlaw_990/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import uart
 from esphome.const import CONF_ID
 
+CODEOWNERS = ["@tangentaudio"]
 DEPENDENCIES = ['uart']
 AUTO_LOAD = ["binary_sensor"]
 MULTI_CONF = True

--- a/esphome/components/outlaw_990/__init__.py
+++ b/esphome/components/outlaw_990/__init__.py
@@ -4,18 +4,21 @@ from esphome.components import uart
 from esphome.const import CONF_ID
 
 CODEOWNERS = ["@tangentaudio"]
-DEPENDENCIES = ['uart']
+DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["binary_sensor"]
 MULTI_CONF = True
 
 CONF_OUTLAW_990_ID = "outlaw_990_id"
 
-outlaw_990_ns = cg.esphome_ns.namespace('outlaw_990')
-Outlaw990 = outlaw_990_ns.class_('Outlaw990', cg.PollingComponent, uart.UARTDevice)
+outlaw_990_ns = cg.esphome_ns.namespace("outlaw_990")
+Outlaw990 = outlaw_990_ns.class_("Outlaw990", cg.PollingComponent, uart.UARTDevice)
 
-CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(): cv.declare_id(Outlaw990)
-}).extend(cv.polling_component_schema("1000ms")).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema({cv.GenerateID(): cv.declare_id(Outlaw990)})
+    .extend(cv.polling_component_schema("1000ms"))
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
 
 def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/outlaw_990/binary_sensor.py
+++ b/esphome/components/outlaw_990/binary_sensor.py
@@ -17,13 +17,11 @@ TYPES = [
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_OUTLAW_990_ID): cv.use_id(Outlaw990),
-
-        cv.Required(CONF_SENSOR_POWER):
-            binary_sensor.binary_sensor_schema(),
-        cv.Required(CONF_SENSOR_MUTE):
-            binary_sensor.binary_sensor_schema()
+        cv.Required(CONF_SENSOR_POWER): binary_sensor.binary_sensor_schema(),
+        cv.Required(CONF_SENSOR_MUTE): binary_sensor.binary_sensor_schema(),
     }
 )
+
 
 async def to_code(config):
     comp = await cg.get_variable(config[CONF_OUTLAW_990_ID])

--- a/esphome/components/outlaw_990/binary_sensor.py
+++ b/esphome/components/outlaw_990/binary_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor
-from esphome.const import CONF_ICON, ICON_POWER
 from . import CONF_OUTLAW_990_ID, Outlaw990
 
 DEPENDENCIES = ["outlaw_990"]

--- a/esphome/components/outlaw_990/binary_sensor.py
+++ b/esphome/components/outlaw_990/binary_sensor.py
@@ -1,0 +1,39 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import CONF_ICON, ICON_POWER
+from . import CONF_OUTLAW_990_ID, Outlaw990
+
+DEPENDENCIES = ["outlaw_990"]
+
+CONF_SENSOR_POWER = "sensor_power"
+CONF_SENSOR_MUTE = "sensor_mute"
+
+TYPES = [
+    CONF_SENSOR_POWER,
+    CONF_SENSOR_MUTE,
+]
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_OUTLAW_990_ID): cv.use_id(Outlaw990),
+
+        cv.Required(CONF_SENSOR_POWER):
+            binary_sensor.binary_sensor_schema(),
+        cv.Required(CONF_SENSOR_MUTE):
+            binary_sensor.binary_sensor_schema()
+    }
+)
+
+async def to_code(config):
+    comp = await cg.get_variable(config[CONF_OUTLAW_990_ID])
+
+    if CONF_SENSOR_POWER in config:
+        conf = config[CONF_SENSOR_POWER]
+        sens = await binary_sensor.new_binary_sensor(conf)
+        cg.add(comp.set_power_binary_sensor(sens))
+
+    if CONF_SENSOR_MUTE in config:
+        conf = config[CONF_SENSOR_MUTE]
+        sens = await binary_sensor.new_binary_sensor(conf)
+        cg.add(comp.set_mute_binary_sensor(sens))

--- a/esphome/components/outlaw_990/outlaw_990.cpp
+++ b/esphome/components/outlaw_990/outlaw_990.cpp
@@ -8,7 +8,7 @@
  * See http://outlawaudio.com/outlaw/docs/990rs232protocol.pdf for protocol details
  */
 
-#include "esphome.h"
+
 #include "esphome/core/log.h"
 #include "outlaw_990.h"
 

--- a/esphome/components/outlaw_990/outlaw_990.cpp
+++ b/esphome/components/outlaw_990/outlaw_990.cpp
@@ -1,0 +1,302 @@
+/*
+ * Outlaw 990 AV Preamp/Processor RS232 Serial Controller
+ * Custom Component for ESPHome
+ *
+ * Steve Richardson (tangentaudio@gmail.com)
+ * September, 2022
+ *
+ * See http://outlawaudio.com/outlaw/docs/990rs232protocol.pdf for protocol details
+ */
+
+#include "esphome.h"
+#include "esphome/core/log.h"
+#include "outlaw_990.h"
+
+namespace esphome {
+namespace outlaw_990 {
+
+static const char* TAG = "outlaw_990.component";
+
+Outlaw990::Outlaw990() :
+  PollingComponent(1000), rx_state_(0), polling_enabled_(true), powering_off_(false)
+{
+}
+
+void Outlaw990::dump_config() {
+  ESP_LOGCONFIG(TAG, "Outlaw 990");
+  LOG_BINARY_SENSOR(TAG, "Power", this->power_binary_sensor_);
+  LOG_BINARY_SENSOR(TAG, "Mute", this->mute_binary_sensor_);
+  LOG_SENSOR(TAG, "Volume", this->volume_sensor_);
+  LOG_TEXT_SENSOR(TAG, "Display", this->display_text_sensor_);
+  LOG_TEXT_SENSOR(TAG, "Audio Input", this->audio_in_text_sensor_);
+  LOG_TEXT_SENSOR(TAG, "Video Input", this->video_in_text_sensor_);
+}
+
+void Outlaw990::setup() {
+  register_service(&Outlaw990::on_volume_adj, "outlaw_volume_adj", {"up"});
+  register_service(&Outlaw990::on_power, "outlaw_power", {"power"});
+  register_service(&Outlaw990::on_mute, "outlaw_mute");
+  register_service(&Outlaw990::on_cmd, "outlaw_command", {"cmd"});
+}
+
+void Outlaw990::update() {
+  if (polling_enabled_ || powering_off_) {
+    ESP_LOGD(TAG, "update() polling %s powering_off_ %s", polling_enabled_ ? "enabled" : "disabled", powering_off_ ? "true":"false");
+    send_pkt(0x53);
+  }
+}
+
+void Outlaw990::send_pkt(byte cmd) {
+  byte obuf[4];
+  obuf[0] = 0x83;
+  obuf[1] = 0x45;
+  obuf[2] = cmd;
+  obuf[3] = obuf[0] + obuf[1] + obuf[2];
+
+  for (int i=0; i<4; i++) {
+    write(obuf[i]);
+  }
+
+  ESP_LOGD(TAG, "sent serial pkt %2X %2X %2X %2X", obuf[0], obuf[1], obuf[2], obuf[3]);
+}
+
+void Outlaw990::on_cmd(int cmd) {
+  ESP_LOGD(TAG, "cmd service: %02X", cmd);
+  send_pkt(cmd);
+}
+
+void Outlaw990::on_volume_adj(bool up) {
+  ESP_LOGD(TAG, "volume adjust service: %s", up ? "UP" : "DOWN");
+  send_pkt(up ? 0x0F : 0x10);
+
+  if (up && volume < 14) volume++;
+  if (!up && volume > -76) volume--;
+
+  if (this->volume_sensor_ != nullptr)
+    this->volume_sensor_->publish_state(volume);
+
+}
+
+void Outlaw990::on_power(bool p) {
+  ESP_LOGD(TAG, "power service: %s", p ? "ON" : "OFF");
+  send_pkt(p ? 0x01 : 0x02);
+
+  powering_off_ = (p == false);
+
+  if (p != power) {
+    disp = power ? "POWERING OFF" : "POWERING ON";
+
+    if (this->display_text_sensor_ != nullptr)
+      this->display_text_sensor_->publish_state(disp);
+  }
+}
+
+void Outlaw990::on_mute() {
+  ESP_LOGD(TAG, "mute service: TOGGLE");
+  send_pkt(0x11);
+}
+
+void Outlaw990::send_idle_values() {
+
+  power = false;
+  mute = false;
+  volume = -76;
+  main_av_in = 0x00;
+  audio_in = "";
+  video_in = "";
+  disp = "OFF";
+
+  if (this->power_binary_sensor_ != nullptr)
+    this->power_binary_sensor_->publish_state(power);
+
+  if (this->mute_binary_sensor_ != nullptr)
+    this->mute_binary_sensor_->publish_state(mute);
+
+  if (this->volume_sensor_ != nullptr)
+    this->volume_sensor_->publish_state(volume);
+
+  if (this->audio_in_text_sensor_ != nullptr)
+    this->audio_in_text_sensor_->publish_state(audio_in);
+
+  if (this->video_in_text_sensor_ != nullptr)
+    this->video_in_text_sensor_->publish_state(video_in);
+
+  if (this->display_text_sensor_ != nullptr)
+    this->display_text_sensor_->publish_state(disp);
+}
+
+void Outlaw990::parse_packet() {
+  byte* text = &rx_buf_[0];
+  byte* status = &rx_buf_[13];
+
+  bool just_turned_on = false;
+
+  bool p = status[0] & 0x01;
+
+  if (power != p) {
+    ESP_LOGI(TAG, "power state changed: %s->%s", power ? "ON":"OFF", p ? "ON":"OFF");
+    if (p) {
+      // turned on
+      just_turned_on = true;
+    }
+    power = p;
+
+    if (this->power_binary_sensor_ != nullptr)
+      this->power_binary_sensor_->publish_state(power);
+  }
+
+  if (power) {
+    ESP_LOGD(TAG, "Power is on, parsing event packet");
+    bool m = status[0] & 0x08;
+    if ((mute != m) || just_turned_on) {
+      ESP_LOGI(TAG, "mute state changed: %s->%s", mute ? "ON":"OFF", m ? "ON":"OFF");
+      mute = m;
+      if (this->mute_binary_sensor_ != nullptr)
+        this->mute_binary_sensor_->publish_state(mute);
+    }
+
+    int v = (int)status[3] - (int)76;
+    if ((volume != v) || just_turned_on) {
+      ESP_LOGI(TAG, "volume changed: %d->%d", volume, v);
+      volume = v;
+
+      if (this->volume_sensor_ != nullptr)
+        this->volume_sensor_->publish_state(volume);
+    }
+
+    byte mav = status[1];
+    if ((main_av_in != mav) || just_turned_on) {
+      ESP_LOGI(TAG, "main AV state changed: %2X->%2X", main_av_in, mav);
+      main_av_in = mav;
+      byte a_in = (mav & 0x0F);
+      byte v_in = (mav & 0xF0) >> 4;
+
+      const char* AUDIO_LABELS[16] = {
+        "FM", "AM", "IN_0x02", "Tuner", "CD", "Aux/USB", "Phono", "DVD",
+        "Video 1", "Video 2", "Video 3", "Video 4", "Video 5",
+        "Tape", "7.1CH Direct", "IN_0x0F"
+      };
+      const char* VIDEO_LABELS[16] = {
+        "IN_0x00", "IN_0x01", "IN_0x02", "IN_0x03", "IN_0x04", "IN_0x05", "IN_0x06",
+        "Video 1", "Video 2", "Video 3", "DVD", "Video 4", "Video 5", "Video Direct",
+        "IN_0x0E", "IN_0x0F"
+      };
+      audio_in = std::string(AUDIO_LABELS[a_in]);
+      video_in = std::string(VIDEO_LABELS[v_in]);
+
+      if (this->audio_in_text_sensor_ != nullptr)
+        this->audio_in_text_sensor_->publish_state(audio_in);
+
+      if (this->video_in_text_sensor_ != nullptr)
+        this->video_in_text_sensor_->publish_state(video_in);
+
+      ESP_LOGD(TAG, " a: (%02X) %s v: (%02X) %s", a_in, audio_in.c_str(), v_in, video_in.c_str());
+    }
+
+    // extract display string
+    std::string d;
+    for (int i=0; i<13; i++) {
+      d += text[i];
+    }
+    if ((disp != d) || just_turned_on) {
+      disp = d;
+
+      if (this->display_text_sensor_ != nullptr)
+        this->display_text_sensor_->publish_state(disp);
+
+      ESP_LOGD(TAG, "|%-13s|", disp.c_str());
+    }
+  } else {
+      ESP_LOGD(TAG, "Power is off, sending off values");
+      send_idle_values();
+
+      powering_off_ = false;
+  }
+
+  if (polling_enabled_)
+    polling_enabled_ = false;
+}
+
+void Outlaw990::loop() {
+  static uint32_t timeout;
+
+  // event packet
+  // 0    1    2    3-15    16..26   27
+  // SYS_ID   CNT   TEXT    STATUS   CKSUM
+  //                CCCCCCCCCCCCCC-----^
+
+  // example
+  // 83:45:18:20:37:2E:31:43:48:20:44:49:52:45:43:54:81:DE:88:3D:32:59:00:00:98:6A:5A:27
+
+  switch (rx_state_) {
+    case RX_STATE_INIT:
+      flush();
+      polling_enabled_ = true;
+      send_idle_values();
+      rx_state_ = RX_STATE_HEADER_BYTE1;
+      break;
+
+    case RX_STATE_HEADER_BYTE1:
+      if (available()) {
+        if (read() == 0x83) {
+          rx_state_ = RX_STATE_HEADER_BYTE2;
+        }
+      }
+      break;
+
+    case RX_STATE_HEADER_BYTE2:
+      if (available()) {
+        if (read() == 0x45) {
+          rx_state_ = RX_STATE_LENGTH;
+        } else {
+          rx_state_ = RX_STATE_INIT;
+        }
+      }
+      break;
+
+    case RX_STATE_LENGTH:
+      if (available()) {
+        if (read() == 0x18) {
+          rx_state_ = RX_STATE_PAYLOAD;
+          timeout = millis();
+        } else {
+          rx_state_ = RX_STATE_INIT;
+        }
+      }
+      break;
+
+    case RX_STATE_PAYLOAD:
+      if (available() >= 25) {
+        read_array(rx_buf_, 25);
+
+        // calculate checksum over payload
+        byte checksum = 0;
+        for (int i=0; i<24; i++) {
+          checksum += rx_buf_[i];
+        }
+
+        if (checksum == rx_buf_[24]) {
+          rx_state_ = RX_STATE_PARSE;
+        } else {
+          ESP_LOGD(TAG, "Checksum error, calc=%2.2X rx=%2.2X", checksum, rx_buf_[24]);
+          rx_state_ = RX_STATE_INIT;
+        }
+      } else if (millis() - timeout > 100) {
+        ESP_LOGE(TAG, "Timed out waiting for payload");
+        rx_state_ = RX_STATE_INIT;
+      }
+      break;
+
+    case RX_STATE_PARSE:
+      parse_packet();
+      rx_state_ = RX_STATE_HEADER_BYTE1;
+      break;
+
+    default:
+      rx_state_ = RX_STATE_INIT;
+      break;
+  }
+}
+
+} // namespace
+} // namespace

--- a/esphome/components/outlaw_990/outlaw_990.cpp
+++ b/esphome/components/outlaw_990/outlaw_990.cpp
@@ -46,8 +46,8 @@ void Outlaw990::update() {
   }
 }
 
-void Outlaw990::send_pkt(byte cmd) {
-  byte obuf[4];
+void Outlaw990::send_pkt(uint8_t cmd) {
+  uint8_t obuf[4];
   obuf[0] = 0x83;
   obuf[1] = 0x45;
   obuf[2] = cmd;
@@ -126,8 +126,8 @@ void Outlaw990::send_idle_values() {
 }
 
 void Outlaw990::parse_packet() {
-  byte* text = &rx_buf_[0];
-  byte* status = &rx_buf_[13];
+  uint8_t* text = &rx_buf_[0];
+  uint8_t* status = &rx_buf_[13];
 
   bool just_turned_on = false;
 
@@ -164,12 +164,12 @@ void Outlaw990::parse_packet() {
         this->volume_sensor_->publish_state(volume);
     }
 
-    byte mav = status[1];
+    uint8_t mav = status[1];
     if ((main_av_in != mav) || just_turned_on) {
       ESP_LOGI(TAG, "main AV state changed: %2X->%2X", main_av_in, mav);
       main_av_in = mav;
-      byte a_in = (mav & 0x0F);
-      byte v_in = (mav & 0xF0) >> 4;
+      uint8_t a_in = (mav & 0x0F);
+      uint8_t v_in = (mav & 0xF0) >> 4;
 
       const char* AUDIO_LABELS[16] = {
         "FM", "AM", "IN_0x02", "Tuner", "CD", "Aux/USB", "Phono", "DVD",
@@ -270,7 +270,7 @@ void Outlaw990::loop() {
         read_array(rx_buf_, 25);
 
         // calculate checksum over payload
-        byte checksum = 0;
+        uint8_t checksum = 0;
         for (int i=0; i<24; i++) {
           checksum += rx_buf_[i];
         }

--- a/esphome/components/outlaw_990/outlaw_990.cpp
+++ b/esphome/components/outlaw_990/outlaw_990.cpp
@@ -14,7 +14,7 @@
 namespace esphome {
 namespace outlaw_990 {
 
-static const char *TAG = "outlaw_990.component";
+static const char *const TAG = "outlaw_990.component";
 
 Outlaw990::Outlaw990() : PollingComponent(1000), rx_state_(0), polling_enabled_(true), powering_off_(false) {}
 

--- a/esphome/components/outlaw_990/outlaw_990.cpp
+++ b/esphome/components/outlaw_990/outlaw_990.cpp
@@ -8,19 +8,15 @@
  * See http://outlawaudio.com/outlaw/docs/990rs232protocol.pdf for protocol details
  */
 
-
 #include "esphome/core/log.h"
 #include "outlaw_990.h"
 
 namespace esphome {
 namespace outlaw_990 {
 
-static const char* TAG = "outlaw_990.component";
+static const char *TAG = "outlaw_990.component";
 
-Outlaw990::Outlaw990() :
-  PollingComponent(1000), rx_state_(0), polling_enabled_(true), powering_off_(false)
-{
-}
+Outlaw990::Outlaw990() : PollingComponent(1000), rx_state_(0), polling_enabled_(true), powering_off_(false) {}
 
 void Outlaw990::dump_config() {
   ESP_LOGCONFIG(TAG, "Outlaw 990");
@@ -41,7 +37,8 @@ void Outlaw990::setup() {
 
 void Outlaw990::update() {
   if (polling_enabled_ || powering_off_) {
-    ESP_LOGD(TAG, "update() polling %s powering_off_ %s", polling_enabled_ ? "enabled" : "disabled", powering_off_ ? "true":"false");
+    ESP_LOGD(TAG, "update() polling %s powering_off_ %s", polling_enabled_ ? "enabled" : "disabled",
+             powering_off_ ? "true" : "false");
     send_pkt(0x53);
   }
 }
@@ -53,7 +50,7 @@ void Outlaw990::send_pkt(uint8_t cmd) {
   obuf[2] = cmd;
   obuf[3] = obuf[0] + obuf[1] + obuf[2];
 
-  for (int i=0; i<4; i++) {
+  for (int i = 0; i < 4; i++) {
     write(obuf[i]);
   }
 
@@ -69,12 +66,13 @@ void Outlaw990::on_volume_adj(bool up) {
   ESP_LOGD(TAG, "volume adjust service: %s", up ? "UP" : "DOWN");
   send_pkt(up ? 0x0F : 0x10);
 
-  if (up && volume < 14) volume++;
-  if (!up && volume > -76) volume--;
+  if (up && volume < 14)
+    volume++;
+  if (!up && volume > -76)
+    volume--;
 
   if (this->volume_sensor_ != nullptr)
     this->volume_sensor_->publish_state(volume);
-
 }
 
 void Outlaw990::on_power(bool p) {
@@ -97,7 +95,6 @@ void Outlaw990::on_mute() {
 }
 
 void Outlaw990::send_idle_values() {
-
   power = false;
   mute = false;
   volume = -76;
@@ -126,15 +123,15 @@ void Outlaw990::send_idle_values() {
 }
 
 void Outlaw990::parse_packet() {
-  uint8_t* text = &rx_buf_[0];
-  uint8_t* status = &rx_buf_[13];
+  uint8_t *text = &rx_buf_[0];
+  uint8_t *status = &rx_buf_[13];
 
   bool just_turned_on = false;
 
   bool p = status[0] & 0x01;
 
   if (power != p) {
-    ESP_LOGI(TAG, "power state changed: %s->%s", power ? "ON":"OFF", p ? "ON":"OFF");
+    ESP_LOGI(TAG, "power state changed: %s->%s", power ? "ON" : "OFF", p ? "ON" : "OFF");
     if (p) {
       // turned on
       just_turned_on = true;
@@ -149,13 +146,13 @@ void Outlaw990::parse_packet() {
     ESP_LOGD(TAG, "Power is on, parsing event packet");
     bool m = status[0] & 0x08;
     if ((mute != m) || just_turned_on) {
-      ESP_LOGI(TAG, "mute state changed: %s->%s", mute ? "ON":"OFF", m ? "ON":"OFF");
+      ESP_LOGI(TAG, "mute state changed: %s->%s", mute ? "ON" : "OFF", m ? "ON" : "OFF");
       mute = m;
       if (this->mute_binary_sensor_ != nullptr)
         this->mute_binary_sensor_->publish_state(mute);
     }
 
-    int v = (int)status[3] - (int)76;
+    int v = (int) status[3] - (int) 76;
     if ((volume != v) || just_turned_on) {
       ESP_LOGI(TAG, "volume changed: %d->%d", volume, v);
       volume = v;
@@ -171,16 +168,12 @@ void Outlaw990::parse_packet() {
       uint8_t a_in = (mav & 0x0F);
       uint8_t v_in = (mav & 0xF0) >> 4;
 
-      const char* AUDIO_LABELS[16] = {
-        "FM", "AM", "IN_0x02", "Tuner", "CD", "Aux/USB", "Phono", "DVD",
-        "Video 1", "Video 2", "Video 3", "Video 4", "Video 5",
-        "Tape", "7.1CH Direct", "IN_0x0F"
-      };
-      const char* VIDEO_LABELS[16] = {
-        "IN_0x00", "IN_0x01", "IN_0x02", "IN_0x03", "IN_0x04", "IN_0x05", "IN_0x06",
-        "Video 1", "Video 2", "Video 3", "DVD", "Video 4", "Video 5", "Video Direct",
-        "IN_0x0E", "IN_0x0F"
-      };
+      const char *AUDIO_LABELS[16] = {"FM",      "AM",   "IN_0x02",      "Tuner",   "CD",      "Aux/USB",
+                                      "Phono",   "DVD",  "Video 1",      "Video 2", "Video 3", "Video 4",
+                                      "Video 5", "Tape", "7.1CH Direct", "IN_0x0F"};
+      const char *VIDEO_LABELS[16] = {"IN_0x00", "IN_0x01",      "IN_0x02", "IN_0x03", "IN_0x04", "IN_0x05",
+                                      "IN_0x06", "Video 1",      "Video 2", "Video 3", "DVD",     "Video 4",
+                                      "Video 5", "Video Direct", "IN_0x0E", "IN_0x0F"};
       audio_in = std::string(AUDIO_LABELS[a_in]);
       video_in = std::string(VIDEO_LABELS[v_in]);
 
@@ -195,7 +188,7 @@ void Outlaw990::parse_packet() {
 
     // extract display string
     std::string d;
-    for (int i=0; i<13; i++) {
+    for (int i = 0; i < 13; i++) {
       d += text[i];
     }
     if ((disp != d) || just_turned_on) {
@@ -207,10 +200,10 @@ void Outlaw990::parse_packet() {
       ESP_LOGD(TAG, "|%-13s|", disp.c_str());
     }
   } else {
-      ESP_LOGD(TAG, "Power is off, sending off values");
-      send_idle_values();
+    ESP_LOGD(TAG, "Power is off, sending off values");
+    send_idle_values();
 
-      powering_off_ = false;
+    powering_off_ = false;
   }
 
   if (polling_enabled_)
@@ -271,7 +264,7 @@ void Outlaw990::loop() {
 
         // calculate checksum over payload
         uint8_t checksum = 0;
-        for (int i=0; i<24; i++) {
+        for (int i = 0; i < 24; i++) {
           checksum += rx_buf_[i];
         }
 
@@ -298,5 +291,5 @@ void Outlaw990::loop() {
   }
 }
 
-} // namespace
-} // namespace
+}  // namespace outlaw_990
+}  // namespace esphome

--- a/esphome/components/outlaw_990/outlaw_990.h
+++ b/esphome/components/outlaw_990/outlaw_990.h
@@ -32,7 +32,7 @@ class Outlaw990 : public PollingComponent, public uart::UARTDevice, public api::
   void set_audio_in_text_sensor(text_sensor::TextSensor *ts) { this->audio_in_text_sensor_ = ts; }
   void set_video_in_text_sensor(text_sensor::TextSensor *ts) { this->video_in_text_sensor_ = ts; }
 
-  enum RX_STATES {
+  enum RxStates {
     RX_STATE_INIT = 0,
     RX_STATE_HEADER_BYTE1,
     RX_STATE_HEADER_BYTE2,
@@ -54,15 +54,15 @@ class Outlaw990 : public PollingComponent, public uart::UARTDevice, public api::
   text_sensor::TextSensor *audio_in_text_sensor_{nullptr};
   text_sensor::TextSensor *video_in_text_sensor_{nullptr};
 
-  void send_pkt(uint8_t cmd);
+  void send_pkt_(uint8_t cmd);
 
-  void on_cmd(int cmd);
-  void on_volume_adj(bool up);
-  void on_power(bool p);
-  void on_mute();
+  void on_cmd_(int cmd);
+  void on_volume_adj_(bool up);
+  void on_power_(bool p);
+  void on_mute_();
 
-  void send_idle_values();
-  void parse_packet();
+  void send_idle_values_();
+  void parse_packet_();
 
   int rx_state_;
   uint8_t rx_buf_[25];

--- a/esphome/components/outlaw_990/outlaw_990.h
+++ b/esphome/components/outlaw_990/outlaw_990.h
@@ -17,7 +17,7 @@ namespace esphome {
 namespace outlaw_990 {
 
 class Outlaw990 : public PollingComponent, public uart::UARTDevice, public api::CustomAPIDevice {
-public:
+ public:
   Outlaw990();
 
   void setup() override;
@@ -46,7 +46,7 @@ public:
   bool power, mute;
   int volume;
 
-protected:
+ protected:
   binary_sensor::BinarySensor *power_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *mute_binary_sensor_{nullptr};
   sensor::Sensor *volume_sensor_{nullptr};
@@ -70,5 +70,5 @@ protected:
   bool powering_off_;
 };
 
-} // namespace
-} // namespace
+}  // namespace outlaw_990
+}  // namespace esphome

--- a/esphome/components/outlaw_990/outlaw_990.h
+++ b/esphome/components/outlaw_990/outlaw_990.h
@@ -1,0 +1,74 @@
+/*
+ * Outlaw 990 AV Preamp/Processor RS232 Serial Controller
+ * Custom Component for ESPHome
+ *
+ * Steve Richardson (tangentaudio@gmail.com)
+ * September, 2022
+ *
+ */
+
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/api/custom_api_device.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace outlaw_990 {
+
+class Outlaw990 : public PollingComponent, public uart::UARTDevice, public api::CustomAPIDevice {
+public:
+  Outlaw990();
+
+  void setup() override;
+  void update() override;
+  void loop() override;
+  void dump_config() override;
+
+  void set_power_binary_sensor(binary_sensor::BinarySensor *bs) { this->power_binary_sensor_ = bs; }
+  void set_mute_binary_sensor(binary_sensor::BinarySensor *bs) { this->mute_binary_sensor_ = bs; }
+  void set_volume_sensor(sensor::Sensor *s) { this->volume_sensor_ = s; }
+  void set_display_text_sensor(text_sensor::TextSensor *ts) { this->display_text_sensor_ = ts; }
+  void set_audio_in_text_sensor(text_sensor::TextSensor *ts) { this->audio_in_text_sensor_ = ts; }
+  void set_video_in_text_sensor(text_sensor::TextSensor *ts) { this->video_in_text_sensor_ = ts; }
+
+  enum RX_STATES {
+    RX_STATE_INIT = 0,
+    RX_STATE_HEADER_BYTE1,
+    RX_STATE_HEADER_BYTE2,
+    RX_STATE_LENGTH,
+    RX_STATE_PAYLOAD,
+    RX_STATE_PARSE
+  };
+
+  std::string disp, audio_in, video_in;
+  byte main_av_in;
+  bool power, mute;
+  int volume;
+
+protected:
+  binary_sensor::BinarySensor *power_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *mute_binary_sensor_{nullptr};
+  sensor::Sensor *volume_sensor_{nullptr};
+  text_sensor::TextSensor *display_text_sensor_{nullptr};
+  text_sensor::TextSensor *audio_in_text_sensor_{nullptr};
+  text_sensor::TextSensor *video_in_text_sensor_{nullptr};
+
+  void send_pkt(byte cmd);
+
+  void on_cmd(int cmd);
+  void on_volume_adj(bool up);
+  void on_power(bool p);
+  void on_mute();
+
+  void send_idle_values();
+  void parse_packet();
+
+  int rx_state_;
+  byte rx_buf_[25];
+  bool polling_enabled_;
+  bool powering_off_;
+};
+
+} // namespace
+} // namespace

--- a/esphome/components/outlaw_990/outlaw_990.h
+++ b/esphome/components/outlaw_990/outlaw_990.h
@@ -42,7 +42,7 @@ public:
   };
 
   std::string disp, audio_in, video_in;
-  byte main_av_in;
+  uint8_t main_av_in;
   bool power, mute;
   int volume;
 
@@ -54,7 +54,7 @@ protected:
   text_sensor::TextSensor *audio_in_text_sensor_{nullptr};
   text_sensor::TextSensor *video_in_text_sensor_{nullptr};
 
-  void send_pkt(byte cmd);
+  void send_pkt(uint8_t cmd);
 
   void on_cmd(int cmd);
   void on_volume_adj(bool up);
@@ -65,7 +65,7 @@ protected:
   void parse_packet();
 
   int rx_state_;
-  byte rx_buf_[25];
+  uint8_t rx_buf_[25];
   bool polling_enabled_;
   bool powering_off_;
 };

--- a/esphome/components/outlaw_990/sensor.py
+++ b/esphome/components/outlaw_990/sensor.py
@@ -15,14 +15,12 @@ TYPES = [
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_OUTLAW_990_ID): cv.use_id(Outlaw990),
-
-        cv.Required(CONF_SENSOR_VOLUME):
-            sensor.sensor_schema(
-                unit_of_measurement=UNIT_DECIBEL,
-                accuracy_decimals=0
-            )
+        cv.Required(CONF_SENSOR_VOLUME): sensor.sensor_schema(
+            unit_of_measurement=UNIT_DECIBEL, accuracy_decimals=0
+        ),
     }
 )
+
 
 async def to_code(config):
     comp = await cg.get_variable(config[CONF_OUTLAW_990_ID])

--- a/esphome/components/outlaw_990/sensor.py
+++ b/esphome/components/outlaw_990/sensor.py
@@ -1,0 +1,33 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import UNIT_DECIBEL
+from . import CONF_OUTLAW_990_ID, Outlaw990
+
+DEPENDENCIES = ["outlaw_990"]
+
+CONF_SENSOR_VOLUME = "sensor_volume"
+
+TYPES = [
+    CONF_SENSOR_VOLUME,
+]
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_OUTLAW_990_ID): cv.use_id(Outlaw990),
+
+        cv.Required(CONF_SENSOR_VOLUME):
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_DECIBEL,
+                accuracy_decimals=0
+            )
+    }
+)
+
+async def to_code(config):
+    comp = await cg.get_variable(config[CONF_OUTLAW_990_ID])
+
+    if CONF_SENSOR_VOLUME in config:
+        conf = config[CONF_SENSOR_VOLUME]
+        sens = await sensor.new_sensor(conf)
+        cg.add(comp.set_volume_sensor(sens))

--- a/esphome/components/outlaw_990/text_sensor.py
+++ b/esphome/components/outlaw_990/text_sensor.py
@@ -1,0 +1,47 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+from . import CONF_OUTLAW_990_ID, Outlaw990
+
+DEPENDENCIES = ["outlaw_990"]
+
+CONF_SENSOR_DISPLAY = "sensor_display"
+CONF_SENSOR_AUDIO_IN = "sensor_audio_in"
+CONF_SENSOR_VIDEO_IN = "sensor_video_in"
+
+TYPES = [
+    CONF_SENSOR_DISPLAY,
+    CONF_SENSOR_AUDIO_IN,
+    CONF_SENSOR_VIDEO_IN
+]
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_OUTLAW_990_ID): cv.use_id(Outlaw990),
+
+        cv.Required(CONF_SENSOR_DISPLAY):
+            text_sensor.text_sensor_schema(),
+        cv.Required(CONF_SENSOR_AUDIO_IN):
+            text_sensor.text_sensor_schema(),
+        cv.Required(CONF_SENSOR_VIDEO_IN):
+            text_sensor.text_sensor_schema()
+    }
+)
+
+async def to_code(config):
+    comp = await cg.get_variable(config[CONF_OUTLAW_990_ID])
+
+    if CONF_SENSOR_DISPLAY in config:
+        conf = config[CONF_SENSOR_DISPLAY]
+        sens = await text_sensor.new_text_sensor(conf)
+        cg.add(comp.set_display_text_sensor(sens))
+
+    if CONF_SENSOR_AUDIO_IN in config:
+        conf = config[CONF_SENSOR_AUDIO_IN]
+        sens = await text_sensor.new_text_sensor(conf)
+        cg.add(comp.set_audio_in_text_sensor(sens))
+
+    if CONF_SENSOR_VIDEO_IN in config:
+        conf = config[CONF_SENSOR_VIDEO_IN]
+        sens = await text_sensor.new_text_sensor(conf)
+        cg.add(comp.set_video_in_text_sensor(sens))

--- a/esphome/components/outlaw_990/text_sensor.py
+++ b/esphome/components/outlaw_990/text_sensor.py
@@ -9,24 +9,17 @@ CONF_SENSOR_DISPLAY = "sensor_display"
 CONF_SENSOR_AUDIO_IN = "sensor_audio_in"
 CONF_SENSOR_VIDEO_IN = "sensor_video_in"
 
-TYPES = [
-    CONF_SENSOR_DISPLAY,
-    CONF_SENSOR_AUDIO_IN,
-    CONF_SENSOR_VIDEO_IN
-]
+TYPES = [CONF_SENSOR_DISPLAY, CONF_SENSOR_AUDIO_IN, CONF_SENSOR_VIDEO_IN]
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_OUTLAW_990_ID): cv.use_id(Outlaw990),
-
-        cv.Required(CONF_SENSOR_DISPLAY):
-            text_sensor.text_sensor_schema(),
-        cv.Required(CONF_SENSOR_AUDIO_IN):
-            text_sensor.text_sensor_schema(),
-        cv.Required(CONF_SENSOR_VIDEO_IN):
-            text_sensor.text_sensor_schema()
+        cv.Required(CONF_SENSOR_DISPLAY): text_sensor.text_sensor_schema(),
+        cv.Required(CONF_SENSOR_AUDIO_IN): text_sensor.text_sensor_schema(),
+        cv.Required(CONF_SENSOR_VIDEO_IN): text_sensor.text_sensor_schema(),
     }
 )
+
 
 async def to_code(config):
     comp = await cg.get_variable(config[CONF_OUTLAW_990_ID])

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -82,6 +82,8 @@ wifi:
   reboot_timeout: 120s
   power_save_mode: light
 
+api:
+
 mdns:
   disabled: false
 
@@ -319,7 +321,14 @@ mcp23s17:
     cs_pin: GPIO12
     deviceaddress: 1
 
+outlaw_990:
+  id: outlaw
+  uart_id: uart0
+
 sensor:
+  - platform: outlaw_990
+    sensor_volume:
+      name: "Outlaw Volume Status"
   - platform: ble_client
     ble_client_id: ble_foo
     name: Green iTag btn
@@ -1185,6 +1194,11 @@ esp32_touch:
   voltage_attenuation: 1.5V
 
 binary_sensor:
+  - platform: outlaw_990
+    sensor_power:
+      name: "Outlaw Power Status"
+    sensor_mute:
+      name: "Outlaw Mute Status"
   - platform: gpio
     name: "MCP23S08 Pin #1"
     pin:
@@ -2757,6 +2771,13 @@ globals:
     initial_value: "false"
 
 text_sensor:
+  - platform: outlaw_990
+    sensor_display:
+      name: "Outlaw Display"
+    sensor_audio_in:
+      name: "Outlaw Audio Input"
+    sensor_video_in:
+      name: "Outlaw Video Input"
   - platform: ble_client
     ble_client_id: ble_foo
     name: Sensor Location
@@ -3002,3 +3023,6 @@ button:
     name: Midea Power Inverse
     on_press:
       midea_ac.power_toggle:
+
+
+


### PR DESCRIPTION
# What does this implement/fix?

Adds a new component to control the Outlaw 990 A/V preamp/processor via UART (RS232).

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2349

## Test Environment

- [X] ESP32

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  rx_pin: GPIO14
  tx_pin: GPIO13
  baud_rate: 9600
  id: uart1
outlaw_990:
  id: outlaw
  uart_id: uart1
binary_sensor:
  - platform: outlaw_990
    sensor_power:
      name: "Outlaw Power Status"
    sensor_mute:
      name: "Outlaw Mute Status"
sensor:
  - platform: outlaw_990
    sensor_volume:
      name: "Outlaw Volume Status"
text_sensor:
  - platform: outlaw_990
    sensor_display:
      name: "Outlaw Display"
    sensor_audio_in:
      name: "Outlaw Audio Input"
    sensor_video_in:
      name: "Outlaw Video Input"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
