### PR TITLE
[PSRam] Change log unit to KB to minimize rounding error.

### DIFF
--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -21,7 +21,7 @@ void PsramComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Available: %s", YESNO(available));
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
   if (available) {
-    ESP_LOGCONFIG(TAG, "  Size: %d MB", heap_caps_get_total_size(MALLOC_CAP_SPIRAM) / 1024 / 1024);
+    ESP_LOGCONFIG(TAG, "  Size: %d KB", heap_caps_get_total_size(MALLOC_CAP_SPIRAM) / 1024);
   }
 #endif
 }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
PSRam is displaying rounded down to MB.
Often a few bytes of PSRam is used before log print causing message to be incorrect.
Changing to round down to KB to have smaller rounding error.
Few examples:

OLD:

```txt
[C][psram:020]: PSRAM:
[C][psram:021]:   Available: YES
[C][psram:024]:   Size: 7 MB
```

NEW:

```txt
[C][psram:020]: PSRAM:
[C][psram:021]:   Available: YES
[C][psram:024]:   Size: 8191 KB
```

OLD:

```txt
[C][psram:020]: PSRAM:
[C][psram:021]:   Available: YES
[C][psram:024]:   Size: 3 MB
```

NEW:

```txt
[C][psram:020]: PSRAM:
[C][psram:021]:   Available: YES
[C][psram:024]:   Size: 4095 KB
```
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
