### PR TITLE
Fixes for Arduino 2.7.4 (for FastLED)

### DIFF
--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -7,6 +7,8 @@
 namespace esphome {
 namespace socket {
 
+Socket::~Socket() {}
+
 std::unique_ptr<Socket> socket_ip(int type, int protocol) {
 #if LWIP_IPV6
   return socket(AF_INET6, type, protocol);

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -11,7 +11,7 @@ namespace socket {
 class Socket {
  public:
   Socket() = default;
-  virtual ~Socket() = default;
+  virtual ~Socket();
   Socket(const Socket &) = delete;
   Socket &operator=(const Socket &) = delete;
 
@@ -34,7 +34,7 @@ class Socket {
   virtual ssize_t readv(const struct iovec *iov, int iovcnt) = 0;
   virtual ssize_t write(const void *buf, size_t len) = 0;
   virtual ssize_t writev(const struct iovec *iov, int iovcnt) = 0;
-  virtual ssize_t sendto(const void *buf, size_t len, int flags, const struct sockaddr *to, socklen_t tolen);
+  virtual ssize_t sendto(const void *buf, size_t len, int flags, const struct sockaddr *to, socklen_t tolen) = 0;
 
   virtual int setblocking(bool blocking) = 0;
   virtual int loop() { return 0; };

--- a/esphome/core/string_ref.h
+++ b/esphome/core/string_ref.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <string>
-#include <iterator>
 #include <cstring>
+#include <iterator>
+#include <memory>
+#include <string>
 #include "esphome/core/defines.h"
 
 #ifdef USE_JSON


### PR DESCRIPTION
The FastLED component currently requires the Arduino 2.7.4 framework. Building with this is currently broken.

This change simply adds a missing include and moves the destructor definition to the cpp file (otherwise there is a linkage error).

# What does this implement/fix?

Fixes builds with Arduino framework 2.7.4.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: mintest

wifi:
  networks:
    - ssid: foo
      password: bar123456

api:
  encryption:
    # Created this fresh on https://esphome.io/components/api.html
    # So consider this one burned :-)
    key: "r/njOCAl5ITVIfp4gUBYVCLifR95+E+q+elTUOewCIg="

esp8266:
  framework:
    version: 2.7.4
  board: d1_mini

# Configure LED
light:
  - platform: fastled_clockless
    chipset: WS2811
    pin: D8
    default_transition_length: 10ms
    num_leds: 1
    rgb_order: GRB
    id: led
```

Broken on 2023.4.2, working with a local build.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
