### PR TITLE
[ili9xxx] Add background color to simplify partial refresh

### DIFF
--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import core, automation
 from esphome.automation import maybe_simple_id
+from esphome.components import color
 from esphome.const import (
     CONF_AUTO_CLEAR_ENABLED,
     CONF_ID,
@@ -37,6 +38,7 @@ DisplayOnPageChangeTrigger = display_ns.class_(
 )
 
 CONF_ON_PAGE_CHANGE = "on_page_change"
+CONF_BACKGROUND_COLOR = "background_color"
 
 DISPLAY_ROTATIONS = {
     0: display_ns.DISPLAY_ROTATION_0_DEGREES,
@@ -56,6 +58,7 @@ def validate_rotation(value):
 BASIC_DISPLAY_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_LAMBDA): cv.lambda_,
+        cv.Optional(CONF_BACKGROUND_COLOR): cv.use_id(color),
     }
 )
 

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -389,6 +389,8 @@ class DisplayBuffer {
   /// Internal method to set the display rotation with.
   void set_rotation(DisplayRotation rotation);
 
+  void set_background_color(Color val);
+
   // Internal method to set display auto clearing.
   void set_auto_clear(bool auto_clear_enabled) { this->auto_clear_enabled_ = auto_clear_enabled; }
 
@@ -455,6 +457,7 @@ class DisplayBuffer {
 
   uint8_t *buffer_{nullptr};
   DisplayRotation rotation_{DISPLAY_ROTATION_0_DEGREES};
+  optional<Color> background_color_;
   optional<display_writer_t> writer_{};
   DisplayPage *page_{nullptr};
   DisplayPage *previous_page_{nullptr};

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -120,6 +120,10 @@ async def to_code(config):
         )
         cg.add(var.set_writer(lambda_))
 
+    if display.CONF_BACKGROUND_COLOR in config:
+        c = await cg.get_variable(config[display.CONF_BACKGROUND_COLOR])
+        cg.add(var.set_background_color(c))
+
     if CONF_RESET_PIN in config:
         reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(reset))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add new optional setting `background_color` for simpler partial refresh solution.

If `background_color` is set then during the `print` operation any pixel not used by the font will be set to background color. If you are writing exactly the same pixels the display driver (like ili9xxx) logic can / will ignore them. When writing a new value it will remove old pixels (avoid ghosting).

Without this change you must remember the last printed value, compare them and blank only the area where the value is printed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2852

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml for WT32-SC01 with partial refresh.
    color:
      - id: bg_color
        red: 0%
        green: 0%
        blue: 0%
      - id: font_color
        red: 100%
        green: 3%
        blue: 5%

    display:
      - platform: ili9xxx
        model: ST7796
        cs_pin: 15
        dc_pin: 21
        reset_pin: 22
        auto_clear_enabled: false // Must be set to false
        background_color: bg_color // New setting
        lambda: |-
          static bool first_draw {true};
          if(first_draw) {
            first_draw = false;
            // On first set screen blank.
            it.fill(Color::BLACK);
          }
          // As the first two lines don't change they will not be redrawn. I don't need to remember last printed value.
          it.print(0, 0, id(font_name), id(font_color), TextAlign::TOP_LEFT, "Heading");
          it.printf(0, 40, id(font_name), id(font_color), TextAlign::TOP_LEFT, "%.2f", 123.0f);

          static uint32_t test;
          test++;
          if (test % 2 == 0) {
            it.printf(0, 240, id(font_name), id(font_color), TextAlign::TOP_LEFT, "%u     ", test); // additional spaces as numbers have different width.
          } else {
            it.printf(0, 240, id(font_name), id(font_color), TextAlign::TOP_LEFT, "%u g ", test);
          }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
