### PR TITLE
Send true and not RSSI in ble_presence

### DIFF
--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -58,7 +58,7 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
       case MATCH_BY_SERVICE_UUID:
         for (auto uuid : device.get_service_uuids()) {
           if (this->uuid_ == uuid) {
-            this->publish_state(device.get_rssi());
+            this->publish_state(true);
             this->found_ = true;
             return true;
           }
@@ -83,7 +83,7 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
           return false;
         }
 
-        this->publish_state(device.get_rssi());
+        this->publish_state(true);
         this->found_ = true;
         return true;
     }


### PR DESCRIPTION
# What does this implement/fix?

This fixes published state from RSSI to boolean, which was apparently not changed after copy/pasting from ble_rssi_sensor.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# Example configuration entry
esp32_ble_tracker:

binary_sensor:
  # Presence based on BLE Service UUID
  - platform: ble_presence
    service_uuid: '11aa'
    name: "ESP32 BLE Tracker Test Service 16 bit"
  # Presence based on iBeacon UUID
  - platform: ble_presence
    ibeacon_uuid: '68586f1e-89c2-11eb-8dcd-0242ac130003'
    name: "ESP32 BLE Tracker Test Service iBeacon"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
