### PR TITLE
Keep Device Class in Flash.

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -43,12 +43,7 @@ void BinarySensor::send_state_internal(bool state, bool is_initial) {
 }
 
 BinarySensor::BinarySensor() : state(false) {}
-void BinarySensor::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
-std::string BinarySensor::get_device_class() {
-  if (this->device_class_.has_value())
-    return *this->device_class_;
-  return "";
-}
+
 void BinarySensor::add_filter(Filter *filter) {
   filter->parent_ = this;
   if (this->filter_list_ == nullptr) {

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -34,7 +34,7 @@ namespace binary_sensor {
  * The sub classes should notify the front-end of new states via the publish_state() method which
  * handles inverted inputs for you.
  */
-class BinarySensor : public EntityBase {
+class BinarySensor : public EntityBase, public EntityBase_DeviceClass {
  public:
   explicit BinarySensor();
 
@@ -60,12 +60,6 @@ class BinarySensor : public EntityBase {
   /// The current reported state of the binary sensor.
   bool state;
 
-  /// Manually set the Home Assistant device class (see binary_sensor::device_class)
-  void set_device_class(const std::string &device_class);
-
-  /// Get the device class for this binary sensor, using the manual override if specified.
-  std::string get_device_class();
-
   void add_filter(Filter *filter);
   void add_filters(const std::vector<Filter *> &filters);
 
@@ -82,7 +76,6 @@ class BinarySensor : public EntityBase {
 
  protected:
   CallbackManager<void(bool)> state_callback_{};
-  optional<std::string> device_class_{};  ///< Stores the override of the device class
   Filter *filter_list_{nullptr};
   bool has_state_{false};
   bool publish_initial_state_{false};

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -13,8 +13,5 @@ void Button::press() {
 }
 void Button::add_on_press_callback(std::function<void()> &&callback) { this->press_callback_.add(std::move(callback)); }
 
-void Button::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
-std::string Button::get_device_class() { return this->device_class_; }
-
 }  // namespace button
 }  // namespace esphome

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -26,7 +26,7 @@ namespace button {
  *
  * A button is just a momentary switch that does not have a state, only a trigger.
  */
-class Button : public EntityBase {
+class Button : public EntityBase, public EntityBase_DeviceClass {
  public:
   /** Press this button. This is called by the front-end.
    *
@@ -40,19 +40,12 @@ class Button : public EntityBase {
    */
   void add_on_press_callback(std::function<void()> &&callback);
 
-  /// Set the Home Assistant device class (see button::device_class).
-  void set_device_class(const std::string &device_class);
-
-  /// Get the device class for this button.
-  std::string get_device_class();
-
  protected:
   /** You should implement this virtual method if you want to create your own button.
    */
   virtual void press_action() = 0;
 
   CallbackManager<void()> press_callback_{};
-  std::string device_class_{};
 };
 
 }  // namespace button

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -145,7 +145,7 @@ CoverCall &CoverCall::set_stop(bool stop) {
   return *this;
 }
 bool CoverCall::get_stop() const { return this->stop_; }
-void Cover::set_device_class(const std::string &device_class) { this->device_class_override_ = device_class; }
+
 CoverCall Cover::make_call() { return {this}; }
 void Cover::open() {
   auto call = this->make_call();
@@ -204,11 +204,7 @@ optional<CoverRestoreState> Cover::restore_state_() {
     return {};
   return recovered;
 }
-std::string Cover::get_device_class() {
-  if (this->device_class_override_.has_value())
-    return *this->device_class_override_;
-  return "";
-}
+
 bool Cover::is_fully_open() const { return this->position == COVER_OPEN; }
 bool Cover::is_fully_closed() const { return this->position == COVER_CLOSED; }
 

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -108,7 +108,7 @@ const char *cover_operation_to_str(CoverOperation op);
  * to control all values of the cover. Also implement get_traits() to return what operations
  * the cover supports.
  */
-class Cover : public EntityBase {
+class Cover : public EntityBase, public EntityBase_DeviceClass {
  public:
   explicit Cover();
 
@@ -156,8 +156,6 @@ class Cover : public EntityBase {
   void publish_state(bool save = true);
 
   virtual CoverTraits get_traits() = 0;
-  void set_device_class(const std::string &device_class);
-  std::string get_device_class();
 
   /// Helper method to check if the cover is fully open. Equivalent to comparing .position against 1.0
   bool is_fully_open() const;
@@ -172,7 +170,6 @@ class Cover : public EntityBase {
   optional<CoverRestoreState> restore_state_();
 
   CallbackManager<void()> state_callback_{};
-  optional<std::string> device_class_override_{};
 
   ESPPreferenceObject rtc_;
 };

--- a/esphome/components/number/number_traits.cpp
+++ b/esphome/components/number/number_traits.cpp
@@ -16,13 +16,5 @@ std::string NumberTraits::get_unit_of_measurement() {
   return "";
 }
 
-void NumberTraits::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
-
-std::string NumberTraits::get_device_class() {
-  if (this->device_class_.has_value())
-    return *this->device_class_;
-  return "";
-}
-
 }  // namespace number
 }  // namespace esphome

--- a/esphome/components/number/number_traits.h
+++ b/esphome/components/number/number_traits.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome {
@@ -11,7 +12,7 @@ enum NumberMode : uint8_t {
   NUMBER_MODE_SLIDER = 2,
 };
 
-class NumberTraits {
+class NumberTraits : public EntityBase_DeviceClass {
  public:
   // Set/get the number value boundaries.
   void set_min_value(float min_value) { min_value_ = min_value; }
@@ -32,17 +33,12 @@ class NumberTraits {
   void set_mode(NumberMode mode) { this->mode_ = mode; }
   NumberMode get_mode() const { return this->mode_; }
 
-  // Set/get the device class.
-  void set_device_class(const std::string &device_class);
-  std::string get_device_class();
-
  protected:
   float min_value_ = NAN;
   float max_value_ = NAN;
   float step_ = NAN;
   optional<std::string> unit_of_measurement_;  ///< Unit of measurement override
   NumberMode mode_{NUMBER_MODE_AUTO};
-  optional<std::string> device_class_;
 };
 
 }  // namespace number

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -38,13 +38,6 @@ int8_t Sensor::get_accuracy_decimals() {
 }
 void Sensor::set_accuracy_decimals(int8_t accuracy_decimals) { this->accuracy_decimals_ = accuracy_decimals; }
 
-std::string Sensor::get_device_class() {
-  if (this->device_class_.has_value())
-    return *this->device_class_;
-  return "";
-}
-void Sensor::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
-
 void Sensor::set_state_class(StateClass state_class) { this->state_class_ = state_class; }
 StateClass Sensor::get_state_class() {
   if (this->state_class_.has_value())

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -54,7 +54,7 @@ std::string state_class_to_string(StateClass state_class);
  *
  * A sensor has unit of measurement and can use publish_state to send out a new value with the specified accuracy.
  */
-class Sensor : public EntityBase {
+class Sensor : public EntityBase, public EntityBase_DeviceClass {
  public:
   explicit Sensor();
 
@@ -68,10 +68,6 @@ class Sensor : public EntityBase {
   /// Manually set the accuracy in decimals.
   void set_accuracy_decimals(int8_t accuracy_decimals);
 
-  /// Get the device class, using the manual override if set.
-  std::string get_device_class();
-  /// Manually set the device class.
-  void set_device_class(const std::string &device_class);
 
   /// Get the state class, using the manual override if set.
   StateClass get_state_class();
@@ -166,7 +162,6 @@ class Sensor : public EntityBase {
 
   optional<std::string> unit_of_measurement_;           ///< Unit of measurement override
   optional<int8_t> accuracy_decimals_;                  ///< Accuracy in decimals override
-  optional<std::string> device_class_;                  ///< Device class override
   optional<StateClass> state_class_{STATE_CLASS_NONE};  ///< State class override
   bool force_update_{false};                            ///< Force update mode
 };

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -68,7 +68,6 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass {
   /// Manually set the accuracy in decimals.
   void set_accuracy_decimals(int8_t accuracy_decimals);
 
-
   /// Get the state class, using the manual override if set.
   StateClass get_state_class();
   /// Manually set the state class.

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -63,13 +63,6 @@ void Switch::add_on_state_callback(std::function<void(bool)> &&callback) {
 void Switch::set_inverted(bool inverted) { this->inverted_ = inverted; }
 bool Switch::is_inverted() const { return this->inverted_; }
 
-std::string Switch::get_device_class() {
-  if (this->device_class_.has_value())
-    return *this->device_class_;
-  return "";
-}
-void Switch::set_device_class(const std::string &device_class) { this->device_class_ = device_class; }
-
 void log_switch(const char *tag, const char *prefix, const char *type, Switch *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -29,7 +29,7 @@ enum SwitchRestoreMode {
  * A switch is basically just a combination of a binary sensor (for reporting switch values)
  * and a write_state method that writes a state to the hardware.
  */
-class Switch : public EntityBase {
+class Switch : public EntityBase, public EntityBase_DeviceClass {
  public:
   explicit Switch();
 
@@ -103,10 +103,6 @@ class Switch : public EntityBase {
 
   bool is_inverted() const;
 
-  /// Get the device class for this switch.
-  std::string get_device_class();
-  /// Set the Home Assistant device class for this switch.
-  void set_device_class(const std::string &device_class);
   void set_restore_mode(SwitchRestoreMode restore_mode) { this->restore_mode = restore_mode; }
 
  protected:
@@ -124,7 +120,6 @@ class Switch : public EntityBase {
   bool inverted_{false};
   Deduplicator<bool> publish_dedup_;
   ESPPreferenceObject rtc_;
-  optional<std::string> device_class_;
 };
 
 #define LOG_SWITCH(prefix, type, obj) log_switch((TAG), (prefix), LOG_STR_LITERAL(type), (obj))

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -72,6 +72,16 @@ void EntityBase::calc_object_id_() {
     this->object_id_hash_ = fnv1_hash(this->object_id_c_str_);
   }
 }
+
 uint32_t EntityBase::get_object_id_hash() { return this->object_id_hash_; }
+
+std::string EntityBase_DeviceClass::get_device_class() {
+  if (this->device_class_ == nullptr) {
+    return "";
+  }
+  return this->device_class_;
+}
+
+void EntityBase_DeviceClass::set_device_class(const char *device_class) { this->device_class_ = device_class; }
 
 }  // namespace esphome

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -63,4 +63,15 @@ class EntityBase {
   EntityCategory entity_category_{ENTITY_CATEGORY_NONE};
 };
 
+class EntityBase_DeviceClass {
+ public:
+  /// Get the device class, using the manual override if set.
+  std::string get_device_class();
+  /// Manually set the device class.
+  void set_device_class(const char *device_class);
+
+ protected:
+  const char *device_class_{nullptr};  ///< Device class override
+};
+
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Reduce memory consumption by keeping `device_class_` in Flash instead of copying to memory. Each Device Class field uses 24-28 bytes (depending if optional or only string).
Introducing a new base class `EntityBase_DeviceClass` for storing and accessing Device class.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
