### PR TITLE
Only request VA port from first client that is subscribed

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -429,15 +429,16 @@ void APIServer::on_shutdown() {
 
 #ifdef USE_VOICE_ASSISTANT
 bool APIServer::start_voice_assistant() {
-  bool result = false;
   for (auto &c : this->clients_) {
-    result |= c->request_voice_assistant(true);
+    if (c->request_voice_assistant(true))
+      return true;
   }
-  return result;
+  return false;
 }
 void APIServer::stop_voice_assistant() {
   for (auto &c : this->clients_) {
-    c->request_voice_assistant(false);
+    if (c->request_voice_assistant(false))
+      return;
   }
 }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
