### PR TITLE
Allow partially looping animations

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -773,12 +773,31 @@ Color Animation::get_grayscale_pixel(int x, int y) const {
   return Color(gray, gray, gray, alpha);
 }
 Animation::Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, ImageType type)
-    : Image(data_start, width, height, type), current_frame_(0), animation_frame_count_(animation_frame_count) {}
-int Animation::get_animation_frame_count() const { return this->animation_frame_count_; }
+    : Image(data_start, width, height, type),
+      current_frame_(0),
+      animation_frame_count_(animation_frame_count),
+      loop_start_frame_(0),
+      loop_end_frame_(animation_frame_count_),
+      loop_count_(0),
+      loop_current_iteration_(1) {}
+void Animation::set_loop(uint32_t start_frame, uint32_t end_frame, int count) {
+  loop_start_frame_ = std::min(start_frame, animation_frame_count_);
+  loop_end_frame_ = std::min(end_frame, animation_frame_count_);
+  loop_count_ = count;
+  loop_current_iteration_ = 1;
+}
+
+uint32_t Animation::get_animation_frame_count() const { return this->animation_frame_count_; }
 int Animation::get_current_frame() const { return this->current_frame_; }
 void Animation::next_frame() {
   this->current_frame_++;
+  if (loop_count_ && this->current_frame_ == loop_end_frame_ &&
+      (this->loop_current_iteration_ < loop_count_ || loop_count_ < 0)) {
+    this->current_frame_ = loop_start_frame_;
+    this->loop_current_iteration_++;
+  }
   if (this->current_frame_ >= animation_frame_count_) {
+    this->loop_current_iteration_ = 1;
     this->current_frame_ = 0;
   }
 }

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -569,7 +569,7 @@ class Animation : public Image {
   Color get_rgb565_pixel(int x, int y) const override;
   Color get_grayscale_pixel(int x, int y) const override;
 
-  int get_animation_frame_count() const;
+  uint32_t get_animation_frame_count() const;
   int get_current_frame() const override;
   void next_frame();
   void prev_frame();
@@ -580,9 +580,15 @@ class Animation : public Image {
    */
   void set_frame(int frame);
 
+  void set_loop(uint32_t start_frame, uint32_t end_frame, int count);
+
  protected:
   int current_frame_;
-  int animation_frame_count_;
+  uint32_t animation_frame_count_;
+  uint32_t loop_start_frame_;
+  uint32_t loop_end_frame_;
+  int loop_count_;
+  int loop_current_iteration_;
 };
 
 template<typename... Ts> class DisplayPageShowAction : public Action<Ts...> {


### PR DESCRIPTION
# What does this implement/fix?
Add the possibility of specifying a "loop" in an animation; where the
requested frames (start - end) will be repeateadly shown for "count" times.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2847

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
animation:
  - id: fire
    file: "fire.gif"
    loop:
      start_frame: 4
      end_frame: 7
      repeat: 5
# When calling "next_frame()" on the animation, frames 4 to 7 will be repeated 5 times before moving on to frame 8.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
