### PR TITLE
add text sensor to get 1-wire addresses

### DIFF
--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -90,8 +90,9 @@ void DallasComponent::dump_config() {
     std::string addresses;
     bool first = true;
     for (auto &address : this->found_sensors_) {
+      addresses += first ? "" : " ";
       addresses += "0x";
-      addresses += format_hex(address) + (first ? "" : " ");
+      addresses += format_hex(address);
       first = false;
     }
     address_sensor_->publish_state(addresses);

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -85,6 +85,19 @@ void DallasComponent::dump_config() {
     }
   }
 
+#ifdef USE_TEXT_SENSOR
+  if (address_sensor_) {
+    std::string addresses;
+    bool first = true;
+    for (auto &address : this->found_sensors_) {
+      addresses += "0x";
+      addresses += format_hex(address) + (first ? "" : " ");
+      first = false;
+    }
+    address_sensor_->publish_state(addresses);
+  }
+#endif  // USE_TEXT_SENSOR
+
   for (auto *sensor : this->sensors_) {
     LOG_SENSOR("  ", "Device", sensor);
     if (sensor->get_index().has_value()) {

--- a/esphome/components/dallas/dallas_component.h
+++ b/esphome/components/dallas/dallas_component.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include "esphome/core/defines.h"
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+
 #include "esp_one_wire.h"
 
 #include <vector>
@@ -22,6 +27,10 @@ class DallasComponent : public PollingComponent {
 
   void update() override;
 
+#ifdef USE_TEXT_SENSOR
+  void set_address_sensor(text_sensor::TextSensor *address) { address_sensor_ = address; }
+#endif  // USE_TEXT_SENSOR
+
  protected:
   friend DallasTemperatureSensor;
 
@@ -29,6 +38,9 @@ class DallasComponent : public PollingComponent {
   ESPOneWire *one_wire_;
   std::vector<DallasTemperatureSensor *> sensors_;
   std::vector<uint64_t> found_sensors_;
+#ifdef USE_TEXT_SENSOR
+  text_sensor::TextSensor *address_sensor_{nullptr};
+#endif  // USE_TEXT_SENSOR
 };
 
 /// Internal class that helps us create multiple sensors for one Dallas hub.

--- a/esphome/components/dallas/text_sensor.py
+++ b/esphome/components/dallas/text_sensor.py
@@ -1,0 +1,31 @@
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import (
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    ICON_CHIP,
+    CONF_ADDRESS,
+    CONF_DALLAS_ID,
+)
+
+from . import DallasComponent
+
+DEPENDENCIES = ["dallas"]
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_DALLAS_ID): cv.use_id(DallasComponent),
+        cv.Optional(CONF_ADDRESS): text_sensor.text_sensor_schema(
+            icon=ICON_CHIP,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_DALLAS_ID])
+
+    if CONF_ADDRESS in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_ADDRESS])
+        cg.add(hub.set_address_sensor(sens))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2994,6 +2994,9 @@ text_sensor:
     tag_name: OPTARIF
     name: optarif
     teleinfo_id: myteleinfo
+  - platform: dallas
+    address:
+      name: dallas address
 
 sn74hc595:
   - id: sn74hc595_hub


### PR DESCRIPTION
# What does this implement/fix?

It is difficult to find out address of 1-wiere sensors in log over web.
It adds new text sensor which display all address as text sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
text_sensor:
  - platform: dallas
    address:
      name: dallas address

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
https://github.com/esphome/esphome-docs/pull/2682