### PR TITLE
Implement RP2040 preferences

### DIFF
--- a/esphome/components/ota/ota_backend_arduino_rp2040.cpp
+++ b/esphome/components/ota/ota_backend_arduino_rp2040.cpp
@@ -15,6 +15,7 @@ namespace ota {
 OTAResponseTypes ArduinoRP2040OTABackend::begin(size_t image_size) {
   bool ret = Update.begin(image_size, U_FLASH);
   if (ret) {
+    rp2040::preferences_prevent_write(true);
     return OTA_RESPONSE_OK;
   }
 
@@ -46,7 +47,10 @@ OTAResponseTypes ArduinoRP2040OTABackend::end() {
   return OTA_RESPONSE_OK;
 }
 
-void ArduinoRP2040OTABackend::abort() { Update.end(); }
+void ArduinoRP2040OTABackend::abort() {
+  Update.end();
+  rp2040::preferences_prevent_write(false);
+}
 
 }  // namespace ota
 }  // namespace esphome

--- a/esphome/components/rp2040/preferences.cpp
+++ b/esphome/components/rp2040/preferences.cpp
@@ -1,5 +1,10 @@
 #ifdef USE_RP2040
 
+#include <Arduino.h>
+
+#include <hardware/flash.h>
+#include <hardware/sync.h>
+
 #include "preferences.h"
 
 #include <cstring>
@@ -12,33 +17,137 @@ namespace rp2040 {
 
 static const char *const TAG = "rp2040.preferences";
 
+static bool s_prevent_write = false;        // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static uint8_t *s_flash_storage = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static bool s_flash_dirty = false;          // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+static const uint32_t RP2040_FLASH_STORAGE_SIZE = 512;
+
+extern "C" uint8_t _EEPROM_start;
+
+template<class It> uint8_t calculate_crc(It first, It last, uint32_t type) {
+  std::array<uint8_t, 4> type_array = decode_value(type);
+  uint8_t crc = type_array[0] ^ type_array[1] ^ type_array[2] ^ type_array[3];
+  while (first != last) {
+    crc ^= (*first++);
+  }
+  return crc;
+}
+
 class RP2040PreferenceBackend : public ESPPreferenceBackend {
  public:
-  bool save(const uint8_t *data, size_t len) override { return true; }
-  bool load(uint8_t *data, size_t len) override { return false; }
+  size_t offset = 0;
+  uint32_t type = 0;
+
+  bool save(const uint8_t *data, size_t len) override {
+    std::vector<uint8_t> buffer;
+    buffer.resize(len + 1);
+    memcpy(buffer.data(), data, len);
+    buffer[buffer.size() - 1] = calculate_crc(buffer.begin(), buffer.end() - 1, type);
+
+    for (uint32_t i = 0; i < len + 1; i++) {
+      uint32_t j = offset + i;
+      if (j >= RP2040_FLASH_STORAGE_SIZE)
+        return false;
+      uint8_t v = buffer[i];
+      uint8_t *ptr = &s_flash_storage[j];
+      if (*ptr != v)
+        s_flash_dirty = true;
+      *ptr = v;
+    }
+    return true;
+  }
+  bool load(uint8_t *data, size_t len) override {
+    std::vector<uint8_t> buffer;
+    buffer.resize(len + 1);
+
+    for (size_t i = 0; i < len + 1; i++) {
+      uint32_t j = offset + i;
+      if (j >= RP2040_FLASH_STORAGE_SIZE)
+        return false;
+      buffer[i] = s_flash_storage[j];
+    }
+
+    uint8_t crc = calculate_crc(buffer.begin(), buffer.end() - 1, type);
+    if (buffer[buffer.size() - 1] != crc) {
+      return false;
+    }
+
+    memcpy(data, buffer.data(), len);
+    return true;
+  }
 };
 
 class RP2040Preferences : public ESPPreferences {
  public:
+  uint32_t current_flash_offset = 0;
+
+  RP2040Preferences() : eeprom_sector_(&_EEPROM_start) {}
+  void setup() {
+    s_flash_storage = new uint8_t[RP2040_FLASH_STORAGE_SIZE];  // NOLINT
+    ESP_LOGVV(TAG, "Loading preferences from flash...");
+    memcpy(s_flash_storage, this->eeprom_sector_, RP2040_FLASH_STORAGE_SIZE);
+  }
+
   ESPPreferenceObject make_preference(size_t length, uint32_t type, bool in_flash) override {
-    auto *pref = new RP2040PreferenceBackend();  // NOLINT(cppcoreguidelines-owning-memory)
-    return ESPPreferenceObject(pref);
+    return make_preference(length, type);
   }
 
   ESPPreferenceObject make_preference(size_t length, uint32_t type) override {
+    uint32_t start = this->current_flash_offset;
+    uint32_t end = start + length + 1;
+    if (end > RP2040_FLASH_STORAGE_SIZE) {
+      return {};
+    }
     auto *pref = new RP2040PreferenceBackend();  // NOLINT(cppcoreguidelines-owning-memory)
-    return ESPPreferenceObject(pref);
+    pref->offset = start;
+    pref->type = type;
+    current_flash_offset = end;
+    return {pref};
   }
 
-  bool sync() override { return true; }
+  bool sync() override {
+    if (!s_flash_dirty)
+      return true;
+    if (s_prevent_write)
+      return false;
 
-  bool reset() override { return true; }
+    ESP_LOGD(TAG, "Saving preferences to flash...");
+
+    {
+      InterruptLock lock;
+      ::rp2040.idleOtherCore();
+      flash_range_erase((intptr_t) eeprom_sector_ - (intptr_t) XIP_BASE, 4096);
+      flash_range_program((intptr_t) eeprom_sector_ - (intptr_t) XIP_BASE, s_flash_storage, RP2040_FLASH_STORAGE_SIZE);
+      ::rp2040.resumeOtherCore();
+    }
+
+    s_flash_dirty = false;
+    return true;
+  }
+
+  bool reset() override {
+    ESP_LOGD(TAG, "Cleaning up preferences in flash...");
+    {
+      InterruptLock lock;
+      ::rp2040.idleOtherCore();
+      flash_range_erase((intptr_t) eeprom_sector_ - (intptr_t) XIP_BASE, 4096);
+      ::rp2040.resumeOtherCore();
+    }
+    s_prevent_write = true;
+    return true;
+  }
+
+ protected:
+  uint8_t *eeprom_sector_;
 };
 
 void setup_preferences() {
   auto *prefs = new RP2040Preferences();  // NOLINT(cppcoreguidelines-owning-memory)
+  prefs->setup();
   global_preferences = prefs;
 }
+void preferences_prevent_write(bool prevent) { s_prevent_write = prevent; }
 
 }  // namespace rp2040
 

--- a/esphome/components/rp2040/preferences.h
+++ b/esphome/components/rp2040/preferences.h
@@ -6,6 +6,7 @@ namespace esphome {
 namespace rp2040 {
 
 void setup_preferences();
+void preferences_prevent_write(bool prevent);
 
 }  // namespace rp2040
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This implements preferences stored in flash.

https://github.com/esphome/feature-requests/issues/1924

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
