### PR TITLE
2022.12.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,7 +139,7 @@ RUN \
         clang-tidy-11=1:11.0.1-2 \
         patch=2.7.6-7 \
         software-properties-common=0.96.20.2-2.1 \
-        nano=5.4-2+deb11u1 \
+        nano=5.4-2+deb11u2 \
         build-essential=12.9 \
         python3-dev=3.9.2-3 \
     && rm -rf \

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2022.12.4"
+__version__ = "2022.12.5"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump nano version in lint docker image [esphome#4218](https://github.com/esphome/esphome/pull/4218)
