### PR TITLE
Add support Airthings Wave Plus illuminance

### DIFF
--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -79,6 +79,7 @@ void AirthingsWavePlus::read_sensors_(uint8_t *raw_value, uint16_t value_len) {
       if (is_valid_voc_value_(value->voc)) {
         this->tvoc_sensor_->publish_state(value->voc);
       }
+      this->illuminance_sensor_->publish_state(value->ambientLight);
 
       // This instance must not stay connected
       // so other clients can connect to it (e.g. the
@@ -124,6 +125,7 @@ void AirthingsWavePlus::dump_config() {
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
   LOG_SENSOR("  ", "TVOC", this->tvoc_sensor_);
+  LOG_SENSOR("  ", "Illuminance", this->illuminance_sensor_);
 }
 
 AirthingsWavePlus::AirthingsWavePlus()

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.h
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.h
@@ -34,6 +34,7 @@ class AirthingsWavePlus : public PollingComponent, public ble_client::BLEClientN
   void set_pressure(sensor::Sensor *pressure) { pressure_sensor_ = pressure; }
   void set_co2(sensor::Sensor *co2) { co2_sensor_ = co2; }
   void set_tvoc(sensor::Sensor *tvoc) { tvoc_sensor_ = tvoc; }
+  void set_illuminance(sensor::Sensor *ambientLight) { illuminance_sensor_ = ambientLight; }
 
  protected:
   bool is_valid_radon_value_(uint16_t radon);
@@ -50,6 +51,7 @@ class AirthingsWavePlus : public PollingComponent, public ble_client::BLEClientN
   sensor::Sensor *pressure_sensor_{nullptr};
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *tvoc_sensor_{nullptr};
+  sensor::Sensor *illuminance_sensor_{nullptr};
 
   uint16_t handle_;
   esp32_ble_tracker::ESPBTUUID service_uuid_;

--- a/esphome/components/airthings_wave_plus/sensor.py
+++ b/esphome/components/airthings_wave_plus/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_ILLUMINANCE,
     STATE_CLASS_MEASUREMENT,
     UNIT_PERCENT,
     UNIT_CELSIUS,
@@ -20,9 +21,11 @@ from esphome.const import (
     CONF_CO2,
     CONF_PRESSURE,
     CONF_TEMPERATURE,
+    CONF_ILLUMINANCE,
     UNIT_BECQUEREL_PER_CUBIC_METER,
     UNIT_PARTS_PER_MILLION,
     UNIT_PARTS_PER_BILLION,
+    UNIT_LUX,
     ICON_RADIATOR,
 )
 
@@ -80,6 +83,12 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_ILLUMINANCE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_LUX,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_ILLUMINANCE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
         }
     )
     .extend(cv.polling_component_schema("5min"))
@@ -114,3 +123,6 @@ async def to_code(config):
     if CONF_TVOC in config:
         sens = await sensor.new_sensor(config[CONF_TVOC])
         cg.add(var.set_tvoc(sens))
+    if CONF_ILLUMINANCE in config:
+        sens = await sensor.new_sensor(config[CONF_ILLUMINANCE])
+        cg.add(var.set_illuminance(sens))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Add support Airthings Wave Plus illuminance sensor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
    illuminance:
          name: "WavePlus Illuminance"
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
