### PR TITLE
dashboard: Adds "compressed=1" to /download.bin endpoint. (...)

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -536,7 +536,7 @@ class DownloadBinaryRequestHandler(BaseHandler):
                 self.send_error(404)
                 return
 
-        filename = filename + '.gz' if compressed else filename
+        filename = filename + ".gz" if compressed else filename
 
         self.set_header("Content-Type", "application/octet-stream")
         self.set_header("Content-Disposition", f'attachment; filename="{filename}"')

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -3,6 +3,7 @@ import binascii
 import codecs
 import collections
 import functools
+import gzip
 import hashlib
 import hmac
 import json
@@ -485,6 +486,7 @@ class DownloadBinaryRequestHandler(BaseHandler):
     @bind_config
     def get(self, configuration=None):
         type = self.get_argument("type", "firmware.bin")
+        compressed = self.get_argument("compressed", "0") == "1"
 
         storage_path = ext_storage_path(settings.config_dir, configuration)
         storage_json = StorageJSON.load(storage_path)
@@ -534,6 +536,8 @@ class DownloadBinaryRequestHandler(BaseHandler):
                 self.send_error(404)
                 return
 
+        filename = filename + '.gz' if compressed else filename
+
         self.set_header("Content-Type", "application/octet-stream")
         self.set_header("Content-Disposition", f'attachment; filename="{filename}"')
         self.set_header("Cache-Control", "no-cache")
@@ -543,9 +547,20 @@ class DownloadBinaryRequestHandler(BaseHandler):
 
         with open(path, "rb") as f:
             while True:
-                data = f.read(16384)
+                # For a 528KB image used as benchmark:
+                #   - using 256KB blocks resulted in the smallest file size.
+                #   - blocks larger than 256KB didn't improve the size of compressed file.
+                #   - blocks smaller than 256KB hindered compression, making the output file larger.
+
+                # Read file in blocks of 256KB.
+                data = f.read(256 * 1024)
+
                 if not data:
                     break
+
+                if compressed:
+                    data = gzip.compress(data, 9)
+
                 self.write(data)
         self.finish()
 


### PR DESCRIPTION
# What does this implement/fix?

## Adds "compressed=1" to /download.bin endpoint.

As described in [feature-requests#2276](https://github.com/esphome/feature-requests/issues/2276), this would greatly simplify future migrations for other users since they could convert a device just issuing two Tasmota commands:

```
OtaUrl http://my-esphome/download.bin?configuration=my-device.yaml&type=firmware-factory.bin&compressed=1
Upgrade 1
```

This would instruct Tasmota device to download the image directly from esphome web server and flash itself without human intervention via Tasmota web UI. 

## Increases download buffer size to 256KB.

The current code uses a 16KB buffer size which seems very small (even for RPI installs). 

Since the code doesn't give any rationale as to why this value was chosen I took the liberty of increasing it to 256KB, given that this gave me the ideal compression size in some ad hoc tests I made. It could also benefit (albeit in a much smaller capacity) the download of uncompressed images.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [feature-requests#2276](https://github.com/esphome/feature-requests/issues/2276)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** _(none)_

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
