### PR TITLE
Dashboard args for HTTPS

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -792,6 +792,18 @@ def parse_args(argv):
     parser_dashboard.add_argument(
         "--socket", help="Make the dashboard serve under a unix socket", type=str
     )
+    parser_dashboard.add_argument(
+        "--cert",
+        help="The optional path to the full chain pem file to use for HTTPS",
+        type=str,
+        default="",
+    )
+    parser_dashboard.add_argument(
+        "--key",
+        help="The path to the private key pem file to use for HTTPS",
+        type=str,
+        default="",
+    )
 
     parser_vscode = subparsers.add_parser("vscode")
     parser_vscode.add_argument("configuration", help="Your YAML configuration file.")

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -69,7 +69,7 @@ class DashboardSettings:
             self.password_hash = password_hash(password)
         self.config_dir = args.configuration
         self.ssl_cert_path = args.cert or os.getenv("ESPHOME_DASHBOARD_CERT_PATH", "")
-        self.ssl_key_path = args.privkey or os.getenv("ESPHOME_DASHBOARD_KEY_PATH", "")
+        self.ssl_key_path = args.key or os.getenv("ESPHOME_DASHBOARD_KEY_PATH", "")
 
     @property
     def relative_url(self):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -87,7 +87,7 @@ class DashboardSettings:
 
     @property
     def using_ssl(self):
-        return not self.ssl_cert_path == "" and not self.ssl_key_path == ""
+        return self.ssl_cert_path != "" and self.ssl_key_path != ""
 
     @property
     def using_auth(self):


### PR DESCRIPTION
# What does this implement/fix?

Adds arguments to the dashboard command to allow passing SSL certificate pem files to serve the dashboard over HTTPS without the need for proxies.

The `--cert` argument takes the full, not relative path to the full chain pem file,
The `--key` argument takes the full, not relative path to the private key pem file, 

These can also be passes as environmental variables `ESPHOME_DASHBOARD_CERT_PATH` and `ESPHOME_DASHBOARD_KEY_PATH` respectively.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2575

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

**Note**: I could not find existing tests for the dashboard to expand upon and starting them from scratch is beyond my ability

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
