### PR TITLE
Update rp2040 to latest framework release from GitHub

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -37,10 +37,14 @@ def set_core_data(config):
 
 
 def _format_framework_arduino_version(ver: cv.Version) -> str:
+    # The most recent releases haev not been uploaded to platformio so grabbing them directly from
+    # the GitHub release is one path forward for now.
+    return f"https://github.com/earlephilhower/arduino-pico/releases/download/{ver}/rp2040-{ver}.zip"
+
     # format the given arduino (https://github.com/earlephilhower/arduino-pico/releases) version to
     # a PIO earlephilhower/framework-arduinopico value
     # List of package versions: https://api.registry.platformio.org/v3/packages/earlephilhower/tool/framework-arduinopico
-    return f"~1.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
+    # return f"~1.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
 
 
 # NOTE: Keep this in mind when updating the recommended version:
@@ -52,7 +56,7 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
 # The default/recommended arduino framework version
 #  - https://github.com/earlephilhower/arduino-pico/releases
 #  - https://api.registry.platformio.org/v3/packages/earlephilhower/tool/framework-arduinopico
-RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(2, 4, 0)
+RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(2, 6, 2)
 
 # The platformio/raspberrypi version to use for arduino frameworks
 #  - https://github.com/platformio/platform-raspberrypi/releases
@@ -63,8 +67,8 @@ ARDUINO_PLATFORM_VERSION = cv.Version(1, 7, 0)
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": (cv.Version(2, 4, 0), "https://github.com/earlephilhower/arduino-pico"),
-        "latest": (cv.Version(2, 4, 0), None),
+        "dev": (cv.Version(2, 6, 2), "https://github.com/earlephilhower/arduino-pico"),
+        "latest": (cv.Version(2, 6, 2), None),
         "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
 

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -37,7 +37,7 @@ def set_core_data(config):
 
 
 def _format_framework_arduino_version(ver: cv.Version) -> str:
-    # The most recent releases haev not been uploaded to platformio so grabbing them directly from
+    # The most recent releases have not been uploaded to platformio so grabbing them directly from
     # the GitHub release is one path forward for now.
     return f"https://github.com/earlephilhower/arduino-pico/releases/download/{ver}/rp2040-{ver}.zip"
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
The releases have not been uploaded to platformio so ESPHome will pull the zip directly from GitHub until this is the case.

https://github.com/earlephilhower/arduino-pico/issues/935

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
