### PR TITLE
[max7219digit] fix 270° rotation

### DIFF
--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -278,7 +278,9 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
         }
       }
     } else {
-      b = pixels[7 - col];
+      for (uint8_t i = 0; i < 8; i++) {
+          b |= ((pixels[7 - col] >> i) & 1) << (7 - i);
+      }
     }
     // send this byte to display at selected chip
     if (this->invert_) {

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -279,7 +279,7 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
       }
     } else {
       for (uint8_t i = 0; i < 8; i++) {
-          b |= ((pixels[7 - col] >> i) & 1) << (7 - i);
+        b |= ((pixels[7 - col] >> i) & 1) << (7 - i);
       }
     }
     // send this byte to display at selected chip


### PR DESCRIPTION
# What does this implement/fix?

I have a single 8x8 LED matrix with MAX7219. Rotations 0, 90, and 180 degrees work fine and display text correctly.
But on 270° the row order is reversed, e.g. an "L" is displayed with the bottom part up.

As all other orientations are looking fine on my matrix I assume the row order needs to be inverted.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** didn't find any

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not needed

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
spi:
  clk_pin: D5
  mosi_pin: D7

display:
  - platform: max7219digit
    cs_pin: D8
    num_chips: 1
    intensity: 15
    rotate_chip: 270   # 0, 90, 180 look fine
    lambda: |-
      it.print(0, 0, id(digit_font), "HELLO!");

font:
  # font from https://www.dafont.com/pixelmix.font
  - file: "pixelmix.ttf"
    id: digit_font
    size: 6
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
