### PR TITLE
Add binary sensors for pvvx_mithermometer flags

### DIFF
--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
@@ -11,11 +12,23 @@
 namespace esphome {
 namespace pvvx_mithermometer {
 
+using PvvxFlags = union {
+  uint8_t all;
+  struct {
+    uint8_t rds_input : 1;
+    uint8_t trg_output : 1;
+    uint8_t trigger_on : 1;
+    uint8_t temp_out_on : 1;
+    uint8_t humi_out_on : 1;
+  };
+};
+
 struct ParseResult {
   optional<float> temperature;
   optional<float> humidity;
   optional<float> battery_level;
   optional<float> battery_voltage;
+  optional<PvvxFlags> flags;
   int raw_offset;
 };
 
@@ -31,6 +44,11 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
   void set_battery_voltage(sensor::Sensor *battery_voltage) { battery_voltage_ = battery_voltage; }
   void set_signal_strength(sensor::Sensor *signal_strength) { signal_strength_ = signal_strength; }
+  void set_rds_input(binary_sensor::BinarySensor *rds_input) { rds_input_ = rds_input; }
+  void set_trg_output(binary_sensor::BinarySensor *trg_output) { trg_output_ = trg_output; }
+  void set_trigger_on(binary_sensor::BinarySensor *trigger_on) { trigger_on_ = trigger_on; }
+  void set_humi_out_on(binary_sensor::BinarySensor *humi_out_on) { humi_out_on_ = humi_out_on; }
+  void set_temp_out_on(binary_sensor::BinarySensor *temp_out_on) { temp_out_on_ = temp_out_on; }
 
  protected:
   uint64_t address_;
@@ -39,6 +57,11 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
   sensor::Sensor *battery_level_{nullptr};
   sensor::Sensor *battery_voltage_{nullptr};
   sensor::Sensor *signal_strength_{nullptr};
+  binary_sensor::BinarySensor *rds_input_{nullptr};
+  binary_sensor::BinarySensor *trg_output_{nullptr};
+  binary_sensor::BinarySensor *trigger_on_{nullptr};
+  binary_sensor::BinarySensor *humi_out_on_{nullptr};
+  binary_sensor::BinarySensor *temp_out_on_{nullptr};
 
   optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);

--- a/esphome/components/pvvx_mithermometer/sensor.py
+++ b/esphome/components/pvvx_mithermometer/sensor.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor, esp32_ble_tracker
+from esphome.components import binary_sensor, sensor, esp32_ble_tracker
 from esphome.const import (
     CONF_BATTERY_LEVEL,
     CONF_BATTERY_VOLTAGE,
@@ -24,12 +24,18 @@ from esphome.const import (
 
 CODEOWNERS = ["@pasiz"]
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["binary_sensor", "esp32_ble_tracker"]
 
 pvvx_mithermometer_ns = cg.esphome_ns.namespace("pvvx_mithermometer")
 PVVXMiThermometer = pvvx_mithermometer_ns.class_(
     "PVVXMiThermometer", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
 )
+
+CONF_RDS_INPUT = "rds_input"
+CONF_TRG_OUTPUT = "trg_output"
+CONF_TRIGGER_ON = "trigger_on"
+CONF_HUMI_OUT_ON = "humi_out_on"
+CONF_TEMP_OUT_ON = "temp_out_on"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -62,6 +68,11 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
+            cv.Optional(CONF_RDS_INPUT): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_TRG_OUTPUT): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_TRIGGER_ON): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_HUMI_OUT_ON): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_TEMP_OUT_ON): binary_sensor.binary_sensor_schema(),
             cv.Optional(CONF_SIGNAL_STRENGTH): sensor.sensor_schema(
                 unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
                 accuracy_decimals=0,
@@ -95,6 +106,21 @@ async def to_code(config):
     if CONF_BATTERY_VOLTAGE in config:
         sens = await sensor.new_sensor(config[CONF_BATTERY_VOLTAGE])
         cg.add(var.set_battery_voltage(sens))
+    if CONF_RDS_INPUT in config:
+        bs = await binary_sensor.new_binary_sensor(config[CONF_RDS_INPUT])
+        cg.add(var.set_rds_input(bs))
+    if CONF_TRG_OUTPUT in config:
+        bs = await binary_sensor.new_binary_sensor(config[CONF_TRG_OUTPUT])
+        cg.add(var.set_trg_output(bs))
+    if CONF_TRIGGER_ON in config:
+        bs = await binary_sensor.new_binary_sensor(config[CONF_TRIGGER_ON])
+        cg.add(var.set_trigger_on(bs))
+    if CONF_HUMI_OUT_ON in config:
+        bs = await binary_sensor.new_binary_sensor(config[CONF_HUMI_OUT_ON])
+        cg.add(var.set_humi_out_on(bs))
+    if CONF_TEMP_OUT_ON in config:
+        bs = await binary_sensor.new_binary_sensor(config[CONF_TEMP_OUT_ON])
+        cg.add(var.set_temp_out_on(bs))
     if CONF_SIGNAL_STRENGTH in config:
         sens = await sensor.new_sensor(config[CONF_SIGNAL_STRENGTH])
         cg.add(var.set_signal_strength(sens))


### PR DESCRIPTION
# What does this implement/fix?

Binary sensors for pvvx_mithermometer flags field (the five bits currently provided).

(Also AUTO_LOAD esp32_ble_tracker instead of just depending on it, simpler usage that way.)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pvvx_mithermometer
    mac_address: 11:22:33:44:55:66
    rds_input:
      name: hall_motion
      device_class: motion
      filters:
        - delayed_on: 15s
        - delayed_off: 300s
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

If the PR in principle looks good, can create and send another one for the docs too, of course.