### PR TITLE
Implement InterruptLock for RP2040

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -392,16 +392,16 @@ void hsv_to_rgb(int hue, float saturation, float value, float &red, float &green
 // System APIs
 
 #if defined(USE_ESP8266)
-IRAM_ATTR InterruptLock::InterruptLock() { xt_state_ = xt_rsil(15); }
-IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(xt_state_); }
+IRAM_ATTR InterruptLock::InterruptLock() { state_ = xt_rsil(15); }
+IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(state_); }
 #elif defined(USE_ESP32)
 // only affects the executing core
 // so should not be used as a mutex lock, only to get accurate timing
 IRAM_ATTR InterruptLock::InterruptLock() { portDISABLE_INTERRUPTS(); }
 IRAM_ATTR InterruptLock::~InterruptLock() { portENABLE_INTERRUPTS(); }
 #elif defined(USE_RP2040)
-IRAM_ATTR InterruptLock::InterruptLock() { noInterrupts(); }
-IRAM_ATTR InterruptLock::~InterruptLock() { interrupts(); }
+IRAM_ATTR InterruptLock::InterruptLock() { state_ = save_and_disable_interrupts(); }
+IRAM_ATTR InterruptLock::~InterruptLock() { restore_interrupts(state_); }
 #endif
 
 uint8_t HighFrequencyLoopRequester::num_requests = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -399,6 +399,9 @@ IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(xt_state_); }
 // so should not be used as a mutex lock, only to get accurate timing
 IRAM_ATTR InterruptLock::InterruptLock() { portDISABLE_INTERRUPTS(); }
 IRAM_ATTR InterruptLock::~InterruptLock() { portENABLE_INTERRUPTS(); }
+#elif defined(USE_RP2040)
+IRAM_ATTR InterruptLock::InterruptLock() { noInterrupts(); }
+IRAM_ATTR InterruptLock::~InterruptLock() { interrupts(); }
 #endif
 
 uint8_t HighFrequencyLoopRequester::num_requests = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -542,8 +542,8 @@ class InterruptLock {
   ~InterruptLock();
 
  protected:
-#ifdef USE_ESP8266
-  uint32_t xt_state_;
+#if defined(USE_ESP8266) || defined(USE_RP2040)
+  uint32_t state_;
 #endif
 };
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Required for Dallas/dht and potentially other components
Related to https://github.com/esphome/feature-requests/issues/1924

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
