### PR TITLE
add SUB_BUTTON macro and ability to button schema to define the class

### DIFF
--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -17,6 +17,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.cpp_helpers import setup_entity
+from esphome.cpp_generator import MockObjClass
 
 CODEOWNERS = ["@esphome/core"]
 IS_PLATFORM_COMPONENT = True
@@ -56,11 +57,15 @@ _UNDEF = object()
 
 
 def button_schema(
+    class_: MockObjClass = _UNDEF,
+    *,
     icon: str = _UNDEF,
     entity_category: str = _UNDEF,
     device_class: str = _UNDEF,
 ) -> cv.Schema:
     schema = BUTTON_SCHEMA
+    if class_ is not _UNDEF:
+        schema = schema.extend({cv.GenerateID(): cv.declare_id(class_)})
     if icon is not _UNDEF:
         schema = schema.extend({cv.Optional(CONF_ICON, default=icon): cv.icon})
     if entity_category is not _UNDEF:

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -15,6 +15,13 @@ namespace button {
     } \
   }
 
+#define SUB_BUTTON(name) \
+ protected: \
+  button::Button *name##_button_{nullptr}; \
+\
+ public: \
+  void set_##name##_button(button::Button *button) { this->name##_button_ = button; }
+
 /** Base class for all buttons.
  *
  * A button is just a momentary switch that does not have a state, only a trigger.

--- a/esphome/components/copy/button/__init__.py
+++ b/esphome/components/copy/button/__init__.py
@@ -16,10 +16,9 @@ CopyButton = copy_ns.class_("CopyButton", button.Button, cg.Component)
 
 
 CONFIG_SCHEMA = (
-    button.button_schema()
+    button.button_schema(CopyButton)
     .extend(
         {
-            cv.GenerateID(): cv.declare_id(CopyButton),
             cv.Required(CONF_SOURCE_ID): cv.use_id(button.Button),
         }
     )

--- a/esphome/components/factory_reset/button/__init__.py
+++ b/esphome/components/factory_reset/button/__init__.py
@@ -13,15 +13,12 @@ FactoryResetButton = factory_reset_ns.class_(
     "FactoryResetButton", button.Button, cg.Component
 )
 
-CONFIG_SCHEMA = (
-    button.button_schema(
-        device_class=DEVICE_CLASS_RESTART,
-        entity_category=ENTITY_CATEGORY_CONFIG,
-        icon=ICON_RESTART_ALERT,
-    )
-    .extend({cv.GenerateID(): cv.declare_id(FactoryResetButton)})
-    .extend(cv.COMPONENT_SCHEMA)
-)
+CONFIG_SCHEMA = button.button_schema(
+    FactoryResetButton,
+    device_class=DEVICE_CLASS_RESTART,
+    entity_category=ENTITY_CATEGORY_CONFIG,
+    icon=ICON_RESTART_ALERT,
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):

--- a/esphome/components/restart/button/__init__.py
+++ b/esphome/components/restart/button/__init__.py
@@ -10,13 +10,11 @@ from esphome.const import (
 restart_ns = cg.esphome_ns.namespace("restart")
 RestartButton = restart_ns.class_("RestartButton", button.Button, cg.Component)
 
-CONFIG_SCHEMA = (
-    button.button_schema(
-        device_class=DEVICE_CLASS_RESTART, entity_category=ENTITY_CATEGORY_CONFIG
-    )
-    .extend({cv.GenerateID(): cv.declare_id(RestartButton)})
-    .extend(cv.COMPONENT_SCHEMA)
-)
+CONFIG_SCHEMA = button.button_schema(
+    RestartButton,
+    device_class=DEVICE_CLASS_RESTART,
+    entity_category=ENTITY_CATEGORY_CONFIG,
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):

--- a/esphome/components/safe_mode/button/__init__.py
+++ b/esphome/components/safe_mode/button/__init__.py
@@ -17,11 +17,11 @@ SafeModeButton = safe_mode_ns.class_("SafeModeButton", button.Button, cg.Compone
 
 CONFIG_SCHEMA = (
     button.button_schema(
+        SafeModeButton,
         device_class=DEVICE_CLASS_RESTART,
         entity_category=ENTITY_CATEGORY_CONFIG,
         icon=ICON_RESTART_ALERT,
     )
-    .extend({cv.GenerateID(): cv.declare_id(SafeModeButton)})
     .extend({cv.GenerateID(CONF_OTA): cv.use_id(OTAComponent)})
     .extend(cv.COMPONENT_SCHEMA)
 )

--- a/esphome/components/shutdown/button/__init__.py
+++ b/esphome/components/shutdown/button/__init__.py
@@ -10,11 +10,9 @@ from esphome.const import (
 shutdown_ns = cg.esphome_ns.namespace("shutdown")
 ShutdownButton = shutdown_ns.class_("ShutdownButton", button.Button, cg.Component)
 
-CONFIG_SCHEMA = (
-    button.button_schema(entity_category=ENTITY_CATEGORY_CONFIG, icon=ICON_POWER)
-    .extend({cv.GenerateID(): cv.declare_id(ShutdownButton)})
-    .extend(cv.COMPONENT_SCHEMA)
-)
+CONFIG_SCHEMA = button.button_schema(
+    ShutdownButton, entity_category=ENTITY_CATEGORY_CONFIG, icon=ICON_POWER
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

adds the SUB_BUTTON, same as SUB_SENSOR and
add ability to button schema to define the class, just like sensor_schema

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

https://github.com/esphome/esphome/pull/4434


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
