### PR TITLE
Fix missing dependencies for heatpumpir

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_PROTOCOL,
     CONF_VISUAL,
 )
+from esphome.core import CORE
 
 CODEOWNERS = ["@rob-deutsch"]
 
@@ -115,3 +116,6 @@ def to_code(config):
     cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
 
     cg.add_library("tonia/HeatpumpIR", "1.0.20")
+
+    if CORE.is_esp8266 or CORE.is_esp32:
+        cg.add_library("crankyoldgit/IRremoteESP8266", "2.7.12")

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,6 +92,7 @@ lib_deps =
     ESP8266HTTPClient                     ; http_request (Arduino built-in)
     ESP8266mDNS                           ; mdns (Arduino built-in)
     DNSServer                             ; captive_portal (Arduino built-in)
+    crankyoldgit/IRremoteESP8266@2.7.12   ; heatpumpir
 build_flags =
     ${common:arduino.build_flags}
     -Wno-nonnull-compare
@@ -111,16 +112,17 @@ board = nodemcu-32s
 lib_deps =
     ; order matters with lib-deps; some of the libs in common:arduino.lib_deps
     ; don't declare built-in libraries as dependencies, so they have to be declared first
-    FS                              ; web_server_base (Arduino built-in)
-    WiFi                            ; wifi,web_server_base,ethernet (Arduino built-in)
-    Update                          ; ota,web_server_base (Arduino built-in)
+    FS                                   ; web_server_base (Arduino built-in)
+    WiFi                                 ; wifi,web_server_base,ethernet (Arduino built-in)
+    Update                               ; ota,web_server_base (Arduino built-in)
     ${common:arduino.lib_deps}
-    esphome/AsyncTCP-esphome@1.2.2  ; async_tcp
-    WiFiClientSecure                ; http_request,nextion (Arduino built-in)
-    HTTPClient                      ; http_request,nextion (Arduino built-in)
-    ESPmDNS                         ; mdns (Arduino built-in)
-    DNSServer                       ; captive_portal (Arduino built-in)
-    esphome/ESP32-audioI2S@2.1.0    ; i2s_audio
+    esphome/AsyncTCP-esphome@1.2.2       ; async_tcp
+    WiFiClientSecure                     ; http_request,nextion (Arduino built-in)
+    HTTPClient                           ; http_request,nextion (Arduino built-in)
+    ESPmDNS                              ; mdns (Arduino built-in)
+    DNSServer                            ; captive_portal (Arduino built-in)
+    esphome/ESP32-audioI2S@2.1.0         ; i2s_audio
+    crankyoldgit/IRremoteESP8266@2.7.12  ; heatpumpir
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Not sure what caused this to suddenly stop working after the rp2040 code was merged, perhaps a cache was busted?



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
