### PR TITLE
Fix graph limits for negative values and other corner cases

### DIFF
--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -122,11 +122,18 @@ void Graph::draw(DisplayBuffer *buff, uint16_t x_offset, uint16_t y_offset, Colo
   }
 
   // Adjust limits to nice y_per_div boundaries
-  int yn = int(ymin / y_per_div);
-  int ym = int(ymax / y_per_div) + int(1 * (fmodf(ymax, y_per_div) != 0));
-  ymin = yn * y_per_div;
-  ymax = ym * y_per_div;
-  yrange = ymax - ymin;
+  int yn = 0;
+  int ym = 1;
+  if (!std::isnan(ymin) && !std::isnan(ymax)) {
+    yn = (int) floorf(ymin / y_per_div);
+    ym = (int) ceilf(ymax / y_per_div);
+    if (yn == ym) {
+      ym++;
+    }
+    ymin = yn * y_per_div;
+    ymax = ym * y_per_div;
+    yrange = ymax - ymin;
+  }
 
   /// Draw grid
   if (!std::isnan(this->gridspacing_y_)) {


### PR DESCRIPTION
Fix lower graph limit for negative values by rounding down instead of truncating. Consistently handle the corner cases: empty trace, min=max (e.g. single value) by drawing the grid lines for a single grid division.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
fixes https://github.com/esphome/issues/issues/3918

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
not applicable

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
# Bugfix tested with the following config.yaml
# LilyGO T5_V2.3_2.13

esphome:
  name: lilygo
  platform: ESP32
  board: esp32dev

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

# Home Assistant
api:

esp32_ble_tracker:
  scan_parameters:
    active: false

bluetooth_proxy:

binary_sensor:
  - platform: gpio
    pin:
        number: 39
        inverted: true
    name: "button"
    filters:
    - delayed_off: 10ms
    on_press:
        then:
          - component.update: epaper

sensor:
  - platform: homeassistant
    id: wzt
    entity_id: sensor.atc_livingroom_temperature
    filters:
      - delta: 0.2
    on_value:
        then:
          - component.update: epaper
  - platform: homeassistant
    id: wzh
    entity_id: sensor.atc_livingroom_humidity
    filters:
      - delta: 2
    on_value:
        then:
          - component.update: epaper

  - platform: homeassistant
    id: aut
    entity_id: sensor.atc_outside_temperature
    filters:
      - delta: 0.2
    on_value:
        then:
          - component.update: epaper
  - platform: homeassistant
    id: auh
    entity_id: sensor.atc_outside_humidity
    filters:
      - delta: 2
    on_value:
        then:
          - component.update: epaper

time:
  - platform: homeassistant
    id: esptime

graph:
  - id: aut_graph
    duration: 3min
    width: 122
    height: 85
    border: false
    x_grid: 1min
    y_grid: 10
    traces:
      - sensor: wzt
      - sensor: aut

spi:
    clk_pin: 18
    mosi_pin: 23

font:
  - file: Arial.ttf
    id: arial
    size: 16
    glyphs: '!"%()+=,-_.:°0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzÜ#'

display:
  - platform: waveshare_epaper
    id: epaper
    cs_pin: 5
    dc_pin: 17
    busy_pin: 4
    reset_pin: 16
    model: 2.13in-ttgo-b73
    #rotation: 180
    full_update_every: 100
    update_interval: 10s
    lambda: |-
      struct room {
          char const *name;
          Sensor *temp, *humi;
      };
      struct room const room_vec[] = {
          {"WZ",  wzt,  wzh },
          {"AU",  aut,  auh },
          {0},
      };
      int const x0 = 0; // compensate error from rotated display and wrong size: 122px (not 128px) x 250px
      int const y_inc = 18;
      static int update = 1;
      int y = 0;
      struct room const *p = room_vec;
      while (p->name) {
          int x = x0;
          it.printf(x, y, id(arial), p->name);
          x += 38;
          if (p->temp->has_state())
              it.printf(x, y, id(arial), "%.1f°", p->temp->get_state());
          x += 48;
          if (p->humi->has_state())
              it.printf(x, y, id(arial), "%.0f%%", p->humi->get_state());
          x += 38;
          y += y_inc;
          ++p;
      }
      it.graph(x0, y, id(aut_graph));
      it.printf(x0, y, id(arial), "WZT AUT 3h");
      y += 85;
      it.printf(x0, y, id(arial), "#%d", update++);
      it.strftime(x0+50, y, id(arial), "%H:%M", id(esptime).now());
      y += y_inc;

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
