### PR TITLE
Bump ESP32-audioI2s to 2.0.7

### DIFF
--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -97,5 +97,5 @@ async def to_code(config):
 
     cg.add_library("WiFiClientSecure", None)
     cg.add_library("HTTPClient", None)
-    cg.add_library("esphome/ESP32-audioI2S", "2.0.6")
+    cg.add_library("esphome/ESP32-audioI2S", "2.0.7")
     cg.add_build_flag("-DAUDIO_NO_SD_FS")

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,7 +121,7 @@ lib_deps =
     HTTPClient                           ; http_request,nextion (Arduino built-in)
     ESPmDNS                              ; mdns (Arduino built-in)
     DNSServer                            ; captive_portal (Arduino built-in)
-    esphome/ESP32-audioI2S@2.0.6         ; i2s_audio
+    esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
     crankyoldgit/IRremoteESP8266@2.7.12  ; heatpumpir
 build_flags =
     ${common:arduino.build_flags}


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

https://github.com/esphome/ESP32-audioI2S/compare/2.0.6...2.0.7

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4447

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
