### PR TITLE
rp2040: Use fake Mutex lock

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -393,13 +393,13 @@ void hsv_to_rgb(int hue, float saturation, float value, float &red, float &green
 }
 
 // System APIs
-#if defined(USE_ESP8266)
+#if defined(USE_ESP8266) || defined(USE_RP2040)
 // ESP8266 doesn't have mutexes, but that shouldn't be an issue as it's single-core and non-preemptive OS.
 Mutex::Mutex() {}
 void Mutex::lock() {}
 bool Mutex::try_lock() { return true; }
 void Mutex::unlock() {}
-#elif defined(USE_ESP32) || defined(USE_RP2040)
+#elif defined(USE_ESP32)
 Mutex::Mutex() { handle_ = xSemaphoreCreateMutex(); }
 void Mutex::lock() { xSemaphoreTake(this->handle_, portMAX_DELAY); }
 bool Mutex::try_lock() { return xSemaphoreTake(this->handle_, 0) == pdTRUE; }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -17,9 +17,6 @@
 #if defined(USE_ESP32)
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
-#elif defined(USE_RP2040)
-#include <FreeRTOS.h>
-#include <semphr.h>
 #endif
 
 #define HOT __attribute__((hot))
@@ -539,7 +536,7 @@ class Mutex {
   Mutex &operator=(const Mutex &) = delete;
 
  private:
-#if defined(USE_ESP32) || defined(USE_RP2040)
+#if defined(USE_ESP32)
   SemaphoreHandle_t handle_;
 #endif
 };


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

By just having `#include <FreeRTOS.h>` in the code for RP2040, it sets up the whole framework to use FreeRTOS underneath. 

While this might be a good thing in the future, its untested for now and actually broke the `preferences` which put all rp2040 into a bootloop. Not sure why I didnt see this when I tested #4410 

It is safe for rp2040 to use the "fake" Mutex lock for now as we only ever utilize a single core in ESPHome and it can be changed if/when we decide to utilize both and/or FreeRTOS.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4308

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
