### PR TITLE
Drop deprecated entity property base methods

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -41,16 +41,13 @@ void BinarySensor::send_state_internal(bool state, bool is_initial) {
     this->state_callback_.call(state);
   }
 }
-std::string BinarySensor::device_class() { return ""; }
+
 BinarySensor::BinarySensor() : state(false) {}
 void BinarySensor::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
 std::string BinarySensor::get_device_class() {
   if (this->device_class_.has_value())
     return *this->device_class_;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return this->device_class();
-#pragma GCC diagnostic pop
+  return "";
 }
 void BinarySensor::add_filter(Filter *filter) {
   filter->parent_ = this;

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -80,14 +80,6 @@ class BinarySensor : public EntityBase {
 
   virtual bool is_status_binary_sensor() const;
 
-  // ========== OVERRIDE METHODS ==========
-  // (You'll only need this when creating your own custom binary sensor)
-  /** Override this to set the default device class.
-   *
-   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
-   */
-  virtual std::string device_class();
-
  protected:
   CallbackManager<void(bool)> state_callback_{};
   optional<std::string> device_class_{};  ///< Stores the override of the device class

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -208,14 +208,10 @@ Cover::Cover() : Cover("") {}
 std::string Cover::get_device_class() {
   if (this->device_class_override_.has_value())
     return *this->device_class_override_;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return this->device_class();
-#pragma GCC diagnostic pop
+  return "";
 }
 bool Cover::is_fully_open() const { return this->position == COVER_OPEN; }
 bool Cover::is_fully_closed() const { return this->position == COVER_CLOSED; }
-std::string Cover::device_class() { return ""; }
 
 CoverCall CoverRestoreState::to_call(Cover *cover) {
   auto call = cover->make_call();

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -170,12 +170,6 @@ class Cover : public EntityBase {
 
   virtual void control(const CoverCall &call) = 0;
 
-  /** Override this to set the default device class.
-   *
-   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
-   */
-  virtual std::string device_class();
-
   optional<CoverRestoreState> restore_state_();
 
   CallbackManager<void()> state_callback_{};

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -26,48 +26,32 @@ Sensor::Sensor() : Sensor("") {}
 std::string Sensor::get_unit_of_measurement() {
   if (this->unit_of_measurement_.has_value())
     return *this->unit_of_measurement_;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return this->unit_of_measurement();
-#pragma GCC diagnostic pop
+  return "";
 }
 void Sensor::set_unit_of_measurement(const std::string &unit_of_measurement) {
   this->unit_of_measurement_ = unit_of_measurement;
 }
-std::string Sensor::unit_of_measurement() { return ""; }
 
 int8_t Sensor::get_accuracy_decimals() {
   if (this->accuracy_decimals_.has_value())
     return *this->accuracy_decimals_;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return this->accuracy_decimals();
-#pragma GCC diagnostic pop
+  return 0;
 }
 void Sensor::set_accuracy_decimals(int8_t accuracy_decimals) { this->accuracy_decimals_ = accuracy_decimals; }
-int8_t Sensor::accuracy_decimals() { return 0; }
 
 std::string Sensor::get_device_class() {
   if (this->device_class_.has_value())
     return *this->device_class_;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return this->device_class();
-#pragma GCC diagnostic pop
+  return "";
 }
 void Sensor::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
-std::string Sensor::device_class() { return ""; }
 
 void Sensor::set_state_class(StateClass state_class) { this->state_class_ = state_class; }
 StateClass Sensor::get_state_class() {
   if (this->state_class_.has_value())
     return *this->state_class_;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return this->state_class();
-#pragma GCC diagnostic pop
+  return StateClass::STATE_CLASS_NONE;
 }
-StateClass Sensor::state_class() { return StateClass::STATE_CLASS_NONE; }
 
 void Sensor::publish_state(float state) {
   this->raw_state = state;

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -160,30 +160,6 @@ class Sensor : public EntityBase {
   void internal_send_state_to_frontend(float state);
 
  protected:
-  /** Override this to set the default unit of measurement.
-   *
-   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
-   */
-  virtual std::string unit_of_measurement();  // NOLINT
-
-  /** Override this to set the default accuracy in decimals.
-   *
-   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
-   */
-  virtual int8_t accuracy_decimals();  // NOLINT
-
-  /** Override this to set the default device class.
-   *
-   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
-   */
-  virtual std::string device_class();  // NOLINT
-
-  /** Override this to set the default state class.
-   *
-   * @deprecated This method is deprecated, set the property during config validation instead. (2022.1)
-   */
-  virtual StateClass state_class();  // NOLINT
-
   CallbackManager<void(float)> raw_callback_;  ///< Storage for raw state callbacks.
   CallbackManager<void(float)> callback_;      ///< Storage for filtered state callbacks.
 


### PR DESCRIPTION
# What does this implement/fix?

Drop the deprecated old-style `device_class()`, `unit_of_measurement()`, `accuracy_decimals()` and `state_class()` methods that could be used to set the default values of these properties. Defaults should be set in the config schema nowadays.

(I want to drop them now because they got in the way of another cleanup/refactor I'm working on).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
