### PR TITLE
Fix sprinkler switch restore_mode

### DIFF
--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -286,7 +286,9 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_ENABLE_SWITCH): cv.maybe_simple_value(
             switch.switch_schema(
-                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+                SprinklerControllerSwitch,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+                default_restore_mode="RESTORE_DEFAULT_OFF",
             ),
             key=CONF_NAME,
         ),
@@ -333,7 +335,9 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
         cv.Optional(CONF_NAME): cv.string,
         cv.Optional(CONF_AUTO_ADVANCE_SWITCH): cv.maybe_simple_value(
             switch.switch_schema(
-                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+                SprinklerControllerSwitch,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+                default_restore_mode="RESTORE_DEFAULT_OFF",
             ),
             key=CONF_NAME,
         ),
@@ -343,19 +347,25 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_QUEUE_ENABLE_SWITCH): cv.maybe_simple_value(
             switch.switch_schema(
-                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+                SprinklerControllerSwitch,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+                default_restore_mode="RESTORE_DEFAULT_OFF",
             ),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_REVERSE_SWITCH): cv.maybe_simple_value(
             switch.switch_schema(
-                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+                SprinklerControllerSwitch,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+                default_restore_mode="RESTORE_DEFAULT_OFF",
             ),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_STANDBY_SWITCH): cv.maybe_simple_value(
             switch.switch_schema(
-                SprinklerControllerSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+                SprinklerControllerSwitch,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+                default_restore_mode="RESTORE_DEFAULT_OFF",
             ),
             key=CONF_NAME,
         ),

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -1176,6 +1176,20 @@ optional<uint32_t> Sprinkler::time_remaining_current_operation() {
   return nullopt;
 }
 
+bool Sprinkler::any_controller_is_active() {
+  if (this->state_ != IDLE) {
+    return true;
+  }
+
+  for (auto &controller : this->other_controllers_) {
+    if (controller != this) {  // dummy check
+      if (controller->controller_state() != IDLE) {
+        return true;
+      }
+    }
+  }
+}
+
 SprinklerControllerSwitch *Sprinkler::control_switch(size_t valve_number) {
   if (this->is_a_valid_valve(valve_number)) {
     return this->valve_[valve_number].controller_switch;

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -1188,6 +1188,7 @@ bool Sprinkler::any_controller_is_active() {
       }
     }
   }
+  return false;
 }
 
 SprinklerControllerSwitch *Sprinkler::control_switch(size_t valve_number) {

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -406,6 +406,12 @@ class Sprinkler : public Component {
   /// returns the amount of time remaining in seconds for all valves remaining, including the active valve, if any
   optional<uint32_t> time_remaining_current_operation();
 
+  /// returns true if this or any sprinkler controller this controller knows about is active
+  bool any_controller_is_active();
+
+  /// returns the current state of the sprinkler controller
+  SprinklerState controller_state() { return this->state_; };
+
   /// returns a pointer to a valve's control switch object
   SprinklerControllerSwitch *control_switch(size_t valve_number);
 
@@ -503,7 +509,6 @@ class Sprinkler : public Component {
   /// callback functions for timers
   void valve_selection_callback_();
   void sm_timer_callback_();
-  void pump_stop_delay_callback_();
 
   /// Maximum allowed queue size
   const uint8_t max_queue_size_{100};


### PR DESCRIPTION
# What does this implement/fix?

Sprinkler controller switches should restore their state by default; the recent change to default to `ALWAYS_OFF` results in unexpected and generally undesirable behavior for these switches.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** some [discussion on Discord](https://discord.com/channels/429907082951524364/429907082955718657/1101188662538031135)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
