### PR TITLE
Avoid 128bit uuid loop for 16/32 bit uuids

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -449,10 +449,12 @@ ESPBTUUID ESPBTUUID::from_raw(const std::string &data) {
 ESPBTUUID ESPBTUUID::from_uuid(esp_bt_uuid_t uuid) {
   ESPBTUUID ret;
   ret.uuid_.len = uuid.len;
-  ret.uuid_.uuid.uuid16 = uuid.uuid.uuid16;
-  ret.uuid_.uuid.uuid32 = uuid.uuid.uuid32;
-  for (size_t i = 0; i < ESP_UUID_LEN_128; i++)
-    ret.uuid_.uuid.uuid128[i] = uuid.uuid.uuid128[i];
+  if (uuid.len == ESP_UUID_LEN_16)
+    ret.uuid_.uuid.uuid16 = uuid.uuid.uuid16;
+  else if (uuid.len == ESP_UUID_LEN_32)
+    ret.uuid_.uuid.uuid32 = uuid.uuid.uuid32;
+  else if (uuid.len == ESP_UUID_LEN_128)
+    memcpy(ret.uuid_.uuid.uuid128, uuid.uuid.uuid128, ESP_UUID_LEN_128);
   return ret;
 }
 ESPBTUUID ESPBTUUID::as_128bit() const {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -449,12 +449,13 @@ ESPBTUUID ESPBTUUID::from_raw(const std::string &data) {
 ESPBTUUID ESPBTUUID::from_uuid(esp_bt_uuid_t uuid) {
   ESPBTUUID ret;
   ret.uuid_.len = uuid.len;
-  if (uuid.len == ESP_UUID_LEN_16)
+  if (uuid.len == ESP_UUID_LEN_16) {
     ret.uuid_.uuid.uuid16 = uuid.uuid.uuid16;
-  else if (uuid.len == ESP_UUID_LEN_32)
+  } else if (uuid.len == ESP_UUID_LEN_32) {
     ret.uuid_.uuid.uuid32 = uuid.uuid.uuid32;
-  else if (uuid.len == ESP_UUID_LEN_128)
+  } else if (uuid.len == ESP_UUID_LEN_128) {
     memcpy(ret.uuid_.uuid.uuid128, uuid.uuid.uuid128, ESP_UUID_LEN_128);
+  }
   return ret;
 }
 ESPBTUUID ESPBTUUID::as_128bit() const {


### PR DESCRIPTION
# What does this implement/fix?

Avoid 128bit uuid loop for 16/32 bit uuids when calling `from_uuid`


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
