### PR TITLE
fix library override logic

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -653,7 +653,11 @@ class EsphomeCore:
                 f"Library {library} must be instance of Library, not {type(library)}"
             )
         for other in self.libraries[:]:
-            if other.name != library.name or other.name is None or library.name is None:
+            if other.name is None or library.name is None:
+                continue
+            library_name = library.name if '/' not in library.name else library.name.split('/')[1]
+            other_name = other.name if '/' not in other.name else other.name.split('/')[1]
+            if other_name != library_name:
                 continue
             if other.repository is not None:
                 if library.repository is None or other.repository == library.repository:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -655,8 +655,12 @@ class EsphomeCore:
         for other in self.libraries[:]:
             if other.name is None or library.name is None:
                 continue
-            library_name = library.name if '/' not in library.name else library.name.split('/')[1]
-            other_name = other.name if '/' not in other.name else other.name.split('/')[1]
+            library_name = (
+                library.name if "/" not in library.name else library.name.split("/")[1]
+            )
+            other_name = (
+                other.name if "/" not in other.name else other.name.split("/")[1]
+            )
             if other_name != library_name:
                 continue
             if other.repository is not None:


### PR DESCRIPTION
# What does this implement/fix?

Fix ability to override libraries in the form of  `prefix/library_name`

 This PR fixes override functionality for libraries, specified with the prefix in their name, for example: `fastled/FastLED`, where `fastled` is the prefix, and `FastLED` is the library name. As declared in https://github.com/esphome/esphome/blob/c6dc8a11e24f9332bc6557c8733fd12d45ed3dc2/esphome/components/fastled_base/__init__.py#L47

without this PR, user is unable to override this library through their  `config.yaml` with the `libraries:` directive

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
esphome:
  name: test
  libraries:
    - FastLED=https://github.com/mzakharo/FastLED.git
 ```


```yaml
light:
  - platform: fastled_spi
    chipset: APA102
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

