### PR TITLE
Calculate PWM wrap dynamically whenever the frequency is changed

### DIFF
--- a/esphome/components/rp2040_pwm/rp2040_pwm.cpp
+++ b/esphome/components/rp2040_pwm/rp2040_pwm.cpp
@@ -26,7 +26,7 @@ void RP2040PWM::setup_pwm_() {
   pwm_config config = pwm_get_default_config();
 
   uint32_t clock = clock_get_hz(clk_sys);
-  float divider = ceil(clock / (4096 * this-> frequency_)) / 16.0f;
+  float divider = ceil(clock / (4096 * this->frequency_)) / 16.0f;
   uint16_t wrap = clock / divider / this->frequency_ - 1;
   this->wrap_ = wrap;
 

--- a/esphome/components/rp2040_pwm/rp2040_pwm.cpp
+++ b/esphome/components/rp2040_pwm/rp2040_pwm.cpp
@@ -9,6 +9,7 @@
 #include <hardware/clocks.h>
 #include <hardware/gpio.h>
 #include <hardware/pwm.h>
+#include <cmath>
 
 namespace esphome {
 namespace rp2040_pwm {
@@ -23,8 +24,14 @@ void RP2040PWM::setup() {
 
 void RP2040PWM::setup_pwm_() {
   pwm_config config = pwm_get_default_config();
-  pwm_config_set_clkdiv(&config, clock_get_hz(clk_sys) / (255.0f * this->frequency_));
-  pwm_config_set_wrap(&config, 254);
+
+  uint32_t clock = clock_get_hz(clk_sys);
+  float divider = ceil(clock / (4096 * this-> frequency_)) / 16.0f;
+  uint16_t wrap = clock / divider / this->frequency_ - 1;
+  this->wrap_ = wrap;
+
+  pwm_config_set_clkdiv(&config, divider);
+  pwm_config_set_wrap(&config, wrap);
   pwm_init(pwm_gpio_to_slice_num(this->pin_->get_pin()), &config, true);
 }
 
@@ -48,7 +55,7 @@ void HOT RP2040PWM::write_state(float state) {
   }
 
   gpio_set_function(this->pin_->get_pin(), GPIO_FUNC_PWM);
-  pwm_set_gpio_level(this->pin_->get_pin(), state * 255.0f);
+  pwm_set_gpio_level(this->pin_->get_pin(), state * this->wrap_);
 }
 
 }  // namespace rp2040_pwm

--- a/esphome/components/rp2040_pwm/rp2040_pwm.h
+++ b/esphome/components/rp2040_pwm/rp2040_pwm.h
@@ -34,6 +34,7 @@ class RP2040PWM : public output::FloatOutput, public Component {
 
   InternalGPIOPin *pin_;
   float frequency_{1000.0};
+  uint16_t wrap_{65535};
   /// Cache last output level for dynamic frequency updating
   float last_output_{0.0};
   bool frequency_changed_{false};


### PR DESCRIPTION
# What does this implement/fix?
Calculates the PWM wrap and divider pair based on the calculations [here](https://www.i-programmer.info/programming/hardware/14849-the-pico-in-c-basic-pwm.html?start=2) in order to support a broader range of frequencies at the best possible granularity.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [3841](https://github.com/esphome/issues/issues/3841)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: a-pico

rp2040:
  board: rpipicow
  framework:
    # Required until https://github.com/platformio/platform-raspberrypi/pull/36 is merged
    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git

# Enable logging
logger:

# Enable Home Assistant API
api:
  password: ""

ota:
  password: ""

wifi:
  ssid: "somefakewifiname"
  password: "hahanope"
  manual_ip:
    static_ip: 192.168.x.x
    gateway: 192.168.x.x
    subnet: 255.255.255.0

output:
  - platform: rp2040_pwm
    id: pwm_out
    pin: 0
    frequency: 50Hz

switch:
  platform: template
  name: "Servo test switch"
  id: servo_test
  optimistic: True
  turn_on_action:
    servo.write:
      id: serv
      level: -100%
  turn_off_action:
    servo.write:
      id: serv
      level: 100%
servo:
  id: serv
  output: pwm_out
  min_level: 2.5%
  max_level: 12.5%
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
I can add a test if you want me to, something like verifying that the calculated frequency based on the generated divider and wrap closely matches the desired frequency. I haven't yet done so because it doesn't really look like the `tests/component_tests` directory gets much use.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
