### PR TITLE
Fix i2s_audio media_player compiling for esp32-s2

### DIFF
--- a/esphome/components/i2s_audio/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/i2s_audio_media_player.cpp
@@ -103,9 +103,11 @@ void I2SAudioMediaPlayer::stop_() {
 
 void I2SAudioMediaPlayer::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Audio...");
+#if SOC_I2S_SUPPORTS_DAC
   if (this->internal_dac_mode_ != I2S_DAC_CHANNEL_DISABLE) {
     this->audio_ = make_unique<Audio>(true, this->internal_dac_mode_);
   } else {
+#endif
     this->audio_ = make_unique<Audio>(false);
     this->audio_->setPinout(this->bclk_pin_, this->lrclk_pin_, this->dout_pin_);
     this->audio_->forceMono(this->external_dac_channels_ == 1);
@@ -113,7 +115,9 @@ void I2SAudioMediaPlayer::setup() {
       this->mute_pin_->setup();
       this->mute_pin_->digital_write(false);
     }
+#if SOC_I2S_SUPPORTS_DAC
   }
+#endif
   this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
 }
 
@@ -137,6 +141,7 @@ void I2SAudioMediaPlayer::dump_config() {
     ESP_LOGCONFIG(TAG, "Audio failed to initialize!");
     return;
   }
+#if SOC_I2S_SUPPORTS_DAC
   if (this->internal_dac_mode_ != I2S_DAC_CHANNEL_DISABLE) {
     switch (this->internal_dac_mode_) {
       case I2S_DAC_CHANNEL_LEFT_EN:
@@ -152,6 +157,7 @@ void I2SAudioMediaPlayer::dump_config() {
         break;
     }
   }
+#endif
 }
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/i2s_audio_media_player.h
@@ -25,7 +25,9 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer {
   void set_bclk_pin(uint8_t pin) { this->bclk_pin_ = pin; }
   void set_lrclk_pin(uint8_t pin) { this->lrclk_pin_ = pin; }
   void set_mute_pin(GPIOPin *mute_pin) { this->mute_pin_ = mute_pin; }
+#if SOC_I2S_SUPPORTS_DAC
   void set_internal_dac_mode(i2s_dac_mode_t mode) { this->internal_dac_mode_ = mode; }
+#endif
   void set_external_dac_channels(uint8_t channels) { this->external_dac_channels_ = channels; }
 
   media_player::MediaPlayerTraits get_traits() override;
@@ -51,7 +53,9 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer {
   bool muted_{false};
   float unmuted_volume_{0};
 
+#if SOC_I2S_SUPPORTS_DAC
   i2s_dac_mode_t internal_dac_mode_{I2S_DAC_CHANNEL_DISABLE};
+#endif
   uint8_t external_dac_channels_;
 
   HighFrequencyLoopRequester high_freq_;

--- a/esphome/components/i2s_audio/media_player.py
+++ b/esphome/components/i2s_audio/media_player.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import media_player
+from esphome.components import media_player, esp32
 import esphome.config_validation as cv
 
 from esphome import pins
@@ -32,6 +32,18 @@ INTERNAL_DAC_OPTIONS = {
 }
 
 EXTERNAL_DAC_OPTIONS = ["mono", "stereo"]
+
+NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]
+
+
+def validate_esp32_variant(config):
+    if config[CONF_DAC_TYPE] != "internal":
+        return config
+    variant = esp32.get_esp32_variant()
+    if variant in NO_INTERNAL_DAC_VARIANTS:
+        raise cv.Invalid(f"{variant} does not have an internal DAC")
+    return config
+
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
@@ -68,6 +80,7 @@ CONFIG_SCHEMA = cv.All(
         key=CONF_DAC_TYPE,
     ),
     cv.only_with_arduino,
+    validate_esp32_variant,
 )
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3783

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
