### PR TITLE
Ensure component is ready before update.

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -319,7 +319,7 @@ template<typename... Ts> class UpdateComponentAction : public Action<Ts...> {
   UpdateComponentAction(PollingComponent *component) : component_(component) {}
 
   void play(Ts... x) override {
-    if (this->component_->is_failed())
+    if (!this->component_->is_ready())
       return;
     this->component_->update();
   }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -135,6 +135,10 @@ void Component::set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std:
   App.scheduler.set_retry(this, "", initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
 }
 bool Component::is_failed() { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED; }
+bool Component::is_ready() {
+  return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP ||
+         (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_SETUP;
+}
 bool Component::can_proceed() { return true; }
 bool Component::status_has_warning() { return this->component_state_ & STATUS_LED_WARNING; }
 bool Component::status_has_error() { return this->component_state_ & STATUS_LED_ERROR; }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -119,6 +119,8 @@ class Component {
 
   bool is_failed();
 
+  bool is_ready();
+
   virtual bool can_proceed();
 
   bool status_has_warning();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Validate a component `setup` was called before calling `update` from action `component.update`.

Scenario:
- Wifi connection issue and therefore display component setup is not called
- Button press action to update display
- On Button press crash of ESP because display memory is not allocated.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
