### PR TITLE
Update ESP8266WiFi for Arduino 3.1.0+

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -22,6 +22,8 @@ extern "C" {
 #endif
 #if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0)
 #include "LwipDhcpServer.h"
+#endif
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0) && USE_ARDUINO_VERSION_CODE < VERSION_CODE(3, 1, 0)
 #define wifi_softap_set_dhcps_lease(lease) dhcpSoftAP.set_dhcps_lease(lease)
 #define wifi_softap_set_dhcps_lease_time(time) dhcpSoftAP.set_dhcps_lease_time(time)
 #define wifi_softap_set_dhcps_offer_option(offer, mode) dhcpSoftAP.set_dhcps_offer_option(offer, mode)
@@ -701,7 +703,7 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
     return false;
   }
 
-#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 0, 0) && USE_ARDUINO_VERSION_CODE < VERSION_CODE(3, 1, 0)
   dhcpSoftAP.begin(&info);
 #endif
 
@@ -724,12 +726,16 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
     return false;
   }
 
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 1, 0)
+  WiFi.softAPDhcpServer().setRouter(true);  // send ROUTER option with netif's gateway IP
+#else
   uint8_t mode = 1;
   // bit0, 1 enables router information from ESP8266 SoftAP DHCP server.
   if (!wifi_softap_set_dhcps_offer_option(OFFER_ROUTER, &mode)) {
     ESP_LOGV(TAG, "wifi_softap_set_dhcps_offer_option failed!");
     return false;
   }
+#endif
 
   if (!wifi_softap_dhcps_start()) {
     ESP_LOGV(TAG, "Starting SoftAP DHCPS failed!");


### PR DESCRIPTION
Changes based on https://github.com/esphome/esphome/pull/4297

# What does this implement/fix?

Allow building with ESP8266 Arduino core 3.1.

ESP8266 Arduino core 3.1 adds wrappers that restore most of the old dhcps API, while also changing the underlying implementation of `set_dhcps_offer_option` for which the old API hasn't been restored.

Note: tested in conjunction with ESP8266 non-OS SDK 3.0.5, however these DHCP server changes appear to be independent of the SDK version used.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
esp8266:
  board: esp01_1m
  framework:
    # https://github.com/esp8266/Arduino/releases
    version: 3.1.2

captive_portal:
wifi:
  ssid: UnreachableAP
  password: OrBadPwd
  ap:
    ssid: 'Test Fallback AP'
    password: 'strongpassword'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
