### PR TITLE
BL0939 state_class set for energy sensors

### DIFF
--- a/esphome/components/bl0939/sensor.py
+++ b/esphome/components/bl0939/sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_KILOWATT_HOURS,
     UNIT_VOLT,
@@ -66,16 +67,19 @@ CONFIG_SCHEMA = (
                 unit_of_measurement=UNIT_KILOWATT_HOURS,
                 accuracy_decimals=3,
                 device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
             cv.Optional(CONF_ENERGY_2): sensor.sensor_schema(
                 unit_of_measurement=UNIT_KILOWATT_HOURS,
                 accuracy_decimals=3,
                 device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
             cv.Optional(CONF_ENERGY_TOTAL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_KILOWATT_HOURS,
                 accuracy_decimals=3,
                 device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
         }
     )


### PR DESCRIPTION
BL0939 was missing TOTAL_INCREASING for energy (kWh) thus it did not show as statistics in home assistant

# What does this implement/fix?
Fix for missing energy statistics recording in homeassistant mqtt.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)


## Test Environment

- [X] ESP32
Sonoff Dual R3
## Example entry for `config.yaml`:
sensor:
  - platform: bl0939
    update_interval: 5s
    voltage:
      name: "Voltage"
    current_1:
      name: "Current 1"
    current_2:
      name: "Current 2"
    active_power_1:
      name: "Power 1"
    active_power_2:
      name: "Power 2"
    energy_1:
      name: "Energy 1"

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [-] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
