### PR TITLE
Implement a slow sigma-delta modulation based output

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -204,6 +204,7 @@ esphome/components/sgp4x/* @SenexCrenshaw @martgras
 esphome/components/shelly_dimmer/* @edge90 @rnauber
 esphome/components/sht4x/* @sjtrny
 esphome/components/shutdown/* @esphome/core @jsuanet
+esphome/components/sigma_delta_output/* @Cat-Ion
 esphome/components/sim800l/* @glmnet
 esphome/components/sm2135/* @BoukeHaarsma23
 esphome/components/sml/* @alengwenus

--- a/esphome/components/sigma_delta_output/__init__.py
+++ b/esphome/components/sigma_delta_output/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@Cat-Ion"]

--- a/esphome/components/sigma_delta_output/output.py
+++ b/esphome/components/sigma_delta_output/output.py
@@ -5,7 +5,6 @@ import esphome.codegen as cg
 from esphome.const import (
     CONF_ID,
     CONF_PIN,
-    CONF_OUTPUT,
     CONF_TURN_ON_ACTION,
     CONF_TURN_OFF_ACTION,
 )
@@ -24,7 +23,6 @@ CONFIG_SCHEMA = cv.All(
     output.FLOAT_OUTPUT_SCHEMA.extend(cv.polling_component_schema("60s")).extend(
         {
             cv.Required(CONF_ID): cv.declare_id(SigmaDeltaOutput),
-            cv.Optional(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
             cv.Optional(CONF_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_STATE_CHANGE_ACTION): automation.validate_automation(
                 single=True
@@ -66,7 +64,3 @@ async def to_code(config):
         await automation.build_automation(
             var.get_turn_off_trigger(), [], config[CONF_TURN_OFF_ACTION]
         )
-
-    if CONF_OUTPUT in config:
-        output_component = await cg.get_variable(config[CONF_OUTPUT])
-        cg.add(var.set_output(output_component))

--- a/esphome/components/sigma_delta_output/output.py
+++ b/esphome/components/sigma_delta_output/output.py
@@ -1,0 +1,35 @@
+from esphome import pins, automation
+from esphome.components import output
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import (
+    CONF_UPDATE_INTERVAL,
+    CONF_ID,
+    CONF_OUTPUT,
+)
+
+DEPENDENCIES = []
+
+
+sigma_delta_output_ns = cg.esphome_ns.namespace("sigma_delta_output")
+SigmaDeltaOutput = sigma_delta_output_ns.class_(
+    "SigmaDeltaOutput", output.FloatOutput, cg.PollingComponent
+)
+
+CONFIG_SCHEMA = cv.All(
+    output.FLOAT_OUTPUT_SCHEMA.extend(cv.polling_component_schema("60s")).extend(
+        {
+            cv.Required(CONF_ID): cv.declare_id(SigmaDeltaOutput),
+            cv.Required(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
+        }
+    ),
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await output.register_output(var, config)
+
+    output_component = await cg.get_variable(config[CONF_OUTPUT])
+    cg.add(var.set_output(output_component))

--- a/esphome/components/sigma_delta_output/output.py
+++ b/esphome/components/sigma_delta_output/output.py
@@ -1,9 +1,13 @@
+from esphome import automation, pins
 from esphome.components import output
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
     CONF_ID,
+    CONF_PIN,
     CONF_OUTPUT,
+    CONF_TURN_ON_ACTION,
+    CONF_TURN_OFF_ACTION,
 )
 
 DEPENDENCIES = []
@@ -14,11 +18,27 @@ SigmaDeltaOutput = sigma_delta_output_ns.class_(
     "SigmaDeltaOutput", output.FloatOutput, cg.PollingComponent
 )
 
+CONF_STATE_CHANGE_ACTION = "state_change_action"
+
 CONFIG_SCHEMA = cv.All(
     output.FLOAT_OUTPUT_SCHEMA.extend(cv.polling_component_schema("60s")).extend(
         {
             cv.Required(CONF_ID): cv.declare_id(SigmaDeltaOutput),
-            cv.Required(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
+            cv.Optional(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
+            cv.Optional(CONF_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_STATE_CHANGE_ACTION): automation.validate_automation(
+                single=True
+            ),
+            cv.Inclusive(
+                CONF_TURN_ON_ACTION,
+                "on_off",
+                f"{CONF_TURN_ON_ACTION} and {CONF_TURN_OFF_ACTION} must both be defined",
+            ): automation.validate_automation(single=True),
+            cv.Inclusive(
+                CONF_TURN_OFF_ACTION,
+                "on_off",
+                f"{CONF_TURN_ON_ACTION} and {CONF_TURN_OFF_ACTION} must both be defined",
+            ): automation.validate_automation(single=True),
         }
     ),
 )
@@ -29,5 +49,24 @@ async def to_code(config):
     await cg.register_component(var, config)
     await output.register_output(var, config)
 
-    output_component = await cg.get_variable(config[CONF_OUTPUT])
-    cg.add(var.set_output(output_component))
+    if CONF_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_PIN])
+        cg.add(var.set_pin(pin))
+
+    if CONF_STATE_CHANGE_ACTION in config:
+        await automation.build_automation(
+            var.get_state_change_trigger(),
+            [(bool, "state")],
+            config[CONF_STATE_CHANGE_ACTION],
+        )
+    if CONF_TURN_ON_ACTION in config:
+        await automation.build_automation(
+            var.get_turn_on_trigger(), [], config[CONF_TURN_ON_ACTION]
+        )
+        await automation.build_automation(
+            var.get_turn_off_trigger(), [], config[CONF_TURN_OFF_ACTION]
+        )
+
+    if CONF_OUTPUT in config:
+        output_component = await cg.get_variable(config[CONF_OUTPUT])
+        cg.add(var.set_output(output_component))

--- a/esphome/components/sigma_delta_output/output.py
+++ b/esphome/components/sigma_delta_output/output.py
@@ -1,9 +1,7 @@
-from esphome import pins, automation
 from esphome.components import output
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
-    CONF_UPDATE_INTERVAL,
     CONF_ID,
     CONF_OUTPUT,
 )

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -6,22 +6,66 @@ namespace esphome {
 namespace sigma_delta_output {
 class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
  public:
+  Trigger<> *get_turn_on_trigger() {
+    if (!this->turn_on_trigger_)
+      this->turn_on_trigger_ = make_unique<Trigger<>>();
+    return this->turn_on_trigger_.get();
+  }
+  Trigger<> *get_turn_off_trigger() {
+    if (!this->turn_off_trigger_)
+      this->turn_off_trigger_ = make_unique<Trigger<>>();
+    return this->turn_off_trigger_.get();
+  }
+
+  Trigger<bool> *get_state_change_trigger() {
+    if (!this->state_change_trigger_)
+      this->state_change_trigger_ = make_unique<Trigger<bool>>();
+    return this->state_change_trigger_.get();
+  }
+
   void set_output(output::BinaryOutput *output) { this->output_ = output; }
+  void set_pin(GPIOPin *pin) { this->pin_ = pin; };
   void write_state(float state) override { this->state_ = state; }
   void update() override {
     this->accum_ += this->state_;
-    if (this->output_) {
-      this->output_->set_state(this->accum_ > 0);
-    }
-    if (this->accum_ > 0) {
+    const bool next_value = this->accum_ > 0;
+
+    if (next_value) {
       this->accum_ -= 1.;
+    }
+
+    if (next_value != this->value_) {
+      this->value_ = next_value;
+      if (this->pin_) {
+        this->pin_->digital_write(next_value);
+      }
+      if (this->output_) {
+        this->output_->set_state(next_value);
+      }
+
+      if (this->state_change_trigger_) {
+        this->state_change_trigger_->trigger(next_value);
+      }
+
+      if (next_value && this->turn_on_trigger_) {
+        this->turn_on_trigger_->trigger();
+      } else if (!next_value && this->turn_off_trigger_) {
+        this->turn_off_trigger_->trigger();
+      }
     }
   }
 
  protected:
   output::BinaryOutput *output_{nullptr};
+  GPIOPin *pin_{nullptr};
+
+  std::unique_ptr<Trigger<>> turn_on_trigger_{nullptr};
+  std::unique_ptr<Trigger<>> turn_off_trigger_{nullptr};
+  std::unique_ptr<Trigger<bool>> state_change_trigger_{nullptr};
+
   float accum_{0};
   float state_{0.};
+  bool value_{false};
 };
 }  // namespace sigma_delta_output
 }  // namespace esphome

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "esphome/core/component.h"
+#include "esphome/components/output/float_output.h"
+
+namespace esphome {
+namespace sigma_delta_output {
+class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
+ public:
+  void set_output(output::BinaryOutput *output) { this->output_ = output; }
+  void write_state(float state) override { this->state_ = state; }
+  void update() override {
+    this->accum_ += this->state_;
+    if (this->output_) {
+      this->output_->set_state(this->accum_ > 0);
+    }
+    if (this->accum_ > 0) {
+      this->accum_ -= 1.;
+    }
+  }
+
+ protected:
+  output::BinaryOutput *output_{nullptr};
+  float accum_{0};
+  float state_{0.};
+};
+}  // namespace sigma_delta_output
+}  // namespace esphome

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -23,7 +23,6 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
     return this->state_change_trigger_.get();
   }
 
-  void set_output(output::BinaryOutput *output) { this->output_ = output; }
   void set_pin(GPIOPin *pin) { this->pin_ = pin; };
   void write_state(float state) override { this->state_ = state; }
   void update() override {
@@ -39,9 +38,6 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
       if (this->pin_) {
         this->pin_->digital_write(next_value);
       }
-      if (this->output_) {
-        this->output_->set_state(next_value);
-      }
 
       if (this->state_change_trigger_) {
         this->state_change_trigger_->trigger(next_value);
@@ -56,7 +52,6 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
   }
 
  protected:
-  output::BinaryOutput *output_{nullptr};
   GPIOPin *pin_{nullptr};
 
   std::unique_ptr<Trigger<>> turn_on_trigger_{nullptr};

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1313,6 +1313,10 @@ output:
       return {s};
     outputs:
       - id: custom_binary
+  - platform: sigma_delta_output
+    id: sddac
+    update_interval: 60s
+    output: custom_binary
   - platform: custom
     type: float
     lambda: |-

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1317,6 +1317,18 @@ output:
     id: sddac
     update_interval: 60s
     output: custom_binary
+    pin: D4
+    turn_on_action:
+      then:
+        - logger.log: "Turned on"
+    turn_off_action:
+      then:
+        - logger.log: "Turned off"
+    state_change_action:
+      then:
+        - logger.log:
+            format: "Changed state: %d"
+            args: [ 'state' ]
   - platform: custom
     type: float
     lambda: |-

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1316,7 +1316,6 @@ output:
   - platform: sigma_delta_output
     id: sddac
     update_interval: 60s
-    output: custom_binary
     pin: D4
     turn_on_action:
       then:


### PR DESCRIPTION
# What does this implement/fix?

A sigma-delta modulation-based output component that toggles a binary output at fixed intervals.

An example is at https://en.wikipedia.org/wiki/Delta-sigma_modulation#/media/File:Pulse-density_modulation_1_period.gif 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2500

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
output:
  - id: sddac
    platform: sigma_delta_output
    update_interval: 60s
    output: relay_1
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
