### PR TITLE
Only pre-install libraries in docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ RUN \
 COPY requirements.txt requirements_optional.txt script/platformio_install_deps.py platformio.ini /
 RUN \
     pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
-    && /platformio_install_deps.py /platformio.ini
+    && /platformio_install_deps.py /platformio.ini --libraries
 
 
 # ======================= docker-type image =======================

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -2,12 +2,22 @@
 # This script is used to preinstall
 # all platformio libraries in the global storage
 
+import argparse
 import configparser
 import subprocess
-import sys
 
 config = configparser.ConfigParser(inline_comment_prefixes=(";",))
-config.read(sys.argv[1])
+
+parser = argparse.ArgumentParser(description="")
+parser.add_argument("file", help="Path to platformio.ini", nargs=1)
+parser.add_argument("-l", "--libraries", help="Install libraries", action="store_true")
+parser.add_argument("-p", "--platforms", help="Install platforms", action="store_true")
+parser.add_argument("-t", "--tools", help="Install tools", action="store_true")
+
+args = parser.parse_args()
+
+config.read(args.file)
+
 
 libs = []
 tools = []
@@ -15,7 +25,7 @@ platforms = []
 # Extract from every lib_deps key in all sections
 for section in config.sections():
     conf = config[section]
-    if "lib_deps" in conf:
+    if "lib_deps" in conf and args.libraries:
         for lib_dep in conf["lib_deps"].splitlines():
             if not lib_dep:
                 # Empty line or comment
@@ -28,10 +38,10 @@ for section in config.sections():
                 continue
             libs.append("-l")
             libs.append(lib_dep)
-    if "platform" in conf:
+    if "platform" in conf and args.platforms:
         platforms.append("-p")
         platforms.append(conf["platform"])
-    if "platform_packages" in conf:
+    if "platform_packages" in conf and args.tools:
         for tool in conf["platform_packages"].splitlines():
             if not tool:
                 # Empty line or comment

--- a/script/setup
+++ b/script/setup
@@ -15,4 +15,4 @@ pip3 install --no-use-pep517 -e .
 
 pre-commit install
 
-script/platformio_install_deps.py platformio.ini
+script/platformio_install_deps.py platformio.ini --libraries --tools --platforms


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
#4716 made the docker images significantly larger. This keeps the bulk of the changes, while reducing the docker image back to what it originally had. A solution for disappearing toolchains still needs to be solved.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
