### PR TITLE
light: fix compile with ESP-IDF >= 5

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "light_call.h"
 #include "light_state.h"
 #include "esphome/core/log.h"
@@ -283,7 +284,7 @@ LightColorValues LightCall::validate_() {
 
   // validate effect index
   if (this->has_effect_() && *this->effect_ > this->parent_->effects_.size()) {
-    ESP_LOGW(TAG, "'%s' - Invalid effect index %u!", name, *this->effect_);
+    ESP_LOGW(TAG, "'%s' - Invalid effect index %" PRIu32 "!", name, *this->effect_);
     this->effect_.reset();
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fix compilation of the light component with ESP-IDF >= 5.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
