### PR TITLE
Fix EzoCommandType enum

### DIFF
--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -12,14 +12,14 @@ static const char *const TAG = "ezo.sensor";
 
 enum EzoCommandType : uint8_t {
   EZO_READ = 0,
-  EZO_LED = 1,
-  EZO_DEVICE_INFORMATION = 2,
-  EZO_SLOPE = 3,
-  EZO_CALIBRATION = 4,
-  EZO_SLEEP = 5,
-  EZO_I2C = 6,
-  EZO_T = 7,
-  EZO_CUSTOM = 8
+  EZO_LED,
+  EZO_DEVICE_INFORMATION,
+  EZO_SLOPE,
+  EZO_CALIBRATION,
+  EZO_SLEEP,
+  EZO_I2C,
+  EZO_T,
+  EZO_CUSTOM
 };
 
 enum EzoCalibrationType : uint8_t { EZO_CAL_LOW = 0, EZO_CAL_MID = 1, EZO_CAL_HIGH = 2 };

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -15,11 +15,11 @@ enum EzoCommandType : uint8_t {
   EZO_LED = 1,
   EZO_DEVICE_INFORMATION = 2,
   EZO_SLOPE = 3,
-  EZO_CALIBRATION,
-  EZO_SLEEP = 4,
-  EZO_I2C = 5,
-  EZO_T = 6,
-  EZO_CUSTOM = 7
+  EZO_CALIBRATION = 4,
+  EZO_SLEEP = 5,
+  EZO_I2C = 6,
+  EZO_T = 7,
+  EZO_CUSTOM = 8
 };
 
 enum EzoCalibrationType : uint8_t { EZO_CAL_LOW = 0, EZO_CAL_MID = 1, EZO_CAL_HIGH = 2 };


### PR DESCRIPTION
Assign explicit value to EZO_CALIBRATION, and rescale all subsequent values.

# What does this implement/fix?

The current enum definition misses explicit assignment to the EZO_CALIBRATION value. This makes EZO_CALIBRATION and EZO_SLEEP end up with the same value, which causes malfunction in the code. Also, the indexing between EzoCommandType enum and [EZO_COMMAND_TYPE_STRINGS[]](https://github.com/esphome/esphome/blob/cd57469e06aaf223c518c72b17c07e80722982fc/esphome/components/ezo/ezo.cpp#L8) is currently broken.

This patch assigns an explicit value to EZO_CALIBRATION, and rescales all subsequent values, to make the enum work as intended.

## Types of changes

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#4321](https://github.com/esphome/issues/issues/4321)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
