### PR TITLE
Tuya: Prevent loop when setting colors on case-sensitive dps

### DIFF
--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -95,7 +95,7 @@ void TuyaLight::setup() {
   }
 
   if (min_value_datapoint_id_.has_value()) {
-    parent_->set_integer_datapoint_value(*this->min_value_datapoint_id_, this->min_value_);
+    this->parent_->set_integer_datapoint_value(*this->min_value_datapoint_id_, this->min_value_);
   }
 }
 
@@ -164,7 +164,7 @@ void TuyaLight::write_state(light::LightState *state) {
   }
 
   if (!state->current_values.is_on() && this->switch_id_.has_value()) {
-    parent_->set_boolean_datapoint_value(*this->switch_id_, false);
+    this->parent_->set_boolean_datapoint_value(*this->switch_id_, false);
     return;
   }
 
@@ -174,14 +174,14 @@ void TuyaLight::write_state(light::LightState *state) {
       if (this->color_temperature_invert_) {
         color_temp_int = this->color_temperature_max_value_ - color_temp_int;
       }
-      parent_->set_integer_datapoint_value(*this->color_temperature_id_, color_temp_int);
+      this->parent_->set_integer_datapoint_value(*this->color_temperature_id_, color_temp_int);
     }
 
     if (this->dimmer_id_.has_value()) {
       auto brightness_int = static_cast<uint32_t>(brightness * this->max_value_);
       brightness_int = std::max(brightness_int, this->min_value_);
 
-      parent_->set_integer_datapoint_value(*this->dimmer_id_, brightness_int);
+      this->parent_->set_integer_datapoint_value(*this->dimmer_id_, brightness_int);
     }
   }
 
@@ -214,11 +214,11 @@ void TuyaLight::write_state(light::LightState *state) {
         break;
       }
     }
-    parent_->set_string_datapoint_value(*this->color_id_, color_value);
+    this->parent_->set_string_datapoint_value(*this->color_id_, color_value);
   }
 
   if (this->switch_id_.has_value()) {
-    parent_->set_boolean_datapoint_value(*this->switch_id_, true);
+    this->parent_->set_boolean_datapoint_value(*this->switch_id_, true);
   }
 }
 

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -61,15 +61,13 @@ void TuyaLight::setup() {
       switch (*this->color_type_) {
         case TuyaColorType::RGBHSV:
         case TuyaColorType::RGB: {
-          auto red_int = parse_hex<uint8_t>(datapoint.value_string.substr(0, 2));
-          auto green_int = parse_hex<uint8_t>(datapoint.value_string.substr(2, 2));
-          auto blue_int = parse_hex<uint8_t>(datapoint.value_string.substr(4, 2));
-          if (!red_int.has_value() || !green_int.has_value() || !blue_int.has_value())
+          auto rgb = parse_hex<uint32_t>(datapoint.value_string.substr(0, 6));
+          if (!rgb.has_value())
             return;
 
-          red = float(*red_int) / 255;
-          green = float(*green_int) / 255;
-          blue = float(*blue_int) / 255;
+          red = (*rgb >> 16) / 255.0f;
+          green = ((*rgb >> 8) & 0xff) / 255.0f;
+          blue = (*rgb & 0xff) / 255.0f;
           break;
         }
         case TuyaColorType::HSV: {


### PR DESCRIPTION
# What does this implement/fix?

If the TuyaMCU expects lower case color data, the current code gets stuck in an infinite loop
1) ESPHome sets datapoint to uppercase color
2) TuyaMCU sets the datapoint to lowercase color which is treated as a change
3) ESPHome updates state based on reported value from MCU and triggers ESP to set the dp again...

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
