### PR TITLE
Fix BedJet setup priority [fixes esphome/issues#3807]

### DIFF
--- a/esphome/components/bedjet/bedjet_hub.h
+++ b/esphome/components/bedjet/bedjet_hub.h
@@ -116,7 +116,7 @@ class BedJetHub : public esphome::ble_client::BLEClientNode, public PollingCompo
   void update() override;
   void dump_config() override;
   void setup() override { this->codec_ = make_unique<BedjetCodec>(); }
-  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  float get_setup_priority() const override { return setup_priority::BLUETOOTH; }
 
   /** @return The BedJet's configured name, or the MAC address if not discovered yet. */
   std::string get_name() {


### PR DESCRIPTION
# What does this implement/fix?

There is a race condition where a BedJet unit previously had its BLE "notify" flag enabled, and it continues to broadcast these notify packets even after the ESP32 (and BLEClient) goes away, such as during a crash or unplugging power.

BLEClient::setup_priority=AFTER_BLUETOOTH, while BedJetHub::setup_priority=AFTER_WIFI. When the ESP32 starts back up again, BLEClient::setup() happens first and will start receiving the BLE notify packets almost immediately. Since we register the BLEClient child from codegen, BedJetHub is registered as a child already by this point, so BLEClient dispatches the notify status packet (and other gatt events) to the BedJetHub handler, even though BedJetHub::setup() has not been called yet.

We initialize BedJetHub::codec_ in setup(), so if BLEClient starts dispatching gatt events before setup() is called, then codec_ will not be initialized yet. This causes BedJetHub's gatt notify handler to call `this->codec_->decode_notify()` on an uninitialized null pointer. Since invoking a method does not have to dereference the pointer, that method invocation is allowed; but later trying to access memory on that instance results in a StoreProhibited panic.

Changing the BedJetHub's setup_priority to BLUETOOTH causes it to be setup before BLEClient, so that by the time BLEClient starts to receive BLE packets, BedJetHub is ready to receive them.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3807

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esp32_ble_tracker:
ble_client:
  - mac_address: C4:4F:33:00:00:00
    id: bedjet_client
bedjet:
  - ble_client_id: bedjet_client
    id: my_bedjet
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
