### PR TITLE
Always use brackets around single log macros

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -117,10 +117,11 @@ void ADCSensor::dump_config() {
   }
 #endif  // USE_ESP32
 #ifdef USE_RP2040
-  if (this->is_temperature_)
+  if (this->is_temperature_) {
     ESP_LOGCONFIG(TAG, "  Pin: Temperature");
-  else
+  } else {
     LOG_PIN("  Pin: ", pin_);
+  }
 #endif
   LOG_UPDATE_INTERVAL(this);
 }

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -122,8 +122,9 @@ void AHT10Component::update() {
     this->temperature_sensor_->publish_state(temperature);
   }
   if (this->humidity_sensor_ != nullptr) {
-    if (std::isnan(humidity))
+    if (std::isnan(humidity)) {
       ESP_LOGW(TAG, "Invalid humidity! Sensor reported 0%% Hum");
+    }
     this->humidity_sensor_->publish_state(humidity);
   }
   this->status_clear_warning();

--- a/esphome/components/am43/am43.cpp
+++ b/esphome/components/am43/am43.cpp
@@ -104,8 +104,9 @@ void Am43::update() {
       auto status =
           esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_handle_,
                                    packet->length, packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-      if (status)
+      if (status) {
         ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
+      }
     }
     this->current_sensor_++;
   }

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -56,8 +56,9 @@ void Am43Component::control(const CoverCall &call) {
     auto status =
         esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_handle_,
                                  packet->length, packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-    if (status)
+    if (status) {
       ESP_LOGW(TAG, "[%s] Error writing stop command to device, error = %d", this->get_name().c_str(), status);
+    }
   }
   if (call.get_position().has_value()) {
     auto pos = *call.get_position();
@@ -68,8 +69,9 @@ void Am43Component::control(const CoverCall &call) {
     auto status =
         esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_handle_,
                                  packet->length, packet->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-    if (status)
+    if (status) {
       ESP_LOGW(TAG, "[%s] Error writing set_position command to device, error = %d", this->get_name().c_str(), status);
+    }
   }
 }
 
@@ -126,18 +128,21 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
           auto status = esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(),
                                                  this->char_handle_, packet->length, packet->data,
                                                  ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-          if (status)
+          if (status) {
             ESP_LOGW(TAG, "[%s] Error writing set_position to device, error = %d", this->get_name().c_str(), status);
+          }
         } else {
           ESP_LOGW(TAG, "[%s] AM43 pin rejected!", this->get_name().c_str());
         }
       }
 
-      if (this->decoder_->has_set_position_response() && !this->decoder_->set_position_ok_)
+      if (this->decoder_->has_set_position_response() && !this->decoder_->set_position_ok_) {
         ESP_LOGW(TAG, "[%s] Got nack after sending set_position. Bad pin?", this->get_name().c_str());
+      }
 
-      if (this->decoder_->has_set_state_response() && !this->decoder_->set_state_ok_)
+      if (this->decoder_->has_set_state_response() && !this->decoder_->set_state_ok_) {
         ESP_LOGW(TAG, "[%s] Got nack after sending set_state. Bad pin?", this->get_name().c_str());
+      }
       break;
     }
     default:

--- a/esphome/components/anova/anova.cpp
+++ b/esphome/components/anova/anova.cpp
@@ -37,16 +37,18 @@ void Anova::control(const ClimateCall &call) {
     auto status =
         esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_handle_,
                                  pkt->length, pkt->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-    if (status)
+    if (status) {
       ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
+    }
   }
   if (call.get_target_temperature().has_value()) {
     auto *pkt = this->codec_->get_set_target_temp_request(*call.get_target_temperature());
     auto status =
         esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_handle_,
                                  pkt->length, pkt->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-    if (status)
+    if (status) {
       ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
+    }
   }
 }
 
@@ -143,8 +145,9 @@ void Anova::update() {
     auto status =
         esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_handle_,
                                  pkt->length, pkt->data, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-    if (status)
+    if (status) {
       ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
+    }
     this->current_request_++;
   }
 }

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -540,12 +540,15 @@ void Climate::dump_traits_(const char *tag) {
   ESP_LOGCONFIG(tag, "      - Min: %.1f", traits.get_visual_min_temperature());
   ESP_LOGCONFIG(tag, "      - Max: %.1f", traits.get_visual_max_temperature());
   ESP_LOGCONFIG(tag, "      - Step: %.1f", traits.get_visual_temperature_step());
-  if (traits.get_supports_current_temperature())
+  if (traits.get_supports_current_temperature()) {
     ESP_LOGCONFIG(tag, "  [x] Supports current temperature");
-  if (traits.get_supports_two_point_target_temperature())
+  }
+  if (traits.get_supports_two_point_target_temperature()) {
     ESP_LOGCONFIG(tag, "  [x] Supports two-point target temperature");
-  if (traits.get_supports_action())
+  }
+  if (traits.get_supports_action()) {
     ESP_LOGCONFIG(tag, "  [x] Supports action");
+  }
   if (!traits.get_supported_modes().empty()) {
     ESP_LOGCONFIG(tag, "  [x] Supported modes:");
     for (ClimateMode m : traits.get_supported_modes())

--- a/esphome/components/dac7678/dac7678_output.cpp
+++ b/esphome/components/dac7678/dac7678_output.cpp
@@ -29,8 +29,9 @@ void DAC7678Output::setup() {
     ESP_LOGE(TAG, "Reset failed");
     this->mark_failed();
     return;
-  } else
+  } else {
     ESP_LOGV(TAG, "Reset succeeded");
+  }
 
   delayMicroseconds(1000);
 
@@ -40,16 +41,18 @@ void DAC7678Output::setup() {
       ESP_LOGE(TAG, "Set internal reference failed");
       this->mark_failed();
       return;
-    } else
+    } else {
       ESP_LOGV(TAG, "Internal reference enabled");
+    }
   }
 }
 
 void DAC7678Output::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Setting up DAC7678 failed!");
-  } else
+  } else {
     ESP_LOGCONFIG(TAG, "DAC7678 initialised");
+  }
 }
 
 void DAC7678Output::register_channel(DAC7678Channel *channel) {

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -114,9 +114,9 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 #endif
 
   ESP_LOGI(TAG, "Beginning Deep Sleep");
-  if (this->sleep_duration_.has_value())
+  if (this->sleep_duration_.has_value()) {
     ESP_LOGI(TAG, "Sleeping for %" PRId64 "us", *this->sleep_duration_);
-
+  }
   App.run_safe_shutdown_hooks();
 
 #if defined(USE_ESP32)

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -77,14 +77,16 @@ void DFPlayer::loop() {
           case 0x3A:
             if (argument == 1) {
               ESP_LOGI(TAG, "USB loaded");
-            } else if (argument == 2)
+            } else if (argument == 2) {
               ESP_LOGI(TAG, "TF Card loaded");
+            }
             break;
           case 0x3B:
             if (argument == 1) {
               ESP_LOGI(TAG, "USB unloaded");
-            } else if (argument == 2)
+            } else if (argument == 2) {
               ESP_LOGI(TAG, "TF Card unloaded");
+            }
             break;
           case 0x3F:
             if (argument == 1) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -831,8 +831,9 @@ void ESP32BLETracker::print_bt_device_info(const ESPBTDevice &device) {
   }
 
   ESP_LOGD(TAG, "  Address Type: %s", address_type_s);
-  if (!device.get_name().empty())
+  if (!device.get_name().empty()) {
     ESP_LOGD(TAG, "  Name: '%s'", device.get_name().c_str());
+  }
   for (auto &tx_power : device.get_tx_powers()) {
     ESP_LOGD(TAG, "  TX Power: %d", tx_power);
   }

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -177,8 +177,9 @@ void ESP32ImprovComponent::set_state_(improv::State state) {
 }
 
 void ESP32ImprovComponent::set_error_(improv::Error error) {
-  if (error != improv::ERROR_NONE)
+  if (error != improv::ERROR_NONE) {
     ESP_LOGE(TAG, "Error: %d", error);
+  }
   if (this->error_->get_value().empty() || this->error_->get_value()[0] != error) {
     uint8_t data[1]{error};
     this->error_->set_value(data, 1);

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -162,8 +162,9 @@ void EthernetComponent::dump_config() {
 
   ESP_LOGCONFIG(TAG, "Ethernet:");
   this->dump_connect_params_();
-  if (this->power_pin_ != -1)
+  if (this->power_pin_ != -1) {
     ESP_LOGCONFIG(TAG, "  Power Pin: %u", this->power_pin_);
+  }
   ESP_LOGCONFIG(TAG, "  MDC Pin: %u", this->mdc_pin_);
   ESP_LOGCONFIG(TAG, "  MDIO Pin: %u", this->mdio_pin_);
   ESP_LOGCONFIG(TAG, "  Type: %s", eth_type.c_str());

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -14,8 +14,9 @@ static const char *const EZO_CALIBRATION_TYPE_STRINGS[] = {"LOW", "MID", "HIGH"}
 void EZOSensor::dump_config() {
   LOG_SENSOR("", "EZO", this);
   LOG_I2C_DEVICE(this);
-  if (this->is_failed())
+  if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication with EZO circuit failed!");
+  }
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/ezo_pmp/ezo_pmp.cpp
+++ b/esphome/components/ezo_pmp/ezo_pmp.cpp
@@ -40,8 +40,9 @@ static const std::string DOSING_MODE_CONTINUOUS = "Continuous";
 
 void EzoPMP::dump_config() {
   LOG_I2C_DEVICE(this);
-  if (this->is_failed())
+  if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication with EZO-PMP circuit failed!");
+  }
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -20,14 +20,18 @@ const LogString *fan_direction_to_string(FanDirection direction) {
 void FanCall::perform() {
   ESP_LOGD(TAG, "'%s' - Setting:", this->parent_.get_name().c_str());
   this->validate_();
-  if (this->binary_state_.has_value())
+  if (this->binary_state_.has_value()) {
     ESP_LOGD(TAG, "  State: %s", ONOFF(*this->binary_state_));
-  if (this->oscillating_.has_value())
+  }
+  if (this->oscillating_.has_value()) {
     ESP_LOGD(TAG, "  Oscillating: %s", YESNO(*this->oscillating_));
-  if (this->speed_.has_value())
+  }
+  if (this->speed_.has_value()) {
     ESP_LOGD(TAG, "  Speed: %d", *this->speed_);
-  if (this->direction_.has_value())
+  }
+  if (this->direction_.has_value()) {
     ESP_LOGD(TAG, "  Direction: %s", LOG_STR_ARG(fan_direction_to_string(*this->direction_)));
+  }
 
   this->parent_.control(*this);
 }
@@ -90,12 +94,15 @@ void Fan::publish_state() {
 
   ESP_LOGD(TAG, "'%s' - Sending state:", this->name_.c_str());
   ESP_LOGD(TAG, "  State: %s", ONOFF(this->state));
-  if (traits.supports_speed())
+  if (traits.supports_speed()) {
     ESP_LOGD(TAG, "  Speed: %d", this->speed);
-  if (traits.supports_oscillation())
+  }
+  if (traits.supports_oscillation()) {
     ESP_LOGD(TAG, "  Oscillating: %s", YESNO(this->oscillating));
-  if (traits.supports_direction())
+  }
+  if (traits.supports_direction()) {
     ESP_LOGD(TAG, "  Direction: %s", LOG_STR_ARG(fan_direction_to_string(this->direction)));
+  }
 
   this->state_callback_.call();
   this->save_state_();
@@ -147,10 +154,12 @@ void Fan::dump_traits_(const char *tag, const char *prefix) {
     ESP_LOGCONFIG(tag, "%s  Speed: YES", prefix);
     ESP_LOGCONFIG(tag, "%s  Speed count: %d", prefix, this->get_traits().supported_speed_count());
   }
-  if (this->get_traits().supports_oscillation())
+  if (this->get_traits().supports_oscillation()) {
     ESP_LOGCONFIG(tag, "%s  Oscillation: YES", prefix);
-  if (this->get_traits().supports_direction())
+  }
+  if (this->get_traits().supports_direction()) {
     ESP_LOGCONFIG(tag, "%s  Direction: YES", prefix);
+  }
 }
 
 }  // namespace fan

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -256,8 +256,9 @@ void Nextion::loop() {
 
 bool Nextion::remove_from_q_(bool report_empty) {
   if (this->nextion_queue_.empty()) {
-    if (report_empty)
+    if (report_empty) {
       ESP_LOGE(TAG, "Nextion queue is empty!");
+    }
     return false;
   }
 

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -472,8 +472,9 @@ bool OTAComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_
   if (this->safe_mode_rtc_value_ >= num_attempts || is_manual_safe_mode) {
     this->clean_rtc();
 
-    if (!is_manual_safe_mode)
+    if (!is_manual_safe_mode) {
       ESP_LOGE(TAG, "Boot loop detected. Proceeding to safe mode.");
+    }
 
     this->status_set_error();
     this->set_timeout(enable_time, []() {

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -166,18 +166,24 @@ bool PN532::format_mifare_classic_ndef_(std::vector<uint8_t> &uid) {
       return false;
     }
     if (block == 4) {
-      if (!this->write_mifare_classic_block_(block, empty_ndef_message))
-        ESP_LOGE(TAG, "Unable to write block %d", block);
-    } else {
-      if (!this->write_mifare_classic_block_(block, blank_block))
+      if (!this->write_mifare_classic_block_(block, empty_ndef_message)) {
+      }
         ESP_LOGE(TAG, "Unable to write block %d", block);
     }
-    if (!this->write_mifare_classic_block_(block + 1, blank_block))
+    } else {
+      if (!this->write_mifare_classic_block_(block, blank_block)) {
+        ESP_LOGE(TAG, "Unable to write block %d", block);
+      }
+    }
+    if (!this->write_mifare_classic_block_(block + 1, blank_block)) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 1);
-    if (!this->write_mifare_classic_block_(block + 2, blank_block))
+    }
+    if (!this->write_mifare_classic_block_(block + 2, blank_block)) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 2);
-    if (!this->write_mifare_classic_block_(block + 3, ndef_trailer))
+    }
+    if (!this->write_mifare_classic_block_(block + 3, ndef_trailer)) {
       ESP_LOGE(TAG, "Unable to write trailer block %d", block + 3);
+    }
   }
   return true;
 }

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -167,9 +167,8 @@ bool PN532::format_mifare_classic_ndef_(std::vector<uint8_t> &uid) {
     }
     if (block == 4) {
       if (!this->write_mifare_classic_block_(block, empty_ndef_message)) {
-      }
         ESP_LOGE(TAG, "Unable to write block %d", block);
-    }
+      }
     } else {
       if (!this->write_mifare_classic_block_(block, blank_block)) {
         ESP_LOGE(TAG, "Unable to write block %d", block);

--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -236,8 +236,9 @@ void ProntoProtocol::dump(const ProntoData &data) {
     rest = data.data.substr(230);
   }
   ESP_LOGD(TAG, "Received Pronto: data=%s", first.c_str());
-  if (!rest.empty())
+  if (!rest.empty()) {
     ESP_LOGD(TAG, "%s", rest.c_str());
+  }
 }
 
 }  // namespace remote_base

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -49,8 +49,9 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
       data.high = (raw[6] << 8) | raw[7];
       data.code = (raw[8] << 16) | (raw[9] << 8) | raw[10];
 
-      if (action == RF_CODE_LEARN_OK)
+      if (action == RF_CODE_LEARN_OK) {
         ESP_LOGD(TAG, "Learning success");
+      }
 
       ESP_LOGI(TAG, "Received RFBridge Code: sync=0x%04X low=0x%04X high=0x%04X code=0x%06X", data.sync, data.low,
                data.high, data.code);

--- a/esphome/components/shelly_dimmer/stm32flash.cpp
+++ b/esphome/components/shelly_dimmer/stm32flash.cpp
@@ -613,8 +613,9 @@ stm32_unique_ptr stm32_init(uart::UARTDevice *stream, const uint8_t flags, const
         }
     }
   }
-  if (new_cmds)
+  if (new_cmds) {
     ESP_LOGD(TAG, ")");
+  }
   if (stm32_get_ack(stm) != STM32_ERR_OK) {
     return make_stm32_with_deletor(nullptr);
   }

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -196,8 +196,9 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       //           "+CREG: -,-" means not registered ok
       bool registered = message.compare(0, 6, "+CREG:") == 0 && (message[9] == '1' || message[9] == '5');
       if (registered) {
-        if (!this->registered_)
+        if (!this->registered_) {
           ESP_LOGD(TAG, "Registered OK");
+        }
         this->state_ = STATE_CSQ;
         this->expect_ack_ = true;
       } else {

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -53,12 +53,15 @@ void SlowPWMOutput::loop() {
 void SlowPWMOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Slow PWM Output:");
   LOG_PIN("  Pin: ", this->pin_);
-  if (this->state_change_trigger_)
+  if (this->state_change_trigger_) {
     ESP_LOGCONFIG(TAG, "  State change automation configured");
-  if (this->turn_on_trigger_)
+  }
+  if (this->turn_on_trigger_) {
     ESP_LOGCONFIG(TAG, "  Turn on automation configured");
-  if (this->turn_off_trigger_)
+  }
+  if (this->turn_off_trigger_) {
     ESP_LOGCONFIG(TAG, "  Turn off automation configured");
+  }
   ESP_LOGCONFIG(TAG, "  Period: %d ms", this->period_);
   ESP_LOGCONFIG(TAG, "  Restart cycle on state change: %s", YESNO(this->restart_cycle_on_state_change_));
   LOG_FLOAT_OUTPUT(this);

--- a/esphome/components/sonoff_d1/sonoff_d1.cpp
+++ b/esphome/components/sonoff_d1/sonoff_d1.cpp
@@ -71,8 +71,9 @@ void SonoffD1Output::skip_command_() {
   }
 
   // Warn about unexpected bytes in the protocol with UART dimmer
-  if (garbage)
+  if (garbage) {
     ESP_LOGW(TAG, "[%04d] Skip %d bytes from the dimmer", this->write_count_, garbage);
+  }
 }
 
 // This assumes some data is already available

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1307,10 +1307,12 @@ void ThermostatClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Supports FAN_ONLY_ACTION_USES_FAN_MODE_TIMER: %s",
                 YESNO(this->supports_fan_only_action_uses_fan_mode_timer_));
   ESP_LOGCONFIG(TAG, "  Supports FAN_ONLY_COOLING: %s", YESNO(this->supports_fan_only_cooling_));
-  if (this->supports_cool_)
+  if (this->supports_cool_) {
     ESP_LOGCONFIG(TAG, "  Supports FAN_WITH_COOLING: %s", YESNO(this->supports_fan_with_cooling_));
-  if (this->supports_heat_)
+  }
+  if (this->supports_heat_) {
     ESP_LOGCONFIG(TAG, "  Supports FAN_WITH_HEATING: %s", YESNO(this->supports_fan_with_heating_));
+  }
   ESP_LOGCONFIG(TAG, "  Supports HEAT: %s", YESNO(this->supports_heat_));
   ESP_LOGCONFIG(TAG, "  Supports FAN MODE ON: %s", YESNO(this->supports_fan_mode_on_));
   ESP_LOGCONFIG(TAG, "  Supports FAN MODE OFF: %s", YESNO(this->supports_fan_mode_off_));

--- a/esphome/components/tuya/climate/tuya_climate.cpp
+++ b/esphome/components/tuya/climate/tuya_climate.cpp
@@ -138,18 +138,23 @@ climate::ClimateTraits TuyaClimate::traits() {
 
 void TuyaClimate::dump_config() {
   LOG_CLIMATE("", "Tuya Climate", this);
-  if (this->switch_id_.has_value())
+  if (this->switch_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Switch has datapoint ID %u", *this->switch_id_);
-  if (this->active_state_id_.has_value())
+  }
+  if (this->active_state_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Active state has datapoint ID %u", *this->active_state_id_);
-  if (this->target_temperature_id_.has_value())
+  }
+  if (this->target_temperature_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Target Temperature has datapoint ID %u", *this->target_temperature_id_);
-  if (this->current_temperature_id_.has_value())
+  }
+  if (this->current_temperature_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Current Temperature has datapoint ID %u", *this->current_temperature_id_);
+  }
   LOG_PIN("  Heating State Pin: ", this->heating_state_pin_);
   LOG_PIN("  Cooling State Pin: ", this->cooling_state_pin_);
-  if (this->eco_id_.has_value())
+  if (this->eco_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Eco has datapoint ID %u", *this->eco_id_);
+  }
 }
 
 void TuyaClimate::compute_preset_() {

--- a/esphome/components/tuya/cover/tuya_cover.cpp
+++ b/esphome/components/tuya/cover/tuya_cover.cpp
@@ -112,14 +112,18 @@ void TuyaCover::dump_config() {
       ESP_LOGCONFIG(TAG, "   Configured as Inverted, but direction_datapoint isn't configured");
     }
   }
-  if (this->control_id_.has_value())
+  if (this->control_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "   Control has datapoint ID %u", *this->control_id_);
-  if (this->direction_id_.has_value())
+  }
+  if (this->direction_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "   Direction has datapoint ID %u", *this->direction_id_);
-  if (this->position_id_.has_value())
+  }
+  if (this->position_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "   Position has datapoint ID %u", *this->position_id_);
-  if (this->position_report_id_.has_value())
+  }
+  if (this->position_report_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "   Position Report has datapoint ID %u", *this->position_report_id_);
+  }
 }
 
 cover::CoverTraits TuyaCover::get_traits() {

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -49,14 +49,18 @@ void TuyaFan::setup() {
 
 void TuyaFan::dump_config() {
   LOG_FAN("", "Tuya Fan", this);
-  if (this->speed_id_.has_value())
+  if (this->speed_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Speed has datapoint ID %u", *this->speed_id_);
-  if (this->switch_id_.has_value())
+  }
+  if (this->switch_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Switch has datapoint ID %u", *this->switch_id_);
-  if (this->oscillation_id_.has_value())
+  }
+  if (this->oscillation_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Oscillation has datapoint ID %u", *this->oscillation_id_);
-  if (this->direction_id_.has_value())
+  }
+  if (this->direction_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Direction has datapoint ID %u", *this->direction_id_);
+  }
 }
 
 fan::FanTraits TuyaFan::get_traits() {

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -92,10 +92,12 @@ void TuyaLight::setup() {
 
 void TuyaLight::dump_config() {
   ESP_LOGCONFIG(TAG, "Tuya Dimmer:");
-  if (this->dimmer_id_.has_value())
+  if (this->dimmer_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "   Dimmer has datapoint ID %u", *this->dimmer_id_);
-  if (this->switch_id_.has_value())
+  }
+  if (this->switch_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "   Switch has datapoint ID %u", *this->switch_id_);
+  }
   if (this->rgb_id_.has_value()) {
     ESP_LOGCONFIG(TAG, "   RGB has datapoint ID %u", *this->rgb_id_);
   } else if (this->hsv_id_.has_value()) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
In cases where the logging level is set to higher than the log line, it will be pre-processed out and the if/else will then apply to the next line in code potentially causing runtime issues.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
