### PR TITLE
Add ability to await safe mode in codegen

### DIFF
--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -47,6 +47,7 @@ from esphome.cpp_helpers import (  # noqa
     build_registry_list,
     extract_registry_entry_config,
     register_parented,
+    past_safe_mode,
 )
 from esphome.cpp_types import (  # noqa
     global_ns,

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -10,6 +10,8 @@ from esphome.const import (
     CONF_REBOOT_TIMEOUT,
     CONF_SAFE_MODE,
     CONF_TRIGGER_ID,
+    CONF_OTA,
+    KEY_PAST_SAFE_MODE,
 )
 from esphome.core import CORE, coroutine_with_priority
 
@@ -76,6 +78,8 @@ CONFIG_SCHEMA = cv.Schema(
 
 @coroutine_with_priority(50.0)
 async def to_code(config):
+    CORE.data[CONF_OTA] = {}
+
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_port(config[CONF_PORT]))
     cg.add_define("USE_OTA")
@@ -90,6 +94,7 @@ async def to_code(config):
             config[CONF_NUM_ATTEMPTS], config[CONF_REBOOT_TIMEOUT]
         )
         cg.add(RawExpression(f"if ({condition}) return"))
+        CORE.data[CONF_OTA][KEY_PAST_SAFE_MODE] = True
 
     if CORE.is_esp32 and CORE.using_arduino:
         cg.add_library("Update", None)

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1019,6 +1019,7 @@ KEY_TARGET_FRAMEWORK = "target_framework"
 KEY_FRAMEWORK_VERSION = "framework_version"
 KEY_NAME = "name"
 KEY_VARIANT = "variant"
+KEY_PAST_SAFE_MODE = "past_safe_mode"
 
 # Entity categories
 ENTITY_CATEGORY_NONE = ""

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -9,9 +9,13 @@ from esphome.const import (
     CONF_SETUP_PRIORITY,
     CONF_UPDATE_INTERVAL,
     CONF_TYPE_ID,
+    CONF_OTA,
+    CONF_SAFE_MODE,
+    KEY_PAST_SAFE_MODE,
 )
 
 from esphome.core import coroutine, ID, CORE
+from esphome.coroutine import FakeAwaitable
 from esphome.types import ConfigType, ConfigFragmentType
 from esphome.cpp_generator import add, get_variable
 from esphome.cpp_types import App
@@ -127,3 +131,20 @@ async def build_registry_list(registry, config):
         action = await build_registry_entry(registry, conf)
         actions.append(action)
     return actions
+
+
+async def past_safe_mode():
+    safe_mode_enabled = (
+        CONF_OTA in CORE.config and CORE.config[CONF_OTA][CONF_SAFE_MODE]
+    )
+    if not safe_mode_enabled:
+        return
+
+    def _safe_mode_generator():
+        while True:
+            if CORE.data.get(CONF_OTA, {}).get(KEY_PAST_SAFE_MODE, False):
+                return
+            else:
+                yield
+
+    return await FakeAwaitable(_safe_mode_generator())

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -144,7 +144,6 @@ async def past_safe_mode():
         while True:
             if CORE.data.get(CONF_OTA, {}).get(KEY_PAST_SAFE_MODE, False):
                 return
-            else:
-                yield
+            yield
 
     return await FakeAwaitable(_safe_mode_generator())


### PR DESCRIPTION
# What does this implement/fix?

Add the ability to await the OTA safe mode check during codegen, so that code can be inserted outside the safe mode area. Useful for e.g. #3639 and #4509.

Usage is like this:
```python
async def to_code():
    # this code will be inserted before the safe mode check
    cg.add(...)

    await cg.past_safe_mode()

    # this code will be inserted after the safe mode check
    cg.add(...)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
