### PR TITLE
Some RP2040 wifi changes for AP mode

### DIFF
--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -24,6 +24,11 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, true, CYW43_COUNTRY_WORLDWIDE);
     }
   }
+  if (ap.has_value()) {
+    if (ap.value()) {
+      cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, true, CYW43_COUNTRY_WORLDWIDE);
+    }
+  }
   return true;
 }
 
@@ -141,22 +146,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
   if (!this->wifi_mode_({}, true))
     return false;
 
-  if (ap.get_channel().has_value()) {
-    cyw43_wifi_ap_set_channel(&cyw43_state, ap.get_channel().value());
-  }
-
-  const char *ssid = ap.get_ssid().c_str();
-
-  cyw43_wifi_ap_set_ssid(&cyw43_state, strlen(ssid), (const uint8_t *) ssid);
-
-  if (!ap.get_password().empty()) {
-    const char *password = ap.get_password().c_str();
-    cyw43_wifi_ap_set_password(&cyw43_state, strlen(password), (const uint8_t *) password);
-    cyw43_wifi_ap_set_auth(&cyw43_state, CYW43_AUTH_WPA2_MIXED_PSK);
-  } else {
-    cyw43_wifi_ap_set_auth(&cyw43_state, CYW43_AUTH_OPEN);
-  }
-  cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, true, CYW43_COUNTRY_WORLDWIDE);
+  WiFi.beginAP(ap.get_ssid().c_str(), ap.get_password().c_str(), ap.get_channel().value_or(1));
 
   return true;
 }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Use the WiFi library for consistency with wifi settings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
