### PR TITLE
Add support in vbus component for Deltasol BS 2009

### DIFF
--- a/esphome/components/vbus/__init__.py
+++ b/esphome/components/vbus/__init__.py
@@ -15,6 +15,7 @@ VBus = vbus_ns.class_("VBus", uart.UARTDevice, cg.Component)
 CONF_VBUS_ID = "vbus_id"
 
 CONF_DELTASOL_BS_PLUS = "deltasol_bs_plus"
+CONF_DELTASOL_BS_2009 = "deltasol_bs_2009"
 CONF_DELTASOL_C = "deltasol_c"
 CONF_DELTASOL_CS2 = "deltasol_cs2"
 CONF_DELTASOL_CS_PLUS = "deltasol_cs_plus"

--- a/esphome/components/vbus/binary_sensor/__init__.py
+++ b/esphome/components/vbus/binary_sensor/__init__.py
@@ -264,6 +264,41 @@ async def to_code(config):
             sens = await binary_sensor.new_binary_sensor(config[CONF_HQM])
             cg.add(var.set_hqm_bsensor(sens))
 
+    elif config[CONF_MODEL] == CONF_DELTASOL_BS_2009:
+        cg.add(var.set_command(0x0100))
+        cg.add(var.set_source(0x427B))
+        cg.add(var.set_dest(0x0010))
+        if CONF_SENSOR1_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR1_ERROR])
+            cg.add(var.set_s1_error_bsensor(sens))
+        if CONF_SENSOR2_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR2_ERROR])
+            cg.add(var.set_s2_error_bsensor(sens))
+        if CONF_SENSOR3_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR3_ERROR])
+            cg.add(var.set_s3_error_bsensor(sens))
+        if CONF_SENSOR4_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR4_ERROR])
+            cg.add(var.set_s4_error_bsensor(sens))
+        if CONF_COLLECTOR_MAX in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_COLLECTOR_MAX])
+            cg.add(var.set_collector_max_bsensor(sens))
+        if CONF_COLLECTOR_MIN in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_COLLECTOR_MIN])
+            cg.add(var.set_collector_min_bsensor(sens))
+        if CONF_COLLECTOR_FROST in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_COLLECTOR_FROST])
+            cg.add(var.set_collector_frost_bsensor(sens))
+        if CONF_TUBE_COLLECTOR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_TUBE_COLLECTOR])
+            cg.add(var.set_tube_collector_bsensor(sens))
+        if CONF_RECOOLING in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_RECOOLING])
+            cg.add(var.set_recooling_bsensor(sens))
+        if CONF_HQM in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_HQM])
+            cg.add(var.set_hqm_bsensor(sens))
+
     elif config[CONF_MODEL] == CONF_DELTASOL_C:
         cg.add(var.set_command(0x0100))
         cg.add(var.set_source(0x4212))

--- a/esphome/components/vbus/binary_sensor/__init__.py
+++ b/esphome/components/vbus/binary_sensor/__init__.py
@@ -44,6 +44,7 @@ CONF_COLLECTOR_FROST = "collector_frost"
 CONF_TUBE_COLLECTOR = "tube_collector"
 CONF_RECOOLING = "recooling"
 CONF_HQM = "hqm"
+CONF_FROST_PROTECTION_ACTIVE = "frost_protection_active"
 
 CONFIG_SCHEMA = cv.typed_schema(
     {
@@ -109,22 +110,7 @@ CONFIG_SCHEMA = cv.typed_schema(
                     device_class=DEVICE_CLASS_PROBLEM,
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                 ),
-                cv.Optional(CONF_COLLECTOR_MAX): binary_sensor.binary_sensor_schema(
-                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-                ),
-                cv.Optional(CONF_COLLECTOR_MIN): binary_sensor.binary_sensor_schema(
-                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-                ),
-                cv.Optional(CONF_COLLECTOR_FROST): binary_sensor.binary_sensor_schema(
-                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-                ),
-                cv.Optional(CONF_TUBE_COLLECTOR): binary_sensor.binary_sensor_schema(
-                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-                ),
-                cv.Optional(CONF_RECOOLING): binary_sensor.binary_sensor_schema(
-                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-                ),
-                cv.Optional(CONF_HQM): binary_sensor.binary_sensor_schema(
+                cv.Optional(CONF_FROST_PROTECTION_ACTIVE): binary_sensor.binary_sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                 ),
             }
@@ -280,24 +266,9 @@ async def to_code(config):
         if CONF_SENSOR4_ERROR in config:
             sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR4_ERROR])
             cg.add(var.set_s4_error_bsensor(sens))
-        if CONF_COLLECTOR_MAX in config:
-            sens = await binary_sensor.new_binary_sensor(config[CONF_COLLECTOR_MAX])
-            cg.add(var.set_collector_max_bsensor(sens))
-        if CONF_COLLECTOR_MIN in config:
-            sens = await binary_sensor.new_binary_sensor(config[CONF_COLLECTOR_MIN])
-            cg.add(var.set_collector_min_bsensor(sens))
-        if CONF_COLLECTOR_FROST in config:
-            sens = await binary_sensor.new_binary_sensor(config[CONF_COLLECTOR_FROST])
-            cg.add(var.set_collector_frost_bsensor(sens))
-        if CONF_TUBE_COLLECTOR in config:
-            sens = await binary_sensor.new_binary_sensor(config[CONF_TUBE_COLLECTOR])
-            cg.add(var.set_tube_collector_bsensor(sens))
-        if CONF_RECOOLING in config:
-            sens = await binary_sensor.new_binary_sensor(config[CONF_RECOOLING])
-            cg.add(var.set_recooling_bsensor(sens))
-        if CONF_HQM in config:
-            sens = await binary_sensor.new_binary_sensor(config[CONF_HQM])
-            cg.add(var.set_hqm_bsensor(sens))
+        if CONF_FROST_PROTECTION_ACTIVE in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_FROST_PROTECTION_ACTIVE])
+            cg.add(var.set_frost_protection_active_bsensor(sens))
 
     elif config[CONF_MODEL] == CONF_DELTASOL_C:
         cg.add(var.set_command(0x0100))

--- a/esphome/components/vbus/binary_sensor/__init__.py
+++ b/esphome/components/vbus/binary_sensor/__init__.py
@@ -18,12 +18,14 @@ from .. import (
     VBus,
     CONF_VBUS_ID,
     CONF_DELTASOL_BS_PLUS,
+    CONF_DELTASOL_BS_2009,
     CONF_DELTASOL_C,
     CONF_DELTASOL_CS2,
     CONF_DELTASOL_CS_PLUS,
 )
 
 DeltaSol_BS_Plus = vbus_ns.class_("DeltaSolBSPlusBSensor", cg.Component)
+DeltaSol_BS_2009 = vbus_ns.class_("DeltaSolBS2009BSensor", cg.Component)
 DeltaSol_C = vbus_ns.class_("DeltaSolCBSensor", cg.Component)
 DeltaSol_CS2 = vbus_ns.class_("DeltaSolCS2BSensor", cg.Component)
 DeltaSol_CS_Plus = vbus_ns.class_("DeltaSolCSPlusBSensor", cg.Component)
@@ -51,6 +53,46 @@ CONFIG_SCHEMA = cv.typed_schema(
                 cv.GenerateID(CONF_VBUS_ID): cv.use_id(VBus),
                 cv.Optional(CONF_RELAY1): binary_sensor.binary_sensor_schema(),
                 cv.Optional(CONF_RELAY2): binary_sensor.binary_sensor_schema(),
+                cv.Optional(CONF_SENSOR1_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_SENSOR2_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_SENSOR3_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_SENSOR4_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_COLLECTOR_MAX): binary_sensor.binary_sensor_schema(
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_COLLECTOR_MIN): binary_sensor.binary_sensor_schema(
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_COLLECTOR_FROST): binary_sensor.binary_sensor_schema(
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_TUBE_COLLECTOR): binary_sensor.binary_sensor_schema(
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_RECOOLING): binary_sensor.binary_sensor_schema(
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_HQM): binary_sensor.binary_sensor_schema(
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+            }
+        ),
+        CONF_DELTASOL_BS_2009: cv.COMPONENT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(DeltaSol_BS_2009),
+                cv.GenerateID(CONF_VBUS_ID): cv.use_id(VBus),
                 cv.Optional(CONF_SENSOR1_ERROR): binary_sensor.binary_sensor_schema(
                     device_class=DEVICE_CLASS_PROBLEM,
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/esphome/components/vbus/binary_sensor/__init__.py
+++ b/esphome/components/vbus/binary_sensor/__init__.py
@@ -110,7 +110,9 @@ CONFIG_SCHEMA = cv.typed_schema(
                     device_class=DEVICE_CLASS_PROBLEM,
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                 ),
-                cv.Optional(CONF_FROST_PROTECTION_ACTIVE): binary_sensor.binary_sensor_schema(
+                cv.Optional(
+                    CONF_FROST_PROTECTION_ACTIVE
+                ): binary_sensor.binary_sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                 ),
             }
@@ -267,7 +269,9 @@ async def to_code(config):
             sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR4_ERROR])
             cg.add(var.set_s4_error_bsensor(sens))
         if CONF_FROST_PROTECTION_ACTIVE in config:
-            sens = await binary_sensor.new_binary_sensor(config[CONF_FROST_PROTECTION_ACTIVE])
+            sens = await binary_sensor.new_binary_sensor(
+                config[CONF_FROST_PROTECTION_ACTIVE]
+            )
             cg.add(var.set_frost_protection_active_bsensor(sens))
 
     elif config[CONF_MODEL] == CONF_DELTASOL_C:

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
@@ -50,6 +50,43 @@ void DeltaSolBSPlusBSensor::handle_message(std::vector<uint8_t> &message) {
     this->hqm_bsensor_->publish_state(message[15] & 0x20);
 }
 
+void DeltaSolBS2009BSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Deltasol BS 2009:");
+  LOG_BINARY_SENSOR("  ", "Sensor 1 Error", this->s1_error_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Sensor 2 Error", this->s2_error_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Sensor 3 Error", this->s3_error_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Sensor 4 Error", this->s4_error_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Option Collector Max", this->collector_max_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Option Collector Min", this->collector_min_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Option Collector Frost", this->collector_frost_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Option Tube Collector", this->tube_collector_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Option Recooling", this->recooling_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Option Heat Quantity Measurement", this->hqm_bsensor_);
+}
+
+void DeltaSolBS2009BSensor::handle_message(std::vector<uint8_t> &message) {
+  if (this->s1_error_bsensor_ != nullptr)
+    this->s1_error_bsensor_->publish_state(message[20] & 1);
+  if (this->s2_error_bsensor_ != nullptr)
+    this->s2_error_bsensor_->publish_state(message[20] & 2);
+  if (this->s3_error_bsensor_ != nullptr)
+    this->s3_error_bsensor_->publish_state(message[20] & 4);
+  if (this->s4_error_bsensor_ != nullptr)
+    this->s4_error_bsensor_->publish_state(message[20] & 8);
+  if (this->collector_max_bsensor_ != nullptr)
+    this->collector_max_bsensor_->publish_state(message[24] & 1);
+  if (this->collector_min_bsensor_ != nullptr)
+    this->collector_min_bsensor_->publish_state(message[24] & 2);
+  if (this->collector_frost_bsensor_ != nullptr)
+    this->collector_frost_bsensor_->publish_state(message[24] & 4);
+  if (this->tube_collector_bsensor_ != nullptr)
+    this->tube_collector_bsensor_->publish_state(message[24] & 8);
+  if (this->recooling_bsensor_ != nullptr)
+    this->recooling_bsensor_->publish_state(message[24] & 0x10);
+  if (this->hqm_bsensor_ != nullptr)
+    this->hqm_bsensor_->publish_state(message[24] & 0x20);
+}
+
 void DeltaSolCBSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "Deltasol C:");
   LOG_BINARY_SENSOR("  ", "Sensor 1 Error", this->s1_error_bsensor_);

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
@@ -56,12 +56,7 @@ void DeltaSolBS2009BSensor::dump_config() {
   LOG_BINARY_SENSOR("  ", "Sensor 2 Error", this->s2_error_bsensor_);
   LOG_BINARY_SENSOR("  ", "Sensor 3 Error", this->s3_error_bsensor_);
   LOG_BINARY_SENSOR("  ", "Sensor 4 Error", this->s4_error_bsensor_);
-  LOG_BINARY_SENSOR("  ", "Option Collector Max", this->collector_max_bsensor_);
-  LOG_BINARY_SENSOR("  ", "Option Collector Min", this->collector_min_bsensor_);
-  LOG_BINARY_SENSOR("  ", "Option Collector Frost", this->collector_frost_bsensor_);
-  LOG_BINARY_SENSOR("  ", "Option Tube Collector", this->tube_collector_bsensor_);
-  LOG_BINARY_SENSOR("  ", "Option Recooling", this->recooling_bsensor_);
-  LOG_BINARY_SENSOR("  ", "Option Heat Quantity Measurement", this->hqm_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Frost Protection Active", this->frost_protection_active_bsensor_);
 }
 
 void DeltaSolBS2009BSensor::handle_message(std::vector<uint8_t> &message) {
@@ -73,18 +68,8 @@ void DeltaSolBS2009BSensor::handle_message(std::vector<uint8_t> &message) {
     this->s3_error_bsensor_->publish_state(message[20] & 4);
   if (this->s4_error_bsensor_ != nullptr)
     this->s4_error_bsensor_->publish_state(message[20] & 8);
-  if (this->collector_max_bsensor_ != nullptr)
-    this->collector_max_bsensor_->publish_state(message[24] & 1);
-  if (this->collector_min_bsensor_ != nullptr)
-    this->collector_min_bsensor_->publish_state(message[24] & 2);
-  if (this->collector_frost_bsensor_ != nullptr)
-    this->collector_frost_bsensor_->publish_state(message[24] & 4);
-  if (this->tube_collector_bsensor_ != nullptr)
-    this->tube_collector_bsensor_->publish_state(message[24] & 8);
-  if (this->recooling_bsensor_ != nullptr)
-    this->recooling_bsensor_->publish_state(message[24] & 0x10);
-  if (this->hqm_bsensor_ != nullptr)
-    this->hqm_bsensor_->publish_state(message[24] & 0x20);
+  if (this->frost_protection_active_bsensor_ != nullptr)
+    this->frost_protection_active_bsensor_->publish_state(message[25] & 1);
 }
 
 void DeltaSolCBSensor::dump_config() {

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
@@ -69,6 +69,7 @@ class DeltaSolBS2009BSensor : public VBusListener, public Component {
 
   void handle_message(std::vector<uint8_t> &message) override;
 };
+
 class DeltaSolCBSensor : public VBusListener, public Component {
  public:
   void dump_config() override;

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
@@ -39,6 +39,36 @@ class DeltaSolBSPlusBSensor : public VBusListener, public Component {
   void handle_message(std::vector<uint8_t> &message) override;
 };
 
+class DeltaSolBS2009BSensor : public VBusListener, public Component {
+ public:
+  void dump_config() override;
+  void set_s1_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s1_error_bsensor_ = bsensor; }
+  void set_s2_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s2_error_bsensor_ = bsensor; }
+  void set_s3_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s3_error_bsensor_ = bsensor; }
+  void set_s4_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s4_error_bsensor_ = bsensor; }
+  void set_collector_max_bsensor(binary_sensor::BinarySensor *bsensor) { this->collector_max_bsensor_ = bsensor; }
+  void set_collector_min_bsensor(binary_sensor::BinarySensor *bsensor) { this->collector_min_bsensor_ = bsensor; }
+  void set_collector_frost_bsensor(binary_sensor::BinarySensor *bsensor) { this->collector_frost_bsensor_ = bsensor; }
+  void set_tube_collector_bsensor(binary_sensor::BinarySensor *bsensor) { this->tube_collector_bsensor_ = bsensor; }
+  void set_recooling_bsensor(binary_sensor::BinarySensor *bsensor) { this->recooling_bsensor_ = bsensor; }
+  void set_hqm_bsensor(binary_sensor::BinarySensor *bsensor) { this->hqm_bsensor_ = bsensor; }
+
+ protected:
+  binary_sensor::BinarySensor *relay1_bsensor_{nullptr};
+  binary_sensor::BinarySensor *relay2_bsensor_{nullptr};
+  binary_sensor::BinarySensor *s1_error_bsensor_{nullptr};
+  binary_sensor::BinarySensor *s2_error_bsensor_{nullptr};
+  binary_sensor::BinarySensor *s3_error_bsensor_{nullptr};
+  binary_sensor::BinarySensor *s4_error_bsensor_{nullptr};
+  binary_sensor::BinarySensor *collector_max_bsensor_{nullptr};
+  binary_sensor::BinarySensor *collector_min_bsensor_{nullptr};
+  binary_sensor::BinarySensor *collector_frost_bsensor_{nullptr};
+  binary_sensor::BinarySensor *tube_collector_bsensor_{nullptr};
+  binary_sensor::BinarySensor *recooling_bsensor_{nullptr};
+  binary_sensor::BinarySensor *hqm_bsensor_{nullptr};
+
+  void handle_message(std::vector<uint8_t> &message) override;
+};
 class DeltaSolCBSensor : public VBusListener, public Component {
  public:
   void dump_config() override;

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
@@ -46,26 +46,14 @@ class DeltaSolBS2009BSensor : public VBusListener, public Component {
   void set_s2_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s2_error_bsensor_ = bsensor; }
   void set_s3_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s3_error_bsensor_ = bsensor; }
   void set_s4_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s4_error_bsensor_ = bsensor; }
-  void set_collector_max_bsensor(binary_sensor::BinarySensor *bsensor) { this->collector_max_bsensor_ = bsensor; }
-  void set_collector_min_bsensor(binary_sensor::BinarySensor *bsensor) { this->collector_min_bsensor_ = bsensor; }
-  void set_collector_frost_bsensor(binary_sensor::BinarySensor *bsensor) { this->collector_frost_bsensor_ = bsensor; }
-  void set_tube_collector_bsensor(binary_sensor::BinarySensor *bsensor) { this->tube_collector_bsensor_ = bsensor; }
-  void set_recooling_bsensor(binary_sensor::BinarySensor *bsensor) { this->recooling_bsensor_ = bsensor; }
-  void set_hqm_bsensor(binary_sensor::BinarySensor *bsensor) { this->hqm_bsensor_ = bsensor; }
+  void set_frost_protection_active_bsensor(binary_sensor::BinarySensor *bsensor) { this->frost_protection_active_bsensor_ = bsensor; }
 
  protected:
-  binary_sensor::BinarySensor *relay1_bsensor_{nullptr};
-  binary_sensor::BinarySensor *relay2_bsensor_{nullptr};
   binary_sensor::BinarySensor *s1_error_bsensor_{nullptr};
   binary_sensor::BinarySensor *s2_error_bsensor_{nullptr};
   binary_sensor::BinarySensor *s3_error_bsensor_{nullptr};
   binary_sensor::BinarySensor *s4_error_bsensor_{nullptr};
-  binary_sensor::BinarySensor *collector_max_bsensor_{nullptr};
-  binary_sensor::BinarySensor *collector_min_bsensor_{nullptr};
-  binary_sensor::BinarySensor *collector_frost_bsensor_{nullptr};
-  binary_sensor::BinarySensor *tube_collector_bsensor_{nullptr};
-  binary_sensor::BinarySensor *recooling_bsensor_{nullptr};
-  binary_sensor::BinarySensor *hqm_bsensor_{nullptr};
+  binary_sensor::BinarySensor *frost_protection_active_bsensor_{nullptr};
 
   void handle_message(std::vector<uint8_t> &message) override;
 };

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
@@ -46,7 +46,9 @@ class DeltaSolBS2009BSensor : public VBusListener, public Component {
   void set_s2_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s2_error_bsensor_ = bsensor; }
   void set_s3_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s3_error_bsensor_ = bsensor; }
   void set_s4_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s4_error_bsensor_ = bsensor; }
-  void set_frost_protection_active_bsensor(binary_sensor::BinarySensor *bsensor) { this->frost_protection_active_bsensor_ = bsensor; }
+  void set_frost_protection_active_bsensor(binary_sensor::BinarySensor *bsensor) {
+    this->frost_protection_active_bsensor_ = bsensor;
+  }
 
  protected:
   binary_sensor::BinarySensor *s1_error_bsensor_{nullptr};

--- a/esphome/components/vbus/sensor/__init__.py
+++ b/esphome/components/vbus/sensor/__init__.py
@@ -33,12 +33,14 @@ from .. import (
     VBus,
     CONF_VBUS_ID,
     CONF_DELTASOL_BS_PLUS,
+    CONF_DELTASOL_BS_2009,
     CONF_DELTASOL_C,
     CONF_DELTASOL_CS2,
     CONF_DELTASOL_CS_PLUS,
 )
 
 DeltaSol_BS_Plus = vbus_ns.class_("DeltaSolBSPlusSensor", cg.Component)
+DeltaSol_BS_2009 = vbus_ns.class_("DeltaSolBS2009Sensor", cg.Component)
 DeltaSol_C = vbus_ns.class_("DeltaSolCSensor", cg.Component)
 DeltaSol_CS2 = vbus_ns.class_("DeltaSolCS2Sensor", cg.Component)
 DeltaSol_CS_Plus = vbus_ns.class_("DeltaSolCSPlusSensor", cg.Component)
@@ -64,6 +66,87 @@ CONFIG_SCHEMA = cv.typed_schema(
         CONF_DELTASOL_BS_PLUS: cv.COMPONENT_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(DeltaSol_BS_Plus),
+                cv.GenerateID(CONF_VBUS_ID): cv.use_id(VBus),
+                cv.Optional(CONF_TEMPERATURE_1): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_TEMPERATURE_2): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_TEMPERATURE_3): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_TEMPERATURE_4): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_PUMP_SPEED_1): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_PERCENT,
+                    icon=ICON_PERCENT,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_EMPTY,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_PUMP_SPEED_2): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_PERCENT,
+                    icon=ICON_PERCENT,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_EMPTY,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_OPERATING_HOURS_1): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_HOUR,
+                    icon=ICON_TIMER,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_DURATION,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_OPERATING_HOURS_2): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_HOUR,
+                    icon=ICON_TIMER,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_DURATION,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_HEAT_QUANTITY): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_WATT_HOURS,
+                    icon=ICON_RADIATOR,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_ENERGY,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_TIME): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_MINUTE,
+                    icon=ICON_TIMER,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_DURATION,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_VERSION): sensor.sensor_schema(
+                    accuracy_decimals=2,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+            }
+        ),
+        CONF_DELTASOL_BS_2009: cv.COMPONENT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(DeltaSol_BS_2009),
                 cv.GenerateID(CONF_VBUS_ID): cv.use_id(VBus),
                 cv.Optional(CONF_TEMPERATURE_1): sensor.sensor_schema(
                     unit_of_measurement=UNIT_CELSIUS,
@@ -402,6 +485,44 @@ async def to_code(config):
     if config[CONF_MODEL] == CONF_DELTASOL_BS_PLUS:
         cg.add(var.set_command(0x0100))
         cg.add(var.set_source(0x4221))
+        cg.add(var.set_dest(0x0010))
+        if CONF_TEMPERATURE_1 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_1])
+            cg.add(var.set_temperature1_sensor(sens))
+        if CONF_TEMPERATURE_2 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_2])
+            cg.add(var.set_temperature2_sensor(sens))
+        if CONF_TEMPERATURE_3 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_3])
+            cg.add(var.set_temperature3_sensor(sens))
+        if CONF_TEMPERATURE_4 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_4])
+            cg.add(var.set_temperature4_sensor(sens))
+        if CONF_PUMP_SPEED_1 in config:
+            sens = await sensor.new_sensor(config[CONF_PUMP_SPEED_1])
+            cg.add(var.set_pump_speed1_sensor(sens))
+        if CONF_PUMP_SPEED_2 in config:
+            sens = await sensor.new_sensor(config[CONF_PUMP_SPEED_2])
+            cg.add(var.set_pump_speed2_sensor(sens))
+        if CONF_OPERATING_HOURS_1 in config:
+            sens = await sensor.new_sensor(config[CONF_OPERATING_HOURS_1])
+            cg.add(var.set_operating_hours1_sensor(sens))
+        if CONF_OPERATING_HOURS_2 in config:
+            sens = await sensor.new_sensor(config[CONF_OPERATING_HOURS_2])
+            cg.add(var.set_operating_hours2_sensor(sens))
+        if CONF_HEAT_QUANTITY in config:
+            sens = await sensor.new_sensor(config[CONF_HEAT_QUANTITY])
+            cg.add(var.set_heat_quantity_sensor(sens))
+        if CONF_TIME in config:
+            sens = await sensor.new_sensor(config[CONF_TIME])
+            cg.add(var.set_time_sensor(sens))
+        if CONF_VERSION in config:
+            sens = await sensor.new_sensor(config[CONF_VERSION])
+            cg.add(var.set_version_sensor(sens))
+
+    elif config[CONF_MODEL] == CONF_DELTASOL_BS_2009:
+        cg.add(var.set_command(0x0100))
+        cg.add(var.set_source(0x427B))
         cg.add(var.set_dest(0x0010))
         if CONF_TEMPERATURE_1 in config:
             sens = await sensor.new_sensor(config[CONF_TEMPERATURE_1])

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -90,7 +90,7 @@ void DeltaSolBS2009Sensor::handle_message(std::vector<uint8_t> &message) {
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 18));
   if (this->heat_quantity_sensor_ != nullptr) {
-    this->heat_quantity_sensor_->publish_state(get_u16(message, 28) + get_u16(message, 30) * 1000;
+    this->heat_quantity_sensor_->publish_state(get_u16(message, 28) + get_u16(message, 30) * 1000);
   }
   if (this->time_sensor_ != nullptr)
     this->time_sensor_->publish_state(get_u16(message, 22));

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -57,6 +57,47 @@ void DeltaSolBSPlusSensor::handle_message(std::vector<uint8_t> &message) {
     this->version_sensor_->publish_state(get_u16(message, 26) * 0.01f);
 }
 
+void DeltaSolBS2009Sensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Deltasol BS 2009:");
+  LOG_SENSOR("  ", "Temperature 1", this->temperature1_sensor_);
+  LOG_SENSOR("  ", "Temperature 2", this->temperature2_sensor_);
+  LOG_SENSOR("  ", "Temperature 3", this->temperature3_sensor_);
+  LOG_SENSOR("  ", "Temperature 4", this->temperature4_sensor_);
+  LOG_SENSOR("  ", "Pump Speed 1", this->pump_speed1_sensor_);
+  LOG_SENSOR("  ", "Pump Speed 2", this->pump_speed2_sensor_);
+  LOG_SENSOR("  ", "Operating Hours 1", this->operating_hours1_sensor_);
+  LOG_SENSOR("  ", "Operating Hours 2", this->operating_hours2_sensor_);
+  LOG_SENSOR("  ", "Heat Quantity", this->heat_quantity_sensor_);
+  LOG_SENSOR("  ", "System Time", this->time_sensor_);
+  LOG_SENSOR("  ", "FW Version", this->version_sensor_);
+}
+
+void DeltaSolBS2009Sensor::handle_message(std::vector<uint8_t> &message) {
+  if (this->temperature1_sensor_ != nullptr)
+    this->temperature1_sensor_->publish_state(get_i16(message, 0) * 0.1f);
+  if (this->temperature2_sensor_ != nullptr)
+    this->temperature2_sensor_->publish_state(get_i16(message, 2) * 0.1f);
+  if (this->temperature3_sensor_ != nullptr)
+    this->temperature3_sensor_->publish_state(get_i16(message, 4) * 0.1f);
+  if (this->temperature4_sensor_ != nullptr)
+    this->temperature4_sensor_->publish_state(get_i16(message, 6) * 0.1f);
+  if (this->pump_speed1_sensor_ != nullptr)
+    this->pump_speed1_sensor_->publish_state(message[8]);
+  if (this->pump_speed2_sensor_ != nullptr)
+    this->pump_speed2_sensor_->publish_state(message[12]);
+  if (this->operating_hours1_sensor_ != nullptr)
+    this->operating_hours1_sensor_->publish_state(get_u16(message, 10));
+  if (this->operating_hours2_sensor_ != nullptr)
+    this->operating_hours2_sensor_->publish_state(get_u16(message, 18));
+  if (this->heat_quantity_sensor_ != nullptr) {
+    this->heat_quantity_sensor_->publish_state(get_u16(message, 28) + get_u16(message, 30) * 1000;
+  }
+  if (this->time_sensor_ != nullptr)
+    this->time_sensor_->publish_state(get_u16(message, 22));
+  if (this->version_sensor_ != nullptr)
+    this->version_sensor_->publish_state(get_u16(message, 32) * 0.01f);
+}
+
 void DeltaSolCSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "Deltasol C:");
   LOG_SENSOR("  ", "Temperature 1", this->temperature1_sensor_);

--- a/esphome/components/vbus/sensor/vbus_sensor.h
+++ b/esphome/components/vbus/sensor/vbus_sensor.h
@@ -37,6 +37,37 @@ class DeltaSolBSPlusSensor : public VBusListener, public Component {
   void handle_message(std::vector<uint8_t> &message) override;
 };
 
+class DeltaSolBS2009Sensor : public VBusListener, public Component {
+ public:
+  void dump_config() override;
+  void set_temperature1_sensor(sensor::Sensor *sensor) { this->temperature1_sensor_ = sensor; }
+  void set_temperature2_sensor(sensor::Sensor *sensor) { this->temperature2_sensor_ = sensor; }
+  void set_temperature3_sensor(sensor::Sensor *sensor) { this->temperature3_sensor_ = sensor; }
+  void set_temperature4_sensor(sensor::Sensor *sensor) { this->temperature4_sensor_ = sensor; }
+  void set_pump_speed1_sensor(sensor::Sensor *sensor) { this->pump_speed1_sensor_ = sensor; }
+  void set_pump_speed2_sensor(sensor::Sensor *sensor) { this->pump_speed2_sensor_ = sensor; }
+  void set_operating_hours1_sensor(sensor::Sensor *sensor) { this->operating_hours1_sensor_ = sensor; }
+  void set_operating_hours2_sensor(sensor::Sensor *sensor) { this->operating_hours2_sensor_ = sensor; }
+  void set_heat_quantity_sensor(sensor::Sensor *sensor) { this->heat_quantity_sensor_ = sensor; }
+  void set_time_sensor(sensor::Sensor *sensor) { this->time_sensor_ = sensor; }
+  void set_version_sensor(sensor::Sensor *sensor) { this->version_sensor_ = sensor; }
+
+ protected:
+  sensor::Sensor *temperature1_sensor_{nullptr};
+  sensor::Sensor *temperature2_sensor_{nullptr};
+  sensor::Sensor *temperature3_sensor_{nullptr};
+  sensor::Sensor *temperature4_sensor_{nullptr};
+  sensor::Sensor *pump_speed1_sensor_{nullptr};
+  sensor::Sensor *pump_speed2_sensor_{nullptr};
+  sensor::Sensor *operating_hours1_sensor_{nullptr};
+  sensor::Sensor *operating_hours2_sensor_{nullptr};
+  sensor::Sensor *heat_quantity_sensor_{nullptr};
+  sensor::Sensor *time_sensor_{nullptr};
+  sensor::Sensor *version_sensor_{nullptr};
+
+  void handle_message(std::vector<uint8_t> &message) override;
+};
+
 class DeltaSolCSensor : public VBusListener, public Component {
  public:
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This extends the `vbus` component by adding support for the Deltasol BS 2009 and Dux H3214 solar controllers.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#2992

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml excerpt
uart:
  id: resol
  rx_pin: GPIO10
  baud_rate: 9600

vbus:
  uart_id: resol

sensor:
  - platform: vbus
    model: deltasol_bs_2009
    temperature_1:
      name: Collector Temp
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
