### PR TITLE
fix handling of servo restore value

### DIFF
--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -24,7 +24,6 @@ void Servo::loop() {
     if (millis() - this->start_millis_ > this->auto_detach_time_) {
       this->detach();
       this->start_millis_ = 0;
-      this->state_ = STATE_DETACHED;
       ESP_LOGD(TAG, "Servo detached on auto_detach_time");
     }
   }

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -18,6 +18,7 @@ class Servo : public Component {
   void write(float value);
   void internal_write(float value);
   void detach() {
+    this->state_ = STATE_DETACHED;
     this->output_->set_level(0.0f);
     this->save_level_(0.0f);
   }
@@ -27,7 +28,7 @@ class Servo : public Component {
       this->rtc_ = global_preferences->make_preference<float>(global_servo_id);
       global_servo_id++;
       if (this->rtc_.load(&v)) {
-        this->output_->set_level(v);
+        this->internal_write(v);
         return;
       }
     }


### PR DESCRIPTION
# What does this implement/fix?

The restore value doesn't get recorded, so the next position change doesn't respect the transition length.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
