### PR TITLE
Sigma delta fix

### DIFF
--- a/esphome/components/sigma_delta_output/sigma_delta_output.cpp
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.cpp
@@ -27,5 +27,31 @@ void SigmaDeltaOutput::dump_config() {
   LOG_FLOAT_OUTPUT(this);
 }
 
+void SigmaDeltaOutput::update() {
+  this->accum_ += this->state_;
+  const bool next_value = this->accum_ > 0;
+
+  if (next_value) {
+    this->accum_ -= 1.;
+  }
+
+  if (next_value != this->value_) {
+    this->value_ = next_value;
+    if (this->pin_) {
+      this->pin_->digital_write(next_value);
+    }
+
+    if (this->state_change_trigger_) {
+      this->state_change_trigger_->trigger(next_value);
+    }
+
+    if (next_value && this->turn_on_trigger_) {
+      this->turn_on_trigger_->trigger();
+    } else if (!next_value && this->turn_off_trigger_) {
+      this->turn_off_trigger_->trigger();
+    }
+  }
+}
+
 }  // namespace sigma_delta_output
 }  // namespace esphome

--- a/esphome/components/sigma_delta_output/sigma_delta_output.cpp
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.cpp
@@ -1,0 +1,31 @@
+#include "sigma_delta_output.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace sigma_delta_output {
+
+static const char *const TAG = "output.sigma_delta";
+
+void SigmaDeltaOutput::setup() {
+  if (this->pin_)
+    this->pin_->setup();
+}
+
+void SigmaDeltaOutput::dump_config() {
+  ESP_LOGCONFIG(TAG, "Sigma Delta Output:");
+  LOG_PIN("  Pin: ", this->pin_);
+  if (this->state_change_trigger_) {
+    ESP_LOGCONFIG(TAG, "  State change automation configured");
+  }
+  if (this->turn_on_trigger_) {
+    ESP_LOGCONFIG(TAG, "  Turn on automation configured");
+  }
+  if (this->turn_off_trigger_) {
+    ESP_LOGCONFIG(TAG, "  Turn off automation configured");
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_FLOAT_OUTPUT(this);
+}
+
+}  // namespace sigma_delta_output
+}  // namespace esphome

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -1,9 +1,14 @@
 #pragma once
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/components/output/float_output.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace sigma_delta_output {
+
+static const char *const TAG = "output.sigma_delta";
+
 class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
  public:
   Trigger<> *get_turn_on_trigger() {
@@ -29,6 +34,22 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
     if (this->pin_)
       this->pin_->setup();
   }
+  void dump_config() override {
+    ESP_LOGCONFIG(TAG, "Sigma Delta Output:");
+    LOG_PIN("  Pin: ", this->pin_);
+    if (this->state_change_trigger_) {
+      ESP_LOGCONFIG(TAG, "  State change automation configured");
+    }
+    if (this->turn_on_trigger_) {
+      ESP_LOGCONFIG(TAG, "  Turn on automation configured");
+    }
+    if (this->turn_off_trigger_) {
+      ESP_LOGCONFIG(TAG, "  Turn off automation configured");
+    }
+    LOG_UPDATE_INTERVAL(this);
+    LOG_FLOAT_OUTPUT(this);
+  }
+
   void update() override {
     this->accum_ += this->state_;
     const bool next_value = this->accum_ > 0;

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -1,13 +1,11 @@
 #pragma once
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
+#include "esphome/core/hal.h"
 #include "esphome/components/output/float_output.h"
-#include "esphome/core/log.h"
 
 namespace esphome {
 namespace sigma_delta_output {
-
-static const char *const TAG = "output.sigma_delta";
 
 class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
  public:
@@ -30,25 +28,8 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
 
   void set_pin(GPIOPin *pin) { this->pin_ = pin; };
   void write_state(float state) override { this->state_ = state; }
-  void setup() override {
-    if (this->pin_)
-      this->pin_->setup();
-  }
-  void dump_config() override {
-    ESP_LOGCONFIG(TAG, "Sigma Delta Output:");
-    LOG_PIN("  Pin: ", this->pin_);
-    if (this->state_change_trigger_) {
-      ESP_LOGCONFIG(TAG, "  State change automation configured");
-    }
-    if (this->turn_on_trigger_) {
-      ESP_LOGCONFIG(TAG, "  Turn on automation configured");
-    }
-    if (this->turn_off_trigger_) {
-      ESP_LOGCONFIG(TAG, "  Turn off automation configured");
-    }
-    LOG_UPDATE_INTERVAL(this);
-    LOG_FLOAT_OUTPUT(this);
-  }
+  void setup() override;
+  void dump_config() override;
 
   void update() override {
     this->accum_ += this->state_;

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -25,6 +25,10 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
 
   void set_pin(GPIOPin *pin) { this->pin_ = pin; };
   void write_state(float state) override { this->state_ = state; }
+  void setup() override {
+    if (this->pin_)
+      this->pin_->setup();
+  }
   void update() override {
     this->accum_ += this->state_;
     const bool next_value = this->accum_ > 0;

--- a/esphome/components/sigma_delta_output/sigma_delta_output.h
+++ b/esphome/components/sigma_delta_output/sigma_delta_output.h
@@ -30,32 +30,7 @@ class SigmaDeltaOutput : public PollingComponent, public output::FloatOutput {
   void write_state(float state) override { this->state_ = state; }
   void setup() override;
   void dump_config() override;
-
-  void update() override {
-    this->accum_ += this->state_;
-    const bool next_value = this->accum_ > 0;
-
-    if (next_value) {
-      this->accum_ -= 1.;
-    }
-
-    if (next_value != this->value_) {
-      this->value_ = next_value;
-      if (this->pin_) {
-        this->pin_->digital_write(next_value);
-      }
-
-      if (this->state_change_trigger_) {
-        this->state_change_trigger_->trigger(next_value);
-      }
-
-      if (next_value && this->turn_on_trigger_) {
-        this->turn_on_trigger_->trigger();
-      } else if (!next_value && this->turn_off_trigger_) {
-        this->turn_off_trigger_->trigger();
-      }
-    }
-  }
+  void update() override;
 
  protected:
   GPIOPin *pin_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

The output pin, if configured, in the Sigma Delta Output was never initialized. This worked as long as the pin had been used as an output since power up since a software reset after an OTA didn't seem to reset the pin registers. Though I'm sure that last bit is probably expected behavior.

This PR also implements dump_config() and adds a missing header for automation.h.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
