### PR TITLE
[SCD30] Disable negative temperature offset

### DIFF
--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -42,13 +42,18 @@ void SCD30Component::setup() {
   ESP_LOGD(TAG, "SCD30 Firmware v%0d.%02d", (uint16_t(raw_firmware_version[0]) >> 8),
            uint16_t(raw_firmware_version[0] & 0xFF));
 
-  if (this->temperature_offset_ != 0) {
-    if (!this->write_command(SCD30_CMD_TEMPERATURE_OFFSET, (uint16_t) (temperature_offset_ * 100.0))) {
-      ESP_LOGE(TAG, "Sensor SCD30 error setting temperature offset.");
-      this->error_code_ = MEASUREMENT_INIT_FAILED;
-      this->mark_failed();
-      return;
-    }
+  uint16_t temp_offset;
+  if (this->temperature_offset_ > 0) {
+    temp_offset = (this->temperature_offset_ * 100);
+  } else {
+    temp_offset = 0;
+  }
+
+  if (!this->write_command(SCD30_CMD_TEMPERATURE_OFFSET, temp_offset)) {
+    ESP_LOGE(TAG, "Sensor SCD30 error setting temperature offset.");
+    this->error_code_ = MEASUREMENT_INIT_FAILED;
+    this->mark_failed();
+    return;
   }
 #ifdef USE_ESP32
   // According ESP32 clock stretching is typically 30ms and up to 150ms "due to

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -68,7 +68,9 @@ CONFIG_SCHEMA = (
                 cv.int_range(min=0, max=0xFFFF, max_included=False),
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
-            cv.Optional(CONF_TEMPERATURE_OFFSET): cv.temperature,
+            cv.Optional(CONF_TEMPERATURE_OFFSET): cv.float(
+                min=0,
+            ),
             cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.All(
                 cv.positive_time_period_seconds,
                 cv.Range(

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -70,9 +70,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
             cv.Optional(CONF_TEMPERATURE_OFFSET): cv.All(
                 cv.temperature,
-                cv.float_range(
-                    min=0,
-                ),
+                cv.float_range(min=0, max=655.35),
             ),
             cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.All(
                 cv.positive_time_period_seconds,

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -68,7 +68,7 @@ CONFIG_SCHEMA = (
                 cv.int_range(min=0, max=0xFFFF, max_included=False),
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
-            cv.Optional(CONF_TEMPERATURE_OFFSET): cv.float(
+            cv.Optional(CONF_TEMPERATURE_OFFSET): cv.float_range(
                 min=0,
             ),
             cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.All(

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -68,8 +68,11 @@ CONFIG_SCHEMA = (
                 cv.int_range(min=0, max=0xFFFF, max_included=False),
             ),
             cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION, default=0): cv.pressure,
-            cv.Optional(CONF_TEMPERATURE_OFFSET): cv.float_range(
-                min=0,
+            cv.Optional(CONF_TEMPERATURE_OFFSET): cv.All(
+                cv.temperature,
+                cv.float_range(
+                    min=0,
+                ),
             ),
             cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.All(
                 cv.positive_time_period_seconds,


### PR DESCRIPTION
# What does this implement/fix?

Setting the temperature offset to a negative number results in bad behavior, as the value is converted to an unsigned int which sends the temperature and humidity readings way out of whack. This updates the config schema to only allow positive (or zero) values. Also changes the code to only set the offset to zero or a positive value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3063

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
