### PR TITLE
remove unused variable last_save_ in total_daily_energy

### DIFF
--- a/esphome/components/total_daily_energy/total_daily_energy.h
+++ b/esphome/components/total_daily_energy/total_daily_energy.h
@@ -37,7 +37,6 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   TotalDailyEnergyMethod method_;
   uint16_t last_day_of_year_{};
   uint32_t last_update_{0};
-  uint32_t last_save_{0};
   bool restore_;
   float total_energy_{0.0f};
   float last_power_state_{0.0f};


### PR DESCRIPTION
Only use of last_save_ was removed in https://github.com/esphome/esphome/commit/bca96f91b27b1b4aa19a46e11e4fa21d71380c99#diff-5c4a6b9944a15cb88e70b864ead906fe775915a22308858c2ab21b3104534281

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
