### PR TITLE
Add sixth OBIS code byte to SML

### DIFF
--- a/esphome/components/sml/__init__.py
+++ b/esphome/components/sml/__init__.py
@@ -32,7 +32,11 @@ async def to_code(config):
 
 def obis_code(value):
     value = cv.string(value)
-    match = re.match(r"^\d{1,3}-\d{1,3}:\d{1,3}\.\d{1,3}\.\d{1,3}$", value)
+    match = re.match(
+        r"^(\d{1,3}-\d{1,3}:\d{1,3}\.\d{1,3}\.\d{1,3})(\*\d{1,3})?$", value
+    )
     if match is None:
         raise cv.Invalid(f"{value} is not a valid OBIS code")
+    if match.groups()[1] is None:
+        value += "*255"
     return value

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -124,7 +124,8 @@ ObisInfo::ObisInfo(bytes server_id, SmlNode val_list_entry) : server_id(std::mov
 }
 
 std::string ObisInfo::code_repr() const {
-  return str_sprintf("%d-%d:%d.%d.%d", this->code[0], this->code[1], this->code[2], this->code[3], this->code[4]);
+  return str_sprintf("%d-%d:%d.%d.%d*%d", this->code[0], this->code[1], this->code[2], this->code[3], this->code[4],
+                     this->code[5]);
 }
 
 }  // namespace sml


### PR DESCRIPTION
# What does this implement/fix?
This adds an extended (optional) `obis-code` parameter to the SML configuration.
Both formats are now accepted:  `obis-code: "A-B:C.D.E"` and `obis-code: "A-B:C.D.E*F"`

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/alengwenus/esphome_components/issues/13

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2602

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sml:
  id: mysml

sensor:
  - platform: sml
    sml_id: mysml
    name: "Total energy"
    obis_code: "1-0:1.8.0*255"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
