### PR TITLE
Handling of sensor read quality refined

### DIFF
--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -70,11 +70,15 @@ bool MopekaProCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     uint32_t distance_value = this->parse_distance_(manu_data.data);
     SensorReadQuality quality_value = this->parse_read_quality_(manu_data.data);
     ESP_LOGD(TAG, "Distance Sensor: Quality (0x%X) Distance (%dmm)", quality_value, distance_value);
-    if (quality_value < QUALITY_HIGH) {
-      ESP_LOGW(TAG, "Poor read quality.");
+    if (quality_value < QUALITY_HIGH && quality_value > QUALITY_LOW) {
+      ESP_LOGW(TAG, "Possibly poor sensor read quality.");
     }
-    if (quality_value < QUALITY_MED) {
+    if (quality_value < QUALITY_MED && quality_value > QUALITY_NONE) {
+      ESP_LOGW(TAG, "Poor sensor read quality.");
+    }
+    if (quality_value <= QUALITY_NONE) {
       // if really bad reading set to 0
+      ESP_LOGW(TAG, "Really bad sensor read quality.");
       ESP_LOGW(TAG, "Setting distance to 0");
       distance_value = 0;
     }

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -39,6 +39,7 @@ class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   void set_distance(sensor::Sensor *distance) { distance_ = distance; };
   void set_tank_full(float full) { full_mm_ = full; };
   void set_tank_empty(float empty) { empty_mm_ = empty; };
+  void set_quality_level(sensor::Sensor *quality_level) { quality_level_ = quality_level; };
 
  protected:
   uint64_t address_;
@@ -46,6 +47,7 @@ class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *distance_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
+  sensor::Sensor *quality_level_{nullptr};
 
   uint32_t full_mm_;
   uint32_t empty_mm_;

--- a/esphome/components/mopeka_pro_check/sensor.py
+++ b/esphome/components/mopeka_pro_check/sensor.py
@@ -15,11 +15,13 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     CONF_BATTERY_LEVEL,
     DEVICE_CLASS_BATTERY,
+    ICON_PERCENT,
 )
 
 CONF_TANK_TYPE = "tank_type"
 CONF_CUSTOM_DISTANCE_FULL = "custom_distance_full"
 CONF_CUSTOM_DISTANCE_EMPTY = "custom_distance_empty"
+CONF_SENSOR_QUALITY = "quality_level"
 
 ICON_PROPANE_TANK = "mdi:propane-tank"
 
@@ -90,6 +92,12 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_BATTERY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_SENSOR_QUALITY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                icon=ICON_PERCENT,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
         }
     )
     .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
@@ -132,3 +140,6 @@ async def to_code(config):
     if CONF_BATTERY_LEVEL in config:
         sens = await sensor.new_sensor(config[CONF_BATTERY_LEVEL])
         cg.add(var.set_battery_level(sens))
+    if CONF_SENSOR_QUALITY in config:
+        sens = await sensor.new_sensor(config[CONF_SENSOR_QUALITY])
+        cg.add(var.set_quality_level(sens))


### PR DESCRIPTION
It's now possible to receive sensor values even when the sensor thinks its read quality is low

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
