### PR TITLE
Update IRremoteESP8266 2.8.4 to support ESP32-C3

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -118,4 +118,4 @@ def to_code(config):
     cg.add_library("tonia/HeatpumpIR", "1.0.20")
 
     if CORE.is_esp8266 or CORE.is_esp32:
-        cg.add_library("crankyoldgit/IRremoteESP8266", "2.7.12")
+        cg.add_library("crankyoldgit/IRremoteESP8266", "2.8.4")

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,7 +92,7 @@ lib_deps =
     ESP8266HTTPClient                     ; http_request (Arduino built-in)
     ESP8266mDNS                           ; mdns (Arduino built-in)
     DNSServer                             ; captive_portal (Arduino built-in)
-    crankyoldgit/IRremoteESP8266@2.7.12   ; heatpumpir
+    crankyoldgit/IRremoteESP8266@2.8.4   ; heatpumpir
 build_flags =
     ${common:arduino.build_flags}
     -Wno-nonnull-compare
@@ -122,7 +122,7 @@ lib_deps =
     ESPmDNS                              ; mdns (Arduino built-in)
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.6         ; i2s_audio
-    crankyoldgit/IRremoteESP8266@2.7.12  ; heatpumpir
+    crankyoldgit/IRremoteESP8266@2.8.4  ; heatpumpir
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP32


### PR DESCRIPTION
Update IRremoteESP8266 2.8.4 to support ESP32-C3

# What does this implement/fix?

Update IRremoteESP8266 2.8.4 to support ESP32-C3

## Types of changes

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <[link to issue](https://github.com/esphome/issues/issues/4208)>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
