### PR TITLE
Add API for dashboard to get boards list

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -33,7 +33,7 @@ from .const import (  # noqa
     VARIANT_FRIENDLY,
     VARIANTS,
 )
-from .boards import BOARD_TO_VARIANT
+from .boards import BOARDS
 
 # force import gpio to register pin schema
 from .gpio import esp32_pin_to_code  # noqa
@@ -230,14 +230,14 @@ def _parse_platform_version(value):
 def _detect_variant(value):
     if CONF_VARIANT not in value:
         board = value[CONF_BOARD]
-        if board not in BOARD_TO_VARIANT:
+        if board not in BOARDS:
             raise cv.Invalid(
                 "This board is unknown, please set the variant manually",
                 path=[CONF_BOARD],
             )
 
         value = value.copy()
-        value[CONF_VARIANT] = BOARD_TO_VARIANT[board]
+        value[CONF_VARIANT] = BOARDS[board][KEY_VARIANT]
 
     return value
 

--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -1066,197 +1066,738 @@ ESP32_BOARD_PINS = {
 }
 
 """
-BOARD_TO_VARIANT generated with:
+BOARDS generated with:
 
 git clone https://github.com/platformio/platform-espressif32
 for x in platform-espressif32/boards/*.json; do
   mcu=$(jq -r .build.mcu <"$x");
+  name=$(jq -r .name <"$x");
   fname=$(basename "$x")
   board="${fname%.*}"
   variant=$(echo "$mcu" | tr '[:lower:]' '[:upper:]')
-  echo "    \"$board\": VARIANT_${variant},"
+  echo "    \"$board\": {\"name\": \"$name\", \"variant\": VARIANT_${variant},},"
 done | sort
 """
 
-BOARD_TO_VARIANT = {
-    "adafruit_feather_esp32s2_tft": VARIANT_ESP32S2,
-    "adafruit_feather_esp32s3_nopsram": VARIANT_ESP32S3,
-    "adafruit_feather_esp32s3_tft": VARIANT_ESP32S3,
-    "adafruit_feather_esp32s3": VARIANT_ESP32S3,
-    "adafruit_feather_esp32_v2": VARIANT_ESP32,
-    "adafruit_funhouse_esp32s2": VARIANT_ESP32S2,
-    "adafruit_itsybitsy_esp32": VARIANT_ESP32,
-    "adafruit_magtag29_esp32s2": VARIANT_ESP32S2,
-    "adafruit_metro_esp32s2": VARIANT_ESP32S2,
-    "adafruit_qtpy_esp32c3": VARIANT_ESP32C3,
-    "adafruit_qtpy_esp32s2": VARIANT_ESP32S2,
-    "adafruit_qtpy_esp32s3_nopsram": VARIANT_ESP32S3,
-    "adafruit_qtpy_esp32": VARIANT_ESP32,
-    "airm2m_core_esp32c3": VARIANT_ESP32C3,
-    "alksesp32": VARIANT_ESP32,
-    "atmegazero_esp32s2": VARIANT_ESP32S2,
-    "az-delivery-devkit-v4": VARIANT_ESP32,
-    "bee_motion_mini": VARIANT_ESP32C3,
-    "bee_motion_s3": VARIANT_ESP32S3,
-    "bee_motion": VARIANT_ESP32S2,
-    "bee_s3": VARIANT_ESP32S3,
-    "bpi-bit": VARIANT_ESP32,
-    "briki_abc_esp32": VARIANT_ESP32,
-    "briki_mbc-wb_esp32": VARIANT_ESP32,
-    "cnrs_aw2eth": VARIANT_ESP32,
-    "connaxio_espoir": VARIANT_ESP32,
-    "d-duino-32": VARIANT_ESP32,
-    "deneyapkart1A": VARIANT_ESP32,
-    "deneyapkartg": VARIANT_ESP32C3,
-    "deneyapkart": VARIANT_ESP32,
-    "deneyapmini": VARIANT_ESP32S2,
-    "denky32": VARIANT_ESP32,
-    "denky_d4": VARIANT_ESP32,
-    "dfrobot_beetle_esp32c3": VARIANT_ESP32C3,
-    "dfrobot_firebeetle2_esp32s3": VARIANT_ESP32S3,
-    "dpu_esp32": VARIANT_ESP32,
-    "esp320": VARIANT_ESP32,
-    "esp32-c3-devkitm-1": VARIANT_ESP32C3,
-    "esp32cam": VARIANT_ESP32,
-    "esp32-devkitlipo": VARIANT_ESP32,
-    "esp32dev": VARIANT_ESP32,
-    "esp32doit-devkit-v1": VARIANT_ESP32,
-    "esp32doit-espduino": VARIANT_ESP32,
-    "esp32-evb": VARIANT_ESP32,
-    "esp32-gateway": VARIANT_ESP32,
-    "esp32-poe-iso": VARIANT_ESP32,
-    "esp32-poe": VARIANT_ESP32,
-    "esp32-pro": VARIANT_ESP32,
-    "esp32-s2-franzininho": VARIANT_ESP32S2,
-    "esp32-s2-kaluga-1": VARIANT_ESP32S2,
-    "esp32-s2-saola-1": VARIANT_ESP32S2,
-    "esp32s3box": VARIANT_ESP32S3,
-    "esp32s3camlcd": VARIANT_ESP32S3,
-    "esp32-s3-devkitc-1": VARIANT_ESP32S3,
-    "esp32thing_plus": VARIANT_ESP32,
-    "esp32thing": VARIANT_ESP32,
-    "esp32vn-iot-uno": VARIANT_ESP32,
-    "espea32": VARIANT_ESP32,
-    "espectro32": VARIANT_ESP32,
-    "espino32": VARIANT_ESP32,
-    "esp-wrover-kit": VARIANT_ESP32,
-    "etboard": VARIANT_ESP32,
-    "featheresp32-s2": VARIANT_ESP32S2,
-    "featheresp32": VARIANT_ESP32,
-    "firebeetle32": VARIANT_ESP32,
-    "fm-devkit": VARIANT_ESP32,
-    "franzininho_wifi_esp32s2": VARIANT_ESP32S2,
-    "franzininho_wifi_msc_esp32s2": VARIANT_ESP32S2,
-    "frogboard": VARIANT_ESP32,
-    "healthypi4": VARIANT_ESP32,
-    "heltec_wifi_kit_32_v2": VARIANT_ESP32,
-    "heltec_wifi_kit_32": VARIANT_ESP32,
-    "heltec_wifi_lora_32_V2": VARIANT_ESP32,
-    "heltec_wifi_lora_32": VARIANT_ESP32,
-    "heltec_wireless_stick_lite": VARIANT_ESP32,
-    "heltec_wireless_stick": VARIANT_ESP32,
-    "honeylemon": VARIANT_ESP32,
-    "hornbill32dev": VARIANT_ESP32,
-    "hornbill32minima": VARIANT_ESP32,
-    "imbrios-logsens-v1p1": VARIANT_ESP32,
-    "inex_openkb": VARIANT_ESP32,
-    "intorobot": VARIANT_ESP32,
-    "iotaap_magnolia": VARIANT_ESP32,
-    "iotbusio": VARIANT_ESP32,
-    "iotbusproteus": VARIANT_ESP32,
-    "kb32-ft": VARIANT_ESP32,
-    "kits-edu": VARIANT_ESP32,
-    "labplus_mpython": VARIANT_ESP32,
-    "lionbit": VARIANT_ESP32,
-    "lolin32_lite": VARIANT_ESP32,
-    "lolin32": VARIANT_ESP32,
-    "lolin_c3_mini": VARIANT_ESP32C3,
-    "lolin_d32_pro": VARIANT_ESP32,
-    "lolin_d32": VARIANT_ESP32,
-    "lolin_s2_mini": VARIANT_ESP32S2,
-    "lolin_s2_pico": VARIANT_ESP32S2,
-    "lolin_s3": VARIANT_ESP32S3,
-    "lopy4": VARIANT_ESP32,
-    "lopy": VARIANT_ESP32,
-    "m5stack-atom": VARIANT_ESP32,
-    "m5stack-core2": VARIANT_ESP32,
-    "m5stack-core-esp32": VARIANT_ESP32,
-    "m5stack-coreink": VARIANT_ESP32,
-    "m5stack-fire": VARIANT_ESP32,
-    "m5stack-grey": VARIANT_ESP32,
-    "m5stack-station": VARIANT_ESP32,
-    "m5stack-timer-cam": VARIANT_ESP32,
-    "m5stick-c": VARIANT_ESP32,
-    "magicbit": VARIANT_ESP32,
-    "mgbot-iotik32a": VARIANT_ESP32,
-    "mgbot-iotik32b": VARIANT_ESP32,
-    "mhetesp32devkit": VARIANT_ESP32,
-    "mhetesp32minikit": VARIANT_ESP32,
-    "microduino-core-esp32": VARIANT_ESP32,
-    "micros2": VARIANT_ESP32S2,
-    "minimain_esp32s2": VARIANT_ESP32S2,
-    "nano32": VARIANT_ESP32,
-    "nina_w10": VARIANT_ESP32,
-    "node32s": VARIANT_ESP32,
-    "nodemcu-32s2": VARIANT_ESP32S2,
-    "nodemcu-32s": VARIANT_ESP32,
-    "nscreen-32": VARIANT_ESP32,
-    "odroid_esp32": VARIANT_ESP32,
-    "onehorse32dev": VARIANT_ESP32,
-    "oroca_edubot": VARIANT_ESP32,
-    "pico32": VARIANT_ESP32,
-    "piranha_esp32": VARIANT_ESP32,
-    "pocket_32": VARIANT_ESP32,
-    "pycom_gpy": VARIANT_ESP32,
-    "qchip": VARIANT_ESP32,
-    "quantum": VARIANT_ESP32,
-    "seeed_xiao_esp32c3": VARIANT_ESP32C3,
-    "sensesiot_weizen": VARIANT_ESP32,
-    "sg-o_airMon": VARIANT_ESP32,
-    "s_odi_ultra": VARIANT_ESP32,
-    "sparkfun_esp32_iot_redboard": VARIANT_ESP32,
-    "sparkfun_esp32micromod": VARIANT_ESP32,
-    "sparkfun_esp32s2_thing_plus_c": VARIANT_ESP32,
-    "sparkfun_esp32s2_thing_plus": VARIANT_ESP32S2,
-    "sparkfun_lora_gateway_1-channel": VARIANT_ESP32,
-    "tamc_termod_s3": VARIANT_ESP32S3,
-    "tinypico": VARIANT_ESP32,
-    "trueverit-iot-driver-mk2": VARIANT_ESP32,
-    "trueverit-iot-driver-mk3": VARIANT_ESP32,
-    "trueverit-iot-driver": VARIANT_ESP32,
-    "ttgo-lora32-v1": VARIANT_ESP32,
-    "ttgo-lora32-v21": VARIANT_ESP32,
-    "ttgo-lora32-v2": VARIANT_ESP32,
-    "ttgo-t1": VARIANT_ESP32,
-    "ttgo-t7-v13-mini32": VARIANT_ESP32,
-    "ttgo-t7-v14-mini32": VARIANT_ESP32,
-    "ttgo-t-beam": VARIANT_ESP32,
-    "ttgo-t-oi-plus": VARIANT_ESP32C3,
-    "ttgo-t-watch": VARIANT_ESP32,
-    "turta_iot_node": VARIANT_ESP32,
-    "um_feathers2_neo": VARIANT_ESP32S2,
-    "um_feathers2": VARIANT_ESP32S2,
-    "um_feathers3": VARIANT_ESP32S3,
-    "um_pros3": VARIANT_ESP32S3,
-    "um_rmp": VARIANT_ESP32S2,
-    "um_tinys2": VARIANT_ESP32S2,
-    "um_tinys3": VARIANT_ESP32S3,
-    "unphone7": VARIANT_ESP32,
-    "unphone8": VARIANT_ESP32S3,
-    "unphone9": VARIANT_ESP32S3,
-    "upesy_wroom": VARIANT_ESP32,
-    "upesy_wrover": VARIANT_ESP32,
-    "vintlabs-devkit-v1": VARIANT_ESP32,
-    "watchy": VARIANT_ESP32,
-    "wemosbat": VARIANT_ESP32,
-    "wemos_d1_mini32": VARIANT_ESP32,
-    "wemos_d1_uno32": VARIANT_ESP32,
-    "wesp32": VARIANT_ESP32,
-    "widora-air": VARIANT_ESP32,
-    "wifiduino32c3": VARIANT_ESP32C3,
-    "wifiduino32s3": VARIANT_ESP32S3,
-    "wifiduino32": VARIANT_ESP32,
-    "wipy3": VARIANT_ESP32,
-    "wt32-eth01": VARIANT_ESP32,
-    "xinabox_cw02": VARIANT_ESP32,
+BOARDS = {
+    "adafruit_feather_esp32s2_tft": {
+        "name": "Adafruit Feather ESP32-S2 TFT",
+        "variant": VARIANT_ESP32S2,
+    },
+    "adafruit_feather_esp32s3": {
+        "name": "Adafruit Feather ESP32-S3 2MB PSRAM",
+        "variant": VARIANT_ESP32S3,
+    },
+    "adafruit_feather_esp32s3_nopsram": {
+        "name": "Adafruit Feather ESP32-S3 No PSRAM",
+        "variant": VARIANT_ESP32S3,
+    },
+    "adafruit_feather_esp32s3_tft": {
+        "name": "Adafruit Feather ESP32-S3 TFT",
+        "variant": VARIANT_ESP32S3,
+    },
+    "adafruit_feather_esp32_v2": {
+        "name": "Adafruit Feather ESP32 V2",
+        "variant": VARIANT_ESP32,
+    },
+    "adafruit_funhouse_esp32s2": {
+        "name": "Adafruit FunHouse",
+        "variant": VARIANT_ESP32S2,
+    },
+    "adafruit_itsybitsy_esp32": {
+        "name": "Adafruit ItsyBitsy ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "adafruit_magtag29_esp32s2": {
+        "name": "Adafruit MagTag 2.9",
+        "variant": VARIANT_ESP32S2,
+    },
+    "adafruit_metro_esp32s2": {
+        "name": "Adafruit Metro ESP32-S2",
+        "variant": VARIANT_ESP32S2,
+    },
+    "adafruit_qtpy_esp32c3": {
+        "name": "Adafruit QT Py ESP32-C3",
+        "variant": VARIANT_ESP32C3,
+    },
+    "adafruit_qtpy_esp32": {
+        "name": "Adafruit QT Py ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "adafruit_qtpy_esp32s2": {
+        "name": "Adafruit QT Py ESP32-S2",
+        "variant": VARIANT_ESP32S2,
+    },
+    "adafruit_qtpy_esp32s3_nopsram": {
+        "name": "Adafruit QT Py ESP32-S3 No PSRAM",
+        "variant": VARIANT_ESP32S3,
+    },
+    "airm2m_core_esp32c3": {
+        "name": "AirM2M CORE ESP32C3",
+        "variant": VARIANT_ESP32C3,
+    },
+    "alksesp32": {
+        "name": "ALKS ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "atmegazero_esp32s2": {
+        "name": "EspinalLab ATMegaZero ESP32-S2",
+        "variant": VARIANT_ESP32S2,
+    },
+    "az-delivery-devkit-v4": {
+        "name": "AZ-Delivery ESP-32 Dev Kit C V4",
+        "variant": VARIANT_ESP32,
+    },
+    "bee_motion_mini": {
+        "name": "Smart Bee Motion Mini",
+        "variant": VARIANT_ESP32C3,
+    },
+    "bee_motion": {
+        "name": "Smart Bee Motion",
+        "variant": VARIANT_ESP32S2,
+    },
+    "bee_motion_s3": {
+        "name": "Smart Bee Motion S3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "bee_s3": {
+        "name": "Smart Bee S3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "bpi-bit": {
+        "name": "BPI-Bit",
+        "variant": VARIANT_ESP32,
+    },
+    "briki_abc_esp32": {
+        "name": "Briki ABC (MBC-WB) - ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "briki_mbc-wb_esp32": {
+        "name": "Briki MBC-WB - ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "cnrs_aw2eth": {
+        "name": "CNRS AW2ETH",
+        "variant": VARIANT_ESP32,
+    },
+    "connaxio_espoir": {
+        "name": "Connaxio's Espoir",
+        "variant": VARIANT_ESP32,
+    },
+    "d-duino-32": {
+        "name": "D-duino-32",
+        "variant": VARIANT_ESP32,
+    },
+    "deneyapkart1A": {
+        "name": "Deneyap Kart 1A",
+        "variant": VARIANT_ESP32,
+    },
+    "deneyapkartg": {
+        "name": "Deneyap Kart G",
+        "variant": VARIANT_ESP32C3,
+    },
+    "deneyapkart": {
+        "name": "Deneyap Kart",
+        "variant": VARIANT_ESP32,
+    },
+    "deneyapmini": {
+        "name": "Deneyap Mini",
+        "variant": VARIANT_ESP32S2,
+    },
+    "denky32": {
+        "name": "Denky32 (WROOM32)",
+        "variant": VARIANT_ESP32,
+    },
+    "denky_d4": {
+        "name": "Denky D4 (PICO-V3-02)",
+        "variant": VARIANT_ESP32,
+    },
+    "dfrobot_beetle_esp32c3": {
+        "name": "DFRobot Beetle ESP32-C3",
+        "variant": VARIANT_ESP32C3,
+    },
+    "dfrobot_firebeetle2_esp32s3": {
+        "name": "DFRobot Firebeetle 2 ESP32-S3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "dpu_esp32": {
+        "name": "TAMC DPU ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "esp320": {
+        "name": "Electronic SweetPeas ESP320",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-c3-devkitm-1": {
+        "name": "Espressif ESP32-C3-DevKitM-1",
+        "variant": VARIANT_ESP32C3,
+    },
+    "esp32cam": {
+        "name": "AI Thinker ESP32-CAM",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-devkitlipo": {
+        "name": "OLIMEX ESP32-DevKit-LiPo",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32dev": {
+        "name": "Espressif ESP32 Dev Module",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32doit-devkit-v1": {
+        "name": "DOIT ESP32 DEVKIT V1",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32doit-espduino": {
+        "name": "DOIT ESPduino32",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-evb": {
+        "name": "OLIMEX ESP32-EVB",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-gateway": {
+        "name": "OLIMEX ESP32-GATEWAY",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-poe-iso": {
+        "name": "OLIMEX ESP32-PoE-ISO",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-poe": {
+        "name": "OLIMEX ESP32-PoE",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-pro": {
+        "name": "OLIMEX ESP32-PRO",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-s2-franzininho": {
+        "name": "Franzininho WiFi Board",
+        "variant": VARIANT_ESP32S2,
+    },
+    "esp32-s2-kaluga-1": {
+        "name": "Espressif ESP32-S2-Kaluga-1 Kit",
+        "variant": VARIANT_ESP32S2,
+    },
+    "esp32-s2-saola-1": {
+        "name": "Espressif ESP32-S2-Saola-1",
+        "variant": VARIANT_ESP32S2,
+    },
+    "esp32s3box": {
+        "name": "Espressif ESP32-S3-Box",
+        "variant": VARIANT_ESP32S3,
+    },
+    "esp32s3camlcd": {
+        "name": "ESP32S3 CAM LCD",
+        "variant": VARIANT_ESP32S3,
+    },
+    "esp32-s3-devkitc-1": {
+        "name": "Espressif ESP32-S3-DevKitC-1-N8 (8 MB QD, No PSRAM)",
+        "variant": VARIANT_ESP32S3,
+    },
+    "esp32thing": {
+        "name": "SparkFun ESP32 Thing",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32thing_plus": {
+        "name": "SparkFun ESP32 Thing Plus",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32vn-iot-uno": {
+        "name": "ESP32vn IoT Uno",
+        "variant": VARIANT_ESP32,
+    },
+    "espea32": {
+        "name": "April Brother ESPea32",
+        "variant": VARIANT_ESP32,
+    },
+    "espectro32": {
+        "name": "ESPectro32",
+        "variant": VARIANT_ESP32,
+    },
+    "espino32": {
+        "name": "ESPino32",
+        "variant": VARIANT_ESP32,
+    },
+    "esp-wrover-kit": {
+        "name": "Espressif ESP-WROVER-KIT",
+        "variant": VARIANT_ESP32,
+    },
+    "etboard": {
+        "name": "ETBoard",
+        "variant": VARIANT_ESP32,
+    },
+    "featheresp32": {
+        "name": "Adafruit ESP32 Feather",
+        "variant": VARIANT_ESP32,
+    },
+    "featheresp32-s2": {
+        "name": "Adafruit ESP32-S2 Feather Development Board",
+        "variant": VARIANT_ESP32S2,
+    },
+    "firebeetle32": {
+        "name": "FireBeetle-ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "fm-devkit": {
+        "name": "ESP32 FM DevKit",
+        "variant": VARIANT_ESP32,
+    },
+    "franzininho_wifi_esp32s2": {
+        "name": "Franzininho WiFi",
+        "variant": VARIANT_ESP32S2,
+    },
+    "franzininho_wifi_msc_esp32s2": {
+        "name": "Franzininho WiFi MSC",
+        "variant": VARIANT_ESP32S2,
+    },
+    "frogboard": {
+        "name": "Frog Board ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "healthypi4": {
+        "name": "ProtoCentral HealthyPi 4",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wifi_kit_32": {
+        "name": "Heltec WiFi Kit 32",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wifi_kit_32_v2": {
+        "name": "Heltec WiFi Kit 32 (V2)",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wifi_lora_32": {
+        "name": "Heltec WiFi LoRa 32",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wifi_lora_32_V2": {
+        "name": "Heltec WiFi LoRa 32 (V2)",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wireless_stick_lite": {
+        "name": "Heltec Wireless Stick Lite",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wireless_stick": {
+        "name": "Heltec Wireless Stick",
+        "variant": VARIANT_ESP32,
+    },
+    "honeylemon": {
+        "name": "HONEYLemon",
+        "variant": VARIANT_ESP32,
+    },
+    "hornbill32dev": {
+        "name": "Hornbill ESP32 Dev",
+        "variant": VARIANT_ESP32,
+    },
+    "hornbill32minima": {
+        "name": "Hornbill ESP32 Minima",
+        "variant": VARIANT_ESP32,
+    },
+    "imbrios-logsens-v1p1": {
+        "name": "Imbrios LogSens V1P1",
+        "variant": VARIANT_ESP32,
+    },
+    "inex_openkb": {
+        "name": "INEX OpenKB",
+        "variant": VARIANT_ESP32,
+    },
+    "intorobot": {
+        "name": "IntoRobot Fig",
+        "variant": VARIANT_ESP32,
+    },
+    "iotaap_magnolia": {
+        "name": "IoTaaP Magnolia",
+        "variant": VARIANT_ESP32,
+    },
+    "iotbusio": {
+        "name": "oddWires IoT-Bus Io",
+        "variant": VARIANT_ESP32,
+    },
+    "iotbusproteus": {
+        "name": "oddWires IoT-Bus Proteus",
+        "variant": VARIANT_ESP32,
+    },
+    "kb32-ft": {
+        "name": "MakerAsia KB32-FT",
+        "variant": VARIANT_ESP32,
+    },
+    "kits-edu": {
+        "name": "KITS ESP32 EDU",
+        "variant": VARIANT_ESP32,
+    },
+    "labplus_mpython": {
+        "name": "Labplus mPython",
+        "variant": VARIANT_ESP32,
+    },
+    "lionbit": {
+        "name": "Lion:Bit Dev Board",
+        "variant": VARIANT_ESP32,
+    },
+    "lolin32_lite": {
+        "name": "WEMOS LOLIN32 Lite",
+        "variant": VARIANT_ESP32,
+    },
+    "lolin32": {
+        "name": "WEMOS LOLIN32",
+        "variant": VARIANT_ESP32,
+    },
+    "lolin_c3_mini": {
+        "name": "WEMOS LOLIN C3 Mini",
+        "variant": VARIANT_ESP32C3,
+    },
+    "lolin_d32": {
+        "name": "WEMOS LOLIN D32",
+        "variant": VARIANT_ESP32,
+    },
+    "lolin_d32_pro": {
+        "name": "WEMOS LOLIN D32 PRO",
+        "variant": VARIANT_ESP32,
+    },
+    "lolin_s2_mini": {
+        "name": "WEMOS LOLIN S2 Mini",
+        "variant": VARIANT_ESP32S2,
+    },
+    "lolin_s2_pico": {
+        "name": "WEMOS LOLIN S2 PICO",
+        "variant": VARIANT_ESP32S2,
+    },
+    "lolin_s3": {
+        "name": "WEMOS LOLIN S3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "lopy4": {
+        "name": "Pycom LoPy4",
+        "variant": VARIANT_ESP32,
+    },
+    "lopy": {
+        "name": "Pycom LoPy",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-atom": {
+        "name": "M5Stack-ATOM",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-core2": {
+        "name": "M5Stack Core2",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-core-esp32": {
+        "name": "M5Stack Core ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-coreink": {
+        "name": "M5Stack-Core Ink",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-fire": {
+        "name": "M5Stack FIRE",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-grey": {
+        "name": "M5Stack GREY ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-station": {
+        "name": "M5Stack Station",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack-timer-cam": {
+        "name": "M5Stack Timer CAM",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stick-c": {
+        "name": "M5Stick-C",
+        "variant": VARIANT_ESP32,
+    },
+    "magicbit": {
+        "name": "MagicBit",
+        "variant": VARIANT_ESP32,
+    },
+    "mgbot-iotik32a": {
+        "name": "MGBOT IOTIK 32A",
+        "variant": VARIANT_ESP32,
+    },
+    "mgbot-iotik32b": {
+        "name": "MGBOT IOTIK 32B",
+        "variant": VARIANT_ESP32,
+    },
+    "mhetesp32devkit": {
+        "name": "MH ET LIVE ESP32DevKIT",
+        "variant": VARIANT_ESP32,
+    },
+    "mhetesp32minikit": {
+        "name": "MH ET LIVE ESP32MiniKit",
+        "variant": VARIANT_ESP32,
+    },
+    "microduino-core-esp32": {
+        "name": "Microduino Core ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "micros2": {
+        "name": "microS2",
+        "variant": VARIANT_ESP32S2,
+    },
+    "minimain_esp32s2": {
+        "name": "Deparment of Alchemy MiniMain ESP32-S2",
+        "variant": VARIANT_ESP32S2,
+    },
+    "nano32": {
+        "name": "MakerAsia Nano32",
+        "variant": VARIANT_ESP32,
+    },
+    "nina_w10": {
+        "name": "u-blox NINA-W10 series",
+        "variant": VARIANT_ESP32,
+    },
+    "node32s": {
+        "name": "Node32s",
+        "variant": VARIANT_ESP32,
+    },
+    "nodemcu-32s2": {
+        "name": "Ai-Thinker NodeMCU-32S2 (ESP-12K)",
+        "variant": VARIANT_ESP32S2,
+    },
+    "nodemcu-32s": {
+        "name": "NodeMCU-32S",
+        "variant": VARIANT_ESP32,
+    },
+    "nscreen-32": {
+        "name": "YeaCreate NSCREEN-32",
+        "variant": VARIANT_ESP32,
+    },
+    "odroid_esp32": {
+        "name": "ODROID-GO",
+        "variant": VARIANT_ESP32,
+    },
+    "onehorse32dev": {
+        "name": "Onehorse ESP32 Dev Module",
+        "variant": VARIANT_ESP32,
+    },
+    "oroca_edubot": {
+        "name": "OROCA EduBot",
+        "variant": VARIANT_ESP32,
+    },
+    "pico32": {
+        "name": "ESP32 Pico Kit",
+        "variant": VARIANT_ESP32,
+    },
+    "piranha_esp32": {
+        "name": "Fishino Piranha ESP-32",
+        "variant": VARIANT_ESP32,
+    },
+    "pocket_32": {
+        "name": "Dongsen Tech Pocket 32",
+        "variant": VARIANT_ESP32,
+    },
+    "pycom_gpy": {
+        "name": "Pycom GPy",
+        "variant": VARIANT_ESP32,
+    },
+    "qchip": {
+        "name": "Qchip",
+        "variant": VARIANT_ESP32,
+    },
+    "quantum": {
+        "name": "Noduino Quantum",
+        "variant": VARIANT_ESP32,
+    },
+    "seeed_xiao_esp32c3": {
+        "name": "Seeed Studio XIAO ESP32C3",
+        "variant": VARIANT_ESP32C3,
+    },
+    "sensesiot_weizen": {
+        "name": "LOGISENSES Senses Weizen",
+        "variant": VARIANT_ESP32,
+    },
+    "sg-o_airMon": {
+        "name": "SG-O AirMon",
+        "variant": VARIANT_ESP32,
+    },
+    "s_odi_ultra": {
+        "name": "S.ODI Ultra v1",
+        "variant": VARIANT_ESP32,
+    },
+    "sparkfun_esp32_iot_redboard": {
+        "name": "SparkFun ESP32 IoT RedBoard",
+        "variant": VARIANT_ESP32,
+    },
+    "sparkfun_esp32micromod": {
+        "name": "SparkFun ESP32 MicroMod",
+        "variant": VARIANT_ESP32,
+    },
+    "sparkfun_esp32s2_thing_plus_c": {
+        "name": "SparkFun ESP32 Thing Plus C",
+        "variant": VARIANT_ESP32,
+    },
+    "sparkfun_esp32s2_thing_plus": {
+        "name": "SparkFun ESP32-S2 Thing Plus",
+        "variant": VARIANT_ESP32S2,
+    },
+    "sparkfun_lora_gateway_1-channel": {
+        "name": "SparkFun LoRa Gateway 1-Channel",
+        "variant": VARIANT_ESP32,
+    },
+    "tamc_termod_s3": {
+        "name": "TAMC Termod S3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "tinypico": {
+        "name": "Unexpected Maker TinyPICO",
+        "variant": VARIANT_ESP32,
+    },
+    "trueverit-iot-driver-mk2": {
+        "name": "Trueverit ESP32 Universal IoT Driver MK II",
+        "variant": VARIANT_ESP32,
+    },
+    "trueverit-iot-driver-mk3": {
+        "name": "Trueverit ESP32 Universal IoT Driver MK III",
+        "variant": VARIANT_ESP32,
+    },
+    "trueverit-iot-driver": {
+        "name": "Trueverit ESP32 Universal IoT Driver",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-lora32-v1": {
+        "name": "TTGO LoRa32-OLED V1",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-lora32-v21": {
+        "name": "TTGO LoRa32-OLED v2.1.6",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-lora32-v2": {
+        "name": "TTGO LoRa32-OLED V2",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t1": {
+        "name": "TTGO T1",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t7-v13-mini32": {
+        "name": "TTGO T7 V1.3 Mini32",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t7-v14-mini32": {
+        "name": "TTGO T7 V1.4 Mini32",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t-beam": {
+        "name": "TTGO T-Beam",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t-oi-plus": {
+        "name": "TTGO T-OI PLUS RISC-V ESP32-C3",
+        "variant": VARIANT_ESP32C3,
+    },
+    "ttgo-t-watch": {
+        "name": "TTGO T-Watch",
+        "variant": VARIANT_ESP32,
+    },
+    "turta_iot_node": {
+        "name": "Turta IoT Node",
+        "variant": VARIANT_ESP32,
+    },
+    "um_feathers2": {
+        "name": "Unexpected Maker FeatherS2",
+        "variant": VARIANT_ESP32S2,
+    },
+    "um_feathers2_neo": {
+        "name": "Unexpected Maker FeatherS2 Neo",
+        "variant": VARIANT_ESP32S2,
+    },
+    "um_feathers3": {
+        "name": "Unexpected Maker FeatherS3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "um_pros3": {
+        "name": "Unexpected Maker PROS3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "um_rmp": {
+        "name": "Unexpected Maker RMP",
+        "variant": VARIANT_ESP32S2,
+    },
+    "um_tinys2": {
+        "name": "Unexpected Maker TinyS2",
+        "variant": VARIANT_ESP32S2,
+    },
+    "um_tinys3": {
+        "name": "Unexpected Maker TinyS3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "unphone7": {
+        "name": "unPhone 7",
+        "variant": VARIANT_ESP32,
+    },
+    "unphone8": {
+        "name": "unPhone 8",
+        "variant": VARIANT_ESP32S3,
+    },
+    "unphone9": {
+        "name": "unPhone 9",
+        "variant": VARIANT_ESP32S3,
+    },
+    "upesy_wroom": {
+        "name": "uPesy ESP32 Wroom DevKit",
+        "variant": VARIANT_ESP32,
+    },
+    "upesy_wrover": {
+        "name": "uPesy ESP32 Wrover DevKit",
+        "variant": VARIANT_ESP32,
+    },
+    "vintlabs-devkit-v1": {
+        "name": "VintLabs ESP32 Devkit",
+        "variant": VARIANT_ESP32,
+    },
+    "watchy": {
+        "name": "SQFMI Watchy v2.0",
+        "variant": VARIANT_ESP32,
+    },
+    "wemosbat": {
+        "name": "WeMos WiFi and Bluetooth Battery",
+        "variant": VARIANT_ESP32,
+    },
+    "wemos_d1_mini32": {
+        "name": "WEMOS D1 MINI ESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "wemos_d1_uno32": {
+        "name": "WEMOS D1 R32",
+        "variant": VARIANT_ESP32,
+    },
+    "wesp32": {
+        "name": "Silicognition wESP32",
+        "variant": VARIANT_ESP32,
+    },
+    "widora-air": {
+        "name": "Widora AIR",
+        "variant": VARIANT_ESP32,
+    },
+    "wifiduino32c3": {
+        "name": "Blinker WiFiduinoV2 (ESP32-C3)",
+        "variant": VARIANT_ESP32C3,
+    },
+    "wifiduino32": {
+        "name": "Blinker WiFiduino32",
+        "variant": VARIANT_ESP32,
+    },
+    "wifiduino32s3": {
+        "name": "Blinker WiFiduino32S3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "wipy3": {
+        "name": "Pycom WiPy3",
+        "variant": VARIANT_ESP32,
+    },
+    "wt32-eth01": {
+        "name": "Wireless-Tag WT32-ETH01 Ethernet Module",
+        "variant": VARIANT_ESP32,
+    },
+    "xinabox_cw02": {
+        "name": "XinaBox CW02",
+        "variant": VARIANT_ESP32,
+    },
 }

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -22,10 +22,11 @@ from .const import (
     CONF_EARLY_PIN_INIT,
     KEY_BOARD,
     KEY_ESP8266,
+    KEY_FLASH_SIZE,
     KEY_PIN_INITIAL_STATES,
     esp8266_ns,
 )
-from .boards import ESP8266_FLASH_SIZES, ESP8266_LD_SCRIPTS
+from .boards import BOARDS, ESP8266_LD_SCRIPTS
 
 from .gpio import PinInitialState, add_pin_initial_states_array
 
@@ -218,8 +219,8 @@ async def to_code(config):
         cg.RawExpression(f"VERSION_CODE({ver.major}, {ver.minor}, {ver.patch})"),
     )
 
-    if config[CONF_BOARD] in ESP8266_FLASH_SIZES:
-        flash_size = ESP8266_FLASH_SIZES[config[CONF_BOARD]]
+    if config[CONF_BOARD] in BOARDS:
+        flash_size = BOARDS[config[CONF_BOARD]][KEY_FLASH_SIZE]
         ld_scripts = ESP8266_LD_SCRIPTS[flash_size]
 
         if ver <= cv.Version(2, 3, 0):

--- a/esphome/components/esp8266/boards.py
+++ b/esphome/components/esp8266/boards.py
@@ -4,50 +4,6 @@ FLASH_SIZE_2_MB = 2 * FLASH_SIZE_1_MB
 FLASH_SIZE_4_MB = 4 * FLASH_SIZE_1_MB
 FLASH_SIZE_16_MB = 16 * FLASH_SIZE_1_MB
 
-ESP8266_FLASH_SIZES = {
-    "d1": FLASH_SIZE_4_MB,
-    "d1_mini": FLASH_SIZE_4_MB,
-    "d1_mini_lite": FLASH_SIZE_1_MB,
-    "d1_mini_pro": FLASH_SIZE_16_MB,
-    "esp01": FLASH_SIZE_512_KB,
-    "esp01_1m": FLASH_SIZE_1_MB,
-    "esp07": FLASH_SIZE_4_MB,
-    "esp12e": FLASH_SIZE_4_MB,
-    "esp210": FLASH_SIZE_4_MB,
-    "esp8285": FLASH_SIZE_1_MB,
-    "esp_wroom_02": FLASH_SIZE_2_MB,
-    "espduino": FLASH_SIZE_4_MB,
-    "espectro": FLASH_SIZE_4_MB,
-    "espino": FLASH_SIZE_4_MB,
-    "espinotee": FLASH_SIZE_4_MB,
-    "espmxdevkit": FLASH_SIZE_1_MB,
-    "espresso_lite_v1": FLASH_SIZE_4_MB,
-    "espresso_lite_v2": FLASH_SIZE_4_MB,
-    "gen4iod": FLASH_SIZE_512_KB,
-    "heltec_wifi_kit_8": FLASH_SIZE_4_MB,
-    "huzzah": FLASH_SIZE_4_MB,
-    "inventone": FLASH_SIZE_4_MB,
-    "modwifi": FLASH_SIZE_2_MB,
-    "nodemcu": FLASH_SIZE_4_MB,
-    "nodemcuv2": FLASH_SIZE_4_MB,
-    "oak": FLASH_SIZE_4_MB,
-    "phoenix_v1": FLASH_SIZE_4_MB,
-    "phoenix_v2": FLASH_SIZE_4_MB,
-    "sonoff_basic": FLASH_SIZE_1_MB,
-    "sonoff_s20": FLASH_SIZE_1_MB,
-    "sonoff_sv": FLASH_SIZE_1_MB,
-    "sonoff_th": FLASH_SIZE_1_MB,
-    "sparkfunBlynk": FLASH_SIZE_4_MB,
-    "thing": FLASH_SIZE_512_KB,
-    "thingdev": FLASH_SIZE_512_KB,
-    "wifi_slot": FLASH_SIZE_1_MB,
-    "wifiduino": FLASH_SIZE_4_MB,
-    "wifinfo": FLASH_SIZE_1_MB,
-    "wio_link": FLASH_SIZE_4_MB,
-    "wio_node": FLASH_SIZE_4_MB,
-    "xinabox_cw01": FLASH_SIZE_4_MB,
-}
-
 ESP8266_LD_SCRIPTS = {
     FLASH_SIZE_512_KB: ("eagle.flash.512k0.ld", "eagle.flash.512k.ld"),
     FLASH_SIZE_1_MB: ("eagle.flash.1m0.ld", "eagle.flash.1m.ld"),
@@ -205,4 +161,202 @@ ESP8266_BOARD_PINS = {
     "wio_link": {"LED": 2, "GROVE": 15, "D0": 14, "D1": 12, "D2": 13, "BUTTON": 0},
     "wio_node": {"LED": 2, "GROVE": 15, "D0": 3, "D1": 5, "BUTTON": 0},
     "xinabox_cw01": {"SDA": 2, "SCL": 14, "LED": 5, "LED_RED": 12, "LED_GREEN": 13},
+}
+
+"""
+BOARDS generate with:
+
+git clone https://github.com/platformio/platform-espressif8266
+for x in platform-espressif8266/boards/*.json; do
+  max_size=$(jq -r .upload.maximum_size <"$x")
+  name=$(jq -r .name <"$x")
+  fname=$(basename "$x")
+  board="${fname%.*}"
+  size_mb=$((max_size / (1024 * 1024)))
+  if [[ $size_mb -gt 0 ]]; then
+    size="${size_mb}_MB"
+  else
+    size="${$((max_size / 1024))}_KB"
+  fi
+  echo "    \"$board\": {\"name\": \"$name\", \"flash_size\": FLASH_SIZE_$size,},"
+done | sort
+"""
+
+BOARDS = {
+    "agruminolemon": {
+        "name": "Lifely Agrumino Lemon v4",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "d1_mini_lite": {
+        "name": "WeMos D1 mini Lite",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "d1_mini": {
+        "name": "WeMos D1 R2 and mini",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "d1_mini_pro": {
+        "name": "WeMos D1 mini Pro",
+        "flash_size": FLASH_SIZE_16_MB,
+    },
+    "d1": {
+        "name": "WEMOS D1 R1",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "eduinowifi": {
+        "name": "Schirmilabs Eduino WiFi",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "esp01_1m": {
+        "name": "Espressif Generic ESP8266 ESP-01 1M",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "esp01": {
+        "name": "Espressif Generic ESP8266 ESP-01 512k",
+        "flash_size": FLASH_SIZE_512_KB,
+    },
+    "esp07": {
+        "name": "Espressif Generic ESP8266 ESP-07 1MB",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "esp07s": {
+        "name": "Espressif Generic ESP8266 ESP-07S",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "esp12e": {
+        "name": "Espressif ESP8266 ESP-12E",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "esp210": {
+        "name": "SweetPea ESP-210",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "esp8285": {
+        "name": "Generic ESP8285 Module",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "espduino": {
+        "name": "ESPDuino (ESP-13 Module)",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "espectro": {
+        "name": "ESPectro Core",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "espino": {
+        "name": "ESPino",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "espinotee": {
+        "name": "ThaiEasyElec ESPino",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "espmxdevkit": {
+        "name": "ESP-Mx DevKit (ESP8285)",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "espresso_lite_v1": {
+        "name": "ESPresso Lite 1.0",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "espresso_lite_v2": {
+        "name": "ESPresso Lite 2.0",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "esp_wroom_02": {
+        "name": "ESP-WROOM-02",
+        "flash_size": FLASH_SIZE_2_MB,
+    },
+    "gen4iod": {
+        "name": "4D Systems gen4 IoD Range",
+        "flash_size": FLASH_SIZE_512_KB,
+    },
+    "heltec_wifi_kit_8": {
+        "name": "Heltec Wifi kit 8",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "huzzah": {
+        "name": "Adafruit HUZZAH ESP8266",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "inventone": {
+        "name": "Invent One",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "modwifi": {
+        "name": "Olimex MOD-WIFI-ESP8266(-DEV)",
+        "flash_size": FLASH_SIZE_2_MB,
+    },
+    "nodemcu": {
+        "name": "NodeMCU 0.9 (ESP-12 Module)",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "nodemcuv2": {
+        "name": "NodeMCU 1.0 (ESP-12E Module)",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "oak": {
+        "name": "DigiStump Oak",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "phoenix_v1": {
+        "name": "Phoenix 1.0",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "phoenix_v2": {
+        "name": "Phoenix 2.0",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "sonoff_basic": {
+        "name": "Sonoff Basic",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "sonoff_s20": {
+        "name": "Sonoff S20",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "sonoff_sv": {
+        "name": "Sonoff SV",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "sonoff_th": {
+        "name": "Sonoff TH",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "sparkfunBlynk": {
+        "name": "SparkFun Blynk Board",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "thingdev": {
+        "name": "SparkFun ESP8266 Thing Dev",
+        "flash_size": FLASH_SIZE_512_KB,
+    },
+    "thing": {
+        "name": "SparkFun ESP8266 Thing",
+        "flash_size": FLASH_SIZE_512_KB,
+    },
+    "wifiduino": {
+        "name": "WiFiduino",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "wifinfo": {
+        "name": "WifInfo",
+        "flash_size": FLASH_SIZE_1_MB,
+    },
+    "wifi_slot": {
+        "name": "WiFi Slot",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "wio_link": {
+        "name": "Wio Link",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "wio_node": {
+        "name": "Wio Node",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
+    "xinabox_cw01": {
+        "name": "XinaBox CW01",
+        "flash_size": FLASH_SIZE_4_MB,
+    },
 }

--- a/esphome/components/esp8266/const.py
+++ b/esphome/components/esp8266/const.py
@@ -5,6 +5,7 @@ KEY_BOARD = "board"
 KEY_PIN_INITIAL_STATES = "pin_initial_states"
 CONF_RESTORE_FROM_FLASH = "restore_from_flash"
 CONF_EARLY_PIN_INIT = "early_pin_init"
+KEY_FLASH_SIZE = "flash_size"
 
 # esp8266 namespace is already defined by arduino, manually prefix esphome
 esp8266_ns = cg.global_ns.namespace("esphome").namespace("esp8266")

--- a/esphome/components/rp2040/boards.py
+++ b/esphome/components/rp2040/boards.py
@@ -17,3 +17,12 @@ RP2040_BOARD_PINS = {
         "SCL1": 27,
     },
 }
+
+BOARDS = {
+    "rpipico": {
+        "name": "Raspberry Pi Pico",
+    },
+    "rpipicow": {
+        "name": "Raspberry Pi Pico W",
+    },
+}

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -992,6 +992,7 @@ KEY_CORE = "core"
 KEY_TARGET_PLATFORM = "target_platform"
 KEY_TARGET_FRAMEWORK = "target_framework"
 KEY_FRAMEWORK_VERSION = "framework_version"
+KEY_NAME = "name"
 
 # Entity categories
 ENTITY_CATEGORY_NONE = ""

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -689,6 +689,24 @@ class PrometheusServiceDiscoveryHandler(BaseHandler):
         self.write(json.dumps(sd))
 
 
+class BoardsRequestHandler(BaseHandler):
+    @authenticated
+    def get(self):
+        from esphome.components.esp32.boards import BOARDS as ESP32_BOARDS
+        from esphome.components.esp8266.boards import BOARDS as ESP8266_BOARDS
+        from esphome.components.rp2040.boards import BOARDS as RP2040_BOARDS
+
+        boards = {
+            "esp32": {key: val[const.KEY_NAME] for key, val in ESP32_BOARDS.items()},
+            "esp8266": {
+                key: val[const.KEY_NAME] for key, val in ESP8266_BOARDS.items()
+            },
+            "rp2040": {key: val[const.KEY_NAME] for key, val in RP2040_BOARDS.items()},
+        }
+        self.set_header("content-type", "application/json")
+        self.write(json.dumps(boards))
+
+
 class MDNSStatusThread(threading.Thread):
     def run(self):
         global IMPORT_RESULT
@@ -1059,6 +1077,7 @@ def make_app(debug=get_bool_env(ENV_DEV)):
             (f"{rel}json-config", JsonConfigRequestHandler),
             (f"{rel}rename", EsphomeRenameHandler),
             (f"{rel}prometheus-sd", PrometheusServiceDiscoveryHandler),
+            (f"{rel}boards", BoardsRequestHandler),
         ],
         **app_settings,
     )

--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -245,7 +245,7 @@ def do_esp32():
 
     setEnum(
         output["esp32"]["schemas"]["CONFIG_SCHEMA"]["schema"]["config_vars"]["board"],
-        list(esp32_boards.BOARD_TO_VARIANT.keys()),
+        list(esp32_boards.BOARDS.keys()),
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Dashboard PR: https://github.com/esphome/dashboard/pull/376

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
