### PR TITLE
Initialize all fields in ESPTime in PCF85063

### DIFF
--- a/esphome/components/pcf85063/pcf85063.cpp
+++ b/esphome/components/pcf85063/pcf85063.cpp
@@ -37,14 +37,18 @@ void PCF85063Component::read_time() {
     ESP_LOGW(TAG, "RTC halted, not syncing to system clock.");
     return;
   }
-  time::ESPTime rtc_time{.second = uint8_t(pcf85063_.reg.second + 10 * pcf85063_.reg.second_10),
-                         .minute = uint8_t(pcf85063_.reg.minute + 10u * pcf85063_.reg.minute_10),
-                         .hour = uint8_t(pcf85063_.reg.hour + 10u * pcf85063_.reg.hour_10),
-                         .day_of_week = uint8_t(pcf85063_.reg.weekday),
-                         .day_of_month = uint8_t(pcf85063_.reg.day + 10u * pcf85063_.reg.day_10),
-                         .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
-                         .month = uint8_t(pcf85063_.reg.month + 10u * pcf85063_.reg.month_10),
-                         .year = uint16_t(pcf85063_.reg.year + 10u * pcf85063_.reg.year_10 + 2000)};
+  time::ESPTime rtc_time{
+      .second = uint8_t(pcf85063_.reg.second + 10 * pcf85063_.reg.second_10),
+      .minute = uint8_t(pcf85063_.reg.minute + 10u * pcf85063_.reg.minute_10),
+      .hour = uint8_t(pcf85063_.reg.hour + 10u * pcf85063_.reg.hour_10),
+      .day_of_week = uint8_t(pcf85063_.reg.weekday),
+      .day_of_month = uint8_t(pcf85063_.reg.day + 10u * pcf85063_.reg.day_10),
+      .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
+      .month = uint8_t(pcf85063_.reg.month + 10u * pcf85063_.reg.month_10),
+      .year = uint16_t(pcf85063_.reg.year + 10u * pcf85063_.reg.year_10 + 2000),
+      .is_dst = false,  // not used
+      .timestamp = 0,   // overwritten by recalc_timestamp_utc(false)
+  };
   rtc_time.recalc_timestamp_utc(false);
   if (!rtc_time.is_valid()) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");


### PR DESCRIPTION
# What does this implement/fix?

Fixes a CI warning.

The underlying cause is that it's kinda stupid for `ESPTime` to store the time as both a timestamp and split-out fields, but that requires a bigger refactor to fix.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
