### PR TITLE
increase size filter range

### DIFF
--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -20,7 +20,7 @@ struct RemoteReceiverComponentStore {
   uint32_t buffer_read_at{0};
   bool overflow{false};
   uint32_t buffer_size{1000};
-  uint8_t filter_us{10};
+  uint32_t filter_us{10};
   ISRInternalGPIOPin pin;
 };
 #endif
@@ -45,7 +45,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_buffer_size(uint32_t buffer_size) { this->buffer_size_ = buffer_size; }
-  void set_filter_us(uint8_t filter_us) { this->filter_us_ = filter_us; }
+  void set_filter_us(uint32_t filter_us) { this->filter_us_ = filter_us; }
   void set_idle_us(uint32_t idle_us) { this->idle_us_ = idle_us; }
 
  protected:
@@ -61,7 +61,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
 #endif
 
   uint32_t buffer_size_{};
-  uint8_t filter_us_{10};
+  uint32_t filter_us_{10};
   uint32_t idle_us_{10000};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Increase size of the filter value from uint8 to unit32 to allow a large number than 255

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <[link to issue](https://github.com/esphome/issues/issues/3537)>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
remote_receiver:
  pin: D0
  dump:
    - rc_switch
  tolerance: 50%
  filter: 350us
  idle: 4ms
  buffer_size: 2kb
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
