### PR TITLE
Support for MH-ET 2.13" black/white/red display (GDEY0213Z98)

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -67,6 +67,7 @@ MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
     "1.54inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN_V2),
     "2.13in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN),
+    "2.13in-mhet-tricolor": ("a",  WaveshareEPaperTypeAModel.MHET_EPAPER_2_13_IN_TRICOLOR),
     "2.13in-ttgo": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN),
     "2.13in-ttgo-b1": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B1),
     "2.13in-ttgo-b73": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B73),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -82,9 +82,7 @@ static const uint8_t PARTIAL_UPDATE_LUT_TTGO_B1[LUT_SIZE_TTGO_B1] = {
     0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x0F, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-void WaveshareEPaper::setup_buffer_() {
-  this->init_internal_(this->get_buffer_length_());
-}
+void WaveshareEPaper::setup_buffer_() { this->init_internal_(this->get_buffer_length_()); }
 void WaveshareEPaper::setup_pins_() {
   this->dc_pin_->setup();  // OUTPUT
   this->dc_pin_->digital_write(false);
@@ -280,7 +278,7 @@ void WaveshareEPaperTypeA::dump_config() {
 }
 void WaveshareEPaperTypeA::fill(Color color) {
   if (this->model_ != MHET_EPAPER_2_13_IN_TRICOLOR) {
-      WaveshareEPaper::fill(color);
+    WaveshareEPaper::fill(color);
   } else {
     uint32_t i;
     uint8_t fill_black;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -30,6 +30,7 @@ class WaveshareEPaper : public PollingComponent,
   void fill(Color color) override;
 
   void setup() override {
+    this->setup_buffer_();
     this->setup_pins_();
     this->initialize();
   }
@@ -43,6 +44,7 @@ class WaveshareEPaper : public PollingComponent,
 
   bool wait_until_idle_();
 
+  virtual void setup_buffer_();
   void setup_pins_();
 
   void reset_() {
@@ -78,6 +80,7 @@ enum WaveshareEPaperTypeAModel {
   TTGO_EPAPER_2_13_IN_B73,
   TTGO_EPAPER_2_13_IN_B1,
   TTGO_EPAPER_2_13_IN_B74,
+  MHET_EPAPER_2_13_IN_TRICOLOR
 };
 
 class WaveshareEPaperTypeA : public WaveshareEPaper {
@@ -91,18 +94,34 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   void display() override;
 
   void deep_sleep() override {
-    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ == WAVESHARE_EPAPER_1_54_IN_V2) {
-      // COMMAND DEEP SLEEP MODE
-      this->command(0x10);
-      this->data(0x01);
-    } else {
-      // COMMAND DEEP SLEEP MODE
-      this->command(0x10);
+    switch (this->model_) {
+      case WAVESHARE_EPAPER_2_9_IN_V2:
+      case WAVESHARE_EPAPER_1_54_IN_V2:
+      case MHET_EPAPER_2_13_IN_TRICOLOR:
+        // COMMAND DEEP SLEEP MODE
+        this->command(0x10);
+        this->data(0x01);
+        break;
+      default:
+        // COMMAND DEEP SLEEP MODE
+        this->command(0x10);
+        break;
     }
     this->wait_until_idle_();
   }
 
   void set_full_update_every(uint32_t full_update_every);
+
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override {
+    switch (this->model_) {
+      case MHET_EPAPER_2_13_IN_TRICOLOR:
+        return display::DisplayType::DISPLAY_TYPE_COLOR;
+      default:
+        return display::DisplayType::DISPLAY_TYPE_BINARY;
+    }
+  }
 
  protected:
   void write_lut_(const uint8_t *lut, uint8_t size);
@@ -115,6 +134,8 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   uint32_t at_update_{0};
   WaveshareEPaperTypeAModel model_;
   uint32_t idle_timeout_() override;
+  void setup_buffer_() override;
+  void draw_absolute_pixel_internal(int x, int y, Color color);
 };
 
 enum WaveshareEPaperTypeBModel {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -135,7 +135,7 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   WaveshareEPaperTypeAModel model_;
   uint32_t idle_timeout_() override;
   void setup_buffer_() override;
-  void draw_absolute_pixel_internal(int x, int y, Color color);
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
 };
 
 enum WaveshareEPaperTypeBModel {


### PR DESCRIPTION
# What does this implement/fix?

My MH-ET Live 2.13" black/white/red displays was not working properly with the existing waveshare_epaper models. Module 2.13in-ttgo-b74 got quite close, but there was a lot of red "garbage" shown in the display, apparently because Write RAM operation was not done for the red color.
The change adds support for the third color by doubling the display buffer size (second half is used for the red) and adding the missing write operation for these kinds of displays.

Even though it's not exactly mentioned anywhere in the MH-ET Live module, the epaper part appears to be Good Display [GDEY0213Z98](https://www.good-display.com/product/392.html).
MH-ET Live sells also a black/white/yellow module which I don't have, but I bet it uses Good Display [GDEM0213C90](https://www.good-display.com/product/333.html). The change aims to support that too by mapping all non-black and non-white pixels to this "third color" (red or yellow).

Didn't add more tests as the existing test4.yaml section for model "2.13in-ttgo-b1" should compile this too.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2506

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
font:
  - file: '/usr/share/fonts/TTF/arial.ttf'
    id: font1
    size: 40

color:
  - id: red 
    red: 100%
    green: 0%
    blue: 0%
    white: 0%

spi:
    mosi_pin: GPIO23
    clk_pin: GPIO22

display:
  - platform: waveshare_epaper
    cs_pin: GPIO21
    dc_pin: GPIO19
    reset_pin: GPIO18
    busy_pin: GPIO5
    model: 2.13in-mhet-tricolor
    rotation: 90
    update_interval: 60s 
    lambda: |-
      it.print(60, 30, id(font1), "black");
      it.print(60, 60, id(font1), red, "red");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
