### PR TITLE
Fix non-threadsafe memory allocation

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -265,6 +265,31 @@ ARDUINO_GLUE_CODE = """\
 #define micros() esphome::micros()
 #define delay(x) esphome::delay(x)
 #define delayMicroseconds(x) esphome::delayMicroseconds(x)
+
+#include <freertos/FreeRTOS.h>
+#include <new>
+#undef new
+#undef delete
+
+void * operator new( size_t size )
+{
+    return pvPortMalloc(size);
+}
+
+void * operator new[]( size_t size )
+{
+    return pvPortMalloc( size );
+}
+
+void operator delete( void * ptr )
+{
+    vPortFree( ptr );
+}
+
+void operator delete[]( void * ptr )
+{
+    vPortFree( ptr );
+}
 """
 
 


### PR DESCRIPTION
# What does this implement/fix?

My ESP32s don't crash on BLE operations with this change.

I'm not sure if its the right fix though so I'm leaving it up here for someone who might know more about the issue.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
