### PR TITLE
fix: json compilation error on rp2040

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -7,6 +7,9 @@
 #ifdef USE_ESP32
 #include <esp_heap_caps.h>
 #endif
+#ifdef USE_RP2040
+#include <Arduino.h>
+#endif
 
 namespace esphome {
 namespace json {

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -70,7 +70,7 @@ void parse_json(const std::string &data, const json_parse_t &f) {
   const size_t free_heap = rp2040.getFreeHeap();
 #endif
   bool pass = false;
-  size_t request_size = std::min(free_heap, (size_t) (data.size() * 1.5));
+  size_t request_size = std::min(free_heap, (size_t)(data.size() * 1.5));
   do {
     DynamicJsonDocument json_document(request_size);
     if (json_document.capacity() == 0) {

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -24,6 +24,8 @@ std::string build_json(const json_build_t &f) {
   const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
 #elif defined(USE_ESP32)
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+#elif defined(USE_RP2040)
+  const size_t free_heap = rp2040.getFreeHeap();
 #endif
 
   size_t request_size = std::min(free_heap, (size_t) 512);
@@ -64,9 +66,11 @@ void parse_json(const std::string &data, const json_parse_t &f) {
   const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
 #elif defined(USE_ESP32)
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+#elif defined(USE_RP2040)
+  const size_t free_heap = rp2040.getFreeHeap();
 #endif
   bool pass = false;
-  size_t request_size = std::min(free_heap, (size_t)(data.size() * 1.5));
+  size_t request_size = std::min(free_heap, (size_t) (data.size() * 1.5));
   do {
     DynamicJsonDocument json_document(request_size);
     if (json_document.capacity() == 0) {


### PR DESCRIPTION
# What does this implement/fix?

This is an itsy-bitsy change to the `json` component to make it compile correctly on RP2040. I noticed that [khoih-prog/AsyncWebServer_RP2040W](https://github.com/khoih-prog/AsyncWebServer_RP2040W) is a near drop in replacement for [esphome/ESPAsyncWebServer](https://github.com/esphome/ESPAsyncWebServer), which is awesome, but using `web_server` requires `json` which will not compile on RP2040 due to allocating memory on the heap.

<!-- Quick description and explanation of changes -->

Helpfully, the Arduino-pico core provides a function to allocate heap space on RP2040, so this is a simple 4 line change to use that allocation method if running on RP2040.

I made other changes that are not part of this PR in order to get the web server to work on RP2040. I'm not submitting them here because it requires a library change, and I'm guessing that you'd like to make changes in your own libraries instead. If you're interested, the details of my changes are at https://github.com/kellertk/kellertk-esphome-configs/tree/main/local_components

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [X] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
web_server:
  js_include: "./web_server/www.js"
  js_url: ""
  version: 2
  ota: false
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
