### PR TITLE
Avoid compiling user services code if none are configured

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -100,6 +100,9 @@ async def to_code(config):
     cg.add(var.set_password(config[CONF_PASSWORD]))
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
 
+    if CONF_SERVICES in config:
+        cg.add_define("USE_API_USER_SERVICES")
+
     for conf in config.get(CONF_SERVICES, []):
         template_args = []
         func_args = []

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -961,6 +961,7 @@ void APIConnection::on_home_assistant_state_response(const HomeAssistantStateRes
     }
   }
 }
+#ifdef USE_API_USER_SERVICES
 void APIConnection::execute_service(const ExecuteServiceRequest &msg) {
   bool found = false;
   for (auto *service : this->parent_->get_user_services()) {
@@ -972,6 +973,7 @@ void APIConnection::execute_service(const ExecuteServiceRequest &msg) {
     ESP_LOGV(TAG, "Could not find matching service!");
   }
 }
+#endif
 void APIConnection::subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) {
   state_subs_at_ = 0;
 }

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -147,7 +147,9 @@ class APIConnection : public APIServerConnection {
     // TODO
     return {};
   }
+#ifdef USE_API_USER_SERVICES
   void execute_service(const ExecuteServiceRequest &msg) override;
+#endif
   void subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) override {
     this->bluetooth_le_advertisement_subscription_ = true;
   }

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -607,12 +607,14 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       break;
     }
     case 42: {
+#ifdef USE_API_USER_SERVICES
       ExecuteServiceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump().c_str());
 #endif
       this->on_execute_service_request(msg);
+#endif
       break;
     }
     case 45: {
@@ -895,6 +897,7 @@ void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
     this->on_fatal_error();
   }
 }
+#ifdef USE_API_USER_SERVICES
 void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
@@ -906,6 +909,7 @@ void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest
   }
   this->execute_service(msg);
 }
+#endif
 #ifdef USE_COVER
 void APIServerConnection::on_cover_command_request(const CoverCommandRequest &msg) {
   if (!this->is_connection_setup()) {

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -93,7 +93,9 @@ class APIServerConnectionBase : public ProtoService {
   bool send_get_time_response(const GetTimeResponse &msg);
   virtual void on_get_time_response(const GetTimeResponse &value){};
   bool send_list_entities_services_response(const ListEntitiesServicesResponse &msg);
+#ifdef USE_API_USER_SERVICES
   virtual void on_execute_service_request(const ExecuteServiceRequest &value){};
+#endif
 #ifdef USE_ESP32_CAMERA
   bool send_list_entities_camera_response(const ListEntitiesCameraResponse &msg);
 #endif
@@ -227,7 +229,9 @@ class APIServerConnection : public APIServerConnectionBase {
   virtual void subscribe_homeassistant_services(const SubscribeHomeassistantServicesRequest &msg) = 0;
   virtual void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) = 0;
   virtual GetTimeResponse get_time(const GetTimeRequest &msg) = 0;
+#ifdef USE_API_USER_SERVICES
   virtual void execute_service(const ExecuteServiceRequest &msg) = 0;
+#endif
 #ifdef USE_COVER
   virtual void cover_command(const CoverCommandRequest &msg) = 0;
 #endif
@@ -299,7 +303,9 @@ class APIServerConnection : public APIServerConnectionBase {
   void on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) override;
   void on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) override;
   void on_get_time_request(const GetTimeRequest &msg) override;
+#ifdef USE_API_USER_SERVICES
   void on_execute_service_request(const ExecuteServiceRequest &msg) override;
+#endif
 #ifdef USE_COVER
   void on_cover_command_request(const CoverCommandRequest &msg) override;
 #endif

--- a/esphome/components/api/custom_api_device.h
+++ b/esphome/components/api/custom_api_device.h
@@ -6,6 +6,7 @@
 
 namespace esphome {
 namespace api {
+#ifdef USE_API_USER_SERVICES
 
 template<typename T, typename... Ts> class CustomAPIDeviceService : public UserServiceBase<Ts...> {
  public:
@@ -213,6 +214,7 @@ class CustomAPIDevice {
     global_api_server->send_homeassistant_service_call(resp);
   }
 };
+#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/list_entities.cpp
+++ b/esphome/components/api/list_entities.cpp
@@ -41,10 +41,12 @@ bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) { return this->client_->s
 
 bool ListEntitiesIterator::on_end() { return this->client_->send_list_info_done(); }
 ListEntitiesIterator::ListEntitiesIterator(APIConnection *client) : client_(client) {}
+#ifdef USE_API_USER_SERVICES
 bool ListEntitiesIterator::on_service(UserServiceDescriptor *service) {
   auto resp = service->encode_list_service_response();
   return this->client_->send_list_entities_services_response(resp);
 }
+#endif
 
 #ifdef USE_ESP32_CAMERA
 bool ListEntitiesIterator::on_camera(esp32_camera::ESP32Camera *camera) {

--- a/esphome/components/api/list_entities.h
+++ b/esphome/components/api/list_entities.h
@@ -36,7 +36,9 @@ class ListEntitiesIterator : public ComponentIterator {
 #ifdef USE_TEXT_SENSOR
   bool on_text_sensor(text_sensor::TextSensor *text_sensor) override;
 #endif
+#ifdef USE_API_USER_SERVICES
   bool on_service(UserServiceDescriptor *service) override;
+#endif
 #ifdef USE_ESP32_CAMERA
   bool on_camera(esp32_camera::ESP32Camera *camera) override;
 #endif

--- a/esphome/components/api/user_services.cpp
+++ b/esphome/components/api/user_services.cpp
@@ -4,6 +4,7 @@
 namespace esphome {
 namespace api {
 
+#ifdef USE_API_USER_SERVICES
 template<> bool get_execute_arg_value<bool>(const ExecuteServiceArgument &arg) { return arg.bool_; }
 template<> int get_execute_arg_value<int>(const ExecuteServiceArgument &arg) {
   if (arg.legacy_int != 0)
@@ -37,6 +38,7 @@ template<> enums::ServiceArgType to_service_arg_type<std::vector<float>>() {
 template<> enums::ServiceArgType to_service_arg_type<std::vector<std::string>>() {
   return enums::SERVICE_ARG_TYPE_STRING_ARRAY;
 }
+#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -9,6 +9,8 @@
 namespace esphome {
 namespace api {
 
+#ifdef USE_API_USER_SERVICES
+
 class UserServiceDescriptor {
  public:
   virtual ListEntitiesServicesResponse encode_list_service_response() = 0;
@@ -69,6 +71,8 @@ template<typename... Ts> class UserServiceTrigger : public UserServiceBase<Ts...
  protected:
   void execute(Ts... x) override { this->trigger(x...); }  // NOLINT
 };
+
+#endif
 
 }  // namespace api
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Avoid compiling user services code if none are configured

It looks like we can ifdef some of this out if there are no services configured

I'm not 100% sure this isn't used for something else though

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
