### PR TITLE
Upgrades add-on base image to 6.2.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 ARG BASEIMGTYPE=docker
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ghcr.io/hassio-addons/debian-base:6.1.3 AS base-hassio
+FROM ghcr.io/hassio-addons/debian-base:6.2.0 AS base-hassio
 # https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye
 FROM debian:bullseye-20221024-slim AS base-docker
 


### PR DESCRIPTION
# What does this implement/fix?

First PR in a range of PRs.

Upgrades the add-on base image to the latest version: 6.2.0
Release notes: https://github.com/hassio-addons/addon-debian-base/releases/tag/v6.2.0

This base version contains a more recent Debian build, and brings in the new style `s6-rc` scripts/services.

![CleanShot 2023-01-18 at 16 41 56](https://user-images.githubusercontent.com/195327/213216947-9d55c1fa-3230-4a2e-9c29-84c3674aa9b0.png)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
