### PR TITLE
Allow auto setting of ble client id if there is only 1 in config

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -66,7 +66,7 @@ CONF_BLE_CLIENT_ID = "ble_client_id"
 
 BLE_CLIENT_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_BLE_CLIENT_ID): cv.use_id(BLEClient),
+        cv.GenerateID(CONF_BLE_CLIENT_ID): cv.use_id(BLEClient),
     }
 )
 
@@ -78,7 +78,7 @@ async def register_ble_node(var, config):
 
 BLE_WRITE_ACTION_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_ID): cv.use_id(BLEClient),
+        cv.GenerateID(CONF_ID): cv.use_id(BLEClient),
         cv.Required(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
         cv.Required(CONF_CHARACTERISTIC_UUID): esp32_ble_tracker.bt_uuid,
         cv.Required(CONF_VALUE): cv.templatable(cv.ensure_list(cv.hex_uint8_t)),


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This allows the user to not have to enter the ble client id if there is only 1 ble_client in config. If there are multiple then a validation error will force setting the id.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
