### PR TITLE
fix stepper jump back with small steps

### DIFF
--- a/esphome/components/a4988/a4988.cpp
+++ b/esphome/components/a4988/a4988.cpp
@@ -46,6 +46,7 @@ void A4988::loop() {
     return;
 
   this->dir_pin_->digital_write(dir == 1);
+  delayMicroseconds(50);
   this->step_pin_->digital_write(true);
   delayMicroseconds(5);
   this->step_pin_->digital_write(false);


### PR DESCRIPTION
# What does this implement/fix?

Sometimes with a reduced number of steps the stepper motor jumps in the opposite direction (clockwise) before turning in the right direction (counterclockwise). This only happens in case of counterclockwise rotation. Reducing `max_speed` does not fix the problem.

It turns out that the direction pin state change is too fast. I added a delay of 50µs and everything is back to normal (jump is still here with 5µs).

The problem was seen with a Wemos D1 mini connected to a cheap controller like [this](https://www.amazon.com/Stepper-DC9-42V-Subdivision-Controller-MicroStepping/dp/B08SG7L54W/ref=sr_1_4_sspa). 
Driving the controller directly with Arduino code did not cause the problem to appear. It's just a simple timing issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
number:
  - platform: template
    name: Stepper Control
    min_value: -400
    max_value: 400
    step: 1
    set_action:
      then:
        - stepper.set_target:
            id: my_stepper
            target: !lambda 'return x;'

stepper:
  - platform: a4988
    id: my_stepper
    acceleration: 1000
    deceleration: 1000
    step_pin:
      number: D2
    dir_pin:
      number: D1
    sleep_pin:
      number: D3
    max_speed: 250 steps/s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
