### PR TITLE
Limit range on filter time period for remote_receiver

### DIFF
--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -12,7 +12,7 @@ from esphome.const import (
     CONF_TOLERANCE,
     CONF_MEMORY_BLOCKS,
 )
-from esphome.core import CORE
+from esphome.core import CORE, TimePeriod
 
 AUTO_LOAD = ["remote_base"]
 remote_receiver_ns = cg.esphome_ns.namespace("remote_receiver")
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             ): cv.validate_bytes,
             cv.Optional(
                 CONF_FILTER, default="50us"
-            ): cv.positive_time_period_microseconds,
+            ): cv.All(cv.positive_time_period_microseconds, cv.Range(max=TimePeriod(microseconds=255))),
             cv.Optional(
                 CONF_IDLE, default="10ms"
             ): cv.positive_time_period_microseconds,

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -33,9 +33,10 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             cv.SplitDefault(
                 CONF_BUFFER_SIZE, esp32="10000b", esp8266="1000b"
             ): cv.validate_bytes,
-            cv.Optional(
-                CONF_FILTER, default="50us"
-            ): cv.All(cv.positive_time_period_microseconds, cv.Range(max=TimePeriod(microseconds=255))),
+            cv.Optional(CONF_FILTER, default="50us"): cv.All(
+                cv.positive_time_period_microseconds,
+                cv.Range(max=TimePeriod(microseconds=255)),
+            ),
             cv.Optional(
                 CONF_IDLE, default="10ms"
             ): cv.positive_time_period_microseconds,


### PR DESCRIPTION
# What does this implement/fix?

Adds range validation to the `CONF_FILTER` option in `remote_receiver` component. As in firmware this value is truncated to 8 bits, this should be better reflected during configuration. Without the upper bound validation for the range the value entered by the user may result in integer rolover with only a compiler warning that may not provide enough information to unknowing users. 

It's quite reasonable the user may wish to filter out spikes larger than 255us and without feedback during configuration would not be aware of this limitation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
remote_receiver:
  pin: D1
  dump: all
  tolerance: 50%
  filter: 260us # <-- This would happily compile, only with a compiler warning of w.r.t integer range. But results in an effective value of 5us.
  idle: 4ms

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
