### PR TITLE
Fix ESP32 SPI hardware assignment in Arduino fw

### DIFF
--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -79,7 +79,7 @@ void SPIComponent::setup() {
 #if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
       this->hw_spi_ = new SPIClass(FSPI);  // NOLINT(cppcoreguidelines-owning-memory)
 #else
-      this->hw_spi_ = new SPIClass(VSPI);  // NOLINT(cppcoreguidelines-owning-memory)
+      this->hw_spi_ = new SPIClass(HSPI);  // NOLINT(cppcoreguidelines-owning-memory)
 #endif  // USE_ESP32_VARIANT
     }
     spi_bus_num++;


### PR DESCRIPTION
# What does this implement/fix?

Given an ESP32 with multiple SPIs configured, such as this:

```yaml
spi:
  - id: spi_0
    clk_pin: 18
    mosi_pin: 23
    miso_pin: 19
  - id: spi_1
    clk_pin: 13
    mosi_pin: 32
    miso_pin: 25
```

...when using the Arduino framework, the incorrect hardware interface is assigned; the result is that only the _last_ interface that appears in the config (and its associated device(s)) will work.

This change corrects which hardware is assigned to the second instance of the SPI.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** this _may_ fix https://github.com/esphome/issues/issues/1708 (I have not tested it...yet) and https://github.com/esphome/issues/issues/4164

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). N/A

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). N/A