### PR TITLE
[internal_temperature] ESP32-S3 needs ESP IDF V4.4.3 or higher

### DIFF
--- a/esphome/components/internal_temperature/internal_temperature.cpp
+++ b/esphome/components/internal_temperature/internal_temperature.cpp
@@ -34,7 +34,8 @@ void InternalTemperatureSensor::update() {
   temp_sensor_set_config(tsens);
   temp_sensor_start();
 #if defined(USE_ESP32_VARIANT_ESP32S3) && (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 3))
-#error "ESP32-S3 internal temperature sensor requires ESP IDF V4.4.3 or higher. See https://github.com/esphome/issues/issues/4271"
+#error \
+    "ESP32-S3 internal temperature sensor requires ESP IDF V4.4.3 or higher. See https://github.com/esphome/issues/issues/4271"
 #endif
   esp_err_t result = temp_sensor_read_celsius(&temperature);
   temp_sensor_stop();

--- a/esphome/components/internal_temperature/internal_temperature.cpp
+++ b/esphome/components/internal_temperature/internal_temperature.cpp
@@ -33,6 +33,9 @@ void InternalTemperatureSensor::update() {
   temp_sensor_config_t tsens = TSENS_CONFIG_DEFAULT();
   temp_sensor_set_config(tsens);
   temp_sensor_start();
+#if defined(USE_ESP32_VARIANT_ESP32S3) && (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 3))
+#error "ESP32-S3 internal temperature sensor requires ESP IDF V4.4.3 or higher. See https://github.com/esphome/issues/issues/4271"
+#endif
   esp_err_t result = temp_sensor_read_celsius(&temperature);
   temp_sensor_stop();
   success = (result == ESP_OK);

--- a/esphome/components/internal_temperature/sensor.py
+++ b/esphome/components/internal_temperature/sensor.py
@@ -1,17 +1,44 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
+from esphome.components.esp32 import get_esp32_variant
+from esphome.components.esp32.const import (
+    VARIANT_ESP32S3,
+)
 from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     DEVICE_CLASS_TEMPERATURE,
     ENTITY_CATEGORY_DIAGNOSTIC,
+    KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
 )
+from esphome.core import CORE
 
 internal_temperature_ns = cg.esphome_ns.namespace("internal_temperature")
 InternalTemperatureSensor = internal_temperature_ns.class_(
     "InternalTemperatureSensor", sensor.Sensor, cg.PollingComponent
 )
+
+
+def validate_config(config):
+    if CORE.is_esp32:
+        variant = get_esp32_variant()
+        if variant == VARIANT_ESP32S3:
+            if CORE.using_arduino and CORE.data[KEY_CORE][
+                KEY_FRAMEWORK_VERSION
+            ] < cv.Version(2, 0, 6):
+                raise cv.Invalid(
+                    "ESP32-S3 Internal Temperature Sensor requires framework version 2.0.6 or higher. See <https://github.com/esphome/issues/issues/4271>."
+                )
+            if CORE.using_esp_idf and CORE.data[KEY_CORE][
+                KEY_FRAMEWORK_VERSION
+            ] < cv.Version(4, 4, 3):
+                raise cv.Invalid(
+                    "ESP32-S3 Internal Temperature Sensor requires framework version 4.4.3 or higher. See <https://github.com/esphome/issues/issues/4271>."
+                )
+    return config
+
 
 CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(
@@ -23,6 +50,7 @@ CONFIG_SCHEMA = cv.All(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ).extend(cv.polling_component_schema("60s")),
     cv.only_on(["esp32", "rp2040"]),
+    validate_config,
 )
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Avoid building non working firmware for ESP32-S3 with internal temperature sensor.
Check in Python code is a bit complex as there is no translation between Arduino version and internally used ESP IDF version.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <https://github.com/esphome/issues/issues/4271>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
