### PR TITLE
Supposed to fix #4069, by changing the default value to 0s (timeunit …

### DIFF
--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -275,7 +275,7 @@ SPRINKLER_ACTION_SET_RUN_DURATION_SCHEMA = cv.Schema(
 SPRINKLER_ACTION_QUEUE_VALVE_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_ID): cv.use_id(Sprinkler),
-        cv.Optional(CONF_RUN_DURATION, default=0): cv.templatable(
+        cv.Optional(CONF_RUN_DURATION, default="0s"): cv.templatable(
             cv.positive_time_period_seconds
         ),
         cv.Required(CONF_VALVE_NUMBER): cv.templatable(cv.positive_int),


### PR DESCRIPTION
# What does this implement/fix?

[#4069](https://github.com/esphome/issues/issues/4069) There was a problem with the default value. The validation wanted a time string like 1m, 1s, 1h but the default value was a plain integer (0)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4069

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
on_press:
      then:
        - lambda: 'ESP_LOGD("main", "Starting program: valve 1 & 2");'
        - sprinkler.queue_valve:
            id: controller
            valve_number: 0
# run_duration not specified so taking default value...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
