### PR TITLE
Fix HttpRequestResponseTrigger again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
             file: tests/test6.yaml
             name: Test tests/test6.yaml
             pio_cache_key: test6
+          - id: test
+            file: tests/test7.yaml
+            name: Test tests/test7.yaml
+            pio_cache_key: test7
           - id: pytest
             name: Run pytest
           - id: clang-format

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -31,9 +31,9 @@ struct Header {
   const char *value;
 };
 
-class HttpRequestResponseTrigger : public Trigger<int, uint32_t> {
+class HttpRequestResponseTrigger : public Trigger<int32_t, uint32_t> {
  public:
-  void process(int status_code, uint32_t duration_ms) { this->trigger(status_code, duration_ms); }
+  void process(int32_t status_code, uint32_t duration_ms) { this->trigger(status_code, duration_ms); }
 };
 
 class HttpRequestComponent : public Component {

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,3 +25,4 @@ Current test_.yaml file contents.
 | test4.yaml | ESP32 | ethernet | None
 | test5.yaml | ESP32 | wifi | ble_server
 | test6.yaml | RP2040 | wifi | N/A
+| test7.yaml | ESP32-C3 | wifi | N/A

--- a/tests/test7.yaml
+++ b/tests/test7.yaml
@@ -1,0 +1,33 @@
+# Tests for ESP32-C3 boards which use toolchain-riscv32-esp
+---
+wifi:
+  ssid: 'ssid'
+
+esp32:
+  board: lolin_c3_mini
+  framework:
+    type: arduino
+
+esphome:
+  name: 'on-response-test'
+  on_boot:
+    then:
+      - http_request.send:
+          method: PUT
+          url: https://esphome.io
+          headers:
+            Content-Type: application/json
+          body: Some data
+          verify_ssl: false
+          on_response:
+            then:
+              - logger.log:
+                  format: "Response status: %d"
+                  args:
+                    - status_code
+
+logger:
+
+http_request:
+  useragent: esphome/tagreader
+  timeout: 10s


### PR DESCRIPTION
# What does this implement/fix?

This fixes HttpRequestResponseTrigger which does not compile correctly with toolchain-riscv32-esp.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4010

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Minimal yaml reproducing the problem.
wifi:
  ssid: 'ssid'

esp32:
  # nodemcu-32s works fine
  # board: nodemcu-32s
  # but lolin_c3_mini does not
  board: lolin_c3_mini
  framework:
    type: arduino

esphome:
  name: 'on-response-test'
  on_boot:
    then:
      - http_request.send:
          method: PUT
          url: https://esphome.io
          headers:
            Content-Type: application/json
          body: Some data
          verify_ssl: false
          on_response:
            then:
              - logger.log:
                  format: "Response status: %d"
                  args:
                    - status_code

logger:

http_request:
  useragent: esphome/tagreader
  timeout: 10s

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
