### PR TITLE
Fix "BLE server / advertising always on"

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -31,11 +31,13 @@ void ESP32BLE::setup() {
     return;
   }
 
-  this->advertising_ = new BLEAdvertising();  // NOLINT(cppcoreguidelines-owning-memory)
+#ifdef USE_ESP32_BLE_SERVER
+    this->advertising_ = new BLEAdvertising();  // NOLINT(cppcoreguidelines-owning-memory)
 
-  this->advertising_->set_scan_response(true);
-  this->advertising_->set_min_preferred_interval(0x06);
-  this->advertising_->start();
+    this->advertising_->set_scan_response(true);
+    this->advertising_->set_min_preferred_interval(0x06);
+    this->advertising_->start();
+#endif  // USE_ESP32_BLE_SERVER
 
   ESP_LOGD(TAG, "BLE setup complete");
 }

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -32,11 +32,11 @@ void ESP32BLE::setup() {
   }
 
 #ifdef USE_ESP32_BLE_SERVER
-    this->advertising_ = new BLEAdvertising();  // NOLINT(cppcoreguidelines-owning-memory)
+  this->advertising_ = new BLEAdvertising();  // NOLINT(cppcoreguidelines-owning-memory)
 
-    this->advertising_->set_scan_response(true);
-    this->advertising_->set_min_preferred_interval(0x06);
-    this->advertising_->start();
+  this->advertising_->set_scan_response(true);
+  this->advertising_->set_min_preferred_interval(0x06);
+  this->advertising_->start();
 #endif  // USE_ESP32_BLE_SERVER
 
   ESP_LOGD(TAG, "BLE setup complete");


### PR DESCRIPTION
# What does this implement/fix?

Don't enable BLE advertising if no BLE server is configured (for example in a BLE client configuration)

https://github.com/esphome/esphome/commit/4aac76c549800ee22ef83730eb6d5dddef2c985c

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml

esp32_ble_tracker:

ble_client:
  mac_address: "AA:BB:CC:DD:EE:FF"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
