### PR TITLE
Detect BLE stack unrecoverable state

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -113,7 +113,6 @@ void ESP32BLETracker::loop() {
         xSemaphoreTake(this->scan_result_lock_, 5L / portTICK_PERIOD_MS)) {
       uint32_t index = this->scan_result_index_;
       if (index) {
-        this->scan_start_fail_count_ = 0;
         if (index >= 16) {
           ESP_LOGW(TAG, "Too many BLE events to process. Some devices may not show up.");
         }
@@ -372,7 +371,9 @@ void ESP32BLETracker::gap_scan_set_param_complete_(const esp_ble_gap_cb_param_t:
 
 void ESP32BLETracker::gap_scan_start_complete_(const esp_ble_gap_cb_param_t::ble_scan_start_cmpl_evt_param &param) {
   this->scan_start_failed_ = param.status;
-  if (param.status != ESP_BT_STATUS_SUCCESS) {
+  if (param.status == ESP_BT_STATUS_SUCCESS) {
+    this->scan_start_fail_count_ = 0;
+  } else {
     xSemaphoreGive(this->scan_end_lock_);
   }
 }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -159,8 +159,8 @@ void ESP32BLETracker::loop() {
     }
 
     if (this->scan_start_failed_ || this->scan_set_param_failed_) {
-      if (this->scan_start_fail_count_ == 255) {
-        ESP_LOGE(TAG, "ESP-IDF BLE scan could not restart after 255 attempts, rebooting to restore BLE stack...");
+      if (this->scan_start_fail_count_ == 1024) {
+        ESP_LOGE(TAG, "ESP-IDF BLE scan could not restart after 1024 attempts, rebooting to restore BLE stack...");
         App.reboot();
       }
       esp_ble_gap_stop_scanning();

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -146,7 +146,7 @@ void ESP32BLETracker::loop() {
 
     if (!connecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
-        if (!connecting && !promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
+        if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
           this->start_scan_(false);
         } else {
           // We didn't start the scan, so we need to release the lock

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -90,8 +90,12 @@ void ESP32BLETracker::loop() {
   int connecting = 0;
   int discovered = 0;
   int searching = 0;
+  int disconnecting = 0;
   for (auto *client : this->clients_) {
     switch (client->state()) {
+      case ClientState::DISCONNECTING:
+        disconnecting++;
+        break;
       case ClientState::DISCOVERED:
         discovered++;
         break;
@@ -144,7 +148,7 @@ void ESP32BLETracker::loop() {
       xSemaphoreGive(this->scan_result_lock_);
     }
 
-    if (!connecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
+    if (!connecting && !disconnecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
         if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
           this->start_scan_(false);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -181,6 +181,7 @@ void ESP32BLETracker::loop() {
         App.reboot();
       }
       esp_ble_gap_stop_scanning();
+      this->cancel_timeout("scan");
       if (this->scan_start_failed_) {
         ESP_LOGE(TAG, "Scan start failed: %d", this->scan_start_failed_);
         this->scan_start_failed_ = ESP_BT_STATUS_SUCCESS;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -176,8 +176,8 @@ void ESP32BLETracker::loop() {
     }
 
     if (this->scan_start_failed_ || this->scan_set_param_failed_) {
-      if (this->scan_start_fail_count_ == 1024) {
-        ESP_LOGE(TAG, "ESP-IDF BLE scan could not restart after 1024 attempts, rebooting to restore BLE stack...");
+      if (this->scan_start_fail_count_ == 255) {
+        ESP_LOGE(TAG, "ESP-IDF BLE scan could not restart after 255 attempts, rebooting to restore BLE stack...");
         App.reboot();
       }
       esp_ble_gap_stop_scanning();

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -147,18 +147,20 @@ void ESP32BLETracker::loop() {
       }
       xSemaphoreGive(this->scan_result_lock_);
     }
-   
-    #
-    # Avoid starting the scanner if:
-    # - we are already scanning
-    # - we are connecting to a device
-    # - we are disconnecting from a device
-    # 
-    # Otherwise the scanner could fail to ever start again
-    # and our only way to recover is to reboot.
-    # 
-    # https://github.com/espressif/esp-idf/issues/6688
-    #
+
+    /*
+
+      Avoid starting the scanner if:
+      - we are already scanning
+      - we are connecting to a device
+      - we are disconnecting from a device
+
+      Otherwise the scanner could fail to ever start again
+      and our only way to recover is to reboot.
+
+      https://github.com/espressif/esp-idf/issues/6688
+
+    */
     if (!connecting && !disconnecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
         if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -159,7 +159,6 @@ void ESP32BLETracker::loop() {
     }
 
     if (this->scan_start_failed_ || this->scan_set_param_failed_) {
-      this->scan_start_fail_count_++;
       if (this->scan_start_fail_count_ == 255) {
         ESP_LOGE(TAG, "ESP-IDF BLE scan could not restart after 255 attempts, rebooting to restore BLE stack...");
         App.reboot();
@@ -374,6 +373,7 @@ void ESP32BLETracker::gap_scan_start_complete_(const esp_ble_gap_cb_param_t::ble
   if (param.status == ESP_BT_STATUS_SUCCESS) {
     this->scan_start_fail_count_ = 0;
   } else {
+    this->scan_start_fail_count_++;
     xSemaphoreGive(this->scan_end_lock_);
   }
 }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -146,7 +146,7 @@ void ESP32BLETracker::loop() {
 
     if (!connecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
-        if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
+        if (!connecting && !promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
           this->start_scan_(false);
         } else {
           // We didn't start the scan, so we need to release the lock

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -181,7 +181,6 @@ void ESP32BLETracker::loop() {
         App.reboot();
       }
       esp_ble_gap_stop_scanning();
-      this->cancel_timeout("scan");
       if (this->scan_start_failed_) {
         ESP_LOGE(TAG, "Scan start failed: %d", this->scan_start_failed_);
         this->scan_start_failed_ = ESP_BT_STATUS_SUCCESS;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -147,7 +147,18 @@ void ESP32BLETracker::loop() {
       }
       xSemaphoreGive(this->scan_result_lock_);
     }
-
+   
+    #
+    # Avoid starting the scanner if:
+    # - we are already scanning
+    # - we are connecting to a device
+    # - we are disconnecting from a device
+    # 
+    # Otherwise the scanner could fail to ever start again
+    # and our only way to recover is to reboot.
+    # 
+    # https://github.com/espressif/esp-idf/issues/6688
+    #
     if (!connecting && !disconnecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
         if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -253,6 +253,7 @@ class ESP32BLETracker : public Component {
   uint32_t scan_duration_;
   uint32_t scan_interval_;
   uint32_t scan_window_;
+  uint8_t scan_start_fail_count_;
   bool scan_continuous_;
   bool scan_active_;
   bool scanner_idle_;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -253,7 +253,7 @@ class ESP32BLETracker : public Component {
   uint32_t scan_duration_;
   uint32_t scan_interval_;
   uint32_t scan_window_;
-  uint8_t scan_start_fail_count_;
+  uint16_t scan_start_fail_count_;
   bool scan_continuous_;
   bool scan_active_;
   bool scanner_idle_;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -253,7 +253,7 @@ class ESP32BLETracker : public Component {
   uint32_t scan_duration_;
   uint32_t scan_interval_;
   uint32_t scan_window_;
-  uint16_t scan_start_fail_count_;
+  uint8_t scan_start_fail_count_;
   bool scan_continuous_;
   bool scan_active_;
   bool scanner_idle_;


### PR DESCRIPTION
# What does this implement/fix?

We currently have a timeout to reboot the ESP if the BLE scan never terminates. This can also present as multiple failures to start a scan.  From https://github.com/espressif/esp-idf/issues/6688 it looks the the only way to get out of this state after is happens is a reboot. Once we hit 255 failures to start a scan trigger the reboot to restore the BLE stack

We also now avoid starting the scanner when we are disconnecting since that seems to be another case were its likely to hit the failure mode in the BLE stack.

This issue presents as pages and pages of

```
[12:35:40][E][esp32_ble_tracker:168]: Scan set param failed: 1
[12:35:40][D][esp32_ble_tracker:292]: Starting scan...
[12:35:40][E][esp32_ble_tracker:164]: Scan start failed: 1
[12:35:40][E][esp32_ble_tracker:168]: Scan set param failed: 1
[12:35:40][D][esp32_ble_tracker:292]: Starting scan...
[12:35:40][E][esp32_ble_tracker:164]: Scan start failed: 1
[12:35:40][E][esp32_ble_tracker:168]: Scan set param failed: 1
[12:35:40][D][esp32_ble_tracker:292]: Starting scan...
[12:35:40][E][esp32_ble_tracker:164]: Scan start failed: 1
[12:35:40][E][esp32_ble_tracker:168]: Scan set param failed: 1
[12:35:40][D][esp32_ble_tracker:292]: Starting scan...
[12:35:40][E][esp32_ble_tracker:164]: Scan start failed: 1
[12:35:40][E][esp32_ble_tracker:168]: Scan set param failed: 1
[12:35:40][D][esp32_ble_tracker:292]: Starting scan...
```


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
