### PR TITLE
Send manufacturer name via API

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -204,6 +204,8 @@ message DeviceInfoResponse {
   uint32 webserver_port = 10;
 
   uint32 bluetooth_proxy_version = 11;
+
+  string manufacturer = 12;
 }
 
 message ListEntitiesRequest {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -932,6 +932,11 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.mac_address = get_mac_address_pretty();
   resp.esphome_version = ESPHOME_VERSION;
   resp.compilation_time = App.get_compilation_time();
+#if defined(USE_ESP8266) || defined(USE_ESP32)
+  resp.manufacturer = "Espressif";
+#elif defined(USE_RP2040)
+  resp.manufacturer = "Raspberry Pi";
+#endif
   resp.model = ESPHOME_BOARD;
 #ifdef USE_DEEP_SLEEP
   resp.has_deep_sleep = deep_sleep::global_has_deep_sleep;

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -576,6 +576,10 @@ bool DeviceInfoResponse::decode_length(uint32_t field_id, ProtoLengthDelimited v
       this->project_version = value.as_string();
       return true;
     }
+    case 12: {
+      this->manufacturer = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -592,6 +596,7 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(9, this->project_version);
   buffer.encode_uint32(10, this->webserver_port);
   buffer.encode_uint32(11, this->bluetooth_proxy_version);
+  buffer.encode_string(12, this->manufacturer);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoResponse::dump_to(std::string &out) const {
@@ -641,6 +646,10 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("  bluetooth_proxy_version: ");
   sprintf(buffer, "%u", this->bluetooth_proxy_version);
   out.append(buffer);
+  out.append("\n");
+
+  out.append("  manufacturer: ");
+  out.append("'").append(this->manufacturer).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -273,6 +273,7 @@ class DeviceInfoResponse : public ProtoMessage {
   std::string project_version{};
   uint32_t webserver_port{0};
   uint32_t bluetooth_proxy_version{0};
+  std::string manufacturer{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Currently Home Assistant assumes all ESPHome devices are made by Espressif and display that in the UI. This will send a different string based on the configured platform.

- https://github.com/esphome/aioesphomeapi/pull/290

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
