### PR TITLE
feat: Add support to unsubscribe from BLE advertisements

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1365,5 +1365,4 @@ message BluetoothDeviceUnpairingResponse {
 message UnsubscribeBluetoothLEAdvertisementsRequest {
   option (id) = 87;
   option (source) = SOURCE_CLIENT;
-  option (ifdef) = "USE_BLUETOOTH_PROXY";
 }

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -53,6 +53,8 @@ service APIConnection {
   rpc bluetooth_gatt_write_descriptor(BluetoothGATTWriteDescriptorRequest) returns (void) {}
   rpc bluetooth_gatt_notify(BluetoothGATTNotifyRequest) returns (void) {}
   rpc subscribe_bluetooth_connections_free(SubscribeBluetoothConnectionsFreeRequest) returns (BluetoothConnectionsFreeResponse) {}
+  rpc unsubscribe_bluetooth_le_advertisements(UnsubscribeBluetoothLEAdvertisementsRequest) returns (void) {}
+
 }
 
 
@@ -1358,4 +1360,10 @@ message BluetoothDeviceUnpairingResponse {
   uint64 address = 1;
   bool success = 2;
   int32 error = 3;
+}
+
+message UnsubscribeBluetoothLEAdvertisementsRequest {
+  option (id) = 87;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
 }

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -153,6 +153,9 @@ class APIConnection : public APIServerConnection {
   void subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) override {
     this->bluetooth_le_advertisement_subscription_ = true;
   }
+  void unsubscribe_bluetooth_le_advertisements(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) override {
+    this->bluetooth_le_advertisement_subscription_ = false;
+  }
   bool is_authenticated() override { return this->connection_state_ == ConnectionState::AUTHENTICATED; }
   bool is_connection_setup() override {
     return this->connection_state_ == ConnectionState ::CONNECTED || this->is_authenticated();

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -6060,6 +6060,12 @@ void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+void UnsubscribeBluetoothLEAdvertisementsRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
+  out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
+}
+#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1554,6 +1554,15 @@ class BluetoothDeviceUnpairingResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -806,14 +806,12 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       break;
     }
     case 87: {
-#ifdef USE_BLUETOOTH_PROXY
       UnsubscribeBluetoothLEAdvertisementsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump().c_str());
 #endif
       this->on_unsubscribe_bluetooth_le_advertisements_request(msg);
-#endif
       break;
     }
     default:
@@ -1196,7 +1194,6 @@ void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
   }
 }
 #endif
-#ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_unsubscribe_bluetooth_le_advertisements_request(
     const UnsubscribeBluetoothLEAdvertisementsRequest &msg) {
   if (!this->is_connection_setup()) {
@@ -1209,7 +1206,6 @@ void APIServerConnection::on_unsubscribe_bluetooth_le_advertisements_request(
   }
   this->unsubscribe_bluetooth_le_advertisements(msg);
 }
-#endif
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -805,6 +805,17 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #endif
       break;
     }
+    case 87: {
+#ifdef USE_BLUETOOTH_PROXY
+      UnsubscribeBluetoothLEAdvertisementsRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump().c_str());
+#endif
+      this->on_unsubscribe_bluetooth_le_advertisements_request(msg);
+#endif
+      break;
+    }
     default:
       return false;
   }
@@ -1183,6 +1194,20 @@ void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
   if (!this->send_bluetooth_connections_free_response(ret)) {
     this->on_fatal_error();
   }
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_unsubscribe_bluetooth_le_advertisements_request(
+    const UnsubscribeBluetoothLEAdvertisementsRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->unsubscribe_bluetooth_le_advertisements(msg);
 }
 #endif
 

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -216,10 +216,9 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_BLUETOOTH_PROXY
   bool send_bluetooth_device_unpairing_response(const BluetoothDeviceUnpairingResponse &msg);
 #endif
-#ifdef USE_BLUETOOTH_PROXY
   virtual void on_unsubscribe_bluetooth_le_advertisements_request(
       const UnsubscribeBluetoothLEAdvertisementsRequest &value){};
-#endif
+
  protected:
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
 };
@@ -297,9 +296,8 @@ class APIServerConnection : public APIServerConnectionBase {
   virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(
       const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
 #endif
-#ifdef USE_BLUETOOTH_PROXY
   virtual void unsubscribe_bluetooth_le_advertisements(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) = 0;
-#endif
+
  protected:
   void on_hello_request(const HelloRequest &msg) override;
   void on_connect_request(const ConnectRequest &msg) override;
@@ -371,9 +369,8 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_BLUETOOTH_PROXY
   void on_subscribe_bluetooth_connections_free_request(const SubscribeBluetoothConnectionsFreeRequest &msg) override;
 #endif
-#ifdef USE_BLUETOOTH_PROXY
-  void on_unsubscribe_bluetooth_le_advertisements_request(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) override;
-#endif
+  void on_unsubscribe_bluetooth_le_advertisements_request(
+      const UnsubscribeBluetoothLEAdvertisementsRequest &msg) override;
 };
 
 }  // namespace api

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -216,6 +216,10 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_BLUETOOTH_PROXY
   bool send_bluetooth_device_unpairing_response(const BluetoothDeviceUnpairingResponse &msg);
 #endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_unsubscribe_bluetooth_le_advertisements_request(
+      const UnsubscribeBluetoothLEAdvertisementsRequest &value){};
+#endif
  protected:
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
 };
@@ -293,6 +297,9 @@ class APIServerConnection : public APIServerConnectionBase {
   virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(
       const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
 #endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void unsubscribe_bluetooth_le_advertisements(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) = 0;
+#endif
  protected:
   void on_hello_request(const HelloRequest &msg) override;
   void on_connect_request(const ConnectRequest &msg) override;
@@ -363,6 +370,9 @@ class APIServerConnection : public APIServerConnectionBase {
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   void on_subscribe_bluetooth_connections_free_request(const SubscribeBluetoothConnectionsFreeRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_unsubscribe_bluetooth_le_advertisements_request(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) override;
 #endif
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Adds support to unsubscribe from BLE advertisements. At the moment after subscribing, the messages will be sent over the API connection even if they are ignored by the client.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
