### PR TITLE
Fix bluetooth_gatt_write_descriptor never getting a response

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -236,7 +236,7 @@ esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
   return ESP_OK;
 }
 
-esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::string &data) {
+esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT descriptor, not connected.", this->connection_index_,
              this->address_str_.c_str());
@@ -252,9 +252,9 @@ esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::stri
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor %s", this->connection_index_, this->address_str_.c_str(),
            descriptor->uuid.to_string().c_str());
 
-  auto err =
-      esp_ble_gattc_write_char_descr(this->gattc_if_, this->conn_id_, descriptor->handle, data.size(),
-                                     (uint8_t *) data.data(), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+  esp_err_t err = esp_ble_gattc_write_char_descr(
+      this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
+      response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char_descr error, err=%d", this->connection_index_,
              this->address_str_.c_str(), err);

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -17,7 +17,7 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   esp_err_t read_characteristic(uint16_t handle);
   esp_err_t write_characteristic(uint16_t handle, const std::string &data, bool response);
   esp_err_t read_descriptor(uint16_t handle);
-  esp_err_t write_descriptor(uint16_t handle, const std::string &data);
+  esp_err_t write_descriptor(uint16_t handle, const std::string &data, bool response);
 
   esp_err_t notify_characteristic(uint16_t handle, bool enable);
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -241,7 +241,7 @@ void BluetoothProxy::bluetooth_gatt_write_descriptor(const api::BluetoothGATTWri
     return;
   }
 
-  auto err = connection->write_descriptor(msg.handle, msg.data);
+  auto err = connection->write_descriptor(msg.handle, msg.data, true);
   if (err != ESP_OK) {
     api::global_api_server->send_bluetooth_gatt_error(msg.address, msg.handle, err);
   }


### PR DESCRIPTION
# What does this implement/fix?

Fix bluetooth_gatt_write_descriptor never getting a response

We always wrote these with `ESP_GATT_WRITE_TYPE_NO_RSP` 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
