### PR TITLE
Fix restore

### DIFF
--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -63,7 +63,7 @@ FanIsOffCondition = fan_ns.class_("FanIsOffCondition", automation.Condition.temp
 FAN_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).extend(
     {
         cv.GenerateID(): cv.declare_id(Fan),
-        cv.Optional(CONF_RESTORE_MODE, default="RESTORE_DEFAULT_OFF"): cv.enum(
+        cv.Optional(CONF_RESTORE_MODE, default="ALWAYS_OFF"): cv.enum(
             RESTORE_MODES, upper=True, space="_"
         ),
         cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTFanComponent),

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -60,7 +60,7 @@ LIGHT_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).ex
     {
         cv.GenerateID(): cv.declare_id(LightState),
         cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTJSONLightComponent),
-        cv.Optional(CONF_RESTORE_MODE, default="restore_default_off"): cv.enum(
+        cv.Optional(CONF_RESTORE_MODE, default="ALWAYS_OFF"): cv.enum(
             RESTORE_MODES, upper=True, space="_"
         ),
         cv.Optional(CONF_ON_TURN_ON): auto.validate_automation(

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -92,7 +92,7 @@ def switch_schema(
     device_class: str = _UNDEF,
     icon: str = _UNDEF,
     block_inverted: bool = False,
-    default_restore_mode: str = "RESTORE_DEFAULT_OFF",
+    default_restore_mode: str = "ALWAYS_OFF",
 ):
     schema = _SWITCH_SCHEMA.extend(
         {


### PR DESCRIPTION
# What does this implement/fix?

By default does not persist the changes over a power cycle.
It's unexpected that after a power cycle e.g. a switch or a light will automatically turn on.
It should be a conscious decision by the user.

https://github.com/esphome/issues/issues/4390

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2830

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
