### PR TITLE
Fix outdated filter string in platformio_api

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -47,7 +47,7 @@ FILTER_PLATFORMIO_LINES = [
     r"CONFIGURATION: https://docs.platformio.org/.*",
     r"DEBUG: Current.*",
     r"LDF Modes:.*",
-    r"LDF: Library Dependency Finder -> http://bit.ly/configure-pio-ldf.*",
+    r"LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf.*",
     f"Looking for {IGNORE_LIB_WARNINGS} library in registry",
     f"Warning! Library `.*'{IGNORE_LIB_WARNINGS}.*` has not been found in PlatformIO Registry.",
     f"You can ignore this message, if `.*{IGNORE_LIB_WARNINGS}.*` is a built-in library.*",


### PR DESCRIPTION
# What does this implement/fix?
I stumbled across a filtered string that wasn't filtered in the `platformio` output.

Note that the screenshot below shows the string I fixed, but here it has an "s" in "https".

![image](https://user-images.githubusercontent.com/1027111/226142932-577a2a93-5813-4253-bfb4-2c4c6a81beab.png)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
