### PR TITLE
sn74hc165 fixes

### DIFF
--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -64,7 +64,7 @@ void SN74HC165Component::read_gpio_() {
 
 float SN74HC165Component::get_setup_priority() const { return setup_priority::IO; }
 
-bool SN74HC165GPIOPin::digital_read() { return this->parent_->digital_read_(this->pin_); }
+bool SN74HC165GPIOPin::digital_read() { return this->parent_->digital_read_(this->pin_) != this->inverted_; }
 
 std::string SN74HC165GPIOPin::dump_summary() const { return str_snprintf("%u via SN74HC165", 18, pin_); }
 

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -49,7 +49,7 @@ void SN74HC165Component::read_gpio_() {
 
   for (uint8_t i = 0; i < this->sr_count_; i++) {
     for (uint8_t j = 0; j < 8; j++) {
-      this->input_bits_[(i*8) + (7-j)] = this->data_pin_->digital_read();
+      this->input_bits_[(i * 8) + (7 - j)] = this->data_pin_->digital_read();
 
       this->clock_pin_->digital_write(true);
       delayMicroseconds(10);

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -52,6 +52,7 @@ void SN74HC165Component::read_gpio_() {
     this->clock_pin_->digital_write(true);
     delayMicroseconds(10);
     this->clock_pin_->digital_write(false);
+    delayMicroseconds(10);
   }
 
   if (this->clock_inhibit_pin_ != nullptr)

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -40,9 +40,9 @@ bool SN74HC165Component::digital_read_(uint16_t pin) {
 
 void SN74HC165Component::read_gpio_() {
   this->load_pin_->digital_write(false);
-  delayMicroseconds(5);
+  delayMicroseconds(10);
   this->load_pin_->digital_write(true);
-  delayMicroseconds(5);
+  delayMicroseconds(10);
 
   if (this->clock_inhibit_pin_ != nullptr)
     this->clock_inhibit_pin_->digital_write(false);
@@ -50,7 +50,7 @@ void SN74HC165Component::read_gpio_() {
   for (int16_t i = (this->sr_count_ * 8) - 1; i >= 0; i--) {
     this->input_bits_[i] = this->data_pin_->digital_read();
     this->clock_pin_->digital_write(true);
-    delayMicroseconds(5);
+    delayMicroseconds(10);
     this->clock_pin_->digital_write(false);
   }
 

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -52,15 +52,19 @@ void SN74HC165Component::read_gpio_() {
   if (this->clock_inhibit_pin_ != nullptr)
     this->clock_inhibit_pin_->digital_write(false);
 
-  for (int16_t i = (this->sr_count_ * 8) - 1; i >= 0; i--) {
-    this->input_bits_[i] = this->data_pin_->digital_read();
+  for (uint8_t i = 0; i < this->sr_count_; i++) {
+    for (uint8_t j = 0; j < 8; j++) {
+      this->input_bits_[(i*8) + (7-j)] = this->data_pin_->digital_read();
 
+      if (log_input)
+        pins += this->input_bits_[i] ? "1" : "0";
+      this->clock_pin_->digital_write(true);
+      delayMicroseconds(10);
+      this->clock_pin_->digital_write(false);
+      delayMicroseconds(10);
+    }
     if (log_input)
-      pins += this->input_bits_[i] ? "1" : "0";
-    this->clock_pin_->digital_write(true);
-    delayMicroseconds(10);
-    this->clock_pin_->digital_write(false);
-    delayMicroseconds(10);
+      pins += " ";
   }
 
   if (log_input) {

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -39,11 +39,6 @@ bool SN74HC165Component::digital_read_(uint16_t pin) {
 }
 
 void SN74HC165Component::read_gpio_() {
-  bool log_input = false;
-  static uint32_t last_log = 0;
-  std::string pins;
-  log_input = (millis() - last_log) > 1000;
-
   this->load_pin_->digital_write(false);
   delayMicroseconds(10);
   this->load_pin_->digital_write(true);
@@ -56,20 +51,11 @@ void SN74HC165Component::read_gpio_() {
     for (uint8_t j = 0; j < 8; j++) {
       this->input_bits_[(i*8) + (7-j)] = this->data_pin_->digital_read();
 
-      if (log_input)
-        pins += this->input_bits_[i] ? "1" : "0";
       this->clock_pin_->digital_write(true);
       delayMicroseconds(10);
       this->clock_pin_->digital_write(false);
       delayMicroseconds(10);
     }
-    if (log_input)
-      pins += " ";
-  }
-
-  if (log_input) {
-    ESP_LOGD(TAG, "Read: %s", pins.c_str());
-    last_log = millis();
   }
 
   if (this->clock_inhibit_pin_ != nullptr)

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -50,6 +50,7 @@ void SN74HC165Component::read_gpio_() {
   for (int16_t i = (this->sr_count_ * 8) - 1; i >= 0; i--) {
     this->input_bits_[i] = this->data_pin_->digital_read();
     this->clock_pin_->digital_write(true);
+    delayMicroseconds(5);
     this->clock_pin_->digital_write(false);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

A few timing fixes, fix inverted, and also reverses the pin bits to match lettering, pin A is bit/pin 0 now.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
