### PR TITLE
Filters for output component

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -223,7 +223,7 @@ void AcDimmer::dump_config() {
     ESP_LOGCONFIG(TAG, "   Method: trailing");
   }
 
-  LOG_FLOAT_OUTPUT(this);
+  // LOG_FLOAT_OUTPUT(this);
   ESP_LOGV(TAG, "  Estimated Frequency: %.3fHz", 1e6f / this->store_.cycle_time_us / 2);
 }
 

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -176,7 +176,6 @@ void AcDimmer::setup() {
   this->store_.gate_pin = this->gate_pin_->to_isr();
   this->store_.zero_cross_pin_number = this->zero_cross_pin_->get_pin();
   this->store_.min_power = static_cast<uint16_t>(this->min_power_ * 1000);
-  this->min_power_ = 0;
   this->store_.method = this->method_;
 
   if (setup_zero_cross_pin) {
@@ -223,7 +222,6 @@ void AcDimmer::dump_config() {
     ESP_LOGCONFIG(TAG, "   Method: trailing");
   }
 
-  // LOG_FLOAT_OUTPUT(this);
   ESP_LOGV(TAG, "  Estimated Frequency: %.3fHz", 1e6f / this->store_.cycle_time_us / 2);
 }
 

--- a/esphome/components/ac_dimmer/ac_dimmer.h
+++ b/esphome/components/ac_dimmer/ac_dimmer.h
@@ -53,6 +53,7 @@ class AcDimmer : public output::FloatOutput, public Component {
   void set_zero_cross_pin(InternalGPIOPin *zero_cross_pin) { zero_cross_pin_ = zero_cross_pin; }
   void set_init_with_half_cycle(bool init_with_half_cycle) { init_with_half_cycle_ = init_with_half_cycle; }
   void set_method(DimMethod method) { method_ = method; }
+  void set_min_power(float min_power) { this->min_power_ = min_power; }
 
  protected:
   void write_state(float state) override;
@@ -62,6 +63,7 @@ class AcDimmer : public output::FloatOutput, public Component {
   AcDimmerDataStore store_;
   bool init_with_half_cycle_;
   DimMethod method_;
+  float min_power_;
 };
 
 }  // namespace ac_dimmer

--- a/esphome/components/ac_dimmer/output.py
+++ b/esphome/components/ac_dimmer/output.py
@@ -29,6 +29,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_METHOD, default="leading pulse"): cv.enum(
                 DIM_METHODS, upper=True, space="_"
             ),
+            cv.Optional(CONF_MIN_POWER, 0.1): cv.percentage,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
@@ -38,10 +39,6 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-
-    # override default min power to 10%
-    if CONF_MIN_POWER not in config:
-        config[CONF_MIN_POWER] = 0.1
     await output.register_output(var, config)
 
     pin = await cg.gpio_pin_expression(config[CONF_GATE_PIN])
@@ -50,3 +47,4 @@ async def to_code(config):
     cg.add(var.set_zero_cross_pin(pin))
     cg.add(var.set_init_with_half_cycle(config[CONF_INIT_WITH_HALF_CYCLE]))
     cg.add(var.set_method(config[CONF_METHOD]))
+    cg.add(var.set_min_power(config[CONF_MIN_POWER]))

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -13,7 +13,7 @@ void BLEBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str().c_str());
   ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_string().c_str());
   ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_string().c_str());
-  LOG_BINARY_OUTPUT(this);
+  // LOG_BINARY_OUTPUT(this);
 }
 
 void BLEBinaryOutput::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -13,7 +13,6 @@ void BLEBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str().c_str());
   ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_string().c_str());
   ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_string().c_str());
-  // LOG_BINARY_OUTPUT(this);
 }
 
 void BLEBinaryOutput::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/esp32_dac/esp32_dac.cpp
+++ b/esphome/components/esp32_dac/esp32_dac.cpp
@@ -30,7 +30,6 @@ void ESP32DAC::setup() {
 void ESP32DAC::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 DAC:");
   LOG_PIN("  Pin: ", this->pin_);
-  // LOG_FLOAT_OUTPUT(this);
 }
 
 void ESP32DAC::write_state(float state) {

--- a/esphome/components/esp32_dac/esp32_dac.cpp
+++ b/esphome/components/esp32_dac/esp32_dac.cpp
@@ -30,7 +30,7 @@ void ESP32DAC::setup() {
 void ESP32DAC::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 DAC:");
   LOG_PIN("  Pin: ", this->pin_);
-  LOG_FLOAT_OUTPUT(this);
+  // LOG_FLOAT_OUTPUT(this);
 }
 
 void ESP32DAC::write_state(float state) {

--- a/esphome/components/esp8266_pwm/esp8266_pwm.cpp
+++ b/esphome/components/esp8266_pwm/esp8266_pwm.cpp
@@ -22,7 +22,7 @@ void ESP8266PWM::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP8266 PWM:");
   LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG, "  Frequency: %.1f Hz", this->frequency_);
-  LOG_FLOAT_OUTPUT(this);
+  // LOG_FLOAT_OUTPUT(this);
 }
 void HOT ESP8266PWM::write_state(float state) {
   this->last_output_ = state;

--- a/esphome/components/esp8266_pwm/esp8266_pwm.cpp
+++ b/esphome/components/esp8266_pwm/esp8266_pwm.cpp
@@ -22,7 +22,6 @@ void ESP8266PWM::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP8266 PWM:");
   LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG, "  Frequency: %.1f Hz", this->frequency_);
-  // LOG_FLOAT_OUTPUT(this);
 }
 void HOT ESP8266PWM::write_state(float state) {
   this->last_output_ = state;

--- a/esphome/components/gpio/output/gpio_binary_output.cpp
+++ b/esphome/components/gpio/output/gpio_binary_output.cpp
@@ -9,7 +9,6 @@ static const char *const TAG = "gpio.output";
 void GPIOBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "GPIO Binary Output:");
   LOG_PIN("  Pin: ", this->pin_);
-  // LOG_BINARY_OUTPUT(this);
 }
 
 }  // namespace gpio

--- a/esphome/components/gpio/output/gpio_binary_output.cpp
+++ b/esphome/components/gpio/output/gpio_binary_output.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "gpio.output";
 void GPIOBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "GPIO Binary Output:");
   LOG_PIN("  Pin: ", this->pin_);
-  LOG_BINARY_OUTPUT(this);
+  // LOG_BINARY_OUTPUT(this);
 }
 
 }  // namespace gpio

--- a/esphome/components/ledc/ledc_output.h
+++ b/esphome/components/ledc/ledc_output.h
@@ -19,6 +19,7 @@ class LEDCOutput : public output::FloatOutput, public Component {
 
   void set_channel(uint8_t channel) { this->channel_ = channel; }
   void set_frequency(float frequency) { this->frequency_ = frequency; }
+  void set_inverted(bool inverted) { this->inverted_ = inverted; }
   /// Dynamically change frequency at runtime
   void update_frequency(float frequency) override;
 
@@ -38,6 +39,7 @@ class LEDCOutput : public output::FloatOutput, public Component {
   float frequency_{};
   float duty_{0.0f};
   bool initialized_ = false;
+  bool inverted_;
 };
 
 template<typename... Ts> class SetFrequencyAction : public Action<Ts...> {

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
     CONF_CHANNEL,
+    CONF_FILTERS,
     CONF_FREQUENCY,
     CONF_ID,
     CONF_PIN,
@@ -50,6 +51,17 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
+def output_inverted(config):
+    inverted_filter = list(
+        filter(lambda x: "inverted" in x, dict(config).get(CONF_FILTERS, []))
+    )
+
+    if len(inverted_filter) == 0:
+        return False
+
+    return inverted_filter[0]["inverted"]
+
+
 async def to_code(config):
     gpio = await cg.gpio_pin_expression(config[CONF_PIN])
     var = cg.new_Pvariable(config[CONF_ID], gpio)
@@ -58,6 +70,7 @@ async def to_code(config):
     if CONF_CHANNEL in config:
         cg.add(var.set_channel(config[CONF_CHANNEL]))
     cg.add(var.set_frequency(config[CONF_FREQUENCY]))
+    cg.add(var.set_inverted(output_inverted(config)))
 
 
 @automation.register_action(

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -51,7 +51,6 @@ void ModbusFloatOutput::write_state(float value) {
 
 void ModbusFloatOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Float Output:");
-  // LOG_FLOAT_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
   ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));
@@ -101,7 +100,6 @@ void ModbusBinaryOutput::write_state(bool state) {
 
 void ModbusBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Binary Output:");
-  // LOG_BINARY_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
   ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -51,7 +51,7 @@ void ModbusFloatOutput::write_state(float value) {
 
 void ModbusFloatOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Float Output:");
-  LOG_FLOAT_OUTPUT(this);
+  // LOG_FLOAT_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
   ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));
@@ -101,7 +101,7 @@ void ModbusBinaryOutput::write_state(bool state) {
 
 void ModbusBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Binary Output:");
-  LOG_BINARY_OUTPUT(this);
+  // LOG_BINARY_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
   ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
   ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -6,6 +6,7 @@ from esphome.components import power_supply
 from esphome.const import (
     CONF_FILTERS,
     CONF_ID,
+    CONF_INVERTED,
     CONF_LEVEL,
     CONF_MAX_POWER,
     CONF_MIN_POWER,
@@ -45,10 +46,25 @@ BINARY_OUTPUT_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_POWER_SUPPLY): cv.use_id(power_supply.PowerSupply),
         cv.Optional(CONF_FILTERS): validate_filters,
+        cv.Optional(CONF_INVERTED): cv.invalid(
+            "inverted has been removed since 2022.11.0. filter: inverted should be used instead."
+        ),
     }
 )
 
-FLOAT_OUTPUT_SCHEMA = BINARY_OUTPUT_SCHEMA
+FLOAT_OUTPUT_SCHEMA = BINARY_OUTPUT_SCHEMA.extend(
+    {
+        cv.Optional(CONF_MAX_POWER): cv.invalid(
+            "max_power has been removed since 2022.11.0. filter: range should be used instead."
+        ),
+        cv.Optional(CONF_MIN_POWER): cv.invalid(
+            "min_power has been removed since 2022.11.0. filter: range should be used instead."
+        ),
+        cv.Optional(CONF_ZERO_MEANS_ZERO): cv.invalid(
+            "zero_means_zero has been removed since 2022.11.0. filter: range should be used instead."
+        ),
+    }
+)
 
 
 async def build_filters(config):

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -38,6 +38,7 @@ SetLevelAction = output_ns.class_("SetLevelAction", automation.Action)
 Filter = output_ns.class_("Filter")
 InvertedFilter = output_ns.class_("InvertedFilter", Filter)
 RangeFilter = output_ns.class_("RangeFilter", Filter)
+LambdaFilter = output_ns.class_("LambdaFilter", Filter)
 
 
 BINARY_OUTPUT_SCHEMA = cv.Schema(
@@ -131,6 +132,14 @@ async def range_filter_to_code(config, filter_id):
         config[CONF_MAX_POWER],
         config[CONF_ZERO_MEANS_ZERO],
     )
+
+
+@FILTER_REGISTRY.register("lambda", LambdaFilter, cv.returning_lambda)
+async def lambda_filter_to_code(config, filter_id):
+    lambda_ = await cg.process_lambda(
+        config, [(float, "x")], return_type=cg.optional.template(float)
+    )
+    return cg.new_Pvariable(filter_id, lambda_)
 
 
 async def to_code(config):

--- a/esphome/components/output/binary_output.cpp
+++ b/esphome/components/output/binary_output.cpp
@@ -1,0 +1,37 @@
+#include "binary_output.h"
+
+namespace esphome {
+namespace output {
+
+void BinaryOutput::add_filter(Filter *filter) {
+  if (this->filter_list_ == nullptr) {
+    this->filter_list_ = filter;
+  } else {
+    Filter *last_filter = this->filter_list_;
+    while (last_filter->next_ != nullptr)
+      last_filter = last_filter->next_;
+    last_filter->initialize(this, filter);
+  }
+  filter->initialize(this, nullptr);
+}
+void BinaryOutput::add_filters(const std::vector<Filter *> &filters) {
+  for (Filter *filter : filters) {
+    this->add_filter(filter);
+  }
+}
+void BinaryOutput::set_filters(const std::vector<Filter *> &filters) {
+  this->clear_filters();
+  this->add_filters(filters);
+}
+void BinaryOutput::clear_filters() { this->filter_list_ = nullptr; }
+
+void BinaryOutput::write_state(float state) {
+  if (state > 0.0f) {  // ON
+    this->write_state(true);
+  } else {
+    this->write_state(false);
+  }
+}
+
+}  // namespace output
+}  // namespace esphome

--- a/esphome/components/output/binary_output.cpp
+++ b/esphome/components/output/binary_output.cpp
@@ -1,9 +1,13 @@
 #include "binary_output.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace output {
 
+static const char *const TAG = "binary_output";
+
 void BinaryOutput::add_filter(Filter *filter) {
+  ESP_LOGVV(TAG, "BinaryOutput(%p)::add_filter(%p)", this, filter);
   if (this->filter_list_ == nullptr) {
     this->filter_list_ = filter;
   } else {
@@ -14,16 +18,24 @@ void BinaryOutput::add_filter(Filter *filter) {
   }
   filter->initialize(this, nullptr);
 }
+
 void BinaryOutput::add_filters(const std::vector<Filter *> &filters) {
   for (Filter *filter : filters) {
     this->add_filter(filter);
   }
 }
+
 void BinaryOutput::set_filters(const std::vector<Filter *> &filters) {
   this->clear_filters();
   this->add_filters(filters);
 }
-void BinaryOutput::clear_filters() { this->filter_list_ = nullptr; }
+
+void BinaryOutput::clear_filters() {
+  if (this->filter_list_ != nullptr) {
+    ESP_LOGVV(TAG, "BinaryOutput(%p)::clear_filters()", this);
+  }
+  this->filter_list_ = nullptr;
+}
 
 void BinaryOutput::write_state(float state) {
   if (state > 0.0f) {  // ON

--- a/esphome/components/output/binary_output.h
+++ b/esphome/components/output/binary_output.h
@@ -45,9 +45,23 @@ class BinaryOutput {
   /// Disable this binary output.
   virtual void turn_off() { this->set_state(false); }
 
+  /// Add a filter to the filter chain. Will be appended to the back.
   void add_filter(Filter *filter);
+
+  /** Add a list of vectors to the back of the filter chain.
+   *
+   * This may look like:
+   *
+   * output->add_filters({
+   *   InvertedFilter(true),
+   * });
+   */
   void add_filters(const std::vector<Filter *> &filters);
+
+  /// Clear the filters and replace them by filters.
   void set_filters(const std::vector<Filter *> &filters);
+
+  /// Clear the entire filter chain.
   void clear_filters();
 
  protected:

--- a/esphome/components/output/filter.cpp
+++ b/esphome/components/output/filter.cpp
@@ -2,12 +2,16 @@
 #include "binary_output.h"
 #include "float_output.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace output {
 
+static const char *const TAG = "output.filter";
+
 // Filter
 void Filter::input(float value) {
+  ESP_LOGVV(TAG, "Filter(%p)::input(%f)", this, value);
   optional<float> out = this->new_value(value);
   if (out.has_value())
     this->output(*out);
@@ -16,6 +20,7 @@ void Filter::input(float value) {
 void Filter::output(float value) {
   value = clamp(value, 0.0f, 1.0f);
   if (this->next_ == nullptr) {
+    ESP_LOGVV(TAG, "Filter(%p)::output(%f) -> OUTPUT", this, value);
 #ifdef USE_POWER_SUPPLY
     if (value > 0.0f) {  // ON
       this->parent_->power_.request();
@@ -26,11 +31,13 @@ void Filter::output(float value) {
 
     this->parent_->write_state(value);
   } else {
+    ESP_LOGVV(TAG, "Filter(%p)::output(%f) -> %p", this, value, this->next_);
     this->next_->input(value);
   }
 }
 
 void Filter::initialize(BinaryOutput *parent, Filter *next) {
+  ESP_LOGVV(TAG, "Filter(%p)::initialize(parent=%p next=%p)", this, parent, next);
   this->parent_ = parent;
   this->next_ = next;
 }

--- a/esphome/components/output/filter.cpp
+++ b/esphome/components/output/filter.cpp
@@ -53,5 +53,19 @@ optional<float> InvertedFilter::new_value(float value) {
   }
 }
 
+// RangeFilter
+RangeFilter::RangeFilter(float min_power, float max_power, bool zero_means_zero) {
+  this->min_power_ = min_power;
+  this->max_power_ = max_power;
+  this->zero_means_zero_ = zero_means_zero;
+}
+
+optional<float> RangeFilter::new_value(float value) {
+  if (value == 0.0f && this->zero_means_zero_)
+    return value;
+
+  return lerp(value, this->min_power_, this->max_power_);
+}
+
 }  // namespace output
 }  // namespace esphome

--- a/esphome/components/output/filter.cpp
+++ b/esphome/components/output/filter.cpp
@@ -67,5 +67,14 @@ optional<float> RangeFilter::new_value(float value) {
   return lerp(value, this->min_power_, this->max_power_);
 }
 
+// LambdaFilter
+LambdaFilter::LambdaFilter(lambda_filter_t lambda_filter) : lambda_filter_(std::move(lambda_filter)) {}
+
+optional<float> LambdaFilter::new_value(float value) {
+  auto it = this->lambda_filter_(value);
+  ESP_LOGVV(TAG, "LambdaFilter(%p)::new_value(%f) -> %f", this, value, it.value_or(INFINITY));
+  return it;
+}
+
 }  // namespace output
 }  // namespace esphome

--- a/esphome/components/output/filter.cpp
+++ b/esphome/components/output/filter.cpp
@@ -43,7 +43,7 @@ void Filter::initialize(BinaryOutput *parent, Filter *next) {
 }
 
 // InvertedFilter
-InvertedFilter::InvertedFilter(bool inverted) { this->inverted_ = inverted_; }
+InvertedFilter::InvertedFilter(bool inverted) { this->inverted_ = inverted; }
 
 optional<float> InvertedFilter::new_value(float value) {
   if (this->inverted_) {
@@ -68,7 +68,8 @@ optional<float> RangeFilter::new_value(float value) {
 }
 
 // LambdaFilter
-LambdaFilter::LambdaFilter(lambda_filter_t lambda_filter) : lambda_filter_(std::move(lambda_filter)) {}
+LambdaFilter::LambdaFilter(std::function<optional<float>(float)> lambda_filter)
+    : lambda_filter_(std::move(lambda_filter)) {}
 
 optional<float> LambdaFilter::new_value(float value) {
   auto it = this->lambda_filter_(value);

--- a/esphome/components/output/filter.cpp
+++ b/esphome/components/output/filter.cpp
@@ -1,0 +1,50 @@
+#include "filter.h"
+#include "binary_output.h"
+#include "float_output.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace output {
+
+// Filter
+void Filter::input(float value) {
+  optional<float> out = this->new_value(value);
+  if (out.has_value())
+    this->output(*out);
+}
+
+void Filter::output(float value) {
+  value = clamp(value, 0.0f, 1.0f);
+  if (this->next_ == nullptr) {
+#ifdef USE_POWER_SUPPLY
+    if (value > 0.0f) {  // ON
+      this->parent_->power_.request();
+    } else {  // OFF
+      this->parent_->power_.unrequest();
+    }
+#endif
+
+    this->parent_->write_state(value);
+  } else {
+    this->next_->input(value);
+  }
+}
+
+void Filter::initialize(BinaryOutput *parent, Filter *next) {
+  this->parent_ = parent;
+  this->next_ = next;
+}
+
+// InvertedFilter
+InvertedFilter::InvertedFilter(bool inverted) { this->inverted_ = inverted_; }
+
+optional<float> InvertedFilter::new_value(float value) {
+  if (this->inverted_) {
+    return 1.0f - value;
+  } else {
+    return value;
+  }
+}
+
+}  // namespace output
+}  // namespace esphome

--- a/esphome/components/output/filter.h
+++ b/esphome/components/output/filter.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "esphome/core/optional.h"
+
+namespace esphome {
+namespace output {
+
+class BinaryOutput;
+
+class Filter {
+ public:
+  virtual optional<float> new_value(float value) = 0;
+  virtual void initialize(BinaryOutput *parent, Filter *next);
+
+  void input(float value);
+
+  void output(float value);
+
+ protected:
+  friend BinaryOutput;
+
+  Filter *next_{nullptr};
+  BinaryOutput *parent_{nullptr};
+};
+
+class InvertedFilter : public Filter {
+ public:
+  explicit InvertedFilter(bool inverted);
+
+  optional<float> new_value(float value) override;
+
+ protected:
+  bool inverted_;
+};
+
+}  // namespace output
+}  // namespace esphome

--- a/esphome/components/output/filter.h
+++ b/esphome/components/output/filter.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "esphome/core/optional.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace output {
@@ -44,16 +44,14 @@ class RangeFilter : public Filter {
   bool zero_means_zero_;
 };
 
-using lambda_filter_t = std::function<optional<float>(float)>;
-
 class LambdaFilter : public Filter {
  public:
-  explicit LambdaFilter(lambda_filter_t lambda_filter);
+  explicit LambdaFilter(std::function<optional<float>(float)> lambda_filter);
 
   optional<float> new_value(float value) override;
 
  protected:
-  lambda_filter_t lambda_filter_;
+  std::function<optional<float>(float)> lambda_filter_;
 };
 
 }  // namespace output

--- a/esphome/components/output/filter.h
+++ b/esphome/components/output/filter.h
@@ -44,5 +44,17 @@ class RangeFilter : public Filter {
   bool zero_means_zero_;
 };
 
+using lambda_filter_t = std::function<optional<float>(float)>;
+
+class LambdaFilter : public Filter {
+ public:
+  explicit LambdaFilter(lambda_filter_t lambda_filter);
+
+  optional<float> new_value(float value) override;
+
+ protected:
+  lambda_filter_t lambda_filter_;
+};
+
 }  // namespace output
 }  // namespace esphome

--- a/esphome/components/output/filter.h
+++ b/esphome/components/output/filter.h
@@ -32,5 +32,17 @@ class InvertedFilter : public Filter {
   bool inverted_;
 };
 
+class RangeFilter : public Filter {
+ public:
+  explicit RangeFilter(float min_power, float max_power, bool zero_means_zero);
+
+  optional<float> new_value(float value) override;
+
+ protected:
+  float min_power_;
+  float max_power_;
+  bool zero_means_zero_;
+};
+
 }  // namespace output
 }  // namespace esphome

--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -5,42 +5,24 @@
 namespace esphome {
 namespace output {
 
-static const char *const TAG = "output.float";
-
-void FloatOutput::set_max_power(float max_power) {
-  this->max_power_ = clamp(max_power, this->min_power_, 1.0f);  // Clamp to MIN>=MAX>=1.0
-}
-
-float FloatOutput::get_max_power() const { return this->max_power_; }
-
-void FloatOutput::set_min_power(float min_power) {
-  this->min_power_ = clamp(min_power, 0.0f, this->max_power_);  // Clamp to 0.0>=MIN>=MAX
-}
-
-void FloatOutput::set_zero_means_zero(bool zero_means_zero) { this->zero_means_zero_ = zero_means_zero; }
-
-float FloatOutput::get_min_power() const { return this->min_power_; }
-
 void FloatOutput::set_level(float state) {
   state = clamp(state, 0.0f, 1.0f);
 
+  if (this->filter_list_ == nullptr) {
 #ifdef USE_POWER_SUPPLY
-  if (state > 0.0f) {  // ON
-    this->power_.request();
-  } else {  // OFF
-    this->power_.unrequest();
-  }
+    if (state > 0.0f) {  // ON
+      this->power_.request();
+    } else {  // OFF
+      this->power_.unrequest();
+    }
 #endif
-
-  if (!(state == 0.0f && this->zero_means_zero_))  // regardless of min_power_, 0.0 means off
-    state = (state * (this->max_power_ - this->min_power_)) + this->min_power_;
-
-  if (this->is_inverted())
-    state = 1.0f - state;
-  this->write_state(state);
+    this->write_state(state);
+  } else {
+    this->filter_list_->input(state);
+  }
 }
 
-void FloatOutput::write_state(bool state) { this->set_level(state != this->inverted_ ? 1.0f : 0.0f); }
+void FloatOutput::write_state(bool state) { this->set_level(state ? 1.0f : 0.0f); }
 
 }  // namespace output
 }  // namespace esphome

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -37,7 +37,7 @@ class FloatOutput : public BinaryOutput {
  protected:
   /// Implement BinarySensor's write_enabled; this should never be called.
   void write_state(bool state) override;
-  virtual void write_state(float state) = 0;
+  void write_state(float state) override = 0;
 };
 
 }  // namespace output

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -16,8 +16,7 @@ namespace output {
  * That method will be called for you with inversion and max-min power and offset to min power already applied.
  *
  * This interface is compatible with BinaryOutput (and will automatically convert the binary states to floating
- * point states for you). Additionally, this class provides a way for users to set a minimum and/or maximum power
- * output
+ * point states for you).
  */
 class FloatOutput : public BinaryOutput {
  public:

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -6,15 +6,6 @@
 namespace esphome {
 namespace output {
 
-#define LOG_FLOAT_OUTPUT(this) \
-  LOG_BINARY_OUTPUT(this) \
-  if (this->max_power_ != 1.0f) { \
-    ESP_LOGCONFIG(TAG, "  Max Power: %.1f%%", this->max_power_ * 100.0f); \
-  } \
-  if (this->min_power_ != 0.0f) { \
-    ESP_LOGCONFIG(TAG, "  Min Power: %.1f%%", this->min_power_ * 100.0f); \
-  }
-
 /** Base class for all output components that can output a variable level, like PWM.
  *
  * Floating Point Outputs always use output values in the range from 0.0 to 1.0 (inclusive), where 0.0 means off
@@ -30,28 +21,6 @@ namespace output {
  */
 class FloatOutput : public BinaryOutput {
  public:
-  /** Set the maximum power output of this component.
-   *
-   * All values are multiplied by max_power - min_power and offset to min_power to get the adjusted value.
-   *
-   * @param max_power Automatically clamped from 0 or min_power to 1.
-   */
-  void set_max_power(float max_power);
-
-  /** Set the minimum power output of this component.
-   *
-   * All values are multiplied by max_power - min_power and offset by min_power to get the adjusted value.
-   *
-   * @param min_power Automatically clamped from 0 to max_power or 1.
-   */
-  void set_min_power(float min_power);
-
-  /** Sets this output to ignore min_power for a 0 state
-   *
-   * @param zero True if a 0 state should mean 0 and not min_power.
-   */
-  void set_zero_means_zero(bool zero_means_zero);
-
   /** Set the level of this float output, this is called from the front-end.
    *
    * @param state The new state.
@@ -66,23 +35,10 @@ class FloatOutput : public BinaryOutput {
    */
   virtual void update_frequency(float frequency) {}
 
-  // ========== INTERNAL METHODS ==========
-  // (In most use cases you won't need these)
-
-  /// Get the maximum power output.
-  float get_max_power() const;
-
-  /// Get the minimum power output.
-  float get_min_power() const;
-
  protected:
   /// Implement BinarySensor's write_enabled; this should never be called.
   void write_state(bool state) override;
   virtual void write_state(float state) = 0;
-
-  float max_power_{1.0f};
-  float min_power_{0.0f};
-  bool zero_means_zero_;
 };
 
 }  // namespace output

--- a/esphome/components/rp2040_pwm/rp2040_pwm.cpp
+++ b/esphome/components/rp2040_pwm/rp2040_pwm.cpp
@@ -23,7 +23,6 @@ void RP2040PWM::dump_config() {
   ESP_LOGCONFIG(TAG, "RP2040 PWM:");
   LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG, "  Frequency: %.1f Hz", this->frequency_);
-  // LOG_FLOAT_OUTPUT(this);
 }
 void HOT RP2040PWM::write_state(float state) {
   this->last_output_ = state;

--- a/esphome/components/rp2040_pwm/rp2040_pwm.cpp
+++ b/esphome/components/rp2040_pwm/rp2040_pwm.cpp
@@ -23,7 +23,7 @@ void RP2040PWM::dump_config() {
   ESP_LOGCONFIG(TAG, "RP2040 PWM:");
   LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG, "  Frequency: %.1f Hz", this->frequency_);
-  LOG_FLOAT_OUTPUT(this);
+  // LOG_FLOAT_OUTPUT(this);
 }
 void HOT RP2040PWM::write_state(float state) {
   this->last_output_ = state;

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -61,7 +61,6 @@ void SlowPWMOutput::dump_config() {
     ESP_LOGCONFIG(TAG, "  Turn off automation configured");
   ESP_LOGCONFIG(TAG, "  Period: %d ms", this->period_);
   ESP_LOGCONFIG(TAG, "  Restart cycle on state change: %s", YESNO(this->restart_cycle_on_state_change_));
-  // LOG_FLOAT_OUTPUT(this);
 }
 
 void SlowPWMOutput::write_state(float state) {

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -61,7 +61,7 @@ void SlowPWMOutput::dump_config() {
     ESP_LOGCONFIG(TAG, "  Turn off automation configured");
   ESP_LOGCONFIG(TAG, "  Period: %d ms", this->period_);
   ESP_LOGCONFIG(TAG, "  Restart cycle on state change: %s", YESNO(this->restart_cycle_on_state_change_));
-  LOG_FLOAT_OUTPUT(this);
+  // LOG_FLOAT_OUTPUT(this);
 }
 
 void SlowPWMOutput::write_state(float state) {

--- a/esphome/components/sx1509/output/sx1509_float_output.cpp
+++ b/esphome/components/sx1509/output/sx1509_float_output.cpp
@@ -24,7 +24,7 @@ void SX1509FloatOutputChannel::setup() {
 void SX1509FloatOutputChannel::dump_config() {
   ESP_LOGCONFIG(TAG, "SX1509 PWM:");
   ESP_LOGCONFIG(TAG, "  sx1509 pin: %d", this->pin_);
-  LOG_FLOAT_OUTPUT(this);
+  // LOG_FLOAT_OUTPUT(this);
 }
 
 }  // namespace sx1509

--- a/esphome/components/sx1509/output/sx1509_float_output.cpp
+++ b/esphome/components/sx1509/output/sx1509_float_output.cpp
@@ -24,7 +24,6 @@ void SX1509FloatOutputChannel::setup() {
 void SX1509FloatOutputChannel::dump_config() {
   ESP_LOGCONFIG(TAG, "SX1509 PWM:");
   ESP_LOGCONFIG(TAG, "  sx1509 pin: %d", this->pin_);
-  // LOG_FLOAT_OUTPUT(this);
 }
 
 }  // namespace sx1509

--- a/esphome/components/tm1638/output/tm1638_output_led.cpp
+++ b/esphome/components/tm1638/output/tm1638_output_led.cpp
@@ -8,10 +8,7 @@ static const char *const TAG = "tm1638.led";
 
 void TM1638OutputLed::write_state(bool state) { tm1638_->set_led(led_, state); }
 
-void TM1638OutputLed::dump_config() {
-  // LOG_BINARY_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  LED: %d", led_);
-}
+void TM1638OutputLed::dump_config() { ESP_LOGCONFIG(TAG, "  LED: %d", led_); }
 
 }  // namespace tm1638
 }  // namespace esphome

--- a/esphome/components/tm1638/output/tm1638_output_led.cpp
+++ b/esphome/components/tm1638/output/tm1638_output_led.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "tm1638.led";
 void TM1638OutputLed::write_state(bool state) { tm1638_->set_led(led_, state); }
 
 void TM1638OutputLed::dump_config() {
-  LOG_BINARY_OUTPUT(this);
+  // LOG_BINARY_OUTPUT(this);
   ESP_LOGCONFIG(TAG, "  LED: %d", led_);
 }
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1451,13 +1451,17 @@ output:
     pin: GPIO26
     id: gpio_26
     power_supply: atx_power_supply
-    inverted: false
+    filters:
+      - inverted: false
   - platform: ledc
     pin: 19
     id: gpio_19
     frequency: 1500Hz
     channel: 14
-    max_power: 0.5
+    filters:
+      - range:
+          max_power: 0.5
+      - lambda: return pow(x, 2);
   - platform: pca9685
     id: pca_0
     channel: 0

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1576,6 +1576,9 @@ output:
     id: dimmer1
     gate_pin: GPIO5
     zero_cross_pin: GPIO26
+    filters:
+      - range:
+          min_power: 0.1
   - platform: esp32_dac
     pin: GPIO25
     id: dac_output

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -76,6 +76,9 @@ output:
     id: dimmer1
     gate_pin: GPIO5
     zero_cross_pin: GPIO12
+    filters:
+      - range:
+          min_power: 0.1
 
 sensor:
   - platform: homeassistant

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -184,7 +184,9 @@ output:
   - platform: tlc5947
     id: output_red
     channel: 0
-    max_power: 0.8
+    filters:
+      - range:
+          max_power: 0.8
 
   - platform: mcp47a1
     id: output_mcp47a1


### PR DESCRIPTION
# What does this implement/fix?

This PR adds output filters that allow users to change or filters data on output components before they are sent to the physical output. This can be useful if you need to do something complex with the value before it is sent to the connected device.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2405

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
output:
  - platform: esp8266_pwm
    pin: GPIO2
    id: internal_led
    filters:
      - lambda: return pow(x, 2);
      - range:
          max_power: 0.8
      - inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
