### PR TITLE
mqtt: add ESP-IDF >= 5.0 support

### DIFF
--- a/esphome/components/mqtt/mqtt_backend_idf.cpp
+++ b/esphome/components/mqtt/mqtt_backend_idf.cpp
@@ -11,6 +11,7 @@ namespace mqtt {
 static const char *const TAG = "mqtt.idf";
 
 bool MQTTBackendIDF::initialize_() {
+#if ESP_IDF_VERSION_MAJOR < 5
   mqtt_cfg_.user_context = (void *) this;
   mqtt_cfg_.buffer_size = MQTT_BUFFER_SIZE;
 
@@ -47,6 +48,41 @@ bool MQTTBackendIDF::initialize_() {
   } else {
     mqtt_cfg_.transport = MQTT_TRANSPORT_OVER_TCP;
   }
+#else
+  mqtt_cfg_.broker.address.hostname = this->host_.c_str();
+  mqtt_cfg_.broker.address.port = this->port_;
+  mqtt_cfg_.session.keepalive = this->keep_alive_;
+  mqtt_cfg_.session.disable_clean_session = !this->clean_session_;
+
+  if (!this->username_.empty()) {
+    mqtt_cfg_.credentials.username = this->username_.c_str();
+    if (!this->password_.empty()) {
+      mqtt_cfg_.credentials.authentication.password = this->password_.c_str();
+    }
+  }
+
+  if (!this->lwt_topic_.empty()) {
+    mqtt_cfg_.session.last_will.topic = this->lwt_topic_.c_str();
+    this->mqtt_cfg_.session.last_will.qos = this->lwt_qos_;
+    this->mqtt_cfg_.session.last_will.retain = this->lwt_retain_;
+
+    if (!this->lwt_message_.empty()) {
+      mqtt_cfg_.session.last_will.msg = this->lwt_message_.c_str();
+      mqtt_cfg_.session.last_will.msg_len = this->lwt_message_.size();
+    }
+  }
+
+  if (!this->client_id_.empty()) {
+    mqtt_cfg_.credentials.client_id = this->client_id_.c_str();
+  }
+  if (ca_certificate_.has_value()) {
+    mqtt_cfg_.broker.verification.certificate = ca_certificate_.value().c_str();
+    mqtt_cfg_.broker.verification.skip_cert_common_name_check = skip_cert_cn_check_;
+    mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_SSL;
+  } else {
+    mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_TCP;
+  }
+#endif
   auto *mqtt_client = esp_mqtt_client_init(&mqtt_cfg_);
   if (mqtt_client) {
     handler_.reset(mqtt_client);
@@ -80,7 +116,7 @@ void MQTTBackendIDF::mqtt_event_handler_(const Event &event) {
       ESP_LOGV(TAG, "MQTT_EVENT_CONNECTED");
       // TODO session present check
       this->is_connected_ = true;
-      this->on_connect_.call(!mqtt_cfg_.disable_clean_session);
+      this->on_connect_.call();
       break;
     case MQTT_EVENT_DISCONNECTED:
       ESP_LOGV(TAG, "MQTT_EVENT_DISCONNECTED");

--- a/esphome/components/mqtt/mqtt_backend_idf.cpp
+++ b/esphome/components/mqtt/mqtt_backend_idf.cpp
@@ -114,9 +114,8 @@ void MQTTBackendIDF::mqtt_event_handler_(const Event &event) {
 
     case MQTT_EVENT_CONNECTED:
       ESP_LOGV(TAG, "MQTT_EVENT_CONNECTED");
-      // TODO session present check
       this->is_connected_ = true;
-      this->on_connect_.call();
+      this->on_connect_.call(event.session_present);
       break;
     case MQTT_EVENT_DISCONNECTED:
       ESP_LOGV(TAG, "MQTT_EVENT_DISCONNECTED");

--- a/esphome/components/mqtt/mqtt_backend_idf.h
+++ b/esphome/components/mqtt/mqtt_backend_idf.h
@@ -22,6 +22,7 @@ struct Event {
   bool retain;
   int qos;
   bool dup;
+  bool session_present;
   esp_mqtt_error_codes_t error_handle;
 
   // Construct from esp_mqtt_event_t
@@ -36,6 +37,7 @@ struct Event {
         retain(event.retain),
         qos(event.qos),
         dup(event.dup),
+        session_present(event.session_present),
         error_handle(*event.error_handle) {}
 };
 

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -118,7 +118,7 @@ bool MQTTComponent::send_discovery_() {
         } else {
           if (discovery_info.unique_id_generator == MQTT_MAC_ADDRESS_UNIQUE_ID_GENERATOR) {
             char friendly_name_hash[9];
-            sprintf(friendly_name_hash, "%08x", fnv1_hash(this->friendly_name()));
+            sprintf(friendly_name_hash, "%08" PRIx32, fnv1_hash(this->friendly_name()));
             friendly_name_hash[8] = 0;  // ensure the hash-string ends with null
             root[MQTT_UNIQUE_ID] = get_mac_address() + "-" + this->component_type() + "-" + friendly_name_hash;
           } else {

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "mqtt_sensor.h"
 #include "esphome/core/log.h"
 
@@ -26,7 +27,7 @@ void MQTTSensorComponent::setup() {
 void MQTTSensorComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT Sensor '%s':", this->sensor_->get_name().c_str());
   if (this->get_expire_after() > 0) {
-    ESP_LOGCONFIG(TAG, "  Expire After: %us", this->get_expire_after() / 1000);
+    ESP_LOGCONFIG(TAG, "  Expire After: %" PRIu32 "s", this->get_expire_after() / 1000);
   }
   LOG_MQTT_COMPONENT(true, false)
 }


### PR DESCRIPTION
# What does this implement/fix?

Add ESP-IDF >= 5.0 support to the MQTT component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
