### PR TITLE
display: move `Image`, `Font` and `Animation` code into components

### DIFF
--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from esphome import automation, core
-from esphome.components import display, font
+from esphome.components import font
 import esphome.components.image as espImage
 from esphome.components.image import CONF_USE_TRANSPARENCY
 import esphome.config_validation as cv
@@ -18,6 +18,7 @@ from esphome.core import CORE, HexInt
 
 _LOGGER = logging.getLogger(__name__)
 
+AUTO_LOAD = ["image"]
 CODEOWNERS = ["@syndlex"]
 DEPENDENCIES = ["display"]
 MULTI_CONF = True
@@ -27,16 +28,18 @@ CONF_START_FRAME = "start_frame"
 CONF_END_FRAME = "end_frame"
 CONF_FRAME = "frame"
 
-Animation_ = display.display_ns.class_("Animation", espImage.Image_)
+animation_ns = cg.esphome_ns.namespace("animation")
+
+Animation_ = animation_ns.class_("Animation", espImage.Image_)
 
 # Actions
-NextFrameAction = display.display_ns.class_(
+NextFrameAction = animation_ns.class_(
     "AnimationNextFrameAction", automation.Action, cg.Parented.template(Animation_)
 )
-PrevFrameAction = display.display_ns.class_(
+PrevFrameAction = animation_ns.class_(
     "AnimationPrevFrameAction", automation.Action, cg.Parented.template(Animation_)
 )
-SetFrameAction = display.display_ns.class_(
+SetFrameAction = animation_ns.class_(
     "AnimationSetFrameAction", automation.Action, cg.Parented.template(Animation_)
 )
 

--- a/esphome/components/animation/animation.cpp
+++ b/esphome/components/animation/animation.cpp
@@ -3,9 +3,10 @@
 #include "esphome/core/hal.h"
 
 namespace esphome {
-namespace display {
+namespace animation {
 
-Animation::Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, ImageType type)
+Animation::Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count,
+                     image::ImageType type)
     : Image(data_start, width, height, type),
       animation_data_start_(data_start),
       current_frame_(0),
@@ -65,5 +66,5 @@ void Animation::update_data_start_() {
   this->data_start_ = this->animation_data_start_ + image_size * this->current_frame_;
 }
 
-}  // namespace display
+}  // namespace animation
 }  // namespace esphome

--- a/esphome/components/animation/animation.h
+++ b/esphome/components/animation/animation.h
@@ -1,14 +1,14 @@
 #pragma once
-#include "image.h"
+#include "esphome/components/image/image.h"
 
 #include "esphome/core/automation.h"
 
 namespace esphome {
-namespace display {
+namespace animation {
 
-class Animation : public Image {
+class Animation : public image::Image {
  public:
-  Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, ImageType type);
+  Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, image::ImageType type);
 
   uint32_t get_animation_frame_count() const;
   int get_current_frame() const;
@@ -63,5 +63,5 @@ template<typename... Ts> class AnimationSetFrameAction : public Action<Ts...> {
   Animation *parent_;
 };
 
-}  // namespace display
+}  // namespace animation
 }  // namespace esphome

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -7,7 +7,6 @@ import re
 import requests
 
 from esphome import core
-from esphome.components import display
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.helpers import copy_file_if_changed
@@ -29,9 +28,11 @@ DOMAIN = "font"
 DEPENDENCIES = ["display"]
 MULTI_CONF = True
 
-Font = display.display_ns.class_("Font")
-Glyph = display.display_ns.class_("Glyph")
-GlyphData = display.display_ns.struct("GlyphData")
+font_ns = cg.esphome_ns.namespace("font")
+
+Font = font_ns.class_("Font")
+Glyph = font_ns.class_("Glyph")
+GlyphData = font_ns.struct("GlyphData")
 
 
 def validate_glyphs(value):

--- a/esphome/components/font/font.cpp
+++ b/esphome/components/font/font.cpp
@@ -2,13 +2,15 @@
 
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/color.h"
+#include "esphome/components/display/display_buffer.h"
 
 namespace esphome {
-namespace display {
+namespace font {
 
-static const char *const TAG = "display";
+static const char *const TAG = "font";
 
-void Glyph::draw(int x_at, int y_start, DisplayBuffer *display, Color color) const {
+void Glyph::draw(int x_at, int y_start, display::DisplayBuffer *display, Color color) const {
   int scan_x1, scan_y1, scan_width, scan_height;
   this->scan_area(&scan_x1, &scan_y1, &scan_width, &scan_height);
 
@@ -116,7 +118,7 @@ void Font::measure(const char *str, int *width, int *x_offset, int *baseline, in
   *x_offset = min_x;
   *width = x - min_x;
 }
-void Font::print(int x_start, int y_start, DisplayBuffer *display, Color color, const char *text) {
+void Font::print(int x_start, int y_start, display::DisplayBuffer *display, Color color, const char *text) {
   int i = 0;
   int x_at = x_start;
   while (text[i] != '\0') {
@@ -143,5 +145,5 @@ void Font::print(int x_start, int y_start, DisplayBuffer *display, Color color, 
   }
 }
 
-}  // namespace display
+}  // namespace font
 }  // namespace esphome

--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "esphome/core/datatypes.h"
-#include "display_buffer.h"
+#include "esphome/core/color.h"
+#include "esphome/components/display/display_buffer.h"
 
 namespace esphome {
-namespace display {
+namespace font {
 
-class DisplayBuffer;
 class Font;
 
 struct GlyphData {
@@ -22,7 +22,7 @@ class Glyph {
  public:
   Glyph(const GlyphData *data) : glyph_data_(data) {}
 
-  void draw(int x, int y, DisplayBuffer *display, Color color) const;
+  void draw(int x, int y, display::DisplayBuffer *display, Color color) const;
 
   const char *get_char() const;
 
@@ -38,7 +38,7 @@ class Glyph {
   const GlyphData *glyph_data_;
 };
 
-class Font : public BaseFont {
+class Font : public display::BaseFont {
  public:
   /** Construct the font with the given glyphs.
    *
@@ -50,7 +50,7 @@ class Font : public BaseFont {
 
   int match_next_glyph(const char *str, int *match_length);
 
-  void print(int x_start, int y_start, DisplayBuffer *display, Color color, const char *text) override;
+  void print(int x_start, int y_start, display::DisplayBuffer *display, Color color, const char *text) override;
   void measure(const char *str, int *width, int *x_offset, int *baseline, int *height) override;
   inline int get_baseline() { return this->baseline_; }
   inline int get_height() { return this->height_; }
@@ -63,5 +63,5 @@ class Font : public BaseFont {
   int height_;
 };
 
-}  // namespace display
+}  // namespace font
 }  // namespace esphome

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -1,6 +1,5 @@
 #include "graph.h"
 #include "esphome/components/display/display_buffer.h"
-#include "esphome/components/display/font.h"
 #include "esphome/core/color.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -11,7 +11,7 @@ namespace esphome {
 // forward declare DisplayBuffer
 namespace display {
 class DisplayBuffer;
-class Font;
+class BaseFont;
 }  // namespace display
 
 namespace graph {
@@ -45,8 +45,8 @@ enum ValuePositionType {
 class GraphLegend {
  public:
   void init(Graph *g);
-  void set_name_font(display::Font *font) { this->font_label_ = font; }
-  void set_value_font(display::Font *font) { this->font_value_ = font; }
+  void set_name_font(display::BaseFont *font) { this->font_label_ = font; }
+  void set_value_font(display::BaseFont *font) { this->font_value_ = font; }
   void set_width(uint32_t width) { this->width_ = width; }
   void set_height(uint32_t height) { this->height_ = height; }
   void set_border(bool val) { this->border_ = val; }
@@ -63,8 +63,8 @@ class GraphLegend {
   ValuePositionType values_{VALUE_POSITION_TYPE_AUTO};
   bool units_{true};
   DirectionType direction_{DIRECTION_TYPE_AUTO};
-  display::Font *font_label_{nullptr};
-  display::Font *font_value_{nullptr};
+  display::BaseFont *font_label_{nullptr};
+  display::BaseFont *font_value_{nullptr};
   // Calculated values
   Graph *parent_{nullptr};
   //                      (x0)          (xs,ys)         (xs,ys)

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -6,7 +6,7 @@ import re
 import requests
 
 from esphome import core
-from esphome.components import display, font
+from esphome.components import font
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
@@ -28,7 +28,9 @@ DOMAIN = "image"
 DEPENDENCIES = ["display"]
 MULTI_CONF = True
 
-ImageType = display.display_ns.enum("ImageType")
+image_ns = cg.esphome_ns.namespace("image")
+
+ImageType = image_ns.enum("ImageType")
 IMAGE_TYPE = {
     "BINARY": ImageType.IMAGE_TYPE_BINARY,
     "TRANSPARENT_BINARY": ImageType.IMAGE_TYPE_BINARY,
@@ -46,7 +48,7 @@ MDI_DOWNLOAD_TIMEOUT = 30  # seconds
 SOURCE_LOCAL = "local"
 SOURCE_MDI = "mdi"
 
-Image_ = display.display_ns.class_("Image")
+Image_ = image_ns.class_("Image")
 
 
 def _compute_local_icon_path(value) -> Path:

--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -3,9 +3,9 @@
 #include "esphome/core/hal.h"
 
 namespace esphome {
-namespace display {
+namespace image {
 
-void Image::draw(int x, int y, DisplayBuffer *display, Color color_on, Color color_off) {
+void Image::draw(int x, int y, display::DisplayBuffer *display, Color color_on, Color color_off) {
   switch (type_) {
     case IMAGE_TYPE_BINARY: {
       for (int img_x = 0; img_x < width_; img_x++) {
@@ -130,5 +130,5 @@ ImageType Image::get_type() const { return this->type_; }
 Image::Image(const uint8_t *data_start, int width, int height, ImageType type)
     : width_(width), height_(height), type_(type), data_start_(data_start) {}
 
-}  // namespace display
+}  // namespace image
 }  // namespace esphome

--- a/esphome/components/image/image.h
+++ b/esphome/components/image/image.h
@@ -1,9 +1,9 @@
 #pragma once
 #include "esphome/core/color.h"
-#include "display_buffer.h"
+#include "esphome/components/display/display_buffer.h"
 
 namespace esphome {
-namespace display {
+namespace image {
 
 enum ImageType {
   IMAGE_TYPE_BINARY = 0,
@@ -31,15 +31,15 @@ inline int image_type_to_bpp(ImageType type) {
 
 inline int image_type_to_width_stride(int width, ImageType type) { return (width * image_type_to_bpp(type) + 7u) / 8u; }
 
-class Image : public BaseImage {
+class Image : public display::BaseImage {
  public:
   Image(const uint8_t *data_start, int width, int height, ImageType type);
-  Color get_pixel(int x, int y, Color color_on = COLOR_ON, Color color_off = COLOR_OFF) const;
+  Color get_pixel(int x, int y, Color color_on = display::COLOR_ON, Color color_off = display::COLOR_OFF) const;
   int get_width() const override;
   int get_height() const override;
   ImageType get_type() const;
 
-  void draw(int x, int y, DisplayBuffer *display, Color color_on, Color color_off) override;
+  void draw(int x, int y, display::DisplayBuffer *display, Color color_on, Color color_off) override;
 
   void set_transparency(bool transparent) { transparent_ = transparent; }
   bool has_transparency() const { return transparent_; }
@@ -58,5 +58,5 @@ class Image : public BaseImage {
   bool transparent_;
 };
 
-}  // namespace display
+}  // namespace image
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This includes changes from https://github.com/esphome/esphome/pull/4956.

- display: move `Image` to `components/image`
- display: move `Animation` to `components/animation`, make it depend on `Image`
- display: move `Font` to `components/font`
- graph: fix to depend on `Font`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected): changes source code location
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32S3
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
