### PR TITLE
I2c scan recovery reset fix

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -240,7 +240,7 @@ void ArduinoI2CBus::recover_() {
       esp_task_wdt_reset();
       delayMicroseconds(half_period_usec * 2);
 #elif  defined(USE_ESP8266)
-      EspClass::ESP.wdtFeed();
+      EspClass::wdtFeed();
       delayMicroseconds(half_period_usec * 2);
 #elif
       delay(25);

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -239,7 +239,7 @@ void ArduinoI2CBus::recover_() {
 #if defined(USE_ESP32)
       esp_task_wdt_reset();
       delayMicroseconds(half_period_usec * 2);
-#elif  defined(USE_ESP8266)
+#elif defined(USE_ESP8266)
       EspClass::wdtFeed();
       delayMicroseconds(half_period_usec * 2);
 #elif

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -234,7 +234,7 @@ void ArduinoI2CBus::recover_() {
     // No point in trying to recover the bus by forcing a uC reset. Bus
     // should recover in a few ms or less else not likely to recovery at
     // all.
-    auto wait = 200;
+    auto wait = 250;
     while (wait-- && digitalRead(scl_pin_) == LOW) {  // NOLINT
 #if defined(USE_ESP32) || defined(USE_ESP8266)
       esp_task_wdt_reset();

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -5,9 +5,7 @@
 #include "esphome/core/helpers.h"
 #include <Arduino.h>
 #include <cstring>
-#if defined(USE_ESP32)
-#include <esp_task_wdt.h>
-#endif
+#include "esphome/core/application.h";
 
 namespace esphome {
 namespace i2c {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -236,15 +236,8 @@ void ArduinoI2CBus::recover_() {
     // all.
     auto wait = 250;
     while (wait-- && digitalRead(scl_pin_) == LOW) {  // NOLINT
-#if defined(USE_ESP32)
-      esp_task_wdt_reset();
+      App.feed_wdt();
       delayMicroseconds(half_period_usec * 2);
-#elif defined(USE_ESP8266)
-      EspClass::wdtFeed();
-      delayMicroseconds(half_period_usec * 2);
-#elif
-      delay(25);
-#endif
     }
     if (digitalRead(scl_pin_) == LOW) {  // NOLINT
       ESP_LOGE(TAG, "Recovery failed: SCL is held LOW during clock pulse cycle");

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -5,7 +5,7 @@
 #include "esphome/core/helpers.h"
 #include <Arduino.h>
 #include <cstring>
-#if defined(USE_ESP32) || defined(USE_ESP8266)
+#if defined(USE_ESP32)
 #include <esp_task_wdt.h>
 #endif
 
@@ -236,8 +236,11 @@ void ArduinoI2CBus::recover_() {
     // all.
     auto wait = 250;
     while (wait-- && digitalRead(scl_pin_) == LOW) {  // NOLINT
-#if defined(USE_ESP32) || defined(USE_ESP8266)
+#if defined(USE_ESP32)
       esp_task_wdt_reset();
+      delayMicroseconds(half_period_usec*2);
+#elif  defined(USE_ESP8266)
+      ESP.wdtFeed();
       delayMicroseconds(half_period_usec*2);
 #elif
       delay(25);

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -238,10 +238,10 @@ void ArduinoI2CBus::recover_() {
     while (wait-- && digitalRead(scl_pin_) == LOW) {  // NOLINT
 #if defined(USE_ESP32)
       esp_task_wdt_reset();
-      delayMicroseconds(half_period_usec*2);
+      delayMicroseconds(half_period_usec * 2);
 #elif  defined(USE_ESP8266)
-      ESP.wdtFeed();
-      delayMicroseconds(half_period_usec*2);
+      EspClass::ESP.wdtFeed();
+      delayMicroseconds(half_period_usec * 2);
 #elif
       delay(25);
 #endif

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -3,9 +3,9 @@
 #include "i2c_bus_arduino.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/application.h"
 #include <Arduino.h>
 #include <cstring>
-#include "esphome/core/application.h";
 
 namespace esphome {
 namespace i2c {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -4,9 +4,9 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/application.h"
 #include <cstring>
 #include <cinttypes>
-#include "esphome/core/application.h";
 
 namespace esphome {
 namespace i2c {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -280,7 +280,7 @@ void IDFI2CBus::recover_() {
     // all.
     auto wait = 250;
     while (wait-- && gpio_get_level(scl_pin) == 0) {
-      esp_task_wdt_reset();
+      App.feed_wdt();
       delayMicroseconds(half_period_usec * 2);
     }
     if (gpio_get_level(scl_pin) == 0) {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -278,7 +278,7 @@ void IDFI2CBus::recover_() {
     // No point in trying to recover the bus by forcing a uC reset. Bus
     // should recover in a few ms or less else not likely to recovery at
     // all.
-    auto wait = 200;
+    auto wait = 250;
     while (wait-- && gpio_get_level(scl_pin) == 0) {
       esp_task_wdt_reset();
       delayMicroseconds(half_period_usec*2);

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -281,7 +281,7 @@ void IDFI2CBus::recover_() {
     auto wait = 250;
     while (wait-- && gpio_get_level(scl_pin) == 0) {
       esp_task_wdt_reset();
-      delayMicroseconds(half_period_usec*2);
+      delayMicroseconds(half_period_usec * 2);
     }
     if (gpio_get_level(scl_pin) == 0) {
       ESP_LOGE(TAG, "Recovery failed: SCL is held LOW during clock pulse cycle");

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -6,7 +6,7 @@
 #include "esphome/core/helpers.h"
 #include <cstring>
 #include <cinttypes>
-#include <esp_task_wdt.h>
+#include "esphome/core/application.h";
 
 namespace esphome {
 namespace i2c {


### PR DESCRIPTION
# What does this implement/fix?

This fixes i2c's bus recovery logic, especially when combined with scan, to avoid WDT reboot.

Current i2c bus recovery logic has an arbitrary (based on comment) 500ms delay when attempting to recover the i2c bus when the clock line is held low. This both violates the esphome mandate of no delays longer than 10ms, but also triggers the WDT, ensuring recovery is never possible.

This bug was discovered because of an issue with a wiring harness which resulted in the i2c bus clock line held low. While this does prevent recovery of the bus, it also prevents continued operation of the device without the associated i2c bus as it simply boot loops because of the WDT.

This fix does several things. One, it uses the related cycles count as a basis for retry timing. Two, attempts many more retries for recovery. Three, arbitrary reduces the net retry duration below that of the esphome delay mandate. Four, resets the WDT while within the clock recovery logic. 

Technically the reset is not required (untested) as is, however, the pre-existing comment says the 500ms is arbitrary, is rather large, and I do not know if larger delays are required for universal compatibility with i2c devices which may be slow to respond. Which means either the cycle count and/or the delay can be changed well above the 10ms esphome mandate if required, to universally support all i2c devices which may hold low the bus longer than the current values (I defer to i2c expert here). Regardless, removal of the WDT logic is on the table. As is modification to the recovery delay/cycle count.

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [] ESP32 IDF
- [x] ESP8266 *compiled
- [ ] RP2040

Tested against ESP32, arduino.
Compiled against ESP8266, arduino.
Code also modifies IDF variant. Not compiled. Not tested.

## Example entry for `config.yaml`:
i2c:
  # For debugging, set scan to true. For production
  # set scan to 'false'.
  scan: true
  frequency: 10kHz

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Tested against ESP32, arduino.
Compiled against ESP8266, arduino.
Code also modifies IDF variant. Not compiled. Not tested.

Testing on ESP32, with the clock line pulled low confirms the follow resolution:
1. board no longer reboots because of WDT - allowing progression of scan and recovery attempts
2. bus scan now correctly continues and fails, logging the failures of address detection
3. the i2c bus fails and associated devices on the bus are ignored
4. esphome continues running on the node with the associated failed bus/devices.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
