### PR TITLE
Increase watchdog timeout when starting OTA

### DIFF
--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -1,6 +1,8 @@
 #include "esphome/core/defines.h"
 #ifdef USE_ESP_IDF
 
+#include <esp_task_wdt.h>
+
 #include "ota_backend_esp_idf.h"
 #include "ota_component.h"
 #include <esp_ota_ops.h>
@@ -14,7 +16,9 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
   if (this->partition_ == nullptr) {
     return OTA_RESPONSE_ERROR_NO_UPDATE_PARTITION;
   }
+  esp_task_wdt_init(15, false);  // The following function takes longer than the 5 seconds timeout of WDT
   esp_err_t err = esp_ota_begin(this->partition_, image_size, &this->update_handle_);
+  esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, false);  // Set the WDT back to the configured timeout
   if (err != ESP_OK) {
     esp_ota_abort(this->update_handle_);
     this->update_handle_ = 0;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
As noticed in https://github.com/espressif/arduino-esp32/issues/3775 `esp_ota_begin` can take longer than 5 seconds to execute which triggers the Watchdog Timeout which is set to 5 seconds by default.

This PR alters the timeout right before that call to 15 seconds, then changes back to 5 (or whatever was the compiled default) afterwards.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
