### PR TITLE
debug component, allow without debug logging

### DIFF
--- a/esphome/components/debug/__init__.py
+++ b/esphome/components/debug/__init__.py
@@ -1,15 +1,11 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-import esphome.final_validate as fv
-from esphome.components import logger
 from esphome.const import (
     CONF_BLOCK,
     CONF_DEVICE,
     CONF_FRAGMENTATION,
     CONF_FREE,
     CONF_ID,
-    CONF_LEVEL,
-    CONF_LOGGER,
     CONF_LOOP_TIME,
 )
 
@@ -41,18 +37,6 @@ CONFIG_SCHEMA = cv.Schema(
         ),
     }
 ).extend(cv.polling_component_schema("60s"))
-
-
-def _final_validate(_):
-    logger_conf = fv.full_config.get()[CONF_LOGGER]
-    severity = logger.LOG_LEVEL_SEVERITY.index(logger_conf[CONF_LEVEL])
-    if severity < logger.LOG_LEVEL_SEVERITY.index("DEBUG"):
-        raise cv.Invalid(
-            "The debug component requires the logger to be at least at DEBUG level"
-        )
-
-
-FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -37,6 +37,10 @@ static uint32_t get_free_heap() {
 }
 
 void DebugComponent::dump_config() {
+#ifndef ESPHOME_LOG_HAS_DEBUG
+  return;  // Can't log below if debug logging is disabled
+#endif
+
   std::string device_info;
   std::string reset_reason;
   device_info.reserve(256);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

#4076 disabled this, but really the sensors and text sensors can still be useful without logging.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3915

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
