### PR TITLE
Add API for dashboard to get boards list by platform

### DIFF
--- a/esphome/const.py
+++ b/esphome/const.py
@@ -993,6 +993,7 @@ KEY_TARGET_PLATFORM = "target_platform"
 KEY_TARGET_FRAMEWORK = "target_framework"
 KEY_FRAMEWORK_VERSION = "framework_version"
 KEY_NAME = "name"
+KEY_VARIANT = "variant"
 
 # Entity categories
 ENTITY_CATEGORY_NONE = ""

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -728,18 +728,6 @@ def _get_platform_boards(platform, title=None):
 
 class BoardsRequestHandler(BaseHandler):
     @authenticated
-    def get(self):
-        boards = {}
-        boards.update(_get_platform_boards("esp32"))
-        boards.update(_get_platform_boards("esp8266"))
-        boards.update(_get_platform_boards("rp2040", "Raspberry Pi"))
-
-        self.set_header("content-type", "application/json")
-        self.write(json.dumps(boards))
-
-
-class BoardsPlatformRequestHandler(BaseHandler):
-    @authenticated
     def get(self, platform: str):
         boards = _get_platform_boards(platform)
 
@@ -1117,8 +1105,7 @@ def make_app(debug=get_bool_env(ENV_DEV)):
             (f"{rel}json-config", JsonConfigRequestHandler),
             (f"{rel}rename", EsphomeRenameHandler),
             (f"{rel}prometheus-sd", PrometheusServiceDiscoveryHandler),
-            (f"{rel}boards", BoardsRequestHandler),
-            (f"{rel}boards/(.*)", BoardsPlatformRequestHandler),
+            (f"{rel}boards/(.*)", BoardsRequestHandler),
         ],
         **app_settings,
     )

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -695,9 +695,6 @@ class PrometheusServiceDiscoveryHandler(BaseHandler):
 
 def _get_platform_boards(platform, title=None):
     from esphome.components.esp32.boards import BOARDS as ESP32_BOARDS
-    from esphome.components.esp32.const import (
-        VARIANT_FRIENDLY as ESP32_VARIANT_FRIENDLY,
-    )
     from esphome.components.esp8266.boards import BOARDS as ESP8266_BOARDS
     from esphome.components.rp2040.boards import BOARDS as RP2040_BOARDS
 
@@ -710,7 +707,6 @@ def _get_platform_boards(platform, title=None):
     is_esp32 = platform.startswith("esp32")
     platform_boards = boards["esp32"] if is_esp32 else boards[platform]
     variant = platform.upper() if is_esp32 else None
-    variant_title = ESP32_VARIANT_FRIENDLY[variant] if is_esp32 else None
 
     boards_items = {
         key: val[const.KEY_NAME]

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -695,6 +695,9 @@ class PrometheusServiceDiscoveryHandler(BaseHandler):
 
 def _get_platform_boards(platform, title=None):
     from esphome.components.esp32.boards import BOARDS as ESP32_BOARDS
+    from esphome.components.esp32.const import (
+        VARIANT_FRIENDLY as ESP32_VARIANT_FRIENDLY,
+    )
     from esphome.components.esp8266.boards import BOARDS as ESP8266_BOARDS
     from esphome.components.rp2040.boards import BOARDS as RP2040_BOARDS
 
@@ -703,12 +706,22 @@ def _get_platform_boards(platform, title=None):
         "esp8266": ESP8266_BOARDS,
         "rp2040": RP2040_BOARDS,
     }
+
+    is_esp32 = platform.startswith("esp32")
+    platform_boards = boards["esp32"] if is_esp32 else boards[platform]
+    variant = platform.upper() if is_esp32 else None
+    variant_title = ESP32_VARIANT_FRIENDLY[variant] if is_esp32 else None
+
+    boards_items = {
+        key: val[const.KEY_NAME]
+        for key, val in platform_boards.items()
+        if variant is None or val[const.KEY_VARIANT] == variant
+    }
+    boards_items = sorted(boards_items.items(), key=lambda item: item[1])
     return {
         platform: {
-            "title": title or platform.upper(),
-            "items": {
-                key: val[const.KEY_NAME] for key, val in boards[platform].items()
-            },
+            "title": title or variant_title or platform.upper(),
+            "items": dict(boards_items),
         },
     }
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -720,7 +720,6 @@ def _get_platform_boards(platform, title=None):
     boards_items = sorted(boards_items.items(), key=lambda item: item[1])
     return {
         platform: {
-            "title": title or variant_title or platform.upper(),
             "items": dict(boards_items),
         },
     }

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -709,20 +709,17 @@ class BoardsRequestHandler(BaseHandler):
             "rp2040": RP2040_BOARDS,
         }
         # filter all ESP32 variants by requested platform
-        for variant, boards in platform_to_boards.items():
-            if not variant.startswith("esp32"):
-                continue
-            platform_to_boards[variant] = {
+        if platform.startswith("esp32"):
+            boards = {
                 k: v
-                for k, v in boards.items()
-                if v[const.KEY_VARIANT] == variant.upper()
+                for k, v in platform_to_boards[platform].items()
+                if v[const.KEY_VARIANT] == platform.upper()
             }
+        else:
+            boards = platform_to_boards[platform]
 
         # map to a {board_name: board_title} dict
-        platform_boards = {
-            key: val[const.KEY_NAME]
-            for key, val in platform_to_boards[platform].items()
-        }
+        platform_boards = {key: val[const.KEY_NAME] for key, val in boards.items()}
         # sort by board title
         boards_items = sorted(platform_boards.items(), key=lambda item: item[1])
         output = [dict(items=dict(boards_items))]

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -702,9 +702,6 @@ class BoardsRequestHandler(BaseHandler):
 
         platform_to_boards = {
             "esp32": ESP32_BOARDS,
-            "esp32s2": ESP32_BOARDS,
-            "esp32s3": ESP32_BOARDS,
-            "esp32c3": ESP32_BOARDS,
             "esp8266": ESP8266_BOARDS,
             "rp2040": RP2040_BOARDS,
         }
@@ -712,7 +709,7 @@ class BoardsRequestHandler(BaseHandler):
         if platform.startswith("esp32"):
             boards = {
                 k: v
-                for k, v in platform_to_boards[platform].items()
+                for k, v in platform_to_boards["esp32"].items()
                 if v[const.KEY_VARIANT] == platform.upper()
             }
         else:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This PR changes the newly-added dashboard API for board retrieval (I'm really glad you added this!). A new endpoint is added, to allow retrieval of boards by platform. Furthermore, the structure is a bit different - it contains section titles in the response (i.e. "ESP32", or "ESP8266").

I created [a PR in `dashboard` as well](https://github.com/esphome/dashboard/pull/382). It refactors the wizard dialog a bit, making the user first choose "a platform", and, in the next step, "a board" that belongs to this platform. 
There's a mapping with default boards for each platform. If a platform (say, ESP32) has a default board (`esp32dev`), the next dialog page will not be shown - **thus, the current UI flow stays the same for all ESP platforms** after my changes.

These two PRs will greatly simplify integrating the dashboard with [my LibreTuya pull request](https://github.com/esphome/esphome/pull/3509) making the experience more seamless. The dialog for choosing a board looks like this:
![obraz](https://user-images.githubusercontent.com/30433568/206793637-02e00caa-6639-485b-980b-d1e2aa52a8b2.png)

Consider this PR a (hopefully) non-breaking, non-functional change, that just makes the API and UI more extendable.

Note that both PRs would have to be merged simultaneously, as the dashboard can't work without the wizard API changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] tested with dashboard in dev mode

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).