### PR TITLE
SCD30 Added support for manual calibration

### DIFF
--- a/esphome/components/scd30/automation.h
+++ b/esphome/components/scd30/automation.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "scd30.h"
+
+namespace esphome {
+namespace scd30 {
+
+template<typename... Ts> class ForceRecalibrationWithReference : public Action<Ts...>, public Parented<SCD30Component> {
+ public:
+  void play(Ts... x) override {
+    if (this->value_.has_value()) {
+      this->parent_->force_recalibration_with_reference(this->value_.value(x...));
+    }
+  }
+
+ protected:
+  TEMPLATABLE_VALUE(uint16_t, value)
+};
+
+}  // namespace scd30
+}  // namespace esphome

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -216,12 +216,12 @@ bool SCD30Component::force_recalibration_with_reference(uint16_t co2_reference) 
 }
 
 uint16_t SCD30Component::get_forced_calibration_reference() {
-  uint16_t forced_calibration_reference_;
+  uint16_t forced_calibration_reference;
   // Get current CO2 calibration
-  if (!this->get_register(SCD30_CMD_FORCED_CALIBRATION, forced_calibration_reference_)) {
+  if (!this->get_register(SCD30_CMD_FORCED_CALIBRATION, forced_calibration_reference)) {
     ESP_LOGE(TAG, "Unable to read forced calibration reference.");
   }
-  return forced_calibration_reference_;
+  return forced_calibration_reference;
 }
 
 }  // namespace scd30

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -202,5 +202,27 @@ bool SCD30Component::is_data_ready_() {
   return is_data_ready == 1;
 }
 
+bool SCD30Component::force_recalibration_with_reference(uint16_t co2_reference) {
+  ESP_LOGD(TAG, "Performing CO2 force recalibration with reference %dppm.", co2_reference);
+  if (this->write_command(SCD30_CMD_FORCED_CALIBRATION, co2_reference)) {
+    ESP_LOGD(TAG, "Force recalibration complete.");
+    return true;
+  } else {
+    ESP_LOGE(TAG, "Failed to force recalibration with reference.");
+    this->error_code_ = FORCE_RECALIBRATION_FAILED;
+    this->status_set_warning();
+    return false;
+  }
+}
+
+uint16_t SCD30Component::get_forced_calibration_reference() {
+  uint16_t forced_calibration_reference_;
+  // Get current CO2 calibration
+  if (!this->get_register(SCD30_CMD_FORCED_CALIBRATION, forced_calibration_reference_)) {
+    ESP_LOGE(TAG, "Unable to read forced calibration reference.");
+  }
+  return forced_calibration_reference_;
+}
+
 }  // namespace scd30
 }  // namespace esphome

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -20,6 +20,8 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
   }
   void set_temperature_offset(float offset) { temperature_offset_ = offset; }
   void set_update_interval(uint16_t interval) { update_interval_ = interval; }
+  bool force_recalibration_with_reference(uint16_t co2_reference);
+  uint16_t get_forced_calibration_reference();
 
   void setup() override;
   void update();
@@ -33,6 +35,7 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
     COMMUNICATION_FAILED,
     FIRMWARE_IDENTIFICATION_FAILED,
     MEASUREMENT_INIT_FAILED,
+    FORCE_RECALIBRATION_FAILED,
     UNKNOWN
   } error_code_{UNKNOWN};
   bool enable_asc_{true};

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -1,6 +1,7 @@
-from esphome import core
+from esphome import automation, core
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.automation import maybe_simple_id
 from esphome.components import i2c, sensor
 from esphome.components import sensirion_common
 from esphome.const import (
@@ -9,6 +10,7 @@ from esphome.const import (
     CONF_TEMPERATURE,
     CONF_CO2,
     CONF_UPDATE_INTERVAL,
+    CONF_VALUE,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
@@ -24,6 +26,11 @@ AUTO_LOAD = ["sensirion_common"]
 scd30_ns = cg.esphome_ns.namespace("scd30")
 SCD30Component = scd30_ns.class_(
     "SCD30Component", cg.Component, sensirion_common.SensirionI2CDevice
+)
+
+# Actions
+ForceRecalibrationWithReference = scd30_ns.class_(
+    "ForceRecalibrationWithReference", automation.Action
 )
 
 CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
@@ -106,3 +113,22 @@ async def to_code(config):
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature_sensor(sens))
+
+@automation.register_action(
+    "scd30.force_recalibration_with_reference",
+    ForceRecalibrationWithReference,
+    maybe_simple_id(
+        {
+            cv.GenerateID(): cv.use_id(SCD30Component),
+            cv.Required(CONF_VALUE): cv.templatable(
+                cv.int_range(min=400, max=2000, max_included=True)
+            ),
+        }
+    ),
+)
+async def scd30_force_recalibration_with_reference_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.uint16)
+    cg.add(var.set_value(template_))
+    return var

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -114,7 +114,7 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature_sensor(sens))
 
-        
+
 @automation.register_action(
     "scd30.force_recalibration_with_reference",
     ForceRecalibrationWithReference,
@@ -127,7 +127,6 @@ async def to_code(config):
         }
     ),
 )
-
 async def scd30_force_recalibration_with_reference_to_code(
     config, action_id, template_arg, args
 ):

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -114,6 +114,7 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature_sensor(sens))
 
+        
 @automation.register_action(
     "scd30.force_recalibration_with_reference",
     ForceRecalibrationWithReference,
@@ -126,6 +127,7 @@ async def to_code(config):
         }
     ),
 )
+
 async def scd30_force_recalibration_with_reference_to_code(
     config, action_id, template_arg, args
 ):

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -126,7 +126,9 @@ async def to_code(config):
         }
     ),
 )
-async def scd30_force_recalibration_with_reference_to_code(config, action_id, template_arg, args):
+async def scd30_force_recalibration_with_reference_to_code(
+    config, action_id, template_arg, args
+):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_VALUE], args, cg.uint16)

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -1,7 +1,6 @@
 from esphome import automation, core
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.automation import maybe_simple_id
 from esphome.components import i2c, sensor
 from esphome.components import sensirion_common
 from esphome.const import (
@@ -118,13 +117,14 @@ async def to_code(config):
 @automation.register_action(
     "scd30.force_recalibration_with_reference",
     ForceRecalibrationWithReference,
-    maybe_simple_id(
+    cv.maybe_simple_value(
         {
             cv.GenerateID(): cv.use_id(SCD30Component),
             cv.Required(CONF_VALUE): cv.templatable(
                 cv.int_range(min=400, max=2000, max_included=True)
             ),
-        }
+        },
+        key=CONF_VALUE,
     ),
 )
 async def scd30_force_recalibration_with_reference_to_code(


### PR DESCRIPTION
# What does this implement/fix?

Added support to calibrate the SCD30 sensor to a known CO2 value. The calibration is adapted immediately.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2631

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
```yaml
button:
  - platform: template
    name: "SCD30 Force manual calibration"
    entity_category: "config"
    on_press:
      then:
        - scd30.force_recalibration_with_reference:
            value: !lambda 'return id(co2_cal).state;'


number:
  - platform: template
    name: "CO2 calibration value"
    optimistic: true
    min_value: 350
    max_value: 4500
    step: 1
    id: co2_cal
    icon: "mdi:molecule-co2"
    entity_category: "config"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
