### PR TITLE
Run YAML test 8 during CI and fix board used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        file: [1, 2, 3, 3.1, 4, 5, 6, 7]
+        file: [1, 2, 3, 3.1, 4, 5, 6, 7, 8]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.5.2

--- a/tests/test8.yaml
+++ b/tests/test8.yaml
@@ -4,7 +4,7 @@ wifi:
   ssid: "ssid"
 
 esp32:
-  board: esp32-c3-devkitm-1
+  board: esp32s3box
   variant: ESP32S3
   framework:
     type: arduino


### PR DESCRIPTION
# What does this implement/fix?

- `test8.yaml` will actually be compiled during CI
- `test8.yaml` will use an ESP32-S3 board instead of ESP32-C3

I chose the ESP32-S3-BOX as it is an official Espressif development board and has a PlatformIO board specification.
Also, we are currently developing a few components for this board, so having a test YAML for that would be good.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A
## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
