### PR TITLE
Update pid_controller.cpp

### DIFF
--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -29,7 +29,7 @@ float PIDController::update(float setpoint, float process_value) {
 bool PIDController::in_deadband() {
   // return (fabs(error) < deadband_threshold);
   float err = -error_;
-  return ((err > 0 && err < threshold_high_) || (err < 0 && err > threshold_low_));
+  return ((err >= 0 && err < threshold_high_) || (err <= 0 && err > threshold_low_));
 }
 
 void PIDController::calculate_proportional_term_() {


### PR DESCRIPTION
# What does this implement/fix?

Fix PIDController::in_deadband() function. Function returned false when error was 0. As a result samples variable suddenly changes.

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
climate:
  - platform: pid
    name: "Aquarium Climate Controller"
    sensor: aqua_temp
    default_target_temperature: 24°C
    heat_output: aqua_heat
    cool_output: aqua_cool
    id: pid_climate
    control_parameters:
      kp: 2.0
      ki: 0.0100
      kd: 0.5
      min_integral: -0.15 
      max_integral: 0.15
      output_averaging_samples: 10 
      derivative_averaging_samples: 3 
    deadband_parameters:
      threshold_high: 0.25°C
      threshold_low: -1.0°C
      kp_multiplier: 0.15
      ki_multiplier: 0.15
      kd_multiplier: 0.0
      deadband_output_averaging_samples: 15 
    visual:
      min_temperature: 22 °C
      max_temperature: 27 °C

```

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
