### PR TITLE
Mark esp32_touch supported only on standard esp32 variant

### DIFF
--- a/esphome/components/esp32_touch/__init__.py
+++ b/esphome/components/esp32_touch/__init__.py
@@ -56,7 +56,9 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(ESP32TouchComponent),
             cv.Optional(CONF_SETUP_MODE, default=False): cv.boolean,
-            cv.Optional(CONF_IIR_FILTER): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_IIR_FILTER, default="0ms"
+            ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_SLEEP_DURATION, default="27306us"): cv.All(
                 cv.positive_time_period, cv.Range(max=TimePeriod(microseconds=436906))
             ),

--- a/esphome/components/esp32_touch/__init__.py
+++ b/esphome/components/esp32_touch/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     CONF_VOLTAGE_ATTENUATION,
 )
 from esphome.core import TimePeriod
+from esphome.components import esp32
 
 AUTO_LOAD = ["binary_sensor"]
 DEPENDENCIES = ["esp32"]
@@ -50,30 +51,35 @@ VOLTAGE_ATTENUATION = {
     "0V": cg.global_ns.TOUCH_HVOLT_ATTEN_0V,
 }
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(ESP32TouchComponent),
-        cv.Optional(CONF_SETUP_MODE, default=False): cv.boolean,
-        cv.Optional(
-            CONF_IIR_FILTER, default="0ms"
-        ): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_SLEEP_DURATION, default="27306us"): cv.All(
-            cv.positive_time_period, cv.Range(max=TimePeriod(microseconds=436906))
-        ),
-        cv.Optional(CONF_MEASUREMENT_DURATION, default="8192us"): cv.All(
-            cv.positive_time_period, cv.Range(max=TimePeriod(microseconds=8192))
-        ),
-        cv.Optional(CONF_LOW_VOLTAGE_REFERENCE, default="0.5V"): validate_voltage(
-            LOW_VOLTAGE_REFERENCE
-        ),
-        cv.Optional(CONF_HIGH_VOLTAGE_REFERENCE, default="2.7V"): validate_voltage(
-            HIGH_VOLTAGE_REFERENCE
-        ),
-        cv.Optional(CONF_VOLTAGE_ATTENUATION, default="0V"): validate_voltage(
-            VOLTAGE_ATTENUATION
-        ),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ESP32TouchComponent),
+            cv.Optional(CONF_SETUP_MODE, default=False): cv.boolean,
+            cv.Optional(CONF_IIR_FILTER): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_SLEEP_DURATION, default="27306us"): cv.All(
+                cv.positive_time_period, cv.Range(max=TimePeriod(microseconds=436906))
+            ),
+            cv.Optional(CONF_MEASUREMENT_DURATION, default="8192us"): cv.All(
+                cv.positive_time_period, cv.Range(max=TimePeriod(microseconds=8192))
+            ),
+            cv.Optional(CONF_LOW_VOLTAGE_REFERENCE, default="0.5V"): validate_voltage(
+                LOW_VOLTAGE_REFERENCE
+            ),
+            cv.Optional(CONF_HIGH_VOLTAGE_REFERENCE, default="2.7V"): validate_voltage(
+                HIGH_VOLTAGE_REFERENCE
+            ),
+            cv.Optional(CONF_VOLTAGE_ATTENUATION, default="0V"): validate_voltage(
+                VOLTAGE_ATTENUATION
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    esp32.only_on_variant(
+        supported=[
+            esp32.const.VARIANT_ESP32,
+        ]
+    ),
+)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
