### PR TITLE
ota: fix TWDT with ESP-IDF >= 5

### DIFF
--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -25,8 +25,14 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
   // The following function takes longer than the 5 seconds timeout of WDT
 #if ESP_IDF_VERSION_MAJOR >= 5
   esp_task_wdt_config_t wdtc;
-  wdtc.timeout_ms = 15000;
   wdtc.idle_core_mask = 0;
+#if CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0
+  wdtc.idle_core_mask |= (1 << 0);
+#endif
+#if CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1
+  wdtc.idle_core_mask |= (1 << 1);
+#endif
+  wdtc.timeout_ms = 15000;
   wdtc.trigger_panic = false;
   esp_task_wdt_reconfigure(&wdtc);
 #else
@@ -39,7 +45,7 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
 #if CONFIG_ESP_TASK_WDT_TIMEOUT_S < 15
   // Set the WDT back to the configured timeout
 #if ESP_IDF_VERSION_MAJOR >= 5
-  wdtc.timeout_ms = CONFIG_ESP_TASK_WDT_TIMEOUT_S;
+  wdtc.timeout_ms = CONFIG_ESP_TASK_WDT_TIMEOUT_S * 1000;
   esp_task_wdt_reconfigure(&wdtc);
 #else
   esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, false);


### PR DESCRIPTION
# What does this implement/fix?

* avoid lowering TWDT timeout on OTA start with ESP-IDF >= 5.
* fix TWDT timeout triggering on OTA start with ESP-IDF >= 5.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
