### PR TITLE
Drop unused, broken logging macros

### DIFF
--- a/esphome/core/log.h
+++ b/esphome/core/log.h
@@ -144,19 +144,12 @@ int esp_idf_log_vprintf_(const char *format, va_list args);  // NOLINT
 #endif
 
 #define ESP_LOGE(tag, ...) esph_log_e(tag, __VA_ARGS__)
-#define LOG_E(tag, ...) ESP_LOGE(tag, __VA__ARGS__)
 #define ESP_LOGW(tag, ...) esph_log_w(tag, __VA_ARGS__)
-#define LOG_W(tag, ...) ESP_LOGW(tag, __VA__ARGS__)
 #define ESP_LOGI(tag, ...) esph_log_i(tag, __VA_ARGS__)
-#define LOG_I(tag, ...) ESP_LOGI(tag, __VA__ARGS__)
 #define ESP_LOGD(tag, ...) esph_log_d(tag, __VA_ARGS__)
-#define LOG_D(tag, ...) ESP_LOGD(tag, __VA__ARGS__)
 #define ESP_LOGCONFIG(tag, ...) esph_log_config(tag, __VA_ARGS__)
-#define LOG_CONFIG(tag, ...) ESP_LOGCONFIG(tag, __VA__ARGS__)
 #define ESP_LOGV(tag, ...) esph_log_v(tag, __VA_ARGS__)
-#define LOG_V(tag, ...) ESP_LOGV(tag, __VA__ARGS__)
 #define ESP_LOGVV(tag, ...) esph_log_vv(tag, __VA_ARGS__)
-#define LOG_VV(tag, ...) ESP_LOGVV(tag, __VA__ARGS__)
 
 #define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
 #define BYTE_TO_BINARY(byte) \


### PR DESCRIPTION
# What does this implement/fix?

These macros have been broken (there's an extra underscore in `__VA__ARGS__`) since they were merged into this repository, so presumably nobody uses them and we can drop them.

closes esphome/esphome#4224

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
