### PR TITLE
fix wiegand tag parity

### DIFF
--- a/esphome/components/wiegand/wiegand.cpp
+++ b/esphome/components/wiegand/wiegand.cpp
@@ -38,8 +38,8 @@ void Wiegand::setup() {
 bool check_eparity(uint64_t value, int start, int length) {
   int parity = 0;
   uint64_t mask = 1LL << start;
-  for (int i = 0; i <= length; i++, mask <<= 1) {
-    if (value & i)
+  for (int i = 0; i < length; i++, mask <<= 1) {
+    if (value & mask)
       parity++;
   }
   return !(parity & 1);
@@ -48,8 +48,8 @@ bool check_eparity(uint64_t value, int start, int length) {
 bool check_oparity(uint64_t value, int start, int length) {
   int parity = 0;
   uint64_t mask = 1LL << start;
-  for (int i = 0; i <= length; i++, mask <<= 1) {
-    if (value & i)
+  for (int i = 0; i < length; i++, mask <<= 1) {
+    if (value & mask)
       parity++;
   }
   return parity & 1;


### PR DESCRIPTION
# What does this implement/fix?

Fix parity checks for Wiegand tags

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4220

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
