### PR TITLE
Fix platform restriction for bme680_bsec

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -51,7 +51,10 @@ CONFIG_SCHEMA = cv.All(
     cv.only_with_arduino,
     cv.Any(
         cv.only_on_esp8266,
-        esp32.only_on_variant(supported=[esp32.const.VARIANT_ESP32]),
+        cv.All(
+            cv.only_on_esp32,
+            esp32.only_on_variant(supported=[esp32.const.VARIANT_ESP32]),
+        ),
     ),
 )
 

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -49,7 +49,10 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(i2c.i2c_device_schema(0x76)),
     cv.only_with_arduino,
-    esp32.only_on_variant(supported=[esp32.const.VARIANT_ESP32]),
+    cv.Any(
+        cv.only_on_esp8266,
+        esp32.only_on_variant(supported=[esp32.const.VARIANT_ESP32]),
+    ),
 )
 
 

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -1,10 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import i2c
+from esphome.components import i2c, esp32
 from esphome.const import CONF_ID
 
 CODEOWNERS = ["@trvrnrth"]
-DEPENDENCIES = ["i2c"]
+DEPENDENCIES = ["i2c", "spi"]
 AUTO_LOAD = ["sensor", "text_sensor"]
 MULTI_CONF = True
 
@@ -32,22 +32,25 @@ BME680BSECComponent = bme680_bsec_ns.class_(
     "BME680BSECComponent", cg.Component, i2c.I2CDevice
 )
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(BME680BSECComponent),
-        cv.Optional(CONF_TEMPERATURE_OFFSET, default=0): cv.temperature,
-        cv.Optional(CONF_IAQ_MODE, default="STATIC"): cv.enum(
-            IAQ_MODE_OPTIONS, upper=True
-        ),
-        cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
-            SAMPLE_RATE_OPTIONS, upper=True
-        ),
-        cv.Optional(
-            CONF_STATE_SAVE_INTERVAL, default="6hours"
-        ): cv.positive_time_period_minutes,
-    },
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(BME680BSECComponent),
+            cv.Optional(CONF_TEMPERATURE_OFFSET, default=0): cv.temperature,
+            cv.Optional(CONF_IAQ_MODE, default="STATIC"): cv.enum(
+                IAQ_MODE_OPTIONS, upper=True
+            ),
+            cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
+                SAMPLE_RATE_OPTIONS, upper=True
+            ),
+            cv.Optional(
+                CONF_STATE_SAVE_INTERVAL, default="6hours"
+            ): cv.positive_time_period_minutes,
+        }
+    ).extend(i2c.i2c_device_schema(0x76)),
     cv.only_with_arduino,
-).extend(i2c.i2c_device_schema(0x76))
+    esp32.only_on_variant(supported=[esp32.const.VARIANT_ESP32]),
+)
 
 
 async def to_code(config):
@@ -62,9 +65,6 @@ async def to_code(config):
     cg.add(
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
     )
-
-    # Although this component does not use SPI, the BSEC library requires the SPI library
-    cg.add_library("SPI", None)
 
     cg.add_define("USE_BSEC")
     cg.add_library("boschsensortec/BSEC Software Library", "1.6.1480")

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -4,7 +4,7 @@ from esphome.components import i2c, esp32
 from esphome.const import CONF_ID
 
 CODEOWNERS = ["@trvrnrth"]
-DEPENDENCIES = ["i2c", "spi"]
+DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["sensor", "text_sensor"]
 MULTI_CONF = True
 
@@ -69,5 +69,6 @@ async def to_code(config):
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
     )
 
+    cg.add_library("SPI", None)
     cg.add_define("USE_BSEC")
     cg.add_library("boschsensortec/BSEC Software Library", "1.6.1480")

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -69,6 +69,8 @@ async def to_code(config):
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
     )
 
+    # Although this component does not use SPI, the BSEC library requires the SPI library
     cg.add_library("SPI", None)
+
     cg.add_define("USE_BSEC")
     cg.add_library("boschsensortec/BSEC Software Library", "1.6.1480")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This fixes the restriction requiring Arduino and also introduces a new restriction that only allows on ESP8266 or ESP32 (no ESP32 variants) as @ssieb did a simple compile test and found it does not compile for them without further changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
