### PR TITLE
Fix Template Switch restore_mode support

### DIFF
--- a/esphome/components/template/switch/template_switch.cpp
+++ b/esphome/components/template/switch/template_switch.cpp
@@ -43,15 +43,16 @@ void TemplateSwitch::setup() {
   if (!this->restore_state_)
     return;
 
-  auto restored = this->get_initial_state();
-  if (!restored.has_value())
-    return;
+  optional<bool> initial_state = this->get_initial_state_with_restore_mode();
 
-  ESP_LOGD(TAG, "  Restored state %s", ONOFF(*restored));
-  if (*restored) {
-    this->turn_on();
-  } else {
-    this->turn_off();
+  if (initial_state.has_value()) {
+    ESP_LOGD(TAG, "  Restored state %s", ONOFF(initial_state.value()));
+    // if it has a value, restore_mode is not "DISABLED", therefore act on the switch:
+    if (initial_state.value()) {
+      this->turn_on();
+    } else {
+      this->turn_off();
+    }
   }
 }
 void TemplateSwitch::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Template Switch didn't support `restore_mode`, changing the call to `get_initial_state_with_restore_mode` allows the state to be restored correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4020

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
