### PR TITLE
Expose lambda action to reset a cycle in `slow_pwm`

### DIFF
--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -70,7 +70,7 @@ void SlowPWMOutput::dump_config() {
 void SlowPWMOutput::write_state(float state) {
   this->state_ = state;
   if (this->restart_cycle_on_state_change_)
-    this->period_start_time_ = millis();
+    this->restart_cycle();
 }
 
 }  // namespace slow_pwm

--- a/esphome/components/slow_pwm/slow_pwm_output.h
+++ b/esphome/components/slow_pwm/slow_pwm_output.h
@@ -14,6 +14,7 @@ class SlowPWMOutput : public output::FloatOutput, public Component {
   void set_restart_cycle_on_state_change(bool restart_cycle_on_state_change) {
     restart_cycle_on_state_change_ = restart_cycle_on_state_change;
   }
+  void restart_cycle() { this->period_start_time_ = millis(); }
 
   /// Initialize pin
   void setup() override;


### PR DESCRIPTION
# What does this implement/fix?

In https://github.com/esphome/esphome/pull/3004 the `restart_cycle_on_state_change` configuration option was added to `slow_pwm`. This extracts the code that restarts the cycle to a method and makes that method `public`.

I have a `slow_pwm` that has two control modes:
  1. Climate PID
  2. Manual

I don't want to restart the cycle on state changes when the Climate PID is controlling the `slow_pwm` output but I do want to reset the cycle when when the manual controls are manipulated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other - refactor

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

I don't think this is applicable, as I think it will be auto generated.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
- lambda: "id(my_slow_pwm).reset_cycle();"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

@Chupaka It looks like you added the original reset cycle functionality, what do you think of this?
