### PR TITLE
Improve tuya network status command

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -1,11 +1,14 @@
 #include "tuya.h"
 #include "esphome/components/network/util.h"
-#include "esphome/components/captive_portal/captive_portal.h"
 #include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 #include "esphome/core/gpio.h"
+
+#ifdef USE_CAPTIVE_PORTAL
+#include "esphome/components/captive_portal/captive_portal.h"
+#endif
 
 namespace esphome {
 namespace tuya {
@@ -457,8 +460,12 @@ uint8_t Tuya::get_wifi_status_code_() {
     if (this->protocol_version_ >= 0x03 && remote_is_connected()) {
       status = 0x04;
     }
-  } else if (captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active()) {
-    status = 0x01;
+  } else {
+#ifdef USE_CAPTIVE_PORTAL
+    if (captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active()) {
+      status = 0x01;
+    }
+#endif
   };
 
   return status;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -253,7 +253,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
 
       this->send_command_(
           TuyaCommand{.cmd = TuyaCommandType::GET_NETWORK_STATUS, .payload = std::vector<uint8_t>{wifi_status}});
-      ESP_LOGV(TAG, "Network status requested, reported as %i", status);
+      ESP_LOGV(TAG, "Network status requested, reported as %i", wifi_status);
       break;
     }
     default:

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -1,6 +1,5 @@
 #include "tuya.h"
 #include "esphome/components/network/util.h"
-#include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -248,14 +248,14 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       ESP_LOGE(TAG, "LOCAL_TIME_QUERY is not handled");
 #endif
       break;
-    case TuyaCommandType::GET_NETWORK_STATUS:
-      {
-        uint8_t wifi_status = this->get_wifi_status_code_();
+    case TuyaCommandType::GET_NETWORK_STATUS: {
+      uint8_t wifi_status = this->get_wifi_status_code_();
 
-        this->send_command_(TuyaCommand{.cmd = TuyaCommandType::GET_NETWORK_STATUS, .payload = std::vector<uint8_t>{wifi_status}});
-        ESP_LOGV(TAG, "Network status requested, reported as %i", status);
-        break;
-      }
+      this->send_command_(
+          TuyaCommand{.cmd = TuyaCommandType::GET_NETWORK_STATUS, .payload = std::vector<uint8_t>{wifi_status}});
+      ESP_LOGV(TAG, "Network status requested, reported as %i", status);
+      break;
+    }
     default:
       ESP_LOGE(TAG, "Invalid command (0x%02X) received", command);
   }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -1,5 +1,7 @@
 #include "tuya.h"
 #include "esphome/components/network/util.h"
+#include "esphome/components/captive_portal/captive_portal.h"
+#include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
@@ -243,6 +245,14 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       ESP_LOGE(TAG, "LOCAL_TIME_QUERY is not handled");
 #endif
       break;
+    case TuyaCommandType::GET_NETWORK_STATUS:
+      {
+        uint8_t wifi_status = this->get_wifi_status_code_();
+
+        this->send_command_(TuyaCommand{.cmd = TuyaCommandType::GET_NETWORK_STATUS, .payload = std::vector<uint8_t>{wifi_status}});
+        ESP_LOGV(TAG, "Network status requested, reported as %i", status);
+        break;
+      }
     default:
       ESP_LOGE(TAG, "Invalid command (0x%02X) received", command);
   }
@@ -437,8 +447,9 @@ void Tuya::set_status_pin_() {
   this->status_pin_.value()->digital_write(is_network_ready);
 }
 
-void Tuya::send_wifi_status_() {
+uint8_t Tuya::get_wifi_status_code_() {
   uint8_t status = 0x02;
+
   if (network::is_connected()) {
     status = 0x03;
 
@@ -446,7 +457,15 @@ void Tuya::send_wifi_status_() {
     if (this->protocol_version_ >= 0x03 && remote_is_connected()) {
       status = 0x04;
     }
-  }
+  } else if (captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active()) {
+    status = 0x01;
+  };
+
+  return status;
+}
+
+void Tuya::send_wifi_status_() {
+  uint8_t status = this->get_wifi_status_code_();
 
   if (status == this->wifi_status_) {
     return;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -55,6 +55,7 @@ enum class TuyaCommandType : uint8_t {
   DATAPOINT_QUERY = 0x08,
   WIFI_TEST = 0x0E,
   LOCAL_TIME_QUERY = 0x1C,
+  GET_NETWORK_STATUS = 0x2B,
 };
 
 enum class TuyaInitState : uint8_t {
@@ -120,6 +121,7 @@ class Tuya : public Component, public uart::UARTDevice {
   void send_datapoint_command_(uint8_t datapoint_id, TuyaDatapointType datapoint_type, std::vector<uint8_t> data);
   void set_status_pin_();
   void send_wifi_status_();
+  uint8_t get_wifi_status_code_();
 
 #ifdef USE_TIME
   void send_local_time_();


### PR DESCRIPTION
# What does this implement/fix?

This PR implements handling of the [query network status (`0x2b`) command](https://developer.tuya.com/en/docs/iot/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb#title-28-Get%20the%20current%20network%20status).

While the TuyaMCU integration already has unsolicited sending of the current network status, it did not support responding to network status queries explicitly solicited by the peer. This PR implements such support.

In addition, it makes the returned network status more realistic and if the captive portal is enabled then it reports it as pairing enabled in AP mode (which is Tuna's equivalent of our captive portal system).

Some devices use this to report network connectivity (via a dedicated LED or something) so accurate handling of this command allows the connected device's UI to reflect the true connectivity state.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

# disable default logger to free up UART
logger: null

uart:
  id: myuart
  debug:
  # configure your UART here

tuya:
  uart_id: myuart
```

Send `55 aa 03 2b 00 00 2d` over the UART, you should get back a valid response (according to the Tuya docs) depending on the network status (whether connected, captive portal running, etc).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
