### PR TITLE
2022.12.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,11 +140,10 @@ jobs:
           TOKEN: ${{ secrets.DEPLOY_HA_ADDON_REPO_TOKEN }}
         # yamllint disable rule:line-length
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
           curl \
             -u ":$TOKEN" \
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/esphome/home-assistant-addon/actions/workflows/bump-version.yml/dispatches \
-            -d "{\"ref\":\"main\",\"inputs\":{\"version\":\"$TAG\"}}"
+            -d '{"ref":"main","inputs":{"version":"${{ github.event.release.tag_name }}","content":${{ toJSON(github.event.release.body) }}}}'
         # yamllint enable rule:line-length

--- a/esphome/components/a4988/a4988.cpp
+++ b/esphome/components/a4988/a4988.cpp
@@ -46,6 +46,7 @@ void A4988::loop() {
     return;
 
   this->dir_pin_->digital_write(dir == 1);
+  delayMicroseconds(50);
   this->step_pin_->digital_write(true);
   delayMicroseconds(5);
   this->step_pin_->digital_write(false);

--- a/esphome/components/bme280/bme280.cpp
+++ b/esphome/components/bme280/bme280.cpp
@@ -88,7 +88,10 @@ void BME280Component::setup() {
 
   // Mark as not failed before initializing. Some devices will turn off sensors to save on batteries
   // and when they come back on, the COMPONENT_STATE_FAILED bit must be unset on the component.
-  this->component_state_ &= ~COMPONENT_STATE_FAILED;
+  if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED) {
+    this->component_state_ &= ~COMPONENT_STATE_MASK;
+    this->component_state_ |= COMPONENT_STATE_CONSTRUCTION;
+  }
 
   if (!this->read_byte(BME280_REGISTER_CHIPID, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;

--- a/esphome/components/bmp280/bmp280.cpp
+++ b/esphome/components/bmp280/bmp280.cpp
@@ -1,4 +1,5 @@
 #include "bmp280.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -11,8 +12,11 @@ static const uint8_t BMP280_REGISTER_CONTROL = 0xF4;
 static const uint8_t BMP280_REGISTER_CONFIG = 0xF5;
 static const uint8_t BMP280_REGISTER_PRESSUREDATA = 0xF7;
 static const uint8_t BMP280_REGISTER_TEMPDATA = 0xFA;
+static const uint8_t BMP280_REGISTER_RESET = 0xE0;
 
 static const uint8_t BMP280_MODE_FORCED = 0b01;
+static const uint8_t BMP280_SOFT_RESET = 0xB6;
+static const uint8_t BMP280_STATUS_IM_UPDATE = 0b01;
 
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 
@@ -62,6 +66,28 @@ void BMP280Component::setup() {
   }
   if (chip_id != 0x58) {
     this->error_code_ = WRONG_CHIP_ID;
+    this->mark_failed();
+    return;
+  }
+
+  // Send a soft reset.
+  if (!this->write_byte(BMP280_REGISTER_RESET, BMP280_SOFT_RESET)) {
+    this->mark_failed();
+    return;
+  }
+  // Wait until the NVM data has finished loading.
+  uint8_t status;
+  uint8_t retry = 5;
+  do {
+    delay(2);
+    if (!this->read_byte(BMP280_REGISTER_STATUS, &status)) {
+      ESP_LOGW(TAG, "Error reading status register.");
+      this->mark_failed();
+      return;
+    }
+  } while ((status & BMP280_STATUS_IM_UPDATE) && (--retry));
+  if (status & BMP280_STATUS_IM_UPDATE) {
+    ESP_LOGW(TAG, "Timeout loading NVM.");
     this->mark_failed();
     return;
   }

--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -2,7 +2,7 @@
 #include "esp32_can.h"
 #include "esphome/core/log.h"
 
-#include <driver/can.h>
+#include <driver/twai.h>
 
 // WORKAROUND, because CAN_IO_UNUSED is just defined as (-1) in this version
 // of the framework which does not work with -fpermissive
@@ -14,25 +14,25 @@ namespace esp32_can {
 
 static const char *const TAG = "esp32_can";
 
-static bool get_bitrate(canbus::CanSpeed bitrate, can_timing_config_t *t_config) {
+static bool get_bitrate(canbus::CanSpeed bitrate, twai_timing_config_t *t_config) {
   switch (bitrate) {
     case canbus::CAN_50KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_50KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_50KBITS();
       return true;
     case canbus::CAN_100KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_100KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_100KBITS();
       return true;
     case canbus::CAN_125KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_125KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_125KBITS();
       return true;
     case canbus::CAN_250KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_250KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_250KBITS();
       return true;
     case canbus::CAN_500KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_500KBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_500KBITS();
       return true;
     case canbus::CAN_1000KBPS:
-      *t_config = (can_timing_config_t) CAN_TIMING_CONFIG_1MBITS();
+      *t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_1MBITS();
       return true;
     default:
       return false;
@@ -40,10 +40,10 @@ static bool get_bitrate(canbus::CanSpeed bitrate, can_timing_config_t *t_config)
 }
 
 bool ESP32Can::setup_internal() {
-  can_general_config_t g_config =
-      CAN_GENERAL_CONFIG_DEFAULT((gpio_num_t) this->tx_, (gpio_num_t) this->rx_, CAN_MODE_NORMAL);
-  can_filter_config_t f_config = CAN_FILTER_CONFIG_ACCEPT_ALL();
-  can_timing_config_t t_config;
+  twai_general_config_t g_config =
+      TWAI_GENERAL_CONFIG_DEFAULT((gpio_num_t) this->tx_, (gpio_num_t) this->rx_, TWAI_MODE_NORMAL);
+  twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+  twai_timing_config_t t_config;
 
   if (!get_bitrate(this->bit_rate_, &t_config)) {
     // invalid bit rate
@@ -51,15 +51,15 @@ bool ESP32Can::setup_internal() {
     return false;
   }
 
-  // Install CAN driver
-  if (can_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
+  // Install TWAI driver
+  if (twai_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
     // Failed to install driver
     this->mark_failed();
     return false;
   }
 
-  // Start CAN driver
-  if (can_start() != ESP_OK) {
+  // Start TWAI driver
+  if (twai_start() != ESP_OK) {
     // Failed to start driver
     this->mark_failed();
     return false;
@@ -72,15 +72,15 @@ canbus::Error ESP32Can::send_message(struct canbus::CanFrame *frame) {
     return canbus::ERROR_FAILTX;
   }
 
-  uint32_t flags = CAN_MSG_FLAG_NONE;
+  uint32_t flags = TWAI_MSG_FLAG_NONE;
   if (frame->use_extended_id) {
-    flags |= CAN_MSG_FLAG_EXTD;
+    flags |= TWAI_MSG_FLAG_EXTD;
   }
   if (frame->remote_transmission_request) {
-    flags |= CAN_MSG_FLAG_RTR;
+    flags |= TWAI_MSG_FLAG_RTR;
   }
 
-  can_message_t message = {
+  twai_message_t message = {
       .flags = flags,
       .identifier = frame->can_id,
       .data_length_code = frame->can_data_length_code,
@@ -89,7 +89,7 @@ canbus::Error ESP32Can::send_message(struct canbus::CanFrame *frame) {
     memcpy(message.data, frame->data, frame->can_data_length_code);
   }
 
-  if (can_transmit(&message, pdMS_TO_TICKS(1000)) == ESP_OK) {
+  if (twai_transmit(&message, pdMS_TO_TICKS(1000)) == ESP_OK) {
     return canbus::ERROR_OK;
   } else {
     return canbus::ERROR_ALLTXBUSY;
@@ -97,15 +97,15 @@ canbus::Error ESP32Can::send_message(struct canbus::CanFrame *frame) {
 }
 
 canbus::Error ESP32Can::read_message(struct canbus::CanFrame *frame) {
-  can_message_t message;
+  twai_message_t message;
 
-  if (can_receive(&message, 0) != ESP_OK) {
+  if (twai_receive(&message, 0) != ESP_OK) {
     return canbus::ERROR_NOMSG;
   }
 
   frame->can_id = message.identifier;
-  frame->use_extended_id = message.flags & CAN_MSG_FLAG_EXTD;
-  frame->remote_transmission_request = message.flags & CAN_MSG_FLAG_RTR;
+  frame->use_extended_id = message.flags & TWAI_MSG_FLAG_EXTD;
+  frame->remote_transmission_request = message.flags & TWAI_MSG_FLAG_RTR;
   frame->can_data_length_code = message.data_length_code;
 
   if (!frame->remote_transmission_request) {

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2022.12.6"
+__version__ = "2022.12.7"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Add "content" to deploy-ha-addon-repo dispatch [esphome#4349](https://github.com/esphome/esphome/pull/4349)
- fix stepper jump back with small steps [esphome#4339](https://github.com/esphome/esphome/pull/4339)
- rename esp32 CAN to TWAI, so it compiles again [esphome#4334](https://github.com/esphome/esphome/pull/4334)
- Fix BME280 initialization before wifi setup [esphome#4190](https://github.com/esphome/esphome/pull/4190)
- Add a soft reset in setup() for bmp280 [esphome#4329](https://github.com/esphome/esphome/pull/4329)
