### PR TITLE
Support non-multiarch toolchains on 32-bit ARM

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ ENV \
 # to do this, other than using properly built toolchains...
 # See: https://unix.stackexchange.com/questions/553743/correct-way-to-add-lib-ld-linux-so-3-in-debian
 RUN \
-    if [ "$BUILD_ARCH" != "armhf" ]; then \
+    if [ "$TARGETARCH" == "arm" ]; then \
         ln -s /lib/arm-linux-gnueabihf/ld-linux.so.3 /lib/ld-linux.so.3; \
     fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ ENV \
 # to do this, other than using properly built toolchains...
 # See: https://unix.stackexchange.com/questions/553743/correct-way-to-add-lib-ld-linux-so-3-in-debian
 RUN \
-    if [ "$TARGETARCH" == "arm" ]; then \
+    if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
         ln -s /lib/arm-linux-gnueabihf/ld-linux.so.3 /lib/ld-linux.so.3; \
     fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,9 @@ FROM debian:bullseye-20221024-slim AS base-docker
 
 FROM base-${BASEIMGTYPE} AS base
 
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,14 @@ ENV \
   # Store globally installed pio libs in /piolibs
   PLATFORMIO_GLOBALLIB_DIR=/piolibs
 
+# Support legacy binaries on Debian multiarch system. There is no "correct" way
+# to do this, other than using properly built toolchains...
+# See: https://unix.stackexchange.com/questions/553743/correct-way-to-add-lib-ld-linux-so-3-in-debian
+RUN \
+    if [ "$BUILD_ARCH" != "armhf" ]; then \
+        ln -s /lib/arm-linux-gnueabihf/ld-linux.so.3 /lib/ld-linux.so.3; \
+    fi
+
 RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --no-cache-dir \


### PR DESCRIPTION
# What does this implement/fix?

It seems that newer xtensa toolchains use the non-multiarch dynamic linker in /lib/ld-linux.so.3. There is no dynamic linker provided at this path by modern Debian distributions to support multi-arch systems.

Simply symlink the default dynamic linker to that place to make newer xtensa toolchain work on 32-bit ARM.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3904

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
