### PR TITLE
Copy and adapt files from hrxl_maxsonar_wr to add support #1913

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -94,7 +94,7 @@ esphome/components/heatpumpir/* @rob-deutsch
 esphome/components/hitachi_ac424/* @sourabhjaiswal
 esphome/components/homeassistant/* @OttoWinter
 esphome/components/honeywellabp/* @RubyBailey
-esphome/components/hrxl_maxsonar_wr/* @netmikey
+esphome/components/hrxl_maxsonar_wr/* @Worschi @netmikey
 esphome/components/hydreon_rgxx/* @functionpointer
 esphome/components/i2c/* @esphome/core
 esphome/components/i2s_audio/* @jesserockz
@@ -258,4 +258,5 @@ esphome/components/xiaomi_lywsd03mmc/* @ahpohl
 esphome/components/xiaomi_mhoc303/* @drug123
 esphome/components/xiaomi_mhoc401/* @vevsvevs
 esphome/components/xiaomi_rtcgq02lm/* @jesserockz
+esphome/components/xl_maxsonar_wr/* @netmikey
 esphome/components/xpt2046/* @nielsnl68 @numo68

--- a/esphome/components/xl_maxsonar_wr/sensor.py
+++ b/esphome/components/xl_maxsonar_wr/sensor.py
@@ -1,0 +1,29 @@
+import esphome.codegen as cg
+from esphome.components import sensor, uart
+from esphome.const import (
+    STATE_CLASS_MEASUREMENT,
+    UNIT_METER,
+    ICON_ARROW_EXPAND_VERTICAL,
+)
+
+CODEOWNERS = ["@netmikey"]
+DEPENDENCIES = ["uart"]
+
+xlmaxsonarwr_ns = cg.esphome_ns.namespace("xl_maxsonar_wr")
+XlMaxsonarWrComponent = xlmaxsonarwr_ns.class_(
+    "XlMaxsonarWrComponent", sensor.Sensor, cg.Component, uart.UARTDevice
+)
+
+CONFIG_SCHEMA = sensor.sensor_schema(
+    XlMaxsonarWrComponent,
+    unit_of_measurement=UNIT_METER,
+    icon=ICON_ARROW_EXPAND_VERTICAL,
+    accuracy_decimals=3,
+    state_class=STATE_CLASS_MEASUREMENT,
+).extend(uart.UART_DEVICE_SCHEMA)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/esphome/components/xl_maxsonar_wr/xl_maxsonar_wr.cpp
+++ b/esphome/components/xl_maxsonar_wr/xl_maxsonar_wr.cpp
@@ -1,0 +1,66 @@
+// Official Datasheet:
+//   https://www.maxbotix.com/documents/XL-MaxSonar-WR_Datasheet.pdf
+//
+// This implementation is designed to work with the TTL Versions of the
+// MaxBotix XL MaxSonar WR sensor series. The sensor's TTL Pin (5) should be
+// wired to one of the ESP's input pins and configured as uart rx_pin.
+
+#include "xl_maxsonar_wr.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace xl_maxsonar_wr {
+
+static const char *const TAG = "xl.maxsonar.wr.sensor";
+static const uint8_t ASCII_CR = 0x0D;
+static const uint8_t ASCII_NBSP = 0xFF;
+static const int MAX_DATA_LENGTH_BYTES = 5;
+
+/**
+ * The sensor outputs something like "R123\r" at a fixed rate of 6 to 10 Hz.
+ * Where 123 means a distance of 1,23 m.
+ */
+void XlMaxsonarWrComponent::loop() {
+  uint8_t data;
+  while (this->available() > 0) {
+    if (this->read_byte(&data)) {
+      buffer_ += (char) data;
+      this->check_buffer_();
+    }
+  }
+}
+
+void XlMaxsonarWrComponent::check_buffer_() {
+  // The sensor seems to inject a rogue ASCII 255 byte from time to time. Get rid of that.
+  if (this->buffer_.back() == static_cast<char>(ASCII_NBSP)) {
+    this->buffer_.pop_back();
+    return;
+  }
+
+  // Stop reading at ASCII_CR. Also prevent the buffer from growing
+  // indefinitely if no ASCII_CR is received after MAX_DATA_LENGTH_BYTES.
+  if (this->buffer_.back() == static_cast<char>(ASCII_CR) || this->buffer_.length() >= MAX_DATA_LENGTH_BYTES) {
+    ESP_LOGV(TAG, "Read from serial: %s", this->buffer_.c_str());
+
+    if (this->buffer_.length() == MAX_DATA_LENGTH_BYTES && this->buffer_[0] == 'R' &&
+        this->buffer_.back() == static_cast<char>(ASCII_CR)) {
+      int millimeters = parse_number<int>(this->buffer_.substr(1, MAX_DATA_LENGTH_BYTES - 2)).value_or(0);
+      float meters = float(millimeters) / 1000.0;
+      ESP_LOGV(TAG, "Distance from sensor: %d mm, %f m", millimeters, meters);
+      this->publish_state(meters);
+    } else {
+      ESP_LOGW(TAG, "Invalid data read from sensor: %s", this->buffer_.c_str());
+    }
+    this->buffer_.clear();
+  }
+}
+
+void XlMaxsonarWrComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "XL MaxSonar WR Sensor:");
+  LOG_SENSOR("  ", "Distance", this);
+  // As specified in the sensor's data sheet
+  this->check_uart_settings(9600, 1, esphome::uart::UART_CONFIG_PARITY_NONE, 8);
+}
+
+}  // namespace xl_maxsonar_wr
+}  // namespace esphome

--- a/esphome/components/xl_maxsonar_wr/xl_maxsonar_wr.h
+++ b/esphome/components/xl_maxsonar_wr/xl_maxsonar_wr.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace xl_maxsonar_wr {
+
+class XlMaxsonarWrComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
+ public:
+  // Nothing really public.
+
+  // ========== INTERNAL METHODS ==========
+  void loop() override;
+  void dump_config() override;
+
+ protected:
+  void check_buffer_();
+
+  std::string buffer_;
+};
+
+}  // namespace xl_maxsonar_wr
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Implements https://github.com/esphome/feature-requests/issues/1913: add support for XL-MaxSonar-WR/WRC MaxBotix sensors
Basically, the same code as in hrxl_maxsonar_wr component, but one constant value changed and updated namespaces.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1913

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml

logger:
  level: DEBUG
  baud_rate: 0 # disable logging over uartl

uart:
  id: mb_uart_bus
  tx_pin: TX
  rx_pin: RX
  baud_rate: 9600
  debug:
    after:
      delimiter: "\r"
    sequence:
      - lambda: UARTDebug::log_string(direction, bytes);

sensor:
  - platform: "xl_maxsonar_wr"
    name: "Septic Tank"
    # Tweak the filters for your application
    filters:
      - sliding_window_moving_average:
          window_size: 10
          send_every: 10
      - or:
        - throttle: "10sec"
        - delta: 0.02

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
