### PR TITLE
Added pzemdc reset energy action

### DIFF
--- a/esphome/components/pzemdc/pzemdc.cpp
+++ b/esphome/components/pzemdc/pzemdc.cpp
@@ -7,6 +7,7 @@ namespace pzemdc {
 static const char *const TAG = "pzemdc";
 
 static const uint8_t PZEM_CMD_READ_IN_REGISTERS = 0x04;
+static const uint8_t PZEM_CMD_RESET_ENERGY = 0x42;
 static const uint8_t PZEM_REGISTER_COUNT = 10;  // 10x 16-bit registers
 
 void PZEMDC::on_modbus_data(const std::vector<uint8_t> &data) {
@@ -59,6 +60,13 @@ void PZEMDC::dump_config() {
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);
   LOG_SENSOR("", "Energy", this->energy_sensor_);
+}
+
+void PZEMDC::reset_energy_() {
+  std::vector<uint8_t> cmd;
+  cmd.push_back(this->address_);
+  cmd.push_back(PZEM_CMD_RESET_ENERGY);
+  this->send_raw(cmd);
 }
 
 }  // namespace pzemdc

--- a/esphome/components/pzemdc/pzemdc.cpp
+++ b/esphome/components/pzemdc/pzemdc.cpp
@@ -62,7 +62,7 @@ void PZEMDC::dump_config() {
   LOG_SENSOR("", "Energy", this->energy_sensor_);
 }
 
-void PZEMDC::reset_energy_() {
+void PZEMDC::reset_energy() {
   std::vector<uint8_t> cmd;
   cmd.push_back(this->address_);
   cmd.push_back(PZEM_CMD_RESET_ENERGY);

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -9,8 +9,6 @@
 namespace esphome {
 namespace pzemdc {
 
-template<typename... Ts> class ResetEnergyAction;
-
 class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -25,11 +25,12 @@ class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
   void dump_config() override;
 
  protected:
+  template<typename... Ts> friend class ResetEnergyAction;
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
-
+  
   void reset_energy_();
 };
 

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -30,7 +30,7 @@ class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
-  
+
   void reset_energy_();
 };
 

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -15,8 +15,6 @@ class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }
   void set_power_sensor(sensor::Sensor *power_sensor) { power_sensor_ = power_sensor; }
   void set_energy_sensor(sensor::Sensor *energy_sensor) { energy_sensor_ = energy_sensor; }
-  void set_frequency_sensor(sensor::Sensor *frequency_sensor) { frequency_sensor_ = frequency_sensor; }
-  void set_powerfactor_sensor(sensor::Sensor *powerfactor_sensor) { power_factor_sensor_ = powerfactor_sensor; }
 
   void update() override;
 
@@ -28,8 +26,6 @@ class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
-  sensor::Sensor *frequency_sensor_{nullptr};
-  sensor::Sensor *power_factor_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
 };
 

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -9,6 +9,8 @@
 namespace esphome {
 namespace pzemdc {
 
+template<typename... Ts> class ResetEnergyAction;
+
 class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
@@ -27,6 +29,18 @@ class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
+
+  void reset_energy_();
+};
+
+template<typename... Ts> class ResetEnergyAction : public Action<Ts...> {
+ public:
+  ResetEnergyAction(PZEMDC *pzemdc) : pzemdc_(pzemdc) {}
+
+  void play(Ts... x) override { this->pzemdc_->reset_energy_(); }
+
+ protected:
+  PZEMDC *pzemdc_;
 };
 
 }  // namespace pzemdc

--- a/esphome/components/pzemdc/pzemdc.h
+++ b/esphome/components/pzemdc/pzemdc.h
@@ -24,21 +24,20 @@ class PZEMDC : public PollingComponent, public modbus::ModbusDevice {
 
   void dump_config() override;
 
+  void reset_energy();
+
  protected:
-  template<typename... Ts> friend class ResetEnergyAction;
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
-
-  void reset_energy_();
 };
 
 template<typename... Ts> class ResetEnergyAction : public Action<Ts...> {
  public:
   ResetEnergyAction(PZEMDC *pzemdc) : pzemdc_(pzemdc) {}
 
-  void play(Ts... x) override { this->pzemdc_->reset_energy_(); }
+  void play(Ts... x) override { this->pzemdc_->reset_energy(); }
 
  protected:
   PZEMDC *pzemdc_;

--- a/esphome/components/pzemdc/sensor.py
+++ b/esphome/components/pzemdc/sensor.py
@@ -1,5 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import automation
+from esphome.automation import maybe_simple_id
 from esphome.components import sensor, modbus
 from esphome.const import (
     CONF_CURRENT,
@@ -23,6 +25,9 @@ AUTO_LOAD = ["modbus"]
 
 pzemdc_ns = cg.esphome_ns.namespace("pzemdc")
 PZEMDC = pzemdc_ns.class_("PZEMDC", cg.PollingComponent, modbus.ModbusDevice)
+
+# Actions
+ResetEnergyAction = pzemdc_ns.class_("ResetEnergyAction", automation.Action)
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -58,6 +63,18 @@ CONFIG_SCHEMA = (
     .extend(modbus.modbus_device_schema(0x01))
 )
 
+@automation.register_action(
+    "pzemdc.reset_energy",
+    ResetEnergyAction,
+    maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(PZEMDC),
+        }
+    ),
+)
+async def reset_energy_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/pzemdc/sensor.py
+++ b/esphome/components/pzemdc/sensor.py
@@ -69,7 +69,7 @@ CONFIG_SCHEMA = (
     ResetEnergyAction,
     maybe_simple_id(
         {
-            cv.Required(CONF_ID): cv.use_id(PZEMDC),
+            cv.GenerateID(CONF_ID): cv.use_id(PZEMDC),
         }
     ),
 )

--- a/esphome/components/pzemdc/sensor.py
+++ b/esphome/components/pzemdc/sensor.py
@@ -63,6 +63,7 @@ CONFIG_SCHEMA = (
     .extend(modbus.modbus_device_schema(0x01))
 )
 
+
 @automation.register_action(
     "pzemdc.reset_energy",
     ResetEnergyAction,
@@ -75,6 +76,7 @@ CONFIG_SCHEMA = (
 async def reset_energy_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -579,6 +579,7 @@ sensor:
     power_factor:
       name: PZEMAC Power Factor
   - platform: pzemdc
+    id: pzemdc1
     voltage:
       name: PZEMDC Voltage
     current:
@@ -925,6 +926,11 @@ binary_sensor:
     on_press:
       then:
         - pzemac.reset_energy: pzemac1
+  - platform: template
+    id: pzemdc_reset_energy
+    on_press:
+      then:
+        - pzemdc.reset_energy: pzemdc1
 
   - platform: vbus
     model: deltasol_bs_plus


### PR DESCRIPTION
# What does this implement/fix?

I've added a action to reset the energy on the pzemdc device.
Additionally I removed `frequency_sensor_` & `powerfactor_sensor_` because that was not used and are not documented. This sensors only available for AC devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2700

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

- [x] PZEM-017

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml

uart:
  tx_pin: D1
  rx_pin: D2
  baud_rate: 9600
  stop_bits: 2

sensor:
  - platform: pzemdc
    id: pzemdc_1
    current:
      name: "PZEM-017 Current"
    voltage:
      name: "PZEM-017 Voltage"
    power:
      name: "PZEM-017 Power"
    energy:
      name: "PZEM-017 Energy"
    update_interval: 60s

on_...:
  then:
    - pzemdc.reset_energy: pzemdc_1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
