### PR TITLE
Implement connection retries for http_request

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -4,6 +4,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.const import (
+    CONF_COUNT,
+    CONF_DELAY,
     CONF_ID,
     CONF_TIMEOUT,
     CONF_METHOD,
@@ -33,6 +35,8 @@ CONF_VERIFY_SSL = "verify_ssl"
 CONF_ON_RESPONSE = "on_response"
 CONF_FOLLOW_REDIRECTS = "follow_redirects"
 CONF_REDIRECT_LIMIT = "redirect_limit"
+CONF_RETRY = "retry"
+CONF_BACKOFF_FACTOR = "backoff_factor"
 
 
 def validate_url(value):
@@ -78,6 +82,15 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_TIMEOUT, default="5s"
             ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_RETRY, default={}): cv.Schema(
+                {
+                    cv.Optional(CONF_COUNT, 0): cv.positive_int,
+                    cv.Optional(
+                        CONF_DELAY, default="1s"
+                    ): cv.positive_time_period_milliseconds,
+                    cv.Optional(CONF_BACKOFF_FACTOR, 1.0): cv.float_range(min=1),
+                }
+            ),
             cv.SplitDefault(CONF_ESP8266_DISABLE_SSL_SUPPORT, esp8266=False): cv.All(
                 cv.only_on_esp8266, cv.boolean
             ),
@@ -96,6 +109,9 @@ async def to_code(config):
     cg.add(var.set_useragent(config[CONF_USERAGENT]))
     cg.add(var.set_follow_redirects(config[CONF_FOLLOW_REDIRECTS]))
     cg.add(var.set_redirect_limit(config[CONF_REDIRECT_LIMIT]))
+    cg.add(var.set_retries(config[CONF_RETRY][CONF_COUNT]))
+    cg.add(var.set_retry_delay(config[CONF_RETRY][CONF_DELAY]))
+    cg.add(var.set_retry_backoff_factor(config[CONF_RETRY][CONF_BACKOFF_FACTOR]))
 
     if CORE.is_esp8266 and not config[CONF_ESP8266_DISABLE_SSL_SUPPORT]:
         cg.add_define("USE_HTTP_REQUEST_ESP8266_HTTPS")

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -87,6 +87,10 @@ mdns:
 http_request:
   useragent: esphome/device
   timeout: 10s
+  retry:
+    count: 3
+    delay: 1s
+    backoff_factor: 1.5
 
 mqtt:
   broker: "192.168.178.84"


### PR DESCRIPTION
# What does this implement/fix?

Add `count`, `delay` and `backoff_factor` options to `http_request` component under `retry` option. Use `Component::set_retry()` to retry HTTP requests. Requests are only retried for network and connection errors; if an HTTP response is received the request is not retried.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2940

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
http_request:
  retry:
    count: 10
    delay: 1s
    backoff_factor: 1.5
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
