### PR TITLE
Lower range of CONF_FREQUENCY

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -156,7 +156,7 @@ CONFIG_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
             {
                 cv.Required(CONF_PIN): pins.internal_gpio_input_pin_number,
                 cv.Optional(CONF_FREQUENCY, default="20MHz"): cv.All(
-                    cv.frequency, cv.Range(min=10e6, max=20e6)
+                    cv.frequency, cv.Range(min=8e6, max=20e6)
                 ),
             }
         ),


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
~-[ ] New feature (non-breaking change which adds functionality)~
~ -[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~
~- [ ] Other~

**Related issue or feature (if applicable):** fixes <link to issue>
[esp32_camera not working with 10/20MHZ, only 8MHZ](https://github.com/esphome/issues/issues/4191)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_camera:
  name: MyCam
  external_clock:
    pin: GPIO0
    frequency: 8MHz <-- This line
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
