### PR TITLE
Keep Unit of Measurement in Flash.

### DIFF
--- a/esphome/components/number/number_traits.cpp
+++ b/esphome/components/number/number_traits.cpp
@@ -6,15 +6,5 @@ namespace number {
 
 static const char *const TAG = "number";
 
-void NumberTraits::set_unit_of_measurement(const std::string &unit_of_measurement) {
-  this->unit_of_measurement_ = unit_of_measurement;
-}
-
-std::string NumberTraits::get_unit_of_measurement() {
-  if (this->unit_of_measurement_.has_value())
-    return *this->unit_of_measurement_;
-  return "";
-}
-
 }  // namespace number
 }  // namespace esphome

--- a/esphome/components/number/number_traits.h
+++ b/esphome/components/number/number_traits.h
@@ -12,7 +12,7 @@ enum NumberMode : uint8_t {
   NUMBER_MODE_SLIDER = 2,
 };
 
-class NumberTraits : public EntityBase_DeviceClass {
+class NumberTraits : public EntityBase_DeviceClass, public EntityBase_UnitOfMeasurement {
  public:
   // Set/get the number value boundaries.
   void set_min_value(float min_value) { min_value_ = min_value; }
@@ -24,11 +24,6 @@ class NumberTraits : public EntityBase_DeviceClass {
   void set_step(float step) { step_ = step; }
   float get_step() const { return step_; }
 
-  /// Manually set the unit of measurement.
-  void set_unit_of_measurement(const std::string &unit_of_measurement);
-  /// Get the unit of measurement, using the manual override if set.
-  std::string get_unit_of_measurement();
-
   // Set/get the frontend mode.
   void set_mode(NumberMode mode) { this->mode_ = mode; }
   NumberMode get_mode() const { return this->mode_; }
@@ -37,7 +32,6 @@ class NumberTraits : public EntityBase_DeviceClass {
   float min_value_ = NAN;
   float max_value_ = NAN;
   float step_ = NAN;
-  optional<std::string> unit_of_measurement_;  ///< Unit of measurement override
   NumberMode mode_{NUMBER_MODE_AUTO};
 };
 

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -22,15 +22,6 @@ std::string state_class_to_string(StateClass state_class) {
 
 Sensor::Sensor() : state(NAN), raw_state(NAN) {}
 
-std::string Sensor::get_unit_of_measurement() {
-  if (this->unit_of_measurement_.has_value())
-    return *this->unit_of_measurement_;
-  return "";
-}
-void Sensor::set_unit_of_measurement(const std::string &unit_of_measurement) {
-  this->unit_of_measurement_ = unit_of_measurement;
-}
-
 int8_t Sensor::get_accuracy_decimals() {
   if (this->accuracy_decimals_.has_value())
     return *this->accuracy_decimals_;

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -54,14 +54,9 @@ std::string state_class_to_string(StateClass state_class);
  *
  * A sensor has unit of measurement and can use publish_state to send out a new value with the specified accuracy.
  */
-class Sensor : public EntityBase, public EntityBase_DeviceClass {
+class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBase_UnitOfMeasurement {
  public:
   explicit Sensor();
-
-  /// Get the unit of measurement, using the manual override if set.
-  std::string get_unit_of_measurement();
-  /// Manually set the unit of measurement.
-  void set_unit_of_measurement(const std::string &unit_of_measurement);
 
   /// Get the accuracy in decimals, using the manual override if set.
   int8_t get_accuracy_decimals();
@@ -158,7 +153,6 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass {
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
 
-  optional<std::string> unit_of_measurement_;           ///< Unit of measurement override
   optional<int8_t> accuracy_decimals_;                  ///< Accuracy in decimals override
   optional<StateClass> state_class_{STATE_CLASS_NONE};  ///< State class override
   bool force_update_{false};                            ///< Force update mode

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -84,4 +84,13 @@ std::string EntityBase_DeviceClass::get_device_class() {
 
 void EntityBase_DeviceClass::set_device_class(const char *device_class) { this->device_class_ = device_class; }
 
+std::string EntityBase_UnitOfMeasurement::get_unit_of_measurement() {
+  if (this->unit_of_measurement_ == nullptr)
+    return "";
+  return this->unit_of_measurement_;
+}
+void EntityBase_UnitOfMeasurement::set_unit_of_measurement(const char *unit_of_measurement) {
+  this->unit_of_measurement_ = unit_of_measurement;
+}
+
 }  // namespace esphome

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -74,4 +74,15 @@ class EntityBase_DeviceClass {
   const char *device_class_{nullptr};  ///< Device class override
 };
 
+class EntityBase_UnitOfMeasurement {
+ public:
+  /// Get the unit of measurement, using the manual override if set.
+  std::string get_unit_of_measurement();
+  /// Manually set the unit of measurement.
+  void set_unit_of_measurement(const char *unit_of_measurement);
+
+ protected:
+  const char *unit_of_measurement_{nullptr};  ///< Unit of measurement override
+};
+
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Reduce memory consumption by keeping `unit_of_measurement_` in Flash instead of copying to memory. Each Unit of Measurement field uses 28 bytes (optional plus std::string).
Introducing a new base class EntityBase_UnitOfMeasurement for storing and accessing Unit of Measurement.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
