### PR TITLE
Fix descriptors not being deleted

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -109,8 +109,7 @@ void BluetoothProxy::loop() {
       // after sending them to save memory. If something actually needs them
       // it can parse them again.
       for (auto &characteristic : service->characteristics) {
-        characteristic->parsed = false;
-        characteristic->descriptors.clear();
+        characteristic->release_descriptors();
       }
       connection->send_service_++;
     }

--- a/esphome/components/esp32_ble_client/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_client/ble_characteristic.cpp
@@ -16,6 +16,13 @@ BLECharacteristic::~BLECharacteristic() {
     delete desc;  // NOLINT(cppcoreguidelines-owning-memory)
 }
 
+void BLEService::release_descriptors() {
+  this->parsed = false;
+  for (auto &desc : this->descriptors)
+    delete desc;  // NOLINT(cppcoreguidelines-owning-memory)
+  this->descriptors.clear();
+}
+
 void BLECharacteristic::parse_descriptors() {
   this->parsed = true;
   uint16_t offset = 0;

--- a/esphome/components/esp32_ble_client/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_client/ble_characteristic.cpp
@@ -16,7 +16,7 @@ BLECharacteristic::~BLECharacteristic() {
     delete desc;  // NOLINT(cppcoreguidelines-owning-memory)
 }
 
-void BLEService::release_descriptors() {
+void BLECharacteristic::release_descriptors() {
   this->parsed = false;
   for (auto &desc : this->descriptors)
     delete desc;  // NOLINT(cppcoreguidelines-owning-memory)

--- a/esphome/components/esp32_ble_client/ble_characteristic.h
+++ b/esphome/components/esp32_ble_client/ble_characteristic.h
@@ -24,6 +24,7 @@ class BLECharacteristic {
   esp_gatt_char_prop_t properties;
   std::vector<BLEDescriptor *> descriptors;
   void parse_descriptors();
+  void release_descriptors();
   BLEDescriptor *get_descriptor(espbt::ESPBTUUID uuid);
   BLEDescriptor *get_descriptor(uint16_t uuid);
   BLEDescriptor *get_descriptor_by_handle(uint16_t handle);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -34,6 +34,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
   void connect() override;
   void disconnect();
+  void release_services();
 
   bool connected() { return this->state_ == espbt::ClientState::ESTABLISHED; }
 

--- a/esphome/components/esp32_ble_client/ble_service.cpp
+++ b/esphome/components/esp32_ble_client/ble_service.cpp
@@ -29,6 +29,13 @@ BLEService::~BLEService() {
     delete chr;  // NOLINT(cppcoreguidelines-owning-memory)
 }
 
+void BLEService::release_characteristics() {
+  this->parsed = false;
+  for (auto &chr : this->characteristics)
+    delete chr;  // NOLINT(cppcoreguidelines-owning-memory)
+  this->characteristics.clear();
+}
+
 void BLEService::parse_characteristics() {
   this->parsed = true;
   uint16_t offset = 0;

--- a/esphome/components/esp32_ble_client/ble_service.h
+++ b/esphome/components/esp32_ble_client/ble_service.h
@@ -25,6 +25,7 @@ class BLEService {
   std::vector<BLECharacteristic *> characteristics;
   BLEClientBase *client;
   void parse_characteristics();
+  void release_characteristics();
   BLECharacteristic *get_characteristic(espbt::ESPBTUUID uuid);
   BLECharacteristic *get_characteristic(uint16_t uuid);
 };


### PR DESCRIPTION
# What does this implement/fix?

Fix descriptors not being deleted

#4063 should have deleted them before clearing

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
