### PR TITLE
Fix Fujitsu-General AC to include "Quiet" fan setting.

### DIFF
--- a/esphome/components/fujitsu_general/fujitsu_general.cpp
+++ b/esphome/components/fujitsu_general/fujitsu_general.cpp
@@ -151,11 +151,12 @@ void FujitsuGeneralClimate::transmit_state() {
     case climate::CLIMATE_FAN_LOW:
       SET_NIBBLE(remote_state, FUJITSU_GENERAL_FAN_NIBBLE, FUJITSU_GENERAL_FAN_LOW);
       break;
+    case climate::CLIMATE_FAN_QUIET:
+      SET_NIBBLE(remote_state, FUJITSU_GENERAL_FAN_NIBBLE, FUJITSU_GENERAL_FAN_SILENT);
     case climate::CLIMATE_FAN_AUTO:
     default:
       SET_NIBBLE(remote_state, FUJITSU_GENERAL_FAN_NIBBLE, FUJITSU_GENERAL_FAN_AUTO);
       break;
-      // TODO Quiet / Silent
   }
 
   // Set swing
@@ -345,8 +346,9 @@ bool FujitsuGeneralClimate::on_receive(remote_base::RemoteReceiveData data) {
     const uint8_t recv_fan_mode = GET_NIBBLE(recv_message, FUJITSU_GENERAL_FAN_NIBBLE);
     ESP_LOGV(TAG, "Received fan mode %X", recv_fan_mode);
     switch (recv_fan_mode) {
-      // TODO No Quiet / Silent in ESPH
       case FUJITSU_GENERAL_FAN_SILENT:
+        this->fan_mode = climate::CLIMATE_FAN_QUIET;
+        break;
       case FUJITSU_GENERAL_FAN_LOW:
         this->fan_mode = climate::CLIMATE_FAN_LOW;
         break;

--- a/esphome/components/fujitsu_general/fujitsu_general.h
+++ b/esphome/components/fujitsu_general/fujitsu_general.h
@@ -52,7 +52,7 @@ class FujitsuGeneralClimate : public climate_ir::ClimateIR {
   FujitsuGeneralClimate()
       : ClimateIR(FUJITSU_GENERAL_TEMP_MIN, FUJITSU_GENERAL_TEMP_MAX, 1.0f, true, true,
                   {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
-                   climate::CLIMATE_FAN_HIGH},
+                   climate::CLIMATE_FAN_HIGH, climate::CLIMATE_FAN_QUIET},
                   {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL,
                    climate::CLIMATE_SWING_BOTH}) {}
 


### PR DESCRIPTION
Fixes Issue 4575

# What does this implement/fix?

Climate IR "Fujitsu General" has the option to set fan mode to "Quiet". This wasn't implemented before (even if the actual bytes to be sent through the IR were already mapped) but now it's working (and supported in HomeAssistant)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [4575](https://github.com/esphome/issues/issues/4575)



**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml

esp32:
  board: featheresp32-s2
  framework:
    type: arduino


climate:
  - platform: fujitsu_general      
    name: "Bedroom AC"
    id: "Bedroom_AC_Transmitter"
    sensor: "Bedroom_Temperature"
    receiver_id: "rcvr_bedroom_ac"

remote_transmitter:
  pin: 18
  carrier_duty_percent: 50%

emote_receiver:
 id: "rcvr_bedroom_ac"
 pin:
   number: 16
   inverted: true
   mode:
     input: true
     pullup: true
 # high 55% tolerance is recommended for some remote control units
 tolerance: 55%  

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
