### PR TITLE
ESP32 enable ADC2 when wifi is disabled

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -24,6 +24,7 @@ ATTENUATION_MODES = {
 }
 
 adc1_channel_t = cg.global_ns.enum("adc1_channel_t")
+adc2_channel_t = cg.global_ns.enum("adc2_channel_t")
 
 # From https://github.com/espressif/esp-idf/blob/master/components/driver/include/driver/adc_common.h
 # pin to adc1 channel mapping
@@ -78,6 +79,22 @@ ESP32_VARIANT_ADC1_PIN_TO_CHANNEL = {
     },
 }
 
+ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
+    # TODO: add other variants
+    VARIANT_ESP32: {
+        4: adc2_channel_t.ADC2_CHANNEL_0,
+        0: adc2_channel_t.ADC2_CHANNEL_1,
+        2: adc2_channel_t.ADC2_CHANNEL_2,
+        15: adc2_channel_t.ADC2_CHANNEL_3,
+        13: adc2_channel_t.ADC2_CHANNEL_4,
+        12: adc2_channel_t.ADC2_CHANNEL_5,
+        14: adc2_channel_t.ADC2_CHANNEL_6,
+        27: adc2_channel_t.ADC2_CHANNEL_7,
+        25: adc2_channel_t.ADC2_CHANNEL_8,
+        26: adc2_channel_t.ADC2_CHANNEL_9,
+    },
+}
+
 
 def validate_adc_pin(value):
     if str(value).upper() == "VCC":
@@ -89,11 +106,18 @@ def validate_adc_pin(value):
     if CORE.is_esp32:
         value = pins.internal_gpio_input_pin_number(value)
         variant = get_esp32_variant()
-        if variant not in ESP32_VARIANT_ADC1_PIN_TO_CHANNEL:
+        if (
+            variant not in ESP32_VARIANT_ADC1_PIN_TO_CHANNEL
+            and variant not in ESP32_VARIANT_ADC2_PIN_TO_CHANNEL
+        ):
             raise cv.Invalid(f"This ESP32 variant ({variant}) is not supported")
 
-        if value not in ESP32_VARIANT_ADC1_PIN_TO_CHANNEL[variant]:
+        if (
+            value not in ESP32_VARIANT_ADC1_PIN_TO_CHANNEL[variant]
+            and value not in ESP32_VARIANT_ADC2_PIN_TO_CHANNEL[variant]
+        ):
             raise cv.Invalid(f"{variant} doesn't support ADC on this pin")
+
         return pins.internal_gpio_input_pin_schema(value)
 
     if CORE.is_esp8266:
@@ -104,7 +128,7 @@ def validate_adc_pin(value):
         )
 
         if value != 17:  # A0
-            raise cv.Invalid("ESP8266: Only pin A0 (GPIO17) supports ADC.")
+            raise cv.Invalid("ESP8266: Only pin A0 (GPIO17) supports ADC")
         return pins.gpio_pin_schema(
             {CONF_ANALOG: True, CONF_INPUT: True}, internal=True
         )(value)
@@ -112,7 +136,7 @@ def validate_adc_pin(value):
     if CORE.is_rp2040:
         value = pins.internal_gpio_input_pin_number(value)
         if value not in (26, 27, 28, 29):
-            raise cv.Invalid("RP2040: Only pins 26, 27, 28 and 29 support ADC.")
+            raise cv.Invalid("RP2040: Only pins 26, 27, 28 and 29 support ADC")
         return pins.internal_gpio_input_pin_schema(value)
 
     raise NotImplementedError

--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -93,6 +93,33 @@ ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
         25: adc2_channel_t.ADC2_CHANNEL_8,
         26: adc2_channel_t.ADC2_CHANNEL_9,
     },
+    VARIANT_ESP32S2: {
+        11: adc2_channel_t.ADC2_CHANNEL_0,
+        12: adc2_channel_t.ADC2_CHANNEL_1,
+        13: adc2_channel_t.ADC2_CHANNEL_2,
+        14: adc2_channel_t.ADC2_CHANNEL_3,
+        15: adc2_channel_t.ADC2_CHANNEL_4,
+        16: adc2_channel_t.ADC2_CHANNEL_5,
+        17: adc2_channel_t.ADC2_CHANNEL_6,
+        18: adc2_channel_t.ADC2_CHANNEL_7,
+        19: adc2_channel_t.ADC2_CHANNEL_8,
+        20: adc2_channel_t.ADC2_CHANNEL_9,
+    },
+    VARIANT_ESP32S3: {
+        11: adc2_channel_t.ADC2_CHANNEL_0,
+        12: adc2_channel_t.ADC2_CHANNEL_1,
+        13: adc2_channel_t.ADC2_CHANNEL_2,
+        14: adc2_channel_t.ADC2_CHANNEL_3,
+        15: adc2_channel_t.ADC2_CHANNEL_4,
+        16: adc2_channel_t.ADC2_CHANNEL_5,
+        17: adc2_channel_t.ADC2_CHANNEL_6,
+        18: adc2_channel_t.ADC2_CHANNEL_7,
+        19: adc2_channel_t.ADC2_CHANNEL_8,
+        20: adc2_channel_t.ADC2_CHANNEL_9,
+    },
+    VARIANT_ESP32C3: {
+        5: adc2_channel_t.ADC2_CHANNEL_0,
+    },
 }
 
 

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -26,14 +26,14 @@ static const adc_bits_width_t ADC_WIDTH_MAX_SOC_BITS = static_cast<adc_bits_widt
 
 #ifndef SOC_ADC_RTC_MAX_BITWIDTH
 #if USE_ESP32_VARIANT_ESP32S2
-static const int SOC_ADC_RTC_MAX_BITWIDTH = 13;
+static const int32_t SOC_ADC_RTC_MAX_BITWIDTH = 13;
 #else
-static const int SOC_ADC_RTC_MAX_BITWIDTH = 12;
+static const int32_t SOC_ADC_RTC_MAX_BITWIDTH = 12;
 #endif
 #endif
 
-static const int ADC_MAX = (1 << SOC_ADC_RTC_MAX_BITWIDTH) - 1;    // 4095 (12 bit) or 8191 (13 bit)
-static const int ADC_HALF = (1 << SOC_ADC_RTC_MAX_BITWIDTH) >> 1;  // 2048 (12 bit) or 4096 (13 bit)
+static const int32_t ADC_MAX = (1 << SOC_ADC_RTC_MAX_BITWIDTH) - 1;    // 4095 (12 bit) or 8191 (13 bit)
+static const int32_t ADC_HALF = (1 << SOC_ADC_RTC_MAX_BITWIDTH) >> 1;  // 2048 (12 bit) or 4096 (13 bit)
 #endif
 
 #ifdef USE_RP2040
@@ -59,7 +59,7 @@ extern "C"
   }
 
   // load characteristics for each attenuation
-  for (int i = 0; i < (int) ADC_ATTEN_MAX; i++) {
+  for (int32_t i = 0; i < (int32_t) ADC_ATTEN_MAX; i++) {
     auto adc_unit = channel1_ != ADC1_CHANNEL_MAX ? ADC_UNIT_1 : ADC_UNIT_2;
     auto cal_value = esp_adc_cal_characterize(adc_unit, (adc_atten_t) i, ADC_WIDTH_MAX_SOC_BITS,
                                               1100,  // default vref
@@ -143,9 +143,9 @@ void ADCSensor::update() {
 #ifdef USE_ESP8266
 float ADCSensor::sample() {
 #ifdef USE_ADC_SENSOR_VCC
-  int raw = ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
+  int32_t raw = ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
 #else
-  int raw = analogRead(this->pin_->get_pin());  // NOLINT
+  int32_t raw = analogRead(this->pin_->get_pin());  // NOLINT
 #endif
   if (output_raw_) {
     return raw;
@@ -157,7 +157,7 @@ float ADCSensor::sample() {
 #ifdef USE_ESP32
 float ADCSensor::sample() {
   if (!autorange_) {
-    int raw = -1;
+    int32_t raw = -1;
     if (channel1_ != ADC1_CHANNEL_MAX) {
       raw = adc1_get_raw(channel1_);
     } else if (channel2_ != ADC2_CHANNEL_MAX) {
@@ -170,11 +170,11 @@ float ADCSensor::sample() {
     if (output_raw_) {
       return raw;
     }
-    uint32_t mv = esp_adc_cal_raw_to_voltage(raw, &cal_characteristics_[(int) attenuation_]);
+    uint32_t mv = esp_adc_cal_raw_to_voltage(raw, &cal_characteristics_[(int32_t) attenuation_]);
     return mv / 1000.0f;
   }
 
-  int raw11, raw6 = ADC_MAX, raw2 = ADC_MAX, raw0 = ADC_MAX;
+  int32_t raw11 = ADC_MAX, raw6 = ADC_MAX, raw2 = ADC_MAX, raw0 = ADC_MAX;
 
   if (channel1_ != ADC1_CHANNEL_MAX) {
     adc1_config_channel_atten(channel1_, ADC_ATTEN_DB_11);
@@ -212,10 +212,10 @@ float ADCSensor::sample() {
     return NAN;
   }
 
-  uint32_t mv11 = esp_adc_cal_raw_to_voltage(raw11, &cal_characteristics_[(int) ADC_ATTEN_DB_11]);
-  uint32_t mv6 = esp_adc_cal_raw_to_voltage(raw6, &cal_characteristics_[(int) ADC_ATTEN_DB_6]);
-  uint32_t mv2 = esp_adc_cal_raw_to_voltage(raw2, &cal_characteristics_[(int) ADC_ATTEN_DB_2_5]);
-  uint32_t mv0 = esp_adc_cal_raw_to_voltage(raw0, &cal_characteristics_[(int) ADC_ATTEN_DB_0]);
+  uint32_t mv11 = esp_adc_cal_raw_to_voltage(raw11, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_11]);
+  uint32_t mv6 = esp_adc_cal_raw_to_voltage(raw6, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_6]);
+  uint32_t mv2 = esp_adc_cal_raw_to_voltage(raw2, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_2_5]);
+  uint32_t mv0 = esp_adc_cal_raw_to_voltage(raw0, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_0]);
 
   // Contribution of each value, in range 0-2048 (12 bit ADC) or 0-4096 (13 bit ADC)
   uint32_t c11 = std::min(raw11, ADC_HALF);
@@ -243,7 +243,7 @@ float ADCSensor::sample() {
     adc_select_input(pin - 26);
   }
 
-  int raw = adc_read();
+  int32_t raw = adc_read();
   if (this->is_temperature_) {
     adc_set_temp_sensor_enabled(false);
   }

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -62,7 +62,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   adc1_channel_t channel1_{ADC1_CHANNEL_MAX};
   adc2_channel_t channel2_{ADC2_CHANNEL_MAX};
   bool autorange_{false};
-  esp_adc_cal_characteristics_t cal_characteristics_[(int) ADC_ATTEN_MAX] = {};
+  esp_adc_cal_characteristics_t cal_characteristics_[(int32_t) ADC_ATTEN_MAX] = {};
 #endif
 };
 

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -19,16 +19,23 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 #ifdef USE_ESP32
   /// Set the attenuation for this pin. Only available on the ESP32.
   void set_attenuation(adc_atten_t attenuation) { attenuation_ = attenuation; }
-  void set_channel(adc1_channel_t channel) { channel_ = channel; }
+  void set_channel1(adc1_channel_t channel) {
+    channel1_ = channel;
+    channel2_ = ADC2_CHANNEL_MAX;
+  }
+  void set_channel2(adc2_channel_t channel) {
+    channel2_ = channel;
+    channel1_ = ADC1_CHANNEL_MAX;
+  }
   void set_autorange(bool autorange) { autorange_ = autorange; }
 #endif
 
-  /// Update adc values.
+  /// Update ADC values
   void update() override;
-  /// Setup ADc
+  /// Setup ADC
   void setup() override;
   void dump_config() override;
-  /// `HARDWARE_LATE` setup priority.
+  /// `HARDWARE_LATE` setup priority
   float get_setup_priority() const override;
   void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
   void set_output_raw(bool output_raw) { output_raw_ = output_raw; }
@@ -52,7 +59,8 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 
 #ifdef USE_ESP32
   adc_atten_t attenuation_{ADC_ATTEN_DB_0};
-  adc1_channel_t channel_{};
+  adc1_channel_t channel1_{ADC1_CHANNEL_MAX};
+  adc2_channel_t channel2_{ADC2_CHANNEL_MAX};
   bool autorange_{false};
   esp_adc_cal_characteristics_t cal_characteristics_[(int) ADC_ATTEN_MAX] = {};
 #endif

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -33,14 +33,16 @@ def validate_config(config):
 
 
 def final_validate_config(config):
-    variant = get_esp32_variant()
-    if (
-        CONF_WIFI in fv.full_config.get()
-        and config[CONF_PIN][CONF_NUMBER] in ESP32_VARIANT_ADC2_PIN_TO_CHANNEL[variant]
-    ):
-        raise cv.Invalid(
-            f"{variant} doesn't support ADC on this pin when Wi-Fi is configured"
-        )
+    if CORE.is_esp32:
+        variant = get_esp32_variant()
+        if (
+            CONF_WIFI in fv.full_config.get()
+            and config[CONF_PIN][CONF_NUMBER]
+            in ESP32_VARIANT_ADC2_PIN_TO_CHANNEL[variant]
+        ):
+            raise cv.Invalid(
+                f"{variant} doesn't support ADC on this pin when Wi-Fi is configured"
+            )
 
     return config
 

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 import esphome.final_validate as fv
-from esphome import pins
 from esphome.core import CORE
 from esphome.components import sensor, voltage_sampler
 from esphome.components.esp32 import get_esp32_variant
@@ -16,11 +15,10 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
 )
-from esphome.core import CORE
-
 from . import (
     ATTENUATION_MODES,
     ESP32_VARIANT_ADC1_PIN_TO_CHANNEL,
+    ESP32_VARIANT_ADC2_PIN_TO_CHANNEL,
     validate_adc_pin,
 )
 

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_NUMBER,
     CONF_PIN,
     CONF_RAW,
+    CONF_WIFI,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
@@ -44,7 +45,9 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(
         {
-            cv.Required(CONF_PIN): validate_adc_pin,
+            cv.Required(
+                CONF_PIN, CONF_WIFI
+            ): validate_adc_pin,  # does this work that way?
             cv.Optional(CONF_RAW, default=False): cv.boolean,
             cv.SplitDefault(CONF_ATTENUATION, esp32="0db"): cv.All(
                 cv.only_on_esp32, cv.enum(ATTENUATION_MODES, lower=True)
@@ -81,5 +84,6 @@ async def to_code(config):
     if CORE.is_esp32:
         variant = get_esp32_variant()
         pin_num = config[CONF_PIN][CONF_NUMBER]
+        # need to find pin_num in adc1 or adc2 if the objects are not merged
         chan = ESP32_VARIANT_ADC1_PIN_TO_CHANNEL[variant][pin_num]
         cg.add(var.set_channel(chan))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3072

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
