### PR TITLE
Add logging for BLE connection slots

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -24,7 +24,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       this->set_address(0);
       api::global_api_server->send_bluetooth_connections_free(this->proxy_->get_bluetooth_connections_free(),
                                                               this->proxy_->get_bluetooth_connections_limit());
-      ESP_LOGI(TAG, "[%d] [%s] Disconnected, freeing slot.", this->connection_index_, this->address_str_.c_str());
+      ESP_LOGV(TAG, "[%d] [%s] Disconnected, freeing slot.", this->connection_index_, this->address_str_.c_str());
       break;
     }
     case ESP_GATTC_OPEN_EVT: {

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -24,6 +24,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       this->set_address(0);
       api::global_api_server->send_bluetooth_connections_free(this->proxy_->get_bluetooth_connections_free(),
                                                               this->proxy_->get_bluetooth_connections_limit());
+      ESP_LOGI(TAG, "[%d] [%s] Disconnected, freeing slot.", this->connection_index_, this->address_str_.c_str());
       break;
     }
     case ESP_GATTC_OPEN_EVT: {

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -24,7 +24,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       this->set_address(0);
       api::global_api_server->send_bluetooth_connections_free(this->proxy_->get_bluetooth_connections_free(),
                                                               this->proxy_->get_bluetooth_connections_limit());
-      ESP_LOGV(TAG, "[%d] [%s] Disconnected, freeing slot.", this->connection_index_, this->address_str_.c_str());
       break;
     }
     case ESP_GATTC_OPEN_EVT: {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -52,6 +52,20 @@ void BluetoothProxy::dump_config() {
   ESP_LOGCONFIG(TAG, "  Active: %s", YESNO(this->active_));
 }
 
+int BluetoothProxy::get_bluetooth_connections_free() {
+  int free = 0;
+  for (auto *connection : this->connections_) {
+    if (connection->address_ == 0) {
+      free++;
+      ESP_LOGV(TAG, "[%d] Free connection", connection->get_connection_index());
+    } else {
+      ESP_LOGV(TAG, "[%d] Used connection by [%s]", connection->get_connection_index(),
+               connection->address_str().c_str());
+    }
+  }
+  return free;
+}
+
 void BluetoothProxy::loop() {
   if (!api::global_api_server->is_connected()) {
     for (auto *connection : this->connections_) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -41,15 +41,7 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
   void bluetooth_gatt_send_services(const api::BluetoothGATTGetServicesRequest &msg);
   void bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest &msg);
 
-  int get_bluetooth_connections_free() {
-    int free = 0;
-    for (auto *connection : this->connections_) {
-      if (connection->address_ == 0) {
-        free++;
-      }
-    }
-    return free;
-  }
+  int get_bluetooth_connections_free();
   int get_bluetooth_connections_limit() { return this->connections_.size(); }
 
   void set_active(bool active) { this->active_ = active; }


### PR DESCRIPTION

# What does this implement/fix?
It was hard to tell what was going on with each connection slot which hid the fact that we had needed a guard to fix a race where we could try to connect to the same ble device multiple times which is fixed in #4049


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
