### PR TITLE
Debug component doesn't work on RP2040

### DIFF
--- a/esphome/components/debug/__init__.py
+++ b/esphome/components/debug/__init__.py
@@ -17,26 +17,29 @@ debug_ns = cg.esphome_ns.namespace("debug")
 DebugComponent = debug_ns.class_("DebugComponent", cg.PollingComponent)
 
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(DebugComponent),
-        cv.Optional(CONF_DEVICE): cv.invalid(
-            "The 'device' option has been moved to the 'debug' text_sensor component"
-        ),
-        cv.Optional(CONF_FREE): cv.invalid(
-            "The 'free' option has been moved to the 'debug' sensor component"
-        ),
-        cv.Optional(CONF_BLOCK): cv.invalid(
-            "The 'block' option has been moved to the 'debug' sensor component"
-        ),
-        cv.Optional(CONF_FRAGMENTATION): cv.invalid(
-            "The 'fragmentation' option has been moved to the 'debug' sensor component"
-        ),
-        cv.Optional(CONF_LOOP_TIME): cv.invalid(
-            "The 'loop_time' option has been moved to the 'debug' sensor component"
-        ),
-    }
-).extend(cv.polling_component_schema("60s"))
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DebugComponent),
+            cv.Optional(CONF_DEVICE): cv.invalid(
+                "The 'device' option has been moved to the 'debug' text_sensor component"
+            ),
+            cv.Optional(CONF_FREE): cv.invalid(
+                "The 'free' option has been moved to the 'debug' sensor component"
+            ),
+            cv.Optional(CONF_BLOCK): cv.invalid(
+                "The 'block' option has been moved to the 'debug' sensor component"
+            ),
+            cv.Optional(CONF_FRAGMENTATION): cv.invalid(
+                "The 'fragmentation' option has been moved to the 'debug' sensor component"
+            ),
+            cv.Optional(CONF_LOOP_TIME): cv.invalid(
+                "The 'loop_time' option has been moved to the 'debug' sensor component"
+            ),
+        }
+    ).extend(cv.polling_component_schema("60s")),
+    cv.only_on(["esp32", "esp8266"]),
+)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

The debug component doesn't work on RP2040. This patch makes the compilation fail nicer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
