### PR TITLE
Add ESPHome version to generated platformio.ini

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -143,6 +143,7 @@ def get_ini_content():
     CORE.add_platformio_option("build_flags", sorted(CORE.build_flags))
 
     content = f"[env:{CORE.name}]\n"
+    content += f"description = ESPHome {__version__}\n"
     content += format_ini(CORE.platformio_options)
 
     return content

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -142,8 +142,10 @@ def get_ini_content():
     # Sort to avoid changing build flags order
     CORE.add_platformio_option("build_flags", sorted(CORE.build_flags))
 
-    content = f"[env:{CORE.name}]\n"
+    content = "[platformio]\n"
     content += f"description = ESPHome {__version__}\n"
+
+    content += f"[env:{CORE.name}]\n"
     content += format_ini(CORE.platformio_options)
 
     return content


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This allows force cleaning and full recompile when updating ESPHome version.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
