### PR TITLE
Remove unneeded validation for esp32 gpio pins

### DIFF
--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -123,11 +123,8 @@ def validate_gpio_pin(value):
 
 def validate_supports(value):
     mode = value[CONF_MODE]
-    is_input = mode[CONF_INPUT]
     is_output = mode[CONF_OUTPUT]
     is_open_drain = mode[CONF_OPEN_DRAIN]
-    is_pullup = mode[CONF_PULLUP]
-    is_pulldown = mode[CONF_PULLDOWN]
     variant = CORE.data[KEY_ESP32][KEY_VARIANT]
     if variant not in _esp32_validations:
         raise cv.Invalid(f"Unsupported ESP32 variant {variant}")
@@ -138,26 +135,6 @@ def validate_supports(value):
         )
 
     value = _esp32_validations[variant].usage_validation(value)
-    if CORE.using_arduino:
-        # (input, output, open_drain, pullup, pulldown)
-        supported_modes = {
-            # INPUT
-            (True, False, False, False, False),
-            # OUTPUT
-            (False, True, False, False, False),
-            # INPUT_PULLUP
-            (True, False, False, True, False),
-            # INPUT_PULLDOWN
-            (True, False, False, False, True),
-            # OUTPUT_OPEN_DRAIN
-            (False, True, True, False, False),
-        }
-        key = (is_input, is_output, is_open_drain, is_pullup, is_pulldown)
-        if key not in supported_modes:
-            raise cv.Invalid(
-                "This pin mode is not supported on ESP32 for arduino frameworks",
-                [CONF_MODE],
-            )
     return value
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Prompted by https://github.com/esphome/esphome/pull/4360 I realised we do not need to do this check anymore as esp32 always uses esp-idf pins directly

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
