### PR TITLE
Add timeout to i2c write error logs

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -154,18 +154,25 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
     }
   }
   uint8_t status = wire_->endTransmission(stop);
-  if (status == 0) {
-    return ERROR_OK;
-  } else if (status == 1) {
-    // transmit buffer not large enough
-    ESP_LOGVV(TAG, "TX failed: buffer not large enough");
-    return ERROR_UNKNOWN;
-  } else if (status == 2 || status == 3) {
-    ESP_LOGVV(TAG, "TX failed: not acknowledged");
-    return ERROR_NOT_ACKNOWLEDGED;
+  switch (status) {
+    case 0:
+      return ERROR_OK;
+    case 1:
+      // transmit buffer not large enough
+      ESP_LOGVV(TAG, "TX failed: buffer not large enough");
+      return ERROR_UNKNOWN;
+    case 2:
+    case 3:
+      ESP_LOGVV(TAG, "TX failed: not acknowledged");
+      return ERROR_NOT_ACKNOWLEDGED;
+    case 5:
+      ESP_LOGVV(TAG, "TX failed: timeout");
+      return ERROR_UNKNOWN;
+    case 4:
+    default:
+      ESP_LOGVV(TAG, "TX failed: unknown error %u", status);
+      return ERROR_UNKNOWN;
   }
-  ESP_LOGVV(TAG, "TX failed: unknown error %u", status);
-  return ERROR_UNKNOWN;
 }
 
 /// Perform I2C bus recovery, see:


### PR DESCRIPTION
# What does this implement/fix?

Adds logging timeout on i2c as separate error, not as unknown error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
