### PR TITLE
Bump esp-idf to 4.4.3 via platformio/espressif32 @ 5.3.0

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -138,11 +138,11 @@ ARDUINO_PLATFORM_VERSION = cv.Version(5, 2, 0)
 # The default/recommended esp-idf framework version
 #  - https://github.com/espressif/esp-idf/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
-RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(4, 4, 2)
+RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(4, 4, 3)
 # The platformio/espressif32 version to use for esp-idf frameworks
 #  - https://github.com/platformio/platform-espressif32/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/platform/espressif32
-ESP_IDF_PLATFORM_VERSION = cv.Version(5, 2, 0)
+ESP_IDF_PLATFORM_VERSION = cv.Version(5, 3, 0)
 
 
 def _arduino_check_versions(value):

--- a/platformio.ini
+++ b/platformio.ini
@@ -133,9 +133,9 @@ extra_scripts = post:esphome/components/esp32/post_build.py.script
 ; This are common settings for the ESP32 (all variants) using IDF.
 [common:esp32-idf]
 extends = common:idf
-platform = platformio/espressif32 @ 5.2.0
+platform = platformio/espressif32 @ 5.3.0
 platform_packages =
-    platformio/framework-espidf @ ~3.40402.0
+    platformio/framework-espidf @ ~3.40403.0
 
 framework = espidf
 lib_deps =


### PR DESCRIPTION
# What does this implement/fix?

The new version appears to improve the stability of BLE + WiFi in testing and there are multiple bluetooth fixes in the changelog.

https://github.com/espressif/esp-idf/releases/tag/v4.4.3
changelog: https://github.com/espressif/esp-idf/compare/v4.4.2...v4.4.3
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
