### PR TITLE
Fix negative sqrt root in ct_clamp_sensor.cpp (#2701)

### DIFF
--- a/esphome/components/ct_clamp/ct_clamp_sensor.cpp
+++ b/esphome/components/ct_clamp/ct_clamp_sensor.cpp
@@ -33,7 +33,10 @@ void CTClampSensor::update() {
 
     const float rms_ac_dc_squared = this->sample_squared_sum_ / this->num_samples_;
     const float rms_dc = this->sample_sum_ / this->num_samples_;
-    const float rms_ac = std::sqrt(rms_ac_dc_squared - rms_dc * rms_dc);
+    const float rms_ac_squared = rms_ac_dc_squared - rms_dc * rms_dc;
+    float rms_ac=0;
+    if (rms_ac_squared>0)
+        rms_ac = std::sqrt(rms_ac_squared);
     ESP_LOGD(TAG, "'%s' - Raw AC Value: %.3fA after %d different samples (%d SPS)", this->name_.c_str(), rms_ac,
              this->num_samples_, 1000 * this->num_samples_ / this->sample_duration_);
     this->publish_state(rms_ac);


### PR DESCRIPTION
# What does this implement/fix?

In the ct_clamp_sensor, for zero currents, a negative square root can occur. This results in a published NAN value.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2701

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
