### PR TITLE
Add Haier climate component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -95,6 +95,7 @@ esphome/components/gpio/* @esphome/core
 esphome/components/gps/* @coogle
 esphome/components/graph/* @synco
 esphome/components/growatt_solar/* @leeuwte
+esphome/components/haier/* @Yarikx
 esphome/components/havells_solar/* @sourabhjaiswal
 esphome/components/hbridge/fan/* @WeekendWarrior
 esphome/components/hbridge/light/* @DotNetDann

--- a/esphome/components/haier/__init__.py
+++ b/esphome/components/haier/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@Yarikx"]

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -2,113 +2,40 @@ from esphome.components import climate
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import (
-    CONF_ID,
-)
+from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart"]
 
 haier_ns = cg.esphome_ns.namespace("haier")
 HaierClimate = haier_ns.class_(
-    "Haier", climate.Climate, cg.PollingComponent, uart.UARTDevice
+    "HaierClimate", climate.Climate, cg.PollingComponent, uart.UARTDevice
 )
+SwingMode = haier_ns.enum("SwingMode")
+
+CONF_SWING_MODE = "supported_swing_mode"
+SWING_MODES = {
+    "off": SwingMode.SWING_OFF,
+    "vertical": SwingMode.SWING_VERTICAL,
+    "horizontal": SwingMode.SWING_HORIZONTAL,
+    "both": SwingMode.SWING_BOTH,
+}
 
 CONFIG_SCHEMA = cv.All(
     climate.CLIMATE_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(HaierClimate),
-            # cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
-            # cv.Optional(CONF_SUPPORTS_HEAT, default=True): cv.boolean,
-            # cv.Optional(CONF_SUPPORTS_COOL, default=False): cv.boolean,
-            # cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
-            # cv.Optional(CONF_ACTIVE_STATE_DATAPOINT): cv.uint8_t,
-            # cv.Optional(CONF_ACTIVE_STATE_HEATING_VALUE, default=1): cv.uint8_t,
-            # cv.Optional(CONF_ACTIVE_STATE_COOLING_VALUE): cv.uint8_t,
-            # cv.Optional(CONF_HEATING_STATE_PIN): pins.gpio_input_pin_schema,
-            # cv.Optional(CONF_COOLING_STATE_PIN): pins.gpio_input_pin_schema,
-            # cv.Optional(CONF_TARGET_TEMPERATURE_DATAPOINT): cv.uint8_t,
-            # cv.Optional(CONF_CURRENT_TEMPERATURE_DATAPOINT): cv.uint8_t,
-            # cv.Optional(CONF_TEMPERATURE_MULTIPLIER): cv.positive_float,
-            # cv.Optional(CONF_CURRENT_TEMPERATURE_MULTIPLIER): cv.positive_float,
-            # cv.Optional(CONF_TARGET_TEMPERATURE_MULTIPLIER): cv.positive_float,
-            # cv.Optional(CONF_ECO_DATAPOINT): cv.uint8_t,
-            # cv.Optional(CONF_ECO_TEMPERATURE): cv.temperature,
+            cv.Optional(CONF_SWING_MODE, default="off"): cv.enum(
+                SWING_MODES, lower=True
+            ),
         }
     )
     .extend(cv.polling_component_schema("5s"))
     .extend(uart.UART_DEVICE_SCHEMA),
-    # cv.has_at_least_one_key(CONF_TARGET_TEMPERATURE_DATAPOINT, CONF_SWITCH_DATAPOINT),
-    # validate_temperature_multipliers,
-    # validate_active_state_values,
-    # cv.has_at_most_one_key(CONF_ACTIVE_STATE_DATAPOINT, CONF_HEATING_STATE_PIN),
-    # cv.has_at_most_one_key(CONF_ACTIVE_STATE_DATAPOINT, CONF_COOLING_STATE_PIN),
-    # validate_eco_values,
 )
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = cg.new_Pvariable(config[CONF_ID], config[CONF_SWING_MODE])
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await uart.register_uart_device(var, config)
-
-    # paren = await cg.get_variable(config[CONF_TUYA_ID])
-    # cg.add(var.set_tuya_parent(paren))
-    #
-    # cg.add(var.set_supports_heat(config[CONF_SUPPORTS_HEAT]))
-    # cg.add(var.set_supports_cool(config[CONF_SUPPORTS_COOL]))
-    # if CONF_SWITCH_DATAPOINT in config:
-    #     cg.add(var.set_switch_id(config[CONF_SWITCH_DATAPOINT]))
-    # if CONF_ACTIVE_STATE_DATAPOINT in config:
-    #     cg.add(var.set_active_state_id(config[CONF_ACTIVE_STATE_DATAPOINT]))
-    #     if CONF_ACTIVE_STATE_HEATING_VALUE in config:
-    #         cg.add(
-    #             var.set_active_state_heating_value(
-    #                 config[CONF_ACTIVE_STATE_HEATING_VALUE]
-    #             )
-    #         )
-    #     if CONF_ACTIVE_STATE_COOLING_VALUE in config:
-    #         cg.add(
-    #             var.set_active_state_cooling_value(
-    #                 config[CONF_ACTIVE_STATE_COOLING_VALUE]
-    #             )
-    #         )
-    # else:
-    #     if CONF_HEATING_STATE_PIN in config:
-    #         heating_state_pin = await cg.gpio_pin_expression(
-    #             config[CONF_HEATING_STATE_PIN]
-    #         )
-    #         cg.add(var.set_heating_state_pin(heating_state_pin))
-    #     if CONF_COOLING_STATE_PIN in config:
-    #         cooling_state_pin = await cg.gpio_pin_expression(
-    #             config[CONF_COOLING_STATE_PIN]
-    #         )
-    #         cg.add(var.set_cooling_state_pin(cooling_state_pin))
-    # if CONF_TARGET_TEMPERATURE_DATAPOINT in config:
-    #     cg.add(var.set_target_temperature_id(config[CONF_TARGET_TEMPERATURE_DATAPOINT]))
-    # if CONF_CURRENT_TEMPERATURE_DATAPOINT in config:
-    #     cg.add(
-    #         var.set_current_temperature_id(config[CONF_CURRENT_TEMPERATURE_DATAPOINT])
-    #     )
-    # if CONF_TEMPERATURE_MULTIPLIER in config:
-    #     cg.add(
-    #         var.set_target_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER])
-    #     )
-    #     cg.add(
-    #         var.set_current_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER])
-    #     )
-    # else:
-    #     cg.add(
-    #         var.set_current_temperature_multiplier(
-    #             config[CONF_CURRENT_TEMPERATURE_MULTIPLIER]
-    #         )
-    #     )
-    #     cg.add(
-    #         var.set_target_temperature_multiplier(
-    #             config[CONF_TARGET_TEMPERATURE_MULTIPLIER]
-    #         )
-    #     )
-    # if CONF_ECO_DATAPOINT in config:
-    #     cg.add(var.set_eco_id(config[CONF_ECO_DATAPOINT]))
-    #     if CONF_ECO_TEMPERATURE in config:
-    #         cg.add(var.set_eco_temperature(config[CONF_ECO_TEMPERATURE]))

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -11,7 +11,6 @@ haier_ns = cg.esphome_ns.namespace("haier")
 HaierClimate = haier_ns.class_(
     "HaierClimate", climate.Climate, cg.PollingComponent, uart.UARTDevice
 )
-SwingMode = haier_ns.enum("SwingMode")
 
 ALLOWED_CLIMATE_SWING_MODES = {
     "BOTH": ClimateSwingMode.CLIMATE_SWING_BOTH,

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -1,0 +1,114 @@
+from esphome.components import climate
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import (
+    CONF_ID,
+)
+
+DEPENDENCIES = ["uart"]
+
+haier_ns = cg.esphome_ns.namespace("haier")
+HaierClimate = haier_ns.class_(
+    "Haier", climate.Climate, cg.PollingComponent, uart.UARTDevice
+)
+
+CONFIG_SCHEMA = cv.All(
+    climate.CLIMATE_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(HaierClimate),
+            # cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
+            # cv.Optional(CONF_SUPPORTS_HEAT, default=True): cv.boolean,
+            # cv.Optional(CONF_SUPPORTS_COOL, default=False): cv.boolean,
+            # cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
+            # cv.Optional(CONF_ACTIVE_STATE_DATAPOINT): cv.uint8_t,
+            # cv.Optional(CONF_ACTIVE_STATE_HEATING_VALUE, default=1): cv.uint8_t,
+            # cv.Optional(CONF_ACTIVE_STATE_COOLING_VALUE): cv.uint8_t,
+            # cv.Optional(CONF_HEATING_STATE_PIN): pins.gpio_input_pin_schema,
+            # cv.Optional(CONF_COOLING_STATE_PIN): pins.gpio_input_pin_schema,
+            # cv.Optional(CONF_TARGET_TEMPERATURE_DATAPOINT): cv.uint8_t,
+            # cv.Optional(CONF_CURRENT_TEMPERATURE_DATAPOINT): cv.uint8_t,
+            # cv.Optional(CONF_TEMPERATURE_MULTIPLIER): cv.positive_float,
+            # cv.Optional(CONF_CURRENT_TEMPERATURE_MULTIPLIER): cv.positive_float,
+            # cv.Optional(CONF_TARGET_TEMPERATURE_MULTIPLIER): cv.positive_float,
+            # cv.Optional(CONF_ECO_DATAPOINT): cv.uint8_t,
+            # cv.Optional(CONF_ECO_TEMPERATURE): cv.temperature,
+        }
+    )
+    .extend(cv.polling_component_schema("5s"))
+    .extend(uart.UART_DEVICE_SCHEMA),
+    # cv.has_at_least_one_key(CONF_TARGET_TEMPERATURE_DATAPOINT, CONF_SWITCH_DATAPOINT),
+    # validate_temperature_multipliers,
+    # validate_active_state_values,
+    # cv.has_at_most_one_key(CONF_ACTIVE_STATE_DATAPOINT, CONF_HEATING_STATE_PIN),
+    # cv.has_at_most_one_key(CONF_ACTIVE_STATE_DATAPOINT, CONF_COOLING_STATE_PIN),
+    # validate_eco_values,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await climate.register_climate(var, config)
+    await uart.register_uart_device(var, config)
+
+    # paren = await cg.get_variable(config[CONF_TUYA_ID])
+    # cg.add(var.set_tuya_parent(paren))
+    #
+    # cg.add(var.set_supports_heat(config[CONF_SUPPORTS_HEAT]))
+    # cg.add(var.set_supports_cool(config[CONF_SUPPORTS_COOL]))
+    # if CONF_SWITCH_DATAPOINT in config:
+    #     cg.add(var.set_switch_id(config[CONF_SWITCH_DATAPOINT]))
+    # if CONF_ACTIVE_STATE_DATAPOINT in config:
+    #     cg.add(var.set_active_state_id(config[CONF_ACTIVE_STATE_DATAPOINT]))
+    #     if CONF_ACTIVE_STATE_HEATING_VALUE in config:
+    #         cg.add(
+    #             var.set_active_state_heating_value(
+    #                 config[CONF_ACTIVE_STATE_HEATING_VALUE]
+    #             )
+    #         )
+    #     if CONF_ACTIVE_STATE_COOLING_VALUE in config:
+    #         cg.add(
+    #             var.set_active_state_cooling_value(
+    #                 config[CONF_ACTIVE_STATE_COOLING_VALUE]
+    #             )
+    #         )
+    # else:
+    #     if CONF_HEATING_STATE_PIN in config:
+    #         heating_state_pin = await cg.gpio_pin_expression(
+    #             config[CONF_HEATING_STATE_PIN]
+    #         )
+    #         cg.add(var.set_heating_state_pin(heating_state_pin))
+    #     if CONF_COOLING_STATE_PIN in config:
+    #         cooling_state_pin = await cg.gpio_pin_expression(
+    #             config[CONF_COOLING_STATE_PIN]
+    #         )
+    #         cg.add(var.set_cooling_state_pin(cooling_state_pin))
+    # if CONF_TARGET_TEMPERATURE_DATAPOINT in config:
+    #     cg.add(var.set_target_temperature_id(config[CONF_TARGET_TEMPERATURE_DATAPOINT]))
+    # if CONF_CURRENT_TEMPERATURE_DATAPOINT in config:
+    #     cg.add(
+    #         var.set_current_temperature_id(config[CONF_CURRENT_TEMPERATURE_DATAPOINT])
+    #     )
+    # if CONF_TEMPERATURE_MULTIPLIER in config:
+    #     cg.add(
+    #         var.set_target_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER])
+    #     )
+    #     cg.add(
+    #         var.set_current_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER])
+    #     )
+    # else:
+    #     cg.add(
+    #         var.set_current_temperature_multiplier(
+    #             config[CONF_CURRENT_TEMPERATURE_MULTIPLIER]
+    #         )
+    #     )
+    #     cg.add(
+    #         var.set_target_temperature_multiplier(
+    #             config[CONF_TARGET_TEMPERATURE_MULTIPLIER]
+    #         )
+    #     )
+    # if CONF_ECO_DATAPOINT in config:
+    #     cg.add(var.set_eco_id(config[CONF_ECO_DATAPOINT]))
+    #     if CONF_ECO_TEMPERATURE in config:
+    #         cg.add(var.set_eco_temperature(config[CONF_ECO_TEMPERATURE]))

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -12,7 +12,7 @@ HaierClimate = haier_ns.class_(
 )
 SwingMode = haier_ns.enum("SwingMode")
 
-CONF_SWING_MODE = "supported_swing_mode"
+CONF_SUPPORTED_SWING_MODE = "supported_swing_mode"
 SWING_MODES = {
     "off": SwingMode.SWING_OFF,
     "vertical": SwingMode.SWING_VERTICAL,
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = cv.All(
     climate.CLIMATE_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(HaierClimate),
-            cv.Optional(CONF_SWING_MODE, default="off"): cv.enum(
+            cv.Optional(CONF_SUPPORTED_SWING_MODE, default="off"): cv.enum(
                 SWING_MODES, lower=True
             ),
         }
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID], config[CONF_SWING_MODE])
+    var = cg.new_Pvariable(config[CONF_ID], config[CONF_SUPPORTED_SWING_MODE])
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -2,7 +2,7 @@ from esphome.components import climate
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_SUPPORTED_SWING_MODES
 
 DEPENDENCIES = ["uart"]
 
@@ -12,7 +12,6 @@ HaierClimate = haier_ns.class_(
 )
 SwingMode = haier_ns.enum("SwingMode")
 
-CONF_SUPPORTED_SWING_MODE = "supported_swing_mode"
 SWING_MODES = {
     "off": SwingMode.SWING_OFF,
     "vertical": SwingMode.SWING_VERTICAL,
@@ -24,7 +23,7 @@ CONFIG_SCHEMA = cv.All(
     climate.CLIMATE_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(HaierClimate),
-            cv.Optional(CONF_SUPPORTED_SWING_MODE, default="off"): cv.enum(
+            cv.Optional(CONF_SUPPORTED_SWING_MODES, default="off"): cv.enum(
                 SWING_MODES, lower=True
             ),
         }
@@ -35,7 +34,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID], config[CONF_SUPPORTED_SWING_MODE])
+    var = cg.new_Pvariable(config[CONF_ID], config[CONF_SUPPORTED_SWING_MODES])
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/haier/haier.cpp
+++ b/esphome/components/haier/haier.cpp
@@ -203,16 +203,17 @@ void HaierClimate::control(const climate::ClimateCall &call) {
   }
 
   if (call.get_preset().has_value()) {
-    if (call.get_preset().value() == climate::CLIMATE_PRESET_COMFORT)
+    if (call.get_preset().value() == climate::CLIMATE_PRESET_COMFORT) {
       data_[POWER] |= COMFORT_PRESET_MASK;
-    else
+    } else {
       data_[POWER] &= ~COMFORT_PRESET_MASK;
+    }
   }
 
   if (call.get_target_temperature().has_value()) {
     float target = call.get_target_temperature().value() - MIN_VALID_TEMPERATURE;
 
-    data_[SET_TEMPERATURE] = (uint16) target;
+    data_[SET_TEMPERATURE] = (uint8) target;
 
     if ((int) target == std::lroundf(target)) {
       data_[POWER] &= ~DECIMAL_MASK;
@@ -245,7 +246,7 @@ void HaierClimate::control(const climate::ClimateCall &call) {
     }
   }
 
-  if (call.get_swing_mode().has_value())
+  if (call.get_swing_mode().has_value()) {
     switch (call.get_swing_mode().value()) {
       case climate::CLIMATE_SWING_OFF:
         data_[SWING] = SWING_OFF;
@@ -260,6 +261,7 @@ void HaierClimate::control(const climate::ClimateCall &call) {
         data_[SWING] = SWING_BOTH;
         break;
     }
+  }
 
   // Values for "send"
   data_[COMMAND] = 0;

--- a/esphome/components/haier/haier.cpp
+++ b/esphome/components/haier/haier.cpp
@@ -226,6 +226,7 @@ void HaierClimate::control(const climate::ClimateCall &call) {
       case climate::CLIMATE_FAN_MIDDLE:
       case climate::CLIMATE_FAN_FOCUS:
       case climate::CLIMATE_FAN_DIFFUSE:
+      case climate::CLIMATE_FAN_QUIET:
         break;
     }
   }

--- a/esphome/components/haier/haier.cpp
+++ b/esphome/components/haier/haier.cpp
@@ -1,0 +1,299 @@
+#include <cmath>
+#include "haier.h"
+#include "esphome/core/macros.h"
+
+namespace esphome {
+namespace haier {
+
+static const char *const TAG = "haier";
+
+void HaierClimate::dump_config() {
+  ESP_LOGCONFIG(TAG, "Haier:");
+  ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
+  dump_traits_(TAG);
+  this->check_uart_settings(9600);
+}
+
+void HaierClimate::loop() {
+  if (this->available()) {
+    if (this->read() != 255)
+      return;
+    if (this->read() != 255)
+      return;
+
+    data_[0] = 255;
+    data_[1] = 255;
+
+    this->read_array(data_ + 2, sizeof(data_) - 2);
+
+    read_state_(data_, sizeof(data_));
+  }
+}
+
+void HaierClimate::update() {
+  this->write_array(POLL_REQ, sizeof(POLL_REQ));
+  dump_message_("Poll sent", POLL_REQ, sizeof(POLL_REQ));
+}
+
+climate::ClimateTraits HaierClimate::traits() {
+  auto traits = climate::ClimateTraits();
+
+  traits.set_visual_min_temperature(MIN_VALID_TEMPERATURE);
+  traits.set_visual_max_temperature(MAX_VALID_TEMPERATURE);
+  traits.set_visual_temperature_step(TEMPERATURE_STEP);
+
+  traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL,
+                              climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY});
+
+  traits.set_supported_fan_modes({
+      climate::CLIMATE_FAN_AUTO,
+      climate::CLIMATE_FAN_LOW,
+      climate::CLIMATE_FAN_MEDIUM,
+      climate::CLIMATE_FAN_HIGH,
+  });
+
+  switch (supported_swing_mode_) {
+    case SWING_VERTICAL:
+      traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
+      break;
+
+    case SWING_HORIZONTAL:
+      traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL});
+      break;
+
+    case SWING_BOTH:
+      traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                        climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
+      break;
+    default:
+      break;
+  }
+
+  traits.set_supports_current_temperature(true);
+  traits.set_supports_two_point_target_temperature(false);
+
+  traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
+  traits.add_supported_preset(climate::CLIMATE_PRESET_COMFORT);
+
+  return traits;
+}
+
+void HaierClimate::read_state_(const uint8_t *data, uint8_t size) {
+  dump_message_("Received state", data, size);
+
+  uint8_t check = data[CRC];
+
+  uint8_t crc = get_checksum_(data, size);
+
+  if (check != crc) {
+    ESP_LOGW(TAG, "Invalid checksum");  // TODO more info
+    return;
+  }
+
+  if (MIN_VALID_TEMPERATURE < data[TEMPERATURE] && data[TEMPERATURE] < MAX_VALID_TEMPERATURE) {
+    this->current_temperature = data[TEMPERATURE];
+  }
+
+  this->target_temperature = data[SET_TEMPERATURE] + MIN_VALID_TEMPERATURE;
+
+  if (data[POWER] & DECIMAL_MASK) {
+    this->target_temperature += 0.5f;
+  }
+
+  switch (data[MODE]) {
+    case MODE_SMART:
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+      break;
+    case MODE_COOL:
+      this->mode = climate::CLIMATE_MODE_COOL;
+      break;
+    case MODE_HEAT:
+      this->mode = climate::CLIMATE_MODE_HEAT;
+      break;
+    case MODE_ONLY_FAN:
+      this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+      break;
+    case MODE_DRY:
+      this->mode = climate::CLIMATE_MODE_DRY;
+      break;
+    default:
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+  }
+
+  switch (data[FAN_SPEED]) {
+    case FAN_AUTO:
+      this->fan_mode = climate::CLIMATE_FAN_AUTO;
+      break;
+
+    case FAN_MIN:
+      this->fan_mode = climate::CLIMATE_FAN_LOW;
+      break;
+
+    case FAN_MIDDLE:
+      this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+      break;
+
+    case FAN_MAX:
+      this->fan_mode = climate::CLIMATE_FAN_HIGH;
+      break;
+  }
+
+  switch (data[SWING]) {
+    case SWING_OFF:
+      this->swing_mode = climate::CLIMATE_SWING_OFF;
+      break;
+
+    case SWING_VERTICAL:
+      this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+      break;
+
+    case SWING_HORIZONTAL:
+      this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+      break;
+
+    case SWING_BOTH:
+      this->swing_mode = climate::CLIMATE_SWING_BOTH;
+      break;
+  }
+
+  if (data[POWER] & COMFORT_PRESET_MASK) {
+    this->preset = climate::CLIMATE_PRESET_COMFORT;
+  } else {
+    this->preset = climate::CLIMATE_PRESET_NONE;
+  }
+
+  if ((data[POWER] & POWER_MASK) == 0) {
+    this->mode = climate::CLIMATE_MODE_OFF;
+  }
+
+  this->publish_state();
+}
+
+void HaierClimate::control(const climate::ClimateCall &call) {
+  if (call.get_mode().has_value()) {
+    switch (call.get_mode().value()) {
+      case climate::CLIMATE_MODE_OFF:
+        send_data(OFF_REQ, sizeof(OFF_REQ));
+        break;
+
+      case climate::CLIMATE_MODE_HEAT_COOL:
+      case climate::CLIMATE_MODE_AUTO:
+        data_[POWER] |= POWER_MASK;
+        data_[MODE] = MODE_SMART;
+        break;
+      case climate::CLIMATE_MODE_HEAT:
+        data_[POWER] |= POWER_MASK;
+        data_[MODE] = MODE_HEAT;
+        break;
+      case climate::CLIMATE_MODE_COOL:
+        data_[POWER] |= POWER_MASK;
+        data_[MODE] = MODE_COOL;
+        break;
+
+      case climate::CLIMATE_MODE_FAN_ONLY:
+        data_[POWER] |= POWER_MASK;
+        data_[MODE] = MODE_ONLY_FAN;
+        break;
+
+      case climate::CLIMATE_MODE_DRY:
+        data_[POWER] |= POWER_MASK;
+        data_[MODE] = MODE_DRY;
+        break;
+    }
+  }
+
+  if (call.get_preset().has_value()) {
+    if (call.get_preset().value() == climate::CLIMATE_PRESET_COMFORT)
+      data_[POWER] |= COMFORT_PRESET_MASK;
+    else
+      data_[POWER] &= ~COMFORT_PRESET_MASK;
+  }
+
+  if (call.get_target_temperature().has_value()) {
+    float target = call.get_target_temperature().value() - MIN_VALID_TEMPERATURE;
+
+    data_[SET_TEMPERATURE] = (uint16) target;
+
+    if ((int) target == std::lroundf(target)) {
+      data_[POWER] &= ~DECIMAL_MASK;
+    } else {
+      data_[POWER] |= DECIMAL_MASK;
+    }
+  }
+
+  if (call.get_fan_mode().has_value()) {
+    switch (call.get_fan_mode().value()) {
+      case climate::CLIMATE_FAN_AUTO:
+        data_[FAN_SPEED] = FAN_AUTO;
+        break;
+      case climate::CLIMATE_FAN_LOW:
+        data_[FAN_SPEED] = FAN_MIN;
+        break;
+      case climate::CLIMATE_FAN_MEDIUM:
+        data_[FAN_SPEED] = FAN_MIDDLE;
+        break;
+      case climate::CLIMATE_FAN_HIGH:
+        data_[FAN_SPEED] = FAN_MAX;
+        break;
+
+      case climate::CLIMATE_FAN_ON:
+      case climate::CLIMATE_FAN_OFF:
+      case climate::CLIMATE_FAN_MIDDLE:
+      case climate::CLIMATE_FAN_FOCUS:
+      case climate::CLIMATE_FAN_DIFFUSE:
+        break;
+    }
+  }
+
+  if (call.get_swing_mode().has_value())
+    switch (call.get_swing_mode().value()) {
+      case climate::CLIMATE_SWING_OFF:
+        data_[SWING] = SWING_OFF;
+        break;
+      case climate::CLIMATE_SWING_VERTICAL:
+        data_[SWING] = SWING_VERTICAL;
+        break;
+      case climate::CLIMATE_SWING_HORIZONTAL:
+        data_[SWING] = SWING_HORIZONTAL;
+        break;
+      case climate::CLIMATE_SWING_BOTH:
+        data_[SWING] = SWING_BOTH;
+        break;
+    }
+
+  // Values for "send"
+  data_[COMMAND] = 0;
+  data_[9] = 1;
+  data_[10] = 77;
+  data_[11] = 95;
+
+  send_data_(data_, sizeof(data_));
+}
+
+void HaierClimate::send_data_(const uint8_t *message, uint8_t size) {
+  uint8_t crc = get_checksum_(message, size);
+  this->write_array(message, size - 1);
+  this->write(crc);
+
+  dump_message_("Sent message", message, size);
+}
+
+void HaierClimate::dump_message_(const char *title, const uint8_t *message, uint8_t size) {
+  ESP_LOGV(TAG, "%s:", title);
+  for (int i = 0; i < size; i++) {
+    ESP_LOGV(TAG, "  byte %02d - %d", i, message[i]);
+  }
+}
+
+uint8_t HaierClimate::get_checksum_(const uint8_t *message, size_t size) {
+  uint8_t position = size - 1;
+  uint8_t crc = 0;
+
+  for (int i = 2; i < position; i++)
+    crc += message[i];
+
+  return crc;
+}
+
+}  // namespace haier
+}  // namespace esphome

--- a/esphome/components/haier/haier.cpp
+++ b/esphome/components/haier/haier.cpp
@@ -173,7 +173,7 @@ void HaierClimate::control(const climate::ClimateCall &call) {
   if (call.get_mode().has_value()) {
     switch (call.get_mode().value()) {
       case climate::CLIMATE_MODE_OFF:
-        send_data(OFF_REQ, sizeof(OFF_REQ));
+        send_data_(OFF_REQ, sizeof(OFF_REQ));
         break;
 
       case climate::CLIMATE_MODE_HEAT_COOL:

--- a/esphome/components/haier/haier.cpp
+++ b/esphome/components/haier/haier.cpp
@@ -52,23 +52,7 @@ climate::ClimateTraits HaierClimate::traits() {
       climate::CLIMATE_FAN_HIGH,
   });
 
-  switch (supported_swing_mode_) {
-    case SWING_VERTICAL:
-      traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
-      break;
-
-    case SWING_HORIZONTAL:
-      traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL});
-      break;
-
-    case SWING_BOTH:
-      traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
-                                        climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
-      break;
-    default:
-      break;
-  }
-
+  traits.set_supported_swing_modes(this->supported_swing_modes_);
   traits.set_supports_current_temperature(true);
   traits.set_supports_two_point_target_temperature(false);
 

--- a/esphome/components/haier/haier.cpp
+++ b/esphome/components/haier/haier.cpp
@@ -213,7 +213,7 @@ void HaierClimate::control(const climate::ClimateCall &call) {
   if (call.get_target_temperature().has_value()) {
     float target = call.get_target_temperature().value() - MIN_VALID_TEMPERATURE;
 
-    data_[SET_TEMPERATURE] = (uint8) target;
+    data_[SET_TEMPERATURE] = (uint8_t) target;
 
     if ((int) target == std::lroundf(target)) {
       data_[POWER] &= ~DECIMAL_MASK;

--- a/esphome/components/haier/haier.h
+++ b/esphome/components/haier/haier.h
@@ -7,45 +7,12 @@
 namespace esphome {
 namespace haier {
 
-static const uint8_t TEMPERATURE = 13;
-static const uint8_t HUMIDITY = 15;
-static const uint8_t COMMAND = 17;
-
-static const uint8_t MODE = 23;
 enum Mode : uint8_t { MODE_SMART = 0, MODE_COOL = 1, MODE_HEAT = 2, MODE_ONLY_FAN = 3, MODE_DRY = 4 };
-
-static const uint8_t FAN_SPEED = 25;
 enum FanSpeed : uint8_t { FAN_MAX = 0, FAN_MIDDLE = 1, FAN_MIN = 2, FAN_AUTO = 3 };
-
-static const uint8_t SWING = 27;
 enum SwingMode : uint8_t { SWING_OFF = 0, SWING_VERTICAL = 1, SWING_HORIZONTAL = 2, SWING_BOTH = 3 };
 
-static const uint8_t POWER = 29;
-static const uint8_t POWER_MASK = 1;
-
-static const uint8_t SET_TEMPERATURE = 35;
-static const uint8_t DECIMAL_MASK = (1 << 5);
-
-static const uint8_t CRC = 36;
-
-static const uint8_t COMFORT_PRESET_MASK = (1 << 3);
-
-static const uint8_t MIN_VALID_TEMPERATURE = 16;
-static const uint8_t MAX_VALID_TEMPERATURE = 50;
-static const float TEMPERATURE_STEP = 0.5f;
-
-static const uint8_t POLL_REQ[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 1, 90};
-static const uint8_t OFF_REQ[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 3, 92};
-
 class HaierClimate : public climate::Climate, public uart::UARTDevice, public PollingComponent {
- private:
-  uint8_t data_[37];
-  std::set<climate::ClimateSwingMode> supported_swing_modes_{};
-
  public:
-  HaierClimate() : PollingComponent(5 * 1000) {}
-
-  void setup() override {}
   void loop() override;
   void update() override;
   void dump_config() override;
@@ -60,6 +27,10 @@ class HaierClimate : public climate::Climate, public uart::UARTDevice, public Po
   void send_data_(const uint8_t *message, uint8_t size);
   void dump_message_(const char *title, const uint8_t *message, uint8_t size);
   uint8_t get_checksum_(const uint8_t *message, size_t size);
+
+ private:
+  uint8_t data_[37];
+  std::set<climate::ClimateSwingMode> supported_swing_modes_{};
 };
 
 }  // namespace haier

--- a/esphome/components/haier/haier.h
+++ b/esphome/components/haier/haier.h
@@ -7,8 +7,6 @@
 namespace esphome {
 namespace haier {
 
-static const char *const TAG = "haier";
-
 static const uint8_t TEMPERATURE = 13;
 static const uint8_t HUMIDITY = 15;
 static const uint8_t COMMAND = 17;
@@ -41,308 +39,26 @@ static const uint8_t OFF_REQ[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 3, 92
 
 class HaierClimate : public climate::Climate, public uart::UARTDevice, public PollingComponent {
  private:
-  uint8_t data[37];
-
-  SwingMode supported_swing_mode;
+  uint8_t data_[37];
+  SwingMode supported_swing_mode_;
 
  public:
   HaierClimate(SwingMode supported_swing_mode) : PollingComponent(5 * 1000) {
-    this->supported_swing_mode = supported_swing_mode;
+    this->supported_swing_mode_ = supported_swing_mode;
   }
 
   void setup() override {}
-
-  void loop() override {
-    if (this->available()) {
-      if (this->read() != 255)
-        return;
-      if (this->read() != 255)
-        return;
-
-      data[0] = 255;
-      data[1] = 255;
-
-      this->read_array(data + 2, sizeof(data) - 2);
-
-      readData();
-    }
-  }
-
-  void update() override {
-    this->write_array(POLL_REQ, sizeof(POLL_REQ));
-    ESP_LOGV("Haier", "POLL: %s ", bytesToString(POLL_REQ, sizeof(POLL_REQ)).c_str());
-  }
-
-  void dump_config() {
-    ESP_LOGCONFIG(TAG, "Haier:");
-    ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
-    dump_traits_(TAG);
-    this->check_uart_settings(9600);
-  }
+  void loop() override;
+  void update() override;
+  void dump_config() override;
+  void control(const climate::ClimateCall &call) override;
 
  protected:
-  climate::ClimateTraits traits() override {
-    auto traits = climate::ClimateTraits();
-
-    traits.set_visual_min_temperature(MIN_VALID_TEMPERATURE);
-    traits.set_visual_max_temperature(MAX_VALID_TEMPERATURE);
-    traits.set_visual_temperature_step(TEMPERATURE_STEP);
-
-    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL,
-                                climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY});
-
-    traits.set_supported_fan_modes({
-        climate::CLIMATE_FAN_AUTO,
-        climate::CLIMATE_FAN_LOW,
-        climate::CLIMATE_FAN_MEDIUM,
-        climate::CLIMATE_FAN_HIGH,
-    });
-
-    switch (supported_swing_mode) {
-      case SWING_VERTICAL:
-        traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
-        break;
-
-      case SWING_HORIZONTAL:
-        traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL});
-        break;
-
-      case SWING_BOTH:
-        traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
-                                          climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
-        break;
-      default:
-        break;
-    }
-
-    traits.set_supports_current_temperature(true);
-    traits.set_supports_two_point_target_temperature(false);
-
-    traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
-    traits.add_supported_preset(climate::CLIMATE_PRESET_COMFORT);
-
-    return traits;
-  }
-
- public:
-  void readData() {
-    ESP_LOGV(TAG, "Readed message: %s ", bytesToString(data, sizeof(data)).c_str());
-
-    uint8_t check = data[CRC];
-
-    uint8_t crc = getChecksum(data, sizeof(data));
-
-    if (check != crc) {
-      ESP_LOGW(TAG, "Invalid checksum");  // TODO more info
-      return;
-    }
-
-    if (MIN_VALID_TEMPERATURE < data[TEMPERATURE] && data[TEMPERATURE] < MAX_VALID_TEMPERATURE) {
-      this->current_temperature = data[TEMPERATURE];
-    }
-
-    this->target_temperature = data[SET_TEMPERATURE] + MIN_VALID_TEMPERATURE;
-
-    if (data[POWER] & DECIMAL_MASK) {
-      this->target_temperature += 0.5f;
-    }
-
-    switch (data[MODE]) {
-      case MODE_SMART:
-        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-        break;
-      case MODE_COOL:
-        this->mode = climate::CLIMATE_MODE_COOL;
-        break;
-      case MODE_HEAT:
-        this->mode = climate::CLIMATE_MODE_HEAT;
-        break;
-      case MODE_ONLY_FAN:
-        this->mode = climate::CLIMATE_MODE_FAN_ONLY;
-        break;
-      case MODE_DRY:
-        this->mode = climate::CLIMATE_MODE_DRY;
-        break;
-      default:
-        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-    }
-
-    switch (data[FAN_SPEED]) {
-      case FAN_AUTO:
-        this->fan_mode = climate::CLIMATE_FAN_AUTO;
-        break;
-
-      case FAN_MIN:
-        this->fan_mode = climate::CLIMATE_FAN_LOW;
-        break;
-
-      case FAN_MIDDLE:
-        this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-        break;
-
-      case FAN_MAX:
-        this->fan_mode = climate::CLIMATE_FAN_HIGH;
-        break;
-    }
-
-    switch (data[SWING]) {
-      case SWING_OFF:
-        this->swing_mode = climate::CLIMATE_SWING_OFF;
-        break;
-
-      case SWING_VERTICAL:
-        this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-        break;
-
-      case SWING_HORIZONTAL:
-        this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-        break;
-
-      case SWING_BOTH:
-        this->swing_mode = climate::CLIMATE_SWING_BOTH;
-        break;
-    }
-
-    if (data[POWER] & COMFORT_PRESET_MASK)
-      this->preset = climate::CLIMATE_PRESET_COMFORT;
-    else
-      this->preset = climate::CLIMATE_PRESET_NONE;
-
-    if ((data[POWER] & POWER_MASK) == 0) {
-      this->mode = climate::CLIMATE_MODE_OFF;
-    }
-
-    this->publish_state();
-  }
-
-  void control(const climate::ClimateCall &call) override {
-    if (call.get_mode().has_value()) {
-      switch (call.get_mode().value()) {
-        case climate::CLIMATE_MODE_OFF:
-          sendData(OFF_REQ, sizeof(OFF_REQ));
-          break;
-
-        case climate::CLIMATE_MODE_HEAT_COOL:
-        case climate::CLIMATE_MODE_AUTO:
-          data[POWER] |= POWER_MASK;
-          data[MODE] = MODE_SMART;
-          break;
-        case climate::CLIMATE_MODE_HEAT:
-          data[POWER] |= POWER_MASK;
-          data[MODE] = MODE_HEAT;
-          break;
-        case climate::CLIMATE_MODE_COOL:
-          data[POWER] |= POWER_MASK;
-          data[MODE] = MODE_COOL;
-          break;
-
-        case climate::CLIMATE_MODE_FAN_ONLY:
-          data[POWER] |= POWER_MASK;
-          data[MODE] = MODE_ONLY_FAN;
-          break;
-
-        case climate::CLIMATE_MODE_DRY:
-          data[POWER] |= POWER_MASK;
-          data[MODE] = MODE_DRY;
-          break;
-      }
-    }
-
-    if (call.get_preset().has_value()) {
-      if (call.get_preset().value() == climate::CLIMATE_PRESET_COMFORT)
-        data[POWER] |= COMFORT_PRESET_MASK;
-      else
-        data[POWER] &= ~COMFORT_PRESET_MASK;
-    }
-
-    if (call.get_target_temperature().has_value()) {
-      float target = call.get_target_temperature().value() - MIN_VALID_TEMPERATURE;
-
-      data[SET_TEMPERATURE] = (uint16) target;
-
-      if ((int) target == (int) (target + 0.5))
-        data[POWER] &= ~DECIMAL_MASK;
-      else
-        data[POWER] |= DECIMAL_MASK;
-    }
-
-    if (call.get_fan_mode().has_value()) {
-      switch (call.get_fan_mode().value()) {
-        case climate::CLIMATE_FAN_AUTO:
-          data[FAN_SPEED] = FAN_AUTO;
-          break;
-        case climate::CLIMATE_FAN_LOW:
-          data[FAN_SPEED] = FAN_MIN;
-          break;
-        case climate::CLIMATE_FAN_MEDIUM:
-          data[FAN_SPEED] = FAN_MIDDLE;
-          break;
-        case climate::CLIMATE_FAN_HIGH:
-          data[FAN_SPEED] = FAN_MAX;
-          break;
-
-        case climate::CLIMATE_FAN_ON:
-        case climate::CLIMATE_FAN_OFF:
-        case climate::CLIMATE_FAN_MIDDLE:
-        case climate::CLIMATE_FAN_FOCUS:
-        case climate::CLIMATE_FAN_DIFFUSE:
-          break;
-      }
-    }
-
-    if (call.get_swing_mode().has_value())
-      switch (call.get_swing_mode().value()) {
-        case climate::CLIMATE_SWING_OFF:
-          data[SWING] = SWING_OFF;
-          break;
-        case climate::CLIMATE_SWING_VERTICAL:
-          data[SWING] = SWING_VERTICAL;
-          break;
-        case climate::CLIMATE_SWING_HORIZONTAL:
-          data[SWING] = SWING_HORIZONTAL;
-          break;
-        case climate::CLIMATE_SWING_BOTH:
-          data[SWING] = SWING_BOTH;
-          break;
-      }
-
-    // Values for "send"
-    data[COMMAND] = 0;
-    data[9] = 1;
-    data[10] = 77;
-    data[11] = 95;
-
-    sendData(data, sizeof(data));
-  }
-
-  void sendData(const uint8_t *message, uint8_t size) {
-    uint8_t crc = getChecksum(message, size);
-    this->write_array(message, size - 1);
-    this->write(crc);
-
-    ESP_LOGV(TAG, "Sended message: %s ", bytesToString(message, size).c_str());
-  }
-
-  String bytesToString(const uint8_t *message, uint8_t size) {
-    String raw;
-
-    for (int i = 0; i < size; i++) {
-      raw += "\n" + String(i) + "-" + String(message[i]);
-    }
-    raw.toUpperCase();
-
-    return raw;
-  }
-
-  uint8_t getChecksum(const uint8_t *message, size_t size) {
-    uint8_t position = size - 1;
-    uint8_t crc = 0;
-
-    for (int i = 2; i < position; i++)
-      crc += message[i];
-
-    return crc;
-  }
+  climate::ClimateTraits traits() override;
+  void read_state_(const uint8_t *data, uint8_t size);
+  void send_data_(const uint8_t *message, uint8_t size);
+  void dump_message_(const char *title, const uint8_t *message, uint8_t size);
+  uint8_t get_checksum_(const uint8_t *message, size_t size);
 };
 
 }  // namespace haier

--- a/esphome/components/haier/haier.h
+++ b/esphome/components/haier/haier.h
@@ -40,18 +40,19 @@ static const uint8_t OFF_REQ[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 3, 92
 class HaierClimate : public climate::Climate, public uart::UARTDevice, public PollingComponent {
  private:
   uint8_t data_[37];
-  SwingMode supported_swing_mode_;
+  std::set<climate::ClimateSwingMode> supported_swing_modes_{};
 
  public:
-  HaierClimate(SwingMode supported_swing_mode) : PollingComponent(5 * 1000) {
-    this->supported_swing_mode_ = supported_swing_mode;
-  }
+  HaierClimate() : PollingComponent(5 * 1000) {}
 
   void setup() override {}
   void loop() override;
   void update() override;
   void dump_config() override;
   void control(const climate::ClimateCall &call) override;
+  void set_supported_swing_modes(const std::set<climate::ClimateSwingMode> &modes) {
+    this->supported_swing_modes_ = modes;
+  }
 
  protected:
   climate::ClimateTraits traits() override;

--- a/esphome/components/haier/haier.h
+++ b/esphome/components/haier/haier.h
@@ -1,0 +1,433 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace haier {
+
+static const char *const TAG = "haier";
+
+
+static const uint8_t TEMPERATURE         13
+static const uint8_t HUMIDITY            15
+
+static const uint8_t COMMAND             17
+
+
+static const uint8_t MODE                23
+static const uint8_t MODE_SMART          0
+static const uint8_t MODE_COOL           1
+static const uint8_t MODE_HEAT           2
+static const uint8_t MODE_ONLY_FAN       3
+static const uint8_t MODE_DRY            4
+
+static const uint8_t FAN_SPEED           25
+static const uint8_t FAN_MIN             2
+static const uint8_t FAN_MIDDLE          1
+static const uint8_t FAN_MAX             0
+static const uint8_t FAN_AUTO            3
+
+static const uint8_t SWING               27
+static const uint8_t SWING_MODE          31
+static const uint8_t SWING_OFF           00
+static const uint8_t SWING_VERTICAL      01
+static const uint8_t SWING_HORIZONTAL    02
+static const uint8_t SWING_BOTH          01
+
+
+static const uint8_t SWING_HORIZONTAL_MASK   (1 << 3)
+static const uint8_t SWING_VERTICAL_MASK     (1 << 4)
+
+
+static const uint8_t LOCK                28
+static const uint8_t LOCK_ON             80
+static const uint8_t LOCK_OFF            0
+
+
+static const uint8_t POWER               29
+static const uint8_t POWER_MASK          1
+
+
+static const uint8_t FRESH               31
+static const uint8_t FRESH_ON            1
+static const uint8_t FRESH_OFF           0
+
+
+static const uint8_t SET_TEMPERATURE     35
+static const uint8_t DECIMAL_MASK        (1 << 5)
+
+
+static const uint8_t CRC                 36
+
+
+static const uint8_t CONFORT_PRESET_MASK     (1 << 3)
+
+
+static const uint8_t MIN_SET_TEMPERATURE 16
+static const uint8_t MAX_SET_TEMPERATURE 30
+static const uint8_t STEP_TEMPERATURE 0.5f
+
+
+static const uint8_t MIN_VALID_TEMPERATURE 10
+static const uint8_t MAX_VALID_TEMPERATURE 50
+
+
+class Haier : public climate::Climate, public uart::UARTDevice, public PollingComponent {
+
+private:
+
+    uint8_t lastCRC;
+    uint8_t data[37];
+    uint8_t poll[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 1, 90};
+    uint8_t on[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 2, 91};
+    uint8_t off[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 3, 92};
+
+    bool swing;
+
+public:
+
+
+    Haier() : PollingComponent(5 * 1000) {
+        lastCRC = 0;
+        this->swing = true;
+    }
+
+
+    void setup() override {
+
+    }
+
+    void loop() override {
+        if (this->available()) {
+
+            if (this->read() != 255) return;
+            if (this->read() != 255) return;
+
+            data[0] = 255;
+            data[1] = 255;
+
+            this->read_array(data + 2, sizeof(data) - 2);
+
+            readData();
+        }
+    }
+
+    void update() override {
+        this->write_array(poll, sizeof(poll));
+        auto raw = getHex(poll, sizeof(poll));
+        ESP_LOGD("Haier", "POLL: %s ", raw.c_str());
+    }
+
+    void dump_config() {
+      ESP_LOGCONFIG(TAG, "Haier:");
+      ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
+      this->check_uart_settings(9600);
+    }
+
+protected:
+    climate::ClimateTraits traits() override {
+        auto traits = climate::ClimateTraits();
+
+
+        traits.set_supported_modes({
+                                           climate::CLIMATE_MODE_OFF,
+                                           climate::CLIMATE_MODE_HEAT_COOL,
+                                           climate::CLIMATE_MODE_COOL,
+                                           climate::CLIMATE_MODE_HEAT,
+                                           climate::CLIMATE_MODE_FAN_ONLY,
+                                           climate::CLIMATE_MODE_DRY
+                                   });
+
+        traits.set_supported_fan_modes({
+                                               climate::CLIMATE_FAN_AUTO,
+                                               climate::CLIMATE_FAN_LOW,
+                                               climate::CLIMATE_FAN_MEDIUM,
+                                               climate::CLIMATE_FAN_HIGH,
+                                       });
+
+
+        if (swing) {
+            traits.set_supported_swing_modes({
+                                                     climate::CLIMATE_SWING_OFF,
+                                                     climate::CLIMATE_SWING_BOTH,
+                                                     climate::CLIMATE_SWING_VERTICAL,
+                                                     climate::CLIMATE_SWING_HORIZONTAL
+                                             });
+        }
+
+        traits.set_visual_min_temperature(MIN_SET_TEMPERATURE);
+        traits.set_visual_max_temperature(MAX_SET_TEMPERATURE);
+        traits.set_visual_temperature_step(STEP_TEMPERATURE);
+        traits.set_supports_current_temperature(true);
+        traits.set_supports_two_point_target_temperature(false);
+
+
+        traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
+        traits.add_supported_preset(climate::CLIMATE_PRESET_COMFORT);
+
+
+        return traits;
+    }
+
+public:
+
+    void readData() {
+
+
+        auto raw = getHex(data, sizeof(data));
+        ESP_LOGD("Haier", "Readed message: %s ", raw.c_str());
+
+
+        uint8_t check = data[CRC];
+
+        getChecksum(data, sizeof(data));
+
+        if (check != data[CRC]) {
+            ESP_LOGD("Haier", "Invalid checksum");
+            return;
+        }
+
+
+        lastCRC = check;
+
+
+        if (MIN_VALID_TEMPERATURE < data[TEMPERATURE] && data[TEMPERATURE] < MAX_VALID_TEMPERATURE)
+            current_temperature = data[TEMPERATURE];
+
+
+        target_temperature = data[SET_TEMPERATURE] + 16;
+
+
+        if (data[POWER] & DECIMAL_MASK)
+            target_temperature += 0.5f;
+
+
+        switch (data[MODE]) {
+            case MODE_SMART:
+                mode = climate::CLIMATE_MODE_HEAT_COOL;
+                break;
+            case MODE_COOL:
+                mode = climate::CLIMATE_MODE_COOL;
+                break;
+            case MODE_HEAT:
+                mode = climate::CLIMATE_MODE_HEAT;
+                break;
+            case MODE_ONLY_FAN:
+                mode = climate::CLIMATE_MODE_FAN_ONLY;
+                break;
+            case MODE_DRY:
+                mode = climate::CLIMATE_MODE_DRY;
+                break;
+            default:
+                mode = climate::CLIMATE_MODE_HEAT_COOL;
+        }
+
+
+        switch (data[FAN_SPEED]) {
+            case FAN_AUTO:
+                fan_mode = climate::CLIMATE_FAN_AUTO;
+                break;
+
+            case FAN_MIN:
+                fan_mode = climate::CLIMATE_FAN_LOW;
+                break;
+
+            case FAN_MIDDLE:
+                fan_mode = climate::CLIMATE_FAN_MEDIUM;
+                break;
+
+            case FAN_MAX:
+                fan_mode = climate::CLIMATE_FAN_HIGH;
+                break;
+        }
+
+
+        if (data[SWING] == SWING_OFF) {
+            if (data[SWING_MODE] & SWING_HORIZONTAL_MASK)
+                swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+            else if (data[SWING_MODE] & SWING_VERTICAL_MASK)
+                swing_mode = climate::CLIMATE_SWING_VERTICAL;
+            else
+                swing_mode = climate::CLIMATE_SWING_OFF;
+        } else if (data[SWING] == SWING_BOTH)
+            swing_mode = climate::CLIMATE_SWING_BOTH;
+
+
+        if (data[POWER] & CONFORT_PRESET_MASK)
+            preset = climate::CLIMATE_PRESET_COMFORT;
+        else
+            preset = climate::CLIMATE_PRESET_NONE;
+
+
+        if ((data[POWER] & POWER_MASK) == 0) {
+            mode = climate::CLIMATE_MODE_OFF;
+        }
+
+
+        this->publish_state();
+
+    }
+
+
+    void control(const climate::ClimateCall &call) override {
+        if (call.get_mode().has_value()) {
+            switch (call.get_mode().value()) {
+                case climate::CLIMATE_MODE_OFF:
+                    sendData(off, sizeof(off));
+                    break;
+
+                case climate::CLIMATE_MODE_HEAT_COOL:
+                case climate::CLIMATE_MODE_AUTO:
+                    data[POWER] |= POWER_MASK;
+                    data[MODE] = MODE_SMART;
+                    break;
+                case climate::CLIMATE_MODE_HEAT:
+                    data[POWER] |= POWER_MASK;
+                    data[MODE] = MODE_HEAT;
+                    break;
+                case climate::CLIMATE_MODE_COOL:
+                    data[POWER] |= POWER_MASK;
+                    data[MODE] = MODE_COOL;
+                    break;
+
+                case climate::CLIMATE_MODE_FAN_ONLY:
+                    data[POWER] |= POWER_MASK;
+                    data[MODE] = MODE_ONLY_FAN;
+                    break;
+
+                case climate::CLIMATE_MODE_DRY:
+                    data[POWER] |= POWER_MASK;
+                    data[MODE] = MODE_DRY;
+                    break;
+
+            }
+
+        }
+
+
+        if (call.get_preset().has_value()) {
+
+
+            if (call.get_preset().value() == climate::CLIMATE_PRESET_COMFORT)
+                data[POWER] |= CONFORT_PRESET_MASK;
+            else
+                data[POWER] &= ~CONFORT_PRESET_MASK;
+
+
+        }
+
+
+        if (call.get_target_temperature().has_value()) {
+
+            float target = call.get_target_temperature().value() - 16;
+
+            data[SET_TEMPERATURE] = (uint16) target;
+
+            if ((int) target == (int) (target + 0.5))
+                data[POWER] &= ~DECIMAL_MASK;
+            else
+                data[POWER] |= DECIMAL_MASK;
+
+        }
+
+        if (call.get_fan_mode().has_value()) {
+            switch (call.get_fan_mode().value()) {
+                case climate::CLIMATE_FAN_AUTO:
+                    data[FAN_SPEED] = FAN_AUTO;
+                    break;
+                case climate::CLIMATE_FAN_LOW:
+                    data[FAN_SPEED] = FAN_MIN;
+                    break;
+                case climate::CLIMATE_FAN_MEDIUM:
+                    data[FAN_SPEED] = FAN_MIDDLE;
+                    break;
+                case climate::CLIMATE_FAN_HIGH:
+                    data[FAN_SPEED] = FAN_MAX;
+                    break;
+
+                case climate::CLIMATE_FAN_ON:
+                case climate::CLIMATE_FAN_OFF:
+                case climate::CLIMATE_FAN_MIDDLE:
+                case climate::CLIMATE_FAN_FOCUS:
+                case climate::CLIMATE_FAN_DIFFUSE:
+                    break;
+            }
+
+        }
+
+
+        if (call.get_swing_mode().has_value())
+            switch (call.get_swing_mode().value()) {
+                case climate::CLIMATE_SWING_OFF:
+                    data[SWING] = SWING_OFF;
+                    data[SWING_MODE] &= ~1;
+                    break;
+                case climate::CLIMATE_SWING_VERTICAL:
+                    data[SWING] = SWING_OFF;
+                    data[SWING_MODE] |= SWING_VERTICAL_MASK;
+                    data[SWING_MODE] &= ~SWING_HORIZONTAL_MASK;
+                    break;
+                case climate::CLIMATE_SWING_HORIZONTAL:
+                    data[SWING] = SWING_OFF;
+                    data[SWING_MODE] |= SWING_HORIZONTAL_MASK;
+                    data[SWING_MODE] &= ~SWING_VERTICAL_MASK;
+                    break;
+                case climate::CLIMATE_SWING_BOTH:
+                    data[SWING] = SWING_BOTH;
+                    data[SWING_MODE] &= ~SWING_HORIZONTAL_MASK;
+                    data[SWING_MODE] &= ~SWING_VERTICAL_MASK;
+                    break;
+            }
+
+
+
+
+
+        //Values for "send"
+        data[COMMAND] = 0;
+        data[9] = 1;
+        data[10] = 77;
+        data[11] = 95;
+
+        sendData(data, sizeof(data));
+    }
+
+
+    void sendData(uint8_t *message, uint8_t size) {
+        uint8_t crc = getChecksum(message, size);
+        this->write_array(message, size - 1);
+        this->write(crc);
+
+        auto raw = getHex(message, size);
+        ESP_LOGD("Haier", "Sended message: %s ", raw.c_str());
+    }
+
+    String getHex(uint8_t *message, uint8_t size) {
+        String raw;
+
+        for (int i = 0; i < size; i++) {
+            raw += "\n" + String(i) + "-" + String(message[i]);
+
+        }
+        raw.toUpperCase();
+
+        return raw;
+    }
+
+    uint8_t getChecksum(const uint8_t *message, size_t size) {
+        uint8_t position = size - 1;
+        uint8_t crc = 0;
+
+        for (int i = 2; i < position; i++)
+            crc += message[i];
+
+        return crc;
+
+    }
+};
+
+
+}  // namespace haier
+}  // namespace esphome

--- a/esphome/components/haier/haier.h
+++ b/esphome/components/haier/haier.h
@@ -9,425 +9,341 @@ namespace haier {
 
 static const char *const TAG = "haier";
 
+static const uint8_t TEMPERATURE = 13;
+static const uint8_t HUMIDITY = 15;
+static const uint8_t COMMAND = 17;
 
-static const uint8_t TEMPERATURE         13
-static const uint8_t HUMIDITY            15
+static const uint8_t MODE = 23;
+enum Mode : uint8_t { MODE_SMART = 0, MODE_COOL = 1, MODE_HEAT = 2, MODE_ONLY_FAN = 3, MODE_DRY = 4 };
 
-static const uint8_t COMMAND             17
+static const uint8_t FAN_SPEED = 25;
+enum FanSpeed : uint8_t { FAN_MAX = 0, FAN_MIDDLE = 1, FAN_MIN = 2, FAN_AUTO = 3 };
 
+static const uint8_t SWING = 27;
+enum SwingMode : uint8_t { SWING_OFF = 0, SWING_VERTICAL = 1, SWING_HORIZONTAL = 2, SWING_BOTH = 3 };
 
-static const uint8_t MODE                23
-static const uint8_t MODE_SMART          0
-static const uint8_t MODE_COOL           1
-static const uint8_t MODE_HEAT           2
-static const uint8_t MODE_ONLY_FAN       3
-static const uint8_t MODE_DRY            4
+static const uint8_t POWER = 29;
+static const uint8_t POWER_MASK = 1;
 
-static const uint8_t FAN_SPEED           25
-static const uint8_t FAN_MIN             2
-static const uint8_t FAN_MIDDLE          1
-static const uint8_t FAN_MAX             0
-static const uint8_t FAN_AUTO            3
+static const uint8_t SET_TEMPERATURE = 35;
+static const uint8_t DECIMAL_MASK = (1 << 5);
 
-static const uint8_t SWING               27
-static const uint8_t SWING_MODE          31
-static const uint8_t SWING_OFF           00
-static const uint8_t SWING_VERTICAL      01
-static const uint8_t SWING_HORIZONTAL    02
-static const uint8_t SWING_BOTH          01
+static const uint8_t CRC = 36;
 
+static const uint8_t COMFORT_PRESET_MASK = (1 << 3);
 
-static const uint8_t SWING_HORIZONTAL_MASK   (1 << 3)
-static const uint8_t SWING_VERTICAL_MASK     (1 << 4)
+static const uint8_t MIN_VALID_TEMPERATURE = 16;
+static const uint8_t MAX_VALID_TEMPERATURE = 50;
+static const float TEMPERATURE_STEP = 0.5f;
 
+static const uint8_t POLL_REQ[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 1, 90};
+static const uint8_t OFF_REQ[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 3, 92};
 
-static const uint8_t LOCK                28
-static const uint8_t LOCK_ON             80
-static const uint8_t LOCK_OFF            0
+class HaierClimate : public climate::Climate, public uart::UARTDevice, public PollingComponent {
+ private:
+  uint8_t data[37];
 
+  SwingMode supported_swing_mode;
 
-static const uint8_t POWER               29
-static const uint8_t POWER_MASK          1
+ public:
+  HaierClimate(SwingMode supported_swing_mode) : PollingComponent(5 * 1000) {
+    this->supported_swing_mode = supported_swing_mode;
+  }
 
+  void setup() override {}
 
-static const uint8_t FRESH               31
-static const uint8_t FRESH_ON            1
-static const uint8_t FRESH_OFF           0
+  void loop() override {
+    if (this->available()) {
+      if (this->read() != 255)
+        return;
+      if (this->read() != 255)
+        return;
 
+      data[0] = 255;
+      data[1] = 255;
 
-static const uint8_t SET_TEMPERATURE     35
-static const uint8_t DECIMAL_MASK        (1 << 5)
+      this->read_array(data + 2, sizeof(data) - 2);
 
+      readData();
+    }
+  }
 
-static const uint8_t CRC                 36
+  void update() override {
+    this->write_array(POLL_REQ, sizeof(POLL_REQ));
+    ESP_LOGV("Haier", "POLL: %s ", bytesToString(POLL_REQ, sizeof(POLL_REQ)).c_str());
+  }
 
+  void dump_config() {
+    ESP_LOGCONFIG(TAG, "Haier:");
+    ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
+    dump_traits_(TAG);
+    this->check_uart_settings(9600);
+  }
 
-static const uint8_t CONFORT_PRESET_MASK     (1 << 3)
+ protected:
+  climate::ClimateTraits traits() override {
+    auto traits = climate::ClimateTraits();
 
+    traits.set_visual_min_temperature(MIN_VALID_TEMPERATURE);
+    traits.set_visual_max_temperature(MAX_VALID_TEMPERATURE);
+    traits.set_visual_temperature_step(TEMPERATURE_STEP);
 
-static const uint8_t MIN_SET_TEMPERATURE 16
-static const uint8_t MAX_SET_TEMPERATURE 30
-static const uint8_t STEP_TEMPERATURE 0.5f
+    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL,
+                                climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY});
 
+    traits.set_supported_fan_modes({
+        climate::CLIMATE_FAN_AUTO,
+        climate::CLIMATE_FAN_LOW,
+        climate::CLIMATE_FAN_MEDIUM,
+        climate::CLIMATE_FAN_HIGH,
+    });
 
-static const uint8_t MIN_VALID_TEMPERATURE 10
-static const uint8_t MAX_VALID_TEMPERATURE 50
+    switch (supported_swing_mode) {
+      case SWING_VERTICAL:
+        traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
+        break;
 
+      case SWING_HORIZONTAL:
+        traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL});
+        break;
 
-class Haier : public climate::Climate, public uart::UARTDevice, public PollingComponent {
-
-private:
-
-    uint8_t lastCRC;
-    uint8_t data[37];
-    uint8_t poll[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 1, 90};
-    uint8_t on[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 2, 91};
-    uint8_t off[13] = {255, 255, 10, 0, 0, 0, 0, 0, 1, 1, 77, 3, 92};
-
-    bool swing;
-
-public:
-
-
-    Haier() : PollingComponent(5 * 1000) {
-        lastCRC = 0;
-        this->swing = true;
+      case SWING_BOTH:
+        traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                          climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
+        break;
+      default:
+        break;
     }
 
+    traits.set_supports_current_temperature(true);
+    traits.set_supports_two_point_target_temperature(false);
 
-    void setup() override {
+    traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
+    traits.add_supported_preset(climate::CLIMATE_PRESET_COMFORT);
 
+    return traits;
+  }
+
+ public:
+  void readData() {
+    ESP_LOGV(TAG, "Readed message: %s ", bytesToString(data, sizeof(data)).c_str());
+
+    uint8_t check = data[CRC];
+
+    uint8_t crc = getChecksum(data, sizeof(data));
+
+    if (check != crc) {
+      ESP_LOGW(TAG, "Invalid checksum");  // TODO more info
+      return;
     }
 
-    void loop() override {
-        if (this->available()) {
-
-            if (this->read() != 255) return;
-            if (this->read() != 255) return;
-
-            data[0] = 255;
-            data[1] = 255;
-
-            this->read_array(data + 2, sizeof(data) - 2);
-
-            readData();
-        }
+    if (MIN_VALID_TEMPERATURE < data[TEMPERATURE] && data[TEMPERATURE] < MAX_VALID_TEMPERATURE) {
+      this->current_temperature = data[TEMPERATURE];
     }
 
-    void update() override {
-        this->write_array(poll, sizeof(poll));
-        auto raw = getHex(poll, sizeof(poll));
-        ESP_LOGD("Haier", "POLL: %s ", raw.c_str());
+    this->target_temperature = data[SET_TEMPERATURE] + MIN_VALID_TEMPERATURE;
+
+    if (data[POWER] & DECIMAL_MASK) {
+      this->target_temperature += 0.5f;
     }
 
-    void dump_config() {
-      ESP_LOGCONFIG(TAG, "Haier:");
-      ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
-      this->check_uart_settings(9600);
+    switch (data[MODE]) {
+      case MODE_SMART:
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+        break;
+      case MODE_COOL:
+        this->mode = climate::CLIMATE_MODE_COOL;
+        break;
+      case MODE_HEAT:
+        this->mode = climate::CLIMATE_MODE_HEAT;
+        break;
+      case MODE_ONLY_FAN:
+        this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      case MODE_DRY:
+        this->mode = climate::CLIMATE_MODE_DRY;
+        break;
+      default:
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     }
 
-protected:
-    climate::ClimateTraits traits() override {
-        auto traits = climate::ClimateTraits();
+    switch (data[FAN_SPEED]) {
+      case FAN_AUTO:
+        this->fan_mode = climate::CLIMATE_FAN_AUTO;
+        break;
 
+      case FAN_MIN:
+        this->fan_mode = climate::CLIMATE_FAN_LOW;
+        break;
 
-        traits.set_supported_modes({
-                                           climate::CLIMATE_MODE_OFF,
-                                           climate::CLIMATE_MODE_HEAT_COOL,
-                                           climate::CLIMATE_MODE_COOL,
-                                           climate::CLIMATE_MODE_HEAT,
-                                           climate::CLIMATE_MODE_FAN_ONLY,
-                                           climate::CLIMATE_MODE_DRY
-                                   });
+      case FAN_MIDDLE:
+        this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+        break;
 
-        traits.set_supported_fan_modes({
-                                               climate::CLIMATE_FAN_AUTO,
-                                               climate::CLIMATE_FAN_LOW,
-                                               climate::CLIMATE_FAN_MEDIUM,
-                                               climate::CLIMATE_FAN_HIGH,
-                                       });
-
-
-        if (swing) {
-            traits.set_supported_swing_modes({
-                                                     climate::CLIMATE_SWING_OFF,
-                                                     climate::CLIMATE_SWING_BOTH,
-                                                     climate::CLIMATE_SWING_VERTICAL,
-                                                     climate::CLIMATE_SWING_HORIZONTAL
-                                             });
-        }
-
-        traits.set_visual_min_temperature(MIN_SET_TEMPERATURE);
-        traits.set_visual_max_temperature(MAX_SET_TEMPERATURE);
-        traits.set_visual_temperature_step(STEP_TEMPERATURE);
-        traits.set_supports_current_temperature(true);
-        traits.set_supports_two_point_target_temperature(false);
-
-
-        traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
-        traits.add_supported_preset(climate::CLIMATE_PRESET_COMFORT);
-
-
-        return traits;
+      case FAN_MAX:
+        this->fan_mode = climate::CLIMATE_FAN_HIGH;
+        break;
     }
 
-public:
+    switch (data[SWING]) {
+      case SWING_OFF:
+        this->swing_mode = climate::CLIMATE_SWING_OFF;
+        break;
 
-    void readData() {
+      case SWING_VERTICAL:
+        this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+        break;
 
+      case SWING_HORIZONTAL:
+        this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+        break;
 
-        auto raw = getHex(data, sizeof(data));
-        ESP_LOGD("Haier", "Readed message: %s ", raw.c_str());
-
-
-        uint8_t check = data[CRC];
-
-        getChecksum(data, sizeof(data));
-
-        if (check != data[CRC]) {
-            ESP_LOGD("Haier", "Invalid checksum");
-            return;
-        }
-
-
-        lastCRC = check;
-
-
-        if (MIN_VALID_TEMPERATURE < data[TEMPERATURE] && data[TEMPERATURE] < MAX_VALID_TEMPERATURE)
-            current_temperature = data[TEMPERATURE];
-
-
-        target_temperature = data[SET_TEMPERATURE] + 16;
-
-
-        if (data[POWER] & DECIMAL_MASK)
-            target_temperature += 0.5f;
-
-
-        switch (data[MODE]) {
-            case MODE_SMART:
-                mode = climate::CLIMATE_MODE_HEAT_COOL;
-                break;
-            case MODE_COOL:
-                mode = climate::CLIMATE_MODE_COOL;
-                break;
-            case MODE_HEAT:
-                mode = climate::CLIMATE_MODE_HEAT;
-                break;
-            case MODE_ONLY_FAN:
-                mode = climate::CLIMATE_MODE_FAN_ONLY;
-                break;
-            case MODE_DRY:
-                mode = climate::CLIMATE_MODE_DRY;
-                break;
-            default:
-                mode = climate::CLIMATE_MODE_HEAT_COOL;
-        }
-
-
-        switch (data[FAN_SPEED]) {
-            case FAN_AUTO:
-                fan_mode = climate::CLIMATE_FAN_AUTO;
-                break;
-
-            case FAN_MIN:
-                fan_mode = climate::CLIMATE_FAN_LOW;
-                break;
-
-            case FAN_MIDDLE:
-                fan_mode = climate::CLIMATE_FAN_MEDIUM;
-                break;
-
-            case FAN_MAX:
-                fan_mode = climate::CLIMATE_FAN_HIGH;
-                break;
-        }
-
-
-        if (data[SWING] == SWING_OFF) {
-            if (data[SWING_MODE] & SWING_HORIZONTAL_MASK)
-                swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-            else if (data[SWING_MODE] & SWING_VERTICAL_MASK)
-                swing_mode = climate::CLIMATE_SWING_VERTICAL;
-            else
-                swing_mode = climate::CLIMATE_SWING_OFF;
-        } else if (data[SWING] == SWING_BOTH)
-            swing_mode = climate::CLIMATE_SWING_BOTH;
-
-
-        if (data[POWER] & CONFORT_PRESET_MASK)
-            preset = climate::CLIMATE_PRESET_COMFORT;
-        else
-            preset = climate::CLIMATE_PRESET_NONE;
-
-
-        if ((data[POWER] & POWER_MASK) == 0) {
-            mode = climate::CLIMATE_MODE_OFF;
-        }
-
-
-        this->publish_state();
-
+      case SWING_BOTH:
+        this->swing_mode = climate::CLIMATE_SWING_BOTH;
+        break;
     }
 
+    if (data[POWER] & COMFORT_PRESET_MASK)
+      this->preset = climate::CLIMATE_PRESET_COMFORT;
+    else
+      this->preset = climate::CLIMATE_PRESET_NONE;
 
-    void control(const climate::ClimateCall &call) override {
-        if (call.get_mode().has_value()) {
-            switch (call.get_mode().value()) {
-                case climate::CLIMATE_MODE_OFF:
-                    sendData(off, sizeof(off));
-                    break;
-
-                case climate::CLIMATE_MODE_HEAT_COOL:
-                case climate::CLIMATE_MODE_AUTO:
-                    data[POWER] |= POWER_MASK;
-                    data[MODE] = MODE_SMART;
-                    break;
-                case climate::CLIMATE_MODE_HEAT:
-                    data[POWER] |= POWER_MASK;
-                    data[MODE] = MODE_HEAT;
-                    break;
-                case climate::CLIMATE_MODE_COOL:
-                    data[POWER] |= POWER_MASK;
-                    data[MODE] = MODE_COOL;
-                    break;
-
-                case climate::CLIMATE_MODE_FAN_ONLY:
-                    data[POWER] |= POWER_MASK;
-                    data[MODE] = MODE_ONLY_FAN;
-                    break;
-
-                case climate::CLIMATE_MODE_DRY:
-                    data[POWER] |= POWER_MASK;
-                    data[MODE] = MODE_DRY;
-                    break;
-
-            }
-
-        }
-
-
-        if (call.get_preset().has_value()) {
-
-
-            if (call.get_preset().value() == climate::CLIMATE_PRESET_COMFORT)
-                data[POWER] |= CONFORT_PRESET_MASK;
-            else
-                data[POWER] &= ~CONFORT_PRESET_MASK;
-
-
-        }
-
-
-        if (call.get_target_temperature().has_value()) {
-
-            float target = call.get_target_temperature().value() - 16;
-
-            data[SET_TEMPERATURE] = (uint16) target;
-
-            if ((int) target == (int) (target + 0.5))
-                data[POWER] &= ~DECIMAL_MASK;
-            else
-                data[POWER] |= DECIMAL_MASK;
-
-        }
-
-        if (call.get_fan_mode().has_value()) {
-            switch (call.get_fan_mode().value()) {
-                case climate::CLIMATE_FAN_AUTO:
-                    data[FAN_SPEED] = FAN_AUTO;
-                    break;
-                case climate::CLIMATE_FAN_LOW:
-                    data[FAN_SPEED] = FAN_MIN;
-                    break;
-                case climate::CLIMATE_FAN_MEDIUM:
-                    data[FAN_SPEED] = FAN_MIDDLE;
-                    break;
-                case climate::CLIMATE_FAN_HIGH:
-                    data[FAN_SPEED] = FAN_MAX;
-                    break;
-
-                case climate::CLIMATE_FAN_ON:
-                case climate::CLIMATE_FAN_OFF:
-                case climate::CLIMATE_FAN_MIDDLE:
-                case climate::CLIMATE_FAN_FOCUS:
-                case climate::CLIMATE_FAN_DIFFUSE:
-                    break;
-            }
-
-        }
-
-
-        if (call.get_swing_mode().has_value())
-            switch (call.get_swing_mode().value()) {
-                case climate::CLIMATE_SWING_OFF:
-                    data[SWING] = SWING_OFF;
-                    data[SWING_MODE] &= ~1;
-                    break;
-                case climate::CLIMATE_SWING_VERTICAL:
-                    data[SWING] = SWING_OFF;
-                    data[SWING_MODE] |= SWING_VERTICAL_MASK;
-                    data[SWING_MODE] &= ~SWING_HORIZONTAL_MASK;
-                    break;
-                case climate::CLIMATE_SWING_HORIZONTAL:
-                    data[SWING] = SWING_OFF;
-                    data[SWING_MODE] |= SWING_HORIZONTAL_MASK;
-                    data[SWING_MODE] &= ~SWING_VERTICAL_MASK;
-                    break;
-                case climate::CLIMATE_SWING_BOTH:
-                    data[SWING] = SWING_BOTH;
-                    data[SWING_MODE] &= ~SWING_HORIZONTAL_MASK;
-                    data[SWING_MODE] &= ~SWING_VERTICAL_MASK;
-                    break;
-            }
-
-
-
-
-
-        //Values for "send"
-        data[COMMAND] = 0;
-        data[9] = 1;
-        data[10] = 77;
-        data[11] = 95;
-
-        sendData(data, sizeof(data));
+    if ((data[POWER] & POWER_MASK) == 0) {
+      this->mode = climate::CLIMATE_MODE_OFF;
     }
 
+    this->publish_state();
+  }
 
-    void sendData(uint8_t *message, uint8_t size) {
-        uint8_t crc = getChecksum(message, size);
-        this->write_array(message, size - 1);
-        this->write(crc);
+  void control(const climate::ClimateCall &call) override {
+    if (call.get_mode().has_value()) {
+      switch (call.get_mode().value()) {
+        case climate::CLIMATE_MODE_OFF:
+          sendData(OFF_REQ, sizeof(OFF_REQ));
+          break;
 
-        auto raw = getHex(message, size);
-        ESP_LOGD("Haier", "Sended message: %s ", raw.c_str());
+        case climate::CLIMATE_MODE_HEAT_COOL:
+        case climate::CLIMATE_MODE_AUTO:
+          data[POWER] |= POWER_MASK;
+          data[MODE] = MODE_SMART;
+          break;
+        case climate::CLIMATE_MODE_HEAT:
+          data[POWER] |= POWER_MASK;
+          data[MODE] = MODE_HEAT;
+          break;
+        case climate::CLIMATE_MODE_COOL:
+          data[POWER] |= POWER_MASK;
+          data[MODE] = MODE_COOL;
+          break;
+
+        case climate::CLIMATE_MODE_FAN_ONLY:
+          data[POWER] |= POWER_MASK;
+          data[MODE] = MODE_ONLY_FAN;
+          break;
+
+        case climate::CLIMATE_MODE_DRY:
+          data[POWER] |= POWER_MASK;
+          data[MODE] = MODE_DRY;
+          break;
+      }
     }
 
-    String getHex(uint8_t *message, uint8_t size) {
-        String raw;
-
-        for (int i = 0; i < size; i++) {
-            raw += "\n" + String(i) + "-" + String(message[i]);
-
-        }
-        raw.toUpperCase();
-
-        return raw;
+    if (call.get_preset().has_value()) {
+      if (call.get_preset().value() == climate::CLIMATE_PRESET_COMFORT)
+        data[POWER] |= COMFORT_PRESET_MASK;
+      else
+        data[POWER] &= ~COMFORT_PRESET_MASK;
     }
 
-    uint8_t getChecksum(const uint8_t *message, size_t size) {
-        uint8_t position = size - 1;
-        uint8_t crc = 0;
+    if (call.get_target_temperature().has_value()) {
+      float target = call.get_target_temperature().value() - MIN_VALID_TEMPERATURE;
 
-        for (int i = 2; i < position; i++)
-            crc += message[i];
+      data[SET_TEMPERATURE] = (uint16) target;
 
-        return crc;
-
+      if ((int) target == (int) (target + 0.5))
+        data[POWER] &= ~DECIMAL_MASK;
+      else
+        data[POWER] |= DECIMAL_MASK;
     }
+
+    if (call.get_fan_mode().has_value()) {
+      switch (call.get_fan_mode().value()) {
+        case climate::CLIMATE_FAN_AUTO:
+          data[FAN_SPEED] = FAN_AUTO;
+          break;
+        case climate::CLIMATE_FAN_LOW:
+          data[FAN_SPEED] = FAN_MIN;
+          break;
+        case climate::CLIMATE_FAN_MEDIUM:
+          data[FAN_SPEED] = FAN_MIDDLE;
+          break;
+        case climate::CLIMATE_FAN_HIGH:
+          data[FAN_SPEED] = FAN_MAX;
+          break;
+
+        case climate::CLIMATE_FAN_ON:
+        case climate::CLIMATE_FAN_OFF:
+        case climate::CLIMATE_FAN_MIDDLE:
+        case climate::CLIMATE_FAN_FOCUS:
+        case climate::CLIMATE_FAN_DIFFUSE:
+          break;
+      }
+    }
+
+    if (call.get_swing_mode().has_value())
+      switch (call.get_swing_mode().value()) {
+        case climate::CLIMATE_SWING_OFF:
+          data[SWING] = SWING_OFF;
+          break;
+        case climate::CLIMATE_SWING_VERTICAL:
+          data[SWING] = SWING_VERTICAL;
+          break;
+        case climate::CLIMATE_SWING_HORIZONTAL:
+          data[SWING] = SWING_HORIZONTAL;
+          break;
+        case climate::CLIMATE_SWING_BOTH:
+          data[SWING] = SWING_BOTH;
+          break;
+      }
+
+    // Values for "send"
+    data[COMMAND] = 0;
+    data[9] = 1;
+    data[10] = 77;
+    data[11] = 95;
+
+    sendData(data, sizeof(data));
+  }
+
+  void sendData(const uint8_t *message, uint8_t size) {
+    uint8_t crc = getChecksum(message, size);
+    this->write_array(message, size - 1);
+    this->write(crc);
+
+    ESP_LOGV(TAG, "Sended message: %s ", bytesToString(message, size).c_str());
+  }
+
+  String bytesToString(const uint8_t *message, uint8_t size) {
+    String raw;
+
+    for (int i = 0; i < size; i++) {
+      raw += "\n" + String(i) + "-" + String(message[i]);
+    }
+    raw.toUpperCase();
+
+    return raw;
+  }
+
+  uint8_t getChecksum(const uint8_t *message, size_t size) {
+    uint8_t position = size - 1;
+    uint8_t crc = 0;
+
+    for (int i = 2; i < position; i++)
+      crc += message[i];
+
+    return crc;
+  }
 };
-
 
 }  // namespace haier
 }  // namespace esphome

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1194,7 +1194,7 @@ climate:
       deadband_output_averaging_samples: 1
   - platform: haier
     name: Haier AC
-    supported_swing_mode: both
+    supported_swing_modes: both
     update_interval: 10s
     uart_id: uart12
 

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1194,7 +1194,10 @@ climate:
       deadband_output_averaging_samples: 1
   - platform: haier
     name: Haier AC
-    supported_swing_modes: both
+    supported_swing_modes:
+      - vertical
+      - horizontal
+      - both
     update_interval: 10s
     uart_id: uart12
 

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -283,6 +283,10 @@ uart:
     tx_pin: GPIO4
     rx_pin: GPIO5
     baud_rate: 9600
+  - id: uart12
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
 
 modbus:
   uart_id: uart1
@@ -1188,8 +1192,11 @@ climate:
       ki_multiplier: 0.0
       kd_multiplier: 0.0
       deadband_output_averaging_samples: 1
-
-
+  - platform: haier
+    name: Haier AC
+    supported_swing_mode: both
+    update_interval: 10s
+    uart_id: uart12
 
 sprinkler:
   - id: yard_sprinkler_ctrlr


### PR DESCRIPTION
# What does this implement/fix?

The component adds new Haier climate component. esphome device can talk with various Haier climate devices over UART to control it. This PR is based on https://github.com/MiguelAngelLV/esphaier

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** [esphome/esphome-docs#2431](https://github.com/esphome/esphome-docs/pull/2431)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
logger:
    baud_rate: 0 #Disable UART logging for ESP8266

uart:
    rx_pin: GPIO3
    tx_pin: GPIO1
    baud_rate: 9600

climate:
    platform: haier
    name: Haier AC
    supported_swing_mode: vertical
    update_interval: 10s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
