### PR TITLE
Fix sampling rate of [q|h]mc5883l only using seconds field of update interval

### DIFF
--- a/esphome/components/hmc5883l/sensor.py
+++ b/esphome/components/hmc5883l/sensor.py
@@ -112,6 +112,7 @@ CONFIG_SCHEMA = (
 
 
 def auto_data_rate(config):
+    """Select the minimal sampling rate required to satisfy the requested update interval"""
     interval_msec = config[CONF_UPDATE_INTERVAL].total_milliseconds
     interval_hz = 1000.0 / interval_msec
     for datarate in sorted(HMC5883LDatarates.keys()):

--- a/esphome/components/qmc5883l/sensor.py
+++ b/esphome/components/qmc5883l/sensor.py
@@ -103,6 +103,7 @@ CONFIG_SCHEMA = (
 
 
 def auto_data_rate(config):
+    """Select the minimal sampling rate required to satisfy the requested update interval"""
     interval_ms = config[CONF_UPDATE_INTERVAL].total_milliseconds
     interval_hz = 1000.0 / interval_ms
     for datarate in sorted(QMC5883LDatarates.keys()):

--- a/esphome/components/qmc5883l/sensor.py
+++ b/esphome/components/qmc5883l/sensor.py
@@ -103,8 +103,8 @@ CONFIG_SCHEMA = (
 
 
 def auto_data_rate(config):
-    interval_sec = config[CONF_UPDATE_INTERVAL].seconds
-    interval_hz = 1.0 / interval_sec
+    interval_ms = config[CONF_UPDATE_INTERVAL].total_milliseconds
+    interval_hz = 1000.0 / interval_ms
     for datarate in sorted(QMC5883LDatarates.keys()):
         if float(datarate) >= interval_hz:
             return QMC5883LDatarates[datarate]

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -624,7 +624,9 @@ sensor:
       name: HMC5883L Heading
     range: 130uT
     oversampling: 8x
-    update_interval: 15s
+    update_interval:
+      minutes: 1
+      milliseconds: 500
     i2c_id: i2c_bus
   - platform: honeywellabp
     pressure:
@@ -646,7 +648,9 @@ sensor:
       name: QMC5883L Heading
     range: 800uT
     oversampling: 256x
-    update_interval: 15s
+    update_interval:
+      minutes: 1
+      milliseconds: 500
     i2c_id: i2c_bus
   - platform: hx711
     name: HX711 Value


### PR DESCRIPTION
# What does this implement/fix?

The previous implementation only used the seconds field of the update interval to calculate the sampling rate.

This would not only ignore the values specified in the minutes or milliseconds field but also result in a divison by zero when the seconds field was unset.

I've tested the code on a Wemos D1 Mini with a qmc5883l.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).