### PR TITLE
add SUB_BINARY_SENSOR macro to binary sensor

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -19,6 +19,15 @@ namespace binary_sensor {
     } \
   }
 
+#define SUB_BINARY_SENSOR(name) \
+ protected: \
+  binary_sensor::BinarySensor *name##_binary_sensor_{nullptr}; \
+\
+ public: \
+  void set_##name##_binary_sensor(binary_sensor::BinarySensor *binary_sensor) { \
+    this->name##_binary_sensor_ = binary_sensor; \
+  }
+
 /** Base class for all binary_sensor-type classes.
  *
  * This class includes a callback that components such as MQTT can subscribe to for state changes.


### PR DESCRIPTION
# What does this implement/fix?

adds the SUB_BINARY_SENSOR, same as SUB_SENSOR

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

https://github.com/esphome/esphome/pull/4434

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
