### PR TITLE
fix bug for xiaomi_miscale

### DIFF
--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
@@ -94,9 +94,9 @@ bool XiaomiMiscale::parse_message_v1_(const std::vector<uint8_t> &message, Parse
   const int16_t weight = uint16_t(data[1]) | (uint16_t(data[2]) << 8);
   if (data[0] == 0x22 || data[0] == 0xa2) {
     result.weight = weight * 0.01f / 2.0f;  // unit 'kg'
-  } else if (data[0] == 0x12 || data[0] == 0xb2) {
-    result.weight = weight * 0.01f * 0.6f;  // unit 'jin'
-  } else if (data[0] == 0x03 || data[0] == 0xb3) {
+  } else if (data[0] == 0x32 || data[0] == 0xb2) {
+    result.weight = weight * 0.01f;  // unit 'jin'
+  } else if (data[0] == 0x23 || data[0] == 0xa3) {
     result.weight = weight * 0.01f * 0.453592f;  // unit 'lbs'
   }
 


### PR DESCRIPTION
# What does this implement/fix?

After capture ble package and hack, there are some mistake in miscale code for XMTZC01HM. data[0] = 0x02 or 0x22 or 0xa2, it means kg unit, data[0] = 0x12 or 0x32 or 0xb2, it means jin unit and data[0] = 0x03 or 0x23 or 0xa3, it means lbs unit. For 0x02, 0x12, 0x03, it means in processing and the weight is unstable. For 0x22, 0x32, 0x23, it means processed and the weight is stable. And for 0xa2, 0xb2, 0xa3, it means the history data which is the earliest recent data as same as you measured in miscale. So in code, I just to choose the stable data for record. And the second, for jin unit, I don't know why to * 0.6f. In my device, it is not needed.

## Types of changes

- [√] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
