### PR TITLE
Always send the MTU request for BLE v3 cached connections

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -132,15 +132,15 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->set_state(espbt::ClientState::IDLE);
         break;
       }
-      if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-        this->set_state(espbt::ClientState::CONNECTED);
-        this->state_ = espbt::ClientState::ESTABLISHED;
-        break;
-      }
       auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->open.conn_id);
       if (ret) {
         ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_send_mtu_req failed, status=%x", this->connection_index_,
                  this->address_str_.c_str(), ret);
+      }
+      if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
+        this->set_state(espbt::ClientState::CONNECTED);
+        this->state_ = espbt::ClientState::ESTABLISHED;
+        break;
       }
       esp_ble_gattc_search_service(esp_gattc_if, param->cfg_mtu.conn_id, nullptr);
       break;


### PR DESCRIPTION
# What does this implement/fix?
alternate to #4321 where in this case we put the MTU request in the bluedroid queue but still mark the connection ready right away. Since the notify setup will always end up in the queue after any MTU request, the notify will have the proper MTU set when it comes back. This version does not have the significant performance penalty that #4321 incurs and fixes the issue.

closes #4321
fixes esphome/issues#4041
fixes esphome/issues#3951

This fixes the issue with the 68 byte notify being truncated to 20 bytes reported in esphome/issues#4041 and seen in esphome/issues#3951
<img width="316" alt="Screenshot 2023-01-19 at 4 03 44 PM" src="https://user-images.githubusercontent.com/663432/213602416-2b0394d0-d6fa-40b4-8b0a-80b52b600dcf.png">

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
