### PR TITLE
Fix check for empty clipping array

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -16,11 +16,11 @@ const Color COLOR_OFF(0, 0, 0, 0);
 const Color COLOR_ON(255, 255, 255, 255);
 
 void Rect::expand(int16_t horizontal, int16_t vertical) {
-  if ((*this).is_set() && ((*this).w >= (-2 * horizontal)) && ((*this).h >= (-2 * vertical))) {
-    (*this).x = (*this).x - horizontal;
-    (*this).y = (*this).y - vertical;
-    (*this).w = (*this).w + (2 * horizontal);
-    (*this).h = (*this).h + (2 * vertical);
+  if (this->is_set() && (this->w >= (-2 * horizontal)) && (this->h >= (-2 * vertical))) {
+    this->x = this->x - horizontal;
+    this->y = this->y - vertical;
+    this->w = this->w + (2 * horizontal);
+    this->h = this->h + (2 * vertical);
   }
 }
 

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -400,60 +400,48 @@ class DisplayBuffer {
    */
   virtual DisplayType get_display_type() = 0;
 
-  ///
-  /// Set the clipping rectangle for further drawing
-  ///
-  /// \param[in]  rect:       Pointer to Rect for clipping (or NULL for entire screen)
-  ///
-  /// \return true if success, false if error
-  ///
+  /** Set the clipping rectangle for further drawing
+   *
+   * @param[in]  rect:       Pointer to Rect for clipping (or NULL for entire screen)
+   *
+   * return true if success, false if error
+   */
   void start_clipping(Rect rect);
   void start_clipping(int16_t left, int16_t top, int16_t right, int16_t bottom) {
     start_clipping(Rect(left, top, right - left, bottom - top));
   };
 
-  ///
-  /// Add a rectangular region to the invalidation region
-  /// - This is usually called when an element has been modified
-  ///
-  /// \param[in]  rect: Rectangle to add to the invalidation region
-  ///
-  /// \return none
-  ///
+  /** Add a rectangular region to the invalidation region
+   * - This is usually called when an element has been modified
+   *
+   * @param[in]  rect: Rectangle to add to the invalidation region
+   */
   void extend_clipping(Rect rect);
   void extend_clipping(int16_t left, int16_t top, int16_t right, int16_t bottom) {
     this->extend_clipping(Rect(left, top, right - left, bottom - top));
   };
 
-  ///
-  /// substract a rectangular region to the invalidation region
-  /// - This is usually called when an element has been modified
-  ///
-  /// \param[in]  rect: Rectangle to add to the invalidation region
-  ///
-  /// \return none
-  ///
+  /** substract a rectangular region to the invalidation region
+   *  - This is usually called when an element has been modified
+   *
+   * @param[in]  rect: Rectangle to add to the invalidation region
+   */
   void shrink_clipping(Rect rect);
   void shrink_clipping(uint16_t left, uint16_t top, uint16_t right, uint16_t bottom) {
     this->shrink_clipping(Rect(left, top, right - left, bottom - top));
   };
 
-  ///
-  /// Reset the invalidation region
-  ///
-  /// \return none
-  ///
+  /** Reset the invalidation region
+   */
   void end_clipping();
 
-  ///
-  /// Get the current the clipping rectangle
-  ///
-  ///
-  /// \return rect for active clipping region
-  ///
+  /** Get the current the clipping rectangle
+   *
+   * return rect for active clipping region
+   */
   Rect get_clipping();
 
-  bool is_clipping() const { return this->clipping_rectangle_.empty(); }
+  bool is_clipping() const { return !this->clipping_rectangle_.empty(); }
 
  protected:
   void vprintf_(int x, int y, Font *font, Color color, TextAlign align, const char *format, va_list arg);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
@oxan found i nasty issue on my Clipping PR that did go live earlier this weak, also he suggested that i made some small changed to the *docblocks* and the way i used `(*this).` instead of `this->` both are now updated as well.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [<link to issue>](https://discord.com/channels/429907082951524364/524177279270780928/1074018365036830900)
https://github.com/esphome/issues/issues/4155

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
