### PR TITLE
add task if logger is called from not main thread

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -45,7 +45,12 @@ void Logger::write_header_(int level, const char *tag, int line) {
 
   const char *color = LOG_LEVEL_COLORS[level];
   const char *letter = LOG_LEVEL_LETTERS[level];
-  this->printf_to_buffer_("%s[%s][%s:%03u]: ", color, letter, tag, line);
+  void *current_task = xTaskGetCurrentTaskHandle();
+  if (current_task == main_task) {
+    this->printf_to_buffer_("%s[%s][%s:%03u]: ", color, letter, tag, line);
+  } else {
+    this->printf_to_buffer_("%s[%s][%s:%03u][%s]: ", color, letter, tag, line, pcTaskGetName(current_task));
+  }
 }
 
 void HOT Logger::log_vprintf_(int level, const char *tag, int line, const char *format, va_list args) {  // NOLINT
@@ -151,6 +156,7 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
 Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size) : baud_rate_(baud_rate), tx_buffer_size_(tx_buffer_size) {
   // add 1 to buffer size for null terminator
   this->tx_buffer_ = new char[this->tx_buffer_size_ + 1];  // NOLINT
+  this->main_task = xTaskGetCurrentTaskHandle();
 }
 
 void Logger::pre_setup() {

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -154,6 +154,7 @@ class Logger : public Component {
   CallbackManager<void(int, const char *, const char *)> log_callback_{};
   /// Prevents recursive log calls, if true a log message is already being processed.
   bool recursion_guard_ = false;
+  void *main_task = nullptr;
 };
 
 extern Logger *global_logger;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

There is assumption that most of things is called only from main thread. It is not always the case. Adding thread info to logs will make people aware that there can be something wrong.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
