### PR TITLE
Require step to be set when calling register_number

### DIFF
--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -204,14 +204,13 @@ def number_schema(
 
 
 async def setup_number_core_(
-    var, config, *, min_value: float, max_value: float, step: Optional[float]
+    var, config, *, min_value: float, max_value: float, step: float
 ):
     await setup_entity(var, config)
 
     cg.add(var.traits.set_min_value(min_value))
     cg.add(var.traits.set_max_value(max_value))
-    if step is not None:
-        cg.add(var.traits.set_step(step))
+    cg.add(var.traits.set_step(step))
 
     cg.add(var.traits.set_mode(config[CONF_MODE]))
 
@@ -239,7 +238,7 @@ async def setup_number_core_(
 
 
 async def register_number(
-    var, config, *, min_value: float, max_value: float, step: Optional[float] = None
+    var, config, *, min_value: float, max_value: float, step: float
 ):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

THis is a breaking change for any custom components that create a `number` and did not specify the `step` argument. Internal component have always specified the `step`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
