### PR TITLE
http_request: add request duration logging

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -195,6 +195,8 @@ async def http_request_action_to_code(config, action_id, template_arg, args):
     for conf in config.get(CONF_ON_RESPONSE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
         cg.add(var.register_response_trigger(trigger))
-        await automation.build_automation(trigger, [(int, "status_code")], conf)
+        await automation.build_automation(
+            trigger, [(int, "status_code"), (cg.uint32, "duration_ms")], conf
+        )
 
     return var

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -66,6 +66,9 @@ void HttpRequestComponent::send(const std::vector<HttpRequestResponseTrigger *> 
   }
 
   this->client_.setTimeout(this->timeout_);
+#if defined(USE_ESP32)
+  this->client_.setConnectTimeout(this->timeout_);
+#endif
   if (this->useragent_ != nullptr) {
     this->client_.setUserAgent(this->useragent_);
   }
@@ -73,25 +76,27 @@ void HttpRequestComponent::send(const std::vector<HttpRequestResponseTrigger *> 
     this->client_.addHeader(header.name, header.value, false, true);
   }
 
+  uint32_t start_time = millis();
   int http_code = this->client_.sendRequest(this->method_, this->body_.c_str());
+  uint32_t duration = millis() - start_time;
   for (auto *trigger : response_triggers)
-    trigger->process(http_code);
+    trigger->process(http_code, duration);
 
   if (http_code < 0) {
-    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s", this->url_.c_str(),
-             HTTPClient::errorToString(http_code).c_str());
+    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s; Duration: %u ms", this->url_.c_str(),
+             HTTPClient::errorToString(http_code).c_str(), duration);
     this->status_set_warning();
     return;
   }
 
   if (http_code < 200 || http_code >= 300) {
-    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Code: %d", this->url_.c_str(), http_code);
+    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Code: %d; Duration: %u ms", this->url_.c_str(), http_code, duration);
     this->status_set_warning();
     return;
   }
 
   this->status_clear_warning();
-  ESP_LOGD(TAG, "HTTP Request completed; URL: %s; Code: %d", this->url_.c_str(), http_code);
+  ESP_LOGD(TAG, "HTTP Request completed; URL: %s; Code: %d; Duration: %u ms", this->url_.c_str(), http_code, duration);
 }
 
 #ifdef USE_ESP8266

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -138,9 +138,9 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
   std::vector<HttpRequestResponseTrigger *> response_triggers_;
 };
 
-class HttpRequestResponseTrigger : public Trigger<int> {
+class HttpRequestResponseTrigger : public Trigger<int, uint32_t> {
  public:
-  void process(int status_code) { this->trigger(status_code); }
+  void process(int status_code, uint32_t duration_ms) { this->trigger(status_code, duration_ms); }
 };
 
 }  // namespace http_request


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a few minor changes to `http_request` component:
1. Add request duration to logs (successful and failed requests)
2. Add `duration_ms` additional parameter (besides `status_code`) to `on_response` handler
3. Set connect timeout for ESP32 `client_->setConnectTimeout(timeout)`

Here is example log with these changes:
```
[21:44:17][D][main:216]: Response status: -11, Duration: 1219
[21:44:17][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: read Timeout; Duration: 1219 ms
[21:44:18][D][main:216]: Response status: -11, Duration: 1197
[21:44:18][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: read Timeout; Duration: 1197 ms
[21:44:19][D][main:216]: Response status: 200, Duration: 347
[21:44:19][D][http_request:098]: HTTP Request completed; URL: http://******.***/; Code: 200; Duration: 347 ms
[21:44:19][D][main:216]: Response status: 200, Duration: 458
[21:44:19][D][http_request:098]: HTTP Request completed; URL: http://******.***/; Code: 200; Duration: 458 ms
[21:44:21][D][main:216]: Response status: -11, Duration: 1181
[21:44:21][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: read Timeout; Duration: 1181 ms
[21:44:22][D][main:216]: Response status: -11, Duration: 1207
[21:44:22][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: read Timeout; Duration: 1207 ms
[21:44:24][D][main:216]: Response status: -5, Duration: 1018
[21:44:24][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection lost; Duration: 1018 ms
[21:44:24][D][main:216]: Response status: -1, Duration: 180
[21:44:24][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 180 ms
[21:44:24][D][main:216]: Response status: -1, Duration: 160
[21:44:24][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 160 ms
[21:44:25][D][main:216]: Response status: -1, Duration: 185
[21:44:25][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 185 ms
[21:44:26][D][main:216]: Response status: -1, Duration: 208
[21:44:26][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 208 ms
[21:44:27][D][main:216]: Response status: -1, Duration: 131
[21:44:27][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 131 ms
[21:44:28][D][main:216]: Response status: -1, Duration: 156
[21:44:28][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 156 ms
[21:44:29][D][main:216]: Response status: -1, Duration: 176
[21:44:29][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 176 ms
[21:44:30][D][main:216]: Response status: -1, Duration: 203
[21:44:30][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: connection refused; Duration: 203 ms
[21:44:32][D][main:216]: Response status: 200, Duration: 947
[21:44:32][D][http_request:098]: HTTP Request completed; URL: http://******.***/; Code: 200; Duration: 947 ms
[21:44:33][D][main:216]: Response status: 200, Duration: 1072
[21:44:33][D][http_request:098]: HTTP Request completed; URL: http://******.***/; Code: 200; Duration: 1072 ms
[21:44:34][D][main:216]: Response status: -11, Duration: 1184
[21:44:34][W][http_request:086]: HTTP Request failed; URL: http://******.***/; Error: read Timeout; Duration: 1184 ms
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** https://github.com/esphome/issues/issues/2853 - it doesn't fix this issue, but it could be useful for debugging such cases, and also setting connect timeout could help avoiding WDT firing if connection takes long time to establish.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/2578

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

http_request:
  timeout: 1s

interval:
  - interval: 1sec
    then:
      - http_request.get:
          url: http://google.com
          on_response: 
            then:
              - logger.log:
                  format: 'Response status: %d, Duration: %d'
                  args:
                    - status_code
                    - duration_ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
