### PR TITLE
Make ethernet_info work with esp-idf framework

### DIFF
--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.cpp
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.cpp
@@ -1,7 +1,7 @@
 #include "ethernet_info_text_sensor.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+#ifdef USE_ESP32
 
 namespace esphome {
 namespace ethernet_info {
@@ -13,4 +13,4 @@ void IPAddressEthernetInfo::dump_config() { LOG_TEXT_SENSOR("", "EthernetInfo IP
 }  // namespace ethernet_info
 }  // namespace esphome
 
-#endif  // USE_ESP32_FRAMEWORK_ARDUINO
+#endif  // USE_ESP32

--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.h
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.h
@@ -4,7 +4,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/ethernet/ethernet_component.h"
 
-#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+#ifdef USE_ESP32
 
 namespace esphome {
 namespace ethernet_info {
@@ -30,4 +30,4 @@ class IPAddressEthernetInfo : public PollingComponent, public text_sensor::TextS
 }  // namespace ethernet_info
 }  // namespace esphome
 
-#endif  // USE_ESP32_FRAMEWORK_ARDUINO
+#endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Fixes https://github.com/esphome/issues/issues/4116

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF Ethernet
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: 'test'

esp32:
  board: esp32dev
  framework:
    type: esp-idf

ota:

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO0_IN
  phy_addr: 1
  power_pin: GPIO5

#network:
#    enable_ipv6: true

text_sensor:
  - platform: ethernet_info
    ip_address:
      name: 'IP-Adresse'

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
