### PR TITLE
Fix UUID displaying incorrectly in BLE Tracker logs

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -601,9 +601,9 @@ std::string ESPBTUUID::to_string() const {
     default:
     case ESP_UUID_LEN_128:
       std::string buf;
-      for (int8_t i = 15; i >= 0; i--) {
+      for (uint8_t i = 0; i < 16; i++) {
         buf += str_snprintf("%02X", 2, this->uuid_.uuid.uuid128[i]);
-        if (i == 6 || i == 8 || i == 10 || i == 12)
+        if (i == 3 || i == 5 || i == 7 || i == 9)
           buf += "-";
       }
       return buf;


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue with reversed UUID in BLE Tracker logs.

I found an issue with the UUID is reversed in the [ESP32 BLE Tracker](https://esphome.io/components/esp32_ble_tracker.html) log. If someone sees the BLE Tracker's log to use BLE related components on ESP32, the UUID is displayed incorrectly, and it may be confusing like me to configure BLE related components. 

If you set the UUID to `00112233-4455-6677-8899-AABBCCDDEEFF` as shown in the picture below, it will be displayed as `FFEEDDCC-BBAA-9988-7766-554433221100` in the log. (log level at VERY_VERBOSE)
(Tested on Beacon Simulator app and Home Assistant Android app.)

![beacon](https://user-images.githubusercontent.com/54697735/208573372-6db256cd-0b12-4351-baaa-a82cb22d85c0.jpg)

```
[11:42:03][VV][esp32_ble_tracker:615]:     iBeacon data:
[11:42:03][VV][esp32_ble_tracker:616]:       UUID: FFEEDDCC-BBAA-9988-7766-554433221100
[11:42:03][VV][esp32_ble_tracker:617]:       Major: 10
[11:42:03][VV][esp32_ble_tracker:618]:       Minor: 20
[11:42:03][VV][esp32_ble_tracker:619]:       TXPower: -65
```

I found the [ESPBTUUID::to_string()](https://github.com/esphome/esphome/blob/0c24d951ff07bccd982443733ecce0675e93833d/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp#L604) function wrong in the source. It should start at 0. After looking through the commits, it seems that [1177 PR](https://github.com/esphome/esphome/pull/1177) is the problem. Here the starting value has changed.

It seems that it should be changed from `for (int8_t i = 15; i >= 0; i--)` to `for (uint8_t i = 0; i < 16; i++)`.

`ble_rssi` and `ble_presence` are unaffected because they use [ESPBTUUID::get_uuid()](https://github.com/esphome/esphome/blob/0c24d951ff07bccd982443733ecce0675e93833d/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp#L592). Also, `ble_scanner` doesn't use UUIDs, so it's irrelevant.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** **[esphome/issues/3903](https://github.com/esphome/issues/issues/3903)**

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ~ESP8266~ (N/A)
- [ ] ~RP2040~ (N/A)

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
logger:
  level: VERY_VERBOSE

esp32_ble_tracker:

binary_sensor:
  - platform: ble_presence
    ibeacon_uuid: '00112233-4455-6677-8899-AABBCCDDEEFF'
    name: "ESP32 BLE Tracker Test iBeacon"

external_components:
  - source: github://pr#4187
    components:
      - esp32_ble_tracker
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
