### PR TITLE
Dont set esp32 pin drive strength unless pin is set for output

### DIFF
--- a/esphome/components/esp32/gpio.cpp
+++ b/esphome/components/esp32/gpio.cpp
@@ -86,7 +86,9 @@ void ESP32InternalGPIOPin::setup() {
   conf.pull_down_en = flags_ & gpio::FLAG_PULLDOWN ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE;
   conf.intr_type = GPIO_INTR_DISABLE;
   gpio_config(&conf);
-  gpio_set_drive_capability(pin_, drive_strength_);
+  if (flags_ & gpio::FLAG_OUTPUT) {
+    gpio_set_drive_capability(pin_, drive_strength_);
+  }
 }
 
 void ESP32InternalGPIOPin::pin_mode(gpio::Flags flags) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This fixes an error from esp-idf when the pin is setup for input (or when the pin doesnt support output)
```
[11:10:47][D][esp-idf:000]: E (53) gpio: gpio_set_drive_capability(597): GPIO number error
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
