### PR TITLE
Don't Use Base Network Manual IP for WiFi AP

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -368,7 +368,7 @@ async def to_code(config):
 
     if CONF_AP in config:
         conf = config[CONF_AP]
-        ip_config = conf.get(CONF_MANUAL_IP, config.get(CONF_MANUAL_IP))
+        ip_config = conf.get(CONF_MANUAL_IP, conf.get(CONF_MANUAL_IP))
         cg.with_local_variable(
             conf[CONF_ID],
             WiFiAP(),

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -368,7 +368,7 @@ async def to_code(config):
 
     if CONF_AP in config:
         conf = config[CONF_AP]
-        ip_config = conf.get(CONF_MANUAL_IP, conf.get(CONF_MANUAL_IP))
+        ip_config = conf.get(CONF_MANUAL_IP)
         cg.with_local_variable(
             conf[CONF_ID],
             WiFiAP(),


### PR DESCRIPTION
# What does this implement/fix?

Recommending to not use the base network manual IP address for the WiFi AP when the WiFi AP has no manual IP itself.  The current behavior is undocumented/unexpected and makes using the WiFi AP difficult when a user can't figure out why default IP address 192.168.4.1 isn't working to get to the captive portal.

I believe this was done unintentionally and so I say this is a bug fix, but maybe I am wrong.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  manual_ip:
    static_ip: 192.168.43.21
    gateway: 192.168.43.1
    subnet: 255.255.255.0
    dns1: 192.168.43.1

  ap:
    ap_timeout: 15s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
