### PR TITLE
Fix wrong port multiplexer name in dump GPIO function of sx1509

### DIFF
--- a/esphome/components/sx1509/sx1509_gpio_pin.cpp
+++ b/esphome/components/sx1509/sx1509_gpio_pin.cpp
@@ -13,7 +13,7 @@ bool SX1509GPIOPin::digital_read() { return this->parent_->digital_read(this->pi
 void SX1509GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 std::string SX1509GPIOPin::dump_summary() const {
   char buffer[32];
-  snprintf(buffer, sizeof(buffer), "%u via MCP23016", pin_);
+  snprintf(buffer, sizeof(buffer), "%u via sx1509", pin_);
   return buffer;
 }
 


### PR DESCRIPTION
# Fixing wrong port multiplexer name in GPIO debug dump

Most likely caused by initial copy paste of code from MCP multiplexer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

This is just a simple typo fix.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
