### PR TITLE
Update display_buffer.cpp

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -175,7 +175,8 @@ void DisplayBuffer::print(int x, int y, Font *font, Color color, TextAlign align
       // Unknown char, skip
       ESP_LOGW(TAG,
                "Encountered character without representation in font: '%c'."
-               "Consider adding to glyphs configuration in font.", text[i]);
+               "Consider adding to glyphs configuration in font.",
+               text[i]);
       if (!font->get_glyphs().empty()) {
         uint8_t glyph_width = font->get_glyphs()[0].glyph_data_->width;
         for (int glyph_x = 0; glyph_x < glyph_width; glyph_x++) {

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -173,7 +173,7 @@ void DisplayBuffer::print(int x, int y, Font *font, Color color, TextAlign align
     int glyph_n = font->match_next_glyph(text + i, &match_length);
     if (glyph_n < 0) {
       // Unknown char, skip
-      ESP_LOGW(TAG, "Encountered character without representation in font: '%c'", text[i]);
+      ESP_LOGW(TAG, "Encountered character without representation in font: '%c'. Consider adding to glyphs configuration in font.", text[i]);
       if (!font->get_glyphs().empty()) {
         uint8_t glyph_width = font->get_glyphs()[0].glyph_data_->width;
         for (int glyph_x = 0; glyph_x < glyph_width; glyph_x++) {

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -173,7 +173,9 @@ void DisplayBuffer::print(int x, int y, Font *font, Color color, TextAlign align
     int glyph_n = font->match_next_glyph(text + i, &match_length);
     if (glyph_n < 0) {
       // Unknown char, skip
-      ESP_LOGW(TAG, "Encountered character without representation in font: '%c'. Consider adding to glyphs configuration in font.", text[i]);
+      ESP_LOGW(TAG,
+               "Encountered character without representation in font: '%c'."
+               "Consider adding to glyphs configuration in font.", text[i]);
       if (!font->get_glyphs().empty()) {
         uint8_t glyph_width = font->get_glyphs()[0].glyph_data_->width;
         for (int glyph_x = 0; glyph_x < glyph_width; glyph_x++) {


### PR DESCRIPTION
Improve to Display buffer warning message, when a character without representation is encountered. Missing the character from the "glyphs" configuration in font is the likeliest cause of this error.

# What does this implement/fix?

Improves error message of the display component, when a character without representation is encountered.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other: Changes log message

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```
font:
  - file: "gfonts://Mukta"
    id: mukta
    size: 32
    glyphs: "abcdefghijklmnopqrstuvwxyz?"

spi:
  clk_pin: 13
  mosi_pin: 14

display:
  - platform: waveshare_epaper
    cs_pin: 15
    dc_pin: 27
    busy_pin: 25
    reset_pin: 26
    model: 7.50inV2
    reset_duration: 2ms
    update_interval: 10sec
    lambda: |-
       it.print(x, 0, id(mukta), "???");
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
