### PR TITLE
Remove address type map from bluetooth proxy

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -45,7 +45,6 @@ class BluetoothProxy : public BLEClientBase {
  protected:
   void send_api_packet_(const esp32_ble_tracker::ESPBTDevice &device);
 
-  std::map<uint64_t, esp_ble_addr_type_t> address_type_map_;
   int16_t send_service_{-1};
   bool active_;
 };


### PR DESCRIPTION
# What does this implement/fix?

It seems this map was leaking memory. So I have removed it. 
This would mean its a little bit slower for active connection to connect as they need to wait for an advertisement with the type to come in live but should not be too bad.

Closes #3906

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
external_component:
  - source: github://pr#3905
    components: buetooth_proxy
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
