### PR TITLE
Add pca9554 device to esphome

### DIFF
--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -1,0 +1,76 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import i2c
+from esphome.const import (
+    CONF_ID,
+    CONF_INPUT,
+    CONF_NUMBER,
+    CONF_MODE,
+    CONF_INVERTED,
+    CONF_OUTPUT,
+)
+
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = False
+
+pca9554_ns = cg.esphome_ns.namespace("pca9554")
+
+PCA9554Component = pca9554_ns.class_("PCA9554Component", cg.Component, i2c.I2CDevice)
+PCA9554GPIOPin = pca9554_ns.class_("PCA9554GPIOPin", cg.GPIOPin)
+
+CONF_PCA9554 = "pca9554"
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.declare_id(PCA9554Component)
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x20)) #Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+
+def validate_mode(value):
+    if not (value[CONF_INPUT] or value[CONF_OUTPUT]):
+        raise cv.Invalid("Mode must be either input or output")
+    if value[CONF_INPUT] and value[CONF_OUTPUT]:
+        raise cv.Invalid("Mode must be either input or output")
+    return value
+
+
+PCA9554_PIN_SCHEMA = cv.All(
+    {
+        cv.GenerateID(): cv.declare_id(PCA9554GPIOPin),
+        cv.Required(CONF_PCA9554): cv.use_id(PCA9554Component),
+        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=8),
+        cv.Optional(CONF_MODE, default={}): cv.All(
+            {
+                cv.Optional(CONF_INPUT, default=False): cv.boolean,
+                cv.Optional(CONF_OUTPUT, default=False): cv.boolean,
+            },
+            validate_mode,
+        ),
+        cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+    }
+)
+
+
+@pins.PIN_SCHEMA_REGISTRY.register("pca9554", PCA9554_PIN_SCHEMA)
+async def pca9554_pin_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    parent = await cg.get_variable(config[CONF_PCA9554])
+
+    cg.add(var.set_parent(parent))
+
+    num = config[CONF_NUMBER]
+    cg.add(var.set_pin(num))
+    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
+    return var

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -25,7 +25,7 @@ CONF_PCA9554 = "pca9554"
 CONFIG_SCHEMA = (
   cv.Schema({cv.Required(CONF_ID): cv.declare_id(PCA9554Component)})
   .extend(cv.COMPONENT_SCHEMA)
-  .extend( 
+  .extend(
   i2c.i2c_device_schema(0x20)
   )  # Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
 )

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -10,14 +10,16 @@ from esphome.const import (
     CONF_INVERTED,
     CONF_OUTPUT,
 )
-
+CODEOWNERS = ["@hwstar"]
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = False
 pca9554_ns = cg.esphome_ns.namespace("pca9554")
 
 PCA9554Component = pca9554_ns.class_("PCA9554Component", cg.Component, i2c.I2CDevice)
-PCA9554GPIOPin = pca9554_ns.class_("PCA9554GPIOPin", cg.GPIOPin)
-CODEOWNERS = ["@hwstar"]
+PCA9554GPIOPin = pca9554_ns.class_(
+    "PCA9554GPIOPin", cg.GPIOPin, cg.Parented.template(PCA9554Component)
+)
+
 CONF_PCA9554 = "pca9554"
 CONFIG_SCHEMA = (
     cv.Schema(

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = (
     .extend(cv.COMPONENT_SCHEMA)
     .extend(
         i2c.i2c_device_schema(0x20)
-     )  # Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
+    )  # Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
 )
 
 

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -31,7 +31,6 @@ CONFIG_SCHEMA = (
 )
 
 
-
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -13,12 +13,11 @@ from esphome.const import (
 
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = False
-
 pca9554_ns = cg.esphome_ns.namespace("pca9554")
 
 PCA9554Component = pca9554_ns.class_("PCA9554Component", cg.Component, i2c.I2CDevice)
 PCA9554GPIOPin = pca9554_ns.class_("PCA9554GPIOPin", cg.GPIOPin)
-
+CODEOWNERS = ["@hwstar"]
 CONF_PCA9554 = "pca9554"
 CONFIG_SCHEMA = (
     cv.Schema(

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_INVERTED,
     CONF_OUTPUT,
 )
+
 CODEOWNERS = ["@hwstar"]
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = False
@@ -22,14 +23,13 @@ PCA9554GPIOPin = pca9554_ns.class_(
 
 CONF_PCA9554 = "pca9554"
 CONFIG_SCHEMA = (
-    cv.Schema(
-        {
-            cv.Required(CONF_ID): cv.declare_id(PCA9554Component)
-        }
-    )
-    .extend(cv.COMPONENT_SCHEMA)
-    .extend(i2c.i2c_device_schema(0x20)) #Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
+  cv.Schema({cv.Required(CONF_ID): cv.declare_id(PCA9554Component)})
+  .extend(cv.COMPONENT_SCHEMA)
+  .extend( 
+  i2c.i2c_device_schema(0x20)
+  )  # Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
 )
+
 
 
 async def to_code(config):

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -23,11 +23,11 @@ PCA9554GPIOPin = pca9554_ns.class_(
 
 CONF_PCA9554 = "pca9554"
 CONFIG_SCHEMA = (
-  cv.Schema({cv.Required(CONF_ID): cv.declare_id(PCA9554Component)})
-  .extend(cv.COMPONENT_SCHEMA)
-  .extend(
-  i2c.i2c_device_schema(0x20)
-  )  # Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
+    cv.Schema({cv.Required(CONF_ID): cv.declare_id(PCA9554Component)})
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        i2c.i2c_device_schema(0x20)
+     )  # Note: 0x20 for the non-A part. The PCA9554A parts start at addess 0x38
 )
 
 

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace pca9554 {
 
-const uint8_t INPUT_REG =  0;
+const uint8_t INPUT_REG = 0;
 const uint8_t OUTPUT_REG = 1;
 const uint8_t INVERT_REG = 2;
 const uint8_t CONFIG_REG = 3;
@@ -21,14 +21,20 @@ void PCA9554Component::setup() {
     this->mark_failed();
     return;
   }
-  
-  this->write_register_(INVERT_REG, 0); // No polarity inversion
-  this->config_mask_ = 0; // All inputs at initialization
-  this->write_register_(CONFIG_REG , ~this->config_mask_); // Invert mask as the part sees a 1 as an input
-  this->output_mask_ = 0; // All outputs low
+
+  // No polarity inversion
+  this->write_register_(INVERT_REG, 0);
+  // All inputs at initialization
+  this->config_mask_ = 0;
+  //Invert mask as the part sees a 1 as an input
+  this->write_register_(CONFIG_REG , ~this->config_mask_);
+  // All ouputs low
+  this->output_mask_ = 0;
   this->write_register_(OUTPUT_REG, this->output_mask_);
-  this->read_inputs_(); // Read the inputs
-  ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(), this->status_has_error());
+  // Read the inputs
+  this->read_inputs_();
+  ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
+                    this->status_has_error());
 }
 void PCA9554Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PCA9554:");
@@ -58,34 +64,34 @@ void PCA9554Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->config_mask_ &= ~(1 << pin);
   } else if (flags == gpio::FLAG_OUTPUT) {
     // Set mode mask bit
-    this->config_mask_ |= 1 << pin;
+	this->config_mask_ |= 1 << pin;
   }
-  this->write_register_(CONFIG_REG, ~this->config_mask_); 
+  this->write_register_(CONFIG_REG, ~this->config_mask_);
 }
 
 bool PCA9554Component::read_inputs_() {
   uint8_t inputs;
-  
+
   if (this->is_failed()){
-	ESP_LOGD(TAG, "Device marked failed");
-    return false;
+    ESP_LOGD(TAG, "Device marked failed");
+	return false;
   }
 
-  if((this->last_error = this->read_register(INPUT_REG, &inputs,  1, true)) != esphome::i2c::ERROR_OK){
+  if ((this->last_error_ = this->read_register(INPUT_REG, &inputs,  1, true)) != esphome::i2c::ERROR_OK){
     this->status_set_warning();
-	ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error);
+	  ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
     return false;
   }
   this->status_clear_warning();
-   //ESP_LOGD(TAG, "input_mask_: %02X", inputs); // For testing only
-   this->input_mask_ = inputs;
+  //ESP_LOGD(TAG, "input_mask_: %02X", inputs); // For testing only
+  this->input_mask_ = inputs;
   return true;
 }
 
 bool PCA9554Component::write_register_(uint8_t reg, uint8_t value) {
-  if((this->last_error = this->write_register(reg,  &value, 1, true)) != esphome::i2c::ERROR_OK) {
+  if ((this->last_error_= this->write_register(reg,  &value, 1, true)) != esphome::i2c::ERROR_OK) {
     this->status_set_warning();
-	ESP_LOGE(TAG, "write_register_(): I2C I/O error: %d", (int) this->last_error);
+    ESP_LOGE(TAG, "write_register_(): I2C I/O error: %d", (int) this->last_error_);
     return false;
   }
 

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -1,7 +1,6 @@
 #include "pca9554.h"
 #include "esphome/core/log.h"
 
-
 namespace esphome {
 namespace pca9554 {
 
@@ -9,7 +8,6 @@ const uint8_t INPUT_REG = 0;
 const uint8_t OUTPUT_REG = 1;
 const uint8_t INVERT_REG = 2;
 const uint8_t CONFIG_REG = 3;
-
 
 static const char *const TAG = "pca9554";
 
@@ -34,7 +32,7 @@ void PCA9554Component::setup() {
   // Read the inputs
   this->read_inputs_();
   ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
-  this->status_has_error());
+                    this->status_has_error());
 }
 void PCA9554Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PCA9554:");
@@ -64,7 +62,7 @@ void PCA9554Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->config_mask_ &= ~(1 << pin);
   } else if (flags == gpio::FLAG_OUTPUT) {
       // Set mode mask bit
-	    this->config_mask_ |= 1 << pin;
+    this->config_mask_ |= 1 << pin;
   }
   this->write_register_(CONFIG_REG, ~this->config_mask_);
 }
@@ -77,7 +75,7 @@ bool PCA9554Component::read_inputs_() {
     return false;
   }
 
-  if ((this->last_error_ = this->read_register(INPUT_REG, &inputs,  1, true)) != esphome::i2c::ERROR_OK) {
+  if ((this->last_error_ = this->read_register(INPUT_REG, &inputs, 1, true)) != esphome::i2c::ERROR_OK) {
     this->status_set_warning();
     ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
     return false;
@@ -88,7 +86,7 @@ bool PCA9554Component::read_inputs_() {
 }
 
 bool PCA9554Component::write_register_(uint8_t reg, uint8_t value) {
-  if ((this->last_error_ = this->write_register(reg,  &value, 1, true)) != esphome::i2c::ERROR_OK) {
+  if ((this->last_error_ = this->write_register(reg, &value, 1, true)) != esphome::i2c::ERROR_OK) {
     this->status_set_warning();
     ESP_LOGE(TAG, "write_register_(): I2C I/O error: %d", (int) this->last_error_);
     return false;

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -1,0 +1,109 @@
+#include "pca9554.h"
+#include "esphome/core/log.h"
+
+
+namespace esphome {
+namespace pca9554 {
+
+const uint8_t INPUT_REG =  0;
+const uint8_t OUTPUT_REG = 1;
+const uint8_t INVERT_REG = 2;
+const uint8_t CONFIG_REG = 3;
+
+
+static const char *const TAG = "pca9554";
+
+void PCA9554Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up PCA9554/PCA9554A...");
+  // Test to see if device exists
+  if (!this->read_inputs_()) {
+    ESP_LOGE(TAG, "PCA9554 not available under 0x%02X", this->address_);
+    this->mark_failed();
+    return;
+  }
+  
+  this->write_register_(INVERT_REG, 0); // No polarity inversion
+  this->config_mask_ = 0; // All inputs at initialization
+  this->write_register_(CONFIG_REG , ~this->config_mask_); // Invert mask as the part sees a 1 as an input
+  this->output_mask_ = 0; // All outputs low
+  this->write_register_(OUTPUT_REG, this->output_mask_);
+  this->read_inputs_(); // Read the inputs
+  ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(), this->status_has_error());
+}
+void PCA9554Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "PCA9554:");
+  LOG_I2C_DEVICE(this)
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with PCA9554 failed!");
+  }
+}
+
+bool PCA9554Component::digital_read(uint8_t pin) {
+  this->read_inputs_();
+  return this->input_mask_ & (1 << pin);
+}
+
+void PCA9554Component::digital_write(uint8_t pin, bool value) {
+  if (value) {
+    this->output_mask_ |= (1 << pin);
+  } else {
+    this->output_mask_ &= ~(1 << pin);
+  }
+  this->write_register_(OUTPUT_REG, this->output_mask_);
+}
+
+void PCA9554Component::pin_mode(uint8_t pin, gpio::Flags flags) {
+  if (flags == gpio::FLAG_INPUT) {
+    // Clear mode mask bit
+    this->config_mask_ &= ~(1 << pin);
+  } else if (flags == gpio::FLAG_OUTPUT) {
+    // Set mode mask bit
+    this->config_mask_ |= 1 << pin;
+  }
+  this->write_register_(CONFIG_REG, ~this->config_mask_); 
+}
+
+bool PCA9554Component::read_inputs_() {
+  uint8_t inputs;
+  
+  if (this->is_failed()){
+	ESP_LOGD(TAG, "Device marked failed");
+    return false;
+  }
+
+  if((this->last_error = this->read_register(INPUT_REG, &inputs,  1, true)) != esphome::i2c::ERROR_OK){
+    this->status_set_warning();
+	ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error);
+    return false;
+  }
+  this->status_clear_warning();
+   //ESP_LOGD(TAG, "input_mask_: %02X", inputs); // For testing only
+   this->input_mask_ = inputs;
+  return true;
+}
+
+bool PCA9554Component::write_register_(uint8_t reg, uint8_t value) {
+  if((this->last_error = this->write_register(reg,  &value, 1, true)) != esphome::i2c::ERROR_OK) {
+    this->status_set_warning();
+	ESP_LOGE(TAG, "write_register_(): I2C I/O error: %d", (int) this->last_error);
+    return false;
+  }
+
+  this->status_clear_warning();
+  return true;
+}
+
+float PCA9554Component::get_setup_priority() const { return setup_priority::IO; }
+
+void PCA9554GPIOPin::setup() { pin_mode(flags_); }
+void PCA9554GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->pin_, flags); }
+bool PCA9554GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
+void PCA9554GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
+std::string PCA9554GPIOPin::dump_summary() const {
+  char buffer[32];
+  snprintf(buffer, sizeof(buffer), "%u via PCA9554", pin_);
+  return buffer;
+}
+
+}  // namespace pca9554
+}  // namespace esphome

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -32,7 +32,7 @@ void PCA9554Component::setup() {
   // Read the inputs
   this->read_inputs_();
   ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
-                    this->status_has_error());
+           this->status_has_error());
 }
 void PCA9554Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PCA9554:");
@@ -61,7 +61,7 @@ void PCA9554Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     // Clear mode mask bit
     this->config_mask_ &= ~(1 << pin);
   } else if (flags == gpio::FLAG_OUTPUT) {
-      // Set mode mask bit
+    // Set mode mask bit
     this->config_mask_ |= 1 << pin;
   }
   this->write_register_(CONFIG_REG, ~this->config_mask_);

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -26,15 +26,15 @@ void PCA9554Component::setup() {
   this->write_register_(INVERT_REG, 0);
   // All inputs at initialization
   this->config_mask_ = 0;
-  //Invert mask as the part sees a 1 as an input
-  this->write_register_(CONFIG_REG , ~this->config_mask_);
+  // Invert mask as the part sees a 1 as an input
+  this->write_register_(CONFIG_REG, ~this->config_mask_);
   // All ouputs low
   this->output_mask_ = 0;
   this->write_register_(OUTPUT_REG, this->output_mask_);
   // Read the inputs
   this->read_inputs_();
   ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
-                    this->status_has_error());
+  this->status_has_error());
 }
 void PCA9554Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PCA9554:");
@@ -63,8 +63,8 @@ void PCA9554Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     // Clear mode mask bit
     this->config_mask_ &= ~(1 << pin);
   } else if (flags == gpio::FLAG_OUTPUT) {
-    // Set mode mask bit
-	this->config_mask_ |= 1 << pin;
+      // Set mode mask bit
+	    this->config_mask_ |= 1 << pin;
   }
   this->write_register_(CONFIG_REG, ~this->config_mask_);
 }
@@ -72,24 +72,23 @@ void PCA9554Component::pin_mode(uint8_t pin, gpio::Flags flags) {
 bool PCA9554Component::read_inputs_() {
   uint8_t inputs;
 
-  if (this->is_failed()){
+  if (this->is_failed()) {
     ESP_LOGD(TAG, "Device marked failed");
-	return false;
+    return false;
   }
 
-  if ((this->last_error_ = this->read_register(INPUT_REG, &inputs,  1, true)) != esphome::i2c::ERROR_OK){
+  if ((this->last_error_ = this->read_register(INPUT_REG, &inputs,  1, true)) != esphome::i2c::ERROR_OK) {
     this->status_set_warning();
-	  ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
+    ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
     return false;
   }
   this->status_clear_warning();
-  //ESP_LOGD(TAG, "input_mask_: %02X", inputs); // For testing only
   this->input_mask_ = inputs;
   return true;
 }
 
 bool PCA9554Component::write_register_(uint8_t reg, uint8_t value) {
-  if ((this->last_error_= this->write_register(reg,  &value, 1, true)) != esphome::i2c::ERROR_OK) {
+  if ((this->last_error_ = this->write_register(reg,  &value, 1, true)) != esphome::i2c::ERROR_OK) {
     this->status_set_warning();
     ESP_LOGE(TAG, "write_register_(): I2C I/O error: %d", (int) this->last_error_);
     return false;

--- a/esphome/components/pca9554/pca9554.h
+++ b/esphome/components/pca9554/pca9554.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace pca9554 {
+
+class PCA9554Component : public Component, public i2c::I2CDevice {
+ public:
+  PCA9554Component() = default;
+
+  /// Check i2c availability and setup masks
+  void setup() override;
+  /// Helper function to read the value of a pin.
+  bool digital_read(uint8_t pin);
+  /// Helper function to write the value of a pin.
+  void digital_write(uint8_t pin, bool value);
+  /// Helper function to set the pin mode of a pin.
+  void pin_mode(uint8_t pin, gpio::Flags flags);
+
+
+  float get_setup_priority() const override;
+
+  void dump_config() override;
+
+ protected:
+  bool read_inputs_();
+  
+  bool write_register_(uint8_t reg, uint8_t value);
+  
+
+  /// Mask for the pin config - 1 means OUTPUT, 0 means INPUT
+  uint8_t config_mask_{0x00};
+  /// The mask to write as output state - 1 means HIGH, 0 means LOW
+  uint8_t output_mask_{0x00};
+  /// The state of the actual input pin states - 1 means HIGH, 0 means LOW
+  uint8_t input_mask_{0x00};
+  
+  esphome::i2c::ErrorCode last_error;
+};
+
+/// Helper class to expose a PCA9554 pin as an internal input GPIO pin.
+class PCA9554GPIOPin : public GPIOPin {
+ public:
+  void setup() override;
+  void pin_mode(gpio::Flags flags) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+  std::string dump_summary() const override;
+
+  void set_parent(PCA9554Component *parent) { parent_ = parent; }
+  void set_pin(uint8_t pin) { pin_ = pin; }
+  void set_inverted(bool inverted) { inverted_ = inverted; }
+  void set_flags(gpio::Flags flags) { flags_ = flags; }
+
+ protected:
+  PCA9554Component *parent_;
+  uint8_t pin_;
+  bool inverted_;
+  gpio::Flags flags_;
+};
+
+}  // namespace pca9554
+}  // namespace esphome

--- a/esphome/components/pca9554/pca9554.h
+++ b/esphome/components/pca9554/pca9554.h
@@ -20,16 +20,15 @@ class PCA9554Component : public Component, public i2c::I2CDevice {
   /// Helper function to set the pin mode of a pin.
   void pin_mode(uint8_t pin, gpio::Flags flags);
 
-
   float get_setup_priority() const override;
 
   void dump_config() override;
 
  protected:
   bool read_inputs_();
-  
+
   bool write_register_(uint8_t reg, uint8_t value);
-  
+
 
   /// Mask for the pin config - 1 means OUTPUT, 0 means INPUT
   uint8_t config_mask_{0x00};
@@ -37,8 +36,8 @@ class PCA9554Component : public Component, public i2c::I2CDevice {
   uint8_t output_mask_{0x00};
   /// The state of the actual input pin states - 1 means HIGH, 0 means LOW
   uint8_t input_mask_{0x00};
-  
-  esphome::i2c::ErrorCode last_error;
+  /// Storage for last I2C error seen
+  esphome::i2c::ErrorCode last_error_;
 };
 
 /// Helper class to expose a PCA9554 pin as an internal input GPIO pin.

--- a/esphome/components/pca9554/pca9554.h
+++ b/esphome/components/pca9554/pca9554.h
@@ -29,7 +29,6 @@ class PCA9554Component : public Component, public i2c::I2CDevice {
 
   bool write_register_(uint8_t reg, uint8_t value);
 
-
   /// Mask for the pin config - 1 means OUTPUT, 0 means INPUT
   uint8_t config_mask_{0x00};
   /// The mask to write as output state - 1 means HIGH, 0 means LOW


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This adds support for devices PCA9554, PCA9554A, and PCA9536
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2532

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```
pca9554:
    id: pca9554_device_0
    address: 0x38 # For the PCA9554A part

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
