### PR TITLE
display: fix white screen on binary displays

### DIFF
--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -12,7 +12,7 @@ namespace display {
 
 static const char *const TAG = "display";
 
-const Color COLOR_OFF(0, 0, 0, 255);
+const Color COLOR_OFF(0, 0, 0, 0);
 const Color COLOR_ON(255, 255, 255, 255);
 
 void DisplayBuffer::init_internal_(uint32_t buffer_length) {


### PR DESCRIPTION
# What does this implement/fix?

This a bug introduced by https://github.com/esphome/esphome/pull/4600.

It changed `COLOR_OFF` for reasons not related to the merged PR.
The potential problem with `COLOR_OFF` is steaming from sometimes
a wrong assumption that `Color` represents `RGBA`, where-as it does
in fact represents `RGBW`.

In case of some displays the `W` is considered as a white-level,
and binary displays expect the value of a pixel to be `0` for pixel to be off.
The binary pixel is checked via `Color#is_on()` which does look at `this->raw_32 != 0`.

This does not change how of transparent images are displayed on color/grayscale displays.
Since for transparent pixels are not render at all.

It does not fix rendering of the `PNG` images on binary displays (which is broken currently),
as incorrect luminance is used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue): https://github.com/esphome/issues/issues/4587
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32: TTGO with LoRa, and `SSD1306` (binary) 
- [x] ESP32S3: Fly HALO with `gc9a01` (RGB565)
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
esp32:

esphome:
  name: lora8

i2c:
  sda: SDA
  scl: SCL

logger:

font:
  - file: "gfonts://Roboto"
    id: roboto
    size: 20

image:
  - id: standby_image
    file: "rgb.png"
    resize: 128x64
    type: BINARY
    use_transparency: true

display:
  - platform: ssd1306_i2c
    model: "SSD1306 128x64"
    address: 0x3C
    lambda: |-
      it.print(0, 0, id(roboto), "Hello World");
      it.image(0, 0, id(standby_image));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
