### PR TITLE
allow using a binary output for the status led

### DIFF
--- a/esphome/components/status_led/light/__init__.py
+++ b/esphome/components/status_led/light/__init__.py
@@ -1,26 +1,35 @@
 from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import light
-from esphome.const import CONF_OUTPUT_ID, CONF_PIN
+from esphome.components import light, output
+from esphome.const import CONF_OUTPUT, CONF_OUTPUT_ID, CONF_PIN
 from .. import status_led_ns
+
+AUTO_LOAD = ["output"]
 
 StatusLEDLightOutput = status_led_ns.class_(
     "StatusLEDLightOutput", light.LightOutput, cg.Component
 )
 
-CONFIG_SCHEMA = light.BINARY_LIGHT_SCHEMA.extend(
-    {
-        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(StatusLEDLightOutput),
-        cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
-    }
+CONFIG_SCHEMA = cv.All(
+    light.BINARY_LIGHT_SCHEMA.extend(
+        {
+            cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(StatusLEDLightOutput),
+            cv.Optional(CONF_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
+        }
+    ),
+    cv.has_at_least_one_key(CONF_PIN, CONF_OUTPUT),
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
-    pin = await cg.gpio_pin_expression(config[CONF_PIN])
-    cg.add(var.set_pin(pin))
+    if CONF_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_PIN])
+        cg.add(var.set_pin(pin))
+    if CONF_OUTPUT in config:
+        out = await cg.get_variable(config[CONF_OUTPUT])
+        cg.add(var.set_output(out))
     await cg.register_component(var, config)
-    # cg.add(cg.App.register_component(var))
     await light.register_light(var, config)

--- a/esphome/components/status_led/light/status_led_light.cpp
+++ b/esphome/components/status_led/light/status_led_light.cpp
@@ -15,10 +15,18 @@ void StatusLEDLightOutput::loop() {
   }
 
   if ((new_state & STATUS_LED_ERROR) != 0u) {
-    this->pin_->digital_write(millis() % 250u < 150u);
+    bool out_state = millis() % 250u < 150u;
+    if (this->pin_ != nullptr)
+      this->pin_->digital_write(out_state);
+    if (this->output_ != nullptr)
+      this->output_->set_state(out_state);
     this->last_app_state_ = new_state;
   } else if ((new_state & STATUS_LED_WARNING) != 0u) {
-    this->pin_->digital_write(millis() % 1500u < 250u);
+    bool out_state = millis() % 1500u < 250u;
+    if (this->pin_ != nullptr)
+      this->pin_->digital_write(out_state);
+    if (this->output_ != nullptr)
+      this->output_->set_state(out_state);
     this->last_app_state_ = new_state;
   } else if (new_state != this->last_app_state_) {
     // if no error/warning -> restore light state or turn off
@@ -30,13 +38,8 @@ void StatusLEDLightOutput::loop() {
 
     if (this->pin_ != nullptr)
       this->pin_->digital_write(state);
-    if (this->output_ != nullptr) {
-      if (state) {
-        this->output_->turn_on();
-      } else {
-        this->output_->turn_off();
-      }
-    }
+    if (this->output_ != nullptr)
+      this->output_->set_state(state);
     this->last_app_state_ = new_state;
   }
 }
@@ -57,21 +60,18 @@ void StatusLEDLightOutput::write_state(light::LightState *state) {
     ESP_LOGD(TAG, "'%s': Setting state %s", state->get_name().c_str(), ONOFF(binary));
     if (this->pin_ != nullptr)
       this->pin_->digital_write(binary);
-    if (this->output_ != nullptr) {
-      if (binary) {
-        this->output_->turn_on();
-      } else {
-        this->output_->turn_off();
-      }
-    }
+    if (this->output_ != nullptr)
+      this->output_->set_state(binary);
   }
 }
 
 void StatusLEDLightOutput::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Status LED...");
 
-  this->pin_->setup();
-  this->pin_->digital_write(false);
+  if (this->pin_ != nullptr) {
+    this->pin_->setup();
+    this->pin_->digital_write(false);
+  }
 }
 
 void StatusLEDLightOutput::dump_config() {

--- a/esphome/components/status_led/light/status_led_light.cpp
+++ b/esphome/components/status_led/light/status_led_light.cpp
@@ -31,10 +31,11 @@ void StatusLEDLightOutput::loop() {
     if (this->pin_ != nullptr)
       this->pin_->digital_write(state);
     if (this->output_ != nullptr) {
-      if (state)
+      if (state) {
         this->output_->turn_on();
-      else
+      } else {
         this->output_->turn_off();
+      }
     }
     this->last_app_state_ = new_state;
   }
@@ -57,10 +58,11 @@ void StatusLEDLightOutput::write_state(light::LightState *state) {
     if (this->pin_ != nullptr)
       this->pin_->digital_write(binary);
     if (this->output_ != nullptr) {
-      if (binary)
+      if (binary) {
         this->output_->turn_on();
-      else
+      } else {
         this->output_->turn_off();
+      }
     }
   }
 }

--- a/esphome/components/status_led/light/status_led_light.h
+++ b/esphome/components/status_led/light/status_led_light.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/light/light_output.h"
+#include "esphome/components/output/binary_output.h"
 
 namespace esphome {
 namespace status_led {
@@ -10,6 +11,7 @@ namespace status_led {
 class StatusLEDLightOutput : public light::LightOutput, public Component {
  public:
   void set_pin(GPIOPin *pin) { pin_ = pin; }
+  void set_output(output::BinaryOutput *output) { output_ = output; }
 
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
@@ -31,7 +33,8 @@ class StatusLEDLightOutput : public light::LightOutput, public Component {
   float get_loop_priority() const override { return 50.0f; }
 
  protected:
-  GPIOPin *pin_;
+  GPIOPin *pin_{nullptr};
+  output::BinaryOutput *output_{nullptr};
   light::LightState *lightstate_{};
   uint32_t last_app_state_{0xFFFF};
 };

--- a/esphome/components/status_led/light/status_led_light.h
+++ b/esphome/components/status_led/light/status_led_light.h
@@ -37,6 +37,7 @@ class StatusLEDLightOutput : public light::LightOutput, public Component {
   output::BinaryOutput *output_{nullptr};
   light::LightState *lightstate_{};
   uint32_t last_app_state_{0xFFFF};
+  void output_state_(bool state);
 };
 
 }  // namespace status_led


### PR DESCRIPTION
# What does this implement/fix?

Allows the use of a binary output for the status led as well as a gpio output.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2727

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
