### PR TITLE
Add support for new mpu6050 clones responding with 0x70 address

### DIFF
--- a/esphome/components/mpu6050/mpu6050.cpp
+++ b/esphome/components/mpu6050/mpu6050.cpp
@@ -23,7 +23,8 @@ const float GRAVITY_EARTH = 9.80665f;
 void MPU6050Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MPU6050...");
   uint8_t who_am_i;
-  if (!this->read_byte(MPU6050_REGISTER_WHO_AM_I, &who_am_i) || (who_am_i != 0x68 && who_am_i != 0x98)) {
+  if (!this->read_byte(MPU6050_REGISTER_WHO_AM_I, &who_am_i) ||
+      (who_am_i != 0x68 && who_am_i != 0x70 && who_am_i != 0x98)) {
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Adds support for new clones of mpu6050 responding with 0x70 address.
I personally have 5 samples of these, so there is a good chance that others also will receive these going forward (Aliexpress)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
