### PR TITLE
Allow global setting of compile process limit

### DIFF
--- a/docker/ha-addon-rootfs/etc/services.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/services.d/esphome/run
@@ -22,6 +22,14 @@ if bashio::config.has_value 'relative_url'; then
     export ESPHOME_DASHBOARD_RELATIVE_URL=$(bashio::config 'relative_url')
 fi
 
+if bashio::config.has_value 'default_compile_process_limit'; then
+    export ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT=$(bashio::config 'default_compile_process_limit')
+else
+    if grep -q 'Raspberry Pi 3' /proc/cpuinfo; then
+        export ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT=1;
+    fi
+fi
+
 pio_cache_base=/data/cache/platformio
 # we can't set core_dir, because the settings file is stored in `core_dir/appstate.json`
 # setting `core_dir` would therefore prevent pio from accessing

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -110,6 +110,14 @@ def validate_version(value: str):
     return value
 
 
+if "ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT" in os.environ:
+    _compile_process_limit_default = int(
+        os.environ["ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT"]
+    )
+else:
+    _compile_process_limit_default = cv.UNDEFINED
+
+
 CONF_ESP8266_RESTORE_FROM_FLASH = "esp8266_restore_from_flash"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -153,9 +161,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MIN_VERSION, default=ESPHOME_VERSION): cv.All(
                 cv.version_number, validate_version
             ),
-            cv.Optional(CONF_COMPILE_PROCESS_LIMIT): cv.int_range(
-                min=1, max=multiprocessing.cpu_count()
-            ),
+            cv.Optional(
+                CONF_COMPILE_PROCESS_LIMIT, default=_compile_process_limit_default
+            ): cv.int_range(min=1, max=multiprocessing.cpu_count()),
         }
     ),
     validate_hostname,

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -111,8 +111,9 @@ def validate_version(value: str):
 
 
 if "ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT" in os.environ:
-    _compile_process_limit_default = int(
-        os.environ["ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT"]
+    _compile_process_limit_default = min(
+        int(os.environ["ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT"]),
+        multiprocessing.cpu_count(),
     )
 else:
     _compile_process_limit_default = cv.UNDEFINED


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add option to HA add-on to globally set compile process limit
Automatically set to `1` for RPi3 if not set.

This is a **default** setting and can still be overridden in YAML per device.

Requires PR in https://github.com/esphome/home-assistant-addon

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
