### PR TITLE
Display the configured esphome:comment on the WebServer

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -2,12 +2,12 @@
 
 #include "web_server.h"
 
-#include "esphome/core/log.h"
-#include "esphome/core/application.h"
-#include "esphome/core/entity_base.h"
-#include "esphome/core/util.h"
 #include "esphome/components/json/json_util.h"
 #include "esphome/components/network/util.h"
+#include "esphome/core/application.h"
+#include "esphome/core/entity_base.h"
+#include "esphome/core/log.h"
+#include "esphome/core/util.h"
 
 #include "StreamString.h"
 
@@ -105,6 +105,7 @@ void WebServer::setup() {
 
     client->send(json::build_json([this](JsonObject root) {
                    root["title"] = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
+                   root["comment"] = App.get_comment();
                    root["ota"] = this->allow_ota_;
                    root["lang"] = "en";
                  }).c_str(),

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -2,11 +2,11 @@
 
 #include <string>
 #include <vector>
-#include "esphome/core/defines.h"
-#include "esphome/core/preferences.h"
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/preferences.h"
 #include "esphome/core/scheduler.h"
 
 #ifdef USE_BINARY_SENSOR
@@ -53,8 +53,8 @@ namespace esphome {
 
 class Application {
  public:
-  void pre_setup(const std::string &name, const std::string &friendly_name, const char *compilation_time,
-                 bool name_add_mac_suffix) {
+  void pre_setup(const std::string &name, const std::string &friendly_name, const std::string &comment,
+                 const char *compilation_time, bool name_add_mac_suffix) {
     arch_init();
     this->name_add_mac_suffix_ = name_add_mac_suffix;
     if (name_add_mac_suffix) {
@@ -68,6 +68,7 @@ class Application {
       this->name_ = name;
       this->friendly_name_ = friendly_name;
     }
+    this->comment_ = comment;
     this->compilation_time_ = compilation_time;
   }
 
@@ -138,11 +139,13 @@ class Application {
   /// Make a loop iteration. Call this in your loop() function.
   void loop();
 
-  /// Get the name of this Application set by set_name().
+  /// Get the name of this Application set by pre_setup().
   const std::string &get_name() const { return this->name_; }
 
-  /// Get the friendly name of this Application set by set_friendly_name().
+  /// Get the friendly name of this Application set by pre_setup().
   const std::string &get_friendly_name() const { return this->friendly_name_; }
+  /// Get the comment of this Application set by pre_setup().
+  const std::string &get_comment() const { return this->comment_; }
 
   bool is_name_add_mac_suffix_enabled() const { return this->name_add_mac_suffix_; }
 
@@ -349,6 +352,7 @@ class Application {
 
   std::string name_;
   std::string friendly_name_;
+  std::string comment_;
   std::string compilation_time_;
   bool name_add_mac_suffix_;
   uint32_t last_loop_{0};

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -350,6 +350,7 @@ async def to_code(config):
         cg.App.pre_setup(
             config[CONF_NAME],
             config[CONF_FRIENDLY_NAME],
+            config[CONF_COMMENT],
             cg.RawExpression('__DATE__ ", " __TIME__'),
             config[CONF_NAME_ADD_MAC_SUFFIX],
         )

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -350,7 +350,7 @@ async def to_code(config):
         cg.App.pre_setup(
             config[CONF_NAME],
             config[CONF_FRIENDLY_NAME],
-            config[CONF_COMMENT],
+            config.get(CONF_COMMENT, ""),
             cg.RawExpression('__DATE__ ", " __TIME__'),
             config[CONF_NAME_ADD_MAC_SUFFIX],
         )

--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -3,16 +3,16 @@
 // matter at all, as long as it compiles).
 // Not used during runtime nor for CI.
 
-#include <esphome/core/application.h>
-#include <esphome/components/logger/logger.h>
-#include <esphome/components/wifi/wifi_component.h>
-#include <esphome/components/ota/ota_component.h>
 #include <esphome/components/gpio/switch/gpio_switch.h>
+#include <esphome/components/logger/logger.h>
+#include <esphome/components/ota/ota_component.h>
+#include <esphome/components/wifi/wifi_component.h>
+#include <esphome/core/application.h>
 
 using namespace esphome;
 
 void setup() {
-  App.pre_setup("livingroom", "LivingRoom", __DATE__ ", " __TIME__, false);
+  App.pre_setup("livingroom", "LivingRoom", "comment", __DATE__ ", " __TIME__, false);
   auto *log = new logger::Logger(115200, 512);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);


### PR DESCRIPTION
This code displays the configured `esphome:comment` under the title on the web server.

- It does this by passing through the configured `esphome:comment` through to the App object during setup.
- This is then passed to the WebServer front end as part of the `ping` call.

Example:
```yaml
esphome:
  name: tester-d8407a
  comment: This Will appear in the WebConsole's header

esp8266:
  board: esp01_1m

# Enable logging
logger:

ota:

api:

web_server:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Tester-D8407A Fallback Hotspot"
    password: "lE7PR8uNHwlX"

captive_portal:
```

gives:
![image](https://user-images.githubusercontent.com/122615/210124071-90e35d62-d65f-4230-855b-244b5b22164f.png)

or with no comment configured, gives:
<img width="783" alt="image" src="https://user-images.githubusercontent.com/122615/210124660-81c374fe-be23-4c10-88ec-57fafc6636fc.png">

Note: 
- This requires esphome_frontend chage [esphome-webserver/PR24](https://github.com/esphome/esphome-webserver/pull/24)  to function correctly 
- This is backward compatible, so will not break functionality without the matching frontend version
<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** None

Note: No Doc Changes Required

**Pull request in [esphome-frontend](https://github.com/esphome/esphome-frontend) with relevant code changes:** 
https://github.com/esphome/esphome-webserver/pull/24

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] No changes in functionality or configuration variables.
