### PR TITLE
2022.12.0b4

### DIFF
--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2022.12.0b3"
+__version__ = "2022.12.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyserial==3.5
 platformio==6.1.5  # When updating platformio, also update Dockerfile
 esptool==4.4
 click==8.1.3
-esphome-dashboard==20221207.0
+esphome-dashboard==20221213.0
 aioesphomeapi==13.0.1
 zeroconf==0.39.4
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump esphome-dashboard to 20221213.0 [esphome#4176](https://github.com/esphome/esphome/pull/4176)
