### PR TITLE
fix compilation with latest esp-idf

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,5 +1,6 @@
 #include "api_connection.h"
 #include <cerrno>
+#include <cinttypes>
 #include "esphome/components/network/util.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/hal.h"
@@ -911,7 +912,7 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   this->helper_->set_log_info(client_info_);
   this->client_api_version_major_ = msg.api_version_major;
   this->client_api_version_minor_ = msg.api_version_minor;
-  ESP_LOGV(TAG, "Hello from client: '%s' | API Version %d.%d", this->client_info_.c_str(),
+  ESP_LOGV(TAG, "Hello from client: '%s' | API Version %" PRIu32 ".%" PRIu32, this->client_info_.c_str(),
            this->client_api_version_major_, this->client_api_version_minor_);
 
   HelloResponse resp;

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -1,4 +1,5 @@
 #include "proto.h"
+#include <cinttypes>
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -13,7 +14,7 @@ void ProtoMessage::decode(const uint8_t *buffer, size_t length) {
     uint32_t consumed;
     auto res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
     if (!res.has_value()) {
-      ESP_LOGV(TAG, "Invalid field start at %u", i);
+      ESP_LOGV(TAG, "Invalid field start at %" PRIu32, i);
       break;
     }
 
@@ -25,12 +26,12 @@ void ProtoMessage::decode(const uint8_t *buffer, size_t length) {
       case 0: {  // VarInt
         res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
         if (!res.has_value()) {
-          ESP_LOGV(TAG, "Invalid VarInt at %u", i);
+          ESP_LOGV(TAG, "Invalid VarInt at %" PRIu32, i);
           error = true;
           break;
         }
         if (!this->decode_varint(field_id, *res)) {
-          ESP_LOGV(TAG, "Cannot decode VarInt field %u with value %u!", field_id, res->as_uint32());
+          ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res->as_uint32());
         }
         i += consumed;
         break;
@@ -38,38 +39,38 @@ void ProtoMessage::decode(const uint8_t *buffer, size_t length) {
       case 2: {  // Length-delimited
         res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
         if (!res.has_value()) {
-          ESP_LOGV(TAG, "Invalid Length Delimited at %u", i);
+          ESP_LOGV(TAG, "Invalid Length Delimited at %" PRIu32, i);
           error = true;
           break;
         }
         uint32_t field_length = res->as_uint32();
         i += consumed;
         if (field_length > length - i) {
-          ESP_LOGV(TAG, "Out-of-bounds Length Delimited at %u", i);
+          ESP_LOGV(TAG, "Out-of-bounds Length Delimited at %" PRIu32, i);
           error = true;
           break;
         }
         if (!this->decode_length(field_id, ProtoLengthDelimited(&buffer[i], field_length))) {
-          ESP_LOGV(TAG, "Cannot decode Length Delimited field %u!", field_id);
+          ESP_LOGV(TAG, "Cannot decode Length Delimited field %" PRIu32 "!", field_id);
         }
         i += field_length;
         break;
       }
       case 5: {  // 32-bit
         if (length - i < 4) {
-          ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at %u", i);
+          ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at %" PRIu32, i);
           error = true;
           break;
         }
         uint32_t val = encode_uint32(buffer[i + 3], buffer[i + 2], buffer[i + 1], buffer[i]);
         if (!this->decode_32bit(field_id, Proto32Bit(val))) {
-          ESP_LOGV(TAG, "Cannot decode 32-bit field %u with value %u!", field_id, val);
+          ESP_LOGV(TAG, "Cannot decode 32-bit field %" PRIu32 " with value %" PRIu32 "!", field_id, val);
         }
         i += 4;
         break;
       }
       default:
-        ESP_LOGV(TAG, "Invalid field type at %u", i);
+        ESP_LOGV(TAG, "Invalid field type at %" PRIu32, i);
         error = true;
         break;
     }

--- a/esphome/components/esp32/gpio.cpp
+++ b/esphome/components/esp32/gpio.cpp
@@ -2,6 +2,7 @@
 
 #include "gpio.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace esp32 {
@@ -74,7 +75,7 @@ void ESP32InternalGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpi
 
 std::string ESP32InternalGPIOPin::dump_summary() const {
   char buffer[32];
-  snprintf(buffer, sizeof(buffer), "GPIO%u", static_cast<uint32_t>(pin_));
+  snprintf(buffer, sizeof(buffer), "GPIO%" PRIu32, static_cast<uint32_t>(pin_));
   return buffer;
 }
 

--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/log.h"
 #include <nvs_flash.h>
 #include <cstring>
+#include <cinttypes>
 #include <vector>
 #include <string>
 
@@ -101,7 +102,7 @@ class ESP32Preferences : public ESPPreferences {
     pref->nvs_handle = nvs_handle;
 
     uint32_t keyval = type;
-    pref->key = str_sprintf("%u", keyval);
+    pref->key = str_sprintf("%" PRIu32, keyval);
 
     return ESPPreferenceObject(pref);
   }

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include <cstring>
+#include <cinttypes>
 
 namespace esphome {
 namespace i2c {
@@ -47,7 +48,7 @@ void IDFI2CBus::dump_config() {
   ESP_LOGCONFIG(TAG, "I2C Bus:");
   ESP_LOGCONFIG(TAG, "  SDA Pin: GPIO%u", this->sda_pin_);
   ESP_LOGCONFIG(TAG, "  SCL Pin: GPIO%u", this->scl_pin_);
-  ESP_LOGCONFIG(TAG, "  Frequency: %u Hz", this->frequency_);
+  ESP_LOGCONFIG(TAG, "  Frequency: %" PRIu32 " Hz", this->frequency_);
   switch (this->recovery_result_) {
     case RECOVERY_COMPLETED:
       ESP_LOGCONFIG(TAG, "  Recovery: bus successfully recovered");

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -1,4 +1,5 @@
 #include "logger.h"
+#include <cinttypes>
 
 #ifdef USE_ESP_IDF
 #include <driver/uart.h>
@@ -292,7 +293,7 @@ const char *const UART_SELECTIONS[] = {"UART0", "UART1", "USB_CDC"};
 void Logger::dump_config() {
   ESP_LOGCONFIG(TAG, "Logger:");
   ESP_LOGCONFIG(TAG, "  Level: %s", LOG_LEVELS[ESPHOME_LOG_LEVEL]);
-  ESP_LOGCONFIG(TAG, "  Log Baud Rate: %u", this->baud_rate_);
+  ESP_LOGCONFIG(TAG, "  Log Baud Rate: %" PRIu32, this->baud_rate_);
   ESP_LOGCONFIG(TAG, "  Hardware UART: %s", UART_SELECTIONS[this->uart_]);
   for (auto &it : this->log_levels_) {
     ESP_LOGCONFIG(TAG, "  Level for '%s': %s", it.tag.c_str(), LOG_LEVELS[it.level]);

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1,4 +1,5 @@
 #include "wifi_component.h"
+#include <cinttypes>
 
 #if defined(USE_ESP32) || defined(USE_ESP_IDF)
 #include <esp_wifi.h>
@@ -370,7 +371,7 @@ void WiFiComponent::print_connect_params_() {
   if (this->selected_ap_.get_bssid().has_value()) {
     ESP_LOGV(TAG, "  Priority: %.1f", this->get_sta_priority(*this->selected_ap_.get_bssid()));
   }
-  ESP_LOGCONFIG(TAG, "  Channel: %d", wifi_channel_());
+  ESP_LOGCONFIG(TAG, "  Channel: %" PRId32, wifi_channel_());
   ESP_LOGCONFIG(TAG, "  Subnet: %s", wifi_subnet_mask_().str().c_str());
   ESP_LOGCONFIG(TAG, "  Gateway: %s", wifi_gateway_ip_().str().c_str());
   ESP_LOGCONFIG(TAG, "  DNS1: %s", wifi_dns_ip_(0).str().c_str());

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -11,6 +11,7 @@
 #include <esp_event.h>
 #include <esp_netif.h>
 
+#include <cinttypes>
 #include <utility>
 #include <algorithm>
 #ifdef USE_WIFI_WPA2_EAP
@@ -666,7 +667,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_SCAN_DONE) {
     const auto &it = data->data.sta_scan_done;
-    ESP_LOGV(TAG, "Event: WiFi Scan Done status=%u number=%u scan_id=%u", it.status, it.number, it.scan_id);
+    ESP_LOGV(TAG, "Event: WiFi Scan Done status=%" PRIu32 " number=%u scan_id=%u", it.status, it.number, it.scan_id);
 
     scan_result_.clear();
     this->scan_done_ = true;

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/hal.h"
 #include <algorithm>
+#include <cinttypes>
 
 namespace esphome {
 
@@ -194,8 +195,8 @@ void HOT Scheduler::call() {
 
     // The following should not happen unless I'm missing something
     if (to_remove_ != 0) {
-      ESP_LOGW(TAG, "to_remove_ was %u now: %u items where %zu now %zu. Please report this", to_remove_was, to_remove_,
-               items_was, items_.size());
+      ESP_LOGW(TAG, "to_remove_ was %" PRIu32 " now: %" PRIu32 " items where %zu now %zu. Please report this",
+               to_remove_was, to_remove_, items_was, items_.size());
       to_remove_ = 0;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

When bumping esp-idf to 6.1.0 to fix some other issues, it became apparent that esphome uses wrong modifier for printf when printing u32/i32 integer.
This not completely fixes the build for it and I will make follow up pull requests for the other changes. This can be merged independently as it can also improve compatibility with other targets.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
