### PR TITLE
Update cover.h for compile errors with stop()

### DIFF
--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -140,8 +140,9 @@ class Cover : public EntityBase, public EntityBase_DeviceClass {
   /** Stop the cover.
    *
    * This is a legacy method and may be removed later, please use `.make_call()` instead.
+   * As per solution from issue #2885 the call should include perform()
    */
-  ESPDEPRECATED("stop() is deprecated, use make_call().set_command_stop() instead.", "2021.9")
+  ESPDEPRECATED("stop() is deprecated, use make_call().set_command_stop().perform() instead.", "2021.9")
   void stop();
 
   void add_on_state_callback(std::function<void()> &&f);


### PR DESCRIPTION
As per solution from issue esphome/issues#2885 the instruction within compile errors for the stop call should include perform() It is likely the same for open and close calls aswell but I'm not getting those errors but I do this have this error at compile time and the guidance provided is currently wrong.

# What does this implement/fix?

When compiling and the user is using the legacy stop() call within their cover they will receive a warning within the compile dialogue. The warning currently contains the incorrect call replacement which if the user makes the suggested change will remove the compile error but break the call. The suggested change here fixes the issue by providing the correct call to replace the legacy one.

User currently receives error as below
warning: ‘void esphome::cover::Cover::stop()’ is deprecated (declared at src/esphome/components/cover/cover.h:146): stop() is deprecated, use make_call().set_command_stop() instead. [-Wdeprecated-declarations]

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

esphome/issues#2885

## Test Environment

- [x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
button:
platform: template
name: "Left Blind Stop"
on_press:
lambda: |-
((SomfyESPCover*)id(somfy))->make_call().set_command_stop().perform();
logger.log: Button Pressed
platform: template
name: "Right Blind Stop"
on_press:
lambda: |-
((SomfyESPCover*)id(somfy2))->make_call().set_command_stop().perform();
logger.log: Button Pressed
```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
