### PR TITLE
Fix ezo parsing

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -108,18 +108,16 @@ void EZOSensor::loop() {
 
   ESP_LOGV(TAG, "Received buffer \"%s\" for command type %s", &buf[1], EZO_COMMAND_TYPE_STRINGS[to_run->command_type]);
 
-  if ((buf[0] == 1) || (to_run->command_type == EzoCommandType::EZO_CALIBRATION)) {  // EZO_CALIBRATION returns 0-3
-    // some sensors return multiple comma-separated values, terminate string after first one
-    for (size_t i = 1; i < sizeof(buf) - 1; i++) {
-      if (buf[i] == ',') {
-        buf[i] = '\0';
-        break;
-      }
-    }
+  if (buf[0] == 1) {
     std::string payload = reinterpret_cast<char *>(&buf[1]);
     if (!payload.empty()) {
       switch (to_run->command_type) {
         case EzoCommandType::EZO_READ: {
+          // some sensors return multiple comma-separated values, terminate string after first one
+          int start_location = 0;
+          if ((start_location = payload.find(',')) != std::string::npos) {
+            payload.erase(start_location);
+          }
           auto val = parse_number<float>(payload);
           if (!val.has_value()) {
             ESP_LOGW(TAG, "Can't convert '%s' to number!", payload.c_str());

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -152,7 +152,10 @@ void EZOSensor::loop() {
           break;
         }
         case EzoCommandType::EZO_T: {
-          this->t_callback_.call(payload);
+          int start_location = 0;
+          if ((start_location = payload.find(',')) != std::string::npos) {
+            this->t_callback_.call(payload.substr(start_location + 1));
+          }
           break;
         }
         case EzoCommandType::EZO_CUSTOM: {

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -106,7 +106,7 @@ void EZOSensor::loop() {
       break;
   }
 
-  ESP_LOGV(TAG, "Received buffer \"%s\" for command type %s", buf, EZO_COMMAND_TYPE_STRINGS[to_run->command_type]);
+  ESP_LOGV(TAG, "Received buffer \"%s\" for command type %s", &buf[1], EZO_COMMAND_TYPE_STRINGS[to_run->command_type]);
 
   if ((buf[0] == 1) || (to_run->command_type == EzoCommandType::EZO_CALIBRATION)) {  // EZO_CALIBRATION returns 0-3
     // some sensors return multiple comma-separated values, terminate string after first one


### PR DESCRIPTION
# What does this implement/fix?

The current parsing of the EZO sensor had a few issues that wouldn't make them work. Namely:

- The returned value would be truncated always (not only for EZO_READ), which would not allow any other command to actually work (cd5dae3)
- The temperature-compensated readings were not properly parsed (f91f691)
- Additionally, the component was previously logging binary data (f2dfba2)


This is tested against both a pH and ORP EZO sensors. I've carefully reviewed all EZO datasheets, and they all follow the same pattern, so this code should work with every EZO sensor available at time of writing. The only caveat is the RGB EZO sensor which, by nature, on EZO_READ returns 3 comma-separated values (R,G,B). The current implementation only returns the "R" component. Support for the RGB sensor entails a breaking change, where "EZO_READ" returns an array of values. I'd be happy to implement such a change, but didn't want to introduce a breaking change at this stage.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no documentation updates required)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
Typical use case reading the EZO_CALIBRATION status:

```yaml

button:
  - platform: template
    name: "Retrieve pH calibration status"
    on_press:
      - lambda: |-
         id(ezo_ph).get_calibration();

sensor:
  - platform: ezo
    id: ezo_ph
    address: 99
    name: "pH sensor"
    unit_of_measurement: "pH"
    accuracy_decimals: 2
    on_calibration:
      - text_sensor.template.publish:
          id: ph_calibration_status
          state: !lambda |-
            return x;

```

Without this patch, the "on_calibration" callback is never invoked, due to parsing issues.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
