### PR TITLE
Do not blind exception if component import fails (i.e. componen…

### DIFF
--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -163,7 +163,7 @@ def _lookup_module(domain):
 
     try:
         module = importlib.import_module(f"esphome.components.{domain}")
-    except ImportError as e:
+    except ImportError:
         _LOGGER.error("Unable to import component %s:", domain, exc_info=True)
         return None
     except Exception:  # pylint: disable=broad-except

--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -164,8 +164,7 @@ def _lookup_module(domain):
     try:
         module = importlib.import_module(f"esphome.components.{domain}")
     except ImportError as e:
-        if "No module named" not in str(e):
-            _LOGGER.error("Unable to import component %s:", domain, exc_info=True)
+        _LOGGER.error("Unable to import component %s:", domain, exc_info=True)
         return None
     except Exception:  # pylint: disable=broad-except
         _LOGGER.error("Unable to load component %s:", domain, exc_info=True)


### PR DESCRIPTION

# What does this implement/fix?

Do not blind exception if component import fails (i.e. component's `__init__.py` uses missing dependency). See Test Environment section for instructions to reproduce. While `esphome` should fail in those cases, not providing the stack trace makes it really hard to figure out what the problem is.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3699

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

How to reproduce issue:
1. Add a new non satisfied dependency to any component (i.e. `import svglib` if not installed)
2. Run `esphome config`
3. Error shown is `Component not found: X`, without any further information

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

