### PR TITLE
climate: Add features to generic Toshiba model

### DIFF
--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -124,9 +124,6 @@ void ToshibaClimate::setup() {
   // Set supported modes & temperatures based on model
   this->minimum_temperature_ = this->temperature_min_();
   this->maximum_temperature_ = this->temperature_max_();
-  this->supports_dry_ = this->toshiba_supports_dry_();
-  this->supports_fan_only_ = this->toshiba_supports_fan_only_();
-  this->fan_modes_ = this->toshiba_fan_modes_();
   this->swing_modes_ = this->toshiba_swing_modes_();
   // Never send nan to HA
   if (std::isnan(this->target_temperature))
@@ -178,12 +175,39 @@ void ToshibaClimate::transmit_generic_() {
       mode = TOSHIBA_MODE_COOL;
       break;
 
+    case climate::CLIMATE_MODE_DRY:
+      mode = TOSHIBA_MODE_DRY;
+      break;
+
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      mode = TOSHIBA_MODE_FAN_ONLY;
+      break;
+
     case climate::CLIMATE_MODE_HEAT_COOL:
     default:
       mode = TOSHIBA_MODE_AUTO;
   }
 
-  message[6] |= mode | TOSHIBA_FAN_SPEED_AUTO;
+  uint8_t fan;
+  switch (this->fan_mode.value()) {
+    case climate::CLIMATE_FAN_LOW:
+      fan = TOSHIBA_FAN_SPEED_1;
+      break;
+
+    case climate::CLIMATE_FAN_MEDIUM:
+      fan = TOSHIBA_FAN_SPEED_3;
+      break;
+
+    case climate::CLIMATE_FAN_HIGH:
+      fan = TOSHIBA_FAN_SPEED_5;
+      break;
+
+    case climate::CLIMATE_FAN_AUTO:
+    default:
+      fan = TOSHIBA_FAN_SPEED_AUTO;
+      break;
+  }
+  message[6] = fan | mode;
 
   // Zero
   message[7] = 0x00;

--- a/esphome/components/toshiba/toshiba.h
+++ b/esphome/components/toshiba/toshiba.h
@@ -22,7 +22,10 @@ const float TOSHIBA_RAC_PT1411HWRU_TEMP_F_MAX = 86.0;
 
 class ToshibaClimate : public climate_ir::ClimateIR {
  public:
-  ToshibaClimate() : climate_ir::ClimateIR(TOSHIBA_GENERIC_TEMP_C_MIN, TOSHIBA_GENERIC_TEMP_C_MAX, 1.0f) {}
+  ToshibaClimate()
+      : climate_ir::ClimateIR(TOSHIBA_GENERIC_TEMP_C_MIN, TOSHIBA_GENERIC_TEMP_C_MAX, 1.0f, true, true,
+                              {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
+                               climate::CLIMATE_FAN_HIGH}) {}
 
   void setup() override;
   void set_model(Model model) { this->model_ = model; }
@@ -45,18 +48,6 @@ class ToshibaClimate : public climate_ir::ClimateIR {
   }
   float temperature_max_() {
     return (this->model_ == MODEL_GENERIC) ? TOSHIBA_GENERIC_TEMP_C_MAX : TOSHIBA_RAC_PT1411HWRU_TEMP_C_MAX;
-  }
-  bool toshiba_supports_dry_() {
-    return ((this->model_ == MODEL_RAC_PT1411HWRU_C) || (this->model_ == MODEL_RAC_PT1411HWRU_F));
-  }
-  bool toshiba_supports_fan_only_() {
-    return ((this->model_ == MODEL_RAC_PT1411HWRU_C) || (this->model_ == MODEL_RAC_PT1411HWRU_F));
-  }
-  std::set<climate::ClimateFanMode> toshiba_fan_modes_() {
-    return (this->model_ == MODEL_GENERIC)
-               ? std::set<climate::ClimateFanMode>{}
-               : std::set<climate::ClimateFanMode>{climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
-                                                   climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH};
   }
   std::set<climate::ClimateSwingMode> toshiba_swing_modes_() {
     return (this->model_ == MODEL_GENERIC)


### PR DESCRIPTION
# What does this implement/fix?

Add fan speed, dry and fan-only operation modes to the "generic" Toshiba climate component. 
This reduce differences between generic and PT1411 models.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other:

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
No configuration change.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
