### PR TITLE
Allow using LED pin on rpi pico-w

### DIFF
--- a/esphome/components/rp2040/boards.py
+++ b/esphome/components/rp2040/boards.py
@@ -3,5 +3,5 @@ RP2040_BASE_PINS = {}
 RP2040_BOARD_PINS = {
     "pico": {"LED": 25},
     "rpipico": "pico",
-    "rpipicow": {},
+    "rpipicow": {"LED": 32},
 }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
The LED pin on a pico-w is actually driven by the wifi board and is set a a "fake" gpio pin with number 32.

https://github.com/esphome/feature-requests/issues/1924#issuecomment-1293937383

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
