### PR TITLE
Generate main.h to access globals externally

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -781,12 +781,10 @@ class EsphomeCore:
             text = str(statement(exp))
             text = text.rstrip()
             if "*" in text:
-                exports_code.append('extern '+text)
+                exports_code.append("extern " + text)
             elif text.startswith("using"):
                 exports_code.append(text)
         return "\n".join(exports_code) + "\n"
-
-
 
 
 class AutoLoad(OrderedDict):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -772,6 +772,22 @@ class EsphomeCore:
             global_code.append(text)
         return "\n".join(global_code) + "\n"
 
+    @property
+    def cpp_exports_section(self):
+        from esphome.cpp_generator import statement
+
+        exports_code = []
+        for exp in self.global_statements:
+            text = str(statement(exp))
+            text = text.rstrip()
+            if "*" in text:
+                exports_code.append('extern '+text)
+            elif text.startswith("using"):
+                exports_code.append(text)
+        return "\n".join(exports_code) + "\n"
+
+
+
 
 class AutoLoad(OrderedDict):
     pass

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -341,7 +341,7 @@ def write_cpp(code_s):
     path = CORE.relative_src_path("main.h")
     export_s = '#ifndef _main_h_\n'
     export_s += '#define _main_h_\n'
-    export_s += '#export "esphome.h"\n'
+    export_s += '#include "esphome.h"\n'
     export_s += CORE.cpp_exports_section
     export_s += '#endif'
     write_file_if_changed(path, export_s)

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -339,13 +339,12 @@ def write_cpp(code_s):
     write_file_if_changed(path, full_file)
 
     path = CORE.relative_src_path("main.h")
-    export_s = '#ifndef _main_h_\n'
-    export_s += '#define _main_h_\n'
+    export_s = "#ifndef _main_h_\n"
+    export_s += "#define _main_h_\n"
     export_s += '#include "esphome.h"\n'
     export_s += CORE.cpp_exports_section
-    export_s += '#endif'
+    export_s += "#endif"
     write_file_if_changed(path, export_s)
-
 
 
 def clean_build():

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -328,6 +328,7 @@ def write_cpp(code_s):
 
     copy_src_tree()
     global_s = '#include "esphome.h"\n'
+    global_s += '#include "main.h"\n'
     global_s += CORE.cpp_global_section
 
     full_file = f"{code_format[0] + CPP_INCLUDE_BEGIN}\n{global_s}{CPP_INCLUDE_END}"
@@ -336,6 +337,15 @@ def write_cpp(code_s):
     )
     full_file += code_format[2]
     write_file_if_changed(path, full_file)
+
+    path = CORE.relative_src_path("main.h")
+    export_s = '#ifndef _main_h_\n'
+    export_s += '#define _main_h_\n'
+    export_s += '#export "esphome.h"\n'
+    export_s += CORE.cpp_exports_section
+    export_s += '#endif'
+    write_file_if_changed(path, export_s)
+
 
 
 def clean_build():


### PR DESCRIPTION
Generate main.h which holds all global variables (things with pointers) so you could use id(...) in an external cpp file (which is supported by the includes directive)

# What does this implement/fix?
<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
[esphome/issues#4004](https://github.com/esphome/issues/issues/4004)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 
Will write documentation when this pull request is agreed upon :)
## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: "${device_name}"
  includes:
    - test.h
    - test.cpp
  on_boot:
    priority: 200
    then: 
      - lambda: !lambda test();
```
test.cpp
```c
#include "main.h"
#include "test.h"

void test()
{
  ESP_LOGD("test", "%f", id(input_fan_speed).state);
}
```
test.h
```c
#ifndef _test_h_
#define _test_h_

extern void test();

#endif
```
## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
