### PR TITLE
2022.11.0b4

### DIFF
--- a/esphome/components/async_tcp/__init__.py
+++ b/esphome/components/async_tcp/__init__.py
@@ -8,6 +8,7 @@ CODEOWNERS = ["@OttoWinter"]
 CONFIG_SCHEMA = cv.All(
     cv.Schema({}),
     cv.only_with_arduino,
+    cv.only_on(["esp32", "esp8266"]),
 )
 
 

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -25,6 +25,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
+    cv.only_on(["esp32", "esp8266"]),
 )
 
 

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -250,6 +250,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     validate_config,
+    cv.only_on(["esp32", "esp8266"]),
 )
 
 

--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -10,6 +10,9 @@
 #ifdef USE_ESP8266
 #include "sntp.h"
 #endif
+#ifdef USE_RP2040
+#include "lwip/apps/sntp.h"
+#endif
 
 // Yes, the server names are leaked, but that's fine.
 #ifdef CLANG_TIDY

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -4,6 +4,9 @@
 #ifdef USE_ESP8266
 #include "sys/time.h"
 #endif
+#ifdef USE_RP2040
+#include <sys/time.h>
+#endif
 #include <cerrno>
 
 namespace esphome {

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -75,6 +75,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
+    cv.only_on(["esp32", "esp8266"]),
     default_url,
     validate_local,
 )

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2022.11.0b3"
+__version__ = "2022.11.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

> _"If Java had true garbage collection, most programs would delete themselves upon execution."_

~ Robert Sewell
- Mark webserver and captive portal as not available on rp2040 [esphome#4023](https://github.com/esphome/esphome/pull/4023)
- Fix time components on rp2040 [esphome#4024](https://github.com/esphome/esphome/pull/4024)
- Mark mqtt as unavailable on rp2040 [esphome#4025](https://github.com/esphome/esphome/pull/4025)
