### PR TITLE
rename esp32 CAN to TWAI, so it compiles again

### DIFF
--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -2,7 +2,7 @@
 #include "esp32_can.h"
 #include "esphome/core/log.h"
 
-#include <driver/can.h>
+#include <driver/twai.h>
 
 // WORKAROUND, because CAN_IO_UNUSED is just defined as (-1) in this version
 // of the framework which does not work with -fpermissive
@@ -14,25 +14,25 @@ namespace esp32_can {
 
 static const char *const TAG = "esp32_can";
 
-static bool get_bitrate(canbus::CanSpeed bitrate, can_timing_config_t *t_config) {
+static bool get_bitrate(canbus::CanSpeed bitrate, twai_timing_config_t *t_config) {
   switch (bitrate) {
     case canbus::CAN_50KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_50KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_50KBITS();
       return true;
     case canbus::CAN_100KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_100KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_100KBITS();
       return true;
     case canbus::CAN_125KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_125KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_125KBITS();
       return true;
     case canbus::CAN_250KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_250KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_250KBITS();
       return true;
     case canbus::CAN_500KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_500KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_500KBITS();
       return true;
     case canbus::CAN_1000KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_1MBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_1MBITS();
       return true;
     default:
       return false;
@@ -40,10 +40,10 @@ static bool get_bitrate(canbus::CanSpeed bitrate, can_timing_config_t *t_config)
 }
 
 bool ESP32Can::setup_internal() {
-  can_general_config_t g_config =
-      CAN_GENERAL_CONFIG_DEFAULT((gpio_num_t) this->tx_, (gpio_num_t) this->rx_, CAN_MODE_NORMAL);
-  can_filter_config_t f_config = CAN_FILTER_CONFIG_ACCEPT_ALL();
-  can_timing_config_t t_config;
+  twai_general_config_t g_config =
+      TWAI_GENERAL_CONFIG_DEFAULT((gpio_num_t) this->tx_, (gpio_num_t) this->rx_, TWAI_MODE_NORMAL);
+  twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+  twai_timing_config_t t_config;
 
   if (!get_bitrate(this->bit_rate_, &t_config)) {
     // invalid bit rate
@@ -51,15 +51,15 @@ bool ESP32Can::setup_internal() {
     return false;
   }
 
-  // Install CAN driver
-  if (can_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
+  // Install TWAI driver
+  if (twai_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
     // Failed to install driver
     this->mark_failed();
     return false;
   }
 
-  // Start CAN driver
-  if (can_start() != ESP_OK) {
+  // Start TWAI driver
+  if (twai_start() != ESP_OK) {
     // Failed to start driver
     this->mark_failed();
     return false;
@@ -72,15 +72,15 @@ canbus::Error ESP32Can::send_message(struct canbus::CanFrame *frame) {
     return canbus::ERROR_FAILTX;
   }
 
-  uint32_t flags = CAN_MSG_FLAG_NONE;
+  uint32_t flags = TWAI_MSG_FLAG_NONE;
   if (frame->use_extended_id) {
-    flags |= CAN_MSG_FLAG_EXTD;
+    flags |= TWAI_MSG_FLAG_EXTD;
   }
   if (frame->remote_transmission_request) {
-    flags |= CAN_MSG_FLAG_RTR;
+    flags |= TWAI_MSG_FLAG_RTR;
   }
 
-  can_message_t message = {
+  twai_message_t message = {
       .flags = flags,
       .identifier = frame->can_id,
       .data_length_code = frame->can_data_length_code,
@@ -89,7 +89,7 @@ canbus::Error ESP32Can::send_message(struct canbus::CanFrame *frame) {
     memcpy(message.data, frame->data, frame->can_data_length_code);
   }
 
-  if (can_transmit(&message, pdMS_TO_TICKS(1000)) == ESP_OK) {
+  if (twai_transmit(&message, pdMS_TO_TICKS(1000)) == ESP_OK) {
     return canbus::ERROR_OK;
   } else {
     return canbus::ERROR_ALLTXBUSY;
@@ -97,15 +97,15 @@ canbus::Error ESP32Can::send_message(struct canbus::CanFrame *frame) {
 }
 
 canbus::Error ESP32Can::read_message(struct canbus::CanFrame *frame) {
-  can_message_t message;
+  twai_message_t message;
 
-  if (can_receive(&message, 0) != ESP_OK) {
+  if (twai_receive(&message, 0) != ESP_OK) {
     return canbus::ERROR_NOMSG;
   }
 
   frame->can_id = message.identifier;
-  frame->use_extended_id = message.flags & CAN_MSG_FLAG_EXTD;
-  frame->remote_transmission_request = message.flags & CAN_MSG_FLAG_RTR;
+  frame->use_extended_id = message.flags & TWAI_MSG_FLAG_EXTD;
+  frame->remote_transmission_request = message.flags & TWAI_MSG_FLAG_RTR;
   frame->can_data_length_code = message.data_length_code;
 
   if (!frame->remote_transmission_request) {


### PR DESCRIPTION
# What does this implement/fix?

it fixex a not compiling esp32 can interface.  

Basically a renaming of `can` with `twai` is all that has changed,

The error message given:
```
#warning driver/can.h is deprecated, please use driver/twai.h instead
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

fixes https://github.com/esphome/issues/issues/4023

Background on the renaming: https://github.com/espressif/esp-idf/issues/5580

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esp32cantest
  comment: "rework CAN to TWAI" 

esp32:
  board: esp32-c3-devkitm-1

canbus:
  - platform: esp32_can
    tx_pin: GPIO1
    rx_pin: GPIO3
    can_id: 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
