### PR TITLE
Fix setting wrong traits on midea climate component

### DIFF
--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -90,8 +90,6 @@ ClimateTraits AirConditioner::traits() {
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_LOW);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_MEDIUM);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_HIGH);
-  traits.add_supported_swing_mode(ClimateSwingMode::CLIMATE_SWING_OFF);
-  traits.add_supported_swing_mode(ClimateSwingMode::CLIMATE_SWING_VERTICAL);
   traits.add_supported_preset(ClimatePreset::CLIMATE_PRESET_NONE);
   traits.add_supported_preset(ClimatePreset::CLIMATE_PRESET_SLEEP);
   if (this->base_.getAutoconfStatus() == dudanov::midea::AUTOCONF_OK)

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -84,14 +84,16 @@ ClimateTraits AirConditioner::traits() {
   traits.set_supported_custom_presets(this->supported_custom_presets_);
   traits.set_supported_custom_fan_modes(this->supported_custom_fan_modes_);
   /* + MINIMAL SET OF CAPABILITIES */
-  traits.add_supported_mode(ClimateMode::CLIMATE_MODE_OFF);
-  traits.add_supported_mode(ClimateMode::CLIMATE_MODE_FAN_ONLY);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_AUTO);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_LOW);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_MEDIUM);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_HIGH);
-  traits.add_supported_preset(ClimatePreset::CLIMATE_PRESET_NONE);
-  traits.add_supported_preset(ClimatePreset::CLIMATE_PRESET_SLEEP);
+  if (!this->supported_modes_.empty())
+    traits.add_supported_mode(ClimateMode::CLIMATE_MODE_OFF);
+  if (!this->supported_swing_modes_.empty())
+    traits.add_supported_swing_mode(ClimateSwingMode::CLIMATE_SWING_OFF);
+  if (!this->supported_presets_.empty())
+    traits.add_supported_preset(ClimatePreset::CLIMATE_PRESET_NONE);
   if (this->base_.getAutoconfStatus() == dudanov::midea::AUTOCONF_OK)
     Converters::to_climate_traits(traits, this->base_.getCapabilities());
   return traits;

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -88,14 +88,14 @@ ClimateTraits AirConditioner::traits() {
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_LOW);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_MEDIUM);
   traits.add_supported_fan_mode(ClimateFanMode::CLIMATE_FAN_HIGH);
-  if (!this->supported_modes_.empty())
-    traits.add_supported_mode(ClimateMode::CLIMATE_MODE_OFF);
-  if (!this->supported_swing_modes_.empty())
-    traits.add_supported_swing_mode(ClimateSwingMode::CLIMATE_SWING_OFF);
-  if (!this->supported_presets_.empty())
-    traits.add_supported_preset(ClimatePreset::CLIMATE_PRESET_NONE);
   if (this->base_.getAutoconfStatus() == dudanov::midea::AUTOCONF_OK)
     Converters::to_climate_traits(traits, this->base_.getCapabilities());
+  if (!traits.get_supported_modes().empty())
+    traits.add_supported_mode(ClimateMode::CLIMATE_MODE_OFF);
+  if (!traits.get_supported_swing_modes().empty())
+    traits.add_supported_swing_mode(ClimateSwingMode::CLIMATE_SWING_OFF);
+  if (!traits.get_supported_presets().empty())
+    traits.add_supported_preset(ClimatePreset::CLIMATE_PRESET_NONE);
   return traits;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/3914>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2665

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
