### PR TITLE
Allow dashboard import to pull complete file from github

### DIFF
--- a/esphome/components/dashboard_import/__init__.py
+++ b/esphome/components/dashboard_import/__init__.py
@@ -73,15 +73,15 @@ def import_config(
         )
     else:
         m = re.match(
-            r"github://([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+)/([a-zA-Z0-9\-_.\./]+)(?:@([a-zA-Z0-9\-_.\./]+))(?:\?([a-zA-Z0-9\-_.\./]+))?",
+            r"github://(?P<owner>[a-zA-Z0-9\-]+)/(?P<repo>[a-zA-Z0-9\-\._]+)/(?P<filename>[a-zA-Z0-9\-_.\./]+)(?:@(?P<ref>[a-zA-Z0-9\-_.\./]+))(?:\?(?P<query>[a-zA-Z0-9\-_.\./]+))?",
             import_url,
         )
 
         if m is None:
             raise ValueError
 
-        if m.group(4) and "full_config" in m.group(4):
-            url = f"https://raw.githubusercontent.com/{m.group(1)}/{m.group(2)}/{m.group(4)}/{m.group(3)}"
+        if m.group("query") and "full_config" in m.group("query"):
+            url = f"https://raw.githubusercontent.com/{m.group('owner')}/{m.group('repo')}/{m.group('ref')}/{m.group('filename')}"
             try:
                 req = requests.get(url, timeout=30)
                 req.raise_for_status()

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -417,6 +417,10 @@ class ImportRequestHandler(BaseHandler):
             self.set_status(500)
             self.write("File already exists")
             return
+        except ValueError:
+            self.set_status(422)
+            self.write("Invalid package url")
+            return
 
         self.set_status(200)
         self.finish()

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -1,14 +1,15 @@
-from pathlib import Path
-import subprocess
 import hashlib
 import logging
-from typing import Callable, Optional
+import re
+import subprocess
 import urllib.parse
-
+from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
 
-from esphome.core import CORE, TimePeriodSeconds
 import esphome.config_validation as cv
+from esphome.core import CORE, TimePeriodSeconds
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,3 +104,57 @@ def clone_or_update(
             return repo_dir, revert
 
     return repo_dir, None
+
+
+GIT_DOMAINS = {
+    "github": "github.com",
+    "gitlab": "gitlab.com",
+}
+
+
+@dataclass(frozen=True)
+class GitFile:
+    domain: str
+    owner: str
+    repo: str
+    filename: str
+    ref: str = None
+    query: str = None
+
+    @property
+    def git_url(self) -> str:
+        return f"https://{self.domain}/{self.owner}/{self.repo}.git"
+
+    @property
+    def raw_url(self) -> str:
+        if self.ref is None:
+            raise ValueError("URL has no ref")
+        if self.domain == "github":
+            return f"https://raw.githubusercontent.com/{self.owner}/{self.repo}/{self.ref}/{self.filename}"
+        elif self.domain == "gitlab":
+            return f"https://gitlab.com/{self.owner}/{self.repo}/-/raw/{self.ref}/{self.filename}"
+        raise NotImplementedError(f"Git domain {self.domain} not supported")
+
+    @classmethod
+    def from_shorthand(cls, shorthand):
+        """Parse a git shorthand URL into its components."""
+        if not isinstance(shorthand, str):
+            raise ValueError("Git shorthand must be a string")
+        m = re.match(
+            r"(?P<domain>[a-zA-Z0-9\-]+)://(?P<owner>[a-zA-Z0-9\-]+)/(?P<repo>[a-zA-Z0-9\-\._]+)/(?P<filename>[a-zA-Z0-9\-_.\./]+)(?:@(?P<ref>[a-zA-Z0-9\-_.\./]+))?(?:\?(?P<query>[a-zA-Z0-9\-_.\./]+))?",
+            shorthand,
+        )
+        if m is None:
+            raise ValueError(
+                "URL is not in expected github://username/name/[sub-folder/]file-path.yml[@branch-or-tag] format!"
+            )
+        if m.group("domain") not in GIT_DOMAINS:
+            raise ValueError(f"Unknown git domain {m.group('domain')}")
+        return cls(
+            domain=GIT_DOMAINS[m.group("domain")],
+            owner=m.group("owner"),
+            repo=m.group("repo"),
+            filename=m.group("filename"),
+            ref=m.group("ref"),
+            query=m.group("query"),
+        )

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -131,7 +131,7 @@ class GitFile:
             raise ValueError("URL has no ref")
         if self.domain == "github":
             return f"https://raw.githubusercontent.com/{self.owner}/{self.repo}/{self.ref}/{self.filename}"
-        elif self.domain == "gitlab":
+        if self.domain == "gitlab":
             return f"https://gitlab.com/{self.owner}/{self.repo}/-/raw/{self.ref}/{self.filename}"
         raise NotImplementedError(f"Git domain {self.domain} not supported")
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This allows a pre-flashed device to indicate the user should start with the full config for customisation instead of having to manually copy/paste the file after adoption.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
