### PR TITLE
Update ESP8266 wifi SoftAP DhcpServer to support Arduino 3.1.x

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -26,6 +26,12 @@ extern "C" {
 #define wifi_softap_set_dhcps_lease_time(time) dhcpSoftAP.set_dhcps_lease_time(time)
 #define wifi_softap_set_dhcps_offer_option(offer, mode) dhcpSoftAP.set_dhcps_offer_option(offer, mode)
 #endif
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 1, 0)
+auto &dhcpServer = WiFi.softAPDhcpServer();
+#define wifi_softap_set_dhcps_lease(lease) dhcpServer.set_dhcps_lease(lease)
+#define wifi_softap_set_dhcps_lease_time(time) dhcpServer.set_dhcps_lease_time(time)
+#define wifi_softap_set_dhcps_offer_option(offer, mode) dhcpServer.set_dhcps_offer_option(offer, mode)
+#endif
 }
 
 #include "esphome/core/helpers.h"

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -20,7 +20,7 @@ extern "C" {
 #if LWIP_IPV6
 #include "lwip/netif.h"  // struct netif
 #endif
-#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0) && USE_ARDUINO_VERSION_CODE < VERSION_CODE(3, 1, 0)
 #include "LwipDhcpServer.h"
 #define wifi_softap_set_dhcps_lease(lease) dhcpSoftAP.set_dhcps_lease(lease)
 #define wifi_softap_set_dhcps_lease_time(time) dhcpSoftAP.set_dhcps_lease_time(time)
@@ -699,7 +699,7 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
     return false;
   }
 
-#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0) && USE_ARDUINO_VERSION_CODE < VERSION_CODE(3, 1, 0)
   dhcpSoftAP.begin(&info);
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?
With the release of ESP8266-Arduino 3.1.0, the SoftAP DhcpServer object is initialized on demand.
This PR accommodates this change.


I am new to C++, if this is garbage my feelings will not be hurt if you close the PR.

Related:
- https://github.com/esp8266/Arduino/releases/tag/3.1.0
- https://github.com/esp8266/Arduino/pull/8546

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# config.yaml relevant snippet
esp8266:
  framework:
    version: 3.1.1
    platform_version: 4.0.1
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
  N/A
