### PR TITLE
handle Wiegand 8-bit keys

### DIFF
--- a/esphome/components/wiegand/wiegand.cpp
+++ b/esphome/components/wiegand/wiegand.cpp
@@ -102,6 +102,16 @@ void Wiegand::loop() {
       uint8_t key = KEYS[value];
       this->send_key_(key);
     }
+  } else if (count == 8) {
+    if ((value ^ 0xf0) >> 4 == (value & 0xf)) {
+      value &= 0xf;
+      for (auto *trigger : this->key_triggers_)
+        trigger->trigger(value);
+      if (value < 12) {
+        uint8_t key = KEYS[value];
+        this->send_key_(key);
+      }
+    }
   } else {
     ESP_LOGD(TAG, "received unknown %d-bit value: %llx", count, value);
   }


### PR DESCRIPTION
# What does this implement/fix?

Some Wiegand keypads send 8-bit values for the keys.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://community.home-assistant.io/t/wiegand-protocol-rfid-readers-known-to-work-with-esphome/356765/76

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
