### PR TITLE
Add vector includes

### DIFF
--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -5,6 +5,8 @@
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/light/addressable_light.h"
 
+#include <vector>
+
 namespace esphome {
 namespace addressable_light {
 

--- a/esphome/components/ade7953/ade7953.h
+++ b/esphome/components/ade7953/ade7953.h
@@ -5,6 +5,8 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/sensor/sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace ade7953 {
 

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -5,6 +5,8 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/voltage_sampler/voltage_sampler.h"
 
+#include <vector>
+
 namespace esphome {
 namespace ads1115 {
 

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -7,6 +7,8 @@
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace api {
 

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -12,6 +12,8 @@
 #include "user_services.h"
 #include "api_noise_context.h"
 
+#include <vector>
+
 namespace esphome {
 namespace api {
 

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -5,6 +5,8 @@
 #include "api_pb2.h"
 #include "api_server.h"
 
+#include <vector>
+
 namespace esphome {
 namespace api {
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -4,6 +4,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
+#include <vector>
+
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
 #define HAS_PROTO_MESSAGE_DUMP
 #endif

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"

--- a/esphome/components/atc_mithermometer/atc_mithermometer.h
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 namespace esphome {

--- a/esphome/components/bedjet/bedjet_hub.h
+++ b/esphome/components/bedjet/bedjet_hub.h
@@ -8,6 +8,8 @@
 #include "bedjet_child.h"
 #include "bedjet_codec.h"
 
+#include <vector>
+
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
 #endif

--- a/esphome/components/binary_sensor/automation.h
+++ b/esphome/components/binary_sensor/automation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -5,6 +5,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/binary_sensor/filter.h"
 
+#include <vector>
+
 namespace esphome {
 
 namespace binary_sensor {

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
+#include <vector>
+
 namespace esphome {
 
 namespace binary_sensor {

--- a/esphome/components/binary_sensor_map/binary_sensor_map.h
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.h
@@ -4,6 +4,8 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace binary_sensor_map {
 

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "esphome/core/automation.h"
 #include "esphome/components/ble_client/ble_client.h"

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -7,12 +7,13 @@
 
 #ifdef USE_ESP32
 
-#include <string>
-#include <array>
-#include <esp_gap_ble_api.h>
-#include <esp_gattc_api.h>
 #include <esp_bt_defs.h>
+#include <esp_gap_ble_api.h>
 #include <esp_gatt_common_api.h>
+#include <esp_gattc_api.h>
+#include <array>
+#include <string>
+#include <vector>
 
 namespace esphome {
 namespace ble_client {

--- a/esphome/components/ble_client/sensor/ble_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_sensor.h
@@ -5,6 +5,8 @@
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/sensor/sensor.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 #include <esp_gattc_api.h>
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -3,6 +3,7 @@
 #ifdef USE_ESP32
 
 #include <map>
+#include <vector>
 
 #include "esphome/components/api/api_pb2.h"
 #include "esphome/components/esp32_ble_client/ble_client_base.h"

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -4,6 +4,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/optional.h"
 
+#include <vector>
+
 namespace esphome {
 namespace canbus {
 

--- a/esphome/components/cap1188/cap1188.h
+++ b/esphome/components/cap1188/cap1188.h
@@ -6,6 +6,8 @@
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace cap1188 {
 

--- a/esphome/components/custom/binary_sensor/custom_binary_sensor.h
+++ b/esphome/components/custom/binary_sensor/custom_binary_sensor.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom/climate/custom_climate.h
+++ b/esphome/components/custom/climate/custom_climate.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/climate/climate.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom/cover/custom_cover.h
+++ b/esphome/components/custom/cover/custom_cover.h
@@ -2,6 +2,8 @@
 
 #include "esphome/components/cover/cover.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom/light/custom_light_output.h
+++ b/esphome/components/custom/light/custom_light_output.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/light/light_output.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom/output/custom_output.h
+++ b/esphome/components/custom/output/custom_output.h
@@ -4,6 +4,8 @@
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/output/float_output.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom/sensor/custom_sensor.h
+++ b/esphome/components/custom/sensor/custom_sensor.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom/switch/custom_switch.h
+++ b/esphome/components/custom/switch/custom_switch.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom/text_sensor/custom_text_sensor.h
+++ b/esphome/components/custom/text_sensor/custom_text_sensor.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom {
 

--- a/esphome/components/custom_component/custom_component.h
+++ b/esphome/components/custom_component/custom_component.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/application.h"
 
+#include <vector>
+
 namespace esphome {
 namespace custom_component {
 

--- a/esphome/components/dallas/dallas_component.h
+++ b/esphome/components/dallas/dallas_component.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esp_one_wire.h"
 
+#include <vector>
+
 namespace esphome {
 namespace dallas {
 

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -6,6 +6,8 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/uart/uart.h"
 
+#include <vector>
+
 namespace esphome {
 namespace daly_bms {
 

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -4,7 +4,9 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/automation.h"
 #include "display_color_utils.h"
+
 #include <cstdarg>
+#include <vector>
 
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -13,6 +13,8 @@
 #include <dsmr/parser.h>
 #include <dsmr/fields.h>
 
+#include <vector>
+
 namespace esphome {
 namespace dsmr {
 

--- a/esphome/components/ektf2232/ektf2232.cpp
+++ b/esphome/components/ektf2232/ektf2232.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <vector>
+
 namespace esphome {
 namespace ektf2232 {
 

--- a/esphome/components/esp32_ble_client/ble_characteristic.h
+++ b/esphome/components/esp32_ble_client/ble_characteristic.h
@@ -6,6 +6,8 @@
 
 #include "ble_descriptor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace esp32_ble_client {
 

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <string>
+#include <vector>
 
 #include <esp_bt_defs.h>
 #include <esp_gap_ble_api.h>

--- a/esphome/components/esp32_ble_client/ble_service.h
+++ b/esphome/components/esp32_ble_client/ble_service.h
@@ -6,6 +6,8 @@
 
 #include "ble_characteristic.h"
 
+#include <vector>
+
 namespace esphome {
 namespace esp32_ble_client {
 

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #ifdef USE_ESP32
 

--- a/esphome/components/esp32_ble_server/ble_service.h
+++ b/esphome/components/esp32_ble_server/ble_service.h
@@ -3,6 +3,8 @@
 #include "ble_characteristic.h"
 #include "esphome/components/esp32_ble/ble_uuid.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 #include <esp_gap_ble_api.h>

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -5,10 +5,12 @@
 #include "esphome/core/helpers.h"
 #include "queue.h"
 
+#include <array>
+#include <string>
+#include <vector>
+
 #ifdef USE_ESP32
 
-#include <string>
-#include <array>
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
 #include <esp_bt_defs.h>

--- a/esphome/components/esp32_ble_tracker/queue.h
+++ b/esphome/components/esp32_ble_tracker/queue.h
@@ -4,9 +4,10 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-#include <queue>
-#include <mutex>
 #include <cstring>
+#include <mutex>
+#include <queue>
+#include <vector>
 
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -9,6 +9,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 #include <improv.h>

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -6,6 +6,8 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include <esp_idf_version.h>
 
+#include <vector>
+
 #if ESP_IDF_VERSION_MAJOR >= 4
 #include <driver/touch_sensor.h>
 #else

--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -5,12 +5,14 @@ extern "C" {
 #include "spi_flash.h"
 }
 
-#include "preferences.h"
-#include <cstring>
-#include "esphome/core/preferences.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include "esphome/core/defines.h"
+#include "esphome/core/preferences.h"
+#include "preferences.h"
+
+#include <cstring>
+#include <vector>
 
 namespace esphome {
 namespace esp8266 {

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -6,6 +6,8 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/uart/uart.h"
 
+#include <vector>
+
 namespace esphome {
 namespace fingerprint_grow {
 

--- a/esphome/components/gpio/switch/gpio_switch.h
+++ b/esphome/components/gpio/switch/gpio_switch.h
@@ -4,6 +4,8 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/switch/switch.h"
 
+#include <vector>
+
 namespace esphome {
 namespace gpio {
 

--- a/esphome/components/gps/gps.h
+++ b/esphome/components/gps/gps.h
@@ -7,6 +7,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include <TinyGPS++.h>
 
+#include <vector>
+
 namespace esphome {
 namespace gps {
 

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -1,9 +1,10 @@
 #pragma once
+#include <cstdint>
+#include <utility>
+#include <vector>
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/color.h"
 #include "esphome/core/component.h"
-#include <cstdint>
-#include <utility>
 
 namespace esphome {
 

--- a/esphome/components/growatt_solar/growatt_solar.h
+++ b/esphome/components/growatt_solar/growatt_solar.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
+#include <vector>
+
 namespace esphome {
 namespace growatt_solar {
 

--- a/esphome/components/havells_solar/havells_solar.h
+++ b/esphome/components/havells_solar/havells_solar.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
+#include <vector>
+
 namespace esphome {
 namespace havells_solar {
 

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -6,10 +6,12 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
+
 #include <list>
 #include <map>
-#include <utility>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #ifdef USE_ESP32
 #include <HTTPClient.h>

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -6,6 +6,7 @@
 #include "esphome/core/helpers.h"
 
 #include <improv.h>
+#include <vector>
 
 #ifdef USE_ARDUINO
 #include <HardwareSerial.h>

--- a/esphome/components/lcd_base/lcd_display.h
+++ b/esphome/components/lcd_base/lcd_display.h
@@ -8,6 +8,7 @@
 #endif
 
 #include <map>
+#include <vector>
 
 namespace esphome {
 namespace lcd_base {

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "esphome/core/component.h"
 #include "esphome/components/light/light_state.h"

--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "light_effect.h"
 #include "esphome/core/automation.h"

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -10,6 +10,8 @@
 #include "light_traits.h"
 #include "light_transformer.h"
 
+#include <vector>
+
 namespace esphome {
 namespace light {
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <cstdarg>
+#include <vector>
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
-#include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
-#include <cstdarg>
+#include "esphome/core/helpers.h"
 
 #ifdef USE_ARDUINO
 #if defined(USE_ESP8266) || defined(USE_ESP32)

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <tuple>
+#include <vector>
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 #include "esphome/core/optional.h"
-#include "esphome/components/sensor/sensor.h"
-#include "esphome/components/i2c/i2c.h"
-#include <tuple>
 
 namespace esphome {
 namespace ltr390 {

--- a/esphome/components/max7219digit/max7219digit.h
+++ b/esphome/components/max7219digit/max7219digit.h
@@ -5,6 +5,8 @@
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/spi/spi.h"
 
+#include <vector>
+
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
 #endif

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
+#include <vector>
+
 namespace esphome {
 namespace modbus {
 

--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
@@ -4,6 +4,8 @@
 #include "esphome/components/modbus_controller/modbus_controller.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace modbus_controller {
 

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -4,6 +4,8 @@
 #include "esphome/components/modbus_controller/modbus_controller.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace modbus_controller {
 

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -1,7 +1,6 @@
-#include <vector>
 #include "modbus_output.h"
-#include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace modbus_controller {

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -4,6 +4,8 @@
 #include "esphome/components/modbus_controller/modbus_controller.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace modbus_controller {
 

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "esphome/components/modbus_controller/modbus_controller.h"
 #include "esphome/components/select/select.h"

--- a/esphome/components/modbus_controller/sensor/modbus_sensor.h
+++ b/esphome/components/modbus_controller/sensor/modbus_sensor.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace modbus_controller {
 

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -4,6 +4,8 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace modbus_controller {
 

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -4,6 +4,8 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace modbus_controller {
 

--- a/esphome/components/mopeka_ble/mopeka_ble.h
+++ b/esphome/components/mopeka_ble/mopeka_ble.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 namespace esphome {

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 namespace esphome {

--- a/esphome/components/mpr121/mpr121.h
+++ b/esphome/components/mpr121/mpr121.h
@@ -4,6 +4,8 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace mpr121 {
 

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -16,6 +16,8 @@
 #endif
 #include "lwip/ip_addr.h"
 
+#include <vector>
+
 namespace esphome {
 namespace mqtt {
 

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <deque>
+#include <vector>
+
 #include "esphome/core/defines.h"
 #include "esphome/components/uart/uart.h"
 #include "nextion_base.h"

--- a/esphome/components/nextion/nextion_component_base.h
+++ b/esphome/components/nextion/nextion_component_base.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <utility>
+#include <vector>
 #include "esphome/core/defines.h"
 
 namespace esphome {

--- a/esphome/components/nfc/ndef_message.h
+++ b/esphome/components/nfc/ndef_message.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -3,6 +3,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
+#include <vector>
+
 namespace esphome {
 namespace nfc {
 

--- a/esphome/components/nfc/ndef_record_text.h
+++ b/esphome/components/nfc/ndef_record_text.h
@@ -4,6 +4,8 @@
 #include "esphome/core/helpers.h"
 #include "ndef_record.h"
 
+#include <vector>
+
 namespace esphome {
 namespace nfc {
 

--- a/esphome/components/nfc/ndef_record_uri.h
+++ b/esphome/components/nfc/ndef_record_uri.h
@@ -4,6 +4,8 @@
 #include "esphome/core/helpers.h"
 #include "ndef_record.h"
 
+#include <vector>
+
 namespace esphome {
 namespace nfc {
 

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -6,6 +6,8 @@
 #include "ndef_message.h"
 #include "nfc_tag.h"
 
+#include <vector>
+
 namespace esphome {
 namespace nfc {
 

--- a/esphome/components/nfc/nfc_tag.h
+++ b/esphome/components/nfc/nfc_tag.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/partition/light_partition.h
+++ b/esphome/components/partition/light_partition.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "esphome/core/component.h"
 #include "esphome/components/light/addressable_light.h"

--- a/esphome/components/pid/pid_autotuner.h
+++ b/esphome/components/pid/pid_autotuner.h
@@ -5,6 +5,8 @@
 #include "pid_controller.h"
 #include "pid_simulator.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pid {
 

--- a/esphome/components/pid/pid_simulator.h
+++ b/esphome/components/pid/pid_simulator.h
@@ -5,6 +5,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/output/float_output.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pid {
 

--- a/esphome/components/pipsolar/output/pipsolar_output.h
+++ b/esphome/components/pipsolar/output/pipsolar_output.h
@@ -4,6 +4,8 @@
 #include "esphome/components/output/float_output.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pipsolar {
 

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -7,6 +7,8 @@
 #include "esphome/components/nfc/nfc.h"
 #include "esphome/components/nfc/automation.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pn532 {
 

--- a/esphome/components/pn532_i2c/pn532_i2c.h
+++ b/esphome/components/pn532_i2c/pn532_i2c.h
@@ -4,6 +4,8 @@
 #include "esphome/components/pn532/pn532.h"
 #include "esphome/components/i2c/i2c.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pn532_i2c {
 

--- a/esphome/components/pn532_spi/pn532_spi.h
+++ b/esphome/components/pn532_spi/pn532_spi.h
@@ -4,6 +4,8 @@
 #include "esphome/components/pn532/pn532.h"
 #include "esphome/components/spi/spi.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pn532_spi {
 

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 namespace esphome {

--- a/esphome/components/pzemac/pzemac.h
+++ b/esphome/components/pzemac/pzemac.h
@@ -5,6 +5,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pzemac {
 

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
+#include <vector>
+
 namespace esphome {
 namespace pzemdc {
 

--- a/esphome/components/rc522/rc522.h
+++ b/esphome/components/rc522/rc522.h
@@ -5,6 +5,8 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace rc522 {
 

--- a/esphome/components/rdm6300/rdm6300.h
+++ b/esphome/components/rdm6300/rdm6300.h
@@ -5,6 +5,8 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/uart/uart.h"
 
+#include <vector>
+
 namespace esphome {
 namespace rdm6300 {
 

--- a/esphome/components/remote_base/aeha_protocol.h
+++ b/esphome/components/remote_base/aeha_protocol.h
@@ -2,6 +2,8 @@
 
 #include "remote_base.h"
 
+#include <vector>
+
 namespace esphome {
 namespace remote_base {
 

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -5,6 +5,7 @@
 #include "remote_base.h"
 #include <array>
 #include <utility>
+#include <vector>
 
 namespace esphome {
 namespace remote_base {

--- a/esphome/components/remote_base/pronto_protocol.h
+++ b/esphome/components/remote_base/pronto_protocol.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
+#include <vector>
+
 namespace esphome {
 namespace remote_base {
 

--- a/esphome/components/remote_base/raw_protocol.h
+++ b/esphome/components/remote_base/raw_protocol.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "remote_base.h"
 
+#include <vector>
+
 namespace esphome {
 namespace remote_base {
 

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -1,4 +1,5 @@
 #include <utility>
+#include <vector>
 
 #pragma once
 

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/remote_base/remote_base.h"
 
+#include <vector>
+
 namespace esphome {
 namespace remote_transmitter {
 

--- a/esphome/components/rf_bridge/rf_bridge.h
+++ b/esphome/components/rf_bridge/rf_bridge.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"

--- a/esphome/components/rp2040/preferences.cpp
+++ b/esphome/components/rp2040/preferences.cpp
@@ -8,6 +8,8 @@
 #include "preferences.h"
 
 #include <cstring>
+#include <vector>
+
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/preferences.h"

--- a/esphome/components/sdm_meter/sdm_meter.h
+++ b/esphome/components/sdm_meter/sdm_meter.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
+#include <vector>
+
 namespace esphome {
 namespace sdm_meter {
 

--- a/esphome/components/selec_meter/selec_meter.h
+++ b/esphome/components/selec_meter/selec_meter.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
+#include <vector>
+
 namespace esphome {
 namespace selec_meter {
 

--- a/esphome/components/sensirion_common/i2c_sensirion.h
+++ b/esphome/components/sensirion_common/i2c_sensirion.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "esphome/components/i2c/i2c.h"
 
+#include <vector>
+
 namespace esphome {
 namespace sensirion_common {
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/core/helpers.h"
 #include <queue>
 #include <utility>
+#include <vector>
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace sensor {

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -6,6 +6,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/sensor/filter.h"
 
+#include <vector>
+
 namespace esphome {
 namespace sensor {
 

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -5,6 +5,8 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/switch/switch.h"
 
+#include <vector>
+
 namespace esphome {
 namespace sprinkler {
 

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -6,6 +6,8 @@
 #include "sx1509_gpio_pin.h"
 #include "sx1509_registers.h"
 
+#include <vector>
+
 namespace esphome {
 namespace sx1509 {
 

--- a/esphome/components/teleinfo/teleinfo.h
+++ b/esphome/components/teleinfo/teleinfo.h
@@ -3,6 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
+#include <vector>
+
 namespace esphome {
 namespace teleinfo {
 /*

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -5,6 +5,7 @@
 #include <queue>
 #include <utility>
 #include <map>
+#include <vector>
 
 namespace esphome {
 namespace text_sensor {

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -5,6 +5,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/text_sensor/filter.h"
 
+#include <vector>
+
 namespace esphome {
 namespace text_sensor {
 

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -4,7 +4,9 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
+
 #include <map>
+#include <vector>
 
 namespace esphome {
 namespace thermostat {

--- a/esphome/components/time/automation.h
+++ b/esphome/components/time/automation.h
@@ -4,6 +4,8 @@
 #include "esphome/core/automation.h"
 #include "real_time_clock.h"
 
+#include <vector>
+
 namespace esphome {
 namespace time {
 

--- a/esphome/components/tm1637/tm1637.h
+++ b/esphome/components/tm1637/tm1637.h
@@ -4,6 +4,8 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 
+#include <vector>
+
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
 #endif

--- a/esphome/components/tm1638/tm1638.h
+++ b/esphome/components/tm1638/tm1638.h
@@ -5,6 +5,8 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/hal.h"
 
+#include <vector>
+
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
 #endif

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -1,5 +1,7 @@
 #include "toshiba.h"
 
+#include <vector>
+
 namespace esphome {
 namespace toshiba {
 

--- a/esphome/components/ttp229_bsf/ttp229_bsf.h
+++ b/esphome/components/ttp229_bsf/ttp229_bsf.h
@@ -4,6 +4,8 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
+#include <vector>
+
 namespace esphome {
 namespace ttp229_bsf {
 

--- a/esphome/components/ttp229_lsf/ttp229_lsf.h
+++ b/esphome/components/ttp229_lsf/ttp229_lsf.h
@@ -4,6 +4,8 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
+#include <vector>
+
 namespace esphome {
 namespace ttp229_lsf {
 

--- a/esphome/components/tuya/automation.h
+++ b/esphome/components/tuya/automation.h
@@ -4,6 +4,8 @@
 #include "esphome/core/automation.h"
 #include "tuya.h"
 
+#include <vector>
+
 namespace esphome {
 namespace tuya {
 

--- a/esphome/components/tuya/select/tuya_select.h
+++ b/esphome/components/tuya/select/tuya_select.h
@@ -4,6 +4,8 @@
 #include "esphome/components/tuya/tuya.h"
 #include "esphome/components/select/select.h"
 
+#include <vector>
+
 namespace esphome {
 namespace tuya {
 

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -9,6 +9,8 @@
 #include "esphome/components/time/real_time_clock.h"
 #endif
 
+#include <vector>
+
 namespace esphome {
 namespace tuya {
 

--- a/esphome/components/tx20/tx20.cpp
+++ b/esphome/components/tx20/tx20.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
+#include <vector>
+
 namespace esphome {
 namespace tx20 {
 

--- a/esphome/components/uart/automation.h
+++ b/esphome/components/uart/automation.h
@@ -3,6 +3,8 @@
 #include "uart.h"
 #include "esphome/core/automation.h"
 
+#include <vector>
+
 namespace esphome {
 namespace uart {
 

--- a/esphome/components/uart/switch/uart_switch.h
+++ b/esphome/components/uart/switch/uart_switch.h
@@ -4,6 +4,8 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/switch/switch.h"
 
+#include <vector>
+
 namespace esphome {
 namespace uart {
 

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -4,6 +4,8 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
+
 #include "esphome/core/component.h"
 
 #include <ESPAsyncWebServer.h>

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -5,7 +5,9 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
 #include "esphome/components/network/ip_address.h"
+
 #include <string>
+#include <vector>
 
 #ifdef USE_ESP32_FRAMEWORK_ARDUINO
 #include <esp_wifi.h>

--- a/esphome/components/xiaomi_ble/xiaomi_ble.h
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.h
@@ -3,6 +3,8 @@
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 namespace esphome {

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.h
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.h
@@ -4,6 +4,8 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
+#include <vector>
+
 #ifdef USE_ESP32
 
 namespace esphome {

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -3,6 +3,8 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
+#include <vector>
+
 namespace esphome {
 
 template<typename... Ts> class AndCondition : public Condition<Ts...> {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This adds `#include <vector>` to every header file that uses `std::vector` (or to cpp where its not used in the header)

Files should not rely on it already being included elsewhere in the code

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
