### PR TITLE
Increase SNTP setup priority

### DIFF
--- a/esphome/components/sntp/sntp_component.h
+++ b/esphome/components/sntp/sntp_component.h
@@ -22,7 +22,7 @@ class SNTPComponent : public time::RealTimeClock {
     this->server_2_ = server_2;
     this->server_3_ = server_3;
   }
-  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
 
   void update() override;
   void loop() override;


### PR DESCRIPTION
# What does this implement/fix?

The WireGuard component (currently under development #4256) requires a time source to work properly but the SNTP has a too low setup priority to have WireGuard ready in time for other components (like MQTTClient).

Both MQTTClient and SNTP has the priority set to `AFTER_WIFI` and they setup almost at the same time, and so do WireGuard (even if it has a higher priority), but MQTTClient blocks the proceeding of others and if the broker is on the remote vpn peer nothing will work: MQTT needs WireGuard link to connect to the broker, but WireGuard waits until MQTT finishes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):**
- https://github.com/esphome/esphome/pull/4256#issuecomment-1556167145
- droscy/esphome#4

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

The updated WireGuard code hasn't been merged to official PR #4256 yet, it requires this PR first, so to test this you need to use my custom branch.

```yaml
external_components:
  - source:
      type: git
      url: https://github.com/droscy/esphome
      ref: ft/wg/priority
    components:
      - wireguard

wireguard:
  address: 172.16.34.100
  netmask: 255.255.255.0
  [...]
  peer_allowed_ips:
    - 172.16.34.0/24
  require_connection_to_proceed: true

mqtt:
  broker: 172.16.34.5
  [...]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
