### PR TITLE
Make i2s_audio bclk_pin optional

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -42,8 +42,8 @@ I2S_PORTS = {
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(I2SAudioComponent),
-        cv.Required(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
         cv.Required(CONF_I2S_LRCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
     }
 )
 
@@ -66,5 +66,6 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
-    cg.add(var.set_bclk_pin(config[CONF_I2S_BCLK_PIN]))
     cg.add(var.set_lrclk_pin(config[CONF_I2S_LRCLK_PIN]))
+    if CONF_I2S_BCLK_PIN in config:
+        cg.add(var.set_bclk_pin(config[CONF_I2S_BCLK_PIN]))

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -29,8 +29,8 @@ class I2SAudioComponent : public Component {
     };
   }
 
-  void set_bclk_pin(uint8_t pin) { this->bclk_pin_ = pin; }
-  void set_lrclk_pin(uint8_t pin) { this->lrclk_pin_ = pin; }
+  void set_bclk_pin(int pin) { this->bclk_pin_ = pin; }
+  void set_lrclk_pin(int pin) { this->lrclk_pin_ = pin; }
 
   void lock() { this->lock_.lock(); }
   bool try_lock() { return this->lock_.try_lock(); }
@@ -44,8 +44,8 @@ class I2SAudioComponent : public Component {
   I2SAudioIn *audio_in_{nullptr};
   I2SAudioOut *audio_out_{nullptr};
 
-  uint8_t bclk_pin_{I2S_PIN_NO_CHANGE};
-  uint8_t lrclk_pin_;
+  int bclk_pin_{I2S_PIN_NO_CHANGE};
+  int lrclk_pin_;
   i2s_port_t port_{};
 };
 

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -41,7 +41,10 @@ class I2SAudioComponent : public Component {
  protected:
   Mutex lock_;
 
-  uint8_t bclk_pin_;
+  I2SAudioIn *audio_in_{nullptr};
+  I2SAudioOut *audio_out_{nullptr};
+
+  uint8_t bclk_pin_{I2S_PIN_NO_CHANGE};
   uint8_t lrclk_pin_;
   i2s_port_t port_{};
 };


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1254

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2907

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
