### PR TITLE
Fix cut-off on 2.13" waveshare/ttgo epaper displays

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -137,7 +137,7 @@ void HOT WaveshareEPaper::draw_absolute_pixel_internal(int x, int y, Color color
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
 
-  const uint32_t pos = (x + y * this->get_width_internal()) / 8u;
+  const uint32_t pos = (x + y * this->get_width_controller()) / 8u;
   const uint8_t subpos = x & 0x07;
   // flip logic
   if (!color.is_on()) {
@@ -146,7 +146,9 @@ void HOT WaveshareEPaper::draw_absolute_pixel_internal(int x, int y, Color color
     this->buffer_[pos] &= ~(0x80 >> subpos);
   }
 }
-uint32_t WaveshareEPaper::get_buffer_length_() { return this->get_width_internal() * this->get_height_internal() / 8u; }
+uint32_t WaveshareEPaper::get_buffer_length_() {
+  return this->get_width_controller() * this->get_height_internal() / 8u;
+}
 void WaveshareEPaper::start_command_() {
   this->dc_pin_->digital_write(false);
   this->enable();
@@ -291,7 +293,7 @@ void HOT WaveshareEPaperTypeA::display() {
       // COMMAND SET RAM X ADDRESS START END POSITION
       this->command(0x44);
       this->data(0x00);
-      this->data((this->get_width_internal() - 1) >> 3);
+      this->data((this->get_width_controller() - 1) >> 3);
       // COMMAND SET RAM Y ADDRESS START END POSITION
       this->command(0x45);
       this->data(this->get_height_internal() - 1);
@@ -392,11 +394,25 @@ int WaveshareEPaperTypeA::get_width_internal() {
     case TTGO_EPAPER_2_13_IN_B73:
     case TTGO_EPAPER_2_13_IN_B74:
     case TTGO_EPAPER_2_13_IN_B1:
+      return 122;
     case WAVESHARE_EPAPER_2_9_IN:
     case WAVESHARE_EPAPER_2_9_IN_V2:
       return 128;
   }
   return 0;
+}
+// The controller of the 2.13" displays has a buffer larger than screen size
+int WaveshareEPaperTypeA::get_width_controller() {
+  switch (this->model_) {
+    case WAVESHARE_EPAPER_2_13_IN:
+    case TTGO_EPAPER_2_13_IN:
+    case TTGO_EPAPER_2_13_IN_B73:
+    case TTGO_EPAPER_2_13_IN_B74:
+    case TTGO_EPAPER_2_13_IN_B1:
+      return 128;
+    default:
+      return this->get_width_internal();
+  }
 }
 int WaveshareEPaperTypeA::get_height_internal() {
   switch (this->model_) {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -54,6 +54,8 @@ class WaveshareEPaper : public PollingComponent,
     }
   }
 
+  virtual int get_width_controller() { return this->get_width_internal(); };
+
   uint32_t get_buffer_length_();
   uint32_t reset_duration_{200};
 
@@ -110,6 +112,8 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   int get_width_internal() override;
 
   int get_height_internal() override;
+
+  int get_width_controller() override;
 
   uint32_t full_update_every_{30};
   uint32_t at_update_{0};


### PR DESCRIPTION
# What does this implement/fix?

The controller of the 2.13" waveshare/ttgo epaper displays operates with a 128x250 buffer, while only 122x250 pixels are shown. While this can be ignored for rotations 0/270°, with roations 90/180°, 6 pixels are cut-off from the top or left edge. This change introduces a distinction between object width and controller width, resulting in pixel-perfect rotations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
# Tested with the following config.yaml
# LilyGO T5_V2.3_2.13

esphome:
  name: lilygo
  platform: ESP32
  board: esp32dev

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

# Home Assistant
api:

esp32_ble_tracker:
  scan_parameters:
    active: false

bluetooth_proxy:

binary_sensor:
  - platform: gpio
    pin:
        number: 39
        inverted: true
    name: "button"
    filters:
    - delayed_off: 10ms
    on_press:
        then:
          - component.update: epaper

sensor:
  - platform: homeassistant
    id: wzt
    entity_id: sensor.atc_livingroom_temperature
    filters:
      - delta: 0.2
    on_value:
        then:
          - component.update: epaper
  - platform: homeassistant
    id: wzh
    entity_id: sensor.atc_livingroom_humidity
    filters:
      - delta: 2
    on_value:
        then:
          - component.update: epaper

  - platform: homeassistant
    id: aut
    entity_id: sensor.atc_outside_temperature
    filters:
      - delta: 0.2
    on_value:
        then:
          - component.update: epaper
  - platform: homeassistant
    id: auh
    entity_id: sensor.atc_outside_humidity
    filters:
      - delta: 2
    on_value:
        then:
          - component.update: epaper

time:
  - platform: homeassistant
    id: esptime

graph:
  - id: aut_graph
    duration: 3min
    width: 122
    height: 85
    border: false
    x_grid: 1min
    y_grid: 10
    traces:
      - sensor: wzt
      - sensor: aut

spi:
    clk_pin: 18
    mosi_pin: 23

font:
  - file: Arial.ttf
    id: arial
    size: 16
    glyphs: '!"%()+=,-_.:°0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzÜ#'

display:
  - platform: waveshare_epaper
    id: epaper
    cs_pin: 5
    dc_pin: 17
    busy_pin: 4
    reset_pin: 16
    model: 2.13in-ttgo-b73
    rotation: 180
    full_update_every: 100
    update_interval: 10s
    lambda: |-
      struct room {
          char const *name;
          Sensor *temp, *humi;
      };
      struct room const room_vec[] = {
          {"WZ",  wzt,  wzh },
          {"AU",  aut,  auh },
          {0},
      };
      int const x0 = 0; // 6 pixel offset to compensate rotation error is not needed anymore!
      int const y_inc = 18;
      static int update = 1;
      int y = 0;
      struct room const *p = room_vec;
      while (p->name) {
          int x = x0;
          it.printf(x, y, id(arial), p->name);
          x += 38;
          if (p->temp->has_state())
              it.printf(x, y, id(arial), "%.1f°", p->temp->get_state());
          x += 48;
          if (p->humi->has_state())
              it.printf(x, y, id(arial), "%.0f%%", p->humi->get_state());
          x += 38;
          y += y_inc;
          ++p;
      }
      it.graph(x0, y, id(aut_graph));
      it.printf(x0, y, id(arial), "WZT AUT 3h");
      y += 85;
      it.printf(x0, y, id(arial), "#%d", update++);
      it.strftime(x0+50, y, id(arial), "%H:%M", id(esptime).now());
      y += y_inc;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
