### PR TITLE
Mark unique_id() virtual method as deprecated

### DIFF
--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -150,10 +150,9 @@ class Sensor : public EntityBase {
   /// Return whether this sensor has gotten a full state (that passed through all filters) yet.
   bool has_state() const;
 
-  /** A unique ID for this sensor, empty for no unique id. See unique ID requirements:
-   * https://developers.home-assistant.io/docs/en/entity_registry_index.html#unique-id-requirements
+  /** Override this method to set the unique ID of this sensor.
    *
-   * @return The unique id as a string.
+   * @deprecated Do not use for new sensors, a suitable unique ID is automatically generated (2023.4).
    */
   virtual std::string unique_id();
 

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -61,6 +61,10 @@ class TextSensor : public EntityBase {
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
+  /** Override this method to set the unique ID of this sensor.
+   *
+   * @deprecated Do not use for new sensors, a suitable unique ID is automatically generated (2023.4).
+   */
   virtual std::string unique_id();
 
   bool has_state();


### PR DESCRIPTION
# What does this implement/fix?

These old-style methods are only present for (text) sensors and not for all other types of entities. They are overridden and implemented by only a handful of sensors; the vast majority use the automatic unique ID generation. We'll likely never be able to remove them due to backwards compatibility, but let's stop the bleeding and mark them as deprecated so that we don't get any more components that implement them.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
