### PR TITLE
Revert camera config change for esp-idf

### DIFF
--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -54,7 +54,11 @@ void ESP32Camera::dump_config() {
   ESP_LOGCONFIG(TAG, "  HREF Pin: %d", conf.pin_href);
   ESP_LOGCONFIG(TAG, "  Pixel Clock Pin: %d", conf.pin_pclk);
   ESP_LOGCONFIG(TAG, "  External Clock: Pin:%d Frequency:%u", conf.pin_xclk, conf.xclk_freq_hz);
+#ifdef USE_ESP_IDF  // Temporary until the espressif/esp32-camera library is updated
+  ESP_LOGCONFIG(TAG, "  I2C Pins: SDA:%d SCL:%d", conf.pin_sscb_sda, conf.pin_sscb_scl);
+#else
   ESP_LOGCONFIG(TAG, "  I2C Pins: SDA:%d SCL:%d", conf.pin_sccb_sda, conf.pin_sccb_scl);
+#endif
   ESP_LOGCONFIG(TAG, "  Reset Pin: %d", conf.pin_reset);
   switch (this->config_.frame_size) {
     case FRAMESIZE_QQVGA:
@@ -209,8 +213,13 @@ void ESP32Camera::set_external_clock(uint8_t pin, uint32_t frequency) {
   this->config_.xclk_freq_hz = frequency;
 }
 void ESP32Camera::set_i2c_pins(uint8_t sda, uint8_t scl) {
+#ifdef USE_ESP_IDF  // Temporary until the espressif/esp32-camera library is updated
+  this->config_.pin_sscb_sda = sda;
+  this->config_.pin_sscb_scl = scl;
+#else
   this->config_.pin_sccb_sda = sda;
   this->config_.pin_sccb_scl = scl;
+#endif
 }
 void ESP32Camera::set_reset_pin(uint8_t pin) { this->config_.pin_reset = pin; }
 void ESP32Camera::set_power_down_pin(uint8_t pin) { this->config_.pin_pwdn = pin; }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Until I have more time to upgrade the esp32-camera library or fully implement #4000 this PR fixes the camera for esp-idf

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
