### PR TITLE
Clean up dashboard ping result post-rename/delete

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -281,8 +281,11 @@ class EsphomeLogsHandler(EsphomeCommandWebSocket):
 
 
 class EsphomeRenameHandler(EsphomeCommandWebSocket):
+    old_name: str
+
     def build_command(self, json_message):
         config_file = settings.rel_path(json_message["configuration"])
+        self.old_name = json_message["configuration"]
         return [
             "esphome",
             "--dashboard",
@@ -290,6 +293,15 @@ class EsphomeRenameHandler(EsphomeCommandWebSocket):
             config_file,
             json_message["newName"],
         ]
+
+    def _proc_on_exit(self, returncode):
+        super()._proc_on_exit(returncode)
+
+        if returncode != 0:
+            return
+
+        # Remove the old ping result from the cache
+        PING_RESULT.pop(self.old_name, None)
 
 
 class EsphomeUploadHandler(EsphomeCommandWebSocket):
@@ -844,6 +856,9 @@ class DeleteRequestHandler(BaseHandler):
             build_folder = os.path.join(settings.config_dir, name)
             if build_folder is not None:
                 shutil.rmtree(build_folder, os.path.join(trash_path, name))
+
+        # Remove the old ping result from the cache
+        PING_RESULT.pop(configuration, None)
 
 
 class UndoDeleteRequestHandler(BaseHandler):


### PR DESCRIPTION
# What does this implement/fix?

When a user renames or deletes a configuration, remove the old entry from the ping results cache.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
