### PR TITLE
Draft: Added support for SN74HC165

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -268,3 +268,4 @@ esphome/components/xiaomi_mhoc303/* @drug123
 esphome/components/xiaomi_mhoc401/* @vevsvevs
 esphome/components/xiaomi_rtcgq02lm/* @jesserockz
 esphome/components/xpt2046/* @nielsnl68 @numo68
+esphome/components/sn74hc165 @alsig

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -208,6 +208,7 @@ esphome/components/sim800l/* @glmnet
 esphome/components/sm2135/* @BoukeHaarsma23
 esphome/components/sml/* @alengwenus
 esphome/components/smt100/* @piechade
+esphome/components/sn74hc165/* @alsig
 esphome/components/socket/* @esphome/core
 esphome/components/sonoff_d1/* @anatoly-savchenkov
 esphome/components/spi/* @esphome/core
@@ -268,4 +269,3 @@ esphome/components/xiaomi_mhoc303/* @drug123
 esphome/components/xiaomi_mhoc401/* @vevsvevs
 esphome/components/xiaomi_rtcgq02lm/* @jesserockz
 esphome/components/xpt2046/* @nielsnl68 @numo68
-esphome/components/sn74hc165 @alsig

--- a/esphome/components/sn74hc165/__init__.py
+++ b/esphome/components/sn74hc165/__init__.py
@@ -1,0 +1,46 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.const import (
+    CONF_ID,
+    CONF_DATA_PIN,
+    CONF_CLOCK_PIN,
+)
+
+DEPENDENCIES = []
+MULTI_CONF = True
+CONF_SN74HC165_ID = "sn74hc165_id"
+
+sn74hc165_ns = cg.esphome_ns.namespace("sn74hc165")
+
+SN74HC165Component = sn74hc165_ns.class_("SN74HC165Component", cg.Component)
+SN74HC165GPIOPin = sn74hc165_ns.class_("SN74HC165GPIOPin", cg.GPIOPin)
+
+CONF_SN74HC165 = "sn74hc165"
+CONF_LATCH_PIN = "latch_pin"
+CONF_SCAN_RATE = "scan_rate"
+CONF_SR_COUNT = "sr_count"
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.declare_id(SN74HC165Component),
+        cv.Required(CONF_DATA_PIN): pins.gpio_input_pin_schema,
+        cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_LATCH_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_SR_COUNT, default=1): cv.int_range(1, 4),
+        cv.Optional(CONF_SCAN_RATE, default=100): cv.int_range(1),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    data_pin = await cg.gpio_pin_expression(config[CONF_DATA_PIN])
+    cg.add(var.set_data_pin(data_pin))
+    clock_pin = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
+    cg.add(var.set_clock_pin(clock_pin))
+    latch_pin = await cg.gpio_pin_expression(config[CONF_LATCH_PIN])
+    cg.add(var.set_latch_pin(latch_pin))
+    if CONF_SCAN_RATE in config:
+        cg.add(var.set_scan_rate(config[CONF_SCAN_RATE]))
+    cg.add(var.set_sr_count(config[CONF_SR_COUNT]))

--- a/esphome/components/sn74hc165/__init__.py
+++ b/esphome/components/sn74hc165/__init__.py
@@ -7,6 +7,8 @@ from esphome.const import (
     CONF_CLOCK_PIN,
 )
 
+CODEOWNERS = ["@alsig"]
+
 DEPENDENCIES = []
 MULTI_CONF = True
 CONF_SN74HC165_ID = "sn74hc165_id"

--- a/esphome/components/sn74hc165/binary_sensor.py
+++ b/esphome/components/sn74hc165/binary_sensor.py
@@ -1,0 +1,24 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import CONF_PIN
+from . import sn74hc165_ns, SN74HC165Component, CONF_SN74HC165_ID
+
+DEPENDENCIES = ["sn74hc165"]
+SN74HC165GPIOBinarySensor = sn74hc165_ns.class_(
+    "SN74HC165GPIOBinarySensor", binary_sensor.BinarySensor
+)
+
+CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(SN74HC165GPIOBinarySensor).extend(
+    {
+        cv.GenerateID(CONF_SN74HC165_ID): cv.use_id(SN74HC165Component),
+        cv.Required(CONF_PIN): cv.int_range(min=0, max=31),
+    }
+)
+
+
+async def to_code(config):
+    var = await binary_sensor.new_binary_sensor(config)
+    cg.add(var.set_pin(config[CONF_PIN]))
+    hub = await cg.get_variable(config[CONF_SN74HC165_ID])
+    cg.add(hub.register_input(var))

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -26,13 +26,11 @@ void SN74HC165Component::dump_config() {
   ESP_LOGCONFIG(TAG, "  Scan rate: %u", this->get_update_interval());
 }
 
-void SN74HC165Component::register_input(SN74HC165GPIOBinarySensor* sensor){
-  this->sensors_.push_back(sensor);
-}
+void SN74HC165Component::register_input(SN74HC165GPIOBinarySensor *sensor) { this->sensors_.push_back(sensor); }
 
-void SN74HC165Component::update(){
+void SN74HC165Component::update() {
   const uint32_t input_values = this->read_gpio_();
-  for(auto& sensor: this->sensors_){
+  for (auto &sensor : this->sensors_) {
     sensor->process(input_values);
   }
 }
@@ -52,7 +50,7 @@ uint32_t SN74HC165Component::read_gpio_() {
   return input_bits;
 }
 
-void SN74HC165GPIOBinarySensor::process(uint32_t data){
+void SN74HC165GPIOBinarySensor::process(uint32_t data) {
   const uint32_t idx = (1 << this->pin_);
   const bool value = data & idx;
   publish_state(value);

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -15,17 +15,16 @@ void SN74HC165Component::setup() {
   this->latch_pin_->setup();
   this->clock_pin_->digital_write(true);
   this->data_pin_->digital_write(false);
-  this->latch_pin_->digital_write(true); 
+  this->latch_pin_->digital_write(true);
 }
 
-void SN74HC165Component::dump_config() { 
-  ESP_LOGCONFIG(TAG, "SN74HC165:"); 
+void SN74HC165Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "SN74HC165:");
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Latch Pin: ", this->latch_pin_);
-  ESP_LOGCONFIG(TAG, "  Scan rate: %u", this->get_update_interval());  
+  ESP_LOGCONFIG(TAG, "  Scan rate: %u", this->get_update_interval());
 }
-
 
 void SN74HC165Component::register_input(SN74HC165GPIOBinarySensor* sensor){
   this->sensors_.push_back(sensor);
@@ -38,13 +37,13 @@ void SN74HC165Component::update(){
   }
 }
 
-uint32_t SN74HC165Component::read_gpio_() {  
+uint32_t SN74HC165Component::read_gpio_() {
   this->clock_pin_->digital_write(true);
   this->latch_pin_->digital_write(false);
   this->latch_pin_->digital_write(true);
   uint32_t input_bits{0};
   const uint8_t loop_counter = this->sr_count_ * 8;
-  for (uint8_t i = 0; i < loop_counter; i++) { 
+  for (uint8_t i = 0; i < loop_counter; i++) {
     this->clock_pin_->digital_write(true);
     const bool value = this->data_pin_->digital_read();
     input_bits |= value << (loop_counter - 1 - i);
@@ -53,7 +52,7 @@ uint32_t SN74HC165Component::read_gpio_() {
   return input_bits;
 }
 
-void SN74HC165GPIOBinarySensor::process(const uint32_t data){
+void SN74HC165GPIOBinarySensor::process(uint32_t data){
   const uint32_t idx = (1 << this->pin_);
   const bool value = data & idx;
   publish_state(value);

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -1,0 +1,63 @@
+#include "sn74hc165.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace sn74hc165 {
+
+static const char *const TAG = "sn74hc165";
+
+void SN74HC165Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up SN74HC165...");
+
+  // initialize output pins
+  this->clock_pin_->setup();
+  this->data_pin_->setup();
+  this->latch_pin_->setup();
+  this->clock_pin_->digital_write(true);
+  this->data_pin_->digital_write(false);
+  this->latch_pin_->digital_write(true); 
+}
+
+void SN74HC165Component::dump_config() { 
+  ESP_LOGCONFIG(TAG, "SN74HC165:"); 
+  LOG_PIN("  Clock Pin: ", this->clock_pin_);
+  LOG_PIN("  Data Pin: ", this->data_pin_);
+  LOG_PIN("  Latch Pin: ", this->latch_pin_);
+  ESP_LOGCONFIG(TAG, "  Scan rate: %u", this->get_update_interval());  
+}
+
+
+void SN74HC165Component::register_input(SN74HC165GPIOBinarySensor* sensor){
+  this->sensors_.push_back(sensor);
+}
+
+void SN74HC165Component::update(){
+  const uint32_t input_values = this->read_gpio_();
+  for(auto& sensor: this->sensors_){
+    sensor->process(input_values);
+  }
+}
+
+uint32_t SN74HC165Component::read_gpio_() {  
+  this->clock_pin_->digital_write(true);
+  this->latch_pin_->digital_write(false);
+  this->latch_pin_->digital_write(true);
+  uint32_t input_bits{0};
+  const uint8_t loop_counter = this->sr_count_ * 8;
+  for (uint8_t i = 0; i < loop_counter; i++) { 
+    this->clock_pin_->digital_write(true);
+    const bool value = this->data_pin_->digital_read();
+    input_bits |= value << (loop_counter - 1 - i);
+    this->clock_pin_->digital_write(false);
+  }
+  return input_bits;
+}
+
+void SN74HC165GPIOBinarySensor::process(const uint32_t data){
+  const uint32_t idx = (1 << this->pin_);
+  const bool value = data & idx;
+  publish_state(value);
+}
+
+}  // namespace sn74hc165
+}  // namespace esphome

--- a/esphome/components/sn74hc165/sn74hc165.h
+++ b/esphome/components/sn74hc165/sn74hc165.h
@@ -9,8 +9,9 @@ namespace sn74hc165 {
 
 class SN74HC165GPIOBinarySensor : public binary_sensor::BinarySensor {
  public:
-  void set_pin(const uint8_t pin) { this->pin_ = pin;}
+  void set_pin(const uint8_t pin) { this->pin_ = pin; }
   void process(uint32_t data);
+
  protected:
   uint8_t pin_;
 };
@@ -22,7 +23,7 @@ class SN74HC165Component : public PollingComponent {
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::IO; };
-  void register_input(SN74HC165GPIOBinarySensor* sensor);
+  void register_input(SN74HC165GPIOBinarySensor *sensor);
   void set_data_pin(GPIOPin *pin) { data_pin_ = pin; }
   void set_clock_pin(GPIOPin *pin) { clock_pin_ = pin; }
   void set_latch_pin(GPIOPin *pin) { latch_pin_ = pin; }
@@ -30,7 +31,6 @@ class SN74HC165Component : public PollingComponent {
   void set_scan_rate(uint32_t scan_rate) { this->set_update_interval(scan_rate); }
 
  protected:
-
   void update() override;
 
   uint32_t read_gpio_();
@@ -39,11 +39,8 @@ class SN74HC165Component : public PollingComponent {
   GPIOPin *latch_pin_;
   uint8_t sr_count_;
 
-  std::vector<SN74HC165GPIOBinarySensor*> sensors_;
+  std::vector<SN74HC165GPIOBinarySensor *> sensors_;
 };
-
-
-
 
 }  // namespace sn74hc165
 }  // namespace esphome

--- a/esphome/components/sn74hc165/sn74hc165.h
+++ b/esphome/components/sn74hc165/sn74hc165.h
@@ -10,9 +10,9 @@ namespace sn74hc165 {
 class SN74HC165GPIOBinarySensor : public binary_sensor::BinarySensor {
  public:
   void set_pin(const uint8_t pin) { this->pin_ = pin;}
-  void process(const uint32_t data);
+  void process(uint32_t data);
  protected:
-  uint8_t pin_;  
+  uint8_t pin_;
 };
 
 class SN74HC165Component : public PollingComponent {
@@ -32,11 +32,11 @@ class SN74HC165Component : public PollingComponent {
  protected:
 
   void update() override;
-  
+
   uint32_t read_gpio_();
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;
-  GPIOPin *latch_pin_;  
+  GPIOPin *latch_pin_;
   uint8_t sr_count_;
 
   std::vector<SN74HC165GPIOBinarySensor*> sensors_;

--- a/esphome/components/sn74hc165/sn74hc165.h
+++ b/esphome/components/sn74hc165/sn74hc165.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+
+namespace esphome {
+namespace sn74hc165 {
+
+class SN74HC165GPIOBinarySensor : public binary_sensor::BinarySensor {
+ public:
+  void set_pin(const uint8_t pin) { this->pin_ = pin;}
+  void process(const uint32_t data);
+ protected:
+  uint8_t pin_;  
+};
+
+class SN74HC165Component : public PollingComponent {
+ public:
+  SN74HC165Component() = default;
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::IO; };
+  void register_input(SN74HC165GPIOBinarySensor* sensor);
+  void set_data_pin(GPIOPin *pin) { data_pin_ = pin; }
+  void set_clock_pin(GPIOPin *pin) { clock_pin_ = pin; }
+  void set_latch_pin(GPIOPin *pin) { latch_pin_ = pin; }
+  void set_sr_count(uint8_t count) { sr_count_ = count; }
+  void set_scan_rate(uint32_t scan_rate) { this->set_update_interval(scan_rate); }
+
+ protected:
+
+  void update() override;
+  
+  uint32_t read_gpio_();
+  GPIOPin *data_pin_;
+  GPIOPin *clock_pin_;
+  GPIOPin *latch_pin_;  
+  uint8_t sr_count_;
+
+  std::vector<SN74HC165GPIOBinarySensor*> sensors_;
+};
+
+
+
+
+}  // namespace sn74hc165
+}  // namespace esphome

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1434,7 +1434,10 @@ binary_sensor:
     id: close_sensor
   - platform: template
     id: close_obstacle_sensor
-
+    
+  - platform: sn74hc165
+    name: "SN74HC165 Pin #0"
+    pin: 1
 pca9685:
   frequency: 500
   address: 0x0
@@ -2838,6 +2841,13 @@ sn74hc595:
     clock_pin: GPIO23
     latch_pin: GPIO22
     oe_pin: GPIO32
+    sr_count: 2
+
+sn74hc165:
+  - id: sn74hc165_input    
+    data_pin: GPIO21
+    clock_pin: GPIO23
+    latch_pin: GPIO22
     sr_count: 2
 
 rtttl:

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1434,7 +1434,7 @@ binary_sensor:
     id: close_sensor
   - platform: template
     id: close_obstacle_sensor
-    
+
   - platform: sn74hc165
     name: "SN74HC165 Pin #0"
     pin: 1
@@ -2844,7 +2844,7 @@ sn74hc595:
     sr_count: 2
 
 sn74hc165:
-  - id: sn74hc165_input    
+  - id: sn74hc165_input
     data_pin: GPIO21
     clock_pin: GPIO23
     latch_pin: GPIO22


### PR DESCRIPTION
# What does this implement/fix?

Add support for SN74HC165 shift register.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sn74hc165:
  - id: sn74hc165_input    
    scan_rate: 10
    data_pin: GPIO12
    clock_pin: GPIO16
    latch_pin: GPIO14
    sr_count: 1

binary_sensor:
  - platform: sn74hc165
    name: "SN74HC165 Pin #0"
    pin: 0

```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
