### PR TITLE
Add support for HP206C pressure sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -103,6 +103,7 @@ esphome/components/heatpumpir/* @rob-deutsch
 esphome/components/hitachi_ac424/* @sourabhjaiswal
 esphome/components/homeassistant/* @OttoWinter
 esphome/components/honeywellabp/* @RubyBailey
+esphome/components/hp206c/* @randomplum
 esphome/components/hrxl_maxsonar_wr/* @netmikey
 esphome/components/hte501/* @Stock-M
 esphome/components/hydreon_rgxx/* @functionpointer

--- a/esphome/components/hp206c/__init__.py
+++ b/esphome/components/hp206c/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@randomplum"]

--- a/esphome/components/hp206c/hp206c.cpp
+++ b/esphome/components/hp206c/hp206c.cpp
@@ -1,0 +1,144 @@
+#include "hp206c.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace hp206c {
+
+static const char *const TAG = "hp206c.sensor";
+
+static const uint8_t HP206C_ADDRESS = 0x76;
+static const uint8_t HP206C_COMMAND_SOFT_RST = 0x06;
+static const uint8_t HP206C_COMMAND_READ_PT = 0x10;
+static const uint8_t HP206C_COMMAND_READ_AT = 0x11;
+static const uint8_t HP206C_COMMAND_READ_P = 0x30;
+static const uint8_t HP206C_COMMAND_READ_A = 0x31;
+static const uint8_t HP206C_COMMAND_READ_T = 0x32;
+static const uint8_t HP206C_COMMAND_ANA_CAL = 0x28;
+static const uint8_t HP206C_CHANNEL_TEMP_PRESSURE = 0b00;
+static const uint8_t HP206C_CHANNEL_TEMP_ONLY = 0b10;
+
+static constexpr uint8_t hp206c_command_adc_cvt(uint8_t osr, uint8_t channel) {
+  return (0x40 + ((osr & 0x0F) << 2) + (channel & 0x03));
+}
+
+void HP206CComponent::update() {
+  uint8_t mode;
+  if (this->pressure_ != nullptr) {
+    mode = hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_2048, HP206C_CHANNEL_TEMP_PRESSURE);
+  } else if (this->pressure_ == nullptr && this->temperature_ != nullptr) {
+    mode = hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_2048, HP206C_CHANNEL_TEMP_ONLY);
+  } else {
+    return;
+  }
+
+  if (!this->start_conversion_(mode))
+    return;
+
+  this->set_timeout("hp206c_measure", conversion_time_(mode), [this]() { this->read_data_(); });
+}
+
+void HP206CComponent::setup() { ESP_LOGCONFIG(TAG, "Setting up HP206C..."); }
+
+void HP206CComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "HP206C:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Connection with HP206C failed!");
+  }
+  LOG_UPDATE_INTERVAL(this);
+
+  ESP_LOGCONFIG(TAG, "  OSR setting 0x%02X ", this->filter_mode_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_);
+  LOG_SENSOR("  ", "Pressure", this->pressure_);
+}
+
+float HP206CComponent::get_setup_priority() const { return setup_priority::DATA; }
+
+bool HP206CComponent::start_conversion_(uint8_t mode) {
+  ESP_LOGV(TAG, "Starting conversion 0x%02X...", mode);
+  return this->write_bytes(mode, nullptr, 0);
+}
+
+void HP206CComponent::read_data_() {
+  uint8_t buffer[6];
+
+  if (this->pressure_ != nullptr && this->temperature_ != nullptr) {
+    if (!this->write_bytes(HP206C_COMMAND_READ_PT, nullptr, 0)) {
+      this->status_set_warning();
+      return;
+    }
+    if (!this->read_bytes_raw(buffer, 6)) {
+      this->status_set_warning();
+      return;
+    }
+    const float pressure = (((buffer[3] & 0x0F) << 16) + (buffer[4] << 8) + buffer[5]) / 100.0;
+    this->pressure_->publish_state(pressure);
+    float temperature;
+    if (buffer[0] & 0x08) {
+      temperature = ((((buffer[0] & 0x0F) << 16) + (buffer[1] << 8) + buffer[2]) - (1 << 20)) / 100.0;
+    } else {
+      temperature = (((buffer[0] & 0x0F) << 16) + (buffer[1] << 8) + buffer[2]) / 100.0;
+    }
+    this->temperature_->publish_state(temperature);
+  } else if (this->pressure_ == nullptr && this->temperature_ != nullptr) {
+    if (!this->write_bytes(HP206C_COMMAND_READ_T, nullptr, 0)) {
+      this->status_set_warning();
+      return;
+    }
+    if (!this->read_bytes_raw(buffer, 3)) {
+      this->status_set_warning();
+      return;
+    }
+    float temperature;
+    if (buffer[0] & 0x08) {
+      temperature = ((((buffer[0] & 0x0F) << 16) + (buffer[1] << 8) + buffer[2]) - (1 << 20)) / 100.0;
+    } else {
+      temperature = (((buffer[0] & 0x0F) << 16) + (buffer[1] << 8) + buffer[2]) / 100.0;
+    }
+    this->temperature_->publish_state(temperature);
+  } else if (this->pressure_ != nullptr && this->temperature_ == nullptr) {
+    if (!this->write_bytes(HP206C_COMMAND_READ_P, nullptr, 0)) {
+      this->status_set_warning();
+      return;
+    }
+    if (!this->read_bytes_raw(buffer, 3)) {
+      this->status_set_warning();
+      return;
+    }
+    const float pressure = (((buffer[0] & 0x0F) << 16) + (buffer[1] << 8) + buffer[2]) / 100.0;
+    this->pressure_->publish_state(pressure);
+  }
+}
+
+int HP206CComponent::conversion_time_(uint8_t mode) {
+  switch (mode) {
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_128, HP206C_CHANNEL_TEMP_ONLY):
+      return 3;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_256, HP206C_CHANNEL_TEMP_ONLY):
+      return 5;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_512, HP206C_CHANNEL_TEMP_ONLY):
+      return 9;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_1024, HP206C_CHANNEL_TEMP_ONLY):
+      return 17;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_2048, HP206C_CHANNEL_TEMP_ONLY):
+      return 33;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_4096, HP206C_CHANNEL_TEMP_ONLY):
+      return 66;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_128, HP206C_CHANNEL_TEMP_PRESSURE):
+      return 5;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_256, HP206C_CHANNEL_TEMP_PRESSURE):
+      return 9;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_512, HP206C_CHANNEL_TEMP_PRESSURE):
+      return 17;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_1024, HP206C_CHANNEL_TEMP_PRESSURE):
+      return 33;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_2048, HP206C_CHANNEL_TEMP_PRESSURE):
+      return 66;
+    case hp206c_command_adc_cvt(HP206C_CHANNEL_OSR_4096, HP206C_CHANNEL_TEMP_PRESSURE): /* fallthrough */
+    default:
+      return 132;
+  }
+}
+
+}  // namespace hp206c
+}  // namespace esphome

--- a/esphome/components/hp206c/hp206c.h
+++ b/esphome/components/hp206c/hp206c.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace hp206c {
+
+const uint8_t HP206C_CHANNEL_OSR_4096 = 0b000;
+const uint8_t HP206C_CHANNEL_OSR_2048 = 0b001;
+const uint8_t HP206C_CHANNEL_OSR_1024 = 0b010;
+const uint8_t HP206C_CHANNEL_OSR_512 = 0b011;
+const uint8_t HP206C_CHANNEL_OSR_256 = 0b100;
+const uint8_t HP206C_CHANNEL_OSR_128 = 0b101;
+
+enum HP206CFilterMode {
+  FILTER_OSR_128 = HP206C_CHANNEL_OSR_128,
+  FILTER_OSR_256 = HP206C_CHANNEL_OSR_256,
+  FILTER_OSR_512 = HP206C_CHANNEL_OSR_512,
+  FILTER_OSR_1024 = HP206C_CHANNEL_OSR_1024,
+  FILTER_OSR_2048 = HP206C_CHANNEL_OSR_2048,
+  FILTER_OSR_4096 = HP206C_CHANNEL_OSR_4096
+};
+
+class HP206CComponent : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
+  void set_filter_mode(HP206CFilterMode mode) { filter_mode_ = mode; }
+  void set_pressure(sensor::Sensor *pressure) { pressure_ = pressure; }
+
+  void update() override;
+  void setup() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override;
+
+ protected:
+  bool start_conversion_(uint8_t mode);
+  void read_data_();
+  int conversion_time_(uint8_t mode);
+
+  HP206CFilterMode filter_mode_{FILTER_OSR_2048};
+  sensor::Sensor *temperature_{nullptr};
+  sensor::Sensor *pressure_{nullptr};
+};
+
+}  // namespace hp206c
+}  // namespace esphome

--- a/esphome/components/hp206c/sensor.py
+++ b/esphome/components/hp206c/sensor.py
@@ -1,0 +1,74 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    CONF_INTERNAL_FILTER_MODE,
+    DEVICE_CLASS_ATMOSPHERIC_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_HECTOPASCAL,
+)
+
+DEPENDENCIES = ["i2c"]
+
+hp206c_ns = cg.esphome_ns.namespace("hp206c")
+HP206CComponent = hp206c_ns.class_(
+    "HP206CComponent", cg.PollingComponent, i2c.I2CDevice
+)
+
+HP206CFilterMode = hp206c_ns.enum("InternalFilterMode")
+FILTER_MODES = {
+    "128": HP206CFilterMode.FILTER_OSR_128,
+    "256": HP206CFilterMode.FILTER_OSR_256,
+    "512": HP206CFilterMode.FILTER_OSR_512,
+    "1024": HP206CFilterMode.FILTER_OSR_1024,
+    "2048": HP206CFilterMode.FILTER_OSR_2048,
+    "4096": HP206CFilterMode.FILTER_OSR_4096,
+}
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(HP206CComponent),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_HECTOPASCAL,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_ATMOSPHERIC_PRESSURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_INTERNAL_FILTER_MODE, default="2048"): cv.enum(
+                FILTER_MODES, upper=True
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x76))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    cg.add(var.set_filter_mode(config[CONF_INTERNAL_FILTER_MODE]))
+
+    if CONF_TEMPERATURE in config:
+        conf = config[CONF_TEMPERATURE]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_temperature(sens))
+
+    if CONF_PRESSURE in config:
+        conf = config[CONF_PRESSURE]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_pressure(sens))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -655,6 +655,15 @@ sensor:
     temperature:
       name: Honeywell temperature
     cs_pin: GPIO5
+  - platform: hp206c
+    temperature:
+      name: Outside Temperature
+    pressure:
+      name: Outside Pressure
+    address: 0x76
+    internal_filter_mode: 4096
+    update_interval: 15s
+    i2c_id: i2c_bus
   - platform: hte501
     temperature:
       name: Office Temperature 2


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the HOPERF HP206C pressure sensor (found on https://www.seeedstudio.com/Grove-Barometer-High-Accuracy.html). Chip datasheet https://www.hoperf.com/data/upload/portal/20190307/HP206C_DataSheet_EN_V2.0.pdf

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2732

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
  - platform: hp206c
    i2c_id: bus_a
    update_interval: 10s
    internal_filter_mode: 4096
    pressure:
      name: Pressure
    temperature:
      name: Temp

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
