### PR TITLE
Set humidity accuracy decimals to 1

### DIFF
--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -42,7 +42,7 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,
-            accuracy_decimals=0,
+            accuracy_decimals=1,
             device_class=DEVICE_CLASS_HUMIDITY,
             state_class=STATE_CLASS_MEASUREMENT,
         ),


### PR DESCRIPTION
# What does this implement/fix?

The [technical specification o fthe sensor has a resolution of 0.1%](https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf). I feel like the sensor should send the data as accurately as possible. Reduction of the resolution can then be done via `accuracy_decimals=0` in the configuration, if one is so inclined. As it stands, the higher resolution is intransparent to the user, as the documentation states: 

> "Manually set the number of decimals to use when reporting values. *This does not impact the actual value reported to Home Assistant, it just sets the number of decimals to use when displaying it.*"

The impression I got at first was that there would be no point in increasing the decimals, as there was no obvious way of knowing that there is already a default value in play that hides one digit of resolution.

I suggest either setting the default to 1 or stating in the documentation clearly, that one character of resolution is intentionally hidden.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
