### PR TITLE
Add wind_speed sensor device class

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -67,6 +67,7 @@ from esphome.const import (
     DEVICE_CLASS_VOLTAGE,
     DEVICE_CLASS_VOLUME,
     DEVICE_CLASS_WATER,
+    DEVICE_CLASS_WIND_SPEED,
     DEVICE_CLASS_WEIGHT,
 )
 from esphome.core import CORE, coroutine_with_priority
@@ -114,6 +115,7 @@ DEVICE_CLASSES = [
     DEVICE_CLASS_VOLTAGE,
     DEVICE_CLASS_VOLUME,
     DEVICE_CLASS_WATER,
+    DEVICE_CLASS_WIND_SPEED,
     DEVICE_CLASS_WEIGHT,
 ]
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -960,6 +960,7 @@ DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS = "volatile_organic_compounds"
 DEVICE_CLASS_VOLTAGE = "voltage"
 DEVICE_CLASS_VOLUME = "volume"
 DEVICE_CLASS_WATER = "water"
+DEVICE_CLASS_WIND_SPEED = "wind_speed"
 DEVICE_CLASS_WEIGHT = "weight"
 # device classes of both binary_sensor and button component
 DEVICE_CLASS_UPDATE = "update"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds the `wind_speed` sensor device class.

https://github.com/home-assistant/core/pull/79789

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
