### PR TITLE
Allow the use of multiple RDM6300 devices

### DIFF
--- a/esphome/components/rdm6300/__init__.py
+++ b/esphome/components/rdm6300/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ID, CONF_ON_TAG, CONF_TRIGGER_ID
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["binary_sensor"]
+MULTI_CONF = True
 
 rdm6300_ns = cg.esphome_ns.namespace("rdm6300")
 RDM6300Component = rdm6300_ns.class_("RDM6300Component", cg.Component, uart.UARTDevice)


### PR DESCRIPTION
# What does this implement/fix?
Allows multiple RDM6300 devices to be used
<!-- Quick description and explanation of changes -->
Added MULTI_CONF = True to allow for multiple devices to be configured.
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/3439

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
rdm6300:
  - id: reader1
    uart_id: uart1
  - id: reader2
    uart_id: uart2

binary_sensor:
  - platform: rdm6300
    rdm6300_id: reader1  

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
