### PR TITLE
SX1509 minimum loop period (fixes esphome/issues#4325)

### DIFF
--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -42,6 +42,9 @@ void SX1509Component::dump_config() {
 
 void SX1509Component::loop() {
   if (this->has_keypad_) {
+    if (millis() - this->last_loop_timestamp_ < MIN_LOOP_PERIOD_)
+      return;
+    this->last_loop_timestamp_ = millis();
     uint16_t key_data = this->read_key_data();
     for (auto *binary_sensor : this->keypad_binary_sensors_)
       binary_sensor->process(key_data);

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -42,7 +42,7 @@ void SX1509Component::dump_config() {
 
 void SX1509Component::loop() {
   if (this->has_keypad_) {
-    if (millis() - this->last_loop_timestamp_ < MIN_LOOP_PERIOD_)
+    if (millis() - this->last_loop_timestamp_ < min_loop_period_)
       return;
     this->last_loop_timestamp_ = millis();
     uint16_t key_data = this->read_key_data();

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -69,8 +69,8 @@ class SX1509Component : public Component, public i2c::I2CDevice {
   uint8_t debounce_time_ = 1;
   std::vector<SX1509Processor *> keypad_binary_sensors_;
 
-  long last_loop_timestamp_ = 0;
-  const long min_loop_period_ = 15;  // ms
+  uint32_t last_loop_timestamp_ = 0;
+  const uint32_t min_loop_period_ = 15;  // ms
 
   void setup_keypad_();
   void set_debounce_config_(uint8_t config_value);

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -70,7 +70,7 @@ class SX1509Component : public Component, public i2c::I2CDevice {
   std::vector<SX1509Processor *> keypad_binary_sensors_;
 
   long last_loop_timestamp_ = 0;
-  const long MIN_LOOP_PERIOD_ = 15;  // ms
+  const long min_loop_period_ = 15;  // ms
 
   void setup_keypad_();
   void set_debounce_config_(uint8_t config_value);

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -69,6 +69,9 @@ class SX1509Component : public Component, public i2c::I2CDevice {
   uint8_t debounce_time_ = 1;
   std::vector<SX1509Processor *> keypad_binary_sensors_;
 
+  long last_loop_timestamp_ = 0;
+  const long MIN_LOOP_PERIOD_ = 15;  // ms
+
   void setup_keypad_();
   void set_debounce_config_(uint8_t config_value);
   void set_debounce_time_(uint8_t time);


### PR DESCRIPTION
# What does this implement/fix?

There is no delay / timing check on SX1509 loop function. After network initializes, it runs every 16~30 ms, which is fine. But before network is initialized, loop() runs every ~400 us, which is too fast based on the standard debouncing for SX1509 and causes false key releases on the keypad.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [esphome/issues#4325](https://github.com/esphome/issues/issues/4325)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
