### PR TITLE
Custom mac addresses

### DIFF
--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -32,6 +32,9 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   bool current_ap = current_mode & 0b10;
   bool enable_sta = sta.value_or(current_sta);
   bool enable_ap = ap.value_or(current_ap);
+  uint8_t mac[6];
+  get_mac_address_raw(mac);
+  set_mac_address(mac);
   if (current_sta == enable_sta && current_ap == enable_ap)
     return true;
 

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -114,12 +114,9 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
 }
 
 void WiFiComponent::wifi_pre_setup_() {
-#ifdef USE_ESP32_IGNORE_EFUSE_MAC_CRC
   uint8_t mac[6];
   get_mac_address_raw(mac);
   set_mac_address(mac);
-  ESP_LOGV(TAG, "Use EFuse MAC without checking CRC: %s", get_mac_address_pretty().c_str());
-#endif
   esp_err_t err = esp_netif_init();
   if (err != ERR_OK) {
     ESP_LOGE(TAG, "esp_netif_init failed: %s", esp_err_to_name(err));

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -443,8 +443,7 @@ void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parame
   // without doing the CRC check.
   esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, 48);
 #else
-  if (esp_efuse_mac_get_custom(mac) == ESP_OK) {
-  } else
+  if (esp_efuse_mac_get_custom(mac) != ESP_OK)
     esp_efuse_mac_get_default(mac);
 #endif
 #elif defined(USE_ESP8266)

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -436,16 +436,17 @@ bool HighFrequencyLoopRequester::is_high_frequency() { return num_requests > 0; 
 
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
 #if defined(USE_ESP32)
+  if (esp_efuse_mac_get_custom(mac) != ESP_OK) {
 #if defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
-  // On some devices, the MAC address that is burnt into EFuse does not
-  // match the CRC that goes along with it. For those devices, this
-  // work-around reads and uses the MAC address as-is from EFuse,
-  // without doing the CRC check.
-  esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, 48);
+    // On some devices, the MAC address that is burnt into EFuse does not
+    // match the CRC that goes along with it. For those devices, this
+    // work-around reads and uses the MAC address as-is from EFuse,
+    // without doing the CRC check.
+    esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, 48);
 #else
-  if (esp_efuse_mac_get_custom(mac) != ESP_OK)
     esp_efuse_mac_get_default(mac);
 #endif
+  }
 #elif defined(USE_ESP8266)
   wifi_get_macaddr(STATION_IF, mac);
 #elif defined(USE_RP2040) && defined(USE_WIFI)

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -436,7 +436,10 @@ bool HighFrequencyLoopRequester::is_high_frequency() { return num_requests > 0; 
 
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
 #if defined(USE_ESP32)
-  if (esp_efuse_mac_get_custom(mac) != ESP_OK) {
+  static bool custom_mac_not_set =
+      false;  // avoid repeated attempt to obtain custom macs to avoid spurious error messages in the log
+  if (!custom_mac_not_set && esp_efuse_mac_get_custom(mac) != ESP_OK) {
+    custom_mac_not_set = true;
 #if defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
     // On some devices, the MAC address that is burnt into EFuse does not
     // match the CRC that goes along with it. For those devices, this

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -443,8 +443,9 @@ void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parame
   // without doing the CRC check.
   esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, 48);
 #else
-  if (esp_efuse_mac_get_custom(mac) == ESP_OK) {}
-  else esp_efuse_mac_get_default(mac);
+  if (esp_efuse_mac_get_custom(mac) == ESP_OK) {
+  } else
+    esp_efuse_mac_get_default(mac);
 #endif
 #elif defined(USE_ESP8266)
   wifi_get_macaddr(STATION_IF, mac);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -443,7 +443,8 @@ void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parame
   // without doing the CRC check.
   esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, 48);
 #else
-  esp_efuse_mac_get_default(mac);
+  if (esp_efuse_mac_get_custom(mac) == ESP_OK) {}
+  else esp_efuse_mac_get_default(mac);
 #endif
 #elif defined(USE_ESP8266)
   wifi_get_macaddr(STATION_IF, mac);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -436,10 +436,10 @@ bool HighFrequencyLoopRequester::is_high_frequency() { return num_requests > 0; 
 
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
 #if defined(USE_ESP32)
-  static bool custom_mac_not_set =
+  static bool suppress_custom_mac_address_check =
       false;  // avoid repeated attempt to obtain custom macs to avoid spurious error messages in the log
-  if (!custom_mac_not_set && esp_efuse_mac_get_custom(mac) != ESP_OK) {
-    custom_mac_not_set = true;
+  if (!suppress_custom_mac_address_check && esp_efuse_mac_get_custom(mac) != ESP_OK) {
+    suppress_custom_mac_address_check = true;
 #if defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
     // On some devices, the MAC address that is burnt into EFuse does not
     // match the CRC that goes along with it. For those devices, this


### PR DESCRIPTION
  This commit adds support for custom mac addresses previously implanted with "espefuse.py burn_custom_mac"

## What does this implement/fix?

ESP32 allows user to burn a custom MAC address via espefuse.py
https://docs.espressif.com/projects/esptool/en/latest/esp32/espefuse/burn-custom-mac-cmd.html
This is especially useful when a batch of chips comes out with identical MAC or a blank (00:..:00) MAC
This PR support such MAC

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).