### PR TITLE
Change 150 microsecond delay to 175 microseconds to fix a low recurre…

### DIFF
--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -55,6 +55,31 @@ void LCDDisplay::setup() {
     this->write_n_bits(0x03, 4);
     delay(5);
     this->write_n_bits(0x03, 4);
+
+    // Change 150 microsecond delay to 175 microseconds to fix
+    // a low recurrence of a display initialization error on a
+    // 1602 Buy Display part number ERM1602SYG-6
+    // 3.3V display operating in 4 bit parallel mode
+
+    // After about 1 in 20 power ups or resets the display
+    // will not initialize properly using 150 microseconds.
+    // (I am aware of the boot loop counter forcing entry
+    // into safe mode after 10 short reset attempts, so I did not count that)
+    // I tested a range of values from 125 microseconds
+    // to 300 microseconds and determined that
+    // 125 microseconds caused the display to not
+    // initialize with a 100% failure rate.
+    // 155 microseconds worked 100% of the time,
+    // and I settled on 175 microseconds.
+
+    // Now the strange thing is; is that there
+    // is no timing requirement mentioned in the datasheet
+    // for that particular phase of the initialization for my LCD part,
+    // yet there is a 150 microsecond delay in the original lcd_base.cpp file.
+    // So I either missed something in the datasheet,
+    // or there is an undocumented requirement for
+    // a delay at that point during initialization.
+
     delayMicroseconds(175);
     this->write_n_bits(0x02, 4);
   } else {

--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -55,13 +55,13 @@ void LCDDisplay::setup() {
     this->write_n_bits(0x03, 4);
     delay(5);
     this->write_n_bits(0x03, 4);
-    delayMicroseconds(150);
+    delayMicroseconds(175);
     this->write_n_bits(0x02, 4);
   } else {
     this->command_(LCD_DISPLAY_COMMAND_FUNCTION_SET | display_function);
     delay(5);  // 4.1ms
     this->command_(LCD_DISPLAY_COMMAND_FUNCTION_SET | display_function);
-    delayMicroseconds(150);
+    delayMicroseconds(175);
     this->command_(LCD_DISPLAY_COMMAND_FUNCTION_SET | display_function);
   }
 


### PR DESCRIPTION
…nce of a display initialization error on a 1602 Buy Display part number ERM1602SYG-6 3.3V display operating in 4 bit parallel mode.

# What does this implement/fix?

Change 150 microsecond delay to 175 microseconds to fix a low recurrence of a display initialization error on a 1602 Buy Display part number ERM1602SYG-6 3.3V display operating in 4 bit parallel mode.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
