### PR TITLE
bump nginx-light 1.18.0-6.1+deb11u2 to 1.18.0-6.1+deb11u3 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        nginx-light=1.18.0-6.1+deb11u2 \
+        nginx-light=1.18.0-6.1+deb11u3 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \


### PR DESCRIPTION
# What does this implement/fix?
Currently, building the hassio Docker image fails because of the broken package `nginx-light=1.18.0-6.1+deb11u2`. This bumps the package version to allow building the hassio docker image.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#3793](https://github.com/esphome/issues/issues/3793)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).