### PR TITLE
Fix pressure compensation in SCD4X

### DIFF
--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -59,7 +59,7 @@ void SCD4XComponent::setup() {
 
       // If pressure compensation available use it
       // else use altitude
-      if (ambient_pressure_compensation_) {
+      /*if (ambient_pressure_compensation_) {
         if (!this->update_ambient_pressure_compensation_(ambient_pressure_)) {
           ESP_LOGE(TAG, "Error setting ambient pressure compensation.");
           this->error_code_ = MEASUREMENT_INIT_FAILED;
@@ -73,7 +73,7 @@ void SCD4XComponent::setup() {
           this->mark_failed();
           return;
         }
-      }
+      }*/
 
       if (!this->write_command(SCD4X_CMD_AUTOMATIC_SELF_CALIBRATION, enable_asc_ ? 1 : 0)) {
         ESP_LOGE(TAG, "Error setting automatic self calibration.");
@@ -249,6 +249,9 @@ bool SCD4XComponent::factory_reset() {
       return false;
     }
     ESP_LOGD(TAG, "Factory reset complete");
+    this->set_timeout(1200, [this]() {
+      this->setup();
+    });
     return true;
   });
   return true;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -257,7 +257,7 @@ bool SCD4XComponent::factory_reset() {
 // Note pressure in bar here. Convert to hPa
 void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
   ambient_pressure_compensation_ = true;
-  uint16_t new_ambient_pressure = (uint16_t)(round(pressure_in_bar * 1000));
+  uint16_t new_ambient_pressure = (uint16_t)(pressure_in_bar * 1000);
   if (!initialized_) {
     ambient_pressure_ = new_ambient_pressure;
     return;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -203,6 +203,10 @@ void SCD4XComponent::update() {
 }
 
 bool SCD4XComponent::perform_forced_calibration(uint16_t current_co2_concentration) {
+  if (!initialized_) {
+    return;
+  }
+
   /*
     Operate the SCD4x in the operation mode later used in normal sensor operation (periodic measurement, low power
     periodic measurement or single shot) for > 3 minutes in an environment with homogeneous and constant CO2
@@ -236,6 +240,10 @@ bool SCD4XComponent::perform_forced_calibration(uint16_t current_co2_concentrati
 }
 
 bool SCD4XComponent::factory_reset() {
+  if (!initialized_) {
+    return;
+  }
+
   if (!this->write_command(SCD4X_CMD_STOP_MEASUREMENTS)) {
     ESP_LOGE(TAG, "Failed to stop measurements");
     this->status_set_warning();
@@ -259,7 +267,7 @@ void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
   ambient_pressure_compensation_ = true;
   uint16_t new_ambient_pressure = (uint16_t)(pressure_in_bar * 1000);
   // remove millibar from comparison to avoid frequent updates +/- 10 millibar doesn't matter
-  if (initialized_ && (new_ambient_pressure / 10 != ambient_pressure_ / 10)) {
+  if (new_ambient_pressure / 10 != ambient_pressure_ / 10) {
     update_ambient_pressure_compensation_(new_ambient_pressure);
     ambient_pressure_ = new_ambient_pressure;
   } else {
@@ -268,6 +276,9 @@ void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
 }
 
 bool SCD4XComponent::update_ambient_pressure_compensation_(uint16_t pressure_in_hpa) {
+  if (!initialized_) {
+    return;
+  }
   if (this->write_command(SCD4X_CMD_AMBIENT_PRESSURE_COMPENSATION, pressure_in_hpa)) {
     ESP_LOGD(TAG, "setting ambient pressure compensation to %d hPa", pressure_in_hpa);
     return true;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -149,7 +149,7 @@ void SCD4XComponent::update() {
   }
 
   if (this->ambient_pressure_source_ != nullptr) {
-    float pressure = this->ambient_pressure_source_->state / 1000.0f;
+    float pressure = this->ambient_pressure_source_->state;
     if (!std::isnan(pressure)) {
       set_ambient_pressure_compensation(pressure);
     }
@@ -254,10 +254,9 @@ bool SCD4XComponent::factory_reset() {
   return true;
 }
 
-// Note pressure in bar here. Convert to hPa
-void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
+void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_hpa) {
   ambient_pressure_compensation_ = true;
-  uint16_t new_ambient_pressure = (uint16_t)(pressure_in_bar * 1000);
+  uint16_t new_ambient_pressure = (uint16_t)pressure_in_hpa;
   if (!initialized_) {
     ambient_pressure_ = new_ambient_pressure;
     return;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -262,8 +262,8 @@ void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
     ambient_pressure_ = new_ambient_pressure;
     return;
   }
-  // remove millibar from comparison to avoid frequent updates +/- 10 millibar doesn't matter
-  if (new_ambient_pressure / 10 != ambient_pressure_ / 10) {
+  // Only send pressure value if it has changed since last update
+  if (new_ambient_pressure != ambient_pressure_) {
     update_ambient_pressure_compensation_(new_ambient_pressure);
     ambient_pressure_ = new_ambient_pressure;
   } else {

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -59,7 +59,7 @@ void SCD4XComponent::setup() {
 
       // If pressure compensation available use it
       // else use altitude
-      /*if (ambient_pressure_compensation_) {
+      if (ambient_pressure_compensation_) {
         if (!this->update_ambient_pressure_compensation_(ambient_pressure_)) {
           ESP_LOGE(TAG, "Error setting ambient pressure compensation.");
           this->error_code_ = MEASUREMENT_INIT_FAILED;
@@ -73,7 +73,7 @@ void SCD4XComponent::setup() {
           this->mark_failed();
           return;
         }
-      }*/
+      }
 
       if (!this->write_command(SCD4X_CMD_AUTOMATIC_SELF_CALIBRATION, enable_asc_ ? 1 : 0)) {
         ESP_LOGE(TAG, "Error setting automatic self calibration.");
@@ -249,9 +249,7 @@ bool SCD4XComponent::factory_reset() {
       return false;
     }
     ESP_LOGD(TAG, "Factory reset complete");
-    this->set_timeout(1200, [this]() {
-      this->setup();
-    });
+    this->set_timeout(1200, [this]() { this->setup(); });
     return true;
   });
   return true;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -256,7 +256,7 @@ bool SCD4XComponent::factory_reset() {
 
 void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_hpa) {
   ambient_pressure_compensation_ = true;
-  uint16_t new_ambient_pressure = (uint16_t)pressure_in_hpa;
+  uint16_t new_ambient_pressure = (uint16_t) pressure_in_hpa;
   if (!initialized_) {
     ambient_pressure_ = new_ambient_pressure;
     return;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -151,7 +151,7 @@ void SCD4XComponent::update() {
   if (this->ambient_pressure_source_ != nullptr) {
     float pressure = this->ambient_pressure_source_->state / 1000.0f;
     if (!std::isnan(pressure)) {
-      set_ambient_pressure_compensation(this->ambient_pressure_source_->state / 1000.0f);
+      set_ambient_pressure_compensation(pressure);
     }
   }
 
@@ -203,10 +203,6 @@ void SCD4XComponent::update() {
 }
 
 bool SCD4XComponent::perform_forced_calibration(uint16_t current_co2_concentration) {
-  if (!initialized_) {
-    return;
-  }
-
   /*
     Operate the SCD4x in the operation mode later used in normal sensor operation (periodic measurement, low power
     periodic measurement or single shot) for > 3 minutes in an environment with homogeneous and constant CO2
@@ -240,10 +236,6 @@ bool SCD4XComponent::perform_forced_calibration(uint16_t current_co2_concentrati
 }
 
 bool SCD4XComponent::factory_reset() {
-  if (!initialized_) {
-    return;
-  }
-
   if (!this->write_command(SCD4X_CMD_STOP_MEASUREMENTS)) {
     ESP_LOGE(TAG, "Failed to stop measurements");
     this->status_set_warning();
@@ -266,6 +258,10 @@ bool SCD4XComponent::factory_reset() {
 void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
   ambient_pressure_compensation_ = true;
   uint16_t new_ambient_pressure = (uint16_t)(pressure_in_bar * 1000);
+  if (!initialized_) {
+    ambient_pressure_ = new_ambient_pressure;
+    return;
+  }
   // remove millibar from comparison to avoid frequent updates +/- 10 millibar doesn't matter
   if (new_ambient_pressure / 10 != ambient_pressure_ / 10) {
     update_ambient_pressure_compensation_(new_ambient_pressure);
@@ -276,9 +272,6 @@ void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
 }
 
 bool SCD4XComponent::update_ambient_pressure_compensation_(uint16_t pressure_in_hpa) {
-  if (!initialized_) {
-    return;
-  }
   if (this->write_command(SCD4X_CMD_AMBIENT_PRESSURE_COMPENSATION, pressure_in_hpa)) {
     ESP_LOGD(TAG, "setting ambient pressure compensation to %d hPa", pressure_in_hpa);
     return true;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -257,7 +257,7 @@ bool SCD4XComponent::factory_reset() {
 // Note pressure in bar here. Convert to hPa
 void SCD4XComponent::set_ambient_pressure_compensation(float pressure_in_bar) {
   ambient_pressure_compensation_ = true;
-  uint16_t new_ambient_pressure = (uint16_t)(pressure_in_bar * 1000);
+  uint16_t new_ambient_pressure = (uint16_t)(round(pressure_in_bar * 1000));
   if (!initialized_) {
     ambient_pressure_ = new_ambient_pressure;
     return;

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -249,7 +249,6 @@ bool SCD4XComponent::factory_reset() {
       return false;
     }
     ESP_LOGD(TAG, "Factory reset complete");
-    this->set_timeout(1200, [this]() { this->setup(); });
     return true;
   });
   return true;

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -26,7 +26,7 @@ class SCD4XComponent : public PollingComponent, public sensirion_common::Sensiri
 
   void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
   void set_altitude_compensation(uint16_t altitude) { altitude_compensation_ = altitude; }
-  void set_ambient_pressure_compensation(float pressure_in_bar);
+  void set_ambient_pressure_compensation(float pressure_in_hpa);
   void set_ambient_pressure_source(sensor::Sensor *pressure) { ambient_pressure_source_ = pressure; }
   void set_temperature_offset(float offset) { temperature_offset_ = offset; };
 


### PR DESCRIPTION
# What does this implement/fix?

When setting `ambient_pressure_compensation` with a static value (i.e. not using `ambient_pressure_compensation_source`), the `set_` function was being executed while the sensor was not initialized. So the value was being overridden with 0hPa.

I've separated the `if(initialized_)` check and placed it earlier in the function so `ambient_pressure_` is set correctly when called before setup.

Also, in the dynamic pressure correction I've removed a division that discarded +-10hPa changes. Since pressure is already treated as an integer in hPa (i.e. 990hPa or 1012hPa, without decimals) the I2C updates aren't really that frequent to need rounding down to +-10hPa steps. It should also minimize the small noise introduced when pressure oscillates near round values i.e. 999->990hPa, 1000->1000hPa.

The breaking change is switching from Bar to mBar units (there was a redundant /1000 *1000 operation) to unify with other sensors such as the SCD30 and compensation sensors as BME280/680 etc, that already work in mBar/hPa.
I've added examples in the documentation to offer two compensation options (via sensor and via HASS service).

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Related documentation PR:** esphome/esphome-docs#2626

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
