### PR TITLE
Add ability to clear the gatt cache

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1156,6 +1156,7 @@ enum BluetoothDeviceRequestType {
   BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR = 3;
   BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE = 4;
   BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE = 5;
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE = 6;
 }
 
 message BluetoothDeviceRequest {
@@ -1352,6 +1353,16 @@ message BluetoothDevicePairingResponse {
 
 message BluetoothDeviceUnpairingResponse {
   option (id) = 86;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  bool success = 2;
+  int32 error = 3;
+}
+
+message BluetoothDeviceClearCacheResponse {
+  option (id) = 87;
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_BLUETOOTH_PROXY";
 

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1362,7 +1362,7 @@ message BluetoothDeviceUnpairingResponse {
 }
 
 message BluetoothDeviceClearCacheResponse {
-  option (id) = 87;
+  option (id) = 88;
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_BLUETOOTH_PROXY";
 

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -953,7 +953,9 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.webserver_port = USE_WEBSERVER_PORT;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  resp.bluetooth_proxy_version = bluetooth_proxy::global_bluetooth_proxy->has_active() ? 5 : 1;
+  resp.bluetooth_proxy_version = bluetooth_proxy::global_bluetooth_proxy->has_active()
+                                     ? bluetooth_proxy::ACTIVE_CONNECTIONS_VERSION
+                                     : bluetooth_proxy::PASSIVE_ONLY_VERSION;
 #endif
   return resp;
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -953,7 +953,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.webserver_port = USE_WEBSERVER_PORT;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  resp.bluetooth_proxy_version = bluetooth_proxy::global_bluetooth_proxy->has_active() ? 4 : 1;
+  resp.bluetooth_proxy_version = bluetooth_proxy::global_bluetooth_proxy->has_active() ? 5 : 1;
 #endif
   return resp;
 }

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -74,7 +74,7 @@ const char *api_error_to_str(APIError err) {
 
 #define HELPER_LOG(msg, ...) ESP_LOGVV(TAG, "%s: " msg, info_.c_str(), ##__VA_ARGS__)
 // uncomment to log raw packets
-// #define HELPER_LOG_PACKETS
+//#define HELPER_LOG_PACKETS
 
 #ifdef USE_API_NOISE
 static const char *const PROLOGUE_INIT = "NoiseAPIInit";

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -74,7 +74,7 @@ const char *api_error_to_str(APIError err) {
 
 #define HELPER_LOG(msg, ...) ESP_LOGVV(TAG, "%s: " msg, info_.c_str(), ##__VA_ARGS__)
 // uncomment to log raw packets
-//#define HELPER_LOG_PACKETS
+// #define HELPER_LOG_PACKETS
 
 #ifdef USE_API_NOISE
 static const char *const PROLOGUE_INIT = "NoiseAPIInit";

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -385,8 +385,7 @@ template<> const char *proto_enum_to_string<enums::MediaPlayerCommand>(enums::Me
 }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-template<>
-const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::BluetoothDeviceRequestType value) {
+template<> const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::BluetoothDeviceRequestType value) {
   switch (value) {
     case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT:
       return "BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT";
@@ -400,6 +399,8 @@ const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::Bluet
       return "BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE";
     case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE:
       return "BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE";
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE";
     default:
       return "UNKNOWN";
   }
@@ -6044,6 +6045,49 @@ void BluetoothDeviceUnpairingResponse::encode(ProtoWriteBuffer buffer) const {
 void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceUnpairingResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  success: ");
+  out.append(YESNO(this->success));
+  out.append("\n");
+
+  out.append("  error: ");
+  sprintf(buffer, "%d", this->error);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothDeviceClearCacheResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->success = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->error = value.as_int32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothDeviceClearCacheResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_bool(2, this->success);
+  buffer.encode_int32(3, this->error);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothDeviceClearCacheResponse {\n");
   out.append("  address: ");
   sprintf(buffer, "%llu", this->address);
   out.append(buffer);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -385,7 +385,8 @@ template<> const char *proto_enum_to_string<enums::MediaPlayerCommand>(enums::Me
 }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-template<> const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::BluetoothDeviceRequestType value) {
+template<>
+const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::BluetoothDeviceRequestType value) {
   switch (value) {
     case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT:
       return "BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT";

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -163,6 +163,7 @@ enum BluetoothDeviceRequestType : uint32_t {
   BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR = 3,
   BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE = 4,
   BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE = 5,
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE = 6,
 };
 
 }  // namespace enums
@@ -1542,6 +1543,19 @@ class BluetoothDevicePairingResponse : public ProtoMessage {
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothDeviceUnpairingResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  bool success{false};
+  int32_t error{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothDeviceClearCacheResponse : public ProtoMessage {
  public:
   uint64_t address{0};
   bool success{false};

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -446,7 +446,7 @@ bool APIServerConnectionBase::send_bluetooth_device_clear_cache_response(const B
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_bluetooth_device_clear_cache_response: %s", msg.dump().c_str());
 #endif
-  return this->send_message_<BluetoothDeviceClearCacheResponse>(msg, 87);
+  return this->send_message_<BluetoothDeviceClearCacheResponse>(msg, 88);
 }
 #endif
 bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -185,7 +185,8 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
 #endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
+    const SubscribeHomeAssistantStateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
 #endif
@@ -356,7 +357,8 @@ bool APIServerConnectionBase::send_bluetooth_gatt_get_services_response(const Bl
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-bool APIServerConnectionBase::send_bluetooth_gatt_get_services_done_response(const BluetoothGATTGetServicesDoneResponse &msg) {
+bool APIServerConnectionBase::send_bluetooth_gatt_get_services_done_response(
+    const BluetoothGATTGetServicesDoneResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_bluetooth_gatt_get_services_done_response: %s", msg.dump().c_str());
 #endif
@@ -884,7 +886,8 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(
+    const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;
@@ -1070,7 +1073,8 @@ void APIServerConnection::on_media_player_command_request(const MediaPlayerComma
   this->media_player_command(msg);
 }
 #endif
-void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
+void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
+    const SubscribeBluetoothLEAdvertisementsRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;
@@ -1173,7 +1177,8 @@ void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNo
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-void APIServerConnection::on_subscribe_bluetooth_connections_free_request(const SubscribeBluetoothConnectionsFreeRequest &msg) {
+void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
+    const SubscribeBluetoothConnectionsFreeRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -185,8 +185,7 @@ bool APIServerConnectionBase::send_homeassistant_service_response(const Homeassi
 #endif
   return this->send_message_<HomeassistantServiceResponse>(msg, 35);
 }
-bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(
-    const SubscribeHomeAssistantStateResponse &msg) {
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
 #endif
@@ -357,8 +356,7 @@ bool APIServerConnectionBase::send_bluetooth_gatt_get_services_response(const Bl
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-bool APIServerConnectionBase::send_bluetooth_gatt_get_services_done_response(
-    const BluetoothGATTGetServicesDoneResponse &msg) {
+bool APIServerConnectionBase::send_bluetooth_gatt_get_services_done_response(const BluetoothGATTGetServicesDoneResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_bluetooth_gatt_get_services_done_response: %s", msg.dump().c_str());
 #endif
@@ -439,6 +437,14 @@ bool APIServerConnectionBase::send_bluetooth_device_unpairing_response(const Blu
   ESP_LOGVV(TAG, "send_bluetooth_device_unpairing_response: %s", msg.dump().c_str());
 #endif
   return this->send_message_<BluetoothDeviceUnpairingResponse>(msg, 86);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_device_clear_cache_response(const BluetoothDeviceClearCacheResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_device_clear_cache_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothDeviceClearCacheResponse>(msg, 87);
 }
 #endif
 bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
@@ -878,8 +884,7 @@ void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &
   }
   this->subscribe_logs(msg);
 }
-void APIServerConnection::on_subscribe_homeassistant_services_request(
-    const SubscribeHomeassistantServicesRequest &msg) {
+void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;
@@ -1065,8 +1070,7 @@ void APIServerConnection::on_media_player_command_request(const MediaPlayerComma
   this->media_player_command(msg);
 }
 #endif
-void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
-    const SubscribeBluetoothLEAdvertisementsRequest &msg) {
+void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;
@@ -1169,8 +1173,7 @@ void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNo
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
-    const SubscribeBluetoothConnectionsFreeRequest &msg) {
+void APIServerConnection::on_subscribe_bluetooth_connections_free_request(const SubscribeBluetoothConnectionsFreeRequest &msg) {
   if (!this->is_connection_setup()) {
     this->on_no_setup_connection();
     return;

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -154,8 +154,7 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_MEDIA_PLAYER
   virtual void on_media_player_command_request(const MediaPlayerCommandRequest &value){};
 #endif
-  virtual void on_subscribe_bluetooth_le_advertisements_request(
-      const SubscribeBluetoothLEAdvertisementsRequest &value){};
+  virtual void on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &value){};
 #ifdef USE_BLUETOOTH_PROXY
   bool send_bluetooth_le_advertisement_response(const BluetoothLEAdvertisementResponse &msg);
 #endif
@@ -215,6 +214,9 @@ class APIServerConnectionBase : public ProtoService {
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   bool send_bluetooth_device_unpairing_response(const BluetoothDeviceUnpairingResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_device_clear_cache_response(const BluetoothDeviceClearCacheResponse &msg);
 #endif
  protected:
   bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
@@ -290,8 +292,7 @@ class APIServerConnection : public APIServerConnectionBase {
   virtual void bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg) = 0;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(
-      const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
+  virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
 #endif
  protected:
   void on_hello_request(const HelloRequest &msg) override;

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -154,7 +154,8 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_MEDIA_PLAYER
   virtual void on_media_player_command_request(const MediaPlayerCommandRequest &value){};
 #endif
-  virtual void on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &value){};
+  virtual void on_subscribe_bluetooth_le_advertisements_request(
+      const SubscribeBluetoothLEAdvertisementsRequest &value){};
 #ifdef USE_BLUETOOTH_PROXY
   bool send_bluetooth_le_advertisement_response(const BluetoothLEAdvertisementResponse &msg);
 #endif
@@ -292,7 +293,8 @@ class APIServerConnection : public APIServerConnectionBase {
   virtual void bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg) = 0;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
+  virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(
+      const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
 #endif
  protected:
   void on_hello_request(const HelloRequest &msg) override;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -331,7 +331,7 @@ void APIServer::send_bluetooth_device_unpairing(uint64_t address, bool success, 
   }
 }
 
-void APIServer::send_bluetooth_clear_cache(uint64_t address, bool success, esp_err_t error) {
+void APIServer::send_bluetooth_device_clear_cache(uint64_t address, bool success, esp_err_t error) {
   BluetoothDeviceClearCacheResponse call;
   call.address = address;
   call.success = success;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -331,6 +331,17 @@ void APIServer::send_bluetooth_device_unpairing(uint64_t address, bool success, 
   }
 }
 
+void APIServer::send_bluetooth_clear_cache(uint64_t address, bool success, esp_err_t error) {
+  BluetoothDeviceClearCacheResponse call;
+  call.address = address;
+  call.success = success;
+  call.error = error;
+
+  for (auto &client : this->clients_) {
+    client->send_bluetooth_device_clear_cache_response(call);
+  }
+}
+
 void APIServer::send_bluetooth_connections_free(uint8_t free, uint8_t limit) {
   BluetoothConnectionsFreeResponse call;
   call.free = free;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -80,6 +80,7 @@ class APIServer : public Component, public Controller {
   void send_bluetooth_device_connection(uint64_t address, bool connected, uint16_t mtu = 0, esp_err_t error = ESP_OK);
   void send_bluetooth_device_pairing(uint64_t address, bool paired, esp_err_t error = ESP_OK);
   void send_bluetooth_device_unpairing(uint64_t address, bool success, esp_err_t error = ESP_OK);
+  void send_bluetooth_device_clear_cache(uint64_t address, bool success, esp_err_t error = ESP_OK);
   void send_bluetooth_connections_free(uint8_t free, uint8_t limit);
   void send_bluetooth_gatt_read_response(const BluetoothGATTReadResponse &call);
   void send_bluetooth_gatt_write_response(const BluetoothGATTWriteResponse &call);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -310,7 +310,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
       esp_bd_addr_t address;
       uint64_to_bd_addr(msg.address, address);
       esp_err_t err = esp_ble_gattc_cache_clean(address);
-      api::global_api_server->send_bluetooth_device_clear_cache(msg.address, ret == ESP_OK, err);
+      api::global_api_server->send_bluetooth_device_clear_cache(msg.address, err == ESP_OK, err);
       break;
     }
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -309,8 +309,8 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE: {
       esp_bd_addr_t address;
       uint64_to_bd_addr(msg.address, address);
-      esp_err_t err = esp_ble_gattc_cache_clean(address);
-      api::global_api_server->send_bluetooth_device_clear_cache(msg.address, err == ESP_OK, err);
+      esp_err_t ret = esp_ble_gattc_cache_clean(address);
+      api::global_api_server->send_bluetooth_device_clear_cache(msg.address, ret == ESP_OK, ret);
       break;
     }
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -309,7 +309,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE: {
       esp_bd_addr_t address;
       uint64_to_bd_addr(msg.address, address);
-      esp_err_t ret = esp_ble_gattc_cache_clean(this->remote_bda_);
+      esp_err_t ret = esp_ble_gattc_cache_clean(address);
       api::global_api_server->send_bluetooth_device_clear_cache(msg.address, ret == ESP_OK, err);
       break;
     }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -306,6 +306,13 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
       api::global_api_server->send_bluetooth_device_unpairing(msg.address, ret == ESP_OK, ret);
       break;
     }
+    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE: {
+      esp_bd_addr_t address;
+      uint64_to_bd_addr(msg.address, address);
+      esp_err_t ret = esp_ble_gattc_cache_clean(this->remote_bda_);
+      api::global_api_server->send_bluetooth_device_clear_cache(msg.address, ret == ESP_OK, err);
+      break;
+    }
   }
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -309,7 +309,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE: {
       esp_bd_addr_t address;
       uint64_to_bd_addr(msg.address, address);
-      esp_err_t ret = esp_ble_gattc_cache_clean(address);
+      esp_err_t err = esp_ble_gattc_cache_clean(address);
       api::global_api_server->send_bluetooth_device_clear_cache(msg.address, ret == ESP_OK, err);
       break;
     }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -68,6 +68,14 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
 
 extern BluetoothProxy *global_bluetooth_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+// Version 1: Initial version without active connections
+// Version 2: Support for active connections
+// Version 3: New connection API
+// Version 4: Pairing support
+// Version 5: Cache clear support
+static const uint32_t ACTIVE_CONNECTIONS_VERSION = 5;
+static const uint32_t PASSIVE_ONLY_VERSION = 1;
+
 }  // namespace bluetooth_proxy
 }  // namespace esphome
 


### PR DESCRIPTION


# What does this implement/fix?

With BlueZ we can fully clear the cache when something goes wrong with the services, however since this is also a cache on the ESP32 we need to be able to clear the on device cache as well for the proxies since if something goes wrong with the service resolution it can cache the bad resolution on NVS forever.

Our current client implementation is limited to clearing the memory cache in Home Assistant https://github.com/home-assistant/core/blob/89355e087952417a6824507fd3b197f9d0520e19/homeassistant/components/esphome/bluetooth/client.py#L512

related issue https://github.com/esphome/issues/issues/4156

https://github.com/esphome/aioesphomeapi/pull/410

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
