### PR TITLE
airthings_wave: Battery level reporting

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@ esphome/components/adc/* @esphome/core
 esphome/components/adc128s102/* @DeerMaximum
 esphome/components/addressable_light/* @justfalter
 esphome/components/airthings_ble/* @jeromelaban
-esphome/components/airthings_wave_base/* @jeromelaban @ncareau
+esphome/components/airthings_wave_base/* @jeromelaban @kpfleming @ncareau
 esphome/components/airthings_wave_mini/* @ncareau
 esphome/components/airthings_wave_plus/* @jeromelaban
 esphome/components/alarm_control_panel/* @grahambrown11

--- a/esphome/components/airthings_wave_base/__init__.py
+++ b/esphome/components/airthings_wave_base/__init__.py
@@ -3,25 +3,30 @@ import esphome.config_validation as cv
 from esphome.components import sensor, ble_client
 
 from esphome.const import (
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_PRESSURE,
-    STATE_CLASS_MEASUREMENT,
-    UNIT_PERCENT,
-    UNIT_CELSIUS,
-    UNIT_HECTOPASCAL,
+    CONF_BATTERY_VOLTAGE,
     CONF_HUMIDITY,
-    CONF_TVOC,
     CONF_PRESSURE,
     CONF_TEMPERATURE,
+    CONF_TVOC,
+    DEVICE_CLASS_VOLTAGE,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_HECTOPASCAL,
     UNIT_PARTS_PER_BILLION,
-    ICON_RADIATOR,
+    UNIT_PERCENT,
+    UNIT_VOLT,
 )
 
-CODEOWNERS = ["@ncareau", "@jeromelaban"]
+CODEOWNERS = ["@ncareau", "@jeromelaban", "@kpfleming"]
 
 DEPENDENCIES = ["ble_client"]
+
+CONF_BATTERY_UPDATE_INTERVAL = "battery_update_interval"
 
 airthings_wave_base_ns = cg.esphome_ns.namespace("airthings_wave_base")
 AirthingsWaveBase = airthings_wave_base_ns.class_(
@@ -34,9 +39,9 @@ BASE_SCHEMA = (
         {
             cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=0,
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
-                accuracy_decimals=0,
             ),
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
@@ -52,11 +57,21 @@ BASE_SCHEMA = (
             ),
             cv.Optional(CONF_TVOC): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_BILLION,
-                icon=ICON_RADIATOR,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_BATTERY_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(
+                CONF_BATTERY_UPDATE_INTERVAL,
+                default="24h",
+            ): cv.update_interval,
         }
     )
     .extend(cv.polling_component_schema("5min"))
@@ -81,3 +96,8 @@ async def wave_base_to_code(var, config):
     if config_tvoc := config.get(CONF_TVOC):
         sens = await sensor.new_sensor(config_tvoc)
         cg.add(var.set_tvoc(sens))
+    if config_battery_voltage := config.get(CONF_BATTERY_VOLTAGE):
+        sens = await sensor.new_sensor(config_battery_voltage)
+        cg.add(var.set_battery_voltage(sens))
+    if config_battery_update_interval := config.get(CONF_BATTERY_UPDATE_INTERVAL):
+        cg.add(var.set_battery_update_interval(config_battery_update_interval))

--- a/esphome/components/airthings_wave_base/__init__.py
+++ b/esphome/components/airthings_wave_base/__init__.py
@@ -69,15 +69,15 @@ async def wave_base_to_code(var, config):
 
     await ble_client.register_ble_node(var, config)
 
-    if CONF_HUMIDITY in config:
-        sens = await sensor.new_sensor(config[CONF_HUMIDITY])
+    if config_humidity := config.get(CONF_HUMIDITY):
+        sens = await sensor.new_sensor(config_humidity)
         cg.add(var.set_humidity(sens))
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if config_temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(config_temperature)
         cg.add(var.set_temperature(sens))
-    if CONF_PRESSURE in config:
-        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+    if config_pressure := config.get(CONF_PRESSURE):
+        sens = await sensor.new_sensor(config_pressure)
         cg.add(var.set_pressure(sens))
-    if CONF_TVOC in config:
-        sens = await sensor.new_sensor(config[CONF_TVOC])
+    if config_tvoc := config.get(CONF_TVOC):
+        sens = await sensor.new_sensor(config_tvoc)
         cg.add(var.set_tvoc(sens))

--- a/esphome/components/airthings_wave_base/airthings_wave_base.cpp
+++ b/esphome/components/airthings_wave_base/airthings_wave_base.cpp
@@ -1,5 +1,8 @@
 #include "airthings_wave_base.h"
 
+// All information related to reading battery information came from the sensors.airthings_wave
+// project by Sverre Hamre (https://github.com/sverrham/sensor.airthings_wave)
+
 #ifdef USE_ESP32
 
 namespace esphome {
@@ -18,22 +21,22 @@ void AirthingsWaveBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
     }
 
     case ESP_GATTC_DISCONNECT_EVT: {
+      this->handle_ = 0;
+      this->acp_handle_ = 0;
+      this->cccd_handle_ = 0;
       ESP_LOGW(TAG, "Disconnected!");
       break;
     }
 
     case ESP_GATTC_SEARCH_CMPL_EVT: {
-      this->handle_ = 0;
-      auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->sensors_data_characteristic_uuid_);
-      if (chr == nullptr) {
-        ESP_LOGW(TAG, "No sensor characteristic found at service %s char %s", this->service_uuid_.to_string().c_str(),
-                 this->sensors_data_characteristic_uuid_.to_string().c_str());
-        break;
+      if (this->request_read_values_()) {
+        if (!this->read_battery_next_update_) {
+          this->node_state = espbt::ClientState::ESTABLISHED;
+        } else {
+          // delay setting node_state to ESTABLISHED until confirmation of the notify registration
+          this->request_battery_();
+        }
       }
-      this->handle_ = chr->handle;
-      this->node_state = esp32_ble_tracker::ClientState::ESTABLISHED;
-
-      this->request_read_values_();
 
       // ensure that the client will be disconnected even if no responses arrive
       this->set_response_timeout_();
@@ -54,6 +57,20 @@ void AirthingsWaveBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
       break;
     }
 
+    case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
+      this->node_state = espbt::ClientState::ESTABLISHED;
+      break;
+    }
+
+    case ESP_GATTC_NOTIFY_EVT: {
+      if (param->notify.conn_id != this->parent()->get_conn_id())
+        break;
+      if (param->notify.handle == this->acp_handle_) {
+        this->read_battery_(param->notify.value, param->notify.value_len);
+      }
+      break;
+    }
+
     default:
       break;
   }
@@ -62,7 +79,7 @@ void AirthingsWaveBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt
 bool AirthingsWaveBase::is_valid_voc_value_(uint16_t voc) { return 0 <= voc && voc <= 16383; }
 
 void AirthingsWaveBase::update() {
-  if (this->node_state != esp32_ble_tracker::ClientState::ESTABLISHED) {
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
     if (!this->parent()->enabled) {
       ESP_LOGW(TAG, "Reconnecting to device");
       this->parent()->set_enabled(true);
@@ -73,14 +90,98 @@ void AirthingsWaveBase::update() {
   }
 }
 
-void AirthingsWaveBase::request_read_values_() {
+bool AirthingsWaveBase::request_read_values_() {
+  auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->sensors_data_characteristic_uuid_);
+  if (chr == nullptr) {
+    ESP_LOGW(TAG, "No sensor characteristic found at service %s char %s", this->service_uuid_.to_string().c_str(),
+             this->sensors_data_characteristic_uuid_.to_string().c_str());
+    return false;
+  }
+
+  this->handle_ = chr->handle;
+
   auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->handle_,
                                         ESP_GATT_AUTH_REQ_NONE);
   if (status) {
     ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);
-  } else {
-    this->response_pending_();
+    return false;
   }
+
+  this->response_pending_();
+  return true;
+}
+
+bool AirthingsWaveBase::request_battery_() {
+  uint8_t battery_command = ACCESS_CONTROL_POINT_COMMAND;
+  uint8_t cccd_value[2] = {1, 0};
+
+  auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->access_control_point_characteristic_uuid_);
+  if (chr == nullptr) {
+    ESP_LOGW(TAG, "No access control point characteristic found at service %s char %s",
+             this->service_uuid_.to_string().c_str(),
+             this->access_control_point_characteristic_uuid_.to_string().c_str());
+    return false;
+  }
+
+  auto *descr = this->parent()->get_descriptor(this->service_uuid_, this->access_control_point_characteristic_uuid_,
+                                               CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR_UUID);
+  if (descr == nullptr) {
+    ESP_LOGW(TAG, "No CCC descriptor found at service %s char %s", this->service_uuid_.to_string().c_str(),
+             this->access_control_point_characteristic_uuid_.to_string().c_str());
+    return false;
+  }
+
+  auto reg_status =
+      esp_ble_gattc_register_for_notify(this->parent()->get_gattc_if(), this->parent()->get_remote_bda(), chr->handle);
+  if (reg_status) {
+    ESP_LOGW(TAG, "esp_ble_gattc_register_for_notify failed, status=%d", reg_status);
+    return false;
+  }
+
+  this->acp_handle_ = chr->handle;
+  this->cccd_handle_ = descr->handle;
+
+  auto descr_status =
+      esp_ble_gattc_write_char_descr(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->cccd_handle_,
+                                     2, cccd_value, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
+  if (descr_status) {
+    ESP_LOGW(TAG, "Error sending CCC descriptor write request, status=%d", descr_status);
+    return false;
+  }
+
+  auto chr_status =
+      esp_ble_gattc_write_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->acp_handle_, 1,
+                               &battery_command, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
+  if (chr_status) {
+    ESP_LOGW(TAG, "Error sending read request for battery, status=%d", chr_status);
+    return false;
+  }
+
+  this->response_pending_();
+  return true;
+}
+
+void AirthingsWaveBase::read_battery_(uint8_t *raw_value, uint16_t value_len) {
+  auto *value = (AccessControlPointResponse *) (&raw_value[2]);
+
+  if ((value_len >= (sizeof(AccessControlPointResponse) + 2)) && (raw_value[0] == ACCESS_CONTROL_POINT_COMMAND)) {
+    ESP_LOGD(TAG, "Battery received: %u mV", (unsigned int) value->battery);
+
+    if (this->battery_voltage_ != nullptr) {
+      float voltage = value->battery / 1000.0f;
+
+      this->battery_voltage_->publish_state(voltage);
+    }
+
+    // read the battery again at the configured update interval
+    if (this->battery_update_interval_ != this->update_interval_) {
+      this->read_battery_next_update_ = false;
+      this->set_timeout("battery", this->battery_update_interval_,
+                        [this]() { this->read_battery_next_update_ = true; });
+    }
+  }
+
+  this->response_received_();
 }
 
 void AirthingsWaveBase::response_pending_() {

--- a/esphome/components/airthings_wave_base/airthings_wave_base.h
+++ b/esphome/components/airthings_wave_base/airthings_wave_base.h
@@ -31,7 +31,7 @@ class AirthingsWaveBase : public PollingComponent, public ble_client::BLEClientN
  protected:
   bool is_valid_voc_value_(uint16_t voc);
 
-  virtual void read_sensors(uint8_t *value, uint16_t value_len) = 0;
+  virtual void read_sensors(uint8_t *raw_value, uint16_t value_len) = 0;
   void request_read_values_();
 
   sensor::Sensor *temperature_sensor_{nullptr};

--- a/esphome/components/airthings_wave_base/airthings_wave_base.h
+++ b/esphome/components/airthings_wave_base/airthings_wave_base.h
@@ -42,6 +42,11 @@ class AirthingsWaveBase : public PollingComponent, public ble_client::BLEClientN
   uint16_t handle_;
   esp32_ble_tracker::ESPBTUUID service_uuid_;
   esp32_ble_tracker::ESPBTUUID sensors_data_characteristic_uuid_;
+
+  uint8_t responses_pending_{0};
+  void response_pending_();
+  void response_received_();
+  void set_response_timeout_();
 };
 
 }  // namespace airthings_wave_base

--- a/esphome/components/airthings_wave_base/airthings_wave_base.h
+++ b/esphome/components/airthings_wave_base/airthings_wave_base.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// All information related to reading battery levels came from the sensors.airthings_wave
+// project by Sverre Hamre (https://github.com/sverrham/sensor.airthings_wave)
+
 #ifdef USE_ESP32
 
 #include <esp_gattc_api.h>
@@ -14,6 +17,11 @@
 namespace esphome {
 namespace airthings_wave_base {
 
+namespace espbt = esphome::esp32_ble_tracker;
+
+static const uint8_t ACCESS_CONTROL_POINT_COMMAND = 0x6d;
+static const auto CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR_UUID = espbt::ESPBTUUID::from_uint16(0x2902);
+
 class AirthingsWaveBase : public PollingComponent, public ble_client::BLEClientNode {
  public:
   AirthingsWaveBase() = default;
@@ -27,26 +35,53 @@ class AirthingsWaveBase : public PollingComponent, public ble_client::BLEClientN
   void set_humidity(sensor::Sensor *humidity) { humidity_sensor_ = humidity; }
   void set_pressure(sensor::Sensor *pressure) { pressure_sensor_ = pressure; }
   void set_tvoc(sensor::Sensor *tvoc) { tvoc_sensor_ = tvoc; }
+  void set_battery_voltage(sensor::Sensor *voltage) {
+    battery_voltage_ = voltage;
+    this->read_battery_next_update_ = true;
+  }
+  void set_battery_update_interval(uint32_t interval) { battery_update_interval_ = interval; }
 
  protected:
   bool is_valid_voc_value_(uint16_t voc);
 
+  bool request_read_values_();
   virtual void read_sensors(uint8_t *raw_value, uint16_t value_len) = 0;
-  void request_read_values_();
 
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   sensor::Sensor *pressure_sensor_{nullptr};
   sensor::Sensor *tvoc_sensor_{nullptr};
+  sensor::Sensor *battery_voltage_{nullptr};
 
   uint16_t handle_;
-  esp32_ble_tracker::ESPBTUUID service_uuid_;
-  esp32_ble_tracker::ESPBTUUID sensors_data_characteristic_uuid_;
+  espbt::ESPBTUUID service_uuid_;
+  espbt::ESPBTUUID sensors_data_characteristic_uuid_;
+
+  uint16_t acp_handle_{0};
+  uint16_t cccd_handle_{0};
+  espbt::ESPBTUUID access_control_point_characteristic_uuid_;
 
   uint8_t responses_pending_{0};
   void response_pending_();
   void response_received_();
   void set_response_timeout_();
+
+  // default to *not* reading battery voltage from the device; the
+  // set_* function for the battery sensor will set this to 'true'
+  bool read_battery_next_update_{false};
+  bool request_battery_();
+  void read_battery_(uint8_t *raw_value, uint16_t value_len);
+  uint32_t battery_update_interval_{};
+
+  struct AccessControlPointResponse {
+    uint32_t unused1;
+    uint8_t unused2;
+    uint8_t illuminance;
+    uint8_t unused3[10];
+    uint16_t unused4[4];
+    uint16_t battery;
+    uint16_t unused5;
+  };
 };
 
 }  // namespace airthings_wave_base

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
@@ -26,12 +26,9 @@ void AirthingsWaveMini::read_sensors(uint8_t *raw_value, uint16_t value_len) {
     if ((this->tvoc_sensor_ != nullptr) && this->is_valid_voc_value_(value->voc)) {
       this->tvoc_sensor_->publish_state(value->voc);
     }
-
-    // This instance must not stay connected
-    // so other clients can connect to it (e.g. the
-    // mobile app).
-    this->parent()->set_enabled(false);
   }
+
+  this->response_received_();
 }
 
 void AirthingsWaveMini::dump_config() {

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.cpp
@@ -39,11 +39,14 @@ void AirthingsWaveMini::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
   LOG_SENSOR("  ", "TVOC", this->tvoc_sensor_);
+  LOG_SENSOR("  ", "Battery Voltage", this->battery_voltage_);
 }
 
 AirthingsWaveMini::AirthingsWaveMini() {
-  this->service_uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(SERVICE_UUID);
-  this->sensors_data_characteristic_uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(CHARACTERISTIC_UUID);
+  this->service_uuid_ = espbt::ESPBTUUID::from_raw(SERVICE_UUID);
+  this->sensors_data_characteristic_uuid_ = espbt::ESPBTUUID::from_raw(CHARACTERISTIC_UUID);
+  this->access_control_point_characteristic_uuid_ =
+      espbt::ESPBTUUID::from_raw(ACCESS_CONTROL_POINT_CHARACTERISTIC_UUID);
 }
 
 }  // namespace airthings_wave_mini

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.h
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.h
@@ -17,7 +17,7 @@ class AirthingsWaveMini : public airthings_wave_base::AirthingsWaveBase {
   void dump_config() override;
 
  protected:
-  void read_sensors(uint8_t *value, uint16_t value_len) override;
+  void read_sensors(uint8_t *raw_value, uint16_t value_len) override;
 
   struct WaveMiniReadings {
     uint16_t unused01;

--- a/esphome/components/airthings_wave_mini/airthings_wave_mini.h
+++ b/esphome/components/airthings_wave_mini/airthings_wave_mini.h
@@ -7,8 +7,11 @@
 namespace esphome {
 namespace airthings_wave_mini {
 
+namespace espbt = esphome::esp32_ble_tracker;
+
 static const char *const SERVICE_UUID = "b42e3882-ade7-11e4-89d3-123b93f75cba";
 static const char *const CHARACTERISTIC_UUID = "b42e3b98-ade7-11e4-89d3-123b93f75cba";
+static const char *const ACCESS_CONTROL_POINT_CHARACTERISTIC_UUID = "b42e3ef4-ade7-11e4-89d3-123b93f75cba";
 
 class AirthingsWaveMini : public airthings_wave_base::AirthingsWaveBase {
  public:

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -43,15 +43,12 @@ void AirthingsWavePlus::read_sensors(uint8_t *raw_value, uint16_t value_len) {
       if ((this->tvoc_sensor_ != nullptr) && this->is_valid_voc_value_(value->voc)) {
         this->tvoc_sensor_->publish_state(value->voc);
       }
-
-      // This instance must not stay connected
-      // so other clients can connect to it (e.g. the
-      // mobile app).
-      this->parent()->set_enabled(false);
     } else {
       ESP_LOGE(TAG, "Invalid payload version (%d != 1, newer version or not a Wave Plus?)", value->version);
     }
   }
+
+  this->response_received_();
 }
 
 bool AirthingsWavePlus::is_valid_radon_value_(uint16_t radon) { return 0 <= radon && radon <= 16383; }

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -63,6 +63,7 @@ void AirthingsWavePlus::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
   LOG_SENSOR("  ", "TVOC", this->tvoc_sensor_);
+  LOG_SENSOR("  ", "Battery Voltage", this->battery_voltage_);
 
   LOG_SENSOR("  ", "Radon", this->radon_sensor_);
   LOG_SENSOR("  ", "Radon Long Term", this->radon_long_term_sensor_);
@@ -70,8 +71,10 @@ void AirthingsWavePlus::dump_config() {
 }
 
 AirthingsWavePlus::AirthingsWavePlus() {
-  this->service_uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(SERVICE_UUID);
-  this->sensors_data_characteristic_uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(CHARACTERISTIC_UUID);
+  this->service_uuid_ = espbt::ESPBTUUID::from_raw(SERVICE_UUID);
+  this->sensors_data_characteristic_uuid_ = espbt::ESPBTUUID::from_raw(CHARACTERISTIC_UUID);
+  this->access_control_point_characteristic_uuid_ =
+      espbt::ESPBTUUID::from_raw(ACCESS_CONTROL_POINT_CHARACTERISTIC_UUID);
 }
 
 }  // namespace airthings_wave_plus

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.h
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.h
@@ -7,8 +7,11 @@
 namespace esphome {
 namespace airthings_wave_plus {
 
+namespace espbt = esphome::esp32_ble_tracker;
+
 static const char *const SERVICE_UUID = "b42e1c08-ade7-11e4-89d3-123b93f75cba";
 static const char *const CHARACTERISTIC_UUID = "b42e2a68-ade7-11e4-89d3-123b93f75cba";
+static const char *const ACCESS_CONTROL_POINT_CHARACTERISTIC_UUID = "b42e2d06-ade7-11e4-89d3-123b93f75cba";
 
 class AirthingsWavePlus : public airthings_wave_base::AirthingsWaveBase {
  public:

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.h
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.h
@@ -24,7 +24,7 @@ class AirthingsWavePlus : public airthings_wave_base::AirthingsWaveBase {
   bool is_valid_radon_value_(uint16_t radon);
   bool is_valid_co2_value_(uint16_t co2);
 
-  void read_sensors(uint8_t *value, uint16_t value_len) override;
+  void read_sensors(uint8_t *raw_value, uint16_t value_len) override;
 
   sensor::Sensor *radon_sensor_{nullptr};
   sensor::Sensor *radon_long_term_sensor_{nullptr};

--- a/esphome/components/airthings_wave_plus/sensor.py
+++ b/esphome/components/airthings_wave_plus/sensor.py
@@ -53,12 +53,12 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await airthings_wave_base.wave_base_to_code(var, config)
 
-    if CONF_RADON in config:
-        sens = await sensor.new_sensor(config[CONF_RADON])
+    if config_radon := config.get(CONF_RADON):
+        sens = await sensor.new_sensor(config_radon)
         cg.add(var.set_radon(sens))
-    if CONF_RADON_LONG_TERM in config:
-        sens = await sensor.new_sensor(config[CONF_RADON_LONG_TERM])
+    if config_radon_long_term := config.get(CONF_RADON_LONG_TERM):
+        sens = await sensor.new_sensor(config_radon_long_term)
         cg.add(var.set_radon_long_term(sens))
-    if CONF_CO2 in config:
-        sens = await sensor.new_sensor(config[CONF_CO2])
+    if config_co2 := config.get(CONF_CO2):
+        sens = await sensor.new_sensor(config_co2)
         cg.add(var.set_co2(sens))

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -316,6 +316,7 @@ sensor:
     platform: airthings_wave_plus
     ble_client_id: airthings01
     update_interval: 5min
+    battery_update_interval: 12h
     temperature:
       name: Wave Plus Temperature
     radon:
@@ -330,10 +331,13 @@ sensor:
       name: Wave Plus CO2
     tvoc:
       name: Wave Plus VOC
+    battery_voltage:
+      name: Wave Plus Battery Voltage
   - id: airthingswm
     platform: airthings_wave_mini
     ble_client_id: airthingsmini01
     update_interval: 5min
+    battery_update_interval: 12h
     temperature:
       name: Wave Mini Temperature
     humidity:
@@ -342,6 +346,8 @@ sensor:
       name: Wave Mini Pressure
     tvoc:
       name: Wave Mini VOC
+    battery_voltage:
+      name: Wave Mini Battery Voltage
   - platform: ina260
     address: 0x40
     current:


### PR DESCRIPTION
# What does this implement/fix?

Reports battery voltage of Airthings devices as an additional sensor.

Also adds the author as a CODEOWNER of the modified components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3007

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
sensor:
  - platform: airthings_wave_plus
    ble_client_id: airthings01
    update_interval: 5min # default
    battery_update_interval: 24h # default
    temperature:
      name: "WavePlus Temperature"
    radon:
      name: "WavePlus Radon"
    radon_long_term:
      name: "WavePlus Radon Long Term"
    pressure:
      name: "WavePlus Pressure"
    humidity:
      name: "WavePlus Humidity"
    co2:
      name: "WavePlus CO2"
    tvoc:
      name: "WavePlus VOC"
    battery_voltage:
      name: "WavePlus Battery Voltage"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
