### PR TITLE
Fix crash with bluetooth tracker and esp-idf

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -240,6 +240,8 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
         # https://github.com/espressif/esp-idf/issues/4101
         # https://github.com/espressif/esp-idf/issues/2503
+        # Match arduino CONFIG_BTU_TASK_STACK_SIZE
+        # https://github.com/espressif/arduino-esp32/blob/fd72cf46ad6fc1a6de99c1d83ba8eba17d80a4ee/tools/sdk/esp32/sdkconfig#L1866
         add_idf_sdkconfig_option("CONFIG_BTU_TASK_STACK_SIZE", 8192)
 
     cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -238,6 +238,9 @@ async def to_code(config):
 
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
+        # https://github.com/espressif/esp-idf/issues/4101
+        # https://github.com/espressif/esp-idf/issues/2503
+        add_idf_sdkconfig_option("BTU_TASK_STACK_SIZE", 8192)
 
     cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -240,7 +240,7 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
         # https://github.com/espressif/esp-idf/issues/4101
         # https://github.com/espressif/esp-idf/issues/2503
-        add_idf_sdkconfig_option("BTU_TASK_STACK_SIZE", 8192)
+        add_idf_sdkconfig_option("CONFIG_BTU_TASK_STACK_SIZE", 8192)
 
     cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -199,6 +199,7 @@ void ESP32BLETracker::loop() {
         } else {
           ESP_LOGD(TAG, "Pausing scan to make connection...");
           esp_ble_gap_stop_scanning();
+          this->cancel_timeout("scan");
         }
         break;
       }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -24,7 +24,6 @@
 #include <esp32-hal-bt.h>
 #endif
 
-
 // bt_trace.h
 #undef TAG
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -164,21 +164,13 @@ void ESP32BLETracker::loop() {
     }
 
     if (this->scan_start_failed_ || this->scan_set_param_failed_) {
-<<<<<<< Updated upstream
-      esp_ble_gap_stop_scanning();
-=======
-      if (this->scan_start_fail_count_ == 255) {
-        ESP_LOGE(TAG, "ESP-IDF BLE scan could not restart after 255 attempts, rebooting to restore BLE stack...");
-        App.reboot();
-      }
       if (xSemaphoreTake(this->scan_end_lock_, 0L)) {
         xSemaphoreGive(this->scan_end_lock_);
       } else {
         ESP_LOGD(TAG, "Stopping scan after failure...");
         esp_ble_gap_stop_scanning();
+        this->cancel_timeout("scan");
       }
-      this->cancel_timeout("scan");
->>>>>>> Stashed changes
       if (this->scan_start_failed_) {
         ESP_LOGE(TAG, "Scan start failed: %d", this->scan_start_failed_);
         this->scan_start_failed_ = ESP_BT_STATUS_SUCCESS;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -24,10 +24,6 @@
 #include <esp32-hal-bt.h>
 #endif
 
-#ifdef USE_ESP_IDF
-// https://github.com/espressif/esp-idf/issues/2503
-#define BTU_TASK_STACK_SIZE (6144 + BT_TASK_EXTRA_STACK_SIZE)
-#endif
 
 // bt_trace.h
 #undef TAG


### PR DESCRIPTION

# What does this implement/fix?

Found while investigating https://github.com/home-assistant/core/issues/83212

The scanner does not stop right away so we need to wait until the lock is released to know its done

The BLE stack is too small for the scanner and overflows with A stack overflow in task BTU_TASK has been detected.
Raise it to be the same size as arduino
https://github.com/espressif/arduino-esp32/blob/fd72cf46ad6fc1a6de99c1d83ba8eba17d80a4ee/tools/sdk/esp32/sdkconfig#L1866

```
[15:42:30]***ERROR*** A stack overflow in task BTU_TASK has been detected.
[15:42:30]
[15:42:30]
[15:42:30]Backtrace:0x40082b7a:0x3ffd53c00x40090eb5:0x3ffd53e0 0x40093ff6:0x3ffd5400 0x40092938:0x3ffd5480 0x40090fb4:0x3ffd54b0 0x40090f66:0x3ffd5498  |<-CORRUPTED
WARNING Found stack trace! Trying to decode it
WARNING Decoded 0x40082b7a: panic_abort at /Users/bdraco/.platformio/packages/framework-espidf/components/esp_system/panic.c:402
WARNING Decoded 0x40090eb5: esp_system_abort at /Users/bdraco/.platformio/packages/framework-espidf/components/esp_system/esp_system.c:128
WARNING Decoded 0x40093ff6: vApplicationStackOverflowHook at /Users/bdraco/.platformio/packages/framework-espidf/components/freertos/port/xtensa/port.c:394
WARNING Decoded 0x40092938: vTaskSwitchContext at /Users/bdraco/.platformio/packages/framework-espidf/components/freertos/tasks.c:3504
WARNING Decoded 0x40090fb4: _frxt_dispatch
WARNING Decoded 0x40090f66: _frxt_int_exit
[15:42:31]
[15:42:31]
[15:42:31]
[15:42:31]
[15:42:31]ELF file SHA256: 263d7201737c0b9a
[15:42:31]
[15:42:31]Rebooting...
[15:42:31]ets Jun  8 2016 00:22:57
```

see https://github.com/espressif/esp-idf/issues/2503

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
