### PR TITLE
Fix default NeoPixelBus method for ESP32-S3

### DIFF
--- a/esphome/components/neopixelbus/_methods.py
+++ b/esphome/components/neopixelbus/_methods.py
@@ -13,8 +13,8 @@ from esphome.const import (
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
-    VARIANT_ESP32S2,
     VARIANT_ESP32C3,
+    VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 )
 from esphome.core import CORE
@@ -58,9 +58,9 @@ SPI_SPEEDS = [40e6, 20e6, 10e6, 5e6, 2e6, 1e6, 500e3]
 
 def _esp32_rmt_default_channel():
     return {
+        VARIANT_ESP32C3: 1,
         VARIANT_ESP32S2: 1,
         VARIANT_ESP32S3: 1,
-        VARIANT_ESP32C3: 1,
     }.get(get_esp32_variant(), 6)
 
 
@@ -71,9 +71,9 @@ def _validate_esp32_rmt_channel(value):
         value = cv.int_(value)
     variant_channels = {
         VARIANT_ESP32: [0, 1, 2, 3, 4, 5, 6, 7, CHANNEL_DYNAMIC],
+        VARIANT_ESP32C3: [0, 1, CHANNEL_DYNAMIC],
         VARIANT_ESP32S2: [0, 1, 2, 3, CHANNEL_DYNAMIC],
         VARIANT_ESP32S3: [0, 1, 2, 3, CHANNEL_DYNAMIC],
-        VARIANT_ESP32C3: [0, 1, CHANNEL_DYNAMIC],
     }
     variant = get_esp32_variant()
     if variant not in variant_channels:

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -17,6 +17,7 @@ from esphome.const import (
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32C3,
+    VARIANT_ESP32S3,
 )
 from esphome.core import CORE
 from ._methods import (
@@ -96,7 +97,7 @@ def _choose_default_method(config):
             config[CONF_METHOD] = _validate_method(METHOD_BIT_BANG)
 
     if CORE.is_esp32:
-        if get_esp32_variant() == VARIANT_ESP32C3:
+        if get_esp32_variant() in (VARIANT_ESP32C3, VARIANT_ESP32S3):
             config[CONF_METHOD] = _validate_method(METHOD_ESP32_RMT)
         else:
             config[CONF_METHOD] = _validate_method(METHOD_ESP32_I2S)

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ build_flags =
 [common]
 lib_deps =
     esphome/noise-c@0.1.4                  ; api
-    makuna/NeoPixelBus@2.6.9               ; neopixelbus
+    makuna/NeoPixelBus@2.7.3               ; neopixelbus
     esphome/Improv@1.2.3                   ; improv_serial / esp32_improv
     bblanchon/ArduinoJson@6.18.5           ; json
     wjtje/qr-code-generator-library@1.7.0  ; qr_code


### PR DESCRIPTION
# What does this implement/fix?

Rebased version #4114 on top of current dev. 

I don't have a light strip on hand to connect to a S3, so I haven't actually tested this on-device, but code generation looks good.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
