### PR TITLE
EntityBase: Icon string can stay in flash.

### DIFF
--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -23,8 +23,13 @@ bool EntityBase::is_disabled_by_default() const { return this->disabled_by_defau
 void EntityBase::set_disabled_by_default(bool disabled_by_default) { this->disabled_by_default_ = disabled_by_default; }
 
 // Entity Icon
-const std::string &EntityBase::get_icon() const { return this->icon_; }
-void EntityBase::set_icon(const std::string &name) { this->icon_ = name; }
+const std::string EntityBase::get_icon() const {
+  if (this->icon_c_str_ == nullptr) {
+    return "";
+  }
+  return this->icon_c_str_;
+}
+void EntityBase::set_icon(const char *icon) { this->icon_c_str_ = icon; }
 
 // Entity Category
 EntityCategory EntityBase::get_entity_category() const { return this->entity_category_; }

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -23,7 +23,7 @@ bool EntityBase::is_disabled_by_default() const { return this->disabled_by_defau
 void EntityBase::set_disabled_by_default(bool disabled_by_default) { this->disabled_by_default_ = disabled_by_default; }
 
 // Entity Icon
-const std::string EntityBase::get_icon() const {
+std::string EntityBase::get_icon() const {
   if (this->icon_c_str_ == nullptr) {
     return "";
   }

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -42,8 +42,8 @@ class EntityBase {
   void set_entity_category(EntityCategory entity_category);
 
   // Get/set this entity's icon
-  const std::string &get_icon() const;
-  void set_icon(const std::string &name);
+  const std::string get_icon() const;
+  void set_icon(const char *icon);
 
  protected:
   /// The hash_base() function has been deprecated. It is kept in this
@@ -53,7 +53,7 @@ class EntityBase {
 
   std::string name_;
   std::string object_id_;
-  std::string icon_;
+  const char *icon_c_str_{nullptr};
   uint32_t object_id_hash_;
   bool internal_{false};
   bool disabled_by_default_{false};

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -42,7 +42,7 @@ class EntityBase {
   void set_entity_category(EntityCategory entity_category);
 
   // Get/set this entity's icon
-  const std::string get_icon() const;
+  std::string get_icon() const;
   void set_icon(const char *icon);
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This is a memory improvement. The `EntityBase` string icon does not need to be copied to memory, instead it can stay in Flash. Each `std::string` instance (even empty once) occupy at least 24 bytes (15 byte capacity + length + flags) of memory. By using char pointer instead of `std::string` they stay in flash.

The icon field has zero direct uses.  Therefore no benefit of using an `std::string` here. In case any existing code is referencing this field it will break as the field was renamed.

In my projects I get easily more than 25 instances of `EntityBase`. In my testing I get ~1kb of more free memory by performing this change.

I consider similar changes for the name and object_id field. But I want to change one at a time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
