### PR TITLE
Enable IPv6 for ESP32 arduino

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -1,3 +1,4 @@
+from esphome.core import CORE
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components.esp32 import add_idf_sdkconfig_option
@@ -14,16 +15,20 @@ IPAddress = network_ns.class_("IPAddress")
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.SplitDefault(CONF_ENABLE_IPV6, esp32_idf=False): cv.All(
-            cv.only_with_esp_idf, cv.boolean
+        cv.SplitDefault(CONF_ENABLE_IPV6, esp32=False): cv.All(
+            cv.only_on_esp32, cv.boolean
         ),
     }
 )
 
 
 async def to_code(config):
-    if CONF_ENABLE_IPV6 in config:
-        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
-        add_idf_sdkconfig_option(
-            "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
-        )
+    if CONF_ENABLE_IPV6 in config and config[CONF_ENABLE_IPV6]:
+        if CORE.using_esp_idf:
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
+            add_idf_sdkconfig_option(
+                "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
+            )
+        else:
+            cg.add_build_flag("-DCONFIG_LWIP_IPV6")
+            cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -485,6 +485,9 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       buf[it.ssid_len] = '\0';
       ESP_LOGV(TAG, "Event: Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
                format_mac_addr(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
+#if LWIP_IPV6
+      WiFi.enableIpV6();
+#endif /* LWIP_IPV6 */
 
       break;
     }
@@ -547,6 +550,13 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       s_sta_connecting = false;
       break;
     }
+#if LWIP_IPV6
+    case ESPHOME_EVENT_ID_WIFI_STA_GOT_IP6: {
+      auto it = info.got_ip6.ip6_info;
+      ESP_LOGV(TAG, "Got IPv6 address=" IPV6STR, IPV62STR(it.ip));
+      break;
+    }
+#endif /* LWIP_IPV6 */
     case ESPHOME_EVENT_ID_WIFI_STA_LOST_IP: {
       ESP_LOGV(TAG, "Event: Lost IP");
       break;


### PR DESCRIPTION
# What does this implement/fix?

Initial ESP32 Arduino platform IPv6 support. This should take it to about the same level as the ESP IDF IPv6 support.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: ipv6

esp32:
  board: esp32dev
  framework:
    type: arduino

wifi:
  ssid: wifissid
  password: !secret wifipwd

network:
  enable_ipv6: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
