### PR TITLE
Update ct_clamp to account for 0A values correctly

### DIFF
--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -57,7 +57,7 @@ void CTClampSensor::loop() {
     return;
 
   // Assuming a sine wave, avoid requesting values faster than the ADC can provide them
-  if (this->last_value_ == value)
+  if (this->last_value_ == value && value != 0)
     return;
   this->last_value_ = value;
 


### PR DESCRIPTION
Without this change, when the monitored device is off (sampled value is always 0), num_samples is never incremented.  When the loop expires, the if block on line 28 returns a NaN, when the actual sampled value was 0.

# What does this implement/fix?

ct_clamp sensor returns NaN rather than 0 when no current is flowing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2701

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
N/A, bugfix

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
  - platform: ct_clamp
    sensor: adc_sensor
    name: "Dryer Current"
    id: dryer_current
    update_interval: 15s
    filters:
      - calibrate_linear:
        - 0 -> 0
        - 1.0 -> 30

  - platform: adc
    pin: A0
    id: adc_sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
