### PR TITLE
Move Font glyphs to SPI RAM.

### DIFF
--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -526,10 +526,12 @@ class Font {
   inline int get_baseline() { return this->baseline_; }
   inline int get_height() { return this->height_; }
 
-  const std::vector<Glyph> &get_glyphs() const;
+  Glyph *&get_glyphs() { return this->glyphs_; }
+  const u_int16_t &get_glyphs_size() const { return this->glyphs_size_; }
 
  protected:
-  std::vector<Glyph> glyphs_;
+  Glyph *glyphs_{nullptr};
+  u_int16_t glyphs_size_;
   int baseline_;
   int height_;
 };


### PR DESCRIPTION
# What does this implement/fix?

Move the Font glyph data to SPI RAM (if possible). Given that Display devices are expected to have SPI RAM more infrequent data can be moved to the SPI RAM.

In my scenario with 3 Fonts this saves 3kb of heap size and some fragmentation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
