### PR TITLE
Fix graph limits for negative values

### DIFF
--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -122,8 +122,8 @@ void Graph::draw(DisplayBuffer *buff, uint16_t x_offset, uint16_t y_offset, Colo
   }
 
   // Adjust limits to nice y_per_div boundaries
-  int yn = int(ymin / y_per_div);
-  int ym = int(ymax / y_per_div) + int(1 * (fmodf(ymax, y_per_div) != 0));
+  int yn = floorf(ymin / y_per_div);
+  int ym = ceilf(ymax / y_per_div);
   ymin = yn * y_per_div;
   ymax = ym * y_per_div;
   yrange = ymax - ymin;


### PR DESCRIPTION
Round down min value instead of truncating using.
Use ceilf() to round up to max value.
The size of an example build decreased by 184 bytes Flash and 8 bytes RAM.

# What does this implement/fix?

This fixes graph limit calculation with negative values.
The previous truncation (rounding towards 0) led to wrong min value calculation and graph lines leaving the graph area.
You can also see a description and picture in the issue: 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
fixes [issue 3918](https://github.com/esphome/issues/issues/3918)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
not applicable

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
