### PR TITLE
Fix time components on rp2040

### DIFF
--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -10,6 +10,9 @@
 #ifdef USE_ESP8266
 #include "sntp.h"
 #endif
+#ifdef USE_RP2040
+#include "lwip/apps/sntp.h"
+#endif
 
 // Yes, the server names are leaked, but that's fine.
 #ifdef CLANG_TIDY

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -4,6 +4,9 @@
 #ifdef USE_ESP8266
 #include "sys/time.h"
 #endif
+#ifdef USE_RP2040
+#include <sys/time.h>
+#endif
 #include <cerrno>
 
 namespace esphome {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Fixes time components missing includes for rp2040

https://github.com/esphome/feature-requests/issues/1924#issuecomment-1312278958

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
