### PR TITLE
Start UART assignment at UART0 if the logger is not enabled or is not configured for hardware logging on ESP32

### DIFF
--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -100,6 +100,12 @@ void ESP32ArduinoUARTComponent::setup() {
     }
 #endif  // USE_LOGGER
 
+    if (next_uart_num >= UART_NUM_MAX) {
+      ESP_LOGW(TAG, "Maximum number of UART components created already.");
+      this->mark_failed();
+      return;
+    }
+
     this->number_ = next_uart_num;
     this->hw_serial_ = new HardwareSerial(next_uart_num++);  // NOLINT(cppcoreguidelines-owning-memory)
   }

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -86,15 +86,20 @@ void ESP32ArduinoUARTComponent::setup() {
   is_default_tx = tx_pin_ == nullptr || tx_pin_->get_pin() == 1;
   is_default_rx = rx_pin_ == nullptr || rx_pin_->get_pin() == 3;
 #endif
-  if (is_default_tx && is_default_rx) {
+  static uint8_t next_uart_num = 0;
+  if (is_default_tx && is_default_rx && next_uart_num == 0) {
     this->hw_serial_ = &Serial;
+    next_uart_num++;
   } else {
-    static uint8_t next_uart_num = 0;
 #ifdef USE_LOGGER
+    // The logger doesn't use this UART component, instead it targets the UARTs
+    // directly (i.e. Serial/Serial0, Serial1, and Serial2). If the logger is
+    // enabled, skip the UART that it is configured to use.
     if (logger::global_logger->get_baud_rate() > 0 && logger::global_logger->get_uart() == next_uart_num) {
       next_uart_num++;
     }
-#endif
+#endif  // USE_LOGGER
+
     this->number_ = next_uart_num;
     this->hw_serial_ = new HardwareSerial(next_uart_num++);  // NOLINT(cppcoreguidelines-owning-memory)
   }

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -89,7 +89,12 @@ void ESP32ArduinoUARTComponent::setup() {
   if (is_default_tx && is_default_rx) {
     this->hw_serial_ = &Serial;
   } else {
-    static uint8_t next_uart_num = 1;
+    static uint8_t next_uart_num = 0;
+#ifdef USE_LOGGER
+    if (logger::global_logger->get_baud_rate() > 0 && logger::global_logger->get_uart() == next_uart_num) {
+      next_uart_num++;
+    }
+#endif
     this->number_ = next_uart_num;
     this->hw_serial_ = new HardwareSerial(next_uart_num++);  // NOLINT(cppcoreguidelines-owning-memory)
   }

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -2,6 +2,7 @@
 
 #ifdef USE_ESP32_FRAMEWORK_ARDUINO
 
+#include <driver/uart.h>
 #include <HardwareSerial.h>
 #include <vector>
 #include "esphome/core/component.h"


### PR DESCRIPTION
# What does this implement/fix?

This change modifies the ESP32 Arduino UART component to allow assignment of UART0 if the logger isn't using it. This is particularly useful on devices like ESP32-S2 where there are two hardware UARTs rather than three. In my case, I have an S2 Mini with I'm using to replace an ESP8266-based D1 Mini (an [AirGradient Pro](https://www.airgradient.com/open-airgradient/instructions/diy-pro-v37/)). I need both UARTs for communicating with external sensors, however I found that only one worked with esphome, even if I disabled hardware logging (first by setting the logger's `baud_rate` to 0, and then by removing it outright). With this change, you have the option to forego hardware logging and get its UART back (and incidentally, hardware logging doesn't seem to work right on this board anyway due to some USB CDC stuff, I might look into that next).

I've tested this on both an ESP32-S2 and an ESP32-C3, both of which have the same hardware UART limit (2), and it worked properly on both. This is my first esphome PR so feedback is welcome 😄 I tried to keep the change concise and I _think_ it should be safe to apply to all ESP32 boards, but if there are concerns about that we could perhaps add some conditionals to target S2 and C3 specifically (and maybe other boards where this might be useful).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
# Enable logging over wireless only
logger:
  level: DEBUG
  baud_rate: 0

uart:
  - rx_pin: 7
    tx_pin: 9
    baud_rate: 9600
    id: pms_uart  # Will end up being assigned UART0
  - rx_pin: 16
    tx_pin: 18
    baud_rate: 9600
    id: c02_uart  # Will end up being assigned UART1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
