### PR TITLE
add proper device class to uptime

### DIFF
--- a/esphome/components/uptime/sensor.py
+++ b/esphome/components/uptime/sensor.py
@@ -6,6 +6,7 @@ from esphome.const import (
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_SECOND,
     ICON_TIMER,
+    DEVICE_CLASS_DURATION,
 )
 
 uptime_ns = cg.esphome_ns.namespace("uptime")
@@ -17,6 +18,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(
     icon=ICON_TIMER,
     accuracy_decimals=0,
     state_class=STATE_CLASS_TOTAL_INCREASING,
+    device_class=DEVICE_CLASS_DURATION,
     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
 ).extend(cv.polling_component_schema("60s"))
 


### PR DESCRIPTION
# What does this implement/fix?

Make Uptime sensor appear nicely. HA now has a proper device class for duration, which makes the time appear properly in the frontend:
![image](https://user-images.githubusercontent.com/1550668/197389975-cd028b32-d6e9-43d8-81ae-36eaa7736ed2.png)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2384

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
