### PR TITLE
SHT21 from Sensirion needs longer delay

### DIFF
--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -40,7 +40,7 @@ void HTU21DComponent::update() {
     this->status_set_warning();
     return;
   }
-  delay(50);  // NOLINT
+  delay(80);  // NOLINT
   if (this->read(reinterpret_cast<uint8_t *>(&raw_temperature), 2) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
@@ -54,7 +54,7 @@ void HTU21DComponent::update() {
     this->status_set_warning();
     return;
   }
-  delay(50);  // NOLINT
+  delay(80);  // NOLINT
   if (this->read(reinterpret_cast<uint8_t *>(&raw_humidity), 2) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;


### PR DESCRIPTION
SHT21 from Sensirion does not work with delay 50 but works with 80. HTU21 works with both.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
