### PR TITLE
Dont add wifi block to yaml if discovered device uses ethernet

### DIFF
--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -72,7 +72,9 @@ def import_config(
                 "name_add_mac_suffix": False,
             },
         }
-        p.write_text(
-            dump(config) + (WIFI_CONFIG if network == CONF_WIFI else ""),
-            encoding="utf8",
-        )
+        output = dump(config)
+
+        if network == CONF_WIFI:
+            output += WIFI_CONFIG
+
+        p.write_text(output, encoding="utf8")

--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components.packages import validate_source_shorthand
+from esphome.const import CONF_WIFI
 from esphome.wizard import wizard_file
 from esphome.yaml_util import dump
 
@@ -43,7 +44,9 @@ async def to_code(config):
     cg.add(dashboard_import_ns.set_package_import_url(config[CONF_PACKAGE_IMPORT_URL]))
 
 
-def import_config(path: str, name: str, project_name: str, import_url: str) -> None:
+def import_config(
+    path: str, name: str, project_name: str, import_url: str, network: str = CONF_WIFI
+) -> None:
     p = Path(path)
 
     if p.exists():
@@ -70,6 +73,6 @@ def import_config(path: str, name: str, project_name: str, import_url: str) -> N
             },
         }
         p.write_text(
-            dump(config) + WIFI_CONFIG,
+            dump(config) + (WIFI_CONFIG if network == CONF_WIFI else ""),
             encoding="utf8",
         )

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -400,11 +400,10 @@ class ImportRequestHandler(BaseHandler):
                 (res for res in IMPORT_RESULT.values() if res.device_name == name), None
             )
 
-            network = (
-                imported_device.network
-                if imported_device is not None
-                else const.CONF_WIFI
-            )
+            if imported_device is not None:
+                network = imported_device.network
+            else:
+                network = const.CONF_WIFI
 
             import_config(
                 settings.rel_path(f"{name}.yaml"),

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -395,11 +395,23 @@ class ImportRequestHandler(BaseHandler):
         args = json.loads(self.request.body.decode())
         try:
             name = args["name"]
+
+            imported_device = next(
+                (res for res in IMPORT_RESULT.values() if res.device_name == name), None
+            )
+
+            network = (
+                imported_device.network
+                if imported_device is not None
+                else const.CONF_WIFI
+            )
+
             import_config(
                 settings.rel_path(f"{name}.yaml"),
                 name,
                 args["project_name"],
                 args["package_import_url"],
+                network,
             )
         except FileExistsError:
             self.set_status(500)


### PR DESCRIPTION
# What does this implement/fix?

This will look into the `IMPORT_RESULT` and fetch the new variable `network` to determin if the wifi config should be appended to the generated YAML.

Fixes https://github.com/esphome/dashboard/issues/320

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
