### PR TITLE
Use PSRam for BLE scan results.

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -54,7 +54,7 @@ void ESP32BLETracker::setup() {
     return;
   }
   ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param> allocator(
-      ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param>::ALLOW_FAILURE);
+      ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param>::NONE);
   this->scan_result_buffer_ = allocator.allocate(ESP32BLETracker::SCAN_RESULT_BUFFER_SIZE);
   memset(this->scan_result_buffer_, 0,
          sizeof(esp_ble_gap_cb_param_t::ble_scan_result_evt_param) * ESP32BLETracker::SCAN_RESULT_BUFFER_SIZE);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -54,10 +54,13 @@ void ESP32BLETracker::setup() {
     return;
   }
   ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param> allocator(
-      ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param>::NONE);
+      ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param>::ALLOW_FAILURE);
   this->scan_result_buffer_ = allocator.allocate(ESP32BLETracker::SCAN_RESULT_BUFFER_SIZE);
-  memset(this->scan_result_buffer_, 0,
-         sizeof(esp_ble_gap_cb_param_t::ble_scan_result_evt_param) * ESP32BLETracker::SCAN_RESULT_BUFFER_SIZE);
+
+  if (this->scan_result_buffer_ == nullptr) {
+    ESP_LOGE(TAG, "Could not allocate buffer for BLE Tracker!");
+    this->mark_failed();
+  }
 
   global_esp32_ble_tracker = this;
   this->scan_result_lock_ = xSemaphoreCreateMutex();

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -53,6 +53,11 @@ void ESP32BLETracker::setup() {
     ESP_LOGE(TAG, "BLE Tracker was marked failed by ESP32BLE");
     return;
   }
+  ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param> allocator(
+      ExternalRAMAllocator<esp_ble_gap_cb_param_t::ble_scan_result_evt_param>::ALLOW_FAILURE);
+  this->scan_result_buffer_ = allocator.allocate(this->scan_result_buffer_size_);
+  memset(this->scan_result_buffer_, 0,
+         sizeof(esp_ble_gap_cb_param_t::ble_scan_result_evt_param) * this->scan_result_buffer_size_);
 
   global_esp32_ble_tracker = this;
   this->scan_result_lock_ = xSemaphoreCreateMutex();
@@ -107,7 +112,7 @@ void ESP32BLETracker::loop() {
         xSemaphoreTake(this->scan_result_lock_, 5L / portTICK_PERIOD_MS)) {
       uint32_t index = this->scan_result_index_;
       if (index) {
-        if (index >= 16) {
+        if (index >= this->scan_result_buffer_size_) {
           ESP_LOGW(TAG, "Too many BLE events to process. Some devices may not show up.");
         }
         for (size_t i = 0; i < index; i++) {
@@ -322,7 +327,7 @@ void ESP32BLETracker::gap_scan_stop_complete_(const esp_ble_gap_cb_param_t::ble_
 void ESP32BLETracker::gap_scan_result_(const esp_ble_gap_cb_param_t::ble_scan_result_evt_param &param) {
   if (param.search_evt == ESP_GAP_SEARCH_INQ_RES_EVT) {
     if (xSemaphoreTake(this->scan_result_lock_, 0L)) {
-      if (this->scan_result_index_ < 16) {
+      if (this->scan_result_index_ < this->scan_result_buffer_size_) {
         this->scan_result_buffer_[this->scan_result_index_++] = param;
       }
       xSemaphoreGive(this->scan_result_lock_);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -101,7 +101,7 @@ class ESPBTDevice {
   std::vector<int8_t> tx_powers_{};
   optional<uint16_t> appearance_{};
   optional<uint8_t> ad_flag_{};
-  std::vector<ESPBTUUID> service_uuids_;
+  std::vector<ESPBTUUID> service_uuids_{};
   std::vector<ServiceData> manufacturer_datas_{};
   std::vector<ServiceData> service_datas_{};
   esp_ble_gap_cb_param_t::ble_scan_result_evt_param scan_result_{};
@@ -231,7 +231,12 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   SemaphoreHandle_t scan_result_lock_;
   SemaphoreHandle_t scan_end_lock_;
   size_t scan_result_index_{0};
-  esp_ble_gap_cb_param_t::ble_scan_result_evt_param scan_result_buffer_[16];
+#if BOARD_HAS_PSRAM
+  const static u_int8_t scan_result_buffer_size_= 32;
+#else
+  const static u_int8_t scan_result_buffer_size_= 16;
+#endif // BOARD_HAS_PSRAM
+  esp_ble_gap_cb_param_t::ble_scan_result_evt_param *scan_result_buffer_;
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
 };

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -232,9 +232,9 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   SemaphoreHandle_t scan_end_lock_;
   size_t scan_result_index_{0};
 #if CONFIG_SPIRAM
-  const static u_int8_t scan_result_buffer_size_ = 32;
+  const static u_int8_t SCAN_RESULT_BUFFER_SIZE = 32;
 #else
-  const static u_int8_t scan_result_buffer_size_ = 16;
+  const static u_int8_t SCAN_RESULT_BUFFER_SIZE = 16;
 #endif  // CONFIG_SPIRAM
   esp_ble_gap_cb_param_t::ble_scan_result_evt_param *scan_result_buffer_;
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -232,10 +232,10 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   SemaphoreHandle_t scan_end_lock_;
   size_t scan_result_index_{0};
 #if BOARD_HAS_PSRAM
-  const static u_int8_t scan_result_buffer_size_= 32;
+  const static u_int8_t scan_result_buffer_size_ = 32;
 #else
-  const static u_int8_t scan_result_buffer_size_= 16;
-#endif // BOARD_HAS_PSRAM
+  const static u_int8_t scan_result_buffer_size_ = 16;
+#endif  // BOARD_HAS_PSRAM
   esp_ble_gap_cb_param_t::ble_scan_result_evt_param *scan_result_buffer_;
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -231,11 +231,11 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   SemaphoreHandle_t scan_result_lock_;
   SemaphoreHandle_t scan_end_lock_;
   size_t scan_result_index_{0};
-#if BOARD_HAS_PSRAM
+#if CONFIG_SPIRAM
   const static u_int8_t scan_result_buffer_size_ = 32;
 #else
   const static u_int8_t scan_result_buffer_size_ = 16;
-#endif  // BOARD_HAS_PSRAM
+#endif  // CONFIG_SPIRAM
   esp_ble_gap_cb_param_t::ble_scan_result_evt_param *scan_result_buffer_;
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};


### PR DESCRIPTION
# What does this implement/fix?

Given that the Bluetooth stack is consuming so much memory. I try to reduce the memory consumption a bit by moving the BLE scan results to SPI RAM (PSRAM).  It saves 3kb.

Also if PSRAM is used more scan results can be cached,

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
