### PR TITLE
proto generation updates

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,6 +36,24 @@
           ]
         }
       ]
+    },
+    {
+      "label": "Generate proto files",
+      "type": "shell",
+      "command": "${command:python.interpreterPath}",
+      "args": [
+        "./script/api_protobuf/api_protobuf.py"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "never",
+        "close": true,
+        "panel": "new"
+      },
+      "problemMatcher": []
     }
   ]
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,3 +11,5 @@ pytest-mock==3.10.0
 pytest-asyncio==0.21.0
 asyncmock==0.4.2
 hypothesis==5.49.0
+
+clang-format==13.0.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,4 +12,4 @@ pytest-asyncio==0.21.0
 asyncmock==0.4.2
 hypothesis==5.49.0
 
-clang-format==13.0.1
+clang-format==13.0.1 ; platform_machine != 'armv7l'

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -18,6 +18,7 @@ will be generated, they still need to be formatted
 """
 
 import re
+import os
 from pathlib import Path
 from textwrap import dedent
 from subprocess import call
@@ -944,3 +945,19 @@ with open(root / "api_pb2_service.cpp", "w") as f:
     f.write(cpp)
 
 prot.unlink()
+
+try:
+    import clang_format
+
+    def exec_clang_format(path):
+        clang_format_path = os.path.join(
+            os.path.dirname(clang_format.__file__), "data", "bin", "clang-format"
+        )
+        call([clang_format_path, "-i", path])
+
+    exec_clang_format(root / "api_pb2_service.h")
+    exec_clang_format(root / "api_pb2_service.cpp")
+    exec_clang_format(root / "api_pb2.h")
+    exec_clang_format(root / "api_pb2.cpp")
+except ImportError:
+    pass


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This adds `clang_format` as a "test" dependency which are installed in a dev environment.

Then we can attempt to use the binary included with the python package to auto format the generated protobuf files after the generation is done.

Also adds as a vscode task to execute easily

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
