### PR TITLE
Add cover toggle support to current based cover

### DIFF
--- a/esphome/components/current_based/current_based_cover.h
+++ b/esphome/components/current_based/current_based_cover.h
@@ -89,6 +89,8 @@ class CurrentBasedCover : public cover::Cover, public Component {
   uint32_t start_dir_time_{0};
   uint32_t last_publish_time_{0};
   float target_position_{0};
+  
+  cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
 }  // namespace current_based

--- a/esphome/components/current_based/current_based_cover.h
+++ b/esphome/components/current_based/current_based_cover.h
@@ -89,7 +89,7 @@ class CurrentBasedCover : public cover::Cover, public Component {
   uint32_t start_dir_time_{0};
   uint32_t last_publish_time_{0};
   float target_position_{0};
-  
+
   cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -884,6 +884,7 @@ binary_sensor:
       then:
         - cover.toggle: time_based_cover
         - cover.toggle: endstop_cover
+        - cover.toggle: current_based_cover
   - platform: hydreon_rgxx
     hydreon_rgxx_id: hydreon_rg9
     too_cold:
@@ -1246,6 +1247,7 @@ cover:
     close_duration: 4.5min
   - platform: current_based
     name: Current Based Cover
+    id: current_based_cover
     open_sensor: ade7953_current_a
     open_moving_current_threshold: 0.5
     open_obstacle_current_threshold: 0.8


### PR DESCRIPTION
# What does this implement/fix?

Adds cover toggle support to current based cover.
Step through open/stop/close/stop sequence with every toggle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
toggle support https://github.com/esphome/esphome/pull/1809

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
