### PR TITLE
Change 4 chip limit on sn74hc595 to 256

### DIFF
--- a/esphome/components/sn74hc595/sn74hc595.cpp
+++ b/esphome/components/sn74hc595/sn74hc595.cpp
@@ -29,6 +29,11 @@ void SN74HC595Component::setup() {
 void SN74HC595Component::dump_config() { ESP_LOGCONFIG(TAG, "SN74HC595:"); }
 
 void SN74HC595Component::digital_write_(uint16_t pin, bool value) {
+  if (pin >= this->sr_count_ * 8) {
+    ESP_LOGE(TAG, "Pin %u is out of range! Maximum pin number with %u cihps in series is %u", pin, this->sr_count_,
+             (this->sr_count_ * 8) - 1);
+    return;
+  }
   this->output_bits_[pin] = value;
   this->write_gpio_();
 }

--- a/esphome/components/sn74hc595/sn74hc595.cpp
+++ b/esphome/components/sn74hc595/sn74hc595.cpp
@@ -30,7 +30,7 @@ void SN74HC595Component::dump_config() { ESP_LOGCONFIG(TAG, "SN74HC595:"); }
 
 void SN74HC595Component::digital_write_(uint16_t pin, bool value) {
   if (pin >= this->sr_count_ * 8) {
-    ESP_LOGE(TAG, "Pin %u is out of range! Maximum pin number with %u cihps in series is %u", pin, this->sr_count_,
+    ESP_LOGE(TAG, "Pin %u is out of range! Maximum pin number with %u chips in series is %u", pin, this->sr_count_,
              (this->sr_count_ * 8) - 1);
     return;
   }

--- a/esphome/components/sn74hc595/sn74hc595.cpp
+++ b/esphome/components/sn74hc595/sn74hc595.cpp
@@ -28,24 +28,16 @@ void SN74HC595Component::setup() {
 
 void SN74HC595Component::dump_config() { ESP_LOGCONFIG(TAG, "SN74HC595:"); }
 
-bool SN74HC595Component::digital_read_(uint8_t pin) { return this->output_bits_ >> pin; }
-
-void SN74HC595Component::digital_write_(uint8_t pin, bool value) {
-  uint32_t mask = 1UL << pin;
-  this->output_bits_ &= ~mask;
-  if (value)
-    this->output_bits_ |= mask;
+void SN74HC595Component::digital_write_(uint16_t pin, bool value) {
+  this->output_bits_[pin] = value;
   this->write_gpio_();
 }
 
-bool SN74HC595Component::write_gpio_() {
-  for (int i = this->sr_count_ - 1; i >= 0; i--) {
-    uint8_t data = (uint8_t)(this->output_bits_ >> (8 * i) & 0xff);
-    for (int j = 0; j < 8; j++) {
-      this->data_pin_->digital_write(data & (1 << (7 - j)));
-      this->clock_pin_->digital_write(true);
-      this->clock_pin_->digital_write(false);
-    }
+void SN74HC595Component::write_gpio_() {
+  for (auto bit = this->output_bits_.rbegin(); bit != this->output_bits_.rend(); bit++) {
+    this->data_pin_->digital_write(*bit);
+    this->clock_pin_->digital_write(true);
+    this->clock_pin_->digital_write(false);
   }
 
   // pulse latch to activate new values
@@ -56,8 +48,6 @@ bool SN74HC595Component::write_gpio_() {
   if (this->have_oe_pin_) {
     this->oe_pin_->digital_write(false);
   }
-
-  return true;
 }
 
 float SN74HC595Component::get_setup_priority() const { return setup_priority::IO; }

--- a/esphome/components/sn74hc595/sn74hc595.h
+++ b/esphome/components/sn74hc595/sn74hc595.h
@@ -2,6 +2,9 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+
+#include <vector>
 
 namespace esphome {
 namespace sn74hc595 {
@@ -21,13 +24,15 @@ class SN74HC595Component : public Component {
     oe_pin_ = pin;
     have_oe_pin_ = true;
   }
-  void set_sr_count(uint8_t count) { sr_count_ = count; }
+  void set_sr_count(uint8_t count) {
+    sr_count_ = count;
+    this->output_bits_.resize(count * 8);
+  }
 
  protected:
   friend class SN74HC595GPIOPin;
-  bool digital_read_(uint8_t pin);
-  void digital_write_(uint8_t pin, bool value);
-  bool write_gpio_();
+  void digital_write_(uint16_t pin, bool value);
+  void write_gpio_();
 
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;
@@ -35,11 +40,11 @@ class SN74HC595Component : public Component {
   GPIOPin *oe_pin_;
   uint8_t sr_count_;
   bool have_oe_pin_{false};
-  uint32_t output_bits_{0x00};
+  std::vector<bool> output_bits_;
 };
 
 /// Helper class to expose a SC74HC595 pin as an internal output GPIO pin.
-class SN74HC595GPIOPin : public GPIOPin {
+class SN74HC595GPIOPin : public GPIOPin, public Parented<SN74HC595Component> {
  public:
   void setup() override {}
   void pin_mode(gpio::Flags flags) override {}
@@ -47,13 +52,11 @@ class SN74HC595GPIOPin : public GPIOPin {
   void digital_write(bool value) override;
   std::string dump_summary() const override;
 
-  void set_parent(SN74HC595Component *parent) { parent_ = parent; }
-  void set_pin(uint8_t pin) { pin_ = pin; }
+  void set_pin(uint16_t pin) { pin_ = pin; }
   void set_inverted(bool inverted) { inverted_ = inverted; }
 
  protected:
-  SN74HC595Component *parent_;
-  uint8_t pin_;
+  uint16_t pin_;
   bool inverted_;
 };
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
The previous limit of 4 was set because it was using the bits of a single `uint32_t` to store pin information.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2490

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
