### PR TITLE
Speed up uuid parsing when fetching the service list

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -118,7 +118,7 @@ void BluetoothProxy::loop() {
       api::BluetoothGATTGetServicesResponse resp;
       resp.address = connection->get_address();
       api::BluetoothGATTService service_resp;
-      service_resp.uuid = std::move(get_128bit_uuid_vec(service_result.uuid));
+      service_resp.uuid = get_128bit_uuid_vec(service_result.uuid);
       service_resp.handle = service_result.start_handle;
       uint16_t char_offset = 0;
       esp_gattc_char_elem_t char_result;
@@ -139,7 +139,7 @@ void BluetoothProxy::loop() {
           break;
         }
         api::BluetoothGATTCharacteristic characteristic_resp;
-        characteristic_resp.uuid = std::move(get_128bit_uuid_vec(char_result.uuid));
+        characteristic_resp.uuid = get_128bit_uuid_vec(char_result.uuid);
         characteristic_resp.handle = char_result.char_handle;
         characteristic_resp.properties = char_result.properties;
         char_offset++;
@@ -162,7 +162,7 @@ void BluetoothProxy::loop() {
             break;
           }
           api::BluetoothGATTDescriptor descriptor_resp;
-          descriptor_resp.uuid = std::move(get_128bit_uuid_vec(desc_result.uuid));
+          descriptor_resp.uuid = get_128bit_uuid_vec(desc_result.uuid);
           descriptor_resp.handle = desc_result.handle;
           characteristic_resp.descriptors.push_back(std::move(descriptor_resp));
           desc_offset++;


### PR DESCRIPTION
# What does this implement/fix?

Speed up uuid parsing when fetching the service list.

We avoid converting the uuid twice (once for high and once for low)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
