### PR TITLE
Add API interface to request a complete device config as JSON.

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -932,10 +932,11 @@ class JsonConfigRequestHandler(BaseHandler):
     @bind_config
     def get(self, configuration=None):
         filename = settings.rel_path(configuration)
-        content = ""
-        if os.path.isfile(filename):
-            content = yaml_util.load_yaml(filename, clear_secrets=False)
+        if not os.path.isfile(filename):
+            self.send_error(404)
+            return
 
+        content = yaml_util.load_yaml(filename, clear_secrets=False)
         self.set_header("content-type", "application/json")
         self.write(json.dumps(content))
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -938,7 +938,7 @@ class JsonConfigRequestHandler(BaseHandler):
 
         try:
             content = yaml_util.load_yaml(filename, clear_secrets=False)
-            json_content = json.dumps(content, default=lambda o: f"{repr(o)}")
+            json_content = json.dumps(content, default=lambda o: {"__type": str(type(o)), "repr": repr(o)})
             self.set_header("content-type", "application/json")
             self.write(json_content)
         except Exception as err:  # pylint: disable=broad-except

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -936,9 +936,14 @@ class JsonConfigRequestHandler(BaseHandler):
             self.send_error(404)
             return
 
-        content = yaml_util.load_yaml(filename, clear_secrets=False)
-        self.set_header("content-type", "application/json")
-        self.write(json.dumps(content))
+        try:
+            content = yaml_util.load_yaml(filename, clear_secrets=False)
+            json_content = json.dumps(content, default=lambda o: f"{repr(o)}")
+            self.set_header("content-type", "application/json")
+            self.write(json_content)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning("Error translating file %s to JSON: %s", filename, err)
+            self.send_error(500)
 
 
 def get_base_frontend_path():

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -29,6 +29,7 @@ import tornado.web
 import tornado.websocket
 
 from esphome import const, platformio_api, util, yaml_util
+from esphome.core import EsphomeError
 from esphome.helpers import mkdir_p, get_bool_env, run_system_command
 from esphome.storage_json import (
     EsphomeStorageJSON,
@@ -938,10 +939,12 @@ class JsonConfigRequestHandler(BaseHandler):
 
         try:
             content = yaml_util.load_yaml(filename, clear_secrets=False)
-            json_content = json.dumps(content, default=lambda o: {"__type": str(type(o)), "repr": repr(o)})
+            json_content = json.dumps(
+                content, default=lambda o: {"__type": str(type(o)), "repr": repr(o)}
+            )
             self.set_header("content-type", "application/json")
             self.write(json_content)
-        except Exception as err:  # pylint: disable=broad-except
+        except EsphomeError as err:
             _LOGGER.warning("Error translating file %s to JSON: %s", filename, err)
             self.send_error(500)
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -927,6 +927,19 @@ class SecretKeysRequestHandler(BaseHandler):
         self.write(json.dumps(secret_keys))
 
 
+class JsonConfigRequestHandler(BaseHandler):
+    @authenticated
+    @bind_config
+    def get(self, configuration=None):
+        filename = settings.rel_path(configuration)
+        content = ""
+        if os.path.isfile(filename):
+            content = yaml_util.load_yaml(filename, clear_secrets=False)
+
+        self.set_header("content-type", "application/json")
+        self.write(json.dumps(content))
+
+
 def get_base_frontend_path():
     if ENV_DEV not in os.environ:
         import esphome_dashboard
@@ -1031,6 +1044,7 @@ def make_app(debug=get_bool_env(ENV_DEV)):
             (f"{rel}devices", ListDevicesHandler),
             (f"{rel}import", ImportRequestHandler),
             (f"{rel}secret_keys", SecretKeysRequestHandler),
+            (f"{rel}json-config", JsonConfigRequestHandler),
             (f"{rel}rename", EsphomeRenameHandler),
             (f"{rel}prometheus-sd", PrometheusServiceDiscoveryHandler),
         ],


### PR DESCRIPTION
# What does this implement/fix?

Currently there is no interface for a.o. the Dashboard to get a _complete_ device configuration. I.e. that includes secrets, packages, etc.

IMO this is the core problem for issues like esphome/issues#3697.
Exposing this API is the initial step in fixing the issue above. (Not a complete fix!)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** ~fixes~ esphome/issues#3697.


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
