### PR TITLE
Avoid creating a new espbt::ESPBTUUID each loop when registering for notify

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -299,7 +299,7 @@ BLEDescriptor *BLEClientBase::get_config_descriptor(uint16_t handle) {
   auto *chr = this->get_characteristic(handle);
   if (chr != nullptr) {
     for (auto &desc : chr->descriptors) {
-      if (desc->uuid == espbt::ESPBTUUID::from_uint16(0x2902))
+      if (desc->uuid.get_uuid().uuid.uuid16 == 0x2902)
         return desc;
     }
   }


### PR DESCRIPTION

# What does this implement/fix?

Avoid creating a new espbt::ESPBTUUID each loop when registering for notify

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
