### PR TITLE
Combine the scanner failure check so we only stop the scanner once

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -148,6 +148,9 @@ void ESP32BLETracker::loop() {
       if (this->scan_continuous_) {
         if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
           this->start_scan_(false);
+        } else {
+          // We didn't start the scan, so we need to release the lock
+          xSemaphoreGive(this->scan_end_lock_);
         }
       } else if (!this->scanner_idle_) {
         this->end_of_scan_();

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -146,7 +146,7 @@ void ESP32BLETracker::loop() {
 
     if (!connecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
-        if (!promote_to_connecting) {
+        if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
           this->start_scan_(false);
         }
       } else if (!this->scanner_idle_) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -144,18 +144,6 @@ void ESP32BLETracker::loop() {
       xSemaphoreGive(this->scan_result_lock_);
     }
 
-    if (this->scan_set_param_failed_) {
-      ESP_LOGE(TAG, "Scan set param failed: %d", this->scan_set_param_failed_);
-      esp_ble_gap_stop_scanning();
-      this->scan_set_param_failed_ = ESP_BT_STATUS_SUCCESS;
-    }
-
-    if (this->scan_start_failed_) {
-      ESP_LOGE(TAG, "Scan start failed: %d", this->scan_start_failed_);
-      esp_ble_gap_stop_scanning();
-      this->scan_start_failed_ = ESP_BT_STATUS_SUCCESS;
-    }
-
     if (!connecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
         if (!promote_to_connecting) {
@@ -164,6 +152,18 @@ void ESP32BLETracker::loop() {
       } else if (!this->scanner_idle_) {
         this->end_of_scan_();
         return;
+      }
+    }
+
+    if (this->scan_start_failed_ || this->scan_set_param_failed_) {
+      esp_ble_gap_stop_scanning();
+      if (this->scan_start_failed_) {
+        ESP_LOGE(TAG, "Scan start failed: %d", this->scan_start_failed_);
+        this->scan_start_failed_ = ESP_BT_STATUS_SUCCESS;
+      }
+      if (this->scan_set_param_failed_) {
+        ESP_LOGE(TAG, "Scan set param failed: %d", this->scan_set_param_failed_);
+        this->scan_set_param_failed_ = ESP_BT_STATUS_SUCCESS;
       }
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

If the scanner failed to start and the set scan param failed we could try to stop the scanner twice to get it back in a good state. We now check both at once to ensure we only make one call to esp_ble_gap_stop_scanning per loop.

Move the stop after the start check to ensure we wait to the next loop to start it to give it time to settle.

Fixes the lock not being released if we reject starting the scan.

Fix loop of
```
[10:18:04][E][esp32_ble_tracker:154]: Scan start failed: 1
[10:18:04][D][esp32_ble_tracker:289]: Starting scan...
[10:18:04][E][esp32_ble_tracker:148]: Scan set param failed: 1
[10:18:04][E][esp32_ble_tracker:154]: Scan start failed: 1
[10:18:04][D][esp32_ble_tracker:289]: Starting scan...
[10:18:04][E][esp32_ble_tracker:148]: Scan set param failed: 1
[10:18:04][E][esp32_ble_tracker:154]: Scan start failed: 1
...
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
