### PR TITLE
Fix frequency limit for MCP9600

### DIFF
--- a/esphome/components/mcp9600/sensor.py
+++ b/esphome/components/mcp9600/sensor.py
@@ -58,7 +58,7 @@ CONFIG_SCHEMA = (
 )
 
 FINAL_VALIDATE_SCHEMA = i2c.final_validate_device_schema(
-    "mcp9600", min_frequency="100khz"
+    "mcp9600", min_frequency="10khz"
 )
 
 


### PR DESCRIPTION
# What does this implement/fix? 
According to data sheet the possible Frequency may range from 10 to 100 kHZ
<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3876

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
