### PR TITLE
fix switch initialization

### DIFF
--- a/esphome/components/gpio/switch/gpio_switch.cpp
+++ b/esphome/components/gpio/switch/gpio_switch.cpp
@@ -10,7 +10,7 @@ float GPIOSwitch::get_setup_priority() const { return setup_priority::HARDWARE; 
 void GPIOSwitch::setup() {
   ESP_LOGCONFIG(TAG, "Setting up GPIO Switch '%s'...", this->name_.c_str());
 
-  bool initial_state = Switch::get_initial_state_with_restore_mode();
+  bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
 
   // write state before setup
   if (initial_state) {

--- a/esphome/components/output/switch/output_switch.cpp
+++ b/esphome/components/output/switch/output_switch.cpp
@@ -10,7 +10,7 @@ void OutputSwitch::dump_config() { LOG_SWITCH("", "Output Switch", this); }
 void OutputSwitch::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Output Switch '%s'...", this->name_.c_str());
 
-  bool initial_state = Switch::get_initial_state_with_restore_mode();
+  bool initial_state = this->get_initial_state_with_restore_mode().value_or(false);
 
   if (initial_state) {
     this->turn_on();


### PR DESCRIPTION
# What does this implement/fix?

This fixes the initial state for gpio and output switches.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3878

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
