### PR TITLE
Revert "Template sensors always publish on update interval (#2224)"

### DIFF
--- a/esphome/components/template/sensor/template_sensor.cpp
+++ b/esphome/components/template/sensor/template_sensor.cpp
@@ -8,13 +8,12 @@ namespace template_ {
 static const char *const TAG = "template.sensor";
 
 void TemplateSensor::update() {
-  if (this->f_.has_value()) {
-    auto val = (*this->f_)();
-    if (val.has_value()) {
-      this->publish_state(*val);
-    }
-  } else if (!std::isnan(this->get_raw_state())) {
-    this->publish_state(this->get_raw_state());
+  if (!this->f_.has_value())
+    return;
+
+  auto val = (*this->f_)();
+  if (val.has_value()) {
+    this->publish_state(*val);
   }
 }
 float TemplateSensor::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/template/text_sensor/template_text_sensor.cpp
+++ b/esphome/components/template/text_sensor/template_text_sensor.cpp
@@ -7,13 +7,12 @@ namespace template_ {
 static const char *const TAG = "template.text_sensor";
 
 void TemplateTextSensor::update() {
-  if (this->f_.has_value()) {
-    auto val = (*this->f_)();
-    if (val.has_value()) {
-      this->publish_state(*val);
-    }
-  } else if (this->has_state()) {
-    this->publish_state(this->state);
+  if (!this->f_.has_value())
+    return;
+
+  auto val = (*this->f_)();
+  if (val.has_value()) {
+    this->publish_state(*val);
   }
 }
 float TemplateTextSensor::get_setup_priority() const { return setup_priority::HARDWARE; }


### PR DESCRIPTION
This reverts commit 6180ee8065db319a475692a1dbcbe02b5132e9a3.

# What does this implement/fix?

This reverts the change to always publish values for template sensors on the update interval even if there is not a lambda function for the sensor.  For some use cases this maybe a breaking change as this was originally put in place to help solve issue esphome/issues#2392.  For cases where this functionality is needed a combination of an `or` filter and a `heartbeat` filter can bring it back.

```yaml
filters:
  - or:
      - heatbeat: 60s
      - lambda: return x;
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2889

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
