### PR TITLE
modbus_switch: honor switch:restore_mode

### DIFF
--- a/esphome/components/modbus_controller/switch/modbus_switch.cpp
+++ b/esphome/components/modbus_controller/switch/modbus_switch.cpp
@@ -8,8 +8,8 @@ static const char *const TAG = "modbus_controller.switch";
 
 void ModbusSwitch::setup() {
   optional<bool> initial_state = Switch::get_initial_state_with_restore_mode();
-
   if (initial_state.has_value()) {
+    // if it has a value, restore_mode is not "DISABLED", therefore act on the switch:
     if (initial_state.value()) {
       this->turn_on();
     } else {

--- a/esphome/components/modbus_controller/switch/modbus_switch.cpp
+++ b/esphome/components/modbus_controller/switch/modbus_switch.cpp
@@ -6,7 +6,17 @@ namespace modbus_controller {
 
 static const char *const TAG = "modbus_controller.switch";
 
-void ModbusSwitch::setup() {}
+void ModbusSwitch::setup() {
+  optional<bool> initial_state = Switch::get_initial_state_with_restore_mode();
+
+  if (initial_state.has_value()) {
+    if (initial_state.value()) {
+      this->turn_on();
+    } else {
+      this->turn_off();
+    }
+  }
+}
 void ModbusSwitch::dump_config() { LOG_SWITCH(TAG, "Modbus Controller Switch", this); }
 
 void ModbusSwitch::parse_and_publish(const std::vector<uint8_t> &data) {


### PR DESCRIPTION
# What does this implement/fix?

This PR implements `switch::restore_mode` functionality for Modbus switches. It leverages the groundwork in [PR #3648](https://github.com/esphome/esphome/pull/3648#top), so it is actually a very small change.

Modbus switches can now be restored to the last on/off state as recorded by ESPHome, or started with a forced on/off state, etc.

By default, this feature is disabled so Modbus Switch will behave as it did before this PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
