### PR TITLE
Fix version printing not breaking yaml parsing

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -980,7 +980,7 @@ def run_esphome(argv):
             _LOGGER.error(e, exc_info=args.verbose)
             return 1
 
-    _LOGGER.info(f"ESPHome {const.__version__}")
+    _LOGGER.info("ESPHome %s", const.__version__)
 
     for conf_path in args.configuration:
         if any(os.path.basename(conf_path) == x for x in SECRETS_FILES):

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -980,7 +980,7 @@ def run_esphome(argv):
             _LOGGER.error(e, exc_info=args.verbose)
             return 1
 
-    safe_print(f"ESPHome {const.__version__}")
+    _LOGGER.info(f"ESPHome {const.__version__}")
 
     for conf_path in args.configuration:
         if any(os.path.basename(conf_path) == x for x in SECRETS_FILES):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
