### PR TITLE
Allow 0xA8 ID for APDS9960

### DIFF
--- a/esphome/components/apds9960/apds9960.cpp
+++ b/esphome/components/apds9960/apds9960.cpp
@@ -23,7 +23,7 @@ void APDS9960::setup() {
     return;
   }
 
-  if (id != 0xAB && id != 0x9C) {  // APDS9960 all should have one of these IDs
+  if (id != 0xAB && id != 0x9C && id != 0xA8) {  // APDS9960 all should have one of these IDs
     this->error_code_ = WRONG_ID;
     this->mark_failed();
     return;


### PR DESCRIPTION
# What does this implement/fix?

APDS9960 can have device ID of `0xA8`. 
Both Tasmota and Sparkfun Libraries allow `0xA8`:
https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor/pull/25
https://github.com/arendst/Tasmota/issues/8161

There have been [concerns](https://github.com/esphome/issues/issues/736) that `0xA8` represents clones that don't work in the same way. In my experience, and in the cases of others requesting the above pull requests to other projects, chips with `0xA8` are fully functional.

If you don't trust `0xA8` chips, a reasonable alternative could be to warn rather than error if `0xA8` is found.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/736

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
