### PR TITLE
Don't allow fingerprint_grow enroll cancellation when no enrollment started

### DIFF
--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -77,10 +77,12 @@ void FingerprintGrowComponent::finish_enrollment(uint8_t result) {
     this->enrollment_done_callback_.call(this->enrollment_slot_);
     this->get_fingerprint_count_();
   } else {
-    this->enrollment_failed_callback_.call(this->enrollment_slot_);
+    if (this->enrollment_slot_ != ENROLLMENT_SLOT_UNUSED) {
+      this->enrollment_failed_callback_.call(this->enrollment_slot_);
+    }
   }
   this->enrollment_image_ = 0;
-  this->enrollment_slot_ = 0;
+  this->enrollment_slot_ = ENROLLMENT_SLOT_UNUSED;
   if (this->enrolling_binary_sensor_ != nullptr) {
     this->enrolling_binary_sensor_->publish_state(false);
   }

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -13,6 +13,8 @@ namespace fingerprint_grow {
 
 static const uint16_t START_CODE = 0xEF01;
 
+static const uint16_t ENROLLMENT_SLOT_UNUSED = 0xFFFF;
+
 enum GrowPacketType {
   COMMAND = 0x01,
   DATA = 0x02,
@@ -158,7 +160,7 @@ class FingerprintGrowComponent : public PollingComponent, public uart::UARTDevic
   uint32_t new_password_ = -1;
   GPIOPin *sensing_pin_{nullptr};
   uint8_t enrollment_image_ = 0;
-  uint16_t enrollment_slot_ = 0;
+  uint16_t enrollment_slot_ = ENROLLMENT_SLOT_UNUSED;
   uint8_t enrollment_buffers_ = 5;
   bool waiting_removal_ = false;
   uint32_t last_aura_led_control_ = 0;


### PR DESCRIPTION
# What does this implement/fix?

This fixes an issue where calling `fingerprint_grow.cancel_enroll` with no enrollment started results in triggering `on_enrollment_failed` with `finger_id` set to the (valid) slot 0.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4462

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
