### PR TITLE
Use ENTITY_CATEGORY_CONFIG for sprinkler config switches.

### DIFF
--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_NAME,
     CONF_REPEAT,
     CONF_RUN_DURATION,
+    ENTITY_CATEGORY_CONFIG,
 )
 
 AUTO_LOAD = ["switch"]
@@ -223,7 +224,9 @@ SPRINKLER_ACTION_QUEUE_VALVE_SCHEMA = cv.Schema(
 SPRINKLER_VALVE_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_ENABLE_SWITCH): cv.maybe_simple_value(
-            switch.switch_schema(SprinklerControllerSwitch),
+            switch.switch_schema(
+                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+            ),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_PUMP_OFF_SWITCH_ID): cv.use_id(switch.Switch),
@@ -244,7 +247,9 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Sprinkler),
         cv.Optional(CONF_AUTO_ADVANCE_SWITCH): cv.maybe_simple_value(
-            switch.switch_schema(SprinklerControllerSwitch),
+            switch.switch_schema(
+                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+            ),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_MAIN_SWITCH): cv.maybe_simple_value(
@@ -252,11 +257,15 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             key=CONF_NAME,
         ),
         cv.Optional(CONF_QUEUE_ENABLE_SWITCH): cv.maybe_simple_value(
-            switch.switch_schema(SprinklerControllerSwitch),
+            switch.switch_schema(
+                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+            ),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_REVERSE_SWITCH): cv.maybe_simple_value(
-            switch.switch_schema(SprinklerControllerSwitch),
+            switch.switch_schema(
+                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+            ),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_MANUAL_SELECTION_DELAY): cv.positive_time_period_seconds,


### PR DESCRIPTION
# What does this implement/fix?

This sets the entity_category for the valve/sprinkler configuration switches: ie the valve enable switch, reverse switch and so on.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
