### PR TITLE
Close #3746: erroneous 0 measurments in pulse_meter

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -45,11 +45,7 @@ void PulseMeterSensor::loop() {
   // We quantize our pulse widths to 1 ms to avoid unnecessary jitter
   const uint32_t pulse_width_ms = this->pulse_width_us_ / 1000;
   if (this->pulse_width_dedupe_.next(pulse_width_ms)) {
-    if (pulse_width_ms == 0) {
-      // Treat 0 pulse width as 0 pulses/min (normally because we've not
-      // detected any pulses for a while)
-      this->publish_state(0);
-    } else {
+    if (pulse_width_ms > 0) {
       // Calculate pulses/min from the pulse width in ms
       this->publish_state((60.0f * 1000.0f) / pulse_width_ms);
     }


### PR DESCRIPTION
# What does this implement/fix?

Removes publishing of 0 measurements in case pulse interval is <1ms.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [bug #3746](https://github.com/esphome/issues/issues/3746)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).