### PR TITLE
PMSx003: refactor & improve stability

### DIFF
--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -289,6 +289,10 @@ uart:
     tx_pin: GPIO4
     rx_pin: GPIO5
     baud_rate: 9600
+  - id: uart13
+    tx_pin: GPIO4
+    rx_pin: GPIO5
+    baud_rate: 9600
 
 modbus:
   uart_id: uart1
@@ -628,7 +632,7 @@ sensor:
       name: Particulate Count >10.0um
     update_interval: 30s
   - platform: pmsx003
-    uart_id: uart5
+    uart_id: uart13
     type: PMS5003T
     pm_2_5:
       name: PM 2.5 Concentration


### PR DESCRIPTION
# What does this implement/fix?

Hi! There were a few issues with current PMSx003 implementations, which I tried to fix without major refactoring, but then I found comment https://github.com/esphome/esphome/pull/3053#issuecomment-1020562578 by @oxan, and I agree that in this case state machine probably is a bit overkill and the logic could be simplified.

The main issue I had was that after running it for several hours I got this warning, after which no new measurements were received:
```[W][pmsx003:187]: PMSX003 length 4 doesn't match. Are you using the correct PMSX003 type?```

I have pretty loaded config with BLE and http requests that might cause delays, and probably lead to serial buffer overflow or timing issues that could cause that error.

Another issue was with passive mode management. I found it experimentally that after sensor is put to sleep and then waking up, it resets to active (continuous mode). So it is not enough to set passive mode once (as it was before), you actually have to do it after each wake up. I also found that you have to wait up to 2 seconds between waking up and setting passive mode command so that the latter had applied.

Previously reading data from serial was inside loop. So it could potentially take a few iterations to read whole message. While it could have some pros, namely that it could be less blocking, it also seems more error prone, and I'm not sure if it is really needed. I measured time from sending read request to receiving response, and it takes ~45ms, and this time seems to be pretty stable. So I implemented it in a single method `take_measurement_` that sends request and reads/parses response. For safety it has timeout param (default to 1s), to not stuck forever.

Byproduct of this PR is that now you can set `update_interval` < 30 seconds and values will be updated at exactly this interval, not continuously (every second or so) when new data is available.

Also I made `warmup_interval` configurable, 30 seconds is a good default, but maybe someone wants to experiment with other values.

I will run testing for longer time, but so far it seems to be pretty stable in both modes (update_interval=1s and update_interval=60s)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

Related issue or feature (if applicable): closes https://github.com/esphome/feature-requests/issues/490, closes https://github.com/esphome/feature-requests/issues/2033, closes https://github.com/esphome/feature-requests/issues/919. Actually I think those issues were already obsolete before this PR. 

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs) Not yet, but if PR will be approved, I'll update docs.
