### PR TITLE
play_folder bugfix and addition of play_mp3

### DIFF
--- a/esphome/components/dfplayer/__init__.py
+++ b/esphome/components/dfplayer/__init__.py
@@ -40,6 +40,7 @@ DEVICE = {
 
 NextAction = dfplayer_ns.class_("NextAction", automation.Action)
 PreviousAction = dfplayer_ns.class_("PreviousAction", automation.Action)
+PlayMp3Action = dfplayer_ns.class_("PlayMp3Action", automation.Action)
 PlayFileAction = dfplayer_ns.class_("PlayFileAction", automation.Action)
 PlayFolderAction = dfplayer_ns.class_("PlayFolderAction", automation.Action)
 SetVolumeAction = dfplayer_ns.class_("SetVolumeAction", automation.Action)
@@ -110,6 +111,25 @@ async def dfplayer_next_to_code(config, action_id, template_arg, args):
 async def dfplayer_previous_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@automation.register_action(
+    "dfplayer.play_mp3",
+    PlayMp3Action,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(DFPlayer),
+            cv.Required(CONF_FILE): cv.templatable(cv.int_),
+        },
+        key=CONF_FILE,
+    ),
+)
+async def dfplayer_play_mp3_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    template_ = await cg.templatable(config[CONF_FILE], args, float)
+    cg.add(var.set_file(template_))
     return var
 
 

--- a/esphome/components/dfplayer/__init__.py
+++ b/esphome/components/dfplayer/__init__.py
@@ -372,4 +372,3 @@ async def dfplayer_is_playing_to_code(config, condition_id, template_arg, args):
     var = cg.new_Pvariable(condition_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
-    

--- a/esphome/components/dfplayer/__init__.py
+++ b/esphome/components/dfplayer/__init__.py
@@ -372,3 +372,4 @@ async def dfplayer_is_playing_to_code(config, condition_id, template_arg, args):
     var = cg.new_Pvariable(condition_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
+    

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -7,10 +7,10 @@ namespace dfplayer {
 static const char *const TAG = "dfplayer";
 
 void DFPlayer::play_folder(uint16_t folder, uint16_t file) {
-  if (folder < 100 && file < 256) {
+  if (folder <= 10 && file <= 1000) {
     this->ack_set_is_playing_ = true;
     this->send_cmd_(0x0F, (uint8_t) folder, (uint8_t) file);
-  } else if (folder <= 10 && file <= 1000) {
+  } else if (folder < 100 && file < 256) {
     this->ack_set_is_playing_ = true;
     this->send_cmd_(0x14, (((uint16_t) folder) << 12) | file);
   } else {

--- a/esphome/components/dfplayer/dfplayer.h
+++ b/esphome/components/dfplayer/dfplayer.h
@@ -35,6 +35,10 @@ class DFPlayer : public uart::UARTDevice, public Component {
     this->ack_set_is_playing_ = true;
     this->send_cmd_(0x02);
   }
+  void play_mp3(uint16_t file) {
+    this->ack_set_is_playing_ = true;
+    this->send_cmd_(0x12, file);
+  }
   void play_file(uint16_t file) {
     this->ack_set_is_playing_ = true;
     this->send_cmd_(0x03, file);
@@ -112,6 +116,16 @@ class DFPlayer : public uart::UARTDevice, public Component {
 
 DFPLAYER_SIMPLE_ACTION(NextAction, next)
 DFPLAYER_SIMPLE_ACTION(PreviousAction, previous)
+
+template<typename... Ts> class PlayMp3Action : public Action<Ts...>, public Parented<DFPlayer> {
+ public:
+  TEMPLATABLE_VALUE(uint16_t, file)
+
+  void play(Ts... x) override {
+    auto file = this->file_.value(x...);
+    this->parent_->play_mp3(file);
+  }
+};
 
 template<typename... Ts> class PlayFileAction : public Action<Ts...>, public Parented<DFPlayer> {
  public:


### PR DESCRIPTION
# What does this implement/fix?

There's a bug in the current implementation of play_folder action.
Conditions are swapped for play_folder and play_large_folder.

Also, I added a new command to the esphome implementation supported by dfplayer: play_mp3

Both modifications allow users to easily manage files in the SD card without the need to use a global filenumber on disk needed by the standard play function. Files can be played referencing the name in the folder.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2879

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
on_...:
  then:
    - dfplayer.play_folder:
        folder: 2
        file: 1
```
```yaml
on_...:
  then:
    - dfplayer.play_mp3:
        file: 23
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
