### PR TITLE
Allow entity names to be set to None

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -180,7 +180,8 @@ bool APIConnection::send_binary_sensor_info(binary_sensor::BinarySensor *binary_
   ListEntitiesBinarySensorResponse msg;
   msg.object_id = binary_sensor->get_object_id();
   msg.key = binary_sensor->get_object_id_hash();
-  msg.name = binary_sensor->get_name();
+  if (binary_sensor->has_own_name())
+    msg.name = binary_sensor->get_name();
   msg.unique_id = get_default_unique_id("binary_sensor", binary_sensor);
   msg.device_class = binary_sensor->get_device_class();
   msg.is_status_binary_sensor = binary_sensor->is_status_binary_sensor();
@@ -212,7 +213,8 @@ bool APIConnection::send_cover_info(cover::Cover *cover) {
   ListEntitiesCoverResponse msg;
   msg.key = cover->get_object_id_hash();
   msg.object_id = cover->get_object_id();
-  msg.name = cover->get_name();
+  if (cover->has_own_name())
+    msg.name = cover->get_name();
   msg.unique_id = get_default_unique_id("cover", cover);
   msg.assumed_state = traits.get_is_assumed_state();
   msg.supports_position = traits.get_supports_position();
@@ -275,7 +277,8 @@ bool APIConnection::send_fan_info(fan::Fan *fan) {
   ListEntitiesFanResponse msg;
   msg.key = fan->get_object_id_hash();
   msg.object_id = fan->get_object_id();
-  msg.name = fan->get_name();
+  if (fan->has_own_name())
+    msg.name = fan->get_name();
   msg.unique_id = get_default_unique_id("fan", fan);
   msg.supports_oscillation = traits.supports_oscillation();
   msg.supports_speed = traits.supports_speed();
@@ -337,7 +340,8 @@ bool APIConnection::send_light_info(light::LightState *light) {
   ListEntitiesLightResponse msg;
   msg.key = light->get_object_id_hash();
   msg.object_id = light->get_object_id();
-  msg.name = light->get_name();
+  if (light->has_own_name())
+    msg.name = light->get_name();
   msg.unique_id = get_default_unique_id("light", light);
 
   msg.disabled_by_default = light->is_disabled_by_default();
@@ -418,7 +422,8 @@ bool APIConnection::send_sensor_info(sensor::Sensor *sensor) {
   ListEntitiesSensorResponse msg;
   msg.key = sensor->get_object_id_hash();
   msg.object_id = sensor->get_object_id();
-  msg.name = sensor->get_name();
+  if (sensor->has_own_name())
+    msg.name = sensor->get_name();
   msg.unique_id = sensor->unique_id();
   if (msg.unique_id.empty())
     msg.unique_id = get_default_unique_id("sensor", sensor);
@@ -448,7 +453,8 @@ bool APIConnection::send_switch_info(switch_::Switch *a_switch) {
   ListEntitiesSwitchResponse msg;
   msg.key = a_switch->get_object_id_hash();
   msg.object_id = a_switch->get_object_id();
-  msg.name = a_switch->get_name();
+  if (a_switch->has_own_name())
+    msg.name = a_switch->get_name();
   msg.unique_id = get_default_unique_id("switch", a_switch);
   msg.icon = a_switch->get_icon();
   msg.assumed_state = a_switch->assumed_state();
@@ -533,7 +539,8 @@ bool APIConnection::send_climate_info(climate::Climate *climate) {
   ListEntitiesClimateResponse msg;
   msg.key = climate->get_object_id_hash();
   msg.object_id = climate->get_object_id();
-  msg.name = climate->get_name();
+  if (climate->has_own_name())
+    msg.name = climate->get_name();
   msg.unique_id = get_default_unique_id("climate", climate);
 
   msg.disabled_by_default = climate->is_disabled_by_default();
@@ -609,7 +616,8 @@ bool APIConnection::send_number_info(number::Number *number) {
   ListEntitiesNumberResponse msg;
   msg.key = number->get_object_id_hash();
   msg.object_id = number->get_object_id();
-  msg.name = number->get_name();
+  if (number->has_own_name())
+    msg.name = number->get_name();
   msg.unique_id = get_default_unique_id("number", number);
   msg.icon = number->get_icon();
   msg.disabled_by_default = number->is_disabled_by_default();
@@ -650,7 +658,8 @@ bool APIConnection::send_select_info(select::Select *select) {
   ListEntitiesSelectResponse msg;
   msg.key = select->get_object_id_hash();
   msg.object_id = select->get_object_id();
-  msg.name = select->get_name();
+  if (select->has_own_name())
+    msg.name = select->get_name();
   msg.unique_id = get_default_unique_id("select", select);
   msg.icon = select->get_icon();
   msg.disabled_by_default = select->is_disabled_by_default();
@@ -677,7 +686,8 @@ bool APIConnection::send_button_info(button::Button *button) {
   ListEntitiesButtonResponse msg;
   msg.key = button->get_object_id_hash();
   msg.object_id = button->get_object_id();
-  msg.name = button->get_name();
+  if (button->has_own_name())
+    msg.name = button->get_name();
   msg.unique_id = get_default_unique_id("button", button);
   msg.icon = button->get_icon();
   msg.disabled_by_default = button->is_disabled_by_default();
@@ -708,7 +718,8 @@ bool APIConnection::send_lock_info(lock::Lock *a_lock) {
   ListEntitiesLockResponse msg;
   msg.key = a_lock->get_object_id_hash();
   msg.object_id = a_lock->get_object_id();
-  msg.name = a_lock->get_name();
+  if (a_lock->has_own_name())
+    msg.name = a_lock->get_name();
   msg.unique_id = get_default_unique_id("lock", a_lock);
   msg.icon = a_lock->get_icon();
   msg.assumed_state = a_lock->traits.get_assumed_state();
@@ -753,7 +764,8 @@ bool APIConnection::send_media_player_info(media_player::MediaPlayer *media_play
   ListEntitiesMediaPlayerResponse msg;
   msg.key = media_player->get_object_id_hash();
   msg.object_id = media_player->get_object_id();
-  msg.name = media_player->get_name();
+  if (media_player->has_own_name())
+    msg.name = media_player->get_name();
   msg.unique_id = get_default_unique_id("media_player", media_player);
   msg.icon = media_player->get_icon();
   msg.disabled_by_default = media_player->is_disabled_by_default();
@@ -797,7 +809,8 @@ bool APIConnection::send_camera_info(esp32_camera::ESP32Camera *camera) {
   ListEntitiesCameraResponse msg;
   msg.key = camera->get_object_id_hash();
   msg.object_id = camera->get_object_id();
-  msg.name = camera->get_name();
+  if (camera->has_own_name())
+    msg.name = camera->get_name();
   msg.unique_id = get_default_unique_id("camera", camera);
   msg.disabled_by_default = camera->is_disabled_by_default();
   msg.icon = camera->get_icon();

--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -22,20 +22,12 @@ ESP32ImprovComponent = esp32_improv_ns.class_(
 )
 
 
-def validate_none_(value):
-    if value in ("none", "None"):
-        return None
-    if cv.boolean(value) is False:
-        return None
-    raise cv.Invalid("Must be none")
-
-
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(ESP32ImprovComponent),
         cv.GenerateID(CONF_BLE_SERVER_ID): cv.use_id(esp32_ble_server.BLEServer),
         cv.Required(CONF_AUTHORIZER): cv.Any(
-            validate_none_, cv.use_id(binary_sensor.BinarySensor)
+            cv.none, cv.use_id(binary_sensor.BinarySensor)
         ),
         cv.Optional(CONF_STATUS_INDICATOR): cv.use_id(output.BinaryOutput),
         cv.Optional(

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1504,6 +1504,8 @@ def _entity_base_validator(config):
         config[CONF_NAME] = id.id
         config[CONF_INTERNAL] = True
         return config
+    if config[CONF_NAME] is None:
+        config[CONF_NAME] = ""
     return config
 
 
@@ -1561,6 +1563,23 @@ def validate_registry_entry(name, registry):
         return value
 
     return validator
+
+
+def none(value):
+    if value in ("none", "None"):
+        return None
+    if boolean(value) is False:
+        return None
+    raise Invalid("Must be none")
+
+
+def requires_friendly_name(message):
+    def validate(value):
+        if CORE.friendly_name is None:
+            raise Invalid(message)
+        return value
+
+    return validate
 
 
 def validate_registry(name, registry):
@@ -1622,7 +1641,15 @@ MQTT_COMMAND_COMPONENT_SCHEMA = MQTT_COMPONENT_SCHEMA.extend(
 
 ENTITY_BASE_SCHEMA = Schema(
     {
-        Optional(CONF_NAME): string,
+        Optional(CONF_NAME): Any(
+            All(
+                none,
+                requires_friendly_name(
+                    "Name cannot be None when esphome->friendly_name is not set!"
+                ),
+            ),
+            string,
+        ),
         Optional(CONF_INTERNAL): boolean,
         Optional(CONF_DISABLED_BY_DEFAULT, default=False): boolean,
         Optional(CONF_ICON): icon,

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -1,4 +1,5 @@
 #include "esphome/core/entity_base.h"
+#include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome {
@@ -10,7 +11,13 @@ EntityBase::EntityBase(std::string name) : name_(std::move(name)) { this->calc_o
 // Entity Name
 const std::string &EntityBase::get_name() const { return this->name_; }
 void EntityBase::set_name(const std::string &name) {
-  this->name_ = name;
+  if (name == "") {
+    this->name_ = App.get_friendly_name();
+    this->has_own_name_ = false;
+  } else {
+    this->name_ = name;
+    this->has_own_name_ = true;
+  }
   this->calc_object_id_();
 }
 

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -11,7 +11,7 @@ EntityBase::EntityBase(std::string name) : name_(std::move(name)) { this->calc_o
 // Entity Name
 const std::string &EntityBase::get_name() const { return this->name_; }
 void EntityBase::set_name(const std::string &name) {
-  if (name == "") {
+  if (name.empty()) {
     this->name_ = App.get_friendly_name();
     this->has_own_name_ = false;
   } else {

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -21,6 +21,9 @@ class EntityBase {
   const std::string &get_name() const;
   void set_name(const std::string &name);
 
+  // Get whether this Entity has its own name or it should use the device friendly_name.
+  bool has_own_name() const { return this->has_own_name_; }
+
   // Get the sanitized name of this Entity as an ID. Caching it internally.
   const std::string &get_object_id();
 
@@ -52,6 +55,7 @@ class EntityBase {
   void calc_object_id_();
 
   std::string name_;
+  bool has_own_name_{false};
   std::string object_id_;
   std::string icon_;
   uint32_t object_id_hash_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Allow entity names to be set to `None` if the `esphome` -> `friendly_name` is set. This will then set the entity name to be blank and in Home Assistant this is handled by it being only give the device name.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4269

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2774

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
