### PR TITLE
display/font: optimise font rendering by about 25%

### DIFF
--- a/esphome/components/display/font.h
+++ b/esphome/components/display/font.h
@@ -22,8 +22,6 @@ class Glyph {
  public:
   Glyph(const GlyphData *data) : glyph_data_(data) {}
 
-  bool get_pixel(int x, int y) const;
-
   void draw(int x, int y, DisplayBuffer *display, Color color) const;
 
   const char *get_char() const;


### PR DESCRIPTION
# What does this implement/fix?

This does contains changes from https://github.com/esphome/esphome/pull/4956. They can be merged together or separately. The commit added on top of the other PR: https://github.com/esphome/esphome/pull/4956/commits/ebc33bc0b71efa3a791a9fc148bce368984a8fd2.

- optimise font rendering by about 25%
- add `BaseFont` and introduce `Font::draw` methods
- since the `Font::draw` is introduced the pixel loop is optimised to avoid repetitive operations
- ESP32S3: before: `1840ms`, after: `1411ms`
- the difference will be bigger on ESP8266 due to memory access pattern
- move `BaseFont`, `BaseImage` and `COLOR_*` to `displaybuffer.h` to make image/font only depend on `displaybuffer`, but not other way around
   
## Types of changes

- [x] Other: Performance improvement

## Test Environment

- [ ] ESP32
- [x] ESP32S3 (Fly Halo)
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
display:
      auto_clear_enabled: true
      lambda: |-
        auto start_us = micros();
        it.print(120, 20, id(roboto), TextAlign::TOP_CENTER, "Hello World!");
        auto dt_us = micros() - start_us;
        ESP_LOGE("logo_page", "text draw: %ld", dt_us);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
