### PR TITLE
Fix HttpRequestResponseTrigger

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -31,7 +31,10 @@ struct Header {
   const char *value;
 };
 
-class HttpRequestResponseTrigger;
+class HttpRequestResponseTrigger : public Trigger<int32_t> {
+ public:
+  void process(int32_t status_code) { this->trigger(status_code); }
+};
 
 class HttpRequestComponent : public Component {
  public:
@@ -136,11 +139,6 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
   std::map<const char *, TemplatableValue<std::string, Ts...>> json_{};
   std::function<void(Ts..., JsonObject)> json_func_{nullptr};
   std::vector<HttpRequestResponseTrigger *> response_triggers_;
-};
-
-class HttpRequestResponseTrigger : public Trigger<int> {
- public:
-  void process(int status_code) { this->trigger(status_code); }
 };
 
 }  // namespace http_request


### PR DESCRIPTION
# What does this implement/fix?

This fixes HttpRequestResponseTrigger which does not compile correctly with toolchain-riscv32-esp.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4010

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Minimal yaml reproducing the problem.
wifi:
  ssid: 'ssid'

esp32:
  # nodemcu-32s works fine
  # board: nodemcu-32s
  # but lolin_c3_mini does not
  board: lolin_c3_mini
  framework:
    type: arduino

esphome:
  name: 'on-response-test'
  on_boot:
    then:
      - http_request.send:
          method: PUT
          url: https://esphome.io
          headers:
            Content-Type: application/json
          body: Some data
          verify_ssl: false
          on_response:
            then:
              - logger.log:
                  format: "Response status: %d"
                  args:
                    - status_code

logger:

http_request:
  useragent: esphome/tagreader
  timeout: 10s

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
