### PR TITLE
Add a soft reset in setup() for bmp280

### DIFF
--- a/esphome/components/bmp280/bmp280.cpp
+++ b/esphome/components/bmp280/bmp280.cpp
@@ -1,4 +1,5 @@
 #include "bmp280.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -11,8 +12,11 @@ static const uint8_t BMP280_REGISTER_CONTROL = 0xF4;
 static const uint8_t BMP280_REGISTER_CONFIG = 0xF5;
 static const uint8_t BMP280_REGISTER_PRESSUREDATA = 0xF7;
 static const uint8_t BMP280_REGISTER_TEMPDATA = 0xFA;
+static const uint8_t BMP280_REGISTER_RESET = 0xE0;
 
 static const uint8_t BMP280_MODE_FORCED = 0b01;
+static const uint8_t BMP280_SOFT_RESET = 0xB6;
+static const uint8_t BMP280_STATUS_IM_UPDATE = 0b01;
 
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 
@@ -62,6 +66,28 @@ void BMP280Component::setup() {
   }
   if (chip_id != 0x58) {
     this->error_code_ = WRONG_CHIP_ID;
+    this->mark_failed();
+    return;
+  }
+
+  // Send a soft reset.
+  if (!this->write_byte(BMP280_REGISTER_RESET, BMP280_SOFT_RESET)) {
+    this->mark_failed();
+    return;
+  }
+  // Wait until the NVM data has finished loading.
+  uint8_t status;
+  uint8_t retry = 5;
+  do {
+    delay(2);
+    if (!this->read_byte(BMP280_REGISTER_STATUS, &status)) {
+      ESP_LOGW(TAG, "Error reading status register.");
+      this->mark_failed();
+      return;
+    }
+  } while ((status & BMP280_STATUS_IM_UPDATE) && (--retry));
+  if (status & BMP280_STATUS_IM_UPDATE) {
+    ESP_LOGW(TAG, "Timeout loading NVM.");
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Applies the exact fix in PR #3615 to the BME280's sister chip, BMP280. That PR was inspired by the [Bosch example implementation for the BME280](https://github.com/boschsensortec/BME280_driver/blob/c47f06eb44fc96970f0abfcc941ec16425b2a9e6/bme280.c#L429). The [Bosch example implementation for the BMP280](https://github.com/boschsensortec/BMP280_driver/blob/6fd106b76a815f77a6d583eeef4bc6d2fee7a524/bmp280.c#L251) does exactly the same thing, so this brings that initialization soft reset to the BMP280 as well.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3383 (for the BMP280)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
...

i2c:
  - id: bmp_i2c
    sda: GPIO4
    scl: GPIO5

sensor:
  - platform: bmp280
    address: 0x76 # Gets set to this for some reason...
    pressure:
      name: "Pressure"
      oversampling: 16x
      filters:
        - multiply: 0.02952998330101 # Convert from hPa to inHg
      unit_of_measurement: inHg
      accuracy_decimals: 5
    temperature:
      name: "Pressure Temperature"
      oversampling: 16x
      filters: # Convert to Fahrenheit
        - multiply: 1.8
        - offset: 32.0
      unit_of_measurement: °F
      accuracy_decimals: 2
    iir_filter: 16x
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
