### PR TITLE
IPv6 for ESP32 ethernet

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -98,6 +98,8 @@ void EthernetComponent::setup() {
   ESPHL_ERROR_CHECK(err, "ETH event handler register error");
   err = esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &EthernetComponent::got_ip_event_handler, nullptr);
   ESPHL_ERROR_CHECK(err, "GOT IP event handler register error");
+  err = esp_event_handler_register(IP_EVENT, IP_EVENT_GOT_IP6, &EthernetComponent::got_ip6_event_handler, nullptr);
+  ESPHL_ERROR_CHECK(err, "GOT IP6 event handler register error");
 
   /* start Ethernet driver state machine */
   err = esp_eth_start(this->eth_handle_);
@@ -139,6 +141,17 @@ void EthernetComponent::loop() {
         ESP_LOGW(TAG, "Connection via Ethernet lost! Re-connecting...");
         this->state_ = EthernetComponentState::CONNECTING;
         this->start_connect_();
+      } else if (this->got_ipv6_) {
+        esp_ip6_addr_t ip6_addr;
+        if (esp_netif_get_ip6_global(this->eth_netif_, &ip6_addr) == 0 &&
+            esp_netif_ip6_get_addr_type(&ip6_addr) == ESP_IP6_ADDR_IS_GLOBAL) {
+          ESP_LOGCONFIG(TAG, "IPv6 Addr (Global): " IPV6STR, IPV62STR(ip6_addr));
+        } else {
+          esp_netif_get_ip6_linklocal(this->eth_netif_, &ip6_addr);
+          ESP_LOGCONFIG(TAG, " IPv6: " IPV6STR, IPV62STR(ip6_addr));
+        }
+
+        this->got_ipv6_ = false;
       }
       break;
   }
@@ -230,6 +243,13 @@ void EthernetComponent::got_ip_event_handler(void *arg, esp_event_base_t event_b
   ESP_LOGV(TAG, "[Ethernet event] ETH Got IP (num=%d)", event_id);
 }
 
+void EthernetComponent::got_ip6_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
+                                              void *event_data) {
+  ESP_LOGV(TAG, "[Ethernet event] ETH Got IP6 (num=%d)", event_id);
+  global_eth_component->got_ipv6_ = true;
+  global_eth_component->ipv6_count_ += 1;
+}
+
 void EthernetComponent::start_connect_() {
   this->connect_begin_ = millis();
   this->status_set_warning();
@@ -292,6 +312,10 @@ void EthernetComponent::start_connect_() {
     if (err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STARTED) {
       ESPHL_ERROR_CHECK(err, "DHCPC start error");
     }
+    err = esp_netif_create_ip6_linklocal(this->eth_netif_);
+    if (err != ESP_OK) {
+      ESPHL_ERROR_CHECK(err, "IPv6 local failed");
+    }
   }
 
   this->connect_begin_ = millis();
@@ -318,9 +342,18 @@ void EthernetComponent::dump_connect_params_() {
   ESP_LOGCONFIG(TAG, "  DNS1: %s", network::IPAddress(dns_ip1->addr).str().c_str());
   ESP_LOGCONFIG(TAG, "  DNS2: %s", network::IPAddress(dns_ip2->addr).str().c_str());
 #endif
+  if (this->ipv6_count_ > 0) {
+    esp_ip6_addr_t ip6_addr;
+    esp_netif_get_ip6_linklocal(this->eth_netif_, &ip6_addr);
+    ESP_LOGCONFIG(TAG, " IPv6: " IPV6STR, IPV62STR(ip6_addr));
+
+    if (esp_netif_get_ip6_global(this->eth_netif_, &ip6_addr) == 0 &&
+        esp_netif_ip6_get_addr_type(&ip6_addr) == ESP_IP6_ADDR_IS_GLOBAL) {
+      ESP_LOGCONFIG(TAG, "IPv6 Addr (Global): " IPV6STR, IPV62STR(ip6_addr));
+    }
+  }
 
   esp_err_t err;
-
   uint8_t mac[6];
   err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_G_MAC_ADDR, &mac);
   ESPHL_ERROR_CHECK(err, "ETH_CMD_G_MAC error");

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -64,6 +64,7 @@ class EthernetComponent : public Component {
  protected:
   static void eth_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
   static void got_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
+  static void got_ip6_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
 
   void start_connect_();
   void dump_connect_params_();
@@ -80,6 +81,8 @@ class EthernetComponent : public Component {
 
   bool started_{false};
   bool connected_{false};
+  bool got_ipv6_{false};
+  uint8_t ipv6_count_{0};
   EthernetComponentState state_{EthernetComponentState::STOPPED};
   uint32_t connect_begin_;
   esp_netif_t *eth_netif_{nullptr};

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -1,3 +1,4 @@
+from esphome.core import CORE
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components.esp32 import add_idf_sdkconfig_option
@@ -14,16 +15,20 @@ IPAddress = network_ns.class_("IPAddress")
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.SplitDefault(CONF_ENABLE_IPV6, esp32_idf=False): cv.All(
-            cv.only_with_esp_idf, cv.boolean
+        cv.SplitDefault(CONF_ENABLE_IPV6, esp32=False): cv.All(
+            cv.only_on_esp32, cv.boolean
         ),
     }
 )
 
 
 async def to_code(config):
-    if CONF_ENABLE_IPV6 in config:
-        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
-        add_idf_sdkconfig_option(
-            "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
-        )
+    if CONF_ENABLE_IPV6 in config and config[CONF_ENABLE_IPV6]:
+        if CORE.using_esp_idf:
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
+            add_idf_sdkconfig_option(
+                "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
+            )
+        else:
+            cg.add_build_flag("-DCONFIG_LWIP_IPV6")
+            cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")


### PR DESCRIPTION
# What does this implement/fix?

This adds inital IPv6 support for ESP32 ethernet

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] ESP32 Ethernet

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: ipv6eth

esp32:
  board: esp32dev
  framework:
    type: arduino

network:
  enable_ipv6: true

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
