### PR TITLE
Always use gh releases in base platformio file for rp2040

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -156,7 +156,8 @@ board_build.filesystem_size = 0.5m
 
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 platform_packages =
-    earlephilhower/framework-arduinopico @ ~1.20400.0
+    ; earlephilhower/framework-arduinopico @ ~1.20602.0 ; Cannot use the platformio package until old releases stop getting deleted
+    earlephilhower/framework-arduinopico @ https://github.com/earlephilhower/arduino-pico/releases/download/2.6.2/rp2040-2.6.2.zip
 
 framework = arduino
 lib_deps =


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The "old" version on platformio keep getting deleted by platformio staff so setting the core file to always reference the github release for now.

See https://github.com/earlephilhower/arduino-pico/issues/935

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
