### PR TITLE
Fix some NFC/PN532 crashes

### DIFF
--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -44,6 +44,11 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
       index += id_length;
     }
 
+    if ((data.begin() + index > data.end()) || (data.begin() + index + payload_length > data.end())) {
+      ESP_LOGE(TAG, "Corrupt record encountered; NdefMessage constructor aborting");
+      break;
+    }
+
     std::vector<uint8_t> payload_data(data.begin() + index, data.begin() + index + payload_length);
 
     std::unique_ptr<NdefRecord> record;

--- a/esphome/components/nfc/ndef_record.h
+++ b/esphome/components/nfc/ndef_record.h
@@ -42,8 +42,8 @@ class NdefRecord {
   virtual const std::string &get_payload() const { return this->payload_; };
 
   virtual std::vector<uint8_t> get_encoded_payload() {
-    std::vector<uint8_t> empty_payload;
-    return empty_payload;
+    std::vector<uint8_t> payload(this->payload_.begin(), this->payload_.end());
+    return payload;
   };
 
  protected:

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -89,18 +89,18 @@ uint32_t get_mifare_classic_buffer_size(uint32_t message_length) {
 }
 
 bool mifare_classic_is_first_block(uint8_t block_num) {
-  if (block_num < 128) {
-    return (block_num % 4 == 0);
+  if (block_num < MIFARE_CLASSIC_BLOCKS_PER_SECT_LOW * MIFARE_CLASSIC_16BLOCK_SECT_START) {
+    return (block_num % MIFARE_CLASSIC_BLOCKS_PER_SECT_LOW == 0);
   } else {
-    return (block_num % 16 == 0);
+    return (block_num % MIFARE_CLASSIC_BLOCKS_PER_SECT_HIGH == 0);
   }
 }
 
 bool mifare_classic_is_trailer_block(uint8_t block_num) {
-  if (block_num < 128) {
-    return ((block_num + 1) % 4 == 0);
+  if (block_num < MIFARE_CLASSIC_BLOCKS_PER_SECT_LOW * MIFARE_CLASSIC_16BLOCK_SECT_START) {
+    return ((block_num + 1) % MIFARE_CLASSIC_BLOCKS_PER_SECT_LOW == 0);
   } else {
-    return ((block_num + 1) % 16 == 0);
+    return ((block_num + 1) % MIFARE_CLASSIC_BLOCKS_PER_SECT_HIGH == 0);
   }
 }
 

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -14,6 +14,9 @@ namespace nfc {
 static const uint8_t MIFARE_CLASSIC_BLOCK_SIZE = 16;
 static const uint8_t MIFARE_CLASSIC_LONG_TLV_SIZE = 4;
 static const uint8_t MIFARE_CLASSIC_SHORT_TLV_SIZE = 2;
+static const uint8_t MIFARE_CLASSIC_BLOCKS_PER_SECT_LOW = 4;
+static const uint8_t MIFARE_CLASSIC_BLOCKS_PER_SECT_HIGH = 16;
+static const uint8_t MIFARE_CLASSIC_16BLOCK_SECT_START = 32;
 
 static const uint8_t MIFARE_ULTRALIGHT_PAGE_SIZE = 4;
 static const uint8_t MIFARE_ULTRALIGHT_READ_SIZE = 4;
@@ -30,9 +33,17 @@ static const uint8_t TAG_TYPE_UNKNOWN = 99;
 // Mifare Commands
 static const uint8_t MIFARE_CMD_AUTH_A = 0x60;
 static const uint8_t MIFARE_CMD_AUTH_B = 0x61;
+static const uint8_t MIFARE_CMD_HALT = 0x50;
 static const uint8_t MIFARE_CMD_READ = 0x30;
 static const uint8_t MIFARE_CMD_WRITE = 0xA0;
 static const uint8_t MIFARE_CMD_WRITE_ULTRALIGHT = 0xA2;
+
+// Mifare Ack/Nak
+static const uint8_t MIFARE_CMD_ACK = 0x0A;
+static const uint8_t MIFARE_CMD_NAK_INVALID_XFER_BUFF_VALID = 0x00;
+static const uint8_t MIFARE_CMD_NAK_CRC_ERROR_XFER_BUFF_VALID = 0x01;
+static const uint8_t MIFARE_CMD_NAK_INVALID_XFER_BUFF_INVALID = 0x04;
+static const uint8_t MIFARE_CMD_NAK_CRC_ERROR_XFER_BUFF_INVALID = 0x05;
 
 static const char *const MIFARE_CLASSIC = "Mifare Classic";
 static const char *const NFC_FORUM_TYPE_2 = "NFC Forum Type 2";

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -52,7 +52,13 @@ std::unique_ptr<nfc::NfcTag> PN532::read_mifare_classic_tag_(std::vector<uint8_t
       current_block++;
     }
   }
-  buffer.erase(buffer.begin(), buffer.begin() + message_start_index);
+
+  if (buffer.begin() + message_start_index < buffer.end()) {
+    buffer.erase(buffer.begin(), buffer.begin() + message_start_index);
+  } else {
+    return make_unique<nfc::NfcTag>(uid, nfc::MIFARE_CLASSIC);
+  }
+
   return make_unique<nfc::NfcTag>(uid, nfc::MIFARE_CLASSIC, buffer);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

When reading NFC tags/cards, it's not uncommon to get a "bad read" in which some bits aren't transferred correctly or are incomplete. This can result in bad/invalid length indexes which result in computations that produce out-of-bounds iterators or other similar/related errors when parsing messages/records.

This PR adds some checks for these issues as well as modifies some hard-coded values to use constants for readability and/or consistency.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
