### PR TITLE
Add ESP32-S3 support in NeoPixelBus component

### DIFF
--- a/esphome/components/neopixelbus/_methods.py
+++ b/esphome/components/neopixelbus/_methods.py
@@ -13,8 +13,8 @@ from esphome.const import (
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
-    VARIANT_ESP32S2,
     VARIANT_ESP32C3,
+    VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 )
 from esphome.core import CORE
@@ -58,9 +58,9 @@ SPI_SPEEDS = [40e6, 20e6, 10e6, 5e6, 2e6, 1e6, 500e3]
 
 def _esp32_rmt_default_channel():
     return {
+        VARIANT_ESP32C3: 1,
         VARIANT_ESP32S2: 1,
         VARIANT_ESP32S3: 1,
-        VARIANT_ESP32C3: 1,
     }.get(get_esp32_variant(), 6)
 
 
@@ -71,9 +71,9 @@ def _validate_esp32_rmt_channel(value):
         value = cv.int_(value)
     variant_channels = {
         VARIANT_ESP32: [0, 1, 2, 3, 4, 5, 6, 7, CHANNEL_DYNAMIC],
+        VARIANT_ESP32C3: [0, 1, CHANNEL_DYNAMIC],
         VARIANT_ESP32S2: [0, 1, 2, 3, CHANNEL_DYNAMIC],
         VARIANT_ESP32S3: [0, 1, 2, 3, CHANNEL_DYNAMIC],
-        VARIANT_ESP32C3: [0, 1, CHANNEL_DYNAMIC],
     }
     variant = get_esp32_variant()
     if variant not in variant_channels:

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -17,6 +17,7 @@ from esphome.const import (
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32C3,
+    VARIANT_ESP32S3,
 )
 from esphome.core import CORE
 from ._methods import (
@@ -96,7 +97,7 @@ def _choose_default_method(config):
             config[CONF_METHOD] = _validate_method(METHOD_BIT_BANG)
 
     if CORE.is_esp32:
-        if get_esp32_variant() == VARIANT_ESP32C3:
+        if get_esp32_variant() in (VARIANT_ESP32C3, VARIANT_ESP32S3):
             config[CONF_METHOD] = _validate_method(METHOD_ESP32_RMT)
         else:
             config[CONF_METHOD] = _validate_method(METHOD_ESP32_I2S)

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ build_flags =
 [common]
 lib_deps =
     esphome/noise-c@0.1.4                  ; api
-    makuna/NeoPixelBus@2.6.9               ; neopixelbus
+    makuna/NeoPixelBus@2.7.3               ; neopixelbus
     esphome/Improv@1.2.3                   ; improv_serial / esp32_improv
     bblanchon/ArduinoJson@6.18.5           ; json
     wjtje/qr-code-generator-library@1.7.0  ; qr_code


### PR DESCRIPTION
# Add ESP32-S3 support in NeoPixelBus component

Update NeoPixelBus library dependency to the latest released version (2.7.1), and update the NeoPixelBus component to allow using the ESP32-S3 with the esp32_rmt and bit_bang methods.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2491

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

I have tested this on a "standard" ESP32 (WROOM-32), and the ESP32-S3, and a Wemos D1 Mini.

I've attempted to test bit_bang support on the "high" pins (S3 has GPIO up to 48), but I'm unable to see any signal at all with my logic analyzer. bit_bang does seem to work on the normal pins, and rmt works with multiple channels on all the pins I've tested on.

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: arduino
    version: "2.0.5"
    platform_version: "platformio/espressif32"

light:
  - platform: neopixelbus
    variant: WS2811
    pin: GPIO35
    num_leds: 100
    name: string
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
