### PR TITLE
2022.12.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,9 @@ FROM debian:bullseye-20221024-slim AS base-docker
 
 FROM base-${BASEIMGTYPE} AS base
 
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
@@ -35,6 +38,14 @@ ENV \
   LANG=C.UTF-8 LC_ALL=C.UTF-8 \
   # Store globally installed pio libs in /piolibs
   PLATFORMIO_GLOBALLIB_DIR=/piolibs
+
+# Support legacy binaries on Debian multiarch system. There is no "correct" way
+# to do this, other than using properly built toolchains...
+# See: https://unix.stackexchange.com/questions/553743/correct-way-to-add-lib-ld-linux-so-3-in-debian
+RUN \
+    if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
+        ln -s /lib/arm-linux-gnueabihf/ld-linux.so.3 /lib/ld-linux.so.3; \
+    fi
 
 RUN \
     # Ubuntu python3-pip is missing wheel

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -2,11 +2,13 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 from esphome.core import CORE
-from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant, const
 
 DEPENDENCIES = ["esp32"]
 CODEOWNERS = ["@jesserockz"]
 CONFLICTS_WITH = ["esp32_ble_tracker", "esp32_ble_beacon"]
+
+NO_BLUTOOTH_VARIANTS = [const.VARIANT_ESP32S2]
 
 esp32_ble_ns = cg.esphome_ns.namespace("esp32_ble")
 ESP32BLE = esp32_ble_ns.class_("ESP32BLE", cg.Component)
@@ -17,6 +19,15 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(ESP32BLE),
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
+
+def validate_variant(_):
+    variant = get_esp32_variant()
+    if variant in NO_BLUTOOTH_VARIANTS:
+        raise cv.Invalid(f"{variant} does not support Bluetooth")
+
+
+FINAL_VALIDATE_SCHEMA = validate_variant
 
 
 async def to_code(config):

--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_TYPE, CONF_UUID, CONF_TX_POWER
 from esphome.core import CORE, TimePeriod
 from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.components import esp32_ble
 
 DEPENDENCIES = ["esp32"]
 CONFLICTS_WITH = ["esp32_ble_tracker"]
@@ -53,6 +54,8 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     validate_config,
 )
+
+FINAL_VALIDATE_SCHEMA = esp32_ble.validate_variant
 
 
 async def to_code(config):

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -17,6 +17,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.components import esp32_ble
 
 DEPENDENCIES = ["esp32"]
 
@@ -186,6 +187,8 @@ CONFIG_SCHEMA = cv.Schema(
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
+FINAL_VALIDATE_SCHEMA = esp32_ble.validate_variant
 
 ESP_BLE_DEVICE_SCHEMA = cv.Schema(
     {

--- a/esphome/components/i2s_audio/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/i2s_audio_media_player.cpp
@@ -103,9 +103,11 @@ void I2SAudioMediaPlayer::stop_() {
 
 void I2SAudioMediaPlayer::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Audio...");
+#if SOC_I2S_SUPPORTS_DAC
   if (this->internal_dac_mode_ != I2S_DAC_CHANNEL_DISABLE) {
     this->audio_ = make_unique<Audio>(true, this->internal_dac_mode_);
   } else {
+#endif
     this->audio_ = make_unique<Audio>(false);
     this->audio_->setPinout(this->bclk_pin_, this->lrclk_pin_, this->dout_pin_);
     this->audio_->forceMono(this->external_dac_channels_ == 1);
@@ -113,7 +115,9 @@ void I2SAudioMediaPlayer::setup() {
       this->mute_pin_->setup();
       this->mute_pin_->digital_write(false);
     }
+#if SOC_I2S_SUPPORTS_DAC
   }
+#endif
   this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
 }
 
@@ -137,6 +141,7 @@ void I2SAudioMediaPlayer::dump_config() {
     ESP_LOGCONFIG(TAG, "Audio failed to initialize!");
     return;
   }
+#if SOC_I2S_SUPPORTS_DAC
   if (this->internal_dac_mode_ != I2S_DAC_CHANNEL_DISABLE) {
     switch (this->internal_dac_mode_) {
       case I2S_DAC_CHANNEL_LEFT_EN:
@@ -152,6 +157,7 @@ void I2SAudioMediaPlayer::dump_config() {
         break;
     }
   }
+#endif
 }
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/i2s_audio_media_player.h
@@ -25,7 +25,9 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer {
   void set_bclk_pin(uint8_t pin) { this->bclk_pin_ = pin; }
   void set_lrclk_pin(uint8_t pin) { this->lrclk_pin_ = pin; }
   void set_mute_pin(GPIOPin *mute_pin) { this->mute_pin_ = mute_pin; }
+#if SOC_I2S_SUPPORTS_DAC
   void set_internal_dac_mode(i2s_dac_mode_t mode) { this->internal_dac_mode_ = mode; }
+#endif
   void set_external_dac_channels(uint8_t channels) { this->external_dac_channels_ = channels; }
 
   media_player::MediaPlayerTraits get_traits() override;
@@ -51,7 +53,9 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer {
   bool muted_{false};
   float unmuted_volume_{0};
 
+#if SOC_I2S_SUPPORTS_DAC
   i2s_dac_mode_t internal_dac_mode_{I2S_DAC_CHANNEL_DISABLE};
+#endif
   uint8_t external_dac_channels_;
 
   HighFrequencyLoopRequester high_freq_;

--- a/esphome/components/i2s_audio/media_player.py
+++ b/esphome/components/i2s_audio/media_player.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import media_player
+from esphome.components import media_player, esp32
 import esphome.config_validation as cv
 
 from esphome import pins
@@ -32,6 +32,18 @@ INTERNAL_DAC_OPTIONS = {
 }
 
 EXTERNAL_DAC_OPTIONS = ["mono", "stereo"]
+
+NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]
+
+
+def validate_esp32_variant(config):
+    if config[CONF_DAC_TYPE] != "internal":
+        return config
+    variant = esp32.get_esp32_variant()
+    if variant in NO_INTERNAL_DAC_VARIANTS:
+        raise cv.Invalid(f"{variant} does not have an internal DAC")
+    return config
+
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
@@ -68,6 +80,7 @@ CONFIG_SCHEMA = cv.All(
         key=CONF_DAC_TYPE,
     ),
     cv.only_with_arduino,
+    validate_esp32_variant,
 )
 
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2022.12.0"
+__version__ = "2022.12.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Support non-multiarch toolchains on 32-bit ARM [esphome#4191](https://github.com/esphome/esphome/pull/4191)
- Mark ESP32-S2 as not having Bluetooth [esphome#4194](https://github.com/esphome/esphome/pull/4194)
- Fix i2s_audio media_player compiling for esp32-s2 [esphome#4195](https://github.com/esphome/esphome/pull/4195)
