### PR TITLE
Update_interval less that 1 second in QMC5883L integration

### DIFF
--- a/esphome/components/qmc5883l/sensor.py
+++ b/esphome/components/qmc5883l/sensor.py
@@ -106,7 +106,9 @@ def auto_data_rate(config):
     interval_sec=0
     if config[CONF_UPDATE_INTERVAL].seconds != None:
       interval_sec=config[CONF_UPDATE_INTERVAL].seconds
-    interval_hz = 1.0 / (interval_sec+config[CONF_UPDATE_INTERVAL].milliseconds/1000)
+    if config[CONF_UPDATE_INTERVAL].milliseconds != None: 
+      interval_sec+=config[CONF_UPDATE_INTERVAL].milliseconds/1000
+    interval_hz = 1.0 / interval_sec
     for datarate in sorted(QMC5883LDatarates.keys()):
         if float(datarate) >= interval_hz:
             return QMC5883LDatarates[datarate]

--- a/esphome/components/qmc5883l/sensor.py
+++ b/esphome/components/qmc5883l/sensor.py
@@ -103,8 +103,10 @@ CONFIG_SCHEMA = (
 
 
 def auto_data_rate(config):
-    interval_sec = config[CONF_UPDATE_INTERVAL].seconds
-    interval_hz = 1.0 / interval_sec
+    interval_sec=0
+    if config[CONF_UPDATE_INTERVAL].seconds != None:
+      interval_sec=config[CONF_UPDATE_INTERVAL].seconds
+    interval_hz = 1.0 / (interval_sec+config[CONF_UPDATE_INTERVAL].milliseconds/1000)
     for datarate in sorted(QMC5883LDatarates.keys()):
         if float(datarate) >= interval_hz:
             return QMC5883LDatarates[datarate]

--- a/esphome/components/qmc5883l/sensor.py
+++ b/esphome/components/qmc5883l/sensor.py
@@ -103,11 +103,11 @@ CONFIG_SCHEMA = (
 
 
 def auto_data_rate(config):
-    interval_sec=0
+    interval_sec = 0
     if config[CONF_UPDATE_INTERVAL].seconds is not None:
-      interval_sec=config[CONF_UPDATE_INTERVAL].seconds
-    if config[CONF_UPDATE_INTERVAL].milliseconds is not None: 
-      interval_sec+=config[CONF_UPDATE_INTERVAL].milliseconds/1000
+        interval_sec = config[CONF_UPDATE_INTERVAL].seconds
+    if config[CONF_UPDATE_INTERVAL].milliseconds is not None:
+        interval_sec += config[CONF_UPDATE_INTERVAL].milliseconds / 1000
     interval_hz = 1.0 / interval_sec
     for datarate in sorted(QMC5883LDatarates.keys()):
         if float(datarate) >= interval_hz:

--- a/esphome/components/qmc5883l/sensor.py
+++ b/esphome/components/qmc5883l/sensor.py
@@ -104,9 +104,9 @@ CONFIG_SCHEMA = (
 
 def auto_data_rate(config):
     interval_sec=0
-    if config[CONF_UPDATE_INTERVAL].seconds != None:
+    if config[CONF_UPDATE_INTERVAL].seconds is not None:
       interval_sec=config[CONF_UPDATE_INTERVAL].seconds
-    if config[CONF_UPDATE_INTERVAL].milliseconds != None: 
+    if config[CONF_UPDATE_INTERVAL].milliseconds is not None: 
       interval_sec+=config[CONF_UPDATE_INTERVAL].milliseconds/1000
     interval_hz = 1.0 / interval_sec
     for datarate in sorted(QMC5883LDatarates.keys()):

--- a/esphome/components/qmc5883l/sensor.py
+++ b/esphome/components/qmc5883l/sensor.py
@@ -103,11 +103,7 @@ CONFIG_SCHEMA = (
 
 
 def auto_data_rate(config):
-    interval_sec = 0
-    if config[CONF_UPDATE_INTERVAL].seconds is not None:
-        interval_sec = config[CONF_UPDATE_INTERVAL].seconds
-    if config[CONF_UPDATE_INTERVAL].milliseconds is not None:
-        interval_sec += config[CONF_UPDATE_INTERVAL].milliseconds / 1000
+    interval_sec = config[CONF_UPDATE_INTERVAL].total_milliseconds / 1000
     interval_hz = 1.0 / interval_sec
     for datarate in sorted(QMC5883LDatarates.keys()):
         if float(datarate) >= interval_hz:


### PR DESCRIPTION
Prevents error that looks are described in:
https://github.com/esphome/issues/issues/1564
integration: qmc5883l

# What does this implement/fix?
Allow use an update_interval in milliseconds (less that 1 second) in QMC5883L integration.
Until now, compilation of code with "update_interval" lower than 1s breaks with error
''' interval_hz = 1.0/interval_sec
TypeError: unsupported operand type(s) for /: 'float' and 'NoneType'''

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes 
https://github.com/esphome/issues/issues/1564

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
