### PR TITLE
Fixed access point for ESP32 IDF platform

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -767,11 +767,10 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
     info.gw.addr = static_cast<uint32_t>(network::IPAddress(192, 168, 4, 1));
     info.netmask.addr = static_cast<uint32_t>(network::IPAddress(255, 255, 255, 0));
   }
-  esp_netif_dhcp_status_t dhcp_status;
-  esp_netif_dhcps_get_status(s_sta_netif, &dhcp_status);
-  err = esp_netif_dhcps_stop(s_sta_netif);
-  if (err != ESP_OK) {
-    ESP_LOGV(TAG, "esp_netif_dhcps_stop failed! %d", err);
+
+  err = esp_netif_dhcpc_stop(s_sta_netif);
+  if (err != ESP_OK && err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STOPPED) {
+    ESP_LOGV(TAG, "esp_netif_dhcpc_stop failed: %s", esp_err_to_name(err));
     return false;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Access point on ESP32 IDF didn't work since it tried to stop the wrong dhcp (server instead of client).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: esp32idf

# Example configuration entry
esp32:
  board: esp32dev
  framework:
    type: esp-idf
      # version: 4.3.0
    # Custom sdkconfig options
    sdkconfig_options:
      CONFIG_COMPILER_OPTIMIZATION_SIZE: y
    # Advanced tweaking options
    advanced:
      ignore_efuse_mac_crc: false

wifi:
  ssid: wrongssid
  password: wifipwd
  ap: {}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
