### PR TITLE
Skip validation of defined pins

### DIFF
--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -105,6 +105,12 @@ _esp32_validations = {
 
 def validate_gpio_pin(value):
     value = _translate_pin(value)
+    board = CORE.data[KEY_ESP32][KEY_BOARD]
+    board_pins = boards.ESP32_BOARD_PINS.get(board, {})
+
+    if value in board_pins.values():
+        return value
+
     variant = CORE.data[KEY_ESP32][KEY_VARIANT]
     if variant not in _esp32_validations:
         raise cv.Invalid(f"Unsupported ESP32 variant {variant}")


### PR DESCRIPTION
# What does this implement/fix?

This let ESPHome support chips like ESP32 Pico, which have a different pin schema than the regular ESP32.
E.g. several pins used by ESP32 Pico is blocked by ESPHome as they are used by the flash interface in regular ESP32.

This is implemented by checking if the pin used is defined in the board definition, if it's defined there, it's not checked for reserved usage defined in the ESPHome core.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
