### PR TITLE
Apply configured IIR filter setting in generated BMP280 code

### DIFF
--- a/esphome/components/bmp280/sensor.py
+++ b/esphome/components/bmp280/sensor.py
@@ -94,3 +94,5 @@ async def to_code(config):
         sens = await sensor.new_sensor(conf)
         cg.add(var.set_pressure_sensor(sens))
         cg.add(var.set_pressure_oversampling(conf[CONF_OVERSAMPLING]))
+    
+    cg.add(var.set_iir_filter(config[CONF_IIR_FILTER]))

--- a/esphome/components/bmp280/sensor.py
+++ b/esphome/components/bmp280/sensor.py
@@ -94,5 +94,5 @@ async def to_code(config):
         sens = await sensor.new_sensor(conf)
         cg.add(var.set_pressure_sensor(sens))
         cg.add(var.set_pressure_oversampling(conf[CONF_OVERSAMPLING]))
-    
+
     cg.add(var.set_iir_filter(config[CONF_IIR_FILTER]))


### PR DESCRIPTION
This should match what's done in the similar BME280.

# What does this implement/fix?

The Bosch BMP280 and BME280 are very similar parts and both feature an optional IIR filter. This works properly for the BME280, but the configuration options were being silently ignored in the generated code for the BMP280. This corrects that.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/1695

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
