### PR TITLE
fixing  `shrink` and `extend` functions of the displaybuffer's Rect class 

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -663,7 +663,7 @@ bool Animation::get_pixel(int x, int y) const {
     return false;
   const uint32_t width_8 = ((this->width_ + 7u) / 8u) * 8u;
   const uint32_t frame_index = this->height_ * width_8 * this->current_frame_;
-  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
     return false;
   const uint32_t pos = x + y * width_8 + frame_index;
   return progmem_read_byte(this->data_start_ + (pos / 8u)) & (0x80 >> (pos % 8u));
@@ -672,7 +672,7 @@ Color Animation::get_color_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index) * 3;
   const uint32_t color32 = (progmem_read_byte(this->data_start_ + pos + 2) << 0) |
@@ -684,7 +684,7 @@ Color Animation::get_rgb565_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index) * 2;
   uint16_t rgb565 =

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -32,9 +32,11 @@ void Rect::extend(Rect rect) {
     this->h = rect.h;
   } else {
     if (this->x > rect.x) {
+      this->w = this->w + (this->x - rect.x);
       this->x = rect.x;
     }
     if (this->y > rect.y) {
+      this->h = this->h + (this->y - rect.y);
       this->y = rect.y;
     }
     if (this->x2() < rect.x2()) {
@@ -50,9 +52,11 @@ void Rect::shrink(Rect rect) {
     (*this) = Rect();
   } else {
     if (this->x < rect.x) {
+      this->w = this->w - (this->x - rect.x);
       this->x = rect.x;
     }
     if (this->y < rect.y) {
+      this->h = this->h - (this->y - rect.y);
       this->y = rect.y;
     }
     if (this->x2() > rect.x2()) {

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -51,31 +51,35 @@ void Rect::shrink(Rect rect) {
   if (!this->inside(rect)) {
     (*this) = Rect();
   } else {
-    if (this->x < rect.x) {
-      this->w = this->w - (this->x - rect.x);
-      this->x = rect.x;
-    }
-    if (this->y < rect.y) {
-      this->h = this->h - (this->y - rect.y);
-      this->y = rect.y;
-    }
     if (this->x2() > rect.x2()) {
       this->w = rect.x2() - this->x;
+    }
+    if (this->x < rect.x) {
+      this->w = this->w + (this->x - rect.x);
+      this->x = rect.x;
     }
     if (this->y2() > rect.y2()) {
       this->h = rect.y2() - this->y;
     }
+    if (this->y < rect.y) {
+      this->h = this->h + (this->y - rect.y);
+      this->y = rect.y;
+    }
   }
 }
 
-bool Rect::inside(int16_t x, int16_t y, bool absolute) {  // NOLINT
+bool Rect::equal(Rect rect) {
+  return (rect.x == this->x) && (rect.w == this->w) && (rect.y == this->y) && (rect.h == this->h);
+}
+
+bool Rect::inside(int16_t test_x, int16_t test_y, bool absolute) {  // NOLINT
   if (!this->is_set()) {
     return true;
   }
   if (absolute) {
-    return ((x >= 0) && (x <= this->w) && (y >= 0) && (y <= this->h));
+    return ((test_x >= this->x) && (test_x <= this->x2()) && (test_y >= this->y) && (test_y <= this->y2()));
   } else {
-    return ((x >= this->x) && (x <= this->x2()) && (y >= this->y) && (y <= this->y2()));
+    return ((test_x >= 0) && (test_x <= this->w) && (test_y >= 0) && (test_y <= this->h));
   }
 }
 
@@ -84,15 +88,15 @@ bool Rect::inside(Rect rect, bool absolute) {
     return true;
   }
   if (absolute) {
-    return ((rect.x <= this->w) && (rect.w >= 0) && (rect.y <= this->h) && (rect.h >= 0));
-  } else {
     return ((rect.x <= this->x2()) && (rect.x2() >= this->x) && (rect.y <= this->y2()) && (rect.y2() >= this->y));
+  } else {
+    return ((rect.x <= this->w) && (rect.w >= 0) && (rect.y <= this->h) && (rect.h >= 0));
   }
 }
 
 void Rect::info(const std::string &prefix) {
   if (this->is_set()) {
-    ESP_LOGI(TAG, "%s [%3d,%3d,%3d,%3d]", prefix.c_str(), this->x, this->y, this->w, this->h);
+    ESP_LOGI(TAG, "%s [%3d,%3d,%3d,%3d] (%3d,%3d)", prefix.c_str(), this->x, this->y, this->w, this->h, this->x2() , this->y2());
   } else
     ESP_LOGI(TAG, "%s ** IS NOT SET **", prefix.c_str());
 }
@@ -659,7 +663,7 @@ bool Animation::get_pixel(int x, int y) const {
     return false;
   const uint32_t width_8 = ((this->width_ + 7u) / 8u) * 8u;
   const uint32_t frame_index = this->height_ * width_8 * this->current_frame_;
-  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
     return false;
   const uint32_t pos = x + y * width_8 + frame_index;
   return progmem_read_byte(this->data_start_ + (pos / 8u)) & (0x80 >> (pos % 8u));
@@ -668,7 +672,7 @@ Color Animation::get_color_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index) * 3;
   const uint32_t color32 = (progmem_read_byte(this->data_start_ + pos + 2) << 0) |
@@ -680,7 +684,7 @@ Color Animation::get_rgb565_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index) * 2;
   uint16_t rgb565 =
@@ -694,7 +698,7 @@ Color Animation::get_grayscale_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index);
   const uint8_t gray = progmem_read_byte(this->data_start_ + pos);

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -96,7 +96,8 @@ bool Rect::inside(Rect rect, bool absolute) {
 
 void Rect::info(const std::string &prefix) {
   if (this->is_set()) {
-    ESP_LOGI(TAG, "%s [%3d,%3d,%3d,%3d] (%3d,%3d)", prefix.c_str(), this->x, this->y, this->w, this->h, this->x2() , this->y2());
+    ESP_LOGI(TAG, "%s [%3d,%3d,%3d,%3d] (%3d,%3d)", prefix.c_str(), this->x, this->y, this->w, this->h, this->x2(), 
+             this->y2());
   } else
     ESP_LOGI(TAG, "%s ** IS NOT SET **", prefix.c_str());
 }
@@ -698,7 +699,7 @@ Color Animation::get_grayscale_pixel(int x, int y) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return Color::BLACK;
   const uint32_t frame_index = this->width_ * this->height_ * this->current_frame_;
-  if (frame_index >= (uint32_t) (this->width_ * this->height_ * this->animation_frame_count_))
+  if (frame_index >= (uint32_t)(this->width_ * this->height_ * this->animation_frame_count_))
     return Color::BLACK;
   const uint32_t pos = (x + y * this->width_ + frame_index);
   const uint8_t gray = progmem_read_byte(this->data_start_ + pos);

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -96,7 +96,7 @@ bool Rect::inside(Rect rect, bool absolute) {
 
 void Rect::info(const std::string &prefix) {
   if (this->is_set()) {
-    ESP_LOGI(TAG, "%s [%3d,%3d,%3d,%3d] (%3d,%3d)", prefix.c_str(), this->x, this->y, this->w, this->h, this->x2(), 
+    ESP_LOGI(TAG, "%s [%3d,%3d,%3d,%3d] (%3d,%3d)", prefix.c_str(), this->x, this->y, this->w, this->h, this->x2(),
              this->y2());
   } else
     ESP_LOGI(TAG, "%s ** IS NOT SET **", prefix.c_str());

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -120,8 +120,9 @@ class Rect {
   void extend(Rect rect);
   void shrink(Rect rect);
 
-  bool inside(Rect rect, bool absolute = false);
-  bool inside(int16_t x, int16_t y, bool absolute = false);
+  bool inside(Rect rect, bool absolute = true);
+  bool inside(int16_t test_x, int16_t test_y, bool absolute = true);
+  bool equal(Rect rect);
   void info(const std::string &prefix = "rect info:");
 };
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
