### PR TITLE
Number step not optional

### DIFF
--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -253,7 +253,7 @@ async def register_number(
 
 
 async def new_number(
-    config, *, min_value: float, max_value: float, step: Optional[float] = None
+    config, *, min_value: float, max_value: float, step: float
 ):
     var = cg.new_Pvariable(config[CONF_ID])
     await register_number(

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -251,9 +251,7 @@ async def register_number(
     )
 
 
-async def new_number(
-    config, *, min_value: float, max_value: float, step: float
-):
+async def new_number(config, *, min_value: float, max_value: float, step: float):
     var = cg.new_Pvariable(config[CONF_ID])
     await register_number(
         var, config, min_value=min_value, max_value=max_value, step=step


### PR DESCRIPTION
# What does this implement/fix?

Custom `Number`s are not protected against aioesphome errors where step is required. Currently `new_number` has step listed as Optional, resulting in `NaN` reported as a step, which in turn causes errors as noted in [HA Issue #88887](https://github.com/home-assistant/core/issues/88887)

Partially fixed already by PR esphome/esphome#4622

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [HA Issue #88887](https://github.com/home-assistant/core/issues/88887)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
