### PR TITLE
move pio tools to LED component

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -157,7 +157,6 @@ async def to_code(config):
         "platform_packages",
         [
             f"earlephilhower/framework-arduinopico@{conf[CONF_SOURCE]}",
-            "earlephilhower/tool-pioasm-rp2040-earlephilhower",
         ],
     )
 

--- a/esphome/components/rp2040_pio_led_strip/light.py
+++ b/esphome/components/rp2040_pio_led_strip/light.py
@@ -265,3 +265,9 @@ async def to_code(config):
                 time_to_cycles(config[CONF_BIT1_LOW]),
             ),
         )
+    cg.add_platformio_option(
+        "platform_packages",
+        [
+            "earlephilhower/tool-pioasm-rp2040-earlephilhower",
+        ],
+    )

--- a/tests/test6.yaml
+++ b/tests/test6.yaml
@@ -37,24 +37,24 @@ switch:
     output: pin_4
     id: pin_4_switch
 
-light:
-  - platform: rp2040_pio_led_strip
-    id: led_strip
-    pin: GPIO13
-    num_leds: 60
-    pio: 0
-    rgb_order: GRB
-    chipset: WS2812
-  - platform: rp2040_pio_led_strip
-    id: led_strip_custom_timings
-    pin: GPIO13
-    num_leds: 60
-    pio: 1
-    rgb_order: GRB
-    bit0_high: .1us
-    bit0_low: 1.2us
-    bit1_high: .69us
-    bit1_low: .4us
+#light:
+#  - platform: rp2040_pio_led_strip
+#    id: led_strip
+#    pin: GPIO13
+#    num_leds: 60
+#    pio: 0
+#    rgb_order: GRB
+#    chipset: WS2812
+#  - platform: rp2040_pio_led_strip
+#    id: led_strip_custom_timings
+#    pin: GPIO13
+#    num_leds: 60
+#    pio: 1
+#    rgb_order: GRB
+#    bit0_high: .1us
+#    bit0_low: 1.2us
+#    bit1_high: .69us
+#    bit1_low: .4us
 
 
 sensor:


### PR DESCRIPTION
# What does this implement/fix?

Due to the platformio issue with rpi, the pio tools are currently not available.  This moves the loading to the only place that uses it, so everything else should work.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4541

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
