### PR TITLE
Allow final validate of uart stop bits and parity

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -246,11 +246,13 @@ def final_validate_device_schema(
     baud_rate: Optional[int] = None,
     require_tx: bool = False,
     require_rx: bool = False,
+    parity: Optional[str] = None,
+    stop_bits: Optional[int] = None,
 ):
     def validate_baud_rate(value):
         if value != baud_rate:
             raise cv.Invalid(
-                f"Component {name} required baud rate {baud_rate} for the uart bus"
+                f"Component {name} requires baud rate {baud_rate} for the uart bus"
             )
         return value
 
@@ -265,6 +267,20 @@ def final_validate_device_schema(
             return value
 
         return validator
+
+    def validate_parity(value):
+        if value != parity:
+            raise cv.Invalid(
+                f"Component {name} requires parity {parity} for the uart bus"
+            )
+        return value
+
+    def validate_stop_bits(value):
+        if value != stop_bits:
+            raise cv.Invalid(
+                f"Component {name} requires stop bits {stop_bits} for the uart bus"
+            )
+        return value
 
     def validate_hub(hub_config):
         hub_schema = {}
@@ -288,6 +304,10 @@ def final_validate_device_schema(
             ] = validate_pin(CONF_RX_PIN, device)
         if baud_rate is not None:
             hub_schema[cv.Required(CONF_BAUD_RATE)] = validate_baud_rate
+        if parity is not None:
+            hub_schema[cv.Required(CONF_PARITY)] = validate_parity
+        if stop_bits is not None:
+            hub_schema[cv.Required(CONF_STOP_BITS)] = validate_stop_bits
         return cv.Schema(hub_schema, extra=cv.ALLOW_EXTRA)(hub_config)
 
     return cv.Schema(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
