### PR TITLE
Add support for kamstrup serial protocol.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,6 +122,7 @@ esphome/components/internal_temperature/* @Mat931
 esphome/components/interval/* @esphome/core
 esphome/components/json/* @OttoWinter
 esphome/components/kalman_combinator/* @Cat-Ion
+esphome/components/kamstrup/* @middelink
 esphome/components/key_collector/* @ssieb
 esphome/components/key_provider/* @ssieb
 esphome/components/kuntze/* @ssieb

--- a/esphome/components/kamstrup/__init__.py
+++ b/esphome/components/kamstrup/__init__.py
@@ -1,0 +1,53 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import (
+    CONF_ID,
+    CONF_RECEIVE_TIMEOUT,
+)
+
+CODEOWNERS = ["@middelink"]
+
+MULTI_CONF = True
+
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["sensor", "text_sensor"]
+
+CONF_KAMSTRUP_ID = "kamstrup_id"
+CONF_BUNDLE_REQUESTS = "bundle_requests"
+
+kamstrup_ns = cg.esphome_ns.namespace("kamstrup")
+Kamstrup = kamstrup_ns.class_("Kamstrup", cg.PollingComponent, uart.UARTDevice)
+
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Kamstrup),
+            cv.Optional(CONF_BUNDLE_REQUESTS): cv.uint8_t,
+            cv.Optional(
+                CONF_RECEIVE_TIMEOUT, default="2s"
+            ): cv.positive_time_period_milliseconds,
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.polling_component_schema("1h"))
+)
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "kamstrup",
+    baud_rate=1200,
+    require_tx=True,
+    require_rx=True,
+    parity=None,
+    stop_bits=2,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    cg.add(var.set_receive_timeout(config[CONF_RECEIVE_TIMEOUT].total_milliseconds))
+    if CONF_BUNDLE_REQUESTS in config:
+        cg.add(var.set_bundle_requests(config[CONF_BUNDLE_REQUESTS]))

--- a/esphome/components/kamstrup/kamstrup.cpp
+++ b/esphome/components/kamstrup/kamstrup.cpp
@@ -1,0 +1,275 @@
+#include "kamstrup.h"
+#include "esphome/core/log.h"
+
+#include <algorithm>
+
+/*
+ * As the Kamstrup meter communicates in 1200 baud with long data packages,
+ * we cannot simply wait for the bytes to arrive, instead we read and process
+ * the bytes as they becomes available.
+ */
+
+namespace esphome {
+namespace kamstrup {
+
+static const char TAG[] = "kamstrup";
+
+void Kamstrup::dump_config() {
+  ESP_LOGCONFIG(TAG, "Kamstrup device");
+  ESP_LOGCONFIG(TAG, "  Receive timeout: %.1fs", this->receive_timeout_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Bundle requests: %d", this->bundle_requests_);
+  LOG_UPDATE_INTERVAL(this);
+
+  for (const auto& kv : this->sensors_) {
+    LOG_SENSOR("  ", "Sensor", kv.second);
+    ESP_LOGCONFIG(TAG, "    Register: %d (0x%04x)", kv.first, kv.first);
+  }
+}
+
+void Kamstrup::setup() {
+  this->queue_.reserve(this->sensors_.size());
+  this->working_regs_.reserve(this->sensors_.size());
+  ESP_LOGD(TAG, "setup: done");
+}
+
+void Kamstrup::update() {
+  // Refill the queue
+  this->queue_.clear();
+  for (auto it = this->sensors_.crbegin(); it != this->sensors_.crend(); ++it) {
+    this->queue_.push_back(it->first);
+  }
+  if (this->state_ == IDLE)
+    this->state_ = START;
+}
+
+void Kamstrup::loop() {
+  // Inactive...
+  if (this->state_ == IDLE) {
+    return;
+  }
+  this->handle_serial_();
+}
+
+// handle_serial_ - if data is available, process it while keeping track if
+// we have seen the 0x40 start character and unescaping special characters
+// on the way. When a valid line is detected, it decodes the registers and
+// values and updates their registered sensors.
+void Kamstrup::handle_serial_() {
+  uint8_t r;
+  if (this->state_ == 3 || this->state_ == 4 || this->state_ == 5) {
+    // handle rx timeout
+    if (millis() - this->starttime_ > this->receive_timeout_) {
+      ESP_LOGW(TAG, "Timed out");
+      this->state_ = RETRY;
+      return;
+    }
+    if (!available() || !read_byte(&r)) {
+      return;
+    }
+  }
+
+  switch (this->state_) {
+    case START: // Start a new cycle
+      if (this->queue_.empty()) {
+        // We're done!
+        ESP_LOGV(TAG, "queue empty");
+        this->state_ = IDLE;
+        break;
+      }
+      // transfer `bundle_requests` from queue to working_regs.
+      this->working_regs_.clear();
+      for (int i=0; i<this->bundle_requests_ && !this->queue_.empty(); i++) {
+        uint16_t reg = this->queue_.back();
+        this->queue_.pop_back();
+        this->working_regs_.push_back(reg);
+      }
+      ESP_LOGV(TAG, "got %d working_regs, queue left %d", this->working_regs_.size(), this->queue_.size());
+      this->retry_ = 3;
+      this->state_ = RETRY;
+      break;
+    case RETRY: // (Re)send the get register cmd.
+      if (--this->retry_ == 0) {
+        ESP_LOGD(TAG, "giving up on these registers: %s", format_hex_pretty(this->working_regs_).c_str());
+        this->state_ = START;
+        break;
+      }
+      ESP_LOGV(TAG, "starting work on %s", format_hex_pretty(this->working_regs_).c_str());
+      // Purge rX buffer
+      while (available()) {
+        read_byte(&r);
+      }
+      this->send_command_({this->working_regs_});
+      this->state_ = WAIT_BEGIN;
+      this->starttime_ = millis();
+      this->bufsize_ = 0;
+      break;
+    case WAIT_BEGIN: // Wait for start marker '@'
+      if (r == 0x40) {
+        // We got our marker
+        this->state_ = DATA;
+      }
+      break;
+    case DATA: // Collect data
+      if (r == 0x0d) {
+        // We found our EOL
+        this->state_ = LINE;
+        break;
+      }
+      if (r == 0x1b) {
+        // Break detected
+        this->state_ = ESCAPED_DATA;
+        break;
+      }
+      if (this->bufsize_ != 128) {
+        this->buffer_[this->bufsize_++] = r;
+      }
+      break;
+    case ESCAPED_DATA: // Collect escaped data
+      this->state_ = DATA;
+      r ^= 0xff;
+      if (r != 0x06 && r != 0x0d && r != 0x1b && r != 0x40 && r != 0x80) {
+        ESP_LOGW(TAG, "Missing escape %X", r);
+      }
+      if (this->bufsize_ != 512) {
+        this->buffer_[this->bufsize_++] = r;
+      }
+      break;
+    case LINE: // Got a line!
+      {
+        this->state_ = RETRY;
+        // skip if message is not valid
+        if (this->bufsize_ < 5 || this->buffer_[0] != 0x3f || this->buffer_[1] != 0x10) {
+          ESP_LOGW(TAG, "Invalid message");
+          break;
+        }
+        // check CRC
+        if (this->crc_1021_(this->buffer_.begin(), this->bufsize_)) {
+          ESP_LOGW(TAG, "CRC error");
+          break;
+        }
+        const uint8_t *msgptr = &this->buffer_[2];
+        const uint8_t *end = &this->buffer_[this->bufsize_ - 2];
+        while (msgptr != end) {
+          uint16_t reg;
+          float val;
+          int len = this->consume_register_(msgptr, end, &reg, &val);
+          if (len == 0) {
+            break;
+          }
+          this->sensors_[reg]->publish_state(val);
+          auto pos = std::find(this->working_regs_.begin(), this->working_regs_.end(), reg);
+          if (pos != this->working_regs_.end()) {
+            this->working_regs_.erase(pos);
+          }
+          msgptr += len;
+        }
+        if (!this->working_regs_.empty()) {
+          ESP_LOGD(TAG, "Not all registers reported back: %s", format_hex_pretty(this->working_regs_).c_str());
+          break;
+        }
+        this->state_ = START;
+      }
+      break;
+    default:
+       ESP_LOGD(TAG, "invalid state %d", this->state_);
+       this->state_ = IDLE;
+       break;
+  }
+}
+
+// send_command_ - format the given list of registers to the Kamstrup format,
+// add prefix and crc and finally escape some special chanracters before
+// sending it out.
+void Kamstrup::send_command_(const std::vector<uint16_t>& regs) {
+  // leave room for checksum bytes to message
+  uint8_t newmsg[3 + regs.size() * sizeof(uint16_t) + 2];
+  newmsg[0] = 0x3F;
+  newmsg[1] = 0x10;
+  newmsg[2] = regs.size();
+  int size = 3;
+  for (const uint16_t& reg : regs) {
+    newmsg[size++] = reg >> 8;
+    newmsg[size++] = reg & 0xff;
+  }
+  newmsg[size++] = 0x00;
+  newmsg[size++] = 0x00;
+  uint16_t crc = this->crc_1021_(newmsg, size);
+  newmsg[size - 2] = crc >> 8;
+  newmsg[size - 1] = crc & 0xff;
+
+  // build final transmit message - escape various bytes
+  std::vector<uint8_t> txmsg{0x80}; // prefix
+  txmsg.reserve(size + 5);
+  for (const uint8_t& ch : newmsg) {
+    if (ch == 0x06 || ch == 0x0d || ch == 0x1b || ch == 0x40 || ch == 0x80) {
+      txmsg.push_back(0x1b);
+      txmsg.push_back(ch ^ 0xff);
+    } else {
+      txmsg.push_back(ch);
+    }
+  }
+  txmsg.push_back(0x0d); // EOL
+
+  // send to serial interface
+  write_array(txmsg);
+}
+
+// consume_register_ - extracts the register and its value.
+// Returns length read or 0 if there was a problem
+int Kamstrup::consume_register_(const uint8_t *msg, const uint8_t *end, uint16_t* register_id, float* value) {
+  const size_t len = end - msg;
+  if (len < 5 || len < 5 + msg[3]) {
+    ESP_LOGD(TAG, "Not enough bytes left to decode");
+    return 0;
+  }
+
+  *register_id = (msg[0] << 8) | msg[1];
+  ESP_LOGV(TAG, "Found register %d, decoding", *register_id);
+
+  // Decode the mantissa
+  int32_t x = 0;
+  for (int i = 0; i < msg[3]; i++) {
+    x <<= 8;
+    x |= msg[i + 5];
+  }
+
+  // Decode the exponent
+  int i = msg[4] & 0x3f;
+  if (msg[4] & 0x40) {
+    i = -i;
+  };
+  float ifl = pow(10, i);
+  if (msg[4] & 0x80) {
+    ifl = -ifl;
+  }
+
+  // Return value and final length
+  *value = x * ifl;
+  return 5 + msg[3];
+}
+
+// crc_1021_ - calculate the crc1021 polynominal over the given bytes.
+// Return the crc as an unsigned 16 bit int.
+uint16_t Kamstrup::crc_1021_(const uint8_t msg[], size_t msgsize) const {
+  uint32_t creg = 0x0000;
+  for (size_t i = 0; i < msgsize; i++) {
+    uint8_t mask = 0x80;
+    while (mask > 0) {
+      creg <<= 1;
+      if (msg[i] & mask) {
+        creg |= 1;
+      }
+      mask >>= 1;
+      if (creg & 0x10000) {
+        creg &= 0xffff;
+        creg ^= 0x1021;
+      }
+    }
+  }
+  return creg;
+}
+
+}  // namespace kamstrup
+}  // namespace esphome
+
+// vim: set expandtab tabstop=2 shiftwidth=2:

--- a/esphome/components/kamstrup/kamstrup.cpp
+++ b/esphome/components/kamstrup/kamstrup.cpp
@@ -47,23 +47,23 @@ void Kamstrup::loop() {
   if (this->state_ == IDLE) {
     return;
   }
-  this->handle_serial();
+  this->handle_serial_();
 }
 
-// handle_serial - if data is available, process it while keeping track if
+// handle_serial_ - if data is available, process it while keeping track if
 // we have seen the 0x40 start character and unescaping special characters
 // on the way. When a valid line is detected, it decodes the registers and
 // values and updates their registered sensors.
-void Kamstrup::handle_serial() {
+void Kamstrup::handle_serial_() {
   uint8_t r;
-  if (this->state_ == 3 || this->state_ == 4 || this->state_ == 5) {
+  if (this->state_ == WAIT_BEGIN || this->state_ == DATA || this->state_ == ESCAPED_DATA) {
     // handle rx timeout
     if (millis() - this->starttime_ > this->receive_timeout_) {
       ESP_LOGW(TAG, "Timed out");
       this->state_ = RETRY;
       return;
     }
-    if (!available() || !read_byte(&r)) {
+    if (available() == 0 || !read_byte(&r)) {
       return;
     }
   }
@@ -98,7 +98,7 @@ void Kamstrup::handle_serial() {
       while (available()) {
         read_byte(&r);
       }
-      this->send_command({this->working_regs_});
+      this->send_command_({this->working_regs_});
       this->state_ = WAIT_BEGIN;
       this->starttime_ = millis();
       this->bufsize_ = 0;
@@ -143,7 +143,7 @@ void Kamstrup::handle_serial() {
         break;
       }
       // check CRC
-      if (this->crc_1021(this->buffer_.begin(), this->bufsize_)) {
+      if (this->crc_1021_(this->buffer_.begin(), this->bufsize_)) {
         ESP_LOGW(TAG, "CRC error");
         break;
       }
@@ -152,7 +152,7 @@ void Kamstrup::handle_serial() {
       while (msgptr != end) {
         uint16_t reg;
         float val;
-        int len = this->consume_register(msgptr, end, &reg, &val);
+        int len = this->consume_register_(msgptr, end, &reg, &val);
         if (len == 0) {
           break;
         }
@@ -176,10 +176,10 @@ void Kamstrup::handle_serial() {
   }
 }
 
-// send_command - format the given list of registers to the Kamstrup format,
+// send_command_ - format the given list of registers to the Kamstrup format,
 // add prefix and crc and finally escape some special chanracters before
 // sending it out.
-void Kamstrup::send_command(const std::vector<uint16_t> &regs) {
+void Kamstrup::send_command_(const std::vector<uint16_t> &regs) {
   // leave room for checksum bytes to message
   uint8_t newmsg[3 + regs.size() * sizeof(uint16_t) + 2];
   newmsg[0] = 0x3F;
@@ -192,7 +192,7 @@ void Kamstrup::send_command(const std::vector<uint16_t> &regs) {
   }
   newmsg[size++] = 0x00;
   newmsg[size++] = 0x00;
-  uint16_t crc = this->crc_1021(newmsg, size);
+  uint16_t crc = this->crc_1021_(newmsg, size);
   newmsg[size - 2] = crc >> 8;
   newmsg[size - 1] = crc & 0xff;
 
@@ -213,9 +213,9 @@ void Kamstrup::send_command(const std::vector<uint16_t> &regs) {
   write_array(txmsg);
 }
 
-// consume_register - extracts the register and its value.
+// consume_register_ - extracts the register and its value.
 // Returns length read or 0 if there was a problem
-int Kamstrup::consume_register(const uint8_t *msg, const uint8_t *end, uint16_t *register_id, float *value) {
+int Kamstrup::consume_register_(const uint8_t *msg, const uint8_t *end, uint16_t *register_id, float *value) {
   const size_t len = end - msg;
   if (len < 5 || len < 5 + msg[3]) {
     ESP_LOGD(TAG, "Not enough bytes left to decode");
@@ -247,9 +247,9 @@ int Kamstrup::consume_register(const uint8_t *msg, const uint8_t *end, uint16_t 
   return 5 + msg[3];
 }
 
-// crc_1021 - calculate the crc1021 polynominal over the given bytes.
+// crc_1021_ - calculate the crc1021 polynominal over the given bytes.
 // Return the crc as an unsigned 16 bit int.
-uint16_t Kamstrup::crc_1021(const uint8_t msg[], size_t msgsize) const {
+uint16_t Kamstrup::crc_1021_(const uint8_t msg[], size_t msgsize) const {
   uint32_t creg = 0x0000;
   for (size_t i = 0; i < msgsize; i++) {
     uint8_t mask = 0x80;

--- a/esphome/components/kamstrup/kamstrup.h
+++ b/esphome/components/kamstrup/kamstrup.h
@@ -26,10 +26,10 @@ class Kamstrup : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  void handle_serial();
-  void send_command(const std::vector<uint16_t> &regs);
-  int consume_register(const uint8_t *msg, const uint8_t *end, uint16_t *register_id, float *value);
-  uint16_t crc_1021(const uint8_t msg[], size_t msgsize) const;
+  void handle_serial_();
+  void send_command_(const std::vector<uint16_t> &regs);
+  int consume_register_(const uint8_t *msg, const uint8_t *end, uint16_t *register_id, float *value);
+  uint16_t crc_1021_(const uint8_t msg[], size_t msgsize) const;
 
   std::map<uint16_t, sensor::Sensor *> sensors_;
   uint32_t receive_timeout_{2000};

--- a/esphome/components/kamstrup/kamstrup.h
+++ b/esphome/components/kamstrup/kamstrup.h
@@ -13,9 +13,7 @@ namespace kamstrup {
 
 class Kamstrup : public PollingComponent, public uart::UARTDevice {
  public:
-  void set_sensor(uint16_t reg, sensor::Sensor *sensor) {
-    this->sensors_[reg] = sensor;
-  }
+  void set_sensor(uint16_t reg, sensor::Sensor *sensor) { this->sensors_[reg] = sensor; }
   void set_receive_timeout(uint32_t seconds) { this->receive_timeout_ = seconds; }
   void set_bundle_requests(int count) { this->bundle_requests_ = count; }
 
@@ -29,8 +27,8 @@ class Kamstrup : public PollingComponent, public uart::UARTDevice {
 
  protected:
   void handle_serial_();
-  void send_command_(const std::vector<uint16_t>& regs);
-  int consume_register_(const uint8_t *msg, const uint8_t *end, uint16_t* register_id, float* value);
+  void send_command_(const std::vector<uint16_t> &regs);
+  int consume_register_(const uint8_t *msg, const uint8_t *end, uint16_t *register_id, float *value);
   uint16_t crc_1021_(const uint8_t msg[], size_t msgsize) const;
 
   std::map<uint16_t, sensor::Sensor *> sensors_;
@@ -46,7 +44,7 @@ class Kamstrup : public PollingComponent, public uart::UARTDevice {
   std::array<uint8_t, 512> buffer_;
 };
 
-} // namespace kamstrup
-} // namespace esphome
+}  // namespace kamstrup
+}  // namespace esphome
 
 // vim: set expandtab tabstop=2 shiftwidth=2:

--- a/esphome/components/kamstrup/kamstrup.h
+++ b/esphome/components/kamstrup/kamstrup.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <array>
+#include <map>
+#include <vector>
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace kamstrup {
+
+class Kamstrup : public PollingComponent, public uart::UARTDevice {
+ public:
+  void set_sensor(uint16_t reg, sensor::Sensor *sensor) {
+    this->sensors_[reg] = sensor;
+  }
+  void set_receive_timeout(uint32_t seconds) { this->receive_timeout_ = seconds; }
+  void set_bundle_requests(int count) { this->bundle_requests_ = count; }
+
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void setup() override;
+  void loop() override;
+  void update() override;
+
+  void dump_config() override;
+
+ protected:
+  void handle_serial_();
+  void send_command_(const std::vector<uint16_t>& regs);
+  int consume_register_(const uint8_t *msg, const uint8_t *end, uint16_t* register_id, float* value);
+  uint16_t crc_1021_(const uint8_t msg[], size_t msgsize) const;
+
+  std::map<uint16_t, sensor::Sensor *> sensors_;
+  uint32_t receive_timeout_{2000};
+  uint8_t bundle_requests_{1};
+
+  std::vector<uint16_t> queue_;
+  std::vector<uint16_t> working_regs_;
+  enum { IDLE, START, RETRY, WAIT_BEGIN, DATA, ESCAPED_DATA, LINE } state_{IDLE};
+  int retry_{0};
+  int bufsize_{0};
+  int32_t starttime_{0};
+  std::array<uint8_t, 512> buffer_;
+};
+
+} // namespace kamstrup
+} // namespace esphome
+
+// vim: set expandtab tabstop=2 shiftwidth=2:

--- a/esphome/components/kamstrup/kamstrup.h
+++ b/esphome/components/kamstrup/kamstrup.h
@@ -26,10 +26,10 @@ class Kamstrup : public PollingComponent, public uart::UARTDevice {
   void dump_config() override;
 
  protected:
-  void handle_serial_();
-  void send_command_(const std::vector<uint16_t> &regs);
-  int consume_register_(const uint8_t *msg, const uint8_t *end, uint16_t *register_id, float *value);
-  uint16_t crc_1021_(const uint8_t msg[], size_t msgsize) const;
+  void handle_serial();
+  void send_command(const std::vector<uint16_t> &regs);
+  int consume_register(const uint8_t *msg, const uint8_t *end, uint16_t *register_id, float *value);
+  uint16_t crc_1021(const uint8_t msg[], size_t msgsize) const;
 
   std::map<uint16_t, sensor::Sensor *> sensors_;
   uint32_t receive_timeout_{2000};

--- a/esphome/components/kamstrup/sensor.py
+++ b/esphome/components/kamstrup/sensor.py
@@ -1,0 +1,96 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLUME,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_CELSIUS,
+    UNIT_KELVIN,
+    UNIT_CUBIC_METER,
+)
+
+from . import Kamstrup, CONF_KAMSTRUP_ID
+
+CONF___REGISTER__ = "__register__"
+
+
+def sensor_schema(**kwargs) -> cv.Schema:
+    reg = kwargs.pop("register")
+    return sensor.sensor_schema(**kwargs).extend(
+        {
+            cv.Optional(CONF___REGISTER__, default=reg): cv.uint16_t,
+        }
+    )
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_KAMSTRUP_ID): cv.use_id(Kamstrup),
+        cv.Optional("energy"): sensor_schema(
+            unit_of_measurement="GJ",
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            register=60,  # Heat energy
+        ),
+        cv.Optional("power"): sensor_schema(
+            unit_of_measurement="GJ",
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+            register=80,  # Current Power
+        ),
+        cv.Optional("forward_temp"): sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+            register=86,  # Current Forward Temperature
+        ),
+        cv.Optional("return_temp"): sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+            register=87,  # Current Return Temperature
+        ),
+        cv.Optional("differencial_temp"): sensor_schema(
+            unit_of_measurement=UNIT_KELVIN,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+            register=89,  # Current Differencial Temperature
+        ),
+        cv.Optional("flow"): sensor_schema(
+            unit_of_measurement=UNIT_CUBIC_METER,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_VOLUME,
+            state_class=STATE_CLASS_MEASUREMENT,
+            register=74,  # Current Flow
+        ),
+        cv.Optional("volume"): sensor_schema(
+            unit_of_measurement=UNIT_CUBIC_METER,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_VOLUME,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            register=68,  # Volume
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_KAMSTRUP_ID])
+
+    for _, conf in config.items():
+        if not isinstance(conf, dict):
+            continue
+        id = conf[CONF_ID]
+        if id and id.type == sensor.Sensor:
+            sens = await sensor.new_sensor(conf)
+            cg.add(hub.set_sensor(conf[CONF___REGISTER__], sens))

--- a/tests/test8.yaml
+++ b/tests/test8.yaml
@@ -25,3 +25,23 @@ light:
     name: neopixel-enable
     internal: false
     restore_mode: ALWAYS_OFF
+
+uart:
+  id: uart_1
+  tx_pin: GPIO6
+  rx_pin: GPIO7
+  baud_rate: 1200
+  parity: NONE
+  data_bits: 8
+  stop_bits: 2
+
+kamstrup:
+  uart_id: uart_1
+  receive_timeout: 2.5s
+  bundle_requests: 3
+  update_interval: 15min
+
+sensor:
+  - platform: kamstrup
+    energy:
+      name: "Energy"


### PR DESCRIPTION
# What does this implement/fix?

This PR add support for kamstrup devices with an Optical IR interface. These are often used in Dutch homes for district heating (stadverwarming). For this to work, a optical reader head needs to be connected to one of the serial ports of the ESP.

Note that the Kamstrup device is battery powered and polling at a too fast pace may deplete your battery sooner than your district heating provider expects.

Note to reviewer: I have not created any documentation yet, before doing that I want to know if this code can make it into esphome first :).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
uart:
  id: uart_1
  tx_pin: GPIO6
  rx_pin: GPIO7
  baud_rate: 1200
  parity: NONE
  data_bits: 8
  stop_bits: 2

kamstrup:
  uart_id: uart_1
  receive_timeout: 2.5s
  bundle_requests: 3
  update_interval: 15min    

sensor:
  - platform: kamstrup
    energy:
      name: "Energy"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
