### PR TITLE
Fix regressed 'esphome run'

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -298,7 +298,7 @@ def upload_program(config, args, host):
     ota_conf = config[CONF_OTA]
     remote_port = ota_conf[CONF_PORT]
     password = ota_conf.get(CONF_PASSWORD, "")
-    if args.file is not None:
+    if getattr(args, "file", None) is not None:
         return espota2.run_ota(host, remote_port, password, args.file)
     return espota2.run_ota(host, remote_port, password, CORE.firmware_bin)
 


### PR DESCRIPTION
# What does this implement/fix?

Commit "Allow manually specifying binary file to OTA (#4054)" broke the workings of `esphome run ...`. The upload step fails with the following error:

```
INFO Successfully compiled program.
Traceback (most recent call last):
  File "/usr/local/bin/esphome", line 33, in <module>
    sys.exit(load_entry_point('esphome', 'console_scripts', 'esphome')())
  File "/esphome/esphome/__main__.py", line 961, in main
    return run_esphome(sys.argv)
  File "/esphome/esphome/__main__.py", line 948, in run_esphome
    rc = POST_CONFIG_ACTIONS[args.command](args, config)
  File "/esphome/esphome/__main__.py", line 410, in command_run
    exit_code = upload_program(config, args, port)
  File "/esphome/esphome/__main__.py", line 301, in upload_program
    if args.file is not None:
AttributeError: 'Namespace' object has no attribute 'file'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
