### PR TITLE
Fix parallel invocations of repeat action

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -254,7 +254,11 @@ async def repeat_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     count_template = await cg.templatable(config[CONF_COUNT], args, cg.uint32)
     cg.add(var.set_count(count_template))
-    actions = await build_action_list(config[CONF_THEN], template_arg, args)
+    actions = await build_action_list(
+        config[CONF_THEN],
+        cg.TemplateArguments(cg.uint32, *template_arg.args),
+        [(cg.uint32, "iteration"), *args],
+    )
     cg.add(var.add_then(actions))
     return var
 

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -235,22 +235,21 @@ template<typename... Ts> class RepeatAction : public Action<Ts...> {
  public:
   TEMPLATABLE_VALUE(uint32_t, count)
 
-  void add_then(const std::vector<Action<Ts...> *> &actions) {
+  void add_then(const std::vector<Action<uint32_t, Ts...> *> &actions) {
     this->then_.add_actions(actions);
-    this->then_.add_action(new LambdaAction<Ts...>([this](Ts... x) {
-      this->iteration_++;
-      if (this->iteration_ == this->count_.value(x...))
+    this->then_.add_action(new LambdaAction<uint32_t, Ts...>([this](uint32_t iteration, Ts... x) {
+      iteration++;
+      if (iteration >= this->count_.value(x...))
         this->play_next_tuple_(this->var_);
       else
-        this->then_.play_tuple(this->var_);
+        this->then_.play(iteration, x...);
     }));
   }
 
   void play_complex(Ts... x) override {
     this->num_running_++;
     this->var_ = std::make_tuple(x...);
-    this->iteration_ = 0;
-    this->then_.play_tuple(this->var_);
+    this->then_.play(0, x...);
   }
 
   void play(Ts... x) override { /* ignore - see play_complex */
@@ -259,8 +258,7 @@ template<typename... Ts> class RepeatAction : public Action<Ts...> {
   void stop() override { this->then_.stop(); }
 
  protected:
-  uint32_t iteration_;
-  ActionList<Ts...> then_;
+  ActionList<uint32_t, Ts...> then_;
   std::tuple<Ts...> var_;
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Fix reentrancy of the  `repeat` action.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#2929

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
