### PR TITLE
Cleanup str_sanitize() and str_snake_case()

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -17,13 +17,13 @@ static const char *const TAG = "mqtt.component";
 void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
-  return discovery_info.prefix + "/" + this->component_type() + "/" + App.get_name() + "/" +
-         this->get_object_id() + "/config";
+  return discovery_info.prefix + "/" + this->component_type() + "/" + App.get_name() + "/" + this->get_object_id() +
+         "/config";
 }
 
 std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) const {
-  return global_mqtt_client->get_topic_prefix() + "/" + this->component_type() + "/" + this->get_object_id() +
-         "/" + suffix;
+  return global_mqtt_client->get_topic_prefix() + "/" + this->component_type() + "/" + this->get_object_id() + "/" +
+         suffix;
 }
 
 std::string MQTTComponent::get_state_topic_() const {

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -17,13 +17,12 @@ static const char *const TAG = "mqtt.component";
 void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
-  std::string sanitized_name = str_sanitize(App.get_name());
-  return discovery_info.prefix + "/" + this->component_type() + "/" + sanitized_name + "/" +
-         this->get_default_object_id_() + "/config";
+  return discovery_info.prefix + "/" + this->component_type() + "/" + App.get_name() + "/" +
+         this->get_object_id() + "/config";
 }
 
 std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) const {
-  return global_mqtt_client->get_topic_prefix() + "/" + this->component_type() + "/" + this->get_default_object_id_() +
+  return global_mqtt_client->get_topic_prefix() + "/" + this->component_type() + "/" + this->get_object_id() +
          "/" + suffix;
 }
 
@@ -124,13 +123,13 @@ bool MQTTComponent::send_discovery_() {
           } else {
             // default to almost-unique ID. It's a hack but the only way to get that
             // gorgeous device registry view.
-            root[MQTT_UNIQUE_ID] = "ESP" + this->component_type() + this->get_default_object_id_();
+            root[MQTT_UNIQUE_ID] = "ESP" + this->component_type() + this->get_object_id();
           }
         }
 
         const std::string &node_name = App.get_name();
         if (discovery_info.object_id_generator == MQTT_DEVICE_NAME_OBJECT_ID_GENERATOR)
-          root[MQTT_OBJECT_ID] = node_name + "_" + this->get_default_object_id_();
+          root[MQTT_OBJECT_ID] = node_name + "_" + this->get_object_id();
 
         JsonObject device_info = root.createNestedObject(MQTT_DEVICE);
         device_info[MQTT_DEVICE_IDENTIFIERS] = get_mac_address();
@@ -146,10 +145,6 @@ bool MQTTComponent::get_retain() const { return this->retain_; }
 
 bool MQTTComponent::is_discovery_enabled() const {
   return this->discovery_enabled_ && global_mqtt_client->is_discovery_enabled();
-}
-
-std::string MQTTComponent::get_default_object_id_() const {
-  return str_sanitize(str_snake_case(this->friendly_name()));
 }
 
 void MQTTComponent::subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos) {
@@ -233,6 +228,7 @@ bool MQTTComponent::is_connected_() const { return global_mqtt_client->is_connec
 
 // Pull these properties from EntityBase if not overridden
 std::string MQTTComponent::friendly_name() const { return this->get_entity()->get_name(); }
+std::string MQTTComponent::get_object_id() const { return this->get_entity()->get_object_id(); }
 std::string MQTTComponent::get_icon() const { return this->get_entity()->get_icon(); }
 bool MQTTComponent::is_disabled_by_default() const { return this->get_entity()->is_disabled_by_default(); }
 bool MQTTComponent::is_internal() { return this->get_entity()->is_internal(); }

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -166,6 +166,9 @@ class MQTTComponent : public Component {
   /// Get the friendly name of this MQTT component.
   virtual std::string friendly_name() const;
 
+  /// Get the object id of this MQTT component.
+  virtual std::string get_object_id() const;
+
   /// Get the icon field of this component
   virtual std::string get_icon() const;
 
@@ -185,8 +188,6 @@ class MQTTComponent : public Component {
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
-  /// Generate the Home Assistant MQTT discovery object id by automatically transforming the friendly name.
-  std::string get_default_object_id_() const;
 
   std::string custom_state_topic_{};
   std::string custom_command_topic_{};

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -63,7 +63,7 @@ void EntityBase::calc_object_id_() {
   // Check if `App.get_name()` is constant or dynamic.
   if (!this->has_own_name_ && App.is_name_add_mac_suffix_enabled()) {
     // `App.get_name()` is dynamic.
-    const auto& object_id = App.get_name();
+    const auto &object_id = App.get_name();
     // FNV-1 hash
     this->object_id_hash_ = fnv1_hash(object_id);
   } else {

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -43,10 +43,10 @@ void EntityBase::set_entity_category(EntityCategory entity_category) { this->ent
 std::string EntityBase::get_object_id() const {
   // Check if `App.get_friendly_name()` is constant or dynamic.
   if (!this->has_own_name_ && App.is_name_add_mac_suffix_enabled()) {
-    // `App.get_friendly_name()` is dynamic.
-    return str_sanitize(str_snake_case(App.get_friendly_name()));
+    // `App.get_name()` is dynamic.
+    return App.get_name();
   } else {
-    // `App.get_friendly_name()` is constant.
+    // `App.get_name()` is constant.
     if (this->object_id_c_str_ == nullptr) {
       return "";
     }
@@ -60,14 +60,14 @@ void EntityBase::set_object_id(const char *object_id) {
 
 // Calculate Object ID Hash from Entity Name
 void EntityBase::calc_object_id_() {
-  // Check if `App.get_friendly_name()` is constant or dynamic.
+  // Check if `App.get_name()` is constant or dynamic.
   if (!this->has_own_name_ && App.is_name_add_mac_suffix_enabled()) {
-    // `App.get_friendly_name()` is dynamic.
-    const auto object_id = str_sanitize(str_snake_case(App.get_friendly_name()));
+    // `App.get_name()` is dynamic.
+    const auto& object_id = App.get_name();
     // FNV-1 hash
     this->object_id_hash_ = fnv1_hash(object_id);
   } else {
-    // `App.get_friendly_name()` is constant.
+    // `App.get_name()` is constant.
     // FNV-1 hash
     this->object_id_hash_ = fnv1_hash(this->object_id_c_str_);
   }

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -22,7 +22,7 @@ class EntityBase {
   // Get whether this Entity has its own name or it should use the device friendly_name.
   bool has_own_name() const { return this->has_own_name_; }
 
-  // Get the sanitized name of this Entity as an ID.
+  // Get the object_id or name of this Entity as an ID.
   std::string get_object_id() const;
   void set_object_id(const char *object_id);
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -157,20 +157,6 @@ template<int (*fn)(int)> std::string str_ctype_transform(const std::string &str)
 }
 std::string str_lower_case(const std::string &str) { return str_ctype_transform<std::tolower>(str); }
 std::string str_upper_case(const std::string &str) { return str_ctype_transform<std::toupper>(str); }
-std::string str_snake_case(const std::string &str) {
-  std::string result;
-  result.resize(str.length());
-  std::transform(str.begin(), str.end(), result.begin(), ::tolower);
-  std::replace(result.begin(), result.end(), ' ', '_');
-  return result;
-}
-std::string str_sanitize(const std::string &str) {
-  std::string out;
-  std::copy_if(str.begin(), str.end(), std::back_inserter(out), [](const char &c) {
-    return c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-  });
-  return out;
-}
 std::string str_snprintf(const char *fmt, size_t len, ...) {
   std::string str;
   va_list args;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -276,11 +276,6 @@ std::string str_until(const std::string &str, char ch);
 std::string str_lower_case(const std::string &str);
 /// Convert the string to upper case.
 std::string str_upper_case(const std::string &str);
-/// Convert the string to snake case (lowercase with underscores).
-std::string str_snake_case(const std::string &str);
-
-/// Sanitizes the input string by removing all characters but alphanumerics, dashes and underscores.
-std::string str_sanitize(const std::string &str);
 
 /// snprintf-like function returning std::string of maximum length \p len (excluding null terminator).
 std::string __attribute__((format(printf, 1, 3))) str_snprintf(const char *fmt, size_t len, ...);


### PR DESCRIPTION
# What does this implement/fix?

The `object_id` can be equal `App.get_name())` instead of  sanitization `App.get_friendly_name()`. The `App.name` is strictly checked on compilation stage.

MQTT component can use Entity `object_id` directly, instead of sanitization Entity `name` at runtime. 

As result `str_sanitize()` and `str_snake_case()` aren't needed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
