### PR TITLE
add SUB_NUMBER macro and schema to number

### DIFF
--- a/esphome/components/copy/number/__init__.py
+++ b/esphome/components/copy/number/__init__.py
@@ -15,11 +15,15 @@ from .. import copy_ns
 CopyNumber = copy_ns.class_("CopyNumber", number.Number, cg.Component)
 
 
-CONFIG_SCHEMA = number.number_schema(CopyNumber).extend(
-    {
-        cv.Required(CONF_SOURCE_ID): cv.use_id(number.Number),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    number.number_schema(CopyNumber)
+    .extend(
+        {
+            cv.Required(CONF_SOURCE_ID): cv.use_id(number.Number),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 FINAL_VALIDATE_SCHEMA = cv.All(
     inherit_property_from(CONF_ICON, CONF_SOURCE_ID),

--- a/esphome/components/copy/number/__init__.py
+++ b/esphome/components/copy/number/__init__.py
@@ -15,9 +15,8 @@ from .. import copy_ns
 CopyNumber = copy_ns.class_("CopyNumber", number.Number, cg.Component)
 
 
-CONFIG_SCHEMA = number.NUMBER_SCHEMA.extend(
+CONFIG_SCHEMA = number.number_schema(CopyNumber).extend(
     {
-        cv.GenerateID(): cv.declare_id(CopyNumber),
         cv.Required(CONF_SOURCE_ID): cv.use_id(number.Number),
     }
 ).extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/demo/__init__.py
+++ b/esphome/components/demo/__init__.py
@@ -284,9 +284,8 @@ CONFIG_SCHEMA = cv.Schema(
                 },
             ],
         ): [
-            number.NUMBER_SCHEMA.extend(cv.COMPONENT_SCHEMA).extend(
+            number.number_schema(DemoNumber).extend(cv.COMPONENT_SCHEMA).extend(
                 {
-                    cv.GenerateID(): cv.declare_id(DemoNumber),
                     cv.Required(CONF_TYPE): cv.enum(NUMBER_TYPES, int=True),
                     cv.Required(CONF_MIN_VALUE): cv.float_,
                     cv.Required(CONF_MAX_VALUE): cv.float_,

--- a/esphome/components/demo/__init__.py
+++ b/esphome/components/demo/__init__.py
@@ -284,7 +284,9 @@ CONFIG_SCHEMA = cv.Schema(
                 },
             ],
         ): [
-            number.number_schema(DemoNumber).extend(cv.COMPONENT_SCHEMA).extend(
+            number.number_schema(DemoNumber)
+            .extend(cv.COMPONENT_SCHEMA)
+            .extend(
                 {
                     cv.Required(CONF_TYPE): cv.enum(NUMBER_TYPES, int=True),
                     cv.Required(CONF_MIN_VALUE): cv.float_,

--- a/esphome/components/modbus_controller/number/__init__.py
+++ b/esphome/components/modbus_controller/number/__init__.py
@@ -60,9 +60,9 @@ def validate_modbus_number(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    number.NUMBER_SCHEMA.extend(ModbusItemBaseSchema).extend(
+    number.number_schema(ModbusNumber)
+    .extend(ModbusItemBaseSchema).extend(
         {
-            cv.GenerateID(): cv.declare_id(ModbusNumber),
             cv.Optional(CONF_REGISTER_TYPE, default="holding"): cv.enum(
                 MODBUS_WRITE_REGISTER_TYPE
             ),

--- a/esphome/components/modbus_controller/number/__init__.py
+++ b/esphome/components/modbus_controller/number/__init__.py
@@ -61,7 +61,8 @@ def validate_modbus_number(config):
 
 CONFIG_SCHEMA = cv.All(
     number.number_schema(ModbusNumber)
-    .extend(ModbusItemBaseSchema).extend(
+    .extend(ModbusItemBaseSchema)
+    .extend(
         {
             cv.Optional(CONF_REGISTER_TYPE, default="holding"): cv.enum(
                 MODBUS_WRITE_REGISTER_TYPE

--- a/esphome/components/number/number.h
+++ b/esphome/components/number/number.h
@@ -23,6 +23,13 @@ namespace number {
     } \
   }
 
+#define SUB_NUMBER(name) \
+ protected: \
+  number::Number *name##_number_{nullptr}; \
+\
+ public: \
+  void set_##name##_number(number::Number *number) { this->name##_number_ = number; }
+
 class Number;
 
 /** Base-class for all numbers.

--- a/esphome/components/template/number/__init__.py
+++ b/esphome/components/template/number/__init__.py
@@ -46,7 +46,8 @@ def validate(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    number.number_schema(TemplateNumber).extend(
+    number.number_schema(TemplateNumber)
+    .extend(
         {
             cv.Required(CONF_MAX_VALUE): cv.float_,
             cv.Required(CONF_MIN_VALUE): cv.float_,
@@ -57,7 +58,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INITIAL_VALUE): cv.float_,
             cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
         }
-    ).extend(cv.polling_component_schema("60s")),
+    )
+    .extend(cv.polling_component_schema("60s")),
     validate_min_max,
     validate,
 )

--- a/esphome/components/template/number/__init__.py
+++ b/esphome/components/template/number/__init__.py
@@ -46,9 +46,8 @@ def validate(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    number.NUMBER_SCHEMA.extend(
+    number.number_schema(TemplateNumber).extend(
         {
-            cv.GenerateID(): cv.declare_id(TemplateNumber),
             cv.Required(CONF_MAX_VALUE): cv.float_,
             cv.Required(CONF_MIN_VALUE): cv.float_,
             cv.Required(CONF_STEP): cv.positive_float,

--- a/esphome/components/tuya/number/__init__.py
+++ b/esphome/components/tuya/number/__init__.py
@@ -23,7 +23,8 @@ def validate_min_max(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    number.number_schema(TuyaNumber).extend(
+    number.number_schema(TuyaNumber)
+    .extend(
         {
             cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
             cv.Required(CONF_NUMBER_DATAPOINT): cv.uint8_t,
@@ -31,7 +32,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MIN_VALUE): cv.float_,
             cv.Required(CONF_STEP): cv.positive_float,
         }
-    ).extend(cv.COMPONENT_SCHEMA),
+    )
+    .extend(cv.COMPONENT_SCHEMA),
     validate_min_max,
 )
 

--- a/esphome/components/tuya/number/__init__.py
+++ b/esphome/components/tuya/number/__init__.py
@@ -23,9 +23,8 @@ def validate_min_max(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    number.NUMBER_SCHEMA.extend(
+    number.number_schema(TuyaNumber).extend(
         {
-            cv.GenerateID(): cv.declare_id(TuyaNumber),
             cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
             cv.Required(CONF_NUMBER_DATAPOINT): cv.uint8_t,
             cv.Required(CONF_MAX_VALUE): cv.float_,


### PR DESCRIPTION
# What does this implement/fix?

adds the SUB_NUMBER, same as SUB_SENSOR and `number_schema`, same as `sensor_schema` 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

https://github.com/esphome/esphome/pull/4434

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
