### PR TITLE
Add on_tag_removed trigger for RC522

### DIFF
--- a/esphome/components/rc522/__init__.py
+++ b/esphome/components/rc522/__init__.py
@@ -2,7 +2,12 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation, pins
 from esphome.components import i2c
-from esphome.const import CONF_ON_TAG, CONF_TRIGGER_ID, CONF_RESET_PIN
+from esphome.const import (
+    CONF_ON_TAG,
+    CONF_ON_TAG_REMOVED,
+    CONF_TRIGGER_ID,
+    CONF_RESET_PIN,
+)
 
 CODEOWNERS = ["@glmnet"]
 AUTO_LOAD = ["binary_sensor"]
@@ -24,6 +29,11 @@ RC522_SCHEMA = cv.Schema(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(RC522Trigger),
             }
         ),
+        cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(RC522Trigger),
+            }
+        ),
     }
 ).extend(cv.polling_component_schema("1s"))
 
@@ -37,5 +47,10 @@ async def setup_rc522(var, config):
 
     for conf in config.get(CONF_ON_TAG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
-        cg.add(var.register_trigger(trigger))
+        cg.add(var.register_ontag_trigger(trigger))
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
+    for conf in config.get(CONF_ON_TAG_REMOVED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
+        cg.add(var.register_ontagremoved_trigger(trigger))
         await automation.build_automation(trigger, [(cg.std_string, "x")], conf)

--- a/esphome/components/rc522/rc522.cpp
+++ b/esphome/components/rc522/rc522.cpp
@@ -256,7 +256,7 @@ void RC522::loop() {
 
       this->current_uid_ = rfid_uid;
 
-      for (auto *trigger : this->triggers_)
+      for (auto *trigger : this->triggers_ontag_)
         trigger->process(rfid_uid);
 
       if (report) {
@@ -265,6 +265,11 @@ void RC522::loop() {
       break;
     }
     case STATE_DONE: {
+      if (!this->current_uid_.empty()) {
+        ESP_LOGV(TAG, "Tag '%s' removed", format_uid(this->current_uid_).c_str());
+        for (auto *trigger : this->triggers_ontagremoved_)
+          trigger->process(this->current_uid_);
+      }
       this->current_uid_ = {};
       state_ = STATE_INIT;
       break;

--- a/esphome/components/rc522/rc522.h
+++ b/esphome/components/rc522/rc522.h
@@ -24,7 +24,8 @@ class RC522 : public PollingComponent {
   void loop() override;
 
   void register_tag(RC522BinarySensor *tag) { this->binary_sensors_.push_back(tag); }
-  void register_trigger(RC522Trigger *trig) { this->triggers_.push_back(trig); }
+  void register_ontag_trigger(RC522Trigger *trig) { this->triggers_ontag_.push_back(trig); }
+  void register_ontagremoved_trigger(RC522Trigger *trig) { this->triggers_ontagremoved_.push_back(trig); }
 
   void set_reset_pin(GPIOPin *reset) { this->reset_pin_ = reset; }
 
@@ -242,7 +243,8 @@ class RC522 : public PollingComponent {
   uint8_t reset_count_{0};
   uint32_t reset_timeout_{0};
   std::vector<RC522BinarySensor *> binary_sensors_;
-  std::vector<RC522Trigger *> triggers_;
+  std::vector<RC522Trigger *> triggers_ontag_;
+  std::vector<RC522Trigger *> triggers_ontagremoved_;
   std::vector<uint8_t> current_uid_;
 
   enum RC522Error {


### PR DESCRIPTION
# What does this implement/fix?

Add on_tag_removed trigger for the RC522 component, making it more consistent with other NFC/RFID components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** implements a workaround discussed in https://github.com/esphome/issues/issues/4408

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/2876

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
