### PR TITLE
Update time_based_cover.cpp in order to get an interlock wait time between switches of a time based cover

### DIFF
--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -133,13 +133,13 @@ void TimeBasedCover::start_direction_(CoverOperation dir) {
 
   this->current_operation = dir;
 
-  const uint32_t now = millis();
-  this->start_dir_time_ = now;
-  this->last_recompute_time_ = now;
-
   this->stop_prev_trigger_();
   trig->trigger();
   this->prev_command_trigger_ = trig;
+  
+  const uint32_t now = millis();
+  this->start_dir_time_ = now;
+  this->last_recompute_time_ = now;
 }
 void TimeBasedCover::recompute_position_() {
   if (this->current_operation == COVER_OPERATION_IDLE)


### PR DESCRIPTION
These modifications partially solve the problem of taking into account the interlock time. However, with these modification we cannot use the interlock_wait_time, but we can use a lambda in the open and close actions of the cover in order to inoke the raw blocking **delay** function of ESPHome. Using the non-blocking delay entry does not work. Using the non-blocking interlock_wait_time, does not work.

# What does this implement/fix?

This partially fixes the problem of taking into account the interlock wait time that in many cases is specified for some motor types. Actually the time_based_cover platform just starts counting time of a movement before executing the open and close actions. These actions could await an interlock time before to get completed. This causes interlock time not to be counted.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes issue at https://github.com/esphome/feature-requests/issues/778


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
In this example we want set a 4 seconds interlock wait time and have a scroll time of 5 seconds. Starting at a fully opened position we should observe a total closing time of 9 seconds. Before this modification we observed a total scroll time of 5 seconds (the 4 seconds of interlock overlapped the 5 seconds of the scrolling time). All these observations are also valid while opening the cover, of course.

```yaml
switch:
- id: open_cover
  platform: gpio
  pin:
    number: D3
    inverted: true
    mode:
      output: true
  interlock: &interlock [open_cover, close_cover]
  # - interlock_wait_time: 4s # does not work for now, beacuse it is not blocking
  restore_mode: ALWAYS_OFF
- id: close_cover
  platform: gpio
  pin: 
    number: D4
    inverted: true
    mode:
      output: true
  interlock: *interlock
  # - interlock_wait_time: 4s # does not work for now, beacuse it is not blocking
  restore_mode: ALWAYS_OFF

cover:
- id: the_cover
  platform: time_based
  name: "Cover"
  open_action:
    - switch.turn_off: close_cover
    - lambda: delay(4000)
    # - delay: 4s # does not work for now, beacuse it is not blocking
    - switch.turn_on: open_cover
  open_duration: 5s
  close_action:
    - switch.turn_off: open_cover
    - lambda: delay(4000)
    - switch.turn_on: close_cover
  close_duration: 5s
  stop_action:
    - switch.turn_off: open_cover
    - switch.turn_off: close_cover

```

## Future modifications
We need a mechanism to posticipate the start of time counting just after executing the trigger, in order to allow the use of the non-blocking delay function and/or the use of the interlock_wait_time entry on the switches. This requires a deeper modification of the ESPHome core. An idea is to signal the termination of a trigger to the invoker (in our case the invoker of the trigger is the TimeBasedCover class). When the termination of the trigger is invoked we can start counting the scrolling time of the cover. I will try to do this modification as soon as possible.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
