### PR TITLE
Handle deprecated sdkconfig option

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -356,9 +356,14 @@ async def to_code(config):
 
         if conf[CONF_ADVANCED][CONF_IGNORE_EFUSE_MAC_CRC]:
             cg.add_define("USE_ESP32_IGNORE_EFUSE_MAC_CRC")
-            add_idf_sdkconfig_option(
-                "CONFIG_ESP32_PHY_CALIBRATION_AND_DATA_STORAGE", False
-            )
+            if framework_ver.major >= 4:
+                add_idf_sdkconfig_option(
+                    "CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE", False
+                )
+            else:
+                add_idf_sdkconfig_option(
+                    "CONFIG_ESP32_PHY_CALIBRATION_AND_DATA_STORAGE", False
+                )
 
         cg.add_define(
             "USE_ESP_IDF_VERSION_CODE",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -356,7 +356,7 @@ async def to_code(config):
 
         if conf[CONF_ADVANCED][CONF_IGNORE_EFUSE_MAC_CRC]:
             cg.add_define("USE_ESP32_IGNORE_EFUSE_MAC_CRC")
-            if framework_ver.major >= 4:
+            if (framework_ver.major, framework_ver.minor) >= (4, 4):
                 add_idf_sdkconfig_option(
                     "CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE", False
                 )


### PR DESCRIPTION
# What does this implement/fix?

With ESPHome 2022.12.0 came a new ESP-IDF framework version, in which the sdkconfig option `CONFIG_ESP32_PHY_CALIBRATION_AND_DATA_STORAGE` was deprecated in favour of `CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE`.

This option is used by the esp32 `ignore_efuse_mac_crc` option to circumvent a piece of code of the framework in which the MAC address of the device is read from efuse. The reason to circumvent it, is that the function that handles the reading operation panics when the CRC (also from ufuse, so immutable) mismatches the MAC address from efuse. Some devices have a wrong CRC, which is why this option was implemented.

The problem with using the deprecated sdkconfig option, is that the panicing code has become active again, resulting in a boot loop after flashing with ESPHome 2022.12.0.

Solution from the PR: use the correct sdkconfig option, based on the framwork version against which the code is compiled.

I tested the change with my Xiaomi Bedside Lamp 2 component.
* Flashing 2022.11.0 to 2022.12.0 -> device goes into boot loop after flashing
* Flashing 2022.11.0 to PR commit -> device works after flashing

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/mmakaay/esphome-xiaomi_bslamp2/issues/104

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
