### PR TITLE
Add WiFiUdp.h include to wled component on rp2040.

### DIFF
--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -13,6 +13,10 @@
 #include <WiFiUdp.h>
 #endif
 
+#ifdef USE_RP2040
+#include <WiFiUdp.h>
+#endif
+
 namespace esphome {
 namespace wled {
 

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -8,7 +8,7 @@
 #include <vector>
 #include <memory>
 
-class UDP;
+class WiFiUDP;
 
 namespace esphome {
 namespace wled {
@@ -32,7 +32,7 @@ class WLEDLightEffect : public light::AddressableLightEffect {
   bool parse_dnrgb_frame_(light::AddressableLight &it, const uint8_t *payload, uint16_t size);
 
   uint16_t port_{0};
-  std::unique_ptr<UDP> udp_;
+  std::unique_ptr<WiFiUDP> udp_;
   uint32_t blank_at_{0};
   uint32_t dropped_{0};
 };


### PR DESCRIPTION
# What does this implement/fix?

This PR allows the wled component to be used on the Raspberry Pi Pico (RP2040).

`components/wled/wled_light_effect.cpp` chooses which wifi header to include based on platform. It was missing the include when compiled for rp2040, causing a compile error.

Additionally, `wled_light_effect.h` can no longer forward declare `class UDP;` because its definition is in the [`arduino` namespace](https://github.com/arduino/ArduinoCore-API/blob/master/api/Udp.h#L92) on the rp2040. An easy enough fix was to use the concrete type `WifiUdp` which is still in the global namespace.

I've tested this on a Raspberry Pi Pico with [Prismatik](https://github.com/psieg/Lightpack) sending LED data to the Pico. I did the same test using an ESP32, just to make sure I didn't break anything. I only compiled for ESP8266 but don't have a dev board to test.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
```yaml

rp2040:
  board: rpipicow
  framework:
    # Required until https://github.com/platformio/platform-raspberrypi/pull/36 is merged
    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git

wled:

light:
  - platform: fastled_clockless
    chipset: WS2812B
    rgb_order: GRB
    pin: GPIO01
    num_leds: 60
    effects:
      - wled:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
