### PR TITLE
Allow substitutions to be valid names

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -1,18 +1,13 @@
 import logging
-import re
 
 import esphome.config_validation as cv
 from esphome import core
-from esphome.const import CONF_SUBSTITUTIONS
+from esphome.const import CONF_SUBSTITUTIONS, VALID_SUBSTITUTIONS_CHARACTERS
 from esphome.yaml_util import ESPHomeDataBase, make_data_base
 from esphome.config_helpers import merge_config
 
 CODEOWNERS = ["@esphome/core"]
 _LOGGER = logging.getLogger(__name__)
-
-VALID_SUBSTITUTIONS_CHARACTERS = (
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
-)
 
 
 def validate_substitution_key(value):
@@ -42,12 +37,6 @@ async def to_code(config):
     pass
 
 
-# pylint: disable=consider-using-f-string
-VARIABLE_PROG = re.compile(
-    "\\$([{0}]+|\\{{[{0}]*\\}})".format(VALID_SUBSTITUTIONS_CHARACTERS)
-)
-
-
 def _expand_substitutions(substitutions, value, path, ignore_missing):
     if "$" not in value:
         return value
@@ -56,7 +45,7 @@ def _expand_substitutions(substitutions, value, path, ignore_missing):
 
     i = 0
     while True:
-        m = VARIABLE_PROG.search(value, i)
+        m = cv.VARIABLE_PROG.search(value, i)
         if not m:
             # Nothing more to match. Done
             break

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -460,6 +460,13 @@ def validate_id_name(value):
         raise Invalid(
             "Dashes are not supported in IDs, please use underscores instead."
         )
+
+    # If the value is a substitution, it can't be validated until the substitution is
+    # actually made
+    sub_match = VARIABLE_PROG.match(value)
+    if sub_match:
+        return value
+
     valid_chars = f"{ascii_letters + digits}_"
     for char in value:
         if char not in valid_chars:

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -53,6 +53,7 @@ from esphome.const import (
     KEY_TARGET_PLATFORM,
     TYPE_GIT,
     TYPE_LOCAL,
+    VALID_SUBSTITUTIONS_CHARACTERS,
 )
 from esphome.core import (
     CORE,
@@ -78,6 +79,11 @@ from esphome.voluptuous_schema import _Schema
 from esphome.yaml_util import make_data_base
 
 _LOGGER = logging.getLogger(__name__)
+
+# pylint: disable=consider-using-f-string
+VARIABLE_PROG = re.compile(
+    "\\$([{0}]+|\\{{[{0}]*\\}})".format(VALID_SUBSTITUTIONS_CHARACTERS)
+)
 
 # pylint: disable=invalid-name
 
@@ -265,6 +271,13 @@ def alphanumeric(value):
 
 def valid_name(value):
     value = string_strict(value)
+
+    # If the value is a substitution, it can't be validated until the substitution is
+    # actually made.
+    sub_match = VARIABLE_PROG.search(value)
+    if sub_match:
+        return value
+
     for c in value:
         if c not in ALLOWED_NAME_CHARS:
             raise Invalid(

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -272,11 +272,12 @@ def alphanumeric(value):
 def valid_name(value):
     value = string_strict(value)
 
-    # If the value is a substitution, it can't be validated until the substitution is
-    # actually made.
-    sub_match = VARIABLE_PROG.search(value)
-    if sub_match:
-        return value
+    if CORE.vscode:
+        # If the value is a substitution, it can't be validated until the substitution
+        # is actually made.
+        sub_match = VARIABLE_PROG.search(value)
+        if sub_match:
+            return value
 
     for c in value:
         if c not in ALLOWED_NAME_CHARS:
@@ -461,11 +462,12 @@ def validate_id_name(value):
             "Dashes are not supported in IDs, please use underscores instead."
         )
 
-    # If the value is a substitution, it can't be validated until the substitution is
-    # actually made
-    sub_match = VARIABLE_PROG.match(value)
-    if sub_match:
-        return value
+    if CORE.vscode:
+        # If the value is a substitution, it can't be validated until the substitution
+        # is actually made
+        sub_match = VARIABLE_PROG.match(value)
+        if sub_match:
+            return value
 
     valid_chars = f"{ascii_letters + digits}_"
     for char in value:

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -3,6 +3,9 @@
 __version__ = "2023.6.0-dev"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+VALID_SUBSTITUTIONS_CHARACTERS = (
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+)
 
 PLATFORM_ESP32 = "esp32"
 PLATFORM_ESP8266 = "esp8266"

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -40,6 +40,19 @@ def test_valid_name__invalid(value):
         config_validation.valid_name(value)
 
 
+@pytest.mark.parametrize("value", ("${name}", "${NAME}", "$NAME", "${name}_name"))
+def test_valid_name__substitution_valid(value):
+    actual = config_validation.valid_name(value)
+
+    assert actual == value
+
+
+@pytest.mark.parametrize("value", ("{NAME}", "${A NAME}"))
+def test_valid_name__substitution_like_invalid(value):
+    with pytest.raises(Invalid):
+        config_validation.valid_name(value)
+
+
 @given(one_of(integers(), text()))
 def test_string__valid(value):
     actual = config_validation.string(value)

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -53,6 +53,26 @@ def test_valid_name__substitution_like_invalid(value):
         config_validation.valid_name(value)
 
 
+@pytest.mark.parametrize("value", ("myid", "anID", "SOME_ID_test", "MYID_99"))
+def test_validate_id_name__valid(value):
+    actual = config_validation.validate_id_name(value)
+
+    assert actual == value
+
+
+@pytest.mark.parametrize("value", ("id of mine", "id-4", "{name_id}", "id::name"))
+def test_validate_id_name__invalid(value):
+    with pytest.raises(Invalid):
+        config_validation.validate_id_name(value)
+
+
+@pytest.mark.parametrize("value", ("${id}", "${ID}", "${ID}_test_1", "$MYID"))
+def test_validate_id_name__substitution_valid(value):
+    actual = config_validation.validate_id_name(value)
+
+    assert actual == value
+
+
 @given(one_of(integers(), text()))
 def test_string__valid(value):
     actual = config_validation.string(value)

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -6,7 +6,7 @@ from hypothesis.strategies import one_of, text, integers, builds
 
 from esphome import config_validation
 from esphome.config_validation import Invalid
-from esphome.core import Lambda, HexInt
+from esphome.core import CORE, Lambda, HexInt
 
 
 def test_check_not_templatable__invalid():
@@ -42,9 +42,13 @@ def test_valid_name__invalid(value):
 
 @pytest.mark.parametrize("value", ("${name}", "${NAME}", "$NAME", "${name}_name"))
 def test_valid_name__substitution_valid(value):
+    CORE.vscode = True
     actual = config_validation.valid_name(value)
-
     assert actual == value
+
+    CORE.vscode = False
+    with pytest.raises(Invalid):
+        actual = config_validation.valid_name(value)
 
 
 @pytest.mark.parametrize("value", ("{NAME}", "${A NAME}"))
@@ -68,9 +72,13 @@ def test_validate_id_name__invalid(value):
 
 @pytest.mark.parametrize("value", ("${id}", "${ID}", "${ID}_test_1", "$MYID"))
 def test_validate_id_name__substitution_valid(value):
+    CORE.vscode = True
     actual = config_validation.validate_id_name(value)
-
     assert actual == value
+
+    CORE.vscode = False
+    with pytest.raises(Invalid):
+        config_validation.validate_id_name(value)
 
 
 @given(one_of(integers(), text()))


### PR DESCRIPTION
# What does this implement/fix?

When a config snippet has a substitution used for a name field, allow validation to treat the substitution token as valid.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] VS Code

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# Open with VS Code with ESPHome.esphome-vscode 
# installed and set for local validation
esphome:
  name: ${name}
  build_path: build/${name}
  platform: ESP8266
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
