### PR TITLE
Exposing coordinates from touchscreen binary sensor

### DIFF
--- a/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
+++ b/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
@@ -23,6 +23,12 @@ class TouchscreenBinarySensor : public binary_sensor::BinarySensor,
     this->y_min_ = y_min;
     this->y_max_ = y_max;
   }
+  int16_t get_x_min() { return this->x_min_; }
+  int16_t get_x_max() { return this->x_max_; }
+  int16_t get_y_min() { return this->y_min_; }
+  int16_t get_y_max() { return this->y_max_; }
+  int16_t get_width() { return this->x_max_ - this->x_min_; }
+  int16_t get_height() { return this->y_max_ - this->y_min_; }
 
   void set_page(display::DisplayPage *page) { this->page_ = page; }
 


### PR DESCRIPTION
I’ll need this for a project where I use these coordinates to draw elements on the screen and not have to repeat numbers everywhere

# What does this implement/fix?

Exposes coordinates from touchscreen binary sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:

Not a full example but this is why I need this for.

Say I have this in my config.yaml:

```
image:
  - file: "images/fanblades.png"
    id: fanblades
    type: TRANSPARENT_BINARY

binary_sensor:
  - platform: touchscreen
    id: button_fan_main
    name: Fan Button
    internal: true
    x_min: 0
    x_max: 100
    y_min: 50
    y_max: 150
    on_click:
        ...
```

I then include a .h file with this code:

```
#include "esphome.h"

void drawButton(
  DisplayBuffer *it,
  TouchscreenBinarySensor *sensor,
  Image *image,
  int16_t x_offset = 0,
  int16_t y_offset = 0
) {
  int cx = sensor->get_x_min() + x_offset + (sensor->get_width() - image->get_width()) / 2;
  int cy = sensor->get_y_min() + y_offset + (sensor->get_height() - image->get_height()) / 2;
  it->image(cx, cy, image);
}
```

Then in my display's `lambda` I can do this:
```
    lambda: |-
      drawButton(&it, id(button_fan_main), id(fanblades));
``` 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
