### PR TITLE
Fix SM2135 drivers

### DIFF
--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MAX_POWER_COLOR_CHANNELS, default=2): cv.int_range(
             min=0, max=7
         ),
-        cv.Optional(CONF_MAX_POWER_WHITE_CHANNELS, default=7): cv.int_range(
+        cv.Optional(CONF_MAX_POWER_WHITE_CHANNELS, default=4): cv.int_range(
             min=0, max=10
         ),
     }

--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -12,6 +12,8 @@ CODEOWNERS = ["@BoukeHaarsma23"]
 
 sm2135_ns = cg.esphome_ns.namespace("sm2135")
 SM2135 = sm2135_ns.class_("SM2135", cg.Component)
+CONF_MAX_POWER_COLOR_CHANNELS = "max_power_color_channels"
+CONF_MAX_POWER_WHITE_CHANNELS = "max_power_white_channels"
 
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.Schema(
@@ -19,6 +21,12 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(SM2135),
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_MAX_POWER_COLOR_CHANNELS, default=2): cv.int_range(
+            min=0, max=7
+        ),
+        cv.Optional(CONF_MAX_POWER_WHITE_CHANNELS, default=7): cv.int_range(
+            min=0, max=10
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -31,3 +39,5 @@ async def to_code(config):
     cg.add(var.set_data_pin(data))
     clock = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
     cg.add(var.set_clock_pin(clock))
+    cg.add(var.set_max_power_color_channels(config[CONF_MAX_POWER_COLOR_CHANNELS]))
+    cg.add(var.set_max_power_white_channels(config[CONF_MAX_POWER_WHITE_CHANNELS]))

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -40,7 +40,7 @@ void SM2135::dump_config() {
 }
 
 void SM2135::loop() {
-    if (!this->update_)
+   if (!this->update_)
     return;
 
   uint8_t data[6];

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -19,8 +19,6 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
-
-
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
   this->data_pin_->setup();
@@ -28,7 +26,7 @@ void SM2135::setup() {
   this->clock_pin_->setup();
   this->clock_pin_->digital_write(true);
   this->pwm_amounts_.resize(5, 0);
-  update_=true;
+  update_ = true;
 }
 void SM2135::dump_config() {
   ESP_LOGCONFIG(TAG, "SM2135:");
@@ -36,7 +34,6 @@ void SM2135::dump_config() {
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
   ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u", this->max_power_color_channels_);
   ESP_LOGCONFIG(TAG, "  White Channels Max Power: %u", this->max_power_white_channels_);
-
 }
 
 void SM2135::loop() {

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -19,19 +19,7 @@ static const uint8_t SM2135_ADDR_W = 0xC6;   // Warm
 static const uint8_t SM2135_RGB = 0x00;  // RGB channel
 static const uint8_t SM2135_CW = 0x80;   // CW channel (Chip default)
 
-static const uint8_t SM2135_10MA = 0x00;
-static const uint8_t SM2135_15MA = 0x01;
-static const uint8_t SM2135_20MA = 0x02;  // RGB max current (Chip default)
-static const uint8_t SM2135_25MA = 0x03;
-static const uint8_t SM2135_30MA = 0x04;  // CW max current (Chip default)
-static const uint8_t SM2135_35MA = 0x05;
-static const uint8_t SM2135_40MA = 0x06;
-static const uint8_t SM2135_45MA = 0x07;  // Max value for RGB
-static const uint8_t SM2135_50MA = 0x08;
-static const uint8_t SM2135_55MA = 0x09;
-static const uint8_t SM2135_60MA = 0x0A;
 
-static const uint8_t SM2135_CURRENT = (SM2135_20MA << 4) | SM2135_10MA;
 
 void SM2135::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM2135OutputComponent...");
@@ -40,22 +28,26 @@ void SM2135::setup() {
   this->clock_pin_->setup();
   this->clock_pin_->digital_write(true);
   this->pwm_amounts_.resize(5, 0);
+  update_=true;
 }
 void SM2135::dump_config() {
   ESP_LOGCONFIG(TAG, "SM2135:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
+  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u", this->max_power_color_channels_);
+  ESP_LOGCONFIG(TAG, "  White Channels Max Power: %u", this->max_power_white_channels_);
+
 }
 
 void SM2135::loop() {
-  if (!this->update_)
+    if (!this->update_)
     return;
 
   uint8_t data[6];
   if (this->update_channel_ == 3 || this->update_channel_ == 4) {
     // No color so must be Cold/Warm
     data[0] = SM2135_ADDR_MC;
-    data[1] = SM2135_CURRENT;
+    data[1] = this->max_power_color_channels_ << 4 | this->max_power_white_channels_;
     data[2] = SM2135_CW;
     this->write_buffer_(data, 3);
     delay(1);
@@ -66,7 +58,7 @@ void SM2135::loop() {
   } else {
     // Color
     data[0] = SM2135_ADDR_MC;
-    data[1] = SM2135_CURRENT;
+    data[1] = this->max_power_color_channels_ << 4 | this->max_power_white_channels_;
     data[2] = SM2135_RGB;
     data[3] = this->pwm_amounts_[1];  // Green
     data[4] = this->pwm_amounts_[0];  // Red

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -40,7 +40,7 @@ void SM2135::dump_config() {
 }
 
 void SM2135::loop() {
-   if (!this->update_)
+  if (!this->update_)
     return;
 
   uint8_t data[6];

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -8,9 +8,6 @@
 namespace esphome {
 namespace sm2135 {
 
-namespace esphome {
-namespace sm2135 {
-
 class SM2135 : public Component {
  public:
   class Channel;

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -8,12 +8,21 @@
 namespace esphome {
 namespace sm2135 {
 
+namespace esphome {
+namespace sm2135 {
+
 class SM2135 : public Component {
  public:
   class Channel;
 
   void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }
   void set_clock_pin(GPIOPin *clock_pin) { clock_pin_ = clock_pin; }
+  void set_max_power_color_channels(uint8_t max_power_color_channels) {
+    max_power_color_channels_ = max_power_color_channels;
+  }
+  void set_max_power_white_channels(uint8_t max_power_white_channels) {
+    max_power_white_channels_ = max_power_white_channels;
+  }
 
   void setup() override;
 
@@ -74,6 +83,8 @@ class SM2135 : public Component {
 
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;
+  uint8_t max_power_color_channels_{4};
+  uint8_t max_power_white_channels_{6};
   uint8_t update_channel_;
   std::vector<uint8_t> pwm_amounts_;
   bool update_{true};


### PR DESCRIPTION
Fix SM2135 drivers 

# What does this implement/fix?

Correction of switching CW RGB.
Setting the maximum driver current from the configuration file.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3506 https://github.com/esphome/issues/issues/2546 https://github.com/esphome/issues/issues/2504

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/2867

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```
sm2135:
  data_pin: D7
  clock_pin: D6
  max_power_color_channels: 2 # Valid values 0-7
  max_power_white_channels: 4 # Valid values 0-10
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
