### PR TITLE
Fix time period validation for the auto cleaning interval

### DIFF
--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -119,7 +119,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_PM10,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_AUTO_CLEANING_INTERVAL): cv.time_period_in_seconds_,
+            cv.Optional(CONF_AUTO_CLEANING_INTERVAL): cv.update_interval,
             cv.Optional(CONF_VOC): sensor.sensor_schema(
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -489,6 +489,7 @@ sensor:
       offset: 0
       normalized_offset_slope: 0
       time_constant: 0
+    auto_cleaning_interval: 604800s
     acceleration_mode: low
     store_baseline: true
     address: 0x69


### PR DESCRIPTION
# What does this implement/fix?

Correct validator to fix the `AttributeError: 'OrderedDict' object has no attribute 'microseconds'` error when adding the `auto_cleaning_interval` entity to the sensor.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4507

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: test
  friendly_name: test

esp32:
  board: esp32dev
  framework:
    type: arduino

logger:

api:
  encryption:
    key: "foobar"

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

i2c:
  sda: GPIO6
  scl: GPIO7
  
sensor:
  - platform: sen5x
    auto_cleaning_interval: 604800s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
