### PR TITLE
Add a simple 'skip_initial' filter

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -194,7 +194,7 @@ SensorPublishAction = sensor_ns.class_("SensorPublishAction", automation.Action)
 Filter = sensor_ns.class_("Filter")
 QuantileFilter = sensor_ns.class_("QuantileFilter", Filter)
 MedianFilter = sensor_ns.class_("MedianFilter", Filter)
-SkipFilter = sensor_ns.class_("SkipFilter", Filter)
+SkipInitialFilter = sensor_ns.class_("SkipInitialFilter", Filter)
 MinFilter = sensor_ns.class_("MinFilter", Filter)
 MaxFilter = sensor_ns.class_("MaxFilter", Filter)
 SlidingWindowMovingAverageFilter = sensor_ns.class_(
@@ -366,21 +366,9 @@ MIN_SCHEMA = cv.All(
 )
 
 
-SKIP_SCHEMA = cv.All(
-    cv.Schema(
-        {
-            cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.positive_not_null_int,
-        }
-    ),
-)
-
-
-@FILTER_REGISTRY.register("skip", SkipFilter, SKIP_SCHEMA)
-async def skip_filter_to_code(config, filter_id):
-    return cg.new_Pvariable(
-        filter_id,
-        config[CONF_SEND_FIRST_AT],
-    )
+@FILTER_REGISTRY.register("skip_initial", SkipInitialFilter, cv.positive_not_null_int)
+async def skip_initial_filter_to_code(config, filter_id):
+    return cg.new_Pvariable(filter_id, config)
 
 
 @FILTER_REGISTRY.register("min", MinFilter, MIN_SCHEMA)

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -194,6 +194,7 @@ SensorPublishAction = sensor_ns.class_("SensorPublishAction", automation.Action)
 Filter = sensor_ns.class_("Filter")
 QuantileFilter = sensor_ns.class_("QuantileFilter", Filter)
 MedianFilter = sensor_ns.class_("MedianFilter", Filter)
+SkipFilter = sensor_ns.class_("SkipFilter", Filter)
 MinFilter = sensor_ns.class_("MinFilter", Filter)
 MaxFilter = sensor_ns.class_("MaxFilter", Filter)
 SlidingWindowMovingAverageFilter = sensor_ns.class_(
@@ -363,6 +364,23 @@ MIN_SCHEMA = cv.All(
     ),
     validate_send_first_at,
 )
+
+
+SKIP_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.positive_not_null_int,
+        }
+    ),
+)
+
+
+@FILTER_REGISTRY.register("skip", SkipFilter, SKIP_SCHEMA)
+async def skip_filter_to_code(config, filter_id):
+    return cg.new_Pvariable(
+        filter_id,
+        config[CONF_SEND_FIRST_AT],
+    )
 
 
 @FILTER_REGISTRY.register("min", MinFilter, MIN_SCHEMA)

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -74,6 +74,22 @@ optional<float> MedianFilter::new_value(float value) {
   return {};
 }
 
+// SkipFilter
+SkipFilter::SkipFilter(size_t send_first_at) : num_to_ignore_(send_first_at)
+{
+}
+optional<float> SkipFilter::new_value(float value)
+{
+  if (num_to_ignore_ > 0) {
+    num_to_ignore_--;
+    ESP_LOGV(TAG, "SkipFilter(%p)::new_value(%f) SKIPPING, %u left", this, value, num_to_ignore_);
+    return {};
+  }
+
+  ESP_LOGV(TAG, "SkipFilter(%p)::new_value(%f) SENDING", this, value);
+  return value;
+}
+
 // QuantileFilter
 QuantileFilter::QuantileFilter(size_t window_size, size_t send_every, size_t send_first_at, float quantile)
     : send_every_(send_every), send_at_(send_every - send_first_at), window_size_(window_size), quantile_(quantile) {}

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -75,11 +75,8 @@ optional<float> MedianFilter::new_value(float value) {
 }
 
 // SkipInitialFilter
-SkipInitialFilter::SkipInitialFilter(size_t num_to_ignore) : num_to_ignore_(num_to_ignore)
-{
-}
-optional<float> SkipInitialFilter::new_value(float value)
-{
+SkipInitialFilter::SkipInitialFilter(size_t num_to_ignore) : num_to_ignore_(num_to_ignore) {}
+optional<float> SkipInitialFilter::new_value(float value) {
   if (num_to_ignore_ > 0) {
     num_to_ignore_--;
     ESP_LOGV(TAG, "SkipInitialFilter(%p)::new_value(%f) SKIPPING, %u left", this, value, num_to_ignore_);

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -74,19 +74,19 @@ optional<float> MedianFilter::new_value(float value) {
   return {};
 }
 
-// SkipFilter
-SkipFilter::SkipFilter(size_t send_first_at) : num_to_ignore_(send_first_at)
+// SkipInitialFilter
+SkipInitialFilter::SkipInitialFilter(size_t num_to_ignore) : num_to_ignore_(num_to_ignore)
 {
 }
-optional<float> SkipFilter::new_value(float value)
+optional<float> SkipInitialFilter::new_value(float value)
 {
   if (num_to_ignore_ > 0) {
     num_to_ignore_--;
-    ESP_LOGV(TAG, "SkipFilter(%p)::new_value(%f) SKIPPING, %u left", this, value, num_to_ignore_);
+    ESP_LOGV(TAG, "SkipInitialFilter(%p)::new_value(%f) SKIPPING, %u left", this, value, num_to_ignore_);
     return {};
   }
 
-  ESP_LOGV(TAG, "SkipFilter(%p)::new_value(%f) SENDING", this, value);
+  ESP_LOGV(TAG, "SkipInitialFilter(%p)::new_value(%f) SENDING", this, value);
   return value;
 }
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -102,6 +102,24 @@ class MedianFilter : public Filter {
   size_t window_size_;
 };
 
+/** Simple skip filter.
+ *
+ * Skips the first <send_first_at> values, then passes everything else.
+ */
+class SkipFilter : public Filter {
+ public:
+  /** Construct a SkipFilter.
+   *
+   * @param send_first_at After how many values to forward the very first value.
+   */
+  explicit SkipFilter(size_t send_first_at);
+
+  optional<float> new_value(float value) override;
+
+ protected:
+  size_t num_to_ignore_;
+};
+
 /** Simple min filter.
  *
  * Takes the min of the last <send_every> values and pushes it out every <send_every>.

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -104,15 +104,15 @@ class MedianFilter : public Filter {
 
 /** Simple skip filter.
  *
- * Skips the first <send_first_at> values, then passes everything else.
+ * Skips the first N values, then passes everything else.
  */
-class SkipFilter : public Filter {
+class SkipInitialFilter : public Filter {
  public:
-  /** Construct a SkipFilter.
+  /** Construct a SkipInitialFilter.
    *
-   * @param send_first_at After how many values to forward the very first value.
+   * @param num_to_ignore How many values to ignore before the filter becomes a no-op.
    */
-  explicit SkipFilter(size_t send_first_at);
+  explicit SkipInitialFilter(size_t num_to_ignore);
 
   optional<float> new_value(float value) override;
 


### PR DESCRIPTION
This filter simply skips the first `N` values, then passes everything as-is. This is quite useful when you know the first few sensor readings should be ignored.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes my unreported issue, briefly discussed in Discord.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2760

## Test Environment

I tested on these, but it should be independent on the exact hardware used.

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
sensor:
  - platform: sgp30
    id: mysensor_sgp30
    eco2:
      id: mysensor_sgp30_co2
      name: "eCO₂"
      accuracy_decimals: 0
      filters:
        - skip_initial: 41
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
