### PR TITLE
Make growatt play nicer with other modbus components.

### DIFF
--- a/esphome/components/growatt_solar/growatt_solar.cpp
+++ b/esphome/components/growatt_solar/growatt_solar.cpp
@@ -11,7 +11,8 @@ static const uint8_t MODBUS_REGISTER_COUNT[] = {33, 95};  // indexed with enum G
 
 void GrowattSolar::loop() {
   // If update() was unable to send we retry until we can send.
-  if (!this->waiting_to_update_) return;
+  if (!this->waiting_to_update_)
+    return;
   update();
 }
 
@@ -36,11 +37,13 @@ void GrowattSolar::update() {
 void GrowattSolar::on_modbus_data(const std::vector<uint8_t> &data) {
   // Other components might be sending commands to our device. But we don't get called with enough
   // context to know what is what. So if we didn't do a send, we ignore the data.
-  if (!this->last_send_) return;
+  if (!this->last_send_)
+    return;
   this->last_send_ = 0;
 
   // Also ignore the data if the message is too short. Otherwise we will publish invalid values.
-  if (data.size() < MODBUS_REGISTER_COUNT[this->protocol_version_] * 2) return;
+  if (data.size() < MODBUS_REGISTER_COUNT[this->protocol_version_] * 2)
+    return;
 
   auto publish_1_reg_sensor_state = [&](sensor::Sensor *sensor, size_t i, float unit) -> void {
     if (sensor == nullptr)

--- a/esphome/components/growatt_solar/growatt_solar.cpp
+++ b/esphome/components/growatt_solar/growatt_solar.cpp
@@ -9,11 +9,39 @@ static const char *const TAG = "growatt_solar";
 static const uint8_t MODBUS_CMD_READ_IN_REGISTERS = 0x04;
 static const uint8_t MODBUS_REGISTER_COUNT[] = {33, 95};  // indexed with enum GrowattProtocolVersion
 
+void GrowattSolar::loop() {
+  // If update() was unable to send we retry until we can send.
+  if (!this->waiting_to_update_) return;
+  update();
+}
+
 void GrowattSolar::update() {
+  // If our last send has had no reply yet, and it wasn't that long ago, do nothing.
+  uint32_t now = millis();
+  if (now - this->last_send_ < this->get_update_interval() / 2) {
+    return;
+  }
+
+  // The bus might be slow, or there might be other devices, or other components might be talking to our device.
+  if (this->waiting_for_response()) {
+    this->waiting_to_update_ = true;
+    return;
+  }
+
+  this->waiting_to_update_ = false;
   this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT[this->protocol_version_]);
+  this->last_send_ = millis();
 }
 
 void GrowattSolar::on_modbus_data(const std::vector<uint8_t> &data) {
+  // Other components might be sending commands to our device. But we don't get called with enough
+  // context to know what is what. So if we didn't do a send, we ignore the data.
+  if (!this->last_send_) return;
+  this->last_send_ = 0;
+
+  // Also ignore the data if the message is too short. Otherwise we will publish invalid values.
+  if (data.size() < MODBUS_REGISTER_COUNT[this->protocol_version_] * 2) return;
+
   auto publish_1_reg_sensor_state = [&](sensor::Sensor *sensor, size_t i, float unit) -> void {
     if (sensor == nullptr)
       return;

--- a/esphome/components/growatt_solar/growatt_solar.h
+++ b/esphome/components/growatt_solar/growatt_solar.h
@@ -18,10 +18,6 @@ enum GrowattProtocolVersion {
 };
 
 class GrowattSolar : public PollingComponent, public modbus::ModbusDevice {
- private:
-  bool waiting_to_update_;
-  uint32_t last_send_;
-
  public:
   void loop() override;
   void update() override;
@@ -60,6 +56,9 @@ class GrowattSolar : public PollingComponent, public modbus::ModbusDevice {
   }
 
  protected:
+  bool waiting_to_update_;
+  uint32_t last_send_;
+
   struct GrowattPhase {
     sensor::Sensor *voltage_sensor_{nullptr};
     sensor::Sensor *current_sensor_{nullptr};

--- a/esphome/components/growatt_solar/growatt_solar.h
+++ b/esphome/components/growatt_solar/growatt_solar.h
@@ -18,7 +18,12 @@ enum GrowattProtocolVersion {
 };
 
 class GrowattSolar : public PollingComponent, public modbus::ModbusDevice {
+ private:
+  bool waiting_to_update_;
+  uint32_t last_send_;
+
  public:
+  void loop() override;
   void update() override;
   void on_modbus_data(const std::vector<uint8_t> &data) override;
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

This PR makes the growatt_solar component take into account other components using the same modbus component. By only sending a read request if modbus is not waiting for a response. And when receiving data, ignore data that cannot be a response.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
substitutions:
  friendly_name: "Growatt"

# Disable logging to serial, incase the uart is the usb serial, which is by far the easiest for new-ish inverters.
logger:
  baud_rate: 0

uart:
  - id: usb_uart
    baud_rate: 115200
    tx_pin: GPIO1
    rx_pin: GPIO3

modbus:
  id: usb_modbus
  uart_id: usb_uart

modbus_controller:
  - id: usb_modbus_controller
    modbus_id: usb_modbus
    address: 0x1

# Sets up the growatt_solar component
sensor:
  - platform: growatt_solar
    modbus_id: usb_modbus
    address: 0x1
    update_interval: 5s
    protocol_version: RTU2

    energy_production_day:
      name: "${friendly_name} Energy Produced Today"

    total_energy_production:
      name: "${friendly_name} Total Energy Produced"
      accuracy_decimals: 1

# Sets up a modbus_controller component that reads and writes the same device
number:
  - platform: modbus_controller
    modbus_controller_id: usb_modbus_controller
    name: "${friendly_name} Max Active Output Percent"
    id: max_active_output_percent
    register_type: holding
    address: 0x3
    min_value: 0
    max_value: 100
    unit_of_measurement: "%"
    value_type: U_WORD
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
