### PR TITLE
Add state class back to uptime sensor

### DIFF
--- a/esphome/components/uptime/sensor.py
+++ b/esphome/components/uptime/sensor.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_SECOND,
     ICON_TIMER,
     DEVICE_CLASS_DURATION,
@@ -16,6 +17,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(
     unit_of_measurement=UNIT_SECOND,
     icon=ICON_TIMER,
     accuracy_decimals=0,
+    state_class=STATE_CLASS_TOTAL_INCREASING,
     device_class=DEVICE_CLASS_DURATION,
     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
 ).extend(cv.polling_component_schema("60s"))


### PR DESCRIPTION
Revert "Remove state class from uptime sensor (#4345)"

This reverts commit 36c2e770bfd5b43a5471590be0d10033049eb3ea.

# What does this implement/fix?

ESPHome 2023.2.0 removed the state class from the uptime sensor (#4345). This PR appears to have been to resolve an error in Home Assistant, but I believe that error was actually this bug: home-assistant/core#88096. This change, ironically, caused statistics to break for everyone on all versions of Home Assistant.

Since home-assistant/core#88096 has been fixed, the missing state class can be added back, and get statistics working again.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#4193

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: uptime
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
