### PR TITLE
Fix ESP32 GPIO when using PULLUP or PULLDOWN in INPUT mode

### DIFF
--- a/esphome/components/esp32/gpio.cpp
+++ b/esphome/components/esp32/gpio.cpp
@@ -95,7 +95,7 @@ void ESP32InternalGPIOPin::pin_mode(gpio::Flags flags) {
   // can't call gpio_config here because that logs in esp-idf which may cause issues
   gpio_set_direction(pin_, flags_to_mode(flags));
   gpio_pull_mode_t pull_mode = GPIO_FLOATING;
-  if (flags & (gpio::FLAG_PULLUP | gpio::FLAG_PULLDOWN)) {
+  if ((flags & gpio::FLAG_PULLUP) && (flags & gpio::FLAG_PULLDOWN)) {
     pull_mode = GPIO_PULLUP_PULLDOWN;
   } else if (flags & gpio::FLAG_PULLUP) {
     pull_mode = GPIO_PULLUP_ONLY;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
A small bitwise bug causing the pin pullup mode to be PULLUP_PULLDOWN when only PULLUP **or** PULLDOWN was requested.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
