### PR TITLE
Support Mopeka Standard LPG tank bluetooth sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -159,7 +159,7 @@ esphome/components/modbus_controller/select/* @martgras @stegm
 esphome/components/modbus_controller/sensor/* @martgras
 esphome/components/modbus_controller/switch/* @martgras
 esphome/components/modbus_controller/text_sensor/* @martgras
-esphome/components/mopeka_ble/* @spbrogan @Fabian-Schmidt
+esphome/components/mopeka_ble/* @Fabian-Schmidt @spbrogan
 esphome/components/mopeka_pro_check/* @spbrogan
 esphome/components/mopeka_std_check/* @Fabian-Schmidt
 esphome/components/mpl3115a2/* @kbickar

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -161,7 +161,7 @@ esphome/components/modbus_controller/switch/* @martgras
 esphome/components/modbus_controller/text_sensor/* @martgras
 esphome/components/mopeka_ble/* @spbrogan @Fabian-Schmidt
 esphome/components/mopeka_pro_check/* @spbrogan
-esphome/components/mopeka_pro_check/* @Fabian-Schmidt
+esphome/components/mopeka_std_check/* @Fabian-Schmidt
 esphome/components/mpl3115a2/* @kbickar
 esphome/components/mpu6886/* @fabaff
 esphome/components/network/* @esphome/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -159,8 +159,9 @@ esphome/components/modbus_controller/select/* @martgras @stegm
 esphome/components/modbus_controller/sensor/* @martgras
 esphome/components/modbus_controller/switch/* @martgras
 esphome/components/modbus_controller/text_sensor/* @martgras
-esphome/components/mopeka_ble/* @spbrogan
+esphome/components/mopeka_ble/* @spbrogan @Fabian-Schmidt
 esphome/components/mopeka_pro_check/* @spbrogan
+esphome/components/mopeka_pro_check/* @Fabian-Schmidt
 esphome/components/mpl3115a2/* @kbickar
 esphome/components/mpu6886/* @fabaff
 esphome/components/network/* @esphome/core

--- a/esphome/components/mopeka_ble/__init__.py
+++ b/esphome/components/mopeka_ble/__init__.py
@@ -3,8 +3,10 @@ import esphome.config_validation as cv
 from esphome.components import esp32_ble_tracker
 from esphome.const import CONF_ID
 
-CODEOWNERS = ["@spbrogan"]
+CODEOWNERS = ["@spbrogan", "@Fabian-Schmidt"]
 DEPENDENCIES = ["esp32_ble_tracker"]
+
+CONF_SHOW_SENSORS_WITHOUT_SYNC = "show_sensors_without_sync"
 
 mopeka_ble_ns = cg.esphome_ns.namespace("mopeka_ble")
 MopekaListener = mopeka_ble_ns.class_(
@@ -14,10 +16,13 @@ MopekaListener = mopeka_ble_ns.class_(
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(MopekaListener),
+        cv.Optional(CONF_SHOW_SENSORS_WITHOUT_SYNC, default=False): cv.boolean,
     }
 ).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    if CONF_SHOW_SENSORS_WITHOUT_SYNC in config:
+        cg.add(var.set_show_sensors_without_sync(config[CONF_SHOW_SENSORS_WITHOUT_SYNC]))
     await esp32_ble_tracker.register_ble_device(var, config)

--- a/esphome/components/mopeka_ble/__init__.py
+++ b/esphome/components/mopeka_ble/__init__.py
@@ -24,5 +24,7 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     if CONF_SHOW_SENSORS_WITHOUT_SYNC in config:
-        cg.add(var.set_show_sensors_without_sync(config[CONF_SHOW_SENSORS_WITHOUT_SYNC]))
+        cg.add(
+            var.set_show_sensors_without_sync(config[CONF_SHOW_SENSORS_WITHOUT_SYNC])
+        )
     await esp32_ble_tracker.register_ble_device(var, config)

--- a/esphome/components/mopeka_ble/mopeka_ble.cpp
+++ b/esphome/components/mopeka_ble/mopeka_ble.cpp
@@ -8,23 +8,35 @@ namespace esphome {
 namespace mopeka_ble {
 
 static const char *const TAG = "mopeka_ble";
+
+//Mopeka Std (CC2540) sensor details
 static const uint16_t SERVICE_UUID_CC2540 = 0xADA0;
-static const uint16_t SERVICE_UUID_NRF52 = 0xFEE5;
+static const uint16_t MANUFACTURER_CC2540_ID = 0x000D;  // Texas Instruments (TI)
 static const uint8_t MANUFACTURER_CC2540_DATA_LENGTH = 23;
+
+// Mopeka Pro (NRF52) sensor details
+static const uint16_t SERVICE_UUID_NRF52 = 0xFEE5;
+static const uint16_t MANUFACTURER_NRF52_ID = 0x0059;  // Nordic
 static const uint8_t MANUFACTURER_NRF52_DATA_LENGTH = 10;
-static const uint16_t MANUFACTURER_CC2540_ID = 0x000D;  // TI
-static const uint16_t MANUFACTURER_NRF52_ID = 0x0059;   // Nordic
 
 /**
  * Parse all incoming BLE payloads to see if it is a Mopeka BLE advertisement.
  * Currently this supports the following products:
  *
- *   Mopeka Pro Check.
- *    If the sync button is pressed, report the MAC so a user can add this as a
- * sensor.
+ *  - Mopeka Std Check - uses the chip CC2540 by Texas Instruments (TI)
+ *  - Mopeka Pro Check - uses the chip NRF52 by Nordic
+ *
+ *    If the sync button is pressed, report the MAC so a user can add this as a sensor. Or if user has configured
+ * `show_sensors_without_sync_` than report all visible sensors.
+ * Three points are used to identify a sensor:
+ *
+ * - Bluetooth service uuid
+ * - Bluetooth manufacturer id
+ * - Bluetooth data frame size
  */
 
 bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+  // Fetch information about BLE device.
   const auto &service_uuids = device.get_service_uuids();
   if (service_uuids.size() != 1) {
     return false;
@@ -37,6 +49,7 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   }
   const auto &manu_data = manu_datas[0];
 
+  // Is the device maybe a Mopeka Std (CC2540) sensor.
   if (service_uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_CC2540)) {
     if (manu_data.uuid != esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_CC2540_ID)) {
       return false;
@@ -49,9 +62,10 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     const bool sync_button_pressed = (manu_data.data[3] & 0x80) != 0;
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
-      // button pressed
       ESP_LOGI(TAG, "MOPEKA STD (CC2540) SENSOR FOUND: %s", device.address_str().c_str());
     }
+
+    // Is the device maybe a Mopeka Pro (NRF52) sensor.
   } else if (service_uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_NRF52)) {
     if (manu_data.uuid != esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_NRF52_ID)) {
       return false;
@@ -64,7 +78,6 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     const bool sync_button_pressed = (manu_data.data[2] & 0x80) != 0;
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
-      // button pressed
       ESP_LOGI(TAG, "MOPEKA PRO (NRF52) SENSOR FOUND: %s", device.address_str().c_str());
     }
   }

--- a/esphome/components/mopeka_ble/mopeka_ble.cpp
+++ b/esphome/components/mopeka_ble/mopeka_ble.cpp
@@ -9,7 +9,7 @@ namespace mopeka_ble {
 
 static const char *const TAG = "mopeka_ble";
 
-//Mopeka Std (CC2540) sensor details
+// Mopeka Std (CC2540) sensor details
 static const uint16_t SERVICE_UUID_CC2540 = 0xADA0;
 static const uint16_t MANUFACTURER_CC2540_ID = 0x000D;  // Texas Instruments (TI)
 static const uint8_t MANUFACTURER_CC2540_DATA_LENGTH = 23;

--- a/esphome/components/mopeka_ble/mopeka_ble.cpp
+++ b/esphome/components/mopeka_ble/mopeka_ble.cpp
@@ -1,4 +1,5 @@
 #include "mopeka_ble.h"
+
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -7,42 +8,76 @@ namespace esphome {
 namespace mopeka_ble {
 
 static const char *const TAG = "mopeka_ble";
-static const uint8_t MANUFACTURER_DATA_LENGTH = 10;
-static const uint16_t MANUFACTURER_ID = 0x0059;
+static const uint16_t SERVICE_UUID_CC2540 = 0xADA0;
+static const uint16_t SERVICE_UUID_NRF52 = 0xFEE5;
+static const uint8_t MANUFACTURER_CC2540_DATA_LENGTH = 23;
+static const uint8_t MANUFACTURER_NRF52_DATA_LENGTH = 10;
+static const uint16_t MANUFACTURER_CC2540_ID = 0x000D;  // TI
+static const uint16_t MANUFACTURER_NRF52_ID = 0x0059;   // Nordic
 
 /**
  * Parse all incoming BLE payloads to see if it is a Mopeka BLE advertisement.
  * Currently this supports the following products:
  *
  *   Mopeka Pro Check.
- *    If the sync button is pressed, report the MAC so a user can add this as a sensor.
+ *    If the sync button is pressed, report the MAC so a user can add this as a
+ * sensor.
  */
 
-bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
-  const auto &manu_datas = device.get_manufacturer_datas();
+bool MopekaListener::parse_device(
+    const esp32_ble_tracker::ESPBTDevice &device) {
+  const auto &service_uuids = device.get_service_uuids();
+  if (service_uuids.size() != 1) {
+    return false;
+  }
+  const auto &service_uuid = service_uuids[0];
 
+  const auto &manu_datas = device.get_manufacturer_datas();
   if (manu_datas.size() != 1) {
     return false;
   }
-
   const auto &manu_data = manu_datas[0];
 
-  if (manu_data.data.size() != MANUFACTURER_DATA_LENGTH) {
-    return false;
+  if (service_uuid ==
+      esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_CC2540)) {
+    if (manu_data.uuid !=
+        esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_CC2540_ID)) {
+      return false;
+    }
+
+    if (manu_data.data.size() != MANUFACTURER_CC2540_DATA_LENGTH) {
+      return false;
+    }
+
+    const bool sync_button_pressed = (manu_data.data[3] & 0x80) != 0;
+
+    if (this->show_sensors_without_sync_ || sync_button_pressed) {
+      // button pressed
+      ESP_LOGI(TAG, "MOPEKA STD (CC2540) SENSOR FOUND: %s",
+               device.address_str().c_str());
+    }
+  } else if (service_uuid ==
+             esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_NRF52)) {
+    if (manu_data.uuid !=
+        esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_NRF52_ID)) {
+      return false;
+    }
+
+    if (manu_data.data.size() != MANUFACTURER_NRF52_DATA_LENGTH) {
+      return false;
+    }
+
+    const bool sync_button_pressed = (manu_data.data[2] & 0x80) != 0;
+
+    if (this->show_sensors_without_sync_ || sync_button_pressed) {
+      // button pressed
+      ESP_LOGI(TAG, "MOPEKA PRO (NRF52) SENSOR FOUND: %s",
+               device.address_str().c_str());
+    }
   }
 
-  if (manu_data.uuid != esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_ID)) {
-    return false;
-  }
-
-  if (this->parse_sync_button_(manu_data.data)) {
-    // button pressed
-    ESP_LOGI(TAG, "SENSOR FOUND: %s", device.address_str().c_str());
-  }
   return false;
 }
-
-bool MopekaListener::parse_sync_button_(const std::vector<uint8_t> &message) { return (message[2] & 0x80) != 0; }
 
 }  // namespace mopeka_ble
 }  // namespace esphome

--- a/esphome/components/mopeka_ble/mopeka_ble.cpp
+++ b/esphome/components/mopeka_ble/mopeka_ble.cpp
@@ -24,8 +24,7 @@ static const uint16_t MANUFACTURER_NRF52_ID = 0x0059;   // Nordic
  * sensor.
  */
 
-bool MopekaListener::parse_device(
-    const esp32_ble_tracker::ESPBTDevice &device) {
+bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   const auto &service_uuids = device.get_service_uuids();
   if (service_uuids.size() != 1) {
     return false;
@@ -38,10 +37,8 @@ bool MopekaListener::parse_device(
   }
   const auto &manu_data = manu_datas[0];
 
-  if (service_uuid ==
-      esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_CC2540)) {
-    if (manu_data.uuid !=
-        esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_CC2540_ID)) {
+  if (service_uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_CC2540)) {
+    if (manu_data.uuid != esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_CC2540_ID)) {
       return false;
     }
 
@@ -53,13 +50,10 @@ bool MopekaListener::parse_device(
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
       // button pressed
-      ESP_LOGI(TAG, "MOPEKA STD (CC2540) SENSOR FOUND: %s",
-               device.address_str().c_str());
+      ESP_LOGI(TAG, "MOPEKA STD (CC2540) SENSOR FOUND: %s", device.address_str().c_str());
     }
-  } else if (service_uuid ==
-             esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_NRF52)) {
-    if (manu_data.uuid !=
-        esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_NRF52_ID)) {
+  } else if (service_uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID_NRF52)) {
+    if (manu_data.uuid != esp32_ble_tracker::ESPBTUUID::from_uint16(MANUFACTURER_NRF52_ID)) {
       return false;
     }
 
@@ -71,8 +65,7 @@ bool MopekaListener::parse_device(
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
       // button pressed
-      ESP_LOGI(TAG, "MOPEKA PRO (NRF52) SENSOR FOUND: %s",
-               device.address_str().c_str());
+      ESP_LOGI(TAG, "MOPEKA PRO (NRF52) SENSOR FOUND: %s", device.address_str().c_str());
     }
   }
 

--- a/esphome/components/mopeka_ble/mopeka_ble.h
+++ b/esphome/components/mopeka_ble/mopeka_ble.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
-
 #include <vector>
+
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/core/component.h"
 
 #ifdef USE_ESP32
 
@@ -13,9 +13,12 @@ namespace mopeka_ble {
 class MopekaListener : public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  void set_show_sensors_without_sync(bool show_sensors_without_sync) {
+    show_sensors_without_sync_ = show_sensors_without_sync;
+  }
 
  protected:
-  bool parse_sync_button_(const std::vector<uint8_t> &message);
+  bool show_sensors_without_sync_;
 };
 
 }  // namespace mopeka_ble

--- a/esphome/components/mopeka_std_check/__init__.py
+++ b/esphome/components/mopeka_std_check/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@Fabian-Schmidt"]

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -15,7 +15,7 @@ static const uint16_t MANUFACTURER_ID = 0x000D;
 
 void MopekaStdCheck::dump_config() {
   ESP_LOGCONFIG(TAG, "Mopeka Std Check");
-  ESP_LOGCONFIG(TAG, "  LPG Butane ratio: %.0f%%", this->lpg_butane_ratio_ * 100);
+  ESP_LOGCONFIG(TAG, "  Propane Butane mix: %.0f%%", this->propane_butane_mix_ * 100);
   ESP_LOGCONFIG(TAG, "  Tank distance empty: %imm", this->empty_mm_);
   ESP_LOGCONFIG(TAG, "  Tank distance full: %imm", this->full_mm_);
   LOG_SENSOR("  ", "Level", this->level_);
@@ -194,8 +194,8 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 }
 
 float MopekaStdCheck::get_lpg_speed_of_sound_(float temperature) {
-  return 1040.71f - 4.87f * temperature - 137.5f * this->lpg_butane_ratio_ - 0.0107f * temperature * temperature -
-         1.63f * temperature * this->lpg_butane_ratio_;
+  return 1040.71f - 4.87f * temperature - 137.5f * this->propane_butane_mix_ - 0.0107f * temperature * temperature -
+         1.63f * temperature * this->propane_butane_mix_;
 }
 
 uint8_t MopekaStdCheck::parse_battery_level_(const mopeka_std_package *message) {

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -68,7 +68,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   }
 
   // Now parse the data
-  const auto mopeka_data = (mopeka_std_package *) manu_data.data.data();
+  auto mopeka_data = (const mopeka_std_package *) manu_data.data.data();
 
   const u_int8_t hardware_id = mopeka_data->data_1 & 0xCF;
   if (static_cast<SensorType>(hardware_id) != STANDARD && static_cast<SensorType>(hardware_id) != XL) {
@@ -217,7 +217,7 @@ uint8_t MopekaStdCheck::parse_temperature_(const mopeka_std_package *message) {
   if (tmp == 0x0) {
     return -40;
   } else {
-    return (uint8_t) ((tmp - 25.0f) * 1.776964f);
+    return (uint8_t)((tmp - 25.0f) * 1.776964f);
   }
 }
 

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -15,6 +15,9 @@ static const uint16_t MANUFACTURER_ID = 0x000D;
 
 void MopekaStdCheck::dump_config() {
   ESP_LOGCONFIG(TAG, "Mopeka Std Check");
+  ESP_LOGCONFIG(TAG, "  LPG Butane ratio: %.0f%%", this->lpg_butane_ratio_ * 100);
+  ESP_LOGCONFIG(TAG, "  Tank distance empty: %imm", this->empty_mm_);
+  ESP_LOGCONFIG(TAG, "  Tank distance full: %imm", this->full_mm_);
   LOG_SENSOR("  ", "Level", this->level_);
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -1,0 +1,224 @@
+#include "mopeka_std_check.h"
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace mopeka_std_check {
+
+static const char *const TAG = "mopeka_std_check";
+static const uint16_t SERVICE_UUID = 0xADA0;
+static const uint8_t MANUFACTURER_DATA_LENGTH = 23;
+static const uint16_t MANUFACTURER_ID = 0x000D;
+
+void MopekaStdCheck::dump_config() {
+  ESP_LOGCONFIG(TAG, "Mopeka Std Check");
+  LOG_SENSOR("  ", "Level", this->level_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_);
+  LOG_SENSOR("  ", "Battery Level", this->battery_level_);
+  LOG_SENSOR("  ", "Reading Distance", this->distance_);
+}
+
+/**
+ * Main parse function that gets called for all ble advertisements.
+ * Check if advertisement is for our sensor and if so decode it and
+ * update the sensor state data.
+ */
+bool MopekaStdCheck::parse_device(
+    const esp32_ble_tracker::ESPBTDevice &device) {
+  {
+    // Validate address.
+    if (device.address_uint64() != this->address_) {
+      return false;
+    }
+
+    ESP_LOGVV(TAG, "parse_device(): MAC address %s found.",
+              device.address_str().c_str());
+  }
+
+  {
+    // Validate service uuid
+    const auto &service_uuids = device.get_service_uuids();
+    if (service_uuids.size() != 1) {
+      return false;
+    }
+    const auto &service_uuid = service_uuids[0];
+    if (service_uuid !=
+        esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID)) {
+      return false;
+    }
+  }
+
+  const auto &manu_datas = device.get_manufacturer_datas();
+
+  if (manu_datas.size() != 1) {
+    ESP_LOGE(TAG, "%s: Unexpected manu_datas size (%d)",
+             device.address_str().c_str(), manu_datas.size());
+    return false;
+  }
+
+  const auto &manu_data = manu_datas[0];
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+  ESP_LOGVV(TAG, "%s: Manufacturer data: %s", device.address_str().c_str(),
+            format_hex_pretty(manu_data.data).c_str());
+#endif
+
+  if (manu_data.data.size() != MANUFACTURER_DATA_LENGTH) {
+    ESP_LOGE(TAG, "%s: Unexpected manu_data size (%d)",
+             device.address_str().c_str(), manu_data.data.size());
+    return false;
+  }
+
+  // Now parse the data
+  const u_int8_t hardware_id = manu_data.data[1] & 0xCF;
+  if (static_cast<SensorType>(hardware_id) != STANDARD &&
+      static_cast<SensorType>(hardware_id) != XL) {
+    ESP_LOGE(TAG, "%s: Unsupported Sensor Type (0x%X)",
+             device.address_str().c_str(), hardware_id);
+    return false;
+  }
+
+  // Get battery level first
+  if (this->battery_level_ != nullptr) {
+    uint8_t level = this->parse_battery_level_(manu_data.data);
+    this->battery_level_->publish_state(level);
+  }
+
+  // Get temperature of sensor
+  uint8_t temp_in_c = this->parse_temperature_(manu_data.data);
+  if (this->temperature_ != nullptr) {
+    this->temperature_->publish_state(temp_in_c);
+  }
+
+  // Get distance and level if either are sensors
+  if ((this->distance_ != nullptr) || (this->level_ != nullptr)) {
+    // Message contains 12 sensor dataset each 10 bytes long.
+    // each sensor dataset contains 5 byte time and 5 byte value.
+    // if value is 0 ignore and if combined time is too old ignore.
+
+    // time in 10us ticks.
+    // value is amplitude.
+    const auto message = manu_data.data;
+
+    std::vector<u_int16_t> measurements_time;
+    std::vector<u_int16_t> measurements_value;
+
+    u_int16_t time = 0;
+
+    for (u_int8_t i = 0; i < 3; i++) {
+      u_int8_t start = 4 + i * 5;
+      u_int64_t d = message[start] | (message[start + 1] << 8) |
+                    (message[start + 2] << 16) | (message[start + 3] << 24) |
+                    ((u_int64_t)message[start + 4] << 32);
+      for (u_int8_t i = 0; i < 4; i++) {
+        u_int8_t measurement_time = (d & 0x1F) + 1;
+        d = d >> 5;
+        u_int8_t measurement_value = (d & 0x1F);
+        d = d >> 5;
+
+        if (time > 255) {
+          break;
+        }
+        time += measurement_time;
+
+        if (measurement_value > 0 && measurement_value < 0b00011111 &&
+            time < 255) {
+          u_int16_t value = ((u_int16_t)measurement_value - 1) * 4 + 6;
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+          ESP_LOGVV(TAG, "%s: Valid sensor data %u at time %u.",
+                    device.address_str().c_str(), value, time * 2);
+#endif
+
+          measurements_time.push_back(time * 2);
+          measurements_value.push_back(value);
+        }
+      }
+    }
+
+    if (measurements_time.size() < 2) {
+      // At least two measurement values must be present.
+      ESP_LOGW(TAG, "%s: Poor read quality. Setting distance to 0.",
+               device.address_str().c_str());
+      if (this->distance_ != nullptr) {
+        this->distance_->publish_state(0);
+      }
+      if (this->level_ != nullptr) {
+        this->level_->publish_state(0);
+      }
+    } else {
+      // Basic logic take first response and ignore all other echos.
+      // Possible improvement is to add peak detection for echo values.
+      // Expectation is first value at distance and second lower value at
+      // 2*distance. Ignore low values as noise.
+
+      float lpg_speed_of_sound = this->get_lpg_speed_of_sound(temp_in_c);
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+      ESP_LOGVV(TAG, "%s: Speed of sound in current fluid %f m/s",
+                device.address_str().c_str(), lpg_speed_of_sound);
+#endif
+
+      uint32_t distance_value =
+          measurements_time[0] * lpg_speed_of_sound / 100.0f / 2.0f;
+
+      // update distance sensor
+      if (this->distance_ != nullptr) {
+        this->distance_->publish_state(distance_value);
+      }
+
+      // update level sensor
+      if (this->level_ != nullptr) {
+        uint8_t tank_level = 0;
+        if (distance_value >= this->full_mm_) {
+          tank_level = 100;  // cap at 100%
+        } else if (distance_value > this->empty_mm_) {
+          tank_level = ((100.0f / (this->full_mm_ - this->empty_mm_)) *
+                        (distance_value - this->empty_mm_));
+        }
+        this->level_->publish_state(tank_level);
+      }
+    }
+  }
+
+  return true;
+}
+
+float MopekaStdCheck::get_lpg_speed_of_sound(float temperature) {
+  return 1040.71f - 4.87f * temperature - 137.5f * this->lpg_butane_ratio_ -
+         0.0107f * temperature * temperature -
+         1.63f * temperature * this->lpg_butane_ratio_;
+}
+
+uint8_t MopekaStdCheck::parse_battery_level_(
+    const std::vector<uint8_t> &message) {
+  const float voltage = (float)((message[2] / 256.0f) * 2.0f + 1.5f);
+  ESP_LOGVV(TAG, "Sensor battery voltage: %f V", voltage);
+  // convert voltage and scale for CR2032
+  const float percent = (voltage - 2.2f) / 0.65f * 100.0f;
+  if (percent < 0.0f) {
+    return 0;
+  }
+  if (percent > 100.0f) {
+    return 100;
+  }
+  return (uint8_t)percent;
+}
+
+uint8_t MopekaStdCheck::parse_temperature_(
+    const std::vector<uint8_t> &message) {
+  uint8_t tmp = message[3] & 0x3f;
+  if (tmp == 0) {
+    return -40;
+  } else {
+    return (uint8_t)((tmp - 25.0f) * 1.776964f);
+  }
+}
+
+}  // namespace mopeka_std_check
+}  // namespace esphome
+
+#endif

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -68,7 +68,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   }
 
   // Now parse the data
-  auto mopeka_data = (const mopeka_std_package *) manu_data.data.data();
+  const auto *mopeka_data = (const mopeka_std_package *) manu_data.data.data();
 
   const u_int8_t hardware_id = mopeka_data->data_1 & 0xCF;
   if (static_cast<SensorType>(hardware_id) != STANDARD && static_cast<SensorType>(hardware_id) != XL) {
@@ -105,7 +105,6 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   if ((this->distance_ != nullptr) || (this->level_ != nullptr)) {
     // Message contains 12 sensor dataset each 10 bytes long.
     // each sensor dataset contains 5 byte time and 5 byte value.
-    // if value is 0 ignore.
 
     // time in 10us ticks.
     // value is amplitude.
@@ -138,7 +137,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     {
       u_int16_t measurement_time = 0;
       for (u_int8_t i = 0; i < measurements_value.size(); i++) {
-        // Add time to value.
+        // Time is summed up until a value is reported. This allows time values larger than the 5 bits in transport.
         measurement_time += measurements_time[i];
         if (measurements_value[i] != 0) {
           // I got a value

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -143,7 +143,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
       // Expectation is first value at distance and second lower value at
       // 2*distance. Ignore low values as noise.
 
-      float lpg_speed_of_sound = this->get_lpg_speed_of_sound(temp_in_c);
+      float lpg_speed_of_sound = this->get_lpg_speed_of_sound_(temp_in_c);
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
       ESP_LOGVV(TAG, "%s: Speed of sound in current fluid %f m/s", device.address_str().c_str(), lpg_speed_of_sound);
@@ -172,7 +172,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   return true;
 }
 
-float MopekaStdCheck::get_lpg_speed_of_sound(float temperature) {
+float MopekaStdCheck::get_lpg_speed_of_sound_(float temperature) {
   return 1040.71f - 4.87f * temperature - 137.5f * this->lpg_butane_ratio_ - 0.0107f * temperature * temperature -
          1.63f * temperature * this->lpg_butane_ratio_;
 }

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -196,7 +196,7 @@ uint8_t MopekaStdCheck::parse_temperature_(const std::vector<uint8_t> &message) 
   if (tmp == 0) {
     return -40;
   } else {
-    return (uint8_t) ((tmp - 25.0f) * 1.776964f);
+    return (uint8_t)((tmp - 25.0f) * 1.776964f);
   }
 }
 

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -26,16 +26,14 @@ void MopekaStdCheck::dump_config() {
  * Check if advertisement is for our sensor and if so decode it and
  * update the sensor state data.
  */
-bool MopekaStdCheck::parse_device(
-    const esp32_ble_tracker::ESPBTDevice &device) {
+bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   {
     // Validate address.
     if (device.address_uint64() != this->address_) {
       return false;
     }
 
-    ESP_LOGVV(TAG, "parse_device(): MAC address %s found.",
-              device.address_str().c_str());
+    ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str().c_str());
   }
 
   {
@@ -45,8 +43,7 @@ bool MopekaStdCheck::parse_device(
       return false;
     }
     const auto &service_uuid = service_uuids[0];
-    if (service_uuid !=
-        esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID)) {
+    if (service_uuid != esp32_ble_tracker::ESPBTUUID::from_uint16(SERVICE_UUID)) {
       return false;
     }
   }
@@ -54,30 +51,25 @@ bool MopekaStdCheck::parse_device(
   const auto &manu_datas = device.get_manufacturer_datas();
 
   if (manu_datas.size() != 1) {
-    ESP_LOGE(TAG, "%s: Unexpected manu_datas size (%d)",
-             device.address_str().c_str(), manu_datas.size());
+    ESP_LOGE(TAG, "%s: Unexpected manu_datas size (%d)", device.address_str().c_str(), manu_datas.size());
     return false;
   }
 
   const auto &manu_data = manu_datas[0];
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-  ESP_LOGVV(TAG, "%s: Manufacturer data: %s", device.address_str().c_str(),
-            format_hex_pretty(manu_data.data).c_str());
+  ESP_LOGVV(TAG, "%s: Manufacturer data: %s", device.address_str().c_str(), format_hex_pretty(manu_data.data).c_str());
 #endif
 
   if (manu_data.data.size() != MANUFACTURER_DATA_LENGTH) {
-    ESP_LOGE(TAG, "%s: Unexpected manu_data size (%d)",
-             device.address_str().c_str(), manu_data.data.size());
+    ESP_LOGE(TAG, "%s: Unexpected manu_data size (%d)", device.address_str().c_str(), manu_data.data.size());
     return false;
   }
 
   // Now parse the data
   const u_int8_t hardware_id = manu_data.data[1] & 0xCF;
-  if (static_cast<SensorType>(hardware_id) != STANDARD &&
-      static_cast<SensorType>(hardware_id) != XL) {
-    ESP_LOGE(TAG, "%s: Unsupported Sensor Type (0x%X)",
-             device.address_str().c_str(), hardware_id);
+  if (static_cast<SensorType>(hardware_id) != STANDARD && static_cast<SensorType>(hardware_id) != XL) {
+    ESP_LOGE(TAG, "%s: Unsupported Sensor Type (0x%X)", device.address_str().c_str(), hardware_id);
     return false;
   }
 
@@ -110,9 +102,8 @@ bool MopekaStdCheck::parse_device(
 
     for (u_int8_t i = 0; i < 3; i++) {
       u_int8_t start = 4 + i * 5;
-      u_int64_t d = message[start] | (message[start + 1] << 8) |
-                    (message[start + 2] << 16) | (message[start + 3] << 24) |
-                    ((u_int64_t)message[start + 4] << 32);
+      u_int64_t d = message[start] | (message[start + 1] << 8) | (message[start + 2] << 16) |
+                    (message[start + 3] << 24) | ((u_int64_t) message[start + 4] << 32);
       for (u_int8_t i = 0; i < 4; i++) {
         u_int8_t measurement_time = (d & 0x1F) + 1;
         d = d >> 5;
@@ -124,13 +115,11 @@ bool MopekaStdCheck::parse_device(
         }
         time += measurement_time;
 
-        if (measurement_value > 0 && measurement_value < 0b00011111 &&
-            time < 255) {
-          u_int16_t value = ((u_int16_t)measurement_value - 1) * 4 + 6;
+        if (measurement_value > 0 && measurement_value < 0b00011111 && time < 255) {
+          u_int16_t value = ((u_int16_t) measurement_value - 1) * 4 + 6;
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-          ESP_LOGVV(TAG, "%s: Valid sensor data %u at time %u.",
-                    device.address_str().c_str(), value, time * 2);
+          ESP_LOGVV(TAG, "%s: Valid sensor data %u at time %u.", device.address_str().c_str(), value, time * 2);
 #endif
 
           measurements_time.push_back(time * 2);
@@ -141,8 +130,7 @@ bool MopekaStdCheck::parse_device(
 
     if (measurements_time.size() < 2) {
       // At least two measurement values must be present.
-      ESP_LOGW(TAG, "%s: Poor read quality. Setting distance to 0.",
-               device.address_str().c_str());
+      ESP_LOGW(TAG, "%s: Poor read quality. Setting distance to 0.", device.address_str().c_str());
       if (this->distance_ != nullptr) {
         this->distance_->publish_state(0);
       }
@@ -158,12 +146,10 @@ bool MopekaStdCheck::parse_device(
       float lpg_speed_of_sound = this->get_lpg_speed_of_sound(temp_in_c);
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-      ESP_LOGVV(TAG, "%s: Speed of sound in current fluid %f m/s",
-                device.address_str().c_str(), lpg_speed_of_sound);
+      ESP_LOGVV(TAG, "%s: Speed of sound in current fluid %f m/s", device.address_str().c_str(), lpg_speed_of_sound);
 #endif
 
-      uint32_t distance_value =
-          measurements_time[0] * lpg_speed_of_sound / 100.0f / 2.0f;
+      uint32_t distance_value = measurements_time[0] * lpg_speed_of_sound / 100.0f / 2.0f;
 
       // update distance sensor
       if (this->distance_ != nullptr) {
@@ -176,8 +162,7 @@ bool MopekaStdCheck::parse_device(
         if (distance_value >= this->full_mm_) {
           tank_level = 100;  // cap at 100%
         } else if (distance_value > this->empty_mm_) {
-          tank_level = ((100.0f / (this->full_mm_ - this->empty_mm_)) *
-                        (distance_value - this->empty_mm_));
+          tank_level = ((100.0f / (this->full_mm_ - this->empty_mm_)) * (distance_value - this->empty_mm_));
         }
         this->level_->publish_state(tank_level);
       }
@@ -188,14 +173,12 @@ bool MopekaStdCheck::parse_device(
 }
 
 float MopekaStdCheck::get_lpg_speed_of_sound(float temperature) {
-  return 1040.71f - 4.87f * temperature - 137.5f * this->lpg_butane_ratio_ -
-         0.0107f * temperature * temperature -
+  return 1040.71f - 4.87f * temperature - 137.5f * this->lpg_butane_ratio_ - 0.0107f * temperature * temperature -
          1.63f * temperature * this->lpg_butane_ratio_;
 }
 
-uint8_t MopekaStdCheck::parse_battery_level_(
-    const std::vector<uint8_t> &message) {
-  const float voltage = (float)((message[2] / 256.0f) * 2.0f + 1.5f);
+uint8_t MopekaStdCheck::parse_battery_level_(const std::vector<uint8_t> &message) {
+  const float voltage = (float) ((message[2] / 256.0f) * 2.0f + 1.5f);
   ESP_LOGVV(TAG, "Sensor battery voltage: %f V", voltage);
   // convert voltage and scale for CR2032
   const float percent = (voltage - 2.2f) / 0.65f * 100.0f;
@@ -205,16 +188,15 @@ uint8_t MopekaStdCheck::parse_battery_level_(
   if (percent > 100.0f) {
     return 100;
   }
-  return (uint8_t)percent;
+  return (uint8_t) percent;
 }
 
-uint8_t MopekaStdCheck::parse_temperature_(
-    const std::vector<uint8_t> &message) {
+uint8_t MopekaStdCheck::parse_temperature_(const std::vector<uint8_t> &message) {
   uint8_t tmp = message[3] & 0x3f;
   if (tmp == 0) {
     return -40;
   } else {
-    return (uint8_t)((tmp - 25.0f) * 1.776964f);
+    return (uint8_t) ((tmp - 25.0f) * 1.776964f);
   }
 }
 

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -136,7 +136,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     u_int16_t best_time = 0;
     {
       u_int16_t measurement_time = 0;
-      for (u_int8_t i = 0; i < measurements_value.size(); i++) {
+      for (u_int8_t i = 0; i < 12; i++) {
         // Time is summed up until a value is reported. This allows time values larger than the 5 bits in transport.
         measurement_time += measurements_time[i];
         if (measurements_value[i] != 0) {

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -16,6 +16,30 @@ enum SensorType {
   XL = 0x03,
 };
 
+// 4 values in one struct so it aligns to 8 byte. One `mopeka_std_values` is 40 bit long.
+struct mopeka_std_values {  // NOLINT(readability-identifier-naming,altera-struct-pack-align)
+  u_int16_t time_0 : 5;
+  u_int16_t value_0 : 5;
+  u_int16_t time_1 : 5;
+  u_int16_t value_1 : 5;
+  u_int16_t time_2 : 5;
+  u_int16_t value_2 : 5;
+  u_int16_t time_3 : 5;
+  u_int16_t value_3 : 5;
+} __attribute__((packed));
+
+struct mopeka_std_package {  // NOLINT(readability-identifier-naming,altera-struct-pack-align)
+  u_int8_t data_0 : 8;
+  u_int8_t data_1 : 8;
+  u_int8_t raw_voltage : 8;
+
+  u_int8_t raw_temp : 6;
+  bool slow_update_rate : 1;
+  bool sync_pressed : 1;
+
+  mopeka_std_values val[4];
+} __attribute__((packed));
+
 class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
@@ -44,8 +68,8 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   uint32_t empty_mm_;
 
   float get_lpg_speed_of_sound_(float temperature);
-  uint8_t parse_battery_level_(const std::vector<uint8_t> &message);
-  uint8_t parse_temperature_(const std::vector<uint8_t> &message);
+  uint8_t parse_battery_level_(const mopeka_std_package* message);
+  uint8_t parse_temperature_(const mopeka_std_package* message);
 };
 
 }  // namespace mopeka_std_check

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -42,7 +42,7 @@ class MopekaStdCheck : public Component,
   sensor::Sensor *distance_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
 
-  float lpg_butane_ratio_ = 1.0f;
+  float lpg_butane_ratio_;
   uint32_t full_mm_;
   uint32_t empty_mm_;
 

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -52,7 +52,7 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; };
   void set_battery_level(sensor::Sensor *bat) { this->battery_level_ = bat; };
   void set_distance(sensor::Sensor *distance) { this->distance_ = distance; };
-  void set_lpg_butane_ratio(float val) { this->lpg_butane_ratio_ = val; };
+  void set_propane_butane_mix(float val) { this->propane_butane_mix_ = val; };
   void set_tank_full(float full) { this->full_mm_ = full; };
   void set_tank_empty(float empty) { this->empty_mm_ = empty; };
 
@@ -63,7 +63,7 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   sensor::Sensor *distance_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
 
-  float lpg_butane_ratio_;
+  float propane_butane_mix_;
   uint32_t full_mm_;
   uint32_t empty_mm_;
 

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -43,7 +43,7 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   uint32_t full_mm_;
   uint32_t empty_mm_;
 
-  float get_lpg_speed_of_sound(float temperature);
+  float get_lpg_speed_of_sound_(float temperature);
   uint8_t parse_battery_level_(const std::vector<uint8_t> &message);
   uint8_t parse_temperature_(const std::vector<uint8_t> &message);
 };

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -16,8 +16,7 @@ enum SensorType {
   XL = 0x03,
 };
 
-class MopekaStdCheck : public Component,
-                       public esp32_ble_tracker::ESPBTDeviceListener {
+class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
 
@@ -26,9 +25,7 @@ class MopekaStdCheck : public Component,
   float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_level(sensor::Sensor *level) { level_ = level; };
-  void set_temperature(sensor::Sensor *temperature) {
-    temperature_ = temperature;
-  };
+  void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; };
   void set_battery_level(sensor::Sensor *bat) { battery_level_ = bat; };
   void set_distance(sensor::Sensor *distance) { distance_ = distance; };
   void set_lpg_butane_ratio(float val) { lpg_butane_ratio_ = val; };

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <vector>
+
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace mopeka_std_check {
+
+enum SensorType {
+  STANDARD = 0x02,
+  XL = 0x03,
+};
+
+class MopekaStdCheck : public Component,
+                       public esp32_ble_tracker::ESPBTDeviceListener {
+ public:
+  void set_address(uint64_t address) { address_ = address; };
+
+  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_level(sensor::Sensor *level) { level_ = level; };
+  void set_temperature(sensor::Sensor *temperature) {
+    temperature_ = temperature;
+  };
+  void set_battery_level(sensor::Sensor *bat) { battery_level_ = bat; };
+  void set_distance(sensor::Sensor *distance) { distance_ = distance; };
+  void set_lpg_butane_ratio(float val) { lpg_butane_ratio_ = val; };
+  void set_tank_full(float full) { full_mm_ = full; };
+  void set_tank_empty(float empty) { empty_mm_ = empty; };
+
+ protected:
+  uint64_t address_;
+  sensor::Sensor *level_{nullptr};
+  sensor::Sensor *temperature_{nullptr};
+  sensor::Sensor *distance_{nullptr};
+  sensor::Sensor *battery_level_{nullptr};
+
+  float lpg_butane_ratio_ = 1.0f;
+  uint32_t full_mm_;
+  uint32_t empty_mm_;
+
+  float get_lpg_speed_of_sound(float temperature);
+  uint8_t parse_battery_level_(const std::vector<uint8_t> &message);
+  uint8_t parse_temperature_(const std::vector<uint8_t> &message);
+};
+
+}  // namespace mopeka_std_check
+}  // namespace esphome
+
+#endif

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -48,13 +48,13 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
-  void set_level(sensor::Sensor *level) { level_ = level; };
-  void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; };
-  void set_battery_level(sensor::Sensor *bat) { battery_level_ = bat; };
-  void set_distance(sensor::Sensor *distance) { distance_ = distance; };
-  void set_lpg_butane_ratio(float val) { lpg_butane_ratio_ = val; };
-  void set_tank_full(float full) { full_mm_ = full; };
-  void set_tank_empty(float empty) { empty_mm_ = empty; };
+  void set_level(sensor::Sensor *level) { this->level_ = level; };
+  void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; };
+  void set_battery_level(sensor::Sensor *bat) { this->battery_level_ = bat; };
+  void set_distance(sensor::Sensor *distance) { this->distance_ = distance; };
+  void set_lpg_butane_ratio(float val) { this->lpg_butane_ratio_ = val; };
+  void set_tank_full(float full) { this->full_mm_ = full; };
+  void set_tank_empty(float empty) { this->empty_mm_ = empty; };
 
  protected:
   uint64_t address_;
@@ -68,8 +68,8 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   uint32_t empty_mm_;
 
   float get_lpg_speed_of_sound_(float temperature);
-  uint8_t parse_battery_level_(const mopeka_std_package* message);
-  uint8_t parse_temperature_(const mopeka_std_package* message);
+  uint8_t parse_battery_level_(const mopeka_std_package *message);
+  uint8_t parse_temperature_(const mopeka_std_package *message);
 };
 
 }  // namespace mopeka_std_check

--- a/esphome/components/mopeka_std_check/sensor.py
+++ b/esphome/components/mopeka_std_check/sensor.py
@@ -1,0 +1,141 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, esp32_ble_tracker
+from esphome.const import (
+    CONF_DISTANCE,
+    CONF_MAC_ADDRESS,
+    CONF_ID,
+    ICON_THERMOMETER,
+    ICON_RULER,
+    UNIT_PERCENT,
+    CONF_LEVEL,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_TEMPERATURE,
+    UNIT_CELSIUS,
+    STATE_CLASS_MEASUREMENT,
+    CONF_BATTERY_LEVEL,
+    DEVICE_CLASS_BATTERY,
+)
+
+CONF_TANK_TYPE = "tank_type"
+CONF_CUSTOM_DISTANCE_FULL = "custom_distance_full"
+CONF_CUSTOM_DISTANCE_EMPTY = "custom_distance_empty"
+CONF_LPG_BUTANE_RATIO = "propane_butane_mix"
+
+ICON_PROPANE_TANK = "mdi:propane-tank"
+
+TANK_TYPE_CUSTOM = "CUSTOM"
+
+UNIT_MILLIMETER = "mm"
+
+
+def small_distance(value):
+    """small_distance is stored in mm"""
+    meters = cv.distance(value)
+    return meters * 1000
+
+
+#
+# Map of standard tank types to their
+# empty and full distance values.
+# Format is - tank name: (empty distance in mm, full distance in mm)
+#
+CONF_SUPPORTED_TANKS_MAP = {
+    TANK_TYPE_CUSTOM: (38, 100),
+    "NORTH_AMERICA_20LB_VERTICAL": (38, 254),  # empty/full readings for 20lb US tank
+    "NORTH_AMERICA_30LB_VERTICAL": (38, 381),
+    "NORTH_AMERICA_40LB_VERTICAL": (38, 508),
+    "EUROPE_6KG": (38, 336),
+    "EUROPE_11KG": (38, 366),
+    "EUROPE_14KG": (38, 467),
+}
+
+CODEOWNERS = ["@Fabian-Schmidt"]
+DEPENDENCIES = ["esp32_ble_tracker"]
+
+mopeka_std_check_ns = cg.esphome_ns.namespace("mopeka_std_check")
+MopekaStdCheck = mopeka_std_check_ns.class_(
+    "MopekaStdCheck", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(MopekaStdCheck),
+            cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
+            cv.Optional(CONF_CUSTOM_DISTANCE_FULL): small_distance,
+            cv.Optional(CONF_CUSTOM_DISTANCE_EMPTY): small_distance,
+            cv.Optional(CONF_LPG_BUTANE_RATIO): cv.float_range(0, 1),
+            cv.Required(CONF_TANK_TYPE): cv.enum(CONF_SUPPORTED_TANKS_MAP, upper=True),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_LEVEL): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                icon=ICON_PROPANE_TANK,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_DISTANCE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MILLIMETER,
+                icon=ICON_RULER,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_BATTERY,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await esp32_ble_tracker.register_ble_device(var, config)
+
+    cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
+
+    if config[CONF_TANK_TYPE] == TANK_TYPE_CUSTOM:
+        # Support custom tank min/max
+        if CONF_CUSTOM_DISTANCE_EMPTY in config:
+            cg.add(var.set_tank_empty(config[CONF_CUSTOM_DISTANCE_EMPTY]))
+        else:
+            cg.add(var.set_tank_empty(
+                CONF_SUPPORTED_TANKS_MAP[TANK_TYPE_CUSTOM][0]))
+        if CONF_CUSTOM_DISTANCE_FULL in config:
+            cg.add(var.set_tank_full(config[CONF_CUSTOM_DISTANCE_FULL]))
+        else:
+            cg.add(var.set_tank_full(
+                CONF_SUPPORTED_TANKS_MAP[TANK_TYPE_CUSTOM][1]))
+    else:
+        # Set the Tank empty and full based on map - User is requesting standard tank
+        t = config[CONF_TANK_TYPE]
+        cg.add(var.set_tank_empty(CONF_SUPPORTED_TANKS_MAP[t][0]))
+        cg.add(var.set_tank_full(CONF_SUPPORTED_TANKS_MAP[t][1]))
+
+    if CONF_LPG_BUTANE_RATIO in config:
+        cg.add(var.set_lpg_butane_ratio(config[CONF_LPG_BUTANE_RATIO]))
+
+    if CONF_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature(sens))
+    if CONF_LEVEL in config:
+        sens = await sensor.new_sensor(config[CONF_LEVEL])
+        cg.add(var.set_level(sens))
+    if CONF_DISTANCE in config:
+        sens = await sensor.new_sensor(config[CONF_DISTANCE])
+        cg.add(var.set_distance(sens))
+    if CONF_BATTERY_LEVEL in config:
+        sens = await sensor.new_sensor(config[CONF_BATTERY_LEVEL])
+        cg.add(var.set_battery_level(sens))

--- a/esphome/components/mopeka_std_check/sensor.py
+++ b/esphome/components/mopeka_std_check/sensor.py
@@ -65,7 +65,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_CUSTOM_DISTANCE_FULL): small_distance,
             cv.Optional(CONF_CUSTOM_DISTANCE_EMPTY): small_distance,
-            cv.Optional(CONF_PROPANE_BUTANE_MIX, default=1.0): cv.float_range(0, 1),
+            cv.Optional(CONF_PROPANE_BUTANE_MIX, default="100%"): cv.percentage,
             cv.Required(CONF_TANK_TYPE): cv.enum(CONF_SUPPORTED_TANKS_MAP, upper=True),
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,

--- a/esphome/components/mopeka_std_check/sensor.py
+++ b/esphome/components/mopeka_std_check/sensor.py
@@ -65,7 +65,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_CUSTOM_DISTANCE_FULL): small_distance,
             cv.Optional(CONF_CUSTOM_DISTANCE_EMPTY): small_distance,
-            cv.Optional(CONF_LPG_BUTANE_RATIO): cv.float_range(0, 1),
+            cv.Optional(CONF_LPG_BUTANE_RATIO, default=1.0): cv.float_range(0, 1),
             cv.Required(CONF_TANK_TYPE): cv.enum(CONF_SUPPORTED_TANKS_MAP, upper=True),
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,

--- a/esphome/components/mopeka_std_check/sensor.py
+++ b/esphome/components/mopeka_std_check/sensor.py
@@ -111,13 +111,11 @@ async def to_code(config):
         if CONF_CUSTOM_DISTANCE_EMPTY in config:
             cg.add(var.set_tank_empty(config[CONF_CUSTOM_DISTANCE_EMPTY]))
         else:
-            cg.add(var.set_tank_empty(
-                CONF_SUPPORTED_TANKS_MAP[TANK_TYPE_CUSTOM][0]))
+            cg.add(var.set_tank_empty(CONF_SUPPORTED_TANKS_MAP[TANK_TYPE_CUSTOM][0]))
         if CONF_CUSTOM_DISTANCE_FULL in config:
             cg.add(var.set_tank_full(config[CONF_CUSTOM_DISTANCE_FULL]))
         else:
-            cg.add(var.set_tank_full(
-                CONF_SUPPORTED_TANKS_MAP[TANK_TYPE_CUSTOM][1]))
+            cg.add(var.set_tank_full(CONF_SUPPORTED_TANKS_MAP[TANK_TYPE_CUSTOM][1]))
     else:
         # Set the Tank empty and full based on map - User is requesting standard tank
         t = config[CONF_TANK_TYPE]

--- a/esphome/components/mopeka_std_check/sensor.py
+++ b/esphome/components/mopeka_std_check/sensor.py
@@ -123,7 +123,7 @@ async def to_code(config):
         cg.add(var.set_tank_full(CONF_SUPPORTED_TANKS_MAP[t][1]))
 
     if CONF_PROPANE_BUTANE_MIX in config:
-        cg.add(var.set_lpg_butane_ratio(config[CONF_PROPANE_BUTANE_MIX]))
+        cg.add(var.set_propane_butane_mix(config[CONF_PROPANE_BUTANE_MIX]))
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])

--- a/esphome/components/mopeka_std_check/sensor.py
+++ b/esphome/components/mopeka_std_check/sensor.py
@@ -20,7 +20,7 @@ from esphome.const import (
 CONF_TANK_TYPE = "tank_type"
 CONF_CUSTOM_DISTANCE_FULL = "custom_distance_full"
 CONF_CUSTOM_DISTANCE_EMPTY = "custom_distance_empty"
-CONF_LPG_BUTANE_RATIO = "propane_butane_mix"
+CONF_PROPANE_BUTANE_MIX = "propane_butane_mix"
 
 ICON_PROPANE_TANK = "mdi:propane-tank"
 
@@ -65,7 +65,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_CUSTOM_DISTANCE_FULL): small_distance,
             cv.Optional(CONF_CUSTOM_DISTANCE_EMPTY): small_distance,
-            cv.Optional(CONF_LPG_BUTANE_RATIO, default=1.0): cv.float_range(0, 1),
+            cv.Optional(CONF_PROPANE_BUTANE_MIX, default=1.0): cv.float_range(0, 1),
             cv.Required(CONF_TANK_TYPE): cv.enum(CONF_SUPPORTED_TANKS_MAP, upper=True),
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
@@ -122,8 +122,8 @@ async def to_code(config):
         cg.add(var.set_tank_empty(CONF_SUPPORTED_TANKS_MAP[t][0]))
         cg.add(var.set_tank_full(CONF_SUPPORTED_TANKS_MAP[t][1]))
 
-    if CONF_LPG_BUTANE_RATIO in config:
-        cg.add(var.set_lpg_butane_ratio(config[CONF_LPG_BUTANE_RATIO]))
+    if CONF_PROPANE_BUTANE_MIX in config:
+        cg.add(var.set_lpg_butane_ratio(config[CONF_PROPANE_BUTANE_MIX]))
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add support for Mopeka Standard Check LP BLE sensor and update generic component that helps find the BLE MAC address.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/feature-requests/issues/2080>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2624

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
    esp32_ble_tracker:
    
    sensor:
      # Example using 11kg 100% propane tank.
      - platform: mopeka_std_check
        mac_address: D3:75:F2:DC:16:91
        tank_type: Europe_11kg
        temperature:
            name: "Propane test temp"
        level:
            name: "Propane test level"
        distance:
            name: "Propane test distance"
        battery_level:
            name: "Propane test battery level"
    
      # Custom example - user defined empty / full points and 80% butane and 20% propane.
      - platform: mopeka_std_check
        mac_address: D3:75:F2:DC:16:91
        tank_type: CUSTOM
        custom_distance_full: 40cm
        custom_distance_empty: 32mm
        propane_butane_mix: 0.2
        temperature:
            name: "Propane c test temp"
        level:
            name: "Propane c test level"
        distance:
            name: "Propane c test distance"
        battery_level:
            name: "Propane c test battery level"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
