### PR TITLE
NeoPixel - Add support for ESP32-S3

### DIFF
--- a/esphome/components/neopixelbus/_methods.py
+++ b/esphome/components/neopixelbus/_methods.py
@@ -15,6 +15,7 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32,
     VARIANT_ESP32S2,
     VARIANT_ESP32C3,
+    VARIANT_ESP32S3,
 )
 from esphome.core import CORE
 from .const import (
@@ -58,6 +59,7 @@ SPI_SPEEDS = [40e6, 20e6, 10e6, 5e6, 2e6, 1e6, 500e3]
 def _esp32_rmt_default_channel():
     return {
         VARIANT_ESP32S2: 1,
+        VARIANT_ESP32S3: 1,
         VARIANT_ESP32C3: 1,
     }.get(get_esp32_variant(), 6)
 
@@ -70,6 +72,7 @@ def _validate_esp32_rmt_channel(value):
     variant_channels = {
         VARIANT_ESP32: [0, 1, 2, 3, 4, 5, 6, 7, CHANNEL_DYNAMIC],
         VARIANT_ESP32S2: [0, 1, 2, 3, CHANNEL_DYNAMIC],
+        VARIANT_ESP32S3: [0, 1, 2, 3, CHANNEL_DYNAMIC],
         VARIANT_ESP32C3: [0, 1, CHANNEL_DYNAMIC],
     }
     variant = get_esp32_variant()

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -220,4 +220,5 @@ async def to_code(config):
     cg.add(var.set_pixel_order(getattr(ESPNeoPixelOrder, config[CONF_TYPE])))
 
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
-    cg.add_library("makuna/NeoPixelBus", "2.6.9")
+    # Version Listed Here: https://registry.platformio.org/libraries/makuna/NeoPixelBus/versions
+    cg.add_library("makuna/NeoPixelBus", "2.7.3")

--- a/script/test
+++ b/script/test
@@ -11,3 +11,4 @@ esphome compile tests/test2.yaml
 esphome compile tests/test3.yaml
 esphome compile tests/test4.yaml
 esphome compile tests/test5.yaml
+esphome compile tests/test8.yaml

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,3 +26,4 @@ Current test_.yaml file contents.
 | test5.yaml | ESP32 | wifi | ble_server
 | test6.yaml | RP2040 | wifi | N/A
 | test7.yaml | ESP32-C3 | wifi | N/A
+| test8.yaml | ESP32-S3 | wifi | None

--- a/tests/test8.yaml
+++ b/tests/test8.yaml
@@ -1,0 +1,27 @@
+# Tests for ESP32-S3 boards
+---
+wifi:
+  ssid: "ssid"
+
+esp32:
+  board: esp32-c3-devkitm-1
+  variant: ESP32S3
+  framework:
+    type: arduino
+
+esphome:
+  name: "esp32-s3-test"
+
+logger:
+
+light:
+  - platform: neopixelbus
+    type: GRB
+    variant: WS2812
+    pin: 33
+    num_leds: 1
+    id: neopixel
+    method: esp32_rmt
+    name: "neopixel-enable"
+    internal: false
+    restore_mode: ALWAYS_OFF


### PR DESCRIPTION
# What does this implement/fix?

NeoPixelBus release [v2.7.2](https://github.com/Makuna/NeoPixelBus/releases/tag/2.7.2) adds support for ESP32-S3 using the RMT method. 

This change updates NeoPixelBus from v2.6.9 to v2.7.3 and updates the ESPHome configuration to properly configure the ESP32-S3. Only the RMT method seems to be supported. I was unable to get i2s working and several issues suggested it wasn't supported yet (Makuna/NeoPixelBus#605, Makuna/NeoPixelBus#559)

Channel numbers confirmed from [here](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32s3/api-reference/peripherals/rmt.html). I used channel 1 as the default because chan 0 didn't seem to work correctly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2669

## Test Environment

I tested this on an [Adafruit Feather ESP32-S3](https://www.adafruit.com/product/5323) and confirmed that I can see the onboard NeoPixel flash.

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: feather-s3

substitutions:
  plant: Orchid

esp32:
  board: adafruit_feather_esp32s3
  variant: esp32s3
  framework:
    type: arduino
    version: 2.0.6

# Enable logging
logger:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

mqtt:
  broker: mqtt.example.com

light:
  - platform: neopixelbus
    type: GRB
    variant: WS2812
    pin: 33
    num_leds: 1
    id: neopixel
    method: esp32_rmt
    name: "neopixel-enable"
    internal: false
    restore_mode: ALWAYS_OFF
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). esphome/esphome-docs#2669
