### PR TITLE
Add support for ESP32-S3-BOX-Lite displays

### DIFF
--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -44,6 +44,7 @@ MODELS = {
     "ILI9486": ili9XXX_ns.class_("ILI9XXXILI9486", ili9XXXSPI),
     "ILI9488": ili9XXX_ns.class_("ILI9XXXILI9488", ili9XXXSPI),
     "ST7796": ili9XXX_ns.class_("ILI9XXXST7796", ili9XXXSPI),
+    "S3BOX_LITE": ili9XXX_ns.class_("ILI9XXXS3BoxLite", ili9XXXSPI),
 }
 
 COLOR_PALETTE = cv.one_of("NONE", "GRAYSCALE", "IMAGE_ADAPTIVE")

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -421,5 +421,17 @@ void ILI9XXXST7796::initialize() {
   }
 }
 
+//   24_TFT rotated display
+void ILI9XXXS3BoxLite::initialize() {
+  this->init_lcd_(INITCMD_S3BOXLITE);
+  if (this->width_ == 0) {
+    this->width_ = 320;
+  }
+  if (this->height_ == 0) {
+    this->height_ = 240;
+  }
+  this->invert_display_(true);
+}
+
 }  // namespace ili9xxx
 }  // namespace esphome

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -134,5 +134,10 @@ class ILI9XXXST7796 : public ILI9XXXDisplay {
   void initialize() override;
 };
 
+class ILI9XXXS3BoxLite : public ILI9XXXDisplay {
+ protected:
+  void initialize() override;
+};
+
 }  // namespace ili9xxx
 }  // namespace esphome

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -169,6 +169,36 @@ static const uint8_t PROGMEM INITCMD_ST7796[] = {
   0x00                                   // End of list
 };
 
+static const uint8_t PROGMEM INITCMD_S3BOXLITE[] = {
+  0xEF, 3, 0x03, 0x80, 0x02,
+  0xCF, 3, 0x00, 0xC1, 0x30,
+  0xED, 4, 0x64, 0x03, 0x12, 0x81,
+  0xE8, 3, 0x85, 0x00, 0x78,
+  0xCB, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
+  0xF7, 1, 0x20,
+  0xEA, 2, 0x00, 0x00,
+  ILI9XXX_PWCTR1  , 1, 0x23,             // Power control VRH[5:0]
+  ILI9XXX_PWCTR2  , 1, 0x10,             // Power control SAP[2:0];BT[3:0]
+  ILI9XXX_VMCTR1  , 2, 0x3e, 0x28,       // VCM control
+  ILI9XXX_VMCTR2  , 1, 0x86,             // VCM control2
+  ILI9XXX_MADCTL  , 1, 0x40,             // Memory Access Control
+  ILI9XXX_VSCRSADD, 1, 0x00,             // Vertical scroll zero
+  ILI9XXX_PIXFMT  , 1, 0x55,
+  ILI9XXX_FRMCTR1 , 2, 0x00, 0x18,
+  ILI9XXX_DFUNCTR , 3, 0x08, 0x82, 0x27, // Display Function Control
+  0xF2, 1, 0x00,                         // 3Gamma Function Disable
+  ILI9XXX_GAMMASET , 1, 0x01,             // Gamma curve selected
+  ILI9XXX_GMCTRP1 , 15, 0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, // Set Gamma
+                        0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03,
+                        0x0E, 0x09, 0x00,
+  ILI9XXX_GMCTRN1 , 15, 0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, // Set Gamma
+                        0x31, 0xC1, 0x48, 0x08, 0x0F, 0x0C,
+                        0x31, 0x36, 0x0F,
+  ILI9XXX_SLPOUT  , 0x80,                // Exit Sleep
+  ILI9XXX_DISPON  , 0x80,                // Display on
+  0x00                                   // End of list
+};
+
 // clang-format on
 }  // namespace ili9xxx
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

The ESP32-S3-BOX-Lite display seems to have an ILI9xxx driver (regardless of the documentation mentioning st7789v).
Add the needed configuration so that it works.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

Related to esphome/feature-requests/issues/2239 (Not a full fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2988

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: ili9xxx
    model: S3BOX_LITE
    cs_pin: GPIO5
    dc_pin: GPIO4
    reset_pin: GPIO48
    id: lcd
    # Width = 320, Height = 240
    lambda: |-
      it.fill(Color(32, 32, 0));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
