### PR TITLE
Use proper schema for delta filter

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -25,10 +25,12 @@ from esphome.const import (
     CONF_STATE_CLASS,
     CONF_TO,
     CONF_TRIGGER_ID,
+    CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_WINDOW_SIZE,
     CONF_MQTT_ID,
     CONF_FORCE_UPDATE,
+    CONF_VALUE,
     DEVICE_CLASS_APPARENT_POWER,
     DEVICE_CLASS_AQI,
     DEVICE_CLASS_ATMOSPHERIC_PRESSURE,
@@ -476,21 +478,38 @@ async def lambda_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id, lambda_)
 
 
+DELTA_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_VALUE): cv.positive_float,
+        cv.Optional(CONF_TYPE, default="absolute"): cv.one_of(
+            "absolute", "percentage", lower=True
+        ),
+    }
+)
+
+
 def validate_delta(config):
     try:
-        return (cv.positive_float(config), False)
+        value = cv.positive_float(config)
+        return DELTA_SCHEMA({CONF_VALUE: value, CONF_TYPE: "absolute"})
     except cv.Invalid:
         pass
     try:
-        return (cv.percentage(config), True)
+        value = cv.percentage(config)
+        return DELTA_SCHEMA({CONF_VALUE: value, CONF_TYPE: "percentage"})
     except cv.Invalid:
         pass
     raise cv.Invalid("Delta filter requires a positive number or percentage value.")
 
 
-@FILTER_REGISTRY.register("delta", DeltaFilter, validate_delta)
+@FILTER_REGISTRY.register("delta", DeltaFilter, cv.Any(DELTA_SCHEMA, validate_delta))
 async def delta_filter_to_code(config, filter_id):
-    return cg.new_Pvariable(filter_id, *config)
+    percentage = config[CONF_TYPE] == "percentage"
+    return cg.new_Pvariable(
+        filter_id,
+        config[CONF_VALUE],
+        percentage,
+    )
 
 
 @FILTER_REGISTRY.register("or", OrFilter, validate_filters)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The delta filter was altered to allow percentage based checks in #4391.

https://github.com/esphome/issues/issues/4436 shows that this does not work with the kalman_combinator sensor because it implements `FINAL_VALIDATE_SCHEMA`.

The reason I believe is because the schema is initially validated, and the validation for delta returns a tuple, which no longer passes the validation which is run again for the `FINAL_VALIDATE_SCHEMA`.

This changes to use a proper schema so it will pass both times.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4436

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
