### PR TITLE
current-based cover fix copy paste mistake

### DIFF
--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -179,7 +179,7 @@ bool CurrentBasedCover::is_closing_blocked_() const {
   if (this->close_obstacle_current_threshold_ == FLT_MAX) {
     return false;
   }
-  return this->open_sensor_->get_state() > this->open_obstacle_current_threshold_;
+  return this->close_sensor_->get_state() > this->close_obstacle_current_threshold_;
 }
 bool CurrentBasedCover::is_initial_delay_finished_() const {
   return millis() - this->start_dir_time_ > this->start_sensing_delay_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
If using individual current sensors for the open and close, it would not work properly as the closing blocked check was watching the open_sensor.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
