### PR TITLE
Add next_url to improv serial component config

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -107,6 +107,7 @@ esphome/components/hte501/* @Stock-M
 esphome/components/hydreon_rgxx/* @functionpointer
 esphome/components/i2c/* @esphome/core
 esphome/components/i2s_audio/* @jesserockz
+esphome/components/improv_base/* @esphome/core
 esphome/components/improv_serial/* @esphome/core
 esphome/components/ina260/* @MrEditor97
 esphome/components/inkbird_ibsth1_mini/* @fkirill

--- a/esphome/components/improv_base/__init__.py
+++ b/esphome/components/improv_base/__init__.py
@@ -1,0 +1,42 @@
+import re
+
+import esphome.config_validation as cv
+import esphome.codegen as cg
+
+from esphome.const import __version__
+
+CODEOWNERS = ["@esphome/core"]
+
+CONF_NEXT_URL = "next_url"
+
+VALID_SUBSTITUTIONS = ["esphome_version", "ip_address", "device_name"]
+
+
+def validate_next_url(value):
+    value = cv.url(value)
+    test = r"{{(?!" + r"\b|".join(VALID_SUBSTITUTIONS) + r"\b)(\w+)}}"
+    result = re.search(test, value)
+    if result:
+        raise cv.Invalid(
+            f"Invalid substitution(s) ({', '.join(result.groups())}) in next_url. Valid substitutions are: {', '.join(VALID_SUBSTITUTIONS)}"
+        )
+    return value
+
+
+IMPROV_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_NEXT_URL): validate_next_url,
+    }
+)
+
+
+def _process_next_url(url: str):
+    if "{{esphome_version}}" in url:
+        url = url.replace("{{esphome_version}}", __version__)
+    return url
+
+
+async def setup_improv_core(var, config):
+    if CONF_NEXT_URL in config:
+        cg.add(var.set_next_url(_process_next_url(config[CONF_NEXT_URL])))
+    cg.add_library("esphome/Improv", "1.2.3")

--- a/esphome/components/improv_base/improv_base.cpp
+++ b/esphome/components/improv_base/improv_base.cpp
@@ -14,7 +14,7 @@ std::string ImprovBase::get_formatted_next_url_() {
   // Device name
   std::size_t pos = this->next_url_.find("{{device_name}}");
   if (pos != std::string::npos) {
-    std::string device_name = App.get_name();
+    const std::string &device_name = App.get_name();
     copy.replace(pos, 15, device_name);
   }
 

--- a/esphome/components/improv_base/improv_base.cpp
+++ b/esphome/components/improv_base/improv_base.cpp
@@ -1,0 +1,32 @@
+#include "improv_base.h"
+
+#include "esphome/components/network/util.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace improv_base {
+
+std::string ImprovBase::get_formatted_next_url_() {
+  if (this->next_url_.empty()) {
+    return "";
+  }
+  std::string copy = this->next_url_;
+  // Device name
+  std::size_t pos = this->next_url_.find("{{device_name}}");
+  if (pos != std::string::npos) {
+    std::string device_name = App.get_name();
+    copy.replace(pos, 15, device_name);
+  }
+
+  // Ip address
+  pos = this->next_url_.find("{{ip_address}}");
+  if (pos != std::string::npos) {
+    std::string ip = network::IPAddress(network::get_ip_address()).str();
+    copy.replace(pos, 14, ip);
+  }
+
+  return copy;
+}
+
+}  // namespace improv_base
+}  // namespace esphome

--- a/esphome/components/improv_base/improv_base.h
+++ b/esphome/components/improv_base/improv_base.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+namespace esphome {
+namespace improv_base {
+
+class ImprovBase {
+ public:
+  void set_next_url(const std::string &next_url) { this->next_url_ = next_url; }
+
+ protected:
+  std::string get_formatted_next_url_();
+  std::string next_url_;
+};
+
+}  // namespace improv_base
+}  // namespace esphome

--- a/esphome/components/improv_serial/__init__.py
+++ b/esphome/components/improv_serial/__init__.py
@@ -4,7 +4,9 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE
 import esphome.final_validate as fv
+from esphome.components import improv_base
 
+AUTO_LOAD = ["improv_base"]
 CODEOWNERS = ["@esphome/core"]
 DEPENDENCIES = ["logger", "wifi"]
 
@@ -12,11 +14,15 @@ improv_serial_ns = cg.esphome_ns.namespace("improv_serial")
 
 ImprovSerialComponent = improv_serial_ns.class_("ImprovSerialComponent", cg.Component)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(ImprovSerialComponent),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ImprovSerialComponent),
+        }
+    )
+    .extend(improv_base.IMPROV_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 def validate_logger(config):
@@ -37,4 +43,4 @@ FINAL_VALIDATE_SCHEMA = validate_logger
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    cg.add_library("esphome/Improv", "1.2.3")
+    await improv_base.setup_improv_core(var, config)

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -95,14 +95,14 @@ void ImprovSerialComponent::loop() {
 
 std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv::Command command) {
   std::vector<std::string> urls;
+  if (!this->next_url_.empty()) {
+    urls.push_back(this->get_formatted_next_url_());
+  }
 #ifdef USE_WEBSERVER
   auto ip = wifi::global_wifi_component->wifi_sta_ip();
   std::string webserver_url = "http://" + ip.str() + ":" + to_string(USE_WEBSERVER_PORT);
   urls.push_back(webserver_url);
 #endif
-  if (!this->next_url_.empty()) {
-    urls.push_back(this->get_formatted_next_url_());
-  }
   std::vector<uint8_t> data = improv::build_rpc_response(command, urls, false);
   return data;
 }

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -100,6 +100,9 @@ std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv:
   std::string webserver_url = "http://" + ip.str() + ":" + to_string(USE_WEBSERVER_PORT);
   urls.push_back(webserver_url);
 #endif
+  if (!this->next_url_.empty()) {
+    urls.push_back(this->get_formatted_next_url_());
+  }
   std::vector<uint8_t> data = improv::build_rpc_response(command, urls, false);
   return data;
 }

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/components/improv_base/improv_base.h"
 #include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -27,7 +28,7 @@ enum ImprovSerialType : uint8_t {
 
 static const uint8_t IMPROV_SERIAL_VERSION = 1;
 
-class ImprovSerialComponent : public Component {
+class ImprovSerialComponent : public Component, public improv_base::ImprovBase {
  public:
   void setup() override;
   void loop() override;

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -298,6 +298,7 @@ logger:
   esp8266_store_log_strings_in_flash: true
 
 improv_serial:
+  next_url: https://esphome.io/?name={{device_name}}&version={{esphome_version}}&ip={{ip_address}}
 
 deep_sleep:
   run_duration: 20s


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This allows project creators to specify their own Next URL for client side tools like ESP Web Tools to link the user through to. This could be something like an online manual, which can also have query params to alter the manual contents such as an IP address which will allow for dynamic changes in the manual specific to the device.

Valid substitutions are `esphome_version`, `ip_address`, `device_name`. See below for an example of how to use them in YAML.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2620

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
improv_serial:
  next_url: https://example.com/new-device?ip={{ip_address}}&name={{device_name}}&version={{esphome_version}}

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
