### PR TITLE
On the ILI9xxx display's enable the psram on esp32 and allow big screen

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -111,6 +111,7 @@ esphome/components/hte501/* @Stock-M
 esphome/components/hydreon_rgxx/* @functionpointer
 esphome/components/i2c/* @esphome/core
 esphome/components/i2s_audio/* @jesserockz
+esphome/components/ili9xxx/* @nielsnl68
 esphome/components/improv_base/* @esphome/core
 esphome/components/improv_serial/* @esphome/core
 esphome/components/ina260/* @MrEditor97

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -111,7 +111,6 @@ esphome/components/hte501/* @Stock-M
 esphome/components/hydreon_rgxx/* @functionpointer
 esphome/components/i2c/* @esphome/core
 esphome/components/i2s_audio/* @jesserockz
-esphome/components/ili9xxx/* @nielsnl68
 esphome/components/improv_base/* @esphome/core
 esphome/components/improv_serial/* @esphome/core
 esphome/components/ina260/* @MrEditor97

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -67,7 +67,6 @@ def _validate(config):
             "Providing color palette images requires palette mode to be 'IMAGE_ADAPTIVE'"
         )
     if CORE.is_esp8266 and config.get(CONF_MODEL) not in [
-        "M5STACK",
         "M5CORE",
         "TFT_2.4",
         "TFT_2.4R",

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -67,7 +67,7 @@ def _validate(config):
             "Providing color palette images requires palette mode to be 'IMAGE_ADAPTIVE'"
         )
     if CORE.is_esp8266 and config.get(CONF_MODEL) not in [
-        "M5CORE",
+        "M5STACK",
         "TFT_2.4",
         "TFT_2.4R",
         "ILI9341",

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -17,10 +17,11 @@ from esphome.const import (
 
 DEPENDENCIES = ["spi"]
 
-if CORE.is_esp32:
-    AUTO_LOAD = ["psram"]
-else:
-    AUTO_LOAD = []
+
+def AUTO_LOAD():
+    if CORE.is_esp32:
+        return ["psram"]
+    return []
 
 
 CODEOWNERS = ["@nielsnl68"]

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -74,7 +74,7 @@ def _validate(config):
         "ILI9342",
     ]:
         raise cv.Invalid(
-            "Providing model can't run on ESP8266. Use an ESP32 with PSRAM onboard"
+            "Provided model can't run on ESP8266. Use an ESP32 with PSRAM onboard"
         )
     return config
 

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -16,7 +16,12 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["spi"]
-AUTO_LOAD = ["psram"]
+
+if CORE.is_esp32:
+    AUTO_LOAD = ["psram"]
+else:
+    AUTO_LOAD = []
+
 
 CODEOWNERS = ["@nielsnl68"]
 
@@ -59,6 +64,17 @@ def _validate(config):
     ):
         raise cv.Invalid(
             "Providing color palette images requires palette mode to be 'IMAGE_ADAPTIVE'"
+        )
+    if CORE.is_esp8266 and config.get(CONF_MODEL) not in [
+        "M5STACK",
+        "M5CORE",
+        "TFT_2.4",
+        "TFT_2.4R",
+        "ILI9341",
+        "ILI9342",
+    ]:
+        raise cv.Invalid(
+            "Providing model can't run on ESP8266. Use an ESP32 with PSRAM onboard"
         )
     return config
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
