### PR TITLE
Fix i2s_audio media_player mutex acquisition

### DIFF
--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -133,7 +133,7 @@ void I2SAudioMediaPlayer::play_() {
 
 void I2SAudioMediaPlayer::start() { this->i2s_state_ = I2S_STATE_STARTING; }
 void I2SAudioMediaPlayer::start_() {
-  if (this->parent_->try_lock()) {
+  if (!this->parent_->try_lock()) {
     return;  // Waiting for another i2s to return lock
   }
 
@@ -156,6 +156,7 @@ void I2SAudioMediaPlayer::start_() {
 #if SOC_I2S_SUPPORTS_DAC
   }
 #endif
+
   this->i2s_state_ = I2S_STATE_RUNNING;
   this->high_freq_.start();
   this->audio_->setVolume(remap<uint8_t, float>(this->volume, 0.0f, 1.0f, 0, 21));
@@ -218,6 +219,12 @@ void I2SAudioMediaPlayer::dump_config() {
       default:
         break;
     }
+  } else {
+#endif
+    ESP_LOGCONFIG(TAG, "  External DAC channels: %d", this->external_dac_channels_);
+    ESP_LOGCONFIG(TAG, "  I2S DOUT Pin: %d", this->dout_pin_);
+    LOG_PIN("  Mute Pin: ", this->mute_pin_);
+#if SOC_I2S_SUPPORTS_DAC
   }
 #endif
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes mutex acquisition and adds the external parameters to the config dump.
All credits go to @rpatel3001.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
