### PR TITLE
add uart number to LOGCONFIG

### DIFF
--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -90,6 +90,7 @@ void ESP32ArduinoUARTComponent::setup() {
     this->hw_serial_ = &Serial;
   } else {
     static uint8_t next_uart_num = 1;
+    this->number_ = next_uart_num;
     this->hw_serial_ = new HardwareSerial(next_uart_num++);  // NOLINT(cppcoreguidelines-owning-memory)
   }
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
@@ -104,7 +105,7 @@ void ESP32ArduinoUARTComponent::setup() {
 }
 
 void ESP32ArduinoUARTComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "UART Bus:");
+  ESP_LOGCONFIG(TAG, "UART%d Bus:", this->number_);
   LOG_PIN("  TX Pin: ", tx_pin_);
   LOG_PIN("  RX Pin: ", rx_pin_);
   if (this->rx_pin_ != nullptr) {

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -105,7 +105,7 @@ void ESP32ArduinoUARTComponent::setup() {
 }
 
 void ESP32ArduinoUARTComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "UART%d Bus:", this->number_);
+  ESP_LOGCONFIG(TAG, "UART Bus %d:", this->number_);
   LOG_PIN("  TX Pin: ", tx_pin_);
   LOG_PIN("  RX Pin: ", rx_pin_);
   if (this->rx_pin_ != nullptr) {

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -32,6 +32,7 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
   void check_logger_conflict() override;
 
   HardwareSerial *hw_serial_{nullptr};
+  uint8_t number_{0};
 };
 
 }  // namespace uart


### PR DESCRIPTION
# What does this implement/fix?
add uart number to LOGCONFIG

<!-- Quick description and explanation of changes -->
For now it is impossible to check which UART is used.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
