### PR TITLE
Add actions to animation

### DIFF
--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from esphome import core
+from esphome import automation, core
 from esphome.components import display, font
 import esphome.components.image as espImage
 from esphome.components.image import CONF_USE_TRANSPARENCY
@@ -18,14 +18,27 @@ from esphome.core import CORE, HexInt
 
 _LOGGER = logging.getLogger(__name__)
 
+CODEOWNERS = ["@syndlex"]
 DEPENDENCIES = ["display"]
 MULTI_CONF = True
 
 CONF_LOOP = "loop"
 CONF_START_FRAME = "start_frame"
 CONF_END_FRAME = "end_frame"
+CONF_FRAME = "frame"
 
 Animation_ = display.display_ns.class_("Animation", espImage.Image_)
+
+# Actions
+NextFrameAction = display.display_ns.class_(
+    "AnimationNextFrameAction", automation.Action, cg.Parented.template(Animation_)
+)
+PrevFrameAction = display.display_ns.class_(
+    "AnimationPrevFrameAction", automation.Action, cg.Parented.template(Animation_)
+)
+SetFrameAction = display.display_ns.class_(
+    "AnimationSetFrameAction", automation.Action, cg.Parented.template(Animation_)
+)
 
 
 def validate_cross_dependencies(config):
@@ -74,7 +87,35 @@ ANIMATION_SCHEMA = cv.Schema(
 
 CONFIG_SCHEMA = cv.All(font.validate_pillow_installed, ANIMATION_SCHEMA)
 
-CODEOWNERS = ["@syndlex"]
+NEXT_FRAME_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(Animation_),
+    }
+)
+PREV_FRAME_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(Animation_),
+    }
+)
+SET_FRAME_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(Animation_),
+        cv.Required(CONF_FRAME): cv.uint16_t,
+    }
+)
+
+
+@automation.register_action("animation.next_frame", NextFrameAction, NEXT_FRAME_SCHEMA)
+@automation.register_action("animation.prev_frame", PrevFrameAction, PREV_FRAME_SCHEMA)
+@automation.register_action("animation.set_frame", SetFrameAction, SET_FRAME_SCHEMA)
+async def animation_action_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+
+    if CONF_FRAME in config:
+        template_ = await cg.templatable(config[CONF_FRAME], args, cg.uint16)
+        cg.add(var.set_frame(template_))
+    return var
 
 
 async def to_code(config):

--- a/esphome/components/display/animation.h
+++ b/esphome/components/display/animation.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "image.h"
 
+#include "esphome/core/automation.h"
+
 namespace esphome {
 namespace display {
 
@@ -31,6 +33,34 @@ class Animation : public Image {
   uint32_t loop_end_frame_;
   int loop_count_;
   int loop_current_iteration_;
+};
+
+template<typename... Ts> class AnimationNextFrameAction : public Action<Ts...> {
+ public:
+  AnimationNextFrameAction(Animation *parent) : parent_(parent) {}
+  void play(Ts... x) override { this->parent_->next_frame(); }
+
+ protected:
+  Animation *parent_;
+};
+
+template<typename... Ts> class AnimationPrevFrameAction : public Action<Ts...> {
+ public:
+  AnimationPrevFrameAction(Animation *parent) : parent_(parent) {}
+  void play(Ts... x) override { this->parent_->prev_frame(); }
+
+ protected:
+  Animation *parent_;
+};
+
+template<typename... Ts> class AnimationSetFrameAction : public Action<Ts...> {
+ public:
+  AnimationSetFrameAction(Animation *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(uint16_t, frame)
+  void play(Ts... x) override { this->parent_->set_frame(this->frame_.value(x...)); }
+
+ protected:
+  Animation *parent_;
 };
 
 }  // namespace display


### PR DESCRIPTION
# What does this implement/fix?

Add actions to be able to easily change the current frame to the animation component.
Instead of needing to use a lambda and c++ code, allow a simple yaml action to switch to the next or previous frame, or to set a specific frame.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3001

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
animation:
  - id: fire
    file: fire.gif

interval:
  - interval: 200ms
    then:
       - animation.next_frame: fire
# Alternative 1:
#       - animation.prev_frame: fire
# Alternative 2:
#       - animation.set_frame:
#          - id: fire
#            frame: 5
       - component.update: disp

display:
  - platform: <xyz>
     id: disp
     lambda: |-
       it.image(0, 0, id(fire));
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
