### PR TITLE
Add option flip_x

### DIFF
--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -17,7 +17,7 @@ CONF_REVERSE_ENABLE = "reverse_enable"
 CONF_NUM_CHIP_LINES = "num_chip_lines"
 CONF_CHIP_LINES_STYLE = "chip_lines_style"
 
-integration_ns = cg.esphome_ns.namespace("max7219digit2")
+integration_ns = cg.esphome_ns.namespace("max7219digit")
 ChipLinesStyle = integration_ns.enum("ChipLinesStyle")
 CHIP_LINES_STYLE = {
     "ZIGZAG": ChipLinesStyle.ZIGZAG,
@@ -37,7 +37,7 @@ CHIP_MODES = {
     "270": 3,
 }
 
-max7219_ns = cg.esphome_ns.namespace("max7219digit2")
+max7219_ns = cg.esphome_ns.namespace("max7219digit")
 MAX7219Component = max7219_ns.class_(
     "MAX7219Component", cg.PollingComponent, spi.SPIDevice, display.DisplayBuffer
 )

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -7,6 +7,7 @@ CODEOWNERS = ["@rspaargaren"]
 DEPENDENCIES = ["spi"]
 
 CONF_ROTATE_CHIP = "rotate_chip"
+CONF_FLIP_X = "flip_x"
 CONF_SCROLL_SPEED = "scroll_speed"
 CONF_SCROLL_DWELL = "scroll_dwell"
 CONF_SCROLL_DELAY = "scroll_delay"
@@ -16,7 +17,7 @@ CONF_REVERSE_ENABLE = "reverse_enable"
 CONF_NUM_CHIP_LINES = "num_chip_lines"
 CONF_CHIP_LINES_STYLE = "chip_lines_style"
 
-integration_ns = cg.esphome_ns.namespace("max7219digit")
+integration_ns = cg.esphome_ns.namespace("max7219digit2")
 ChipLinesStyle = integration_ns.enum("ChipLinesStyle")
 CHIP_LINES_STYLE = {
     "ZIGZAG": ChipLinesStyle.ZIGZAG,
@@ -36,7 +37,7 @@ CHIP_MODES = {
     "270": 3,
 }
 
-max7219_ns = cg.esphome_ns.namespace("max7219digit")
+max7219_ns = cg.esphome_ns.namespace("max7219digit2")
 MAX7219Component = max7219_ns.class_(
     "MAX7219Component", cg.PollingComponent, spi.SPIDevice, display.DisplayBuffer
 )
@@ -67,6 +68,7 @@ CONFIG_SCHEMA = (
                 CONF_SCROLL_DWELL, default="1000ms"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_REVERSE_ENABLE, default=False): cv.boolean,
+            cv.Optional(CONF_FLIP_X, default=False): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("500ms"))
@@ -91,6 +93,7 @@ async def to_code(config):
     cg.add(var.set_scroll(config[CONF_SCROLL_ENABLE]))
     cg.add(var.set_scroll_mode(config[CONF_SCROLL_MODE]))
     cg.add(var.set_reverse(config[CONF_REVERSE_ENABLE]))
+    cg.add(var.set_flip_x([CONF_FLIP_X]))
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -47,7 +47,7 @@ void MAX7219Component::setup() {
 }
 
 void MAX7219Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MAX7219DIGIT2:");
+  ESP_LOGCONFIG(TAG, "MAX7219DIGIT:");
   ESP_LOGCONFIG(TAG, "  Number of Chips: %u", this->num_chips_);
   ESP_LOGCONFIG(TAG, "  Number of Chips Lines: %u", this->num_chip_lines_);
   ESP_LOGCONFIG(TAG, "  Chips Lines Style : %u", this->chip_lines_style_);

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -261,7 +261,7 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
     if (this->orientation_ == 0) {
       for (uint8_t i = 0; i < 8; i++) {
         // run this loop 8 times for all the pixels[8] received
-        if(this->flip_x_) {
+        if (this->flip_x_) {
           b |= ((pixels[i] >> col) & 1) << i;  // change the column bits into row bits
         } else {
           b |= ((pixels[i] >> col) & 1) << (7 - i);  // change the column bits into row bits
@@ -271,7 +271,7 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
       b = pixels[col];
     } else if (this->orientation_ == 2) {
       for (uint8_t i = 0; i < 8; i++) {
-        if(this->flip_x_) {
+        if (this->flip_x_) {
           b |= ((pixels[i] >> (7 - col)) & 1) << (7 - i);
         } else {
           b |= ((pixels[i] >> (7 - col)) & 1) << i;

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -47,7 +47,7 @@ void MAX7219Component::setup() {
 }
 
 void MAX7219Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MAX7219DIGIT:");
+  ESP_LOGCONFIG(TAG, "MAX7219DIGIT2:");
   ESP_LOGCONFIG(TAG, "  Number of Chips: %u", this->num_chips_);
   ESP_LOGCONFIG(TAG, "  Number of Chips Lines: %u", this->num_chip_lines_);
   ESP_LOGCONFIG(TAG, "  Chips Lines Style : %u", this->chip_lines_style_);
@@ -261,13 +261,21 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
     if (this->orientation_ == 0) {
       for (uint8_t i = 0; i < 8; i++) {
         // run this loop 8 times for all the pixels[8] received
-        b |= ((pixels[i] >> col) & 1) << (7 - i);  // change the column bits into row bits
+		if(this->flip_x_) {
+			b |= ((pixels[i] >> col) & 1) << i;  // change the column bits into row bits
+		} else {
+			b |= ((pixels[i] >> col) & 1) << (7 - i);  // change the column bits into row bits
+		}
       }
     } else if (this->orientation_ == 1) {
       b = pixels[col];
     } else if (this->orientation_ == 2) {
       for (uint8_t i = 0; i < 8; i++) {
-        b |= ((pixels[i] >> (7 - col)) & 1) << i;
+  		if(this->flip_x_) {
+			b |= ((pixels[i] >> (7 - col)) & 1) << (7 - i);
+		} else {
+			b |= ((pixels[i] >> (7 - col)) & 1) << i;
+		}
       }
     } else {
       b = pixels[7 - col];

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -261,21 +261,21 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
     if (this->orientation_ == 0) {
       for (uint8_t i = 0; i < 8; i++) {
         // run this loop 8 times for all the pixels[8] received
-		if(this->flip_x_) {
-			b |= ((pixels[i] >> col) & 1) << i;  // change the column bits into row bits
-		} else {
-			b |= ((pixels[i] >> col) & 1) << (7 - i);  // change the column bits into row bits
-		}
+        if(this->flip_x_) {
+          b |= ((pixels[i] >> col) & 1) << i;  // change the column bits into row bits
+        } else {
+          b |= ((pixels[i] >> col) & 1) << (7 - i);  // change the column bits into row bits
+        }
       }
     } else if (this->orientation_ == 1) {
       b = pixels[col];
     } else if (this->orientation_ == 2) {
       for (uint8_t i = 0; i < 8; i++) {
-  		if(this->flip_x_) {
-			b |= ((pixels[i] >> (7 - col)) & 1) << (7 - i);
-		} else {
-			b |= ((pixels[i] >> (7 - col)) & 1) << i;
-		}
+        if(this->flip_x_) {
+          b |= ((pixels[i] >> (7 - col)) & 1) << (7 - i);
+        } else {
+          b |= ((pixels[i] >> (7 - col)) & 1) << i;
+        }
       }
     } else {
       b = pixels[7 - col];

--- a/esphome/components/max7219digit/max7219digit.h
+++ b/esphome/components/max7219digit/max7219digit.h
@@ -67,6 +67,7 @@ class MAX7219Component : public PollingComponent,
   void set_scroll(bool on_off) { this->scroll_ = on_off; };
   void set_scroll_mode(ScrollMode mode) { this->scroll_mode_ = mode; };
   void set_reverse(bool on_off) { this->reverse_ = on_off; };
+  void set_flip_x(bool flip_x) { this->flip_x_ = flip_x; };
 
   void send_char(uint8_t chip, uint8_t data);
   void send64pixels(uint8_t chip, const uint8_t pixels[8]);
@@ -108,6 +109,7 @@ class MAX7219Component : public PollingComponent,
   ChipLinesStyle chip_lines_style_;
   bool scroll_;
   bool reverse_;
+  bool flip_x_;
   bool update_{false};
   uint16_t scroll_speed_;
   uint16_t scroll_delay_;


### PR DESCRIPTION
# What does this implement/fix?

Add option to flip display on x axis

## Types of changes

- [*] New feature (non-breaking change which adds functionality)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2746

## Test Environment

- [ ] ESP32

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
display:
  - platform: max7219digit
    cs_pin: GPIO19
    rotate_chip: 180
    reverse_enable: true
    flip_x: true
    update_interval: 100ms
    num_chips: 9
    lambda: |-
      it.scroll(false);
      it.strftime(0, 0, id(digit_font), "%H:%M:%S %d-%m", id(hass_time).now());
```

## Checklist:
  - [*] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [*] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
