### PR TITLE
Add support for mdi images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,8 @@ RUN \
         git=1:2.30.2-1+deb11u2 \
         curl=7.74.0-1.3+deb11u7 \
         openssh-client=1:8.4p1-5+deb11u1 \
+        python3-reportlab=3.5.59-2 \
+        python3-lxml=4.6.3+dfsg-0.1+deb11u1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,8 @@ RUN \
         git=1:2.30.2-1+deb11u2 \
         curl=7.74.0-1.3+deb11u7 \
         openssh-client=1:8.4p1-5+deb11u1 \
-        python3-reportlab=3.5.59-2 \
-        python3-lxml=4.6.3+dfsg-0.1+deb11u1 \
+        libcairo2=1.16.0-5 \
+        python3-cffi=1.14.5-1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from pathlib import Path
-import time
+import re
 import requests
 
 from esphome import core
@@ -11,15 +11,19 @@ import esphome.codegen as cg
 from esphome.const import (
     CONF_DITHER,
     CONF_FILE,
+    CONF_ICON,
     CONF_ID,
+    CONF_PATH,
     CONF_RAW_DATA_ID,
     CONF_RESIZE,
+    CONF_SOURCE,
     CONF_TYPE,
 )
 from esphome.core import CORE, HexInt
 
 _LOGGER = logging.getLogger(__name__)
 
+DOMAIN = "image"
 DEPENDENCIES = ["display"]
 MULTI_CONF = True
 
@@ -33,15 +37,38 @@ IMAGE_TYPE = {
     "RGBA": ImageType.IMAGE_TYPE_RGBA,
 }
 
-CONF_MDI = "mdi"
 CONF_USE_TRANSPARENCY = "use_transparency"
 
-# If a downloaded MDI image is older than this time, it will be redownloaded
-MDI_CACHE_LIFETIME = 24 * 60 * 60  # seconds
-# If the file cannot be downloaded within this time, abort.
-MDI_DOWNLOAD_TIMEOUT = 10  # seconds
+# If the MDI file cannot be downloaded within this time, abort.
+MDI_DOWNLOAD_TIMEOUT = 30  # seconds
+
+SOURCE_LOCAL = "local"
+SOURCE_MDI = "mdi"
 
 Image_ = display.display_ns.class_("Image")
+
+
+def _compute_local_icon_path(value) -> Path:
+    base_dir = Path(CORE.config_dir) / ".esphome" / DOMAIN / "mdi"
+    return base_dir / f"{value[CONF_ICON]}.svg"
+
+
+def download_mdi(value):
+    mdi_id = value[CONF_ICON]
+    path = _compute_local_icon_path(value)
+    if path.is_file():
+        return value
+    url = f"https://raw.githubusercontent.com/Templarian/MaterialDesign/master/svg/{mdi_id}.svg"
+    _LOGGER.debug("Downloading %s MDI image from %s", mdi_id, url)
+    try:
+        req = requests.get(url, timeout=MDI_DOWNLOAD_TIMEOUT)
+        req.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise cv.Invalid(f"Could not download MDI image {mdi_id} from {url}: {e}")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(req.content)
+    return value
 
 
 def validate_svglib_installed(value):
@@ -78,8 +105,9 @@ def validate_cross_dependencies(config):
     have "use_transparency" set to True.
     Also set the default value for those kind of dependent fields.
     """
+    is_mdi = CONF_FILE in config and config[CONF_FILE][CONF_SOURCE] == SOURCE_MDI
     if CONF_TYPE not in config:
-        if CONF_MDI in config:
+        if is_mdi:
             config[CONF_TYPE] = "TRANSPARENT_BINARY"
         else:
             config[CONF_TYPE] = "BINARY"
@@ -94,20 +122,70 @@ def validate_cross_dependencies(config):
     if is_transparent_type and not config[CONF_USE_TRANSPARENCY]:
         raise cv.Invalid(f"Image type {image_type} must always be transparent.")
 
-    if CONF_MDI in config and config[CONF_TYPE] not in ["BINARY", "TRANSPARENT_BINARY"]:
+    if is_mdi and config[CONF_TYPE] not in ["BINARY", "TRANSPARENT_BINARY"]:
         raise cv.Invalid("MDI images must be binary images.")
 
     return config
 
 
+def validate_file_shorthand(value):
+    value = cv.string_strict(value)
+    if value.startswith("mdi:"):
+        validate_svglib_installed(value)
+
+        match = re.search(r"mdi:([a-zA-Z0-9\-]+)", value)
+        if match is None:
+            raise cv.Invalid("Could not parse mdi icon name.")
+        icon = match.group(1)
+        return FILE_SCHEMA(
+            {
+                CONF_SOURCE: SOURCE_MDI,
+                CONF_ICON: icon,
+            }
+        )
+    return FILE_SCHEMA(
+        {
+            CONF_SOURCE: SOURCE_LOCAL,
+            CONF_PATH: value,
+        }
+    )
+
+
+LOCAL_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_PATH): cv.file_,
+    }
+)
+
+MDI_SCHEMA = cv.All(
+    {
+        cv.Required(CONF_ICON): cv.string,
+    },
+    download_mdi,
+)
+
+TYPED_FILE_SCHEMA = cv.typed_schema(
+    {
+        SOURCE_LOCAL: LOCAL_SCHEMA,
+        SOURCE_MDI: MDI_SCHEMA,
+    },
+    key=CONF_SOURCE,
+)
+
+
+def _file_schema(value):
+    if isinstance(value, str):
+        return validate_file_shorthand(value)
+    return TYPED_FILE_SCHEMA(value)
+
+
+FILE_SCHEMA = cv.Schema(_file_schema)
+
 IMAGE_SCHEMA = cv.Schema(
     cv.All(
         {
             cv.Required(CONF_ID): cv.declare_id(Image_),
-            cv.Exclusive(CONF_FILE, "input"): cv.file_,
-            cv.Exclusive(CONF_MDI, "input"): cv.All(
-                cv.string, validate_svglib_installed
-            ),
+            cv.Required(CONF_FILE): FILE_SCHEMA,
             cv.Optional(CONF_RESIZE): cv.dimensions,
             # Not setting default here on purpose; the default depends on the source type
             # (file or mdi), and will be set in the "validate_cross_dependencies" validator.
@@ -130,42 +208,26 @@ CONFIG_SCHEMA = cv.All(font.validate_pillow_installed, IMAGE_SCHEMA)
 async def to_code(config):
     from PIL import Image
 
-    if CONF_FILE in config:
-        path = CORE.relative_config_path(config[CONF_FILE])
+    conf_file = config[CONF_FILE]
+
+    if conf_file[CONF_SOURCE] == SOURCE_LOCAL:
+        path = CORE.relative_config_path(conf_file[CONF_PATH])
         try:
             image = Image.open(path)
         except Exception as e:
             raise core.EsphomeError(f"Could not load image file {path}: {e}")
-    elif CONF_MDI in config:
+        if CONF_RESIZE in config:
+            image.thumbnail(config[CONF_RESIZE])
+    elif conf_file[CONF_SOURCE] == SOURCE_MDI:
         # Those imports are only needed in case of MDI images; adding them
         # to the top would force configurations not using MDI to also have them
         # installed for no reason.
         from reportlab.graphics import renderPM
         from svglib.svglib import svg2rlg
 
-        # In case the prefix "mdi:" is present remove it.
-        # This allows easily using the mdi intellisense VSCode extension
-        mdi_id = config[CONF_MDI].removeprefix("mdi:")
-        images_path = Path(CORE.build_path, "data", "images")
-        svg_file = Path(images_path, f"{mdi_id}.svg")
-
-        # If the image has not been downloaded yet, or is older than 24 hours, download it again.
-        if (
-            not svg_file.exists()
-            or svg_file.stat().st_mtime + MDI_CACHE_LIFETIME < time.time()
-        ):
-            url = f"https://raw.githubusercontent.com/Templarian/MaterialDesign/master/svg/{mdi_id}.svg"
-            _LOGGER.info("Downloading %s MDI image from %s", mdi_id, url)
-            req = requests.get(url, timeout=MDI_DOWNLOAD_TIMEOUT)
-            if not req.ok:
-                raise core.EsphomeError(
-                    f"Could not download MDI image {mdi_id} from {url}: {req.status_code} - {req.reason}"
-                )
-            images_path.mkdir(parents=True, exist_ok=True)
-            with svg_file.open(mode="w", encoding=req.encoding) as f:
-                f.write(req.text)
-
+        svg_file = _compute_local_icon_path(conf_file)
         svg_image = svg2rlg(svg_file)
+
         if CONF_RESIZE in config:
             orig_width = svg_image.width
             orig_height = svg_image.height
@@ -179,17 +241,12 @@ async def to_code(config):
 
     width, height = image.size
 
-    if CONF_RESIZE in config:
-        if CONF_MDI not in config:
-            image.thumbnail(config[CONF_RESIZE])
-            width, height = image.size
-    else:
-        if width > 500 or height > 500:
-            _LOGGER.warning(
-                'The image "%s" you requested is very big. Please consider'
-                " using the resize parameter.",
-                path,
-            )
+    if CONF_RESIZE not in config and (width > 500 or height > 500):
+        _LOGGER.warning(
+            'The image "%s" you requested is very big. Please consider'
+            " using the resize parameter.",
+            path,
+        )
 
     transparent = config[CONF_USE_TRANSPARENCY]
 

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -110,7 +110,9 @@ async def to_code(config):
         except Exception as e:
             raise core.EsphomeError(f"Could not load image file {path}: {e}")
     elif CONF_MDI in config:
-        mdi_id = config[CONF_MDI]
+        # In case the prefix "mdi:" is present remove it.
+        # This allows easily using the mdi intellisense VSCode extension
+        mdi_id = config[CONF_MDI].removeprefix("mdi:")
         images_path = Path(CORE.build_path, "data", "images")
         svg_file = Path(images_path, f"{mdi_id}.svg")
 

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,4 +1,3 @@
 pillow>4.0.0
-svglib>=1.5.0
-reportlab>=3.5.0
+cairosvg>=2.2.0
 cryptography>=2.0.0,<4

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,2 +1,4 @@
 pillow>4.0.0
+svglib>=1.5.0
+reportlab>=3.5.0
 cryptography>=2.0.0,<4

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -681,10 +681,10 @@ image:
     use_transparency: no
 
   - id: mdi_alert
-    mdi: alert-circle-outline
+    file: mdi:alert-circle-outline
     resize: 50x50
   - id: another_alert_icon
-    mdi: alert-circle
+    file: mdi:alert-outline
     type: BINARY
 
 cap1188:

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -680,6 +680,13 @@ image:
     type: RGB565
     use_transparency: no
 
+  - id: mdi_alert
+    mdi: alert-circle-outline
+    resize: 50x50
+  - id: another_alert_icon
+    mdi: alert-circle
+    type: BINARY
+
 cap1188:
   id: cap1188_component
   address: 0x29


### PR DESCRIPTION
# What does this implement/fix?

This PR add support for specifying Material Design Icons directly in the YAML configuration, without the need of manually downloading them and converting them to PNG.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2837

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
image:
  - file: mdi:alert-outline
    resize: 80x80
    id: alert
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
