### PR TITLE
Revert storing Font glyphs in manually-allocated memory

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -256,7 +256,7 @@ void DisplayBuffer::print(int x, int y, Font *font, Color color, TextAlign align
     if (glyph_n < 0) {
       // Unknown char, skip
       ESP_LOGW(TAG, "Encountered character without representation in font: '%c'", text[i]);
-      if (font->get_glyphs_size() > 0) {
+      if (!font->get_glyphs().empty()) {
         uint8_t glyph_width = font->get_glyphs()[0].glyph_data_->width;
         for (int glyph_x = 0; glyph_x < glyph_width; glyph_x++) {
           for (int glyph_y = 0; glyph_y < height; glyph_y++)
@@ -557,7 +557,7 @@ void Glyph::scan_area(int *x1, int *y1, int *width, int *height) const {
 }
 int Font::match_next_glyph(const char *str, int *match_length) {
   int lo = 0;
-  int hi = this->glyphs_size_ - 1;
+  int hi = this->glyphs_.size() - 1;
   while (lo != hi) {
     int mid = (lo + hi + 1) / 2;
     if (this->glyphs_[mid].compare_to(str)) {
@@ -583,7 +583,7 @@ void Font::measure(const char *str, int *width, int *x_offset, int *baseline, in
     int glyph_n = this->match_next_glyph(str + i, &match_length);
     if (glyph_n < 0) {
       // Unknown char, skip
-      if (this->glyphs_size_ > 0)
+      if (!this->get_glyphs().empty())
         x += this->get_glyphs()[0].glyph_data_->width;
       i++;
       continue;
@@ -604,16 +604,9 @@ void Font::measure(const char *str, int *width, int *x_offset, int *baseline, in
   *width = x - min_x;
 }
 Font::Font(const GlyphData *data, int data_nr, int baseline, int height) : baseline_(baseline), height_(height) {
-  ExternalRAMAllocator<Glyph> allocator(ExternalRAMAllocator<Glyph>::ALLOW_FAILURE);
-  this->glyphs_ = allocator.allocate(data_nr);
-  if (this->glyphs_ == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate buffer for Glyphs!");
-    return;
-  }
-  for (int i = 0; i < data_nr; ++i) {
-    this->glyphs_[i] = Glyph(data + i);
-  }
-  this->glyphs_size_ = data_nr;
+  glyphs_.reserve(data_nr);
+  for (int i = 0; i < data_nr; ++i)
+    glyphs_.emplace_back(&data[i]);
 }
 
 bool Image::get_pixel(int x, int y) const {

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -526,12 +526,10 @@ class Font {
   inline int get_baseline() { return this->baseline_; }
   inline int get_height() { return this->height_; }
 
-  Glyph *&get_glyphs() { return this->glyphs_; }
-  const u_int16_t &get_glyphs_size() const { return this->glyphs_size_; }
+  const std::vector<Glyph, ExternalRAMAllocator<Glyph>> &get_glyphs() const { return glyphs_; }
 
  protected:
-  Glyph *glyphs_{nullptr};
-  u_int16_t glyphs_size_;
+  std::vector<Glyph, ExternalRAMAllocator<Glyph>> glyphs_;
   int baseline_;
   int height_;
 };


### PR DESCRIPTION
Instead of replacing the `std::vector` with manually allocated memory, use `ExternalRAMAllocator` as an allocator for the `std::vector`. 

This also reverts the graceful handling of allocation failure for the glyphs, but that didn't work correctly anyway: if glyph allocation failed and `DisplayBuffer::print()` was called, a null pointer (`this->glyphs_[0]`) was dereferenced in `Font::match_next_glyph`. While not ideal, I'd rather have `abort()` be called on the allocation failure, as that at least makes clear what's going wrong.

This partially reverts commit 62459a8ae1d9a2182772d55ddf7d6ad983277f2e (PR #4485).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
