### PR TITLE
Gracefully reject vacuum map upload requests

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -246,7 +246,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
     case TuyaCommandType::VACUUM_MAP_UPLOAD:
       this->send_command_(
           TuyaCommand{.cmd = TuyaCommandType::VACUUM_MAP_UPLOAD, .payload = std::vector<uint8_t>{0x01}});
-      ESP_LOGI(TAG, "Vacuum map upload requested, responding that it is not enabled.");
+      ESP_LOGW(TAG, "Vacuum map upload requested, responding that it is not enabled.");
       break;
     default:
       ESP_LOGE(TAG, "Invalid command (0x%02X) received", command);

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -243,6 +243,10 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       ESP_LOGE(TAG, "LOCAL_TIME_QUERY is not handled");
 #endif
       break;
+    case TuyaCommandType::VACUUM_MAP_UPLOAD:
+      this->send_command_(TuyaCommand{.cmd = TuyaCommandType::VACUUM_MAP_UPLOAD, .payload = std::vector<uint8_t>{0x01}});
+      ESP_LOGI(TAG, "Vacuum map upload requested, responding that it is not enabled.");
+      break;
     default:
       ESP_LOGE(TAG, "Invalid command (0x%02X) received", command);
   }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -244,7 +244,8 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
 #endif
       break;
     case TuyaCommandType::VACUUM_MAP_UPLOAD:
-      this->send_command_(TuyaCommand{.cmd = TuyaCommandType::VACUUM_MAP_UPLOAD, .payload = std::vector<uint8_t>{0x01}});
+      this->send_command_(
+          TuyaCommand{.cmd = TuyaCommandType::VACUUM_MAP_UPLOAD, .payload = std::vector<uint8_t>{0x01}});
       ESP_LOGI(TAG, "Vacuum map upload requested, responding that it is not enabled.");
       break;
     default:

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -55,6 +55,7 @@ enum class TuyaCommandType : uint8_t {
   DATAPOINT_QUERY = 0x08,
   WIFI_TEST = 0x0E,
   LOCAL_TIME_QUERY = 0x1C,
+  VACUUM_MAP_UPLOAD = 0x28,
 };
 
 enum class TuyaInitState : uint8_t {


### PR DESCRIPTION
# What does this implement/fix?

This implements basic handling of the `0x28` command which is used by robot vacuums to upload map data.

The [Tuya documentation](https://developer.tuya.com/en/docs/iot/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb#title-29-(Optional)%20Map%20streaming%20for%20robot%20vacuum) suggests this is an optional (probably paid) feature and the serial protocol has provisions to be able to reject such requests if the service is not enabled.

This PR implements responses to this command with the `0x01` response code (which means the service is not enabled). This is a more graceful way of rejecting it rather than simply ignoring the command and raising an error.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

To test, you'll need to enable the TuyaMCU integration:

## Example entry for `config.yaml`:
```yaml
# Example config.yaml

# disable default logger to free up UART
logger: null

uart:
  id: myuart
  debug:
  # configure your UART here

tuya:
  uart_id: myuart
```

Once done, send `55 aa 03 28 00 00 2a` (bytes in hex) over the serial port associated with TuyaMCU.

You should receive back `55 aa 00 28 00 01 00 28` and an informational message printed in the ESPHome log.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
