### PR TITLE
esp32_rmt_led_strip: fix compile with ESP-IDF >= 5

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "led_strip.h"
 
 #ifdef USE_ESP32
@@ -195,7 +196,7 @@ void ESP32RMTLEDStripLightOutput::dump_config() {
       break;
   }
   ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order);
-  ESP_LOGCONFIG(TAG, "  Max refresh rate: %u", *this->max_refresh_rate_);
+  ESP_LOGCONFIG(TAG, "  Max refresh rate: %" PRIu32, *this->max_refresh_rate_);
   ESP_LOGCONFIG(TAG, "  Number of LEDs: %u", this->num_leds_);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Fix compilation of the esp32_rmt_led_strip component with ESP-IDF >= 5.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
