### PR TITLE
Fixed touch release issue using the interrupt pin

### DIFF
--- a/esphome/components/xpt2046/xpt2046.h
+++ b/esphome/components/xpt2046/xpt2046.h
@@ -14,8 +14,6 @@ using namespace touchscreen;
 
 struct XPT2046TouchscreenStore {
   volatile bool touch;
-  ISRInternalGPIOPin pin;
-
   static void gpio_intr(XPT2046TouchscreenStore *store);
 };
 


### PR DESCRIPTION

# What does this implement/fix?

Fixed release issue using the interrupt pin
Also:
- removed some redounded code
- added a small delay sending the command and receiving the value, hoping that the ghost point also will be gone.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [<link to issue>](https://github.com/esphome/issues/issues/3709) and https://github.com/esphome/issues/issues/3705


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
touchscreen:
  platform: xpt2046
  id: xpt2046_touchscreen
  cs_pin: 27
  interrupt_pin: 25
  update_interval: 20ms
  report_interval: never
  threshold: 200
  calibration_x_min: 260
  calibration_x_max: 3800
  calibration_y_min: 3900
  calibration_y_max: 380
  swap_x_y: false
  on_touch:
    - lambda: |-
          ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
              id(xpt2046_touchscreen).x,
              id(xpt2046_touchscreen).y,
              id(xpt2046_touchscreen).x_raw,
              id(xpt2046_touchscreen).y_raw
              );

display:
  - platform: ili9341
    model: TFT 2.4
    cs_pin: GPIO5
    dc_pin: GPIO18
    reset_pin: GPIO19
    update_interval: 20ms
    id: my_lcd
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
