### PR TITLE
[SM300D2] Reduce log severity for successful reads

### DIFF
--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -42,7 +42,7 @@ void SM300D2Sensor::update() {
 
   this->status_clear_warning();
 
-  ESP_LOGW(TAG, "Successfully read SM300D2 data");
+  ESP_LOGD(TAG, "Successfully read SM300D2 data");
 
   const uint16_t co2 = (response[2] * 256) + response[3];
   const uint16_t formaldehyde = (response[4] * 256) + response[5];


### PR DESCRIPTION
Reduces the log severity from warning to debug, as a successful data read doesn't really warrant a warning.

# What does this implement/fix?

Reduces the log severity from warning to debug, as a successful data read doesn't really warrant a warning.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#3734

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: sm300d2
    co2:
      name: "SM300D2 CO2 Value"
    formaldehyde:
      name: "SM300D2 Formaldehyde Value"
    tvoc:
      name: "SM300D2 TVOC Value"
    pm_2_5:
      name: "SM300D2 PM2.5 Value"
    pm_10_0:
      name: "SM300D2 PM10 Value"
    temperature:
      name: "SM300D2 Temperature Value"
    humidity:
      name: "SM300D2 Humidity Value"
    update_interval: 30s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
