### PR TITLE
Do not require CS pin for ST7789V

### DIFF
--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -69,7 +69,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MODEL): ST7789V_MODEL,
             cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_EIGHTBITCOLOR, default=False): cv.boolean,
             cv.Optional(CONF_HEIGHT): cv.int_,

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -69,7 +69,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MODEL): ST7789V_MODEL,
             cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_EIGHTBITCOLOR, default=False): cv.boolean,
             cv.Optional(CONF_HEIGHT): cv.int_,
@@ -79,7 +79,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(spi.spi_device_schema()),
+    .extend(spi.spi_device_schema(cs_pin_required=False)),
     validate_st7789v,
 )
 

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -4,7 +4,6 @@ from esphome import pins
 from esphome.components import display, spi
 from esphome.const import (
     CONF_BACKLIGHT_PIN,
-    CONF_CS_PIN,
     CONF_DC_PIN,
     CONF_HEIGHT,
     CONF_ID,


### PR DESCRIPTION
# What does this implement/fix?

Some st7789 modules doesn't have a CS pin. Example: [aliexpress.com](https://aliexpress.com/item/1005003381703710.html)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

https://github.com/esphome/esphome-docs/pull/2354

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
  - platform: st7789v
    backlight_pin: 32
    dc_pin: 33
    reset_pin: 25
    model: Custom
    eightbitcolor: true
    height: 240
    width: 240
    offset_height: 0
    offset_width: 0
    rotation: 180
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
