### PR TITLE
Fix HeatpumpIR fan speeds

### DIFF
--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -142,13 +142,13 @@ void HeatpumpIRClimate::transmit_state() {
 
   switch (this->fan_mode.value_or(climate::CLIMATE_FAN_AUTO)) {
     case climate::CLIMATE_FAN_LOW:
-      fan_speed_cmd = FAN_2;
+      fan_speed_cmd = FAN_1;
       break;
     case climate::CLIMATE_FAN_MEDIUM:
-      fan_speed_cmd = FAN_3;
+      fan_speed_cmd = FAN_2;
       break;
     case climate::CLIMATE_FAN_HIGH:
-      fan_speed_cmd = FAN_4;
+      fan_speed_cmd = FAN_3;
       break;
     case climate::CLIMATE_FAN_AUTO:
     default:


### PR DESCRIPTION
# What does this implement/fix?
According to HeatpumpIR sources ([1](https://github.com/ToniA/arduino-heatpumpir/blob/50ee013623f3396ac00165ba08dbe279a30d1f48/R51MHeatpumpIR.h#L23), [2](https://github.com/ToniA/arduino-heatpumpir/blob/54549d9af8d789e4710e42ab7033c76bd8913350/VaillantHeatpumpIR.h#L30), [3](https://github.com/ToniA/arduino-heatpumpir/blob/50ee013623f3396ac00165ba08dbe279a30d1f48/HisenseHeatpumpIR.h#L34), [4](https://github.com/ToniA/arduino-heatpumpir/blob/50ee013623f3396ac00165ba08dbe279a30d1f48/BGHHeatpumpIR.h#L34), [5](https://github.com/ToniA/arduino-heatpumpir/blob/50ee013623f3396ac00165ba08dbe279a30d1f48/SamsungHeatpumpIR.h#L40), [6](https://github.com/ToniA/arduino-heatpumpir/blob/3ac460b62a25e8e330697e1feea3326e12c9725d/GreeHeatpumpIR.h#L36)) and my AC unit, correct fan speed mapping is
| FAN1: | low  |
|--------|------|
| FAN2: | med |
| FAN3: | high |

Quick description and explanation of changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
