### PR TITLE
Allow mdns services to be exposed by config

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -1,4 +1,4 @@
-from esphome.const import CONF_ID, CONF_PORT, CONF_NAME, CONF_PROTOCOL, CONF_SERVICES
+from esphome.const import CONF_ID, CONF_PORT, CONF_NAME, CONF_PROTOCOL, CONF_SERVICES, CONF_SERVICE
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE, coroutine_with_priority
@@ -23,7 +23,7 @@ CONF_TXT = "txt"
 
 SERVICE_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_NAME): cv.string,
+        cv.Required(CONF_SERVICE): cv.string,
         cv.Required(CONF_PROTOCOL): cv.string,
         cv.Optional(CONF_PORT, default=0): cv.Any(0, cv.port),
         cv.Optional(CONF_TXT, default={}): {cv.string: cv.string},
@@ -73,7 +73,7 @@ async def to_code(config):
 
         exp = cg.StructInitializer(
             MDNSService,
-            ("service_type", service[CONF_NAME]),
+            ("service_type", service[CONF_SERVICE]),
             ("proto", service[CONF_PROTOCOL]),
             ("port", service[CONF_PORT]),
             ("txt_records", txt),

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -1,4 +1,4 @@
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_PORT, CONF_NAME, CONF_PROTOCOL
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE, coroutine_with_priority
@@ -8,7 +8,8 @@ DEPENDENCIES = ["network"]
 
 mdns_ns = cg.esphome_ns.namespace("mdns")
 MDNSComponent = mdns_ns.class_("MDNSComponent", cg.Component)
-
+MDNSTXTRecord = mdns_ns.struct("MDNSTXTRecord")
+MDNSService = mdns_ns.struct("MDNSService")
 
 def _remove_id_if_disabled(value):
     value = value.copy()
@@ -16,6 +17,19 @@ def _remove_id_if_disabled(value):
         value.pop(CONF_ID)
     return value
 
+CONF_TXT = "txt"
+CONF_SERVICES = "services"
+
+SERVICE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_NAME): cv.string,
+        cv.Required(CONF_PROTOCOL): cv.string,
+        cv.Optional(CONF_PORT, default=0): cv.Any(0, cv.port),
+        cv.Optional(CONF_TXT, default={}): {
+            cv.string: cv.string
+        }
+    }
+)
 
 CONF_DISABLED = "disabled"
 CONFIG_SCHEMA = cv.All(
@@ -23,6 +37,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(MDNSComponent),
             cv.Optional(CONF_DISABLED, default=False): cv.boolean,
+            cv.Optional(CONF_SERVICES, default=[]): cv.ensure_list(SERVICE_SCHEMA)
         }
     ),
     _remove_id_if_disabled,
@@ -46,3 +61,22 @@ async def to_code(config):
 
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    for service in config[CONF_SERVICES]:
+        txt = [
+            cg.StructInitializer(
+                    MDNSTXTRecord,
+                    ("key", txt_key),
+                    ("value", txt_value),
+                )
+            for txt_key, txt_value in service[CONF_TXT].items()
+        ]
+
+        exp = cg.StructInitializer(
+            MDNSService,
+            ("service_type", service[CONF_NAME]),
+            ("proto", service[CONF_PROTOCOL]),
+            ("port", service[CONF_PORT]),
+            ("txt_records", txt)
+        )
+        cg.add(var.add_extra_service(exp))

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -1,4 +1,10 @@
-from esphome.const import CONF_ID, CONF_PORT, CONF_NAME, CONF_PROTOCOL, CONF_SERVICES, CONF_SERVICE
+from esphome.const import (
+    CONF_ID,
+    CONF_PORT,
+    CONF_PROTOCOL,
+    CONF_SERVICES,
+    CONF_SERVICE,
+)
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE, coroutine_with_priority

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -1,4 +1,4 @@
-from esphome.const import CONF_ID, CONF_PORT, CONF_NAME, CONF_PROTOCOL
+from esphome.const import CONF_ID, CONF_PORT, CONF_NAME, CONF_PROTOCOL, CONF_SERVICES
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE, coroutine_with_priority
@@ -11,23 +11,22 @@ MDNSComponent = mdns_ns.class_("MDNSComponent", cg.Component)
 MDNSTXTRecord = mdns_ns.struct("MDNSTXTRecord")
 MDNSService = mdns_ns.struct("MDNSService")
 
+
 def _remove_id_if_disabled(value):
     value = value.copy()
     if value[CONF_DISABLED]:
         value.pop(CONF_ID)
     return value
 
+
 CONF_TXT = "txt"
-CONF_SERVICES = "services"
 
 SERVICE_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_NAME): cv.string,
         cv.Required(CONF_PROTOCOL): cv.string,
         cv.Optional(CONF_PORT, default=0): cv.Any(0, cv.port),
-        cv.Optional(CONF_TXT, default={}): {
-            cv.string: cv.string
-        }
+        cv.Optional(CONF_TXT, default={}): {cv.string: cv.string},
     }
 )
 
@@ -37,7 +36,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(MDNSComponent),
             cv.Optional(CONF_DISABLED, default=False): cv.boolean,
-            cv.Optional(CONF_SERVICES, default=[]): cv.ensure_list(SERVICE_SCHEMA)
+            cv.Optional(CONF_SERVICES, default=[]): cv.ensure_list(SERVICE_SCHEMA),
         }
     ),
     _remove_id_if_disabled,
@@ -65,10 +64,10 @@ async def to_code(config):
     for service in config[CONF_SERVICES]:
         txt = [
             cg.StructInitializer(
-                    MDNSTXTRecord,
-                    ("key", txt_key),
-                    ("value", txt_value),
-                )
+                MDNSTXTRecord,
+                ("key", txt_key),
+                ("value", txt_value),
+            )
             for txt_key, txt_value in service[CONF_TXT].items()
         ]
 
@@ -77,6 +76,6 @@ async def to_code(config):
             ("service_type", service[CONF_NAME]),
             ("proto", service[CONF_PROTOCOL]),
             ("port", service[CONF_PORT]),
-            ("txt_records", txt)
+            ("txt_records", txt),
         )
         cg.add(var.add_extra_service(exp))

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -90,6 +90,12 @@ void MDNSComponent::compile_records_() {
   }
 #endif
 
+  this->services_.insert(
+    this->services_.end(),
+    this->services_extra_.begin(),
+    this->services_extra_.end()
+  );
+
   if (this->services_.empty()) {
     // Publish "http" service if not using native API
     // This is just to have *some* mDNS service so that .local resolution works

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -90,11 +90,7 @@ void MDNSComponent::compile_records_() {
   }
 #endif
 
-  this->services_.insert(
-    this->services_.end(),
-    this->services_extra_.begin(),
-    this->services_extra_.end()
-  );
+  this->services_.insert(this->services_.end(), this->services_extra_.begin(), this->services_extra_.end());
 
   if (this->services_.empty()) {
     // Publish "http" service if not using native API

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -33,10 +33,7 @@ class MDNSComponent : public Component {
 #endif
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
-  void add_extra_service(const MDNSService& service)
-  {
-    services_extra_.push_back(service);
-  }
+  void add_extra_service(const MDNSService &service) { services_extra_.push_back(service); }
 
  protected:
   std::vector<MDNSService> services_extra_{};

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -33,7 +33,7 @@ class MDNSComponent : public Component {
 #endif
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
-  void add_extra_service(const MDNSService &service) { services_extra_.push_back(service); }
+  void add_extra_service(MDNSService service) { services_extra_.push_back(std::move(service)); }
 
  protected:
   std::vector<MDNSService> services_extra_{};

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -33,7 +33,13 @@ class MDNSComponent : public Component {
 #endif
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
+  void add_extra_service(const MDNSService& service)
+  {
+    services_extra_.push_back(service);
+  }
+
  protected:
+  std::vector<MDNSService> services_extra_{};
   std::vector<MDNSService> services_{};
   std::string hostname_;
   void compile_records_();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2553

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
mdns:
  services:
    - name: "_nibegw"
      protocol: "_udp"
      port: 10090
      txt:
        read_port: 10091
        write_port: 10092
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
