### PR TITLE
Sprinkler "v2" updates

### DIFF
--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -5,6 +5,7 @@ from esphome.automation import maybe_simple_id
 from esphome.components import number
 from esphome.components import switch
 from esphome.const import (
+    CONF_ENTITY_CATEGORY,
     CONF_ID,
     CONF_INITIAL_VALUE,
     CONF_MAX_VALUE,
@@ -295,6 +296,9 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
             number.NUMBER_SCHEMA.extend(
                 {
                     cv.GenerateID(): cv.declare_id(SprinklerControllerNumber),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+                    ): cv.entity_category,
                     cv.Optional(CONF_INITIAL_VALUE, default=900): cv.positive_int,
                     cv.Optional(CONF_MAX_VALUE, default=86400): cv.positive_int,
                     cv.Optional(CONF_MIN_VALUE, default=1): cv.positive_int,
@@ -356,6 +360,9 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             number.NUMBER_SCHEMA.extend(
                 {
                     cv.GenerateID(): cv.declare_id(SprinklerControllerNumber),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+                    ): cv.entity_category,
                     cv.Optional(CONF_INITIAL_VALUE, default=1): cv.positive_float,
                     cv.Optional(CONF_MAX_VALUE, default=10): cv.positive_float,
                     cv.Optional(CONF_MIN_VALUE, default=0): cv.positive_float,
@@ -374,6 +381,9 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             number.NUMBER_SCHEMA.extend(
                 {
                     cv.GenerateID(): cv.declare_id(SprinklerControllerNumber),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+                    ): cv.entity_category,
                     cv.Optional(CONF_INITIAL_VALUE, default=0): cv.positive_int,
                     cv.Optional(CONF_MAX_VALUE, default=10): cv.positive_int,
                     cv.Optional(CONF_MIN_VALUE, default=0): cv.positive_int,

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -28,6 +28,7 @@ CONF_MANUAL_SELECTION_DELAY = "manual_selection_delay"
 CONF_MULTIPLIER = "multiplier"
 CONF_MULTIPLIER_NUMBER = "multiplier_number"
 CONF_NEXT_PREV_IGNORE_DISABLED = "next_prev_ignore_disabled"
+CONF_NUMBERS_USE_MINUTES = "numbers_use_minutes"
 CONF_PUMP_OFF_SWITCH_ID = "pump_off_switch_id"
 CONF_PUMP_ON_SWITCH_ID = "pump_on_switch_id"
 CONF_PUMP_PULSE_DURATION = "pump_pulse_duration"
@@ -338,6 +339,7 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             key=CONF_NAME,
         ),
         cv.Optional(CONF_NEXT_PREV_IGNORE_DISABLED, default=False): cv.boolean,
+        cv.Optional(CONF_NUMBERS_USE_MINUTES, default=False): cv.boolean,
         cv.Optional(CONF_MANUAL_SELECTION_DELAY): cv.positive_time_period_seconds,
         cv.Optional(CONF_MULTIPLIER_NUMBER): cv.maybe_simple_value(
             number.NUMBER_SCHEMA.extend(
@@ -658,6 +660,12 @@ async def to_code(config):
         cg.add(
             var.set_next_prev_ignore_disabled_valves(
                 sprinkler_controller[CONF_NEXT_PREV_IGNORE_DISABLED]
+            )
+        )
+
+        cg.add(
+            var.set_number_values_are_minutes(
+                sprinkler_controller[CONF_NUMBERS_USE_MINUTES]
             )
         )
 

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -191,6 +191,7 @@ SPRINKLER_ACTION_REPEAT_SCHEMA = cv.maybe_simple_value(
 SPRINKLER_ACTION_SINGLE_VALVE_SCHEMA = cv.maybe_simple_value(
     {
         cv.GenerateID(): cv.use_id(Sprinkler),
+        cv.Optional(CONF_RUN_DURATION): cv.templatable(cv.positive_time_period_seconds),
         cv.Required(CONF_VALVE_NUMBER): cv.templatable(cv.positive_int),
     },
     key=CONF_VALVE_NUMBER,
@@ -390,6 +391,9 @@ async def sprinkler_start_single_valve_to_code(config, action_id, template_arg, 
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_VALVE_NUMBER], args, cg.uint8)
     cg.add(var.set_valve_to_start(template_))
+    if CONF_RUN_DURATION in config:
+        template_ = await cg.templatable(config[CONF_RUN_DURATION], args, cg.uint32)
+        cg.add(var.set_valve_run_duration(template_))
     return var
 
 

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -59,7 +59,7 @@ CONF_VALVES = "valves"
 sprinkler_ns = cg.esphome_ns.namespace("sprinkler")
 Sprinkler = sprinkler_ns.class_("Sprinkler", cg.Component)
 SprinklerControllerNumber = sprinkler_ns.class_(
-    "SprinklerControllerNumber", number.Number, cg.PollingComponent
+    "SprinklerControllerNumber", number.Number, cg.Component
 )
 SprinklerControllerSwitch = sprinkler_ns.class_(
     "SprinklerControllerSwitch", switch.Switch, cg.Component
@@ -308,7 +308,7 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
                         single=True
                     ),
                 }
-            ).extend(cv.polling_component_schema("1s")),
+            ).extend(cv.COMPONENT_SCHEMA),
             validate_min_max,
             key=CONF_NAME,
         ),
@@ -372,7 +372,7 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
                         single=True
                     ),
                 }
-            ).extend(cv.polling_component_schema("1s")),
+            ).extend(cv.COMPONENT_SCHEMA),
             validate_min_max,
             key=CONF_NAME,
         ),
@@ -393,7 +393,7 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
                         single=True
                     ),
                 }
-            ).extend(cv.polling_component_schema("1s")),
+            ).extend(cv.COMPONENT_SCHEMA),
             validate_min_max,
             key=CONF_NAME,
         ),

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -11,7 +11,6 @@ from esphome.const import (
     CONF_MIN_VALUE,
     CONF_NAME,
     CONF_REPEAT,
-    CONF_RESTORE_MODE,
     CONF_RESTORE_VALUE,
     CONF_RUN_DURATION,
     CONF_STEP,
@@ -567,14 +566,6 @@ async def to_code(config):
             await cg.register_component(
                 sw_aa_var, sprinkler_controller[CONF_AUTO_ADVANCE_SWITCH]
             )
-            if CONF_RESTORE_MODE in sprinkler_controller[CONF_AUTO_ADVANCE_SWITCH]:
-                cg.add(
-                    sw_aa_var.set_restore_mode(
-                        sprinkler_controller[CONF_AUTO_ADVANCE_SWITCH][
-                            CONF_RESTORE_MODE
-                        ]
-                    )
-                )
             cg.add(var.set_controller_auto_adv_switch(sw_aa_var))
 
             if CONF_QUEUE_ENABLE_SWITCH in sprinkler_controller:
@@ -584,14 +575,6 @@ async def to_code(config):
                 await cg.register_component(
                     sw_qen_var, sprinkler_controller[CONF_QUEUE_ENABLE_SWITCH]
                 )
-                if CONF_RESTORE_MODE in sprinkler_controller[CONF_QUEUE_ENABLE_SWITCH]:
-                    cg.add(
-                        sw_qen_var.set_restore_mode(
-                            sprinkler_controller[CONF_QUEUE_ENABLE_SWITCH][
-                                CONF_RESTORE_MODE
-                            ]
-                        )
-                    )
                 cg.add(var.set_controller_queue_enable_switch(sw_qen_var))
 
             if CONF_REVERSE_SWITCH in sprinkler_controller:
@@ -601,12 +584,6 @@ async def to_code(config):
                 await cg.register_component(
                     sw_rev_var, sprinkler_controller[CONF_REVERSE_SWITCH]
                 )
-                if CONF_RESTORE_MODE in sprinkler_controller[CONF_REVERSE_SWITCH]:
-                    cg.add(
-                        sw_rev_var.set_restore_mode(
-                            sprinkler_controller[CONF_REVERSE_SWITCH][CONF_RESTORE_MODE]
-                        )
-                    )
                 cg.add(var.set_controller_reverse_switch(sw_rev_var))
 
             if CONF_STANDBY_SWITCH in sprinkler_controller:
@@ -616,12 +593,6 @@ async def to_code(config):
                 await cg.register_component(
                     sw_stb_var, sprinkler_controller[CONF_STANDBY_SWITCH]
                 )
-                if CONF_RESTORE_MODE in sprinkler_controller[CONF_STANDBY_SWITCH]:
-                    cg.add(
-                        sw_stb_var.set_restore_mode(
-                            sprinkler_controller[CONF_STANDBY_SWITCH][CONF_RESTORE_MODE]
-                        )
-                    )
                 cg.add(var.set_controller_standby_switch(sw_stb_var))
 
             if CONF_MULTIPLIER_NUMBER in sprinkler_controller:

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -31,6 +31,7 @@ CONF_PUMP_SWITCH_ID = "pump_switch_id"
 CONF_PUMP_SWITCH_OFF_DURING_VALVE_OPEN_DELAY = "pump_switch_off_during_valve_open_delay"
 CONF_QUEUE_ENABLE_SWITCH = "queue_enable_switch"
 CONF_REVERSE_SWITCH = "reverse_switch"
+CONF_STANDBY_SWITCH = "standby_switch"
 CONF_VALVE_NUMBER = "valve_number"
 CONF_VALVE_OPEN_DELAY = "valve_open_delay"
 CONF_VALVE_OVERLAP = "valve_overlap"
@@ -268,6 +269,10 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             ),
             key=CONF_NAME,
         ),
+        cv.Optional(CONF_STANDBY_SWITCH): cv.maybe_simple_value(
+            switch.switch_schema(SprinklerControllerSwitch),
+            key=CONF_NAME,
+        ),
         cv.Optional(CONF_MANUAL_SELECTION_DELAY): cv.positive_time_period_seconds,
         cv.Optional(CONF_REPEAT): cv.positive_int,
         cv.Optional(CONF_PUMP_PULSE_DURATION): cv.positive_time_period_milliseconds,
@@ -454,6 +459,15 @@ async def to_code(config):
                     sw_rev_var, sprinkler_controller[CONF_REVERSE_SWITCH]
                 )
                 cg.add(var.set_controller_reverse_switch(sw_rev_var))
+
+            if CONF_STANDBY_SWITCH in sprinkler_controller:
+                sw_stb_var = await switch.new_switch(
+                    sprinkler_controller[CONF_STANDBY_SWITCH]
+                )
+                await cg.register_component(
+                    sw_stb_var, sprinkler_controller[CONF_STANDBY_SWITCH]
+                )
+                cg.add(var.set_controller_standby_switch(sw_stb_var))
 
         for valve in sprinkler_controller[CONF_VALVES]:
             sw_valve_var = await switch.new_switch(valve[CONF_VALVE_SWITCH])

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -15,7 +15,10 @@ from esphome.const import (
     CONF_RESTORE_VALUE,
     CONF_RUN_DURATION,
     CONF_STEP,
+    CONF_UNIT_OF_MEASUREMENT,
     ENTITY_CATEGORY_CONFIG,
+    UNIT_MINUTE,
+    UNIT_SECOND,
 )
 
 AUTO_LOAD = ["number", "switch"]
@@ -29,7 +32,6 @@ CONF_MANUAL_SELECTION_DELAY = "manual_selection_delay"
 CONF_MULTIPLIER = "multiplier"
 CONF_MULTIPLIER_NUMBER = "multiplier_number"
 CONF_NEXT_PREV_IGNORE_DISABLED = "next_prev_ignore_disabled"
-CONF_NUMBERS_USE_MINUTES = "numbers_use_minutes"
 CONF_PUMP_OFF_SWITCH_ID = "pump_off_switch_id"
 CONF_PUMP_ON_SWITCH_ID = "pump_on_switch_id"
 CONF_PUMP_PULSE_DURATION = "pump_pulse_duration"
@@ -307,6 +309,9 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
                     cv.Optional(CONF_SET_ACTION): automation.validate_automation(
                         single=True
                     ),
+                    cv.Optional(
+                        CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
+                    ): cv.one_of(UNIT_MINUTE, UNIT_SECOND, lower="True"),
                 }
             ).extend(cv.COMPONENT_SCHEMA),
             validate_min_max,
@@ -354,7 +359,6 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             key=CONF_NAME,
         ),
         cv.Optional(CONF_NEXT_PREV_IGNORE_DISABLED, default=False): cv.boolean,
-        cv.Optional(CONF_NUMBERS_USE_MINUTES, default=False): cv.boolean,
         cv.Optional(CONF_MANUAL_SELECTION_DELAY): cv.positive_time_period_seconds,
         cv.Optional(CONF_MULTIPLIER_NUMBER): cv.maybe_simple_value(
             number.NUMBER_SCHEMA.extend(
@@ -689,12 +693,6 @@ async def to_code(config):
         cg.add(
             var.set_next_prev_ignore_disabled_valves(
                 sprinkler_controller[CONF_NEXT_PREV_IGNORE_DISABLED]
-            )
-        )
-
-        cg.add(
-            var.set_number_values_are_minutes(
-                sprinkler_controller[CONF_NUMBERS_USE_MINUTES]
             )
         )
 

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -27,6 +27,7 @@ CONF_MAIN_SWITCH = "main_switch"
 CONF_MANUAL_SELECTION_DELAY = "manual_selection_delay"
 CONF_MULTIPLIER = "multiplier"
 CONF_MULTIPLIER_NUMBER = "multiplier_number"
+CONF_NEXT_PREV_IGNORE_DISABLED = "next_prev_ignore_disabled"
 CONF_PUMP_OFF_SWITCH_ID = "pump_off_switch_id"
 CONF_PUMP_ON_SWITCH_ID = "pump_on_switch_id"
 CONF_PUMP_PULSE_DURATION = "pump_pulse_duration"
@@ -336,6 +337,7 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             switch.switch_schema(SprinklerControllerSwitch),
             key=CONF_NAME,
         ),
+        cv.Optional(CONF_NEXT_PREV_IGNORE_DISABLED, default=False): cv.boolean,
         cv.Optional(CONF_MANUAL_SELECTION_DELAY): cv.positive_time_period_seconds,
         cv.Optional(CONF_MULTIPLIER_NUMBER): cv.maybe_simple_value(
             number.NUMBER_SCHEMA.extend(
@@ -652,6 +654,12 @@ async def to_code(config):
                 cg.add(var.add_valve(sw_valve_var, sw_en_var))
             else:
                 cg.add(var.add_valve(sw_valve_var))
+
+        cg.add(
+            var.set_next_prev_ignore_disabled_valves(
+                sprinkler_controller[CONF_NEXT_PREV_IGNORE_DISABLED]
+            )
+        )
 
         if CONF_MANUAL_SELECTION_DELAY in sprinkler_controller:
             cg.add(

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -135,6 +135,14 @@ def validate_sprinkler(config):
                     f"{CONF_VALVE_OPEN_DELAY} must be defined when {CONF_PUMP_SWITCH_OFF_DURING_VALVE_OPEN_DELAY} is enabled"
                 )
 
+        if (
+            CONF_REPEAT in sprinkler_controller
+            and CONF_REPEAT_NUMBER in sprinkler_controller
+        ):
+            raise cv.Invalid(
+                f"Do not specify {CONF_REPEAT} when using {CONF_REPEAT_NUMBER}; use number component's {CONF_INITIAL_VALUE} instead"
+            )
+
         for valve in sprinkler_controller[CONF_VALVES]:
             if (
                 CONF_VALVE_OVERLAP in sprinkler_controller

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -11,13 +11,14 @@ from esphome.const import (
     CONF_MIN_VALUE,
     CONF_NAME,
     CONF_REPEAT,
+    CONF_RESTORE_MODE,
+    CONF_RESTORE_VALUE,
     CONF_RUN_DURATION,
     CONF_STEP,
     ENTITY_CATEGORY_CONFIG,
 )
 
-AUTO_LOAD = ["number"]
-AUTO_LOAD = ["switch"]
+AUTO_LOAD = ["number", "switch"]
 CODEOWNERS = ["@kbx81"]
 
 CONF_AUTO_ADVANCE_SWITCH = "auto_advance_switch"
@@ -298,6 +299,7 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
                     cv.Optional(CONF_INITIAL_VALUE, default=900): cv.positive_int,
                     cv.Optional(CONF_MAX_VALUE, default=86400): cv.positive_int,
                     cv.Optional(CONF_MIN_VALUE, default=1): cv.positive_int,
+                    cv.Optional(CONF_RESTORE_VALUE, default=True): cv.boolean,
                     cv.Optional(CONF_STEP, default=1): cv.positive_int,
                     cv.Optional(CONF_SET_ACTION): automation.validate_automation(
                         single=True
@@ -356,6 +358,7 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
                     cv.Optional(CONF_INITIAL_VALUE, default=1): cv.positive_float,
                     cv.Optional(CONF_MAX_VALUE, default=10): cv.positive_float,
                     cv.Optional(CONF_MIN_VALUE, default=0): cv.positive_float,
+                    cv.Optional(CONF_RESTORE_VALUE, default=True): cv.boolean,
                     cv.Optional(CONF_STEP, default=0.1): cv.positive_float,
                     cv.Optional(CONF_SET_ACTION): automation.validate_automation(
                         single=True
@@ -373,6 +376,7 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
                     cv.Optional(CONF_INITIAL_VALUE, default=0): cv.positive_int,
                     cv.Optional(CONF_MAX_VALUE, default=10): cv.positive_int,
                     cv.Optional(CONF_MIN_VALUE, default=0): cv.positive_int,
+                    cv.Optional(CONF_RESTORE_VALUE, default=True): cv.boolean,
                     cv.Optional(CONF_STEP, default=1): cv.positive_int,
                     cv.Optional(CONF_SET_ACTION): automation.validate_automation(
                         single=True
@@ -563,6 +567,14 @@ async def to_code(config):
             await cg.register_component(
                 sw_aa_var, sprinkler_controller[CONF_AUTO_ADVANCE_SWITCH]
             )
+            if CONF_RESTORE_MODE in sprinkler_controller[CONF_AUTO_ADVANCE_SWITCH]:
+                cg.add(
+                    sw_aa_var.set_restore_mode(
+                        sprinkler_controller[CONF_AUTO_ADVANCE_SWITCH][
+                            CONF_RESTORE_MODE
+                        ]
+                    )
+                )
             cg.add(var.set_controller_auto_adv_switch(sw_aa_var))
 
             if CONF_QUEUE_ENABLE_SWITCH in sprinkler_controller:
@@ -572,6 +584,14 @@ async def to_code(config):
                 await cg.register_component(
                     sw_qen_var, sprinkler_controller[CONF_QUEUE_ENABLE_SWITCH]
                 )
+                if CONF_RESTORE_MODE in sprinkler_controller[CONF_QUEUE_ENABLE_SWITCH]:
+                    cg.add(
+                        sw_qen_var.set_restore_mode(
+                            sprinkler_controller[CONF_QUEUE_ENABLE_SWITCH][
+                                CONF_RESTORE_MODE
+                            ]
+                        )
+                    )
                 cg.add(var.set_controller_queue_enable_switch(sw_qen_var))
 
             if CONF_REVERSE_SWITCH in sprinkler_controller:
@@ -581,6 +601,12 @@ async def to_code(config):
                 await cg.register_component(
                     sw_rev_var, sprinkler_controller[CONF_REVERSE_SWITCH]
                 )
+                if CONF_RESTORE_MODE in sprinkler_controller[CONF_REVERSE_SWITCH]:
+                    cg.add(
+                        sw_rev_var.set_restore_mode(
+                            sprinkler_controller[CONF_REVERSE_SWITCH][CONF_RESTORE_MODE]
+                        )
+                    )
                 cg.add(var.set_controller_reverse_switch(sw_rev_var))
 
             if CONF_STANDBY_SWITCH in sprinkler_controller:
@@ -590,6 +616,12 @@ async def to_code(config):
                 await cg.register_component(
                     sw_stb_var, sprinkler_controller[CONF_STANDBY_SWITCH]
                 )
+                if CONF_RESTORE_MODE in sprinkler_controller[CONF_STANDBY_SWITCH]:
+                    cg.add(
+                        sw_stb_var.set_restore_mode(
+                            sprinkler_controller[CONF_STANDBY_SWITCH][CONF_RESTORE_MODE]
+                        )
+                    )
                 cg.add(var.set_controller_standby_switch(sw_stb_var))
 
             if CONF_MULTIPLIER_NUMBER in sprinkler_controller:
@@ -611,8 +643,11 @@ async def to_code(config):
                         sprinkler_controller[CONF_MULTIPLIER_NUMBER][CONF_INITIAL_VALUE]
                     )
                 )
-                cg.add(num_mult_var.set_optimistic("true"))
-                cg.add(num_mult_var.set_restore_value("true"))
+                cg.add(
+                    num_mult_var.set_restore_value(
+                        sprinkler_controller[CONF_MULTIPLIER_NUMBER][CONF_RESTORE_VALUE]
+                    )
+                )
 
                 if CONF_SET_ACTION in sprinkler_controller[CONF_MULTIPLIER_NUMBER]:
                     await automation.build_automation(
@@ -638,8 +673,11 @@ async def to_code(config):
                         sprinkler_controller[CONF_REPEAT_NUMBER][CONF_INITIAL_VALUE]
                     )
                 )
-                cg.add(num_repeat_var.set_optimistic("true"))
-                cg.add(num_repeat_var.set_restore_value("true"))
+                cg.add(
+                    num_repeat_var.set_restore_value(
+                        sprinkler_controller[CONF_REPEAT_NUMBER][CONF_RESTORE_VALUE]
+                    )
+                )
 
                 if CONF_SET_ACTION in sprinkler_controller[CONF_REPEAT_NUMBER]:
                     await automation.build_automation(
@@ -787,8 +825,11 @@ async def to_code(config):
                         valve[CONF_RUN_DURATION_NUMBER][CONF_INITIAL_VALUE]
                     )
                 )
-                cg.add(num_rd_var.set_optimistic("true"))
-                cg.add(num_rd_var.set_restore_value("true"))
+                cg.add(
+                    num_rd_var.set_restore_value(
+                        valve[CONF_RUN_DURATION_NUMBER][CONF_RESTORE_VALUE]
+                    )
+                )
 
                 if CONF_SET_ACTION in valve[CONF_RUN_DURATION_NUMBER]:
                     await automation.build_automation(

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -344,7 +344,9 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             key=CONF_NAME,
         ),
         cv.Optional(CONF_STANDBY_SWITCH): cv.maybe_simple_value(
-            switch.switch_schema(SprinklerControllerSwitch),
+            switch.switch_schema(
+                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+            ),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_NEXT_PREV_IGNORE_DISABLED, default=False): cv.boolean,

--- a/esphome/components/sprinkler/automation.h
+++ b/esphome/components/sprinkler/automation.h
@@ -7,6 +7,18 @@
 namespace esphome {
 namespace sprinkler {
 
+template<typename... Ts> class SetDividerAction : public Action<Ts...> {
+ public:
+  explicit SetDividerAction(Sprinkler *a_sprinkler) : sprinkler_(a_sprinkler) {}
+
+  TEMPLATABLE_VALUE(uint32_t, divider)
+
+  void play(Ts... x) override { this->sprinkler_->set_divider(this->divider_.optional_value(x...)); }
+
+ protected:
+  Sprinkler *sprinkler_;
+};
+
 template<typename... Ts> class SetMultiplierAction : public Action<Ts...> {
  public:
   explicit SetMultiplierAction(Sprinkler *a_sprinkler) : sprinkler_(a_sprinkler) {}

--- a/esphome/components/sprinkler/automation.h
+++ b/esphome/components/sprinkler/automation.h
@@ -98,8 +98,12 @@ template<typename... Ts> class StartSingleValveAction : public Action<Ts...> {
   explicit StartSingleValveAction(Sprinkler *a_sprinkler) : sprinkler_(a_sprinkler) {}
 
   TEMPLATABLE_VALUE(size_t, valve_to_start)
+  TEMPLATABLE_VALUE(uint32_t, valve_run_duration)
 
-  void play(Ts... x) override { this->sprinkler_->start_single_valve(this->valve_to_start_.optional_value(x...)); }
+  void play(Ts... x) override {
+    this->sprinkler_->start_single_valve(this->valve_to_start_.optional_value(x...),
+                                         this->valve_run_duration_.optional_value(x...));
+  }
 
  protected:
   Sprinkler *sprinkler_;

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -598,6 +598,8 @@ void Sprinkler::set_next_prev_ignore_disabled_valves(bool ignore_disabled) {
   this->next_prev_ignore_disabled_ = ignore_disabled;
 }
 
+void Sprinkler::set_number_values_are_minutes(bool use_minutes) { this->number_values_are_minutes_ = use_minutes; }
+
 void Sprinkler::set_pump_start_delay(uint32_t start_delay) {
   this->start_delay_is_valve_delay_ = false;
   this->start_delay_ = start_delay;
@@ -654,7 +656,11 @@ void Sprinkler::set_valve_run_duration(const optional<size_t> valve_number, cons
     if (this->is_a_valid_valve(valve_number.value())) {
       this->valve_[valve_number.value()].run_duration = run_duration.value();
       if (this->valve_[valve_number.value()].run_duration_number != nullptr) {
-        this->valve_[valve_number.value()].run_duration_number->publish_state(run_duration.value());
+        if (this->number_values_are_minutes_) {
+          this->valve_[valve_number.value()].run_duration_number->publish_state(run_duration.value() / 60);
+        } else {
+          this->valve_[valve_number.value()].run_duration_number->publish_state(run_duration.value());
+        }
       }
     }
   }
@@ -702,7 +708,11 @@ void Sprinkler::set_standby(const bool standby) {
 uint32_t Sprinkler::valve_run_duration(const size_t valve_number) {
   if (this->is_a_valid_valve(valve_number)) {
     if (this->valve_[valve_number].run_duration_number != nullptr) {
-      return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state));
+      if (this->number_values_are_minutes_) {
+        return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state * 60));
+      } else {
+        return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state));
+      }
     } else {
       return this->valve_[valve_number].run_duration;
     }

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -161,8 +161,10 @@ Trigger<> *SprinklerControllerSwitch::get_turn_on_trigger() const { return this-
 Trigger<> *SprinklerControllerSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
 
 void SprinklerControllerSwitch::setup() {
-  if (!this->restore_state_)
+  if (!this->restore_state_) {
+    this->state = false;
     return;
+  }
 
   auto restored = this->get_initial_state();
   if (!restored.has_value())

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -709,7 +709,7 @@ void Sprinkler::start_full_cycle() {
   }
 }
 
-void Sprinkler::start_single_valve(const optional<size_t> valve_number) {
+void Sprinkler::start_single_valve(const optional<size_t> valve_number, optional<uint32_t> run_duration) {
   if (this->standby()) {
     ESP_LOGD(TAG, "start_single_valve called but standby is enabled; no action taken");
     return;
@@ -726,7 +726,7 @@ void Sprinkler::start_single_valve(const optional<size_t> valve_number) {
   }
   this->reset_cycle_states_();  // just in case auto-advance is switched on later
   this->repeat_count_ = 0;
-  this->fsm_request_(valve_number.value());
+  this->fsm_request_(valve_number.value(), run_duration.value_or(0));
 }
 
 void Sprinkler::queue_valve(optional<size_t> valve_number, optional<uint32_t> run_duration) {

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -1062,51 +1062,66 @@ uint32_t Sprinkler::total_cycle_time_all_valves() {
 
   for (size_t valve = 0; valve < this->number_of_valves(); valve++) {
     total_time_remaining += this->valve_run_duration_adjusted(valve);
-    if (this->valve_overlap_) {
-      total_time_remaining -= this->switching_delay_.value_or(0);
-    } else {
-      total_time_remaining += this->switching_delay_.value_or(0);
-    }
   }
+
+  if (this->valve_overlap_) {
+    total_time_remaining -= this->switching_delay_.value_or(0) * (this->number_of_valves() - 1);
+  } else {
+    total_time_remaining += this->switching_delay_.value_or(0) * (this->number_of_valves() - 1);
+  }
+
   return total_time_remaining;
 }
 
 uint32_t Sprinkler::total_cycle_time_enabled_valves() {
   uint32_t total_time_remaining = 0;
+  uint32_t valve_count = 0;
 
   for (size_t valve = 0; valve < this->number_of_valves(); valve++) {
     if (this->valve_is_enabled_(valve)) {
       total_time_remaining += this->valve_run_duration_adjusted(valve);
-      if (this->valve_overlap_) {
-        total_time_remaining -= this->switching_delay_.value_or(0);
-      } else {
-        total_time_remaining += this->switching_delay_.value_or(0);
-      }
+      valve_count++;
     }
   }
+
+  if (valve_count) {
+    if (this->valve_overlap_) {
+      total_time_remaining -= this->switching_delay_.value_or(0) * (valve_count - 1);
+    } else {
+      total_time_remaining += this->switching_delay_.value_or(0) * (valve_count - 1);
+    }
+  }
+
   return total_time_remaining;
 }
 
 uint32_t Sprinkler::total_cycle_time_enabled_incomplete_valves() {
   uint32_t total_time_remaining = 0;
+  uint32_t valve_count = 0;
 
   for (size_t valve = 0; valve < this->number_of_valves(); valve++) {
     if (this->valve_is_enabled_(valve) && !this->valve_cycle_complete_(valve)) {
       if (!this->active_valve().has_value() || (valve != this->active_valve().value())) {
         total_time_remaining += this->valve_run_duration_adjusted(valve);
-        if (this->valve_overlap_) {
-          total_time_remaining -= this->switching_delay_.value_or(0);
-        } else {
-          total_time_remaining += this->switching_delay_.value_or(0);
-        }
+        valve_count++;
       }
     }
   }
+
+  if (valve_count) {
+    if (this->valve_overlap_) {
+      total_time_remaining -= this->switching_delay_.value_or(0) * (valve_count - 1);
+    } else {
+      total_time_remaining += this->switching_delay_.value_or(0) * (valve_count - 1);
+    }
+  }
+
   return total_time_remaining;
 }
 
 uint32_t Sprinkler::total_queue_time() {
   uint32_t total_time_remaining = 0;
+  uint32_t valve_count = 0;
 
   for (auto &valve : this->queued_valves_) {
     if (valve.run_duration) {
@@ -1114,12 +1129,17 @@ uint32_t Sprinkler::total_queue_time() {
     } else {
       total_time_remaining += this->valve_run_duration_adjusted(valve.valve_number);
     }
+    valve_count++;
+  }
+
+  if (valve_count) {
     if (this->valve_overlap_) {
-      total_time_remaining -= this->switching_delay_.value_or(0);
+      total_time_remaining -= this->switching_delay_.value_or(0) * (valve_count - 1);
     } else {
-      total_time_remaining += this->switching_delay_.value_or(0);
+      total_time_remaining += this->switching_delay_.value_or(0) * (valve_count - 1);
     }
   }
+
   return total_time_remaining;
 }
 

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -509,6 +509,18 @@ void Sprinkler::configure_valve_pump_switch_pulsed(size_t valve_number, switch_:
   }
 }
 
+void Sprinkler::set_divider(optional<uint32_t> divider) {
+  if (divider.has_value()) {
+    if (divider.value() > 0) {
+      this->set_multiplier(1.0 / divider.value());
+      this->set_repeat(divider.value() - 1);
+    } else if (divider.value() == 0) {
+      this->set_multiplier(1.0);
+      this->set_repeat(0);
+    }
+  }
+}
+
 void Sprinkler::set_multiplier(const optional<float> multiplier) {
   if (multiplier.has_value()) {
     if (multiplier.value() > 0) {

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -634,7 +634,7 @@ void Sprinkler::set_valve_run_duration(const optional<size_t> valve_number, cons
       this->valve_[valve_number.value()].run_duration = run_duration.value();
       if (this->valve_[valve_number.value()].run_duration_number != nullptr) {
         if (this->number_values_are_minutes_) {
-          this->valve_[valve_number.value()].run_duration_number->publish_state(run_duration.value() / 60);
+          this->valve_[valve_number.value()].run_duration_number->publish_state(run_duration.value() / 60.0);
         } else {
           this->valve_[valve_number.value()].run_duration_number->publish_state(run_duration.value());
         }

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -537,30 +537,32 @@ void Sprinkler::configure_valve_run_duration_number(size_t valve_number,
 }
 
 void Sprinkler::set_divider(optional<uint32_t> divider) {
-  if (divider.has_value()) {
-    if (divider.value() > 0) {
-      this->set_multiplier(1.0 / divider.value());
-      this->set_repeat(divider.value() - 1);
-    } else if (divider.value() == 0) {
-      this->set_multiplier(1.0);
-      this->set_repeat(0);
-    }
+  if (!divider.has_value()) {
+    return;
+  }
+  if (divider.value() > 0) {
+    this->set_multiplier(1.0 / divider.value());
+    this->set_repeat(divider.value() - 1);
+  } else if (divider.value() == 0) {
+    this->set_multiplier(1.0);
+    this->set_repeat(0);
   }
 }
 
 void Sprinkler::set_multiplier(const optional<float> multiplier) {
-  if (multiplier.has_value()) {
-    if (multiplier.value() >= 0) {
-      this->multiplier_ = multiplier.value();
-      if (this->multiplier_number_ != nullptr) {
-        if (this->multiplier_number_->state != multiplier.value()) {
-          auto call = this->multiplier_number_->make_call();
-          call.set_value(multiplier.value());
-          call.perform();
-        }
-      }
-    }
+  if ((!multiplier.has_value()) || (multiplier.value() < 0)) {
+    return;
   }
+  this->multiplier_ = multiplier.value();
+  if (this->multiplier_number_ == nullptr) {
+    return;
+  }
+  if (this->multiplier_number_->state == multiplier.value()) {
+    return;
+  }
+  auto call = this->multiplier_number_->make_call();
+  call.set_value(multiplier.value());
+  call.perform();
 }
 
 void Sprinkler::set_next_prev_ignore_disabled_valves(bool ignore_disabled) {
@@ -619,96 +621,109 @@ void Sprinkler::set_manual_selection_delay(uint32_t manual_selection_delay) {
 }
 
 void Sprinkler::set_valve_run_duration(const optional<size_t> valve_number, const optional<uint32_t> run_duration) {
-  if (valve_number.has_value() && run_duration.has_value()) {
-    if (this->is_a_valid_valve(valve_number.value())) {
-      this->valve_[valve_number.value()].run_duration = run_duration.value();
-      if (this->valve_[valve_number.value()].run_duration_number != nullptr) {
-        if (this->valve_[valve_number.value()].run_duration_number->state != run_duration.value()) {
-          auto call = this->valve_[valve_number.value()].run_duration_number->make_call();
-          if (this->valve_[valve_number.value()].run_duration_number->traits.get_unit_of_measurement() == min_str) {
-            call.set_value(run_duration.value() / 60.0);
-          } else {
-            call.set_value(run_duration.value());
-          }
-          call.perform();
-        }
-      }
-    }
+  if (!valve_number.has_value() || !run_duration.has_value()) {
+    return;
   }
+  if (!this->is_a_valid_valve(valve_number.value())) {
+    return;
+  }
+  this->valve_[valve_number.value()].run_duration = run_duration.value();
+  if (this->valve_[valve_number.value()].run_duration_number == nullptr) {
+    return;
+  }
+  if (this->valve_[valve_number.value()].run_duration_number->state == run_duration.value()) {
+    return;
+  }
+  auto call = this->valve_[valve_number.value()].run_duration_number->make_call();
+  if (this->valve_[valve_number.value()].run_duration_number->traits.get_unit_of_measurement() == min_str) {
+    call.set_value(run_duration.value() / 60.0);
+  } else {
+    call.set_value(run_duration.value());
+  }
+  call.perform();
 }
 
 void Sprinkler::set_auto_advance(const bool auto_advance) {
-  if (this->auto_adv_sw_ != nullptr) {
-    if (this->auto_adv_sw_->state != auto_advance) {
-      if (auto_advance) {
-        this->auto_adv_sw_->turn_on();
-      } else {
-        this->auto_adv_sw_->turn_off();
-      }
-    }
+  if (this->auto_adv_sw_ == nullptr) {
+    return;
+  }
+  if (this->auto_adv_sw_->state == auto_advance) {
+    return;
+  }
+  if (auto_advance) {
+    this->auto_adv_sw_->turn_on();
+  } else {
+    this->auto_adv_sw_->turn_off();
   }
 }
 
 void Sprinkler::set_repeat(optional<uint32_t> repeat) {
   this->target_repeats_ = repeat;
-  if (this->repeat_number_ != nullptr) {
-    if (this->repeat_number_->state != repeat.value()) {
-      auto call = this->repeat_number_->make_call();
-      call.set_value(repeat.value_or(0));
-      call.perform();
-    }
+  if (this->repeat_number_ == nullptr) {
+    return;
   }
+  if (this->repeat_number_->state == repeat.value()) {
+    return;
+  }
+  auto call = this->repeat_number_->make_call();
+  call.set_value(repeat.value_or(0));
+  call.perform();
 }
 
 void Sprinkler::set_queue_enable(bool queue_enable) {
-  if (this->queue_enable_sw_ != nullptr) {
-    if (this->queue_enable_sw_->state != queue_enable) {
-      if (queue_enable) {
-        this->queue_enable_sw_->turn_on();
-      } else {
-        this->queue_enable_sw_->turn_off();
-      }
-    }
+  if (this->queue_enable_sw_ == nullptr) {
+    return;
+  }
+  if (this->queue_enable_sw_->state == queue_enable) {
+    return;
+  }
+  if (queue_enable) {
+    this->queue_enable_sw_->turn_on();
+  } else {
+    this->queue_enable_sw_->turn_off();
   }
 }
 
 void Sprinkler::set_reverse(const bool reverse) {
-  if (this->reverse_sw_ != nullptr) {
-    if (this->reverse_sw_->state != reverse) {
-      if (reverse) {
-        this->reverse_sw_->turn_on();
-      } else {
-        this->reverse_sw_->turn_off();
-      }
-    }
+  if (this->reverse_sw_ == nullptr) {
+    return;
+  }
+  if (this->reverse_sw_->state == reverse) {
+    return;
+  }
+  if (reverse) {
+    this->reverse_sw_->turn_on();
+  } else {
+    this->reverse_sw_->turn_off();
   }
 }
 
 void Sprinkler::set_standby(const bool standby) {
-  if (this->standby_sw_ != nullptr) {
-    if (this->standby_sw_->state != standby) {
-      if (standby) {
-        this->standby_sw_->turn_on();
-      } else {
-        this->standby_sw_->turn_off();
-      }
-    }
+  if (this->standby_sw_ == nullptr) {
+    return;
+  }
+  if (this->standby_sw_->state == standby) {
+    return;
+  }
+  if (standby) {
+    this->standby_sw_->turn_on();
+  } else {
+    this->standby_sw_->turn_off();
   }
 }
 
 uint32_t Sprinkler::valve_run_duration(const size_t valve_number) {
-  if (this->is_a_valid_valve(valve_number)) {
-    if (this->valve_[valve_number].run_duration_number != nullptr) {
-      if (this->valve_[valve_number].run_duration_number->traits.get_unit_of_measurement() == min_str) {
-        return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state * 60));
-      } else {
-        return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state));
-      }
+  if (!this->is_a_valid_valve(valve_number)) {
+    return 0;
+  }
+  if (this->valve_[valve_number].run_duration_number != nullptr) {
+    if (this->valve_[valve_number].run_duration_number->traits.get_unit_of_measurement() == min_str) {
+      return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state * 60));
     } else {
-      return this->valve_[valve_number].run_duration;
+      return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state));
     }
   }
-  return 0;
+  return this->valve_[valve_number].run_duration;
 }
 
 uint32_t Sprinkler::valve_run_duration_adjusted(const size_t valve_number) {

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -567,8 +567,6 @@ void Sprinkler::set_next_prev_ignore_disabled_valves(bool ignore_disabled) {
   this->next_prev_ignore_disabled_ = ignore_disabled;
 }
 
-void Sprinkler::set_number_values_are_minutes(bool use_minutes) { this->number_values_are_minutes_ = use_minutes; }
-
 void Sprinkler::set_pump_start_delay(uint32_t start_delay) {
   this->start_delay_is_valve_delay_ = false;
   this->start_delay_ = start_delay;
@@ -627,7 +625,7 @@ void Sprinkler::set_valve_run_duration(const optional<size_t> valve_number, cons
       if (this->valve_[valve_number.value()].run_duration_number != nullptr) {
         if (this->valve_[valve_number.value()].run_duration_number->state != run_duration.value()) {
           auto call = this->valve_[valve_number.value()].run_duration_number->make_call();
-          if (this->number_values_are_minutes_) {
+          if (this->valve_[valve_number.value()].run_duration_number->traits.get_unit_of_measurement() == min_str) {
             call.set_value(run_duration.value() / 60.0);
           } else {
             call.set_value(run_duration.value());
@@ -701,7 +699,7 @@ void Sprinkler::set_standby(const bool standby) {
 uint32_t Sprinkler::valve_run_duration(const size_t valve_number) {
   if (this->is_a_valid_valve(valve_number)) {
     if (this->valve_[valve_number].run_duration_number != nullptr) {
-      if (this->number_values_are_minutes_) {
+      if (this->valve_[valve_number].run_duration_number->traits.get_unit_of_measurement() == min_str) {
         return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state * 60));
       } else {
         return static_cast<uint32_t>(roundf(this->valve_[valve_number].run_duration_number->state));

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -518,6 +518,7 @@ void Sprinkler::configure_valve_switch(size_t valve_number, switch_::Switch *val
   if (this->is_a_valid_valve(valve_number)) {
     this->valve_[valve_number].valve_switch.set_on_switch(valve_switch);
     this->valve_[valve_number].run_duration = run_duration;
+    valve_switch->turn_off();
   }
 }
 
@@ -529,6 +530,8 @@ void Sprinkler::configure_valve_switch_pulsed(size_t valve_number, switch_::Swit
     this->valve_[valve_number].valve_switch.set_on_switch(valve_switch_on);
     this->valve_[valve_number].valve_switch.set_pulse_duration(pulse_duration);
     this->valve_[valve_number].run_duration = run_duration;
+    valve_switch_off->turn_off();
+    valve_switch_on->turn_off();
   }
 }
 
@@ -543,6 +546,7 @@ void Sprinkler::configure_valve_pump_switch(size_t valve_number, switch_::Switch
     this->pump_.resize(this->pump_.size() + 1);
     this->pump_.back().set_on_switch(pump_switch);
     this->valve_[valve_number].pump_switch_index = this->pump_.size() - 1;  // save the index to the new pump
+    pump_switch->turn_off();
   }
 }
 
@@ -561,6 +565,8 @@ void Sprinkler::configure_valve_pump_switch_pulsed(size_t valve_number, switch_:
     this->pump_.back().set_on_switch(pump_switch_on);
     this->pump_.back().set_pulse_duration(pulse_duration);
     this->valve_[valve_number].pump_switch_index = this->pump_.size() - 1;  // save the index to the new pump
+    pump_switch_off->turn_off();
+    pump_switch_on->turn_on();
   }
 }
 

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -208,6 +208,9 @@ class Sprinkler : public Component, public EntityBase {
   void configure_valve_pump_switch_pulsed(size_t valve_number, switch_::Switch *pump_switch_off,
                                           switch_::Switch *pump_switch_on, uint32_t pulse_duration);
 
+  /// sets the multiplier value to '1 / divider' and sets repeat value to divider
+  void set_divider(optional<uint32_t> divider);
+
   /// value multiplied by configured run times -- used to extend or shorten the cycle
   void set_multiplier(optional<float> multiplier);
 

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -91,14 +91,12 @@ struct SprinklerValve {
   std::unique_ptr<Automation<>> valve_turn_on_automation;
 };
 
-class SprinklerControllerNumber : public number::Number, public PollingComponent {
+class SprinklerControllerNumber : public number::Number, public Component {
  public:
   void setup() override;
-  void update() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  void set_template(std::function<optional<float>()> &&f) { this->f_ = f; }
   Trigger<float> *get_set_trigger() const { return set_trigger_; }
   void set_initial_value(float initial_value) { initial_value_ = initial_value; }
   void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
@@ -108,7 +106,6 @@ class SprinklerControllerNumber : public number::Number, public PollingComponent
   float initial_value_{NAN};
   bool restore_value_{true};
   Trigger<float> *set_trigger_ = new Trigger<float>();
-  optional<std::function<optional<float>()>> f_;
 
   ESPPreferenceObject pref_;
 };

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -11,6 +11,8 @@
 namespace esphome {
 namespace sprinkler {
 
+const std::string min_str = "min";
+
 enum SprinklerState : uint8_t {
   // NOTE: these states are used by both SprinklerValveOperator and Sprinkler (the controller)!
   IDLE,      // system/valve is off
@@ -246,9 +248,6 @@ class Sprinkler : public Component, public EntityBase {
 
   /// enable/disable skipping of disabled valves by the next and previous actions
   void set_next_prev_ignore_disabled_valves(bool ignore_disabled);
-
-  /// enable/disable use of minutes by run duration number components
-  void set_number_values_are_minutes(bool use_minutes);
 
   /// set how long the pump should start after the valve (when the pump is starting)
   void set_pump_start_delay(uint32_t start_delay);
@@ -514,9 +513,6 @@ class Sprinkler : public Component, public EntityBase {
 
   /// When set to true, the next and previous actions will skip disabled valves
   bool next_prev_ignore_disabled_{false};
-
-  /// Number components for run durations contain values in minutes
-  bool number_values_are_minutes_{false};
 
   /// Pump should be off during valve_open_delay interval
   bool pump_switch_off_during_valve_open_delay_{false};

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -290,7 +290,7 @@ class Sprinkler : public Component, public EntityBase {
   void start_full_cycle();
 
   /// activates a single valve and disables auto_advance.
-  void start_single_valve(optional<size_t> valve_number);
+  void start_single_valve(optional<size_t> valve_number, optional<uint32_t> run_duration = nullopt);
 
   /// adds a valve into the queue. queued valves have priority over valves to be run as a part of a full cycle.
   /// NOTE: queued valves will always run, regardless of auto-advance and/or valve enable switches.

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -251,6 +251,9 @@ class Sprinkler : public Component, public EntityBase {
   /// enable/disable skipping of disabled valves by the next and previous actions
   void set_next_prev_ignore_disabled_valves(bool ignore_disabled);
 
+  /// enable/disable use of minutes by run duration number components
+  void set_number_values_are_minutes(bool use_minutes);
+
   /// set how long the pump should start after the valve (when the pump is starting)
   void set_pump_start_delay(uint32_t start_delay);
 
@@ -509,6 +512,9 @@ class Sprinkler : public Component, public EntityBase {
 
   /// When set to true, the next and previous actions will skip disabled valves
   bool next_prev_ignore_disabled_{false};
+
+  /// Number components for run durations contain values in minutes
+  bool number_values_are_minutes_{false};
 
   /// Pump should be off during valve_open_delay interval
   bool pump_switch_off_during_valve_open_delay_{false};

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -433,13 +433,13 @@ class Sprinkler : public Component, public EntityBase {
   /// returns true if valve's cycle is flagged as complete
   bool valve_cycle_complete_(size_t valve_number);
 
-  /// returns the number of the next valve in the vector
-  /// if return value == first_valve, no other valves match criteria
-  size_t next_valve_number_(size_t first_valve, bool include_disabled = true, bool include_complete = true);
+  /// returns the number of the next valve in the vector or nullopt if no valves match criteria
+  optional<size_t> next_valve_number_(optional<size_t> first_valve = nullopt, bool include_disabled = true,
+                                      bool include_complete = true);
 
-  /// returns the number of the previous valve in the vector
-  /// if return value == first_valve, no other valves match criteria
-  size_t previous_valve_number_(size_t first_valve, bool include_disabled = true, bool include_complete = true);
+  /// returns the number of the previous valve in the vector or nullopt if no valves match criteria
+  optional<size_t> previous_valve_number_(optional<size_t> first_valve = nullopt, bool include_disabled = true,
+                                          bool include_complete = true);
 
   /// returns the number of the next valve that should be activated in a full cycle.
   ///  if no valve is next (cycle is complete), returns no value (check with 'has_value()')
@@ -450,11 +450,6 @@ class Sprinkler : public Component, public EntityBase {
   ///  queued valves have priority, followed by enabled valves if auto-advance is enabled.
   ///  if no valve is next (for example, a full cycle is complete), next_req_ is reset via reset().
   void load_next_valve_run_request_(optional<size_t> first_valve = nullopt);
-
-  /// returns the number of the next/previous valve that should be activated.
-  ///  if no valve is next (cycle is complete), returns no value (check with 'has_value()')
-  optional<size_t> next_enabled_incomplete_valve_number_(optional<size_t> first_valve);
-  optional<size_t> previous_enabled_incomplete_valve_number_(optional<size_t> first_valve);
 
   /// returns true if any valve is enabled
   bool any_valve_is_enabled_();

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -25,6 +25,12 @@ enum SprinklerTimerIndex : uint8_t {
   TIMER_VALVE_SELECTION = 1,
 };
 
+enum SprinklerValveRunRequestOrigin : uint8_t {
+  USER,
+  CYCLE,
+  QUEUE,
+};
+
 class Sprinkler;                  // this component
 class SprinklerControllerNumber;  // number components that appear in the front end; based on number core
 class SprinklerControllerSwitch;  // switches that appear in the front end; based on switch core
@@ -174,6 +180,7 @@ class SprinklerValveRunRequest {
   SprinklerValveRunRequest(size_t valve_number, uint32_t run_duration, SprinklerValveOperator *valve_op);
   bool has_request();
   bool has_valve_operator();
+  void set_request_from(SprinklerValveRunRequestOrigin origin);
   void set_run_duration(uint32_t run_duration);
   void set_valve(size_t valve_number);
   void set_valve_operator(SprinklerValveOperator *valve_op);
@@ -182,12 +189,14 @@ class SprinklerValveRunRequest {
   size_t valve();
   optional<size_t> valve_as_opt();
   SprinklerValveOperator *valve_operator();
+  SprinklerValveRunRequestOrigin request_is_from();
 
  protected:
   bool has_valve_{false};
   size_t valve_number_{0};
   uint32_t run_duration_{0};
   SprinklerValveOperator *valve_op_{nullptr};
+  SprinklerValveRunRequestOrigin origin_{USER};
 };
 
 class Sprinkler : public Component, public EntityBase {
@@ -353,6 +362,9 @@ class Sprinkler : public Component, public EntityBase {
   /// returns a pointer to a valve's name string object; returns nullptr if valve_number is invalid
   const char *valve_name(size_t valve_number);
 
+  /// returns what invoked the valve that is currently active, if any. check with 'has_value()'
+  optional<SprinklerValveRunRequestOrigin> active_valve_request_is_from();
+
   /// returns the number of the valve that is currently active, if any. check with 'has_value()'
   optional<size_t> active_valve();
 
@@ -475,7 +487,10 @@ class Sprinkler : public Component, public EntityBase {
   /// starts up the system from IDLE state
   void fsm_transition_to_shutdown_();
 
-  /// return the current FSM state as a string
+  /// return the specified SprinklerValveRunRequestOrigin as a string
+  std::string req_as_str_(SprinklerValveRunRequestOrigin origin);
+
+  /// return the specified SprinklerState state as a string
   std::string state_as_str_(SprinklerState state);
 
   /// Start/cancel/get status of valve timers

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -248,6 +248,9 @@ class Sprinkler : public Component, public EntityBase {
   /// value multiplied by configured run times -- used to extend or shorten the cycle
   void set_multiplier(optional<float> multiplier);
 
+  /// enable/disable skipping of disabled valves by the next and previous actions
+  void set_next_prev_ignore_disabled_valves(bool ignore_disabled);
+
   /// set how long the pump should start after the valve (when the pump is starting)
   void set_pump_start_delay(uint32_t start_delay);
 
@@ -430,9 +433,13 @@ class Sprinkler : public Component, public EntityBase {
   /// returns true if valve's cycle is flagged as complete
   bool valve_cycle_complete_(size_t valve_number);
 
-  /// returns the number of the next/previous valve in the vector
-  size_t next_valve_number_(size_t first_valve);
-  size_t previous_valve_number_(size_t first_valve);
+  /// returns the number of the next valve in the vector
+  /// if return value == first_valve, no other valves match criteria
+  size_t next_valve_number_(size_t first_valve, bool include_disabled = true, bool include_complete = true);
+
+  /// returns the number of the previous valve in the vector
+  /// if return value == first_valve, no other valves match criteria
+  size_t previous_valve_number_(size_t first_valve, bool include_disabled = true, bool include_complete = true);
 
   /// returns the number of the next valve that should be activated in a full cycle.
   ///  if no valve is next (cycle is complete), returns no value (check with 'has_value()')
@@ -504,6 +511,9 @@ class Sprinkler : public Component, public EntityBase {
 
   /// Maximum allowed queue size
   const uint8_t max_queue_size_{100};
+
+  /// When set to true, the next and previous actions will skip disabled valves
+  bool next_prev_ignore_disabled_{false};
 
   /// Pump should be off during valve_open_delay interval
   bool pump_switch_off_during_valve_open_delay_{false};

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -385,8 +385,23 @@ class Sprinkler : public Component, public EntityBase {
   /// switches on/off a pump "safely" by checking that the new state will not conflict with another controller
   void set_pump_state(SprinklerSwitch *pump_switch, bool state);
 
-  /// returns the amount of time remaining in seconds for the active valve, if any. check with 'has_value()'
-  optional<uint32_t> time_remaining();
+  /// returns the amount of time in seconds required for all valves
+  uint32_t total_cycle_time_all_valves();
+
+  /// returns the amount of time in seconds required for all enabled valves
+  uint32_t total_cycle_time_enabled_valves();
+
+  /// returns the amount of time in seconds required for all enabled & incomplete valves, not including the active valve
+  uint32_t total_cycle_time_enabled_incomplete_valves();
+
+  /// returns the amount of time in seconds required for all valves in the queue
+  uint32_t total_queue_time();
+
+  /// returns the amount of time remaining in seconds for the active valve, if any
+  optional<uint32_t> time_remaining_active_valve();
+
+  /// returns the amount of time remaining in seconds for all valves remaining, including the active valve, if any
+  optional<uint32_t> time_remaining_current_operation();
 
   /// returns a pointer to a valve's control switch object
   SprinklerControllerSwitch *control_switch(size_t valve_number);

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -196,6 +196,7 @@ class Sprinkler : public Component, public EntityBase {
   void set_controller_auto_adv_switch(SprinklerControllerSwitch *auto_adv_switch);
   void set_controller_queue_enable_switch(SprinklerControllerSwitch *queue_enable_switch);
   void set_controller_reverse_switch(SprinklerControllerSwitch *reverse_switch);
+  void set_controller_standby_switch(SprinklerControllerSwitch *standby_switch);
 
   /// configure a valve's switch object and run duration. run_duration is time in seconds.
   void configure_valve_switch(size_t valve_number, switch_::Switch *valve_switch, uint32_t run_duration);
@@ -250,6 +251,9 @@ class Sprinkler : public Component, public EntityBase {
   /// if reverse is true, controller will iterate through all enabled valves in reverse (descending) order
   void set_reverse(bool reverse);
 
+  /// if standby is true, controller will refuse to activate any valves
+  void set_standby(bool standby);
+
   /// returns valve_number's run duration in seconds
   uint32_t valve_run_duration(size_t valve_number);
 
@@ -273,6 +277,9 @@ class Sprinkler : public Component, public EntityBase {
 
   /// returns true if reverse is enabled
   bool reverse();
+
+  /// returns true if standby is enabled
+  bool standby();
 
   /// starts the controller from the first valve in the queue and disables auto_advance.
   /// if the queue is empty, does nothing.
@@ -518,12 +525,15 @@ class Sprinkler : public Component, public EntityBase {
   SprinklerControllerSwitch *controller_sw_{nullptr};
   SprinklerControllerSwitch *queue_enable_sw_{nullptr};
   SprinklerControllerSwitch *reverse_sw_{nullptr};
+  SprinklerControllerSwitch *standby_sw_{nullptr};
 
   std::unique_ptr<ShutdownAction<>> sprinkler_shutdown_action_;
+  std::unique_ptr<ShutdownAction<>> sprinkler_standby_shutdown_action_;
   std::unique_ptr<ResumeOrStartAction<>> sprinkler_resumeorstart_action_;
 
   std::unique_ptr<Automation<>> sprinkler_turn_off_automation_;
   std::unique_ptr<Automation<>> sprinkler_turn_on_automation_;
+  std::unique_ptr<Automation<>> sprinkler_standby_turn_on_automation_;
 };
 
 }  // namespace sprinkler

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -100,15 +100,13 @@ class SprinklerControllerNumber : public number::Number, public PollingComponent
 
   void set_template(std::function<optional<float>()> &&f) { this->f_ = f; }
   Trigger<float> *get_set_trigger() const { return set_trigger_; }
-  void set_optimistic(bool optimistic) { optimistic_ = optimistic; }
   void set_initial_value(float initial_value) { initial_value_ = initial_value; }
   void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
 
  protected:
   void control(float value) override;
-  bool optimistic_{false};
   float initial_value_{NAN};
-  bool restore_value_{false};
+  bool restore_value_{true};
   Trigger<float> *set_trigger_ = new Trigger<float>();
   optional<std::function<optional<float>()>> f_;
 
@@ -123,27 +121,19 @@ class SprinklerControllerSwitch : public switch_::Switch, public Component {
   void dump_config() override;
 
   void set_state_lambda(std::function<optional<bool>()> &&f);
-  void set_restore_state(bool restore_state);
   Trigger<> *get_turn_on_trigger() const;
   Trigger<> *get_turn_off_trigger() const;
-  void set_optimistic(bool optimistic);
-  void set_assumed_state(bool assumed_state);
   void loop() override;
 
   float get_setup_priority() const override;
 
  protected:
-  bool assumed_state() override;
-
   void write_state(bool state) override;
 
   optional<std::function<optional<bool>()>> f_;
-  bool optimistic_{false};
-  bool assumed_state_{false};
   Trigger<> *turn_on_trigger_;
   Trigger<> *turn_off_trigger_;
   Trigger<> *prev_trigger_{nullptr};
-  bool restore_state_{false};
 };
 
 class SprinklerValveOperator {


### PR DESCRIPTION
# What does this implement/fix?

Oh this one does a lot of things...

- Adds built-in support for defining `number` components for valve run durations, multiplier and repeat values
  - Makes configuration a bit easier/cleaner
  - Enables retaining modified values across device resets
- Adds a `divider` function to split full cycles into multiple cycles while keeping the total run duration the same
- Enables the multiplier value to be set to zero
- Adds a flag to permit the `next` and `previous` actions to skip over disabled valves
- Adds methods to provide more complete "time remaining" data/functionality
- Crushes a bug or two 😉

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes https://github.com/esphome/issues/issues/3740
- Fixes https://github.com/esphome/issues/issues/3692
- Implements and closes https://github.com/esphome/feature-requests/issues/1890
- Implements and closes https://github.com/esphome/feature-requests/issues/1891
- Implements and closes https://github.com/esphome/feature-requests/issues/1892
- Implements and closes https://github.com/esphome/feature-requests/issues/1893
- Implements and closes https://github.com/esphome/feature-requests/issues/1894

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2510

### Breaking Change Note

The method `time_remaining()` has been renamed to `time_remaining_active_valve()` for clarity.
If you use this to display time remaining, simply update the name of the method in your code/lambda(s).

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
