### PR TITLE
Insert Europe Tank Types from mopeka_std_check

### DIFF
--- a/esphome/components/mopeka_pro_check/sensor.py
+++ b/esphome/components/mopeka_pro_check/sensor.py
@@ -44,6 +44,9 @@ CONF_SUPPORTED_TANKS_MAP = {
     "20LB_V": (38, 254),  # empty/full readings for 20lb US tank
     "30LB_V": (38, 381),
     "40LB_V": (38, 508),
+    "EUROPE_6KG": (38, 336),
+    "EUROPE_11KG": (38, 366),
+    "EUROPE_14KG": (38, 467),
 }
 
 CODEOWNERS = ["@spbrogan"]


### PR DESCRIPTION
# What does this implement/fix?

Make Europe Tank Types useable with mopeka pro

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2886

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
