### PR TITLE
Replace BLE address type map cache with a bounded cache

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -9,11 +9,37 @@
 namespace esphome {
 namespace bluetooth_proxy {
 
+static const uint8_t MAX_CACHE_SIZE = 36;
 static const char *const TAG = "bluetooth_proxy";
 
 BluetoothProxy::BluetoothProxy() { global_bluetooth_proxy = this; }
 
 bool BluetoothProxy::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+  uint64_t now = esp_timer_get_time();
+  uint64_t device_address = device.address_uint64();
+
+  if (this->address_time_map_.find(device_address) != this->address_time_map_.end()) {
+    // If we see it again before the cache expires be sure to drop the
+    // old time from the map so we do not leak
+    this->time_address_map_.erase(this->address_time_map_[device_address]);
+  }
+
+  this->times_queue_.push(now);
+  this->time_address_map_[now] = device_address;
+  this->address_time_map_[device_address] = now;
+  this->address_type_map_[device_address] = device.get_address_type();
+
+  while (this->times_queue_.size() > MAX_CACHE_SIZE) {
+    auto top_time = this->times_queue_.top();
+    if (this->address_time_map_.find(top_time) != this->address_time_map_.end()) {
+      uint64_t expire_address = this->address_time_map_[top_time];
+      this->address_type_map_.erase(expire_address);
+      this->address_time_map_.erase(expire_address);
+      this->time_address_map_.erase(top_time);
+    }
+    this->times_queue_.pop();
+  }
+
   if (!api::global_api_server->is_connected())
     return false;
   ESP_LOGV(TAG, "Proxying packet from %s - %s. RSSI: %d dB", device.get_name().c_str(), device.address_str().c_str(),
@@ -162,9 +188,18 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
                  connection->address_str().c_str());
         return;
       }
-      connection->set_state(espbt::ClientState::SEARCHING);
       api::global_api_server->send_bluetooth_connections_free(this->get_bluetooth_connections_free(),
                                                               this->get_bluetooth_connections_limit());
+      if (this->address_type_map_.find(msg.address) != this->address_type_map_.end()) {
+        // Utilize the address type cache
+        connection->set_found_device(msg.address, this->address_type_map_[msg.address]);
+        ESP_LOGV(TAG, "[%d] [%s] Using connect cache", connection->get_connection_index(),
+                 connection->address_str().c_str());
+      } else {
+        ESP_LOGI(TAG, "[%d] [%s] Searching to connect", connection->get_connection_index(),
+                 connection->address_str().c_str());
+        connection->set_state(espbt::ClientState::SEARCHING);
+      }
       break;
     }
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT: {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -52,6 +52,10 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
 
   BluetoothConnection *get_connection_(uint64_t address, bool reserve);
 
+  std::map<uint64_t, esp_ble_addr_type_t> address_type_map_;
+  std::map<uint64_t, uint64_t> address_time_map_;
+  std::map<uint64_t, uint64_t> time_address_map_;
+  std::priority_queue<uint64_t, std::vector<uint64_t>, std::greater<uint64_t>> times_queue_;
   int16_t send_service_{-1};
   bool active_;
 

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -32,6 +32,17 @@ void BLEClientBase::loop() {
 
 float BLEClientBase::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
+void BLEClientBase::set_found_device(uint64_t addr, esp_ble_addr_type_t address_type) {
+  this->remote_bda_[0] = (addr >> 40) & 0xFF;
+  this->remote_bda_[1] = (addr >> 32) & 0xFF;
+  this->remote_bda_[2] = (addr >> 24) & 0xFF;
+  this->remote_bda_[3] = (addr >> 16) & 0xFF;
+  this->remote_bda_[4] = (addr >> 8) & 0xFF;
+  this->remote_bda_[5] = (addr >> 0) & 0xFF;
+  this->remote_addr_type_ = address_type;
+  this->set_state(espbt::ClientState::DISCOVERED);
+}
+
 bool BLEClientBase::parse_device(const espbt::ESPBTDevice &device) {
   if (device.address_uint64() != this->address_)
     return false;
@@ -39,16 +50,7 @@ bool BLEClientBase::parse_device(const espbt::ESPBTDevice &device) {
     return false;
 
   ESP_LOGD(TAG, "[%d] [%s] Found device", this->connection_index_, this->address_str_.c_str());
-  this->set_state(espbt::ClientState::DISCOVERED);
-
-  auto addr = device.address_uint64();
-  this->remote_bda_[0] = (addr >> 40) & 0xFF;
-  this->remote_bda_[1] = (addr >> 32) & 0xFF;
-  this->remote_bda_[2] = (addr >> 24) & 0xFF;
-  this->remote_bda_[3] = (addr >> 16) & 0xFF;
-  this->remote_bda_[4] = (addr >> 8) & 0xFF;
-  this->remote_bda_[5] = (addr >> 0) & 0xFF;
-  this->remote_addr_type_ = device.get_address_type();
+  this->set_found_device(device.address_uint64(), device.get_address_type());
   return true;
 }
 

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -28,6 +28,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   float get_setup_priority() const override;
 
   bool parse_device(const espbt::ESPBTDevice &device) override;
+  void set_found_device(uint64_t addr, esp_ble_addr_type_t address_type);
   void on_scan_end() override {}
   bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;


### PR DESCRIPTION
Superseded by 
https://github.com/esphome/aioesphomeapi/pull/320
https://github.com/esphome/esphome/pull/4115
https://github.com/home-assistant/core/pull/82890

# What does this implement/fix?

Replaces the original solution that was reverted in #3905 with a bounded version that will not leak memory.  This restores the connection performance since it can take longer than the timeout to find the address type which means the connection may never complete without a cache.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
