### PR TITLE
Add an option to force SPI into software mode

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -17,6 +17,7 @@ spi_ns = cg.esphome_ns.namespace("spi")
 SPIComponent = spi_ns.class_("SPIComponent", cg.Component)
 SPIDevice = spi_ns.class_("SPIDevice")
 MULTI_CONF = True
+CONF_FORCE_SW = "force_sw"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -25,6 +26,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_MISO_PIN): pins.gpio_input_pin_schema,
             cv.Optional(CONF_MOSI_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_FORCE_SW, default=False): cv.boolean,
         }
     ),
     cv.has_at_least_one_key(CONF_MISO_PIN, CONF_MOSI_PIN),
@@ -39,6 +41,7 @@ async def to_code(config):
 
     clk = await cg.gpio_pin_expression(config[CONF_CLK_PIN])
     cg.add(var.set_clk(clk))
+    cg.add(var.set_force_sw(config[CONF_FORCE_SW]))
     if CONF_MISO_PIN in config:
         miso = await cg.gpio_pin_expression(config[CONF_MISO_PIN])
         cg.add(var.set_miso(miso))

--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -25,7 +25,7 @@ void SPIComponent::setup() {
   this->clk_->digital_write(true);
 
 #ifdef USE_SPI_ARDUINO_BACKEND
-  bool use_hw_spi = true;
+  bool use_hw_spi = !this->force_sw_;
   const bool has_miso = this->miso_ != nullptr;
   const bool has_mosi = this->mosi_ != nullptr;
   int8_t clk_pin = -1, miso_pin = -1, mosi_pin = -1;

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -74,6 +74,7 @@ class SPIComponent : public Component {
   void set_clk(GPIOPin *clk) { clk_ = clk; }
   void set_miso(GPIOPin *miso) { miso_ = miso; }
   void set_mosi(GPIOPin *mosi) { mosi_ = mosi; }
+  void set_force_sw(bool force_sw) { force_sw_ = force_sw; }
 
   void setup() override;
 
@@ -260,6 +261,7 @@ class SPIComponent : public Component {
   GPIOPin *miso_{nullptr};
   GPIOPin *mosi_{nullptr};
   GPIOPin *active_cs_{nullptr};
+  bool force_sw_{false};
 #ifdef USE_SPI_ARDUINO_BACKEND
   SPIClass *hw_spi_{nullptr};
 #endif  // USE_SPI_ARDUINO_BACKEND


### PR DESCRIPTION
# What does this implement/fix?
Hardware SPI that's used by default when available doesn't work if the pins are reused for a different purpose
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2748

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
spi:
  clk_pin: GPIO14
  miso_pin: GPIO12
  mosi_pin: GPIO13
  force_sw: True
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
