### PR TITLE
2023.5.4

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -932,6 +932,8 @@ def run_esphome(argv):
             _LOGGER.error(e, exc_info=args.verbose)
             return 1
 
+    safe_print(f"ESPHome {const.__version__}")
+
     for conf_path in args.configuration:
         if any(os.path.basename(conf_path) == x for x in SECRETS_FILES):
             _LOGGER.warning("Skipping secrets file %s", conf_path)

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -140,8 +140,9 @@ class Cover : public EntityBase, public EntityBase_DeviceClass {
   /** Stop the cover.
    *
    * This is a legacy method and may be removed later, please use `.make_call()` instead.
+   * As per solution from issue #2885 the call should include perform()
    */
-  ESPDEPRECATED("stop() is deprecated, use make_call().set_command_stop() instead.", "2021.9")
+  ESPDEPRECATED("stop() is deprecated, use make_call().set_command_stop().perform() instead.", "2021.9")
   void stop();
 
   void add_on_state_callback(std::function<void()> &&f);

--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -34,7 +34,7 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     if (this->is_rgbw_) {
-      traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::RGB_WHITE});
+      traits.set_supported_color_modes({light::ColorMode::RGB_WHITE, light::ColorMode::WHITE});
     } else {
       traits.set_supported_color_modes({light::ColorMode::RGB});
     }

--- a/esphome/components/internal_temperature/internal_temperature.cpp
+++ b/esphome/components/internal_temperature/internal_temperature.cpp
@@ -33,6 +33,10 @@ void InternalTemperatureSensor::update() {
   temp_sensor_config_t tsens = TSENS_CONFIG_DEFAULT();
   temp_sensor_set_config(tsens);
   temp_sensor_start();
+#if defined(USE_ESP32_VARIANT_ESP32S3) && (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 3))
+#error \
+    "ESP32-S3 internal temperature sensor requires ESP IDF V4.4.3 or higher. See https://github.com/esphome/issues/issues/4271"
+#endif
   esp_err_t result = temp_sensor_read_celsius(&temperature);
   temp_sensor_stop();
   success = (result == ESP_OK);

--- a/esphome/components/internal_temperature/sensor.py
+++ b/esphome/components/internal_temperature/sensor.py
@@ -1,17 +1,44 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
+from esphome.components.esp32 import get_esp32_variant
+from esphome.components.esp32.const import (
+    VARIANT_ESP32S3,
+)
 from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     DEVICE_CLASS_TEMPERATURE,
     ENTITY_CATEGORY_DIAGNOSTIC,
+    KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
 )
+from esphome.core import CORE
 
 internal_temperature_ns = cg.esphome_ns.namespace("internal_temperature")
 InternalTemperatureSensor = internal_temperature_ns.class_(
     "InternalTemperatureSensor", sensor.Sensor, cg.PollingComponent
 )
+
+
+def validate_config(config):
+    if CORE.is_esp32:
+        variant = get_esp32_variant()
+        if variant == VARIANT_ESP32S3:
+            if CORE.using_arduino and CORE.data[KEY_CORE][
+                KEY_FRAMEWORK_VERSION
+            ] < cv.Version(2, 0, 6):
+                raise cv.Invalid(
+                    "ESP32-S3 Internal Temperature Sensor requires framework version 2.0.6 or higher. See <https://github.com/esphome/issues/issues/4271>."
+                )
+            if CORE.using_esp_idf and CORE.data[KEY_CORE][
+                KEY_FRAMEWORK_VERSION
+            ] < cv.Version(4, 4, 3):
+                raise cv.Invalid(
+                    "ESP32-S3 Internal Temperature Sensor requires framework version 4.4.3 or higher. See <https://github.com/esphome/issues/issues/4271>."
+                )
+    return config
+
 
 CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(
@@ -23,6 +50,7 @@ CONFIG_SCHEMA = cv.All(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ).extend(cv.polling_component_schema("60s")),
     cv.only_on(["esp32", "rp2040"]),
+    validate_config,
 )
 
 

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -506,12 +506,12 @@ void number_to_payload(std::vector<uint16_t> &data, int64_t value, SensorValueTy
     case SensorValueType::U_DWORD:
     case SensorValueType::S_DWORD:
     case SensorValueType::FP32:
-    case SensorValueType::FP32_R:
       data.push_back((value & 0xFFFF0000) >> 16);
       data.push_back(value & 0xFFFF);
       break;
     case SensorValueType::U_DWORD_R:
     case SensorValueType::S_DWORD_R:
+    case SensorValueType::FP32_R:
       data.push_back(value & 0xFFFF);
       data.push_back((value & 0xFFFF0000) >> 16);
       break;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.5.3"
+__version__ = "2023.5.4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [internal_temperature] ESP32-S3 needs ESP IDF V4.4.3 or higher [esphome#4873](https://github.com/esphome/esphome/pull/4873)
- Update cover.h for compile errors with stop() [esphome#4879](https://github.com/esphome/esphome/pull/4879)
- Print ESPHome version when running commands [esphome#4883](https://github.com/esphome/esphome/pull/4883)
- fix modbus sending FP32_R values [esphome#4882](https://github.com/esphome/esphome/pull/4882)
- Fix esp32_rmt_led_strip color modes [esphome#4886](https://github.com/esphome/esphome/pull/4886)
