### PR TITLE
Fix use of dangling pointers in esp-idf MQTT backend

### DIFF
--- a/esphome/components/mqtt/mqtt_backend_idf.cpp
+++ b/esphome/components/mqtt/mqtt_backend_idf.cpp
@@ -108,8 +108,8 @@ void MQTTBackendIDF::mqtt_event_handler_(const Event &event) {
         topic = event.topic;
       }
       ESP_LOGV(TAG, "MQTT_EVENT_DATA %s", topic.c_str());
-      this->on_message_.call(event.topic.length() > 0 ? topic.c_str() : nullptr, event.data.c_str(),
-                             event.data.length(), event.current_data_offset, event.total_data_len);
+      this->on_message_.call(event.topic.length() > 0 ? topic.c_str() : nullptr, event.data.data(), event.data.size(),
+                             event.current_data_offset, event.total_data_len);
     } break;
     case MQTT_EVENT_ERROR:
       ESP_LOGE(TAG, "MQTT_EVENT_ERROR");

--- a/esphome/components/mqtt/mqtt_backend_idf.cpp
+++ b/esphome/components/mqtt/mqtt_backend_idf.cpp
@@ -108,9 +108,8 @@ void MQTTBackendIDF::mqtt_event_handler_(const Event &event) {
         topic = event.topic;
       }
       ESP_LOGV(TAG, "MQTT_EVENT_DATA %s", topic.c_str());
-      this->on_message_.call(event.topic.length() > 0 ? topic.c_str() : nullptr,
-                             event.data.c_str(), event.data.length(),
-                             event.current_data_offset, event.total_data_len);
+      this->on_message_.call(event.topic.length() > 0 ? topic.c_str() : nullptr, event.data.c_str(),
+                             event.data.length(), event.current_data_offset, event.total_data_len);
     } break;
     case MQTT_EVENT_ERROR:
       ESP_LOGE(TAG, "MQTT_EVENT_ERROR");

--- a/esphome/components/mqtt/mqtt_backend_idf.cpp
+++ b/esphome/components/mqtt/mqtt_backend_idf.cpp
@@ -109,10 +109,7 @@ void MQTTBackendIDF::mqtt_event_handler_(const esp_mqtt_event_t &event) {
         topic = std::string(event.topic, event.topic_len);
       }
       ESP_LOGV(TAG, "MQTT_EVENT_DATA %s", topic.c_str());
-      auto data_len = event.data_len;
-      if (data_len == 0)
-        data_len = strlen(event.data);
-      this->on_message_.call(event.topic ? const_cast<char *>(topic.c_str()) : nullptr, event.data, data_len,
+      this->on_message_.call(event.topic ? const_cast<char *>(topic.c_str()) : nullptr, event.data, event.data_len,
                              event.current_data_offset, event.total_data_len);
     } break;
     case MQTT_EVENT_ERROR:

--- a/esphome/components/mqtt/mqtt_backend_idf.cpp
+++ b/esphome/components/mqtt/mqtt_backend_idf.cpp
@@ -69,7 +69,7 @@ void MQTTBackendIDF::loop() {
   }
 }
 
-void MQTTBackendIDF::mqtt_event_handler_(const esp_mqtt_event_t &event) {
+void MQTTBackendIDF::mqtt_event_handler_(const Event &event) {
   ESP_LOGV(TAG, "Event dispatched from event loop event_id=%d", event.event_id);
   switch (event.event_id) {
     case MQTT_EVENT_BEFORE_CONNECT:
@@ -104,25 +104,25 @@ void MQTTBackendIDF::mqtt_event_handler_(const esp_mqtt_event_t &event) {
       break;
     case MQTT_EVENT_DATA: {
       static std::string topic;
-      if (event.topic) {
-        // not 0 terminated - create a string from it
-        topic = std::string(event.topic, event.topic_len);
+      if (event.topic.length() > 0) {
+        topic = event.topic;
       }
       ESP_LOGV(TAG, "MQTT_EVENT_DATA %s", topic.c_str());
-      this->on_message_.call(event.topic ? const_cast<char *>(topic.c_str()) : nullptr, event.data, event.data_len,
+      this->on_message_.call(event.topic.length() > 0 ? topic.c_str() : nullptr,
+                             event.data.c_str(), event.data.length(),
                              event.current_data_offset, event.total_data_len);
     } break;
     case MQTT_EVENT_ERROR:
       ESP_LOGE(TAG, "MQTT_EVENT_ERROR");
-      if (event.error_handle->error_type == MQTT_ERROR_TYPE_TCP_TRANSPORT) {
-        ESP_LOGE(TAG, "Last error code reported from esp-tls: 0x%x", event.error_handle->esp_tls_last_esp_err);
-        ESP_LOGE(TAG, "Last tls stack error number: 0x%x", event.error_handle->esp_tls_stack_err);
-        ESP_LOGE(TAG, "Last captured errno : %d (%s)", event.error_handle->esp_transport_sock_errno,
-                 strerror(event.error_handle->esp_transport_sock_errno));
-      } else if (event.error_handle->error_type == MQTT_ERROR_TYPE_CONNECTION_REFUSED) {
-        ESP_LOGE(TAG, "Connection refused error: 0x%x", event.error_handle->connect_return_code);
+      if (event.error_handle.error_type == MQTT_ERROR_TYPE_TCP_TRANSPORT) {
+        ESP_LOGE(TAG, "Last error code reported from esp-tls: 0x%x", event.error_handle.esp_tls_last_esp_err);
+        ESP_LOGE(TAG, "Last tls stack error number: 0x%x", event.error_handle.esp_tls_stack_err);
+        ESP_LOGE(TAG, "Last captured errno : %d (%s)", event.error_handle.esp_transport_sock_errno,
+                 strerror(event.error_handle.esp_transport_sock_errno));
+      } else if (event.error_handle.error_type == MQTT_ERROR_TYPE_CONNECTION_REFUSED) {
+        ESP_LOGE(TAG, "Connection refused error: 0x%x", event.error_handle.connect_return_code);
       } else {
-        ESP_LOGE(TAG, "Unknown error type: 0x%x", event.error_handle->error_type);
+        ESP_LOGE(TAG, "Unknown error type: 0x%x", event.error_handle.error_type);
       }
       break;
     default:
@@ -137,7 +137,7 @@ void MQTTBackendIDF::mqtt_event_handler(void *handler_args, esp_event_base_t bas
   // queue event to decouple processing
   if (instance) {
     auto event = *static_cast<esp_mqtt_event_t *>(event_data);
-    instance->mqtt_events_.push(event);
+    instance->mqtt_events_.push(Event(event));
   }
 }
 

--- a/esphome/components/mqtt/mqtt_backend_idf.h
+++ b/esphome/components/mqtt/mqtt_backend_idf.h
@@ -14,7 +14,7 @@ namespace mqtt {
 
 struct Event {
   esp_mqtt_event_id_t event_id;
-  std::string data;
+  std::vector<char> data;
   int total_data_len;
   int current_data_offset;
   std::string topic;
@@ -28,7 +28,7 @@ struct Event {
   // Any pointer values that are unsafe to keep are converted to safe copies
   Event(const esp_mqtt_event_t &event)
       : event_id(event.event_id),
-        data(event.data, event.data_len),
+        data(event.data, event.data + event.data_len),
         total_data_len(event.total_data_len),
         current_data_offset(event.current_data_offset),
         topic(event.topic, event.topic_len),

--- a/esphome/components/mqtt/mqtt_backend_idf.h
+++ b/esphome/components/mqtt/mqtt_backend_idf.h
@@ -12,6 +12,28 @@
 namespace esphome {
 namespace mqtt {
 
+struct Event {
+  esp_mqtt_event_id_t event_id;
+  std::string data;
+  int total_data_len;
+  int current_data_offset;
+  std::string topic;
+  int msg_id;
+  bool retain;
+  int qos;
+  bool dup;
+  esp_mqtt_error_codes_t error_handle;
+
+  // Construct from esp_mqtt_event_t
+  // Any pointer values that are unsafe to keep are converted to safe copies
+  Event(esp_mqtt_event_t event):
+    event_id(event.event_id), data(event.data, event.data_len),
+    total_data_len(event.total_data_len), current_data_offset(event.current_data_offset),
+    topic(event.topic, event.topic_len), msg_id(event.msg_id),
+    retain(event.retain), qos(event.qos), dup(event.dup),
+    error_handle(*event.error_handle) {}
+};
+
 class MQTTBackendIDF final : public MQTTBackend {
  public:
   static const size_t MQTT_BUFFER_SIZE = 4096;
@@ -99,7 +121,7 @@ class MQTTBackendIDF final : public MQTTBackend {
 
  protected:
   bool initialize_();
-  void mqtt_event_handler_(const esp_mqtt_event_t &event);
+  void mqtt_event_handler_(const Event &event);
   static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
 
   struct MqttClientDeleter {
@@ -134,7 +156,7 @@ class MQTTBackendIDF final : public MQTTBackend {
   CallbackManager<on_unsubscribe_callback_t> on_unsubscribe_;
   CallbackManager<on_message_callback_t> on_message_;
   CallbackManager<on_publish_user_callback_t> on_publish_;
-  std::queue<esp_mqtt_event_t> mqtt_events_;
+  std::queue<Event> mqtt_events_;
 };
 
 }  // namespace mqtt

--- a/esphome/components/mqtt/mqtt_backend_idf.h
+++ b/esphome/components/mqtt/mqtt_backend_idf.h
@@ -26,12 +26,17 @@ struct Event {
 
   // Construct from esp_mqtt_event_t
   // Any pointer values that are unsafe to keep are converted to safe copies
-  Event(esp_mqtt_event_t event):
-    event_id(event.event_id), data(event.data, event.data_len),
-    total_data_len(event.total_data_len), current_data_offset(event.current_data_offset),
-    topic(event.topic, event.topic_len), msg_id(event.msg_id),
-    retain(event.retain), qos(event.qos), dup(event.dup),
-    error_handle(*event.error_handle) {}
+  Event(esp_mqtt_event_t event)
+      : event_id(event.event_id),
+        data(event.data, event.data_len),
+        total_data_len(event.total_data_len),
+        current_data_offset(event.current_data_offset),
+        topic(event.topic, event.topic_len),
+        msg_id(event.msg_id),
+        retain(event.retain),
+        qos(event.qos),
+        dup(event.dup),
+        error_handle(*event.error_handle) {}
 };
 
 class MQTTBackendIDF final : public MQTTBackend {

--- a/esphome/components/mqtt/mqtt_backend_idf.h
+++ b/esphome/components/mqtt/mqtt_backend_idf.h
@@ -26,7 +26,7 @@ struct Event {
 
   // Construct from esp_mqtt_event_t
   // Any pointer values that are unsafe to keep are converted to safe copies
-  Event(esp_mqtt_event_t event)
+  Event(const esp_mqtt_event_t &event)
       : event_id(event.event_id),
         data(event.data, event.data_len),
         total_data_len(event.total_data_len),


### PR DESCRIPTION
# What does this implement/fix?

See https://github.com/esphome/issues/issues/3406

This fixes invalid MQTT message topics and data under esp-idf due to unsafe copying of `esp_mqtt_event_t`:

https://github.com/esphome/esphome/blob/119a6920f2a82a9f77e42158c8fdf69755803a11/esphome/components/mqtt/mqtt_backend_idf.cpp#L142-L143

Whilst this copies the struct, the pointers in `data`, `topic` and `error_handle` are unsafe to retain beyond the `mqtt_event_handler` call, as they are owned by esp-mqtt and the data they point to may change before the event is then handled later in `mqtt_event_handler_`.

This error is most noticeable on boot, where many retained messages arrive in a short time and the buffer is highly likely to be reused before `mqtt_event_handler_` is called.

The fix is to produce a local `Event` type that correctly owns the event data buffers, such that it can be processed later without risk of dangling pointers.

I have tested this locally and no longer see `MQTT_EVENT_DATA` log messages with mangled topics.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3406

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no change to config)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esp32:
  board: <any>
  framework:
    type: esp-idf

mqtt:
  <any>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
