### PR TITLE
Always save user wifi credentials if non in config

### DIFF
--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -1,9 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-import esphome.final_validate as fv
 from esphome.components import web_server_base
 from esphome.components.web_server_base import CONF_WEB_SERVER_BASE_ID
-from esphome.const import CONF_ID, CONF_NETWORKS, CONF_PASSWORD, CONF_SSID, CONF_WIFI
+from esphome.const import CONF_ID
 from esphome.core import coroutine_with_priority, CORE
 
 AUTO_LOAD = ["web_server_base"]
@@ -13,7 +12,6 @@ CODEOWNERS = ["@OttoWinter"]
 captive_portal_ns = cg.esphome_ns.namespace("captive_portal")
 CaptivePortal = captive_portal_ns.class_("CaptivePortal", cg.Component)
 
-CONF_KEEP_USER_CREDENTIALS = "keep_user_credentials"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -21,28 +19,11 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(CONF_WEB_SERVER_BASE_ID): cv.use_id(
                 web_server_base.WebServerBase
             ),
-            cv.Optional(CONF_KEEP_USER_CREDENTIALS, default=False): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
     cv.only_on(["esp32", "esp8266"]),
 )
-
-
-def validate_wifi(config):
-    wifi_conf = fv.full_config.get()[CONF_WIFI]
-    if config.get(CONF_KEEP_USER_CREDENTIALS, False) and (
-        CONF_SSID in wifi_conf
-        or CONF_PASSWORD in wifi_conf
-        or CONF_NETWORKS in wifi_conf
-    ):
-        raise cv.Invalid(
-            f"WiFi credentials cannot be used together with {CONF_KEEP_USER_CREDENTIALS}"
-        )
-    return config
-
-
-FINAL_VALIDATE_SCHEMA = validate_wifi
 
 
 @coroutine_with_priority(64.0)
@@ -58,6 +39,3 @@ async def to_code(config):
         cg.add_library("WiFi", None)
     if CORE.is_esp8266:
         cg.add_library("DNSServer", None)
-
-    if config.get(CONF_KEEP_USER_CREDENTIALS, False):
-        cg.add_define("USE_CAPTIVE_PORTAL_KEEP_USER_CREDENTIALS")

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -39,11 +39,8 @@ void WiFiComponent::setup() {
   this->last_connected_ = millis();
   this->wifi_pre_setup_();
 
-#ifndef USE_CAPTIVE_PORTAL_KEEP_USER_CREDENTIALS
-  uint32_t hash = fnv1_hash(App.get_compilation_time());
-#else
-  uint32_t hash = 88491487UL;
-#endif
+  uint32_t hash = this->has_sta() ? fnv1_hash(App.get_compilation_time()) : 88491487UL;
+
   this->pref_ = global_preferences->make_preference<wifi::SavedWifiSettings>(hash, true);
 
   SavedWifiSettings save{};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
After #3813 I decided to make the change a lot simpler and always fall to a static flash position for user credentials if firmwares are flashed with no credentials compiled in.

This is a breaking change within the beta, but since it is not released yet, it wont be marked as such.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2443

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
