### PR TITLE
Draft: Testing PR for `display_buffer` approach for display drivers

### DIFF
--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -283,6 +283,7 @@ async def to_code(config):
     var = cg.new_Pvariable(
         config[CONF_ID],
         prog_arr,
+        len(data),
         width,
         height,
         frames,

--- a/esphome/components/animation/animation.cpp
+++ b/esphome/components/animation/animation.cpp
@@ -5,9 +5,9 @@
 namespace esphome {
 namespace animation {
 
-Animation::Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count,
+Animation::Animation(const uint8_t *data_start, int data_size, int width, int height, uint32_t animation_frame_count,
                      image::ImageType type)
-    : Image(data_start, width, height, type),
+    : Image(data_start, data_size, width, height, type),
       animation_data_start_(data_start),
       current_frame_(0),
       animation_frame_count_(animation_frame_count),

--- a/esphome/components/animation/animation.h
+++ b/esphome/components/animation/animation.h
@@ -8,7 +8,8 @@ namespace animation {
 
 class Animation : public image::Image {
  public:
-  Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, image::ImageType type);
+  Animation(const uint8_t *data_start, int data_size, int width, int height, uint32_t animation_frame_count,
+            image::ImageType type);
 
   uint32_t get_animation_frame_count() const;
   int get_current_frame() const;

--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -46,6 +46,16 @@ DISPLAY_ROTATIONS = {
     270: display_ns.DISPLAY_ROTATION_270_DEGREES,
 }
 
+PIXEL_TYPES = {
+    "BINARY": display_ns.enum("PixelW1"),
+    "W2": display_ns.enum("PixelW2"),
+    "W4": display_ns.enum("PixelW4"),
+    "GRAYSCALE": display_ns.enum("PixelW8"),
+    "RGB332": display_ns.enum("PixelRGB332"),
+    "RGB565": display_ns.enum("PixelRGB565_BE"),
+    "RGB24": display_ns.enum("PixelRGB888"),
+    "RGBA": display_ns.enum("PixelRGBA8888")
+}
 
 def validate_rotation(value):
     value = cv.string(value)

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -36,6 +36,10 @@ void HOT Display::line(int x1, int y1, int x2, int y2, Color color) {
   }
 }
 void HOT Display::horizontal_line(int x, int y, int width, Color color) {
+  if (this->filled_rectangle_(x, y, width, 1, color)) {
+    return;
+  }
+
   // Future: Could be made more efficient by manipulating buffer directly in certain rotations.
   for (int i = x; i < x + width; i++)
     this->draw_pixel_at(i, y, color);
@@ -52,6 +56,10 @@ void Display::rectangle(int x1, int y1, int width, int height, Color color) {
   this->vertical_line(x1 + width - 1, y1, height, color);
 }
 void Display::filled_rectangle(int x1, int y1, int width, int height, Color color) {
+  if (this->filled_rectangle_(x1, y1, width, height, color)) {
+    return;
+  }
+
   // Future: Use vertical_line and horizontal_line methods depending on rotation to reduce memory accesses.
   for (int i = y1; i < y1 + height; i++) {
     this->horizontal_line(x1, i, width, color);

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "rect.h"
+#include "pixel_formats.h"
 
 #include "esphome/core/color.h"
 #include "esphome/core/automation.h"
@@ -483,7 +484,15 @@ class Display {
    */
   bool clip(int x, int y);
 
+  virtual PixelFormat get_native_pixel_format() = 0;
+  bool draw_pixels_at(int x, int y, int w, int h, const uint8_t *data, int stride, PixelFormat data_format, Color color_on = COLOR_ON, Color color_off = COLOR_OFF);
+
  protected:
+  virtual uint8_t *get_native_pixels_(int y) { return nullptr; }
+  virtual bool draw_pixels_(int x, int y, int w, int h,
+    const uint8_t *data, int data_line_size, int data_stride) { return false; }
+  virtual bool filled_rectangle_(int x1, int y1, int width, int height, Color color);
+
   bool clamp_x_(int x, int w, int &min_x, int &max_x);
   bool clamp_y_(int y, int h, int &min_y, int &max_y);
   void vprintf_(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, va_list arg);

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -409,6 +409,9 @@ class Display {
 
   /// Internal method to set the display writer lambda.
   void set_writer(display_writer_t &&writer);
+  void set_writer(display_buffer_writer_t writer) {
+    this->set_writer([writer](Display &display) { return writer((display::DisplayBuffer &) display); });
+  }
 
   void show_page(DisplayPage *page);
   void show_next_page();
@@ -500,6 +503,8 @@ class Display {
 class DisplayPage {
  public:
   DisplayPage(display_writer_t writer);
+  DisplayPage(display_buffer_writer_t writer)
+      : DisplayPage([writer](Display &display) { return writer((display::DisplayBuffer &) display); }) {}
   void show();
   void show_next();
   void show_prev();

--- a/esphome/components/display/display_bitblt.cpp
+++ b/esphome/components/display/display_bitblt.cpp
@@ -1,6 +1,7 @@
 #include "display.h"
 
 #include "pixel_helpers.h"
+#include "pixel_bitblt.h"
 
 #include <utility>
 #include "esphome/core/application.h"

--- a/esphome/components/display/display_bitblt.cpp
+++ b/esphome/components/display/display_bitblt.cpp
@@ -1,0 +1,264 @@
+#include "display.h"
+
+#include "pixel_helpers.h"
+
+#include <utility>
+#include "esphome/core/application.h"
+#include "esphome/core/color.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace display {
+
+static const char *const TAG = "display";
+
+template<typename PixelFormat, typename Fn>
+static bool display_direct_draw(int x, int y, int width, int height,
+  const PixelFormat *src, int src_x, int src_stride,
+  Fn draw_pixels) {
+
+  // If pixel is offset, it requires buffer re-alignement, or direct rendering
+  if (PixelFormat::PACKED_PIXELS > 1) {
+    auto packed_pixel = PixelFormat::packed_pixel(x);
+    if (packed_pixel != src_x)
+      return false;
+  }
+
+  auto start_us = micros();
+
+  bool done = draw_pixels(
+    x, y, width, height,
+    (const uint8_t*)src, src_stride, src_stride
+  );
+
+  if (done) {
+    ESP_LOGV(TAG, "Direct Draw: %dx%d/%dx%d, src_x=%d, stride=%d, format=%d, time_us=%d",
+      x, y, width, height,
+      src_x, src_stride, PixelFormat::FORMAT,
+      micros() - start_us);
+  }
+
+  return done;
+}
+
+template<typename DestPixelFormat, typename SrcPixelFormat, typename Fn>
+static bool display_convert_draw(
+  int x, int y, int width, int height,
+  const SrcPixelFormat *src, int src_x, int src_stride,
+  Color color_on, Color color_off, Fn draw_pixels
+) {
+  auto width_stride = DestPixelFormat::array_stride(DestPixelFormat::packed_pixel(x) + width);
+  auto width_bytes_stride = DestPixelFormat::bytes_stride(DestPixelFormat::packed_pixel(x) + width);
+  auto dest = new DestPixelFormat[width_stride];
+  bool done = true;
+  DestPixelFormat dest_on, dest_off;
+
+  if (SrcPixelFormat::COLOR_KEY) {
+    dest_on = from_color<DestPixelFormat>(color_on);
+    dest_off = from_color<DestPixelFormat>(color_off);
+  }
+
+  auto start_us = micros();
+
+  for (int j = 0; j < height && done; j++) {
+    bitblt<SrcPixelFormat, DestPixelFormat, false>(
+      dest, DestPixelFormat::packed_pixel(x),
+      src, src_x, width,
+      dest_on, dest_off
+    );
+    src = (const SrcPixelFormat*)((const uint8_t*)src + src_stride);
+
+    done = draw_pixels(
+      x, y + j, width, 1,
+      (const uint8_t*)dest, width_bytes_stride, width_bytes_stride
+    );
+  }
+
+  if (done) {
+    ESP_LOGV(TAG, "%s Draw: %dx%d/%dx%d, src_x=%d, stride=%d, src_format=%d, dest_format=%d, time_us=%d",
+      SrcPixelFormat::COLOR_KEY ? "Keyed" : "Convert",
+      x, y, width, height,
+      src_x, src_stride,
+      SrcPixelFormat::FORMAT, DestPixelFormat::FORMAT,
+      micros() - start_us);
+  }
+
+  delete [] dest;
+  return done;
+}
+
+template<typename DestPixelFormat, typename SrcPixelFormat, typename Fn>
+static bool display_convert_buffer(
+  int x, int y, int width, int height,
+  const SrcPixelFormat *src, int src_x, int src_stride,
+  Color color_on, Color color_off, Fn get_pixels
+) {
+  DestPixelFormat dest_on, dest_off;
+
+  if (SrcPixelFormat::COLOR_KEY) {
+    dest_on = from_color<DestPixelFormat>(color_on);
+    dest_off = from_color<DestPixelFormat>(color_off);
+  }
+
+  auto start_us = micros();
+
+  for (int j = 0; j < height; j++) {
+    auto dest = (DestPixelFormat*)get_pixels(y + j);
+    if (!dest)
+      return false;
+
+    bitblt<SrcPixelFormat, DestPixelFormat, true>(
+      dest, x,
+      src, src_x, width,
+      dest_on, dest_off);
+    src = (const SrcPixelFormat*)((const uint8_t*)src + src_stride);
+  }
+
+  ESP_LOGV(TAG, "%s Blt: %dx%d/%dx%d, src_x=%d, stride=%d, src_format=%d, dest_format=%d, time_us=%d",
+    SrcPixelFormat::COLOR_KEY ? "Keyed" : "Convert",
+    x, y, width, height,
+    src_x, src_stride,
+    SrcPixelFormat::FORMAT, DestPixelFormat::FORMAT,
+    micros() - start_us);
+
+  return true;
+}
+
+bool HOT Display::draw_pixels_at(int x, int y, int width, int height, const uint8_t *data, int stride, PixelFormat data_format, Color color_on, Color color_off) {
+  ESP_LOGV(TAG, "DrawFormat: %dx%d/%dx%d, size=%d, format=%d=>%d",
+    x, y, width, height,
+    stride * height, data_format, this->get_native_pixel_format());
+
+  int min_x, max_x, min_y, max_y;
+  if (!this->clamp_x_(x, width, min_x, max_x))
+    return true;
+  if (!this->clamp_y_(y, height, min_y, max_y))
+    return true;
+
+  auto get_pixels = [this](int y) {
+    return this->get_native_pixels_(y);
+  };
+  auto draw_pixels = [this](int x, int y, int w, int h,
+    const uint8_t *data, int data_line_size, int data_stride) {
+    return this->draw_pixels_(x, y, w, h, data, data_line_size, data_stride);
+  };
+
+  #define CONVERT_IGNORE_FORMAT(format) \
+    case PixelFormat::format: \
+      break
+
+  #define CONVERT_DEST_FORMAT(dest_format) \
+    case PixelFormat::dest_format: \
+      if (display_convert_buffer<Pixel##dest_format>( \
+        min_x, min_y, max_x - min_x, max_y - min_y, \
+        src_data, src_pixel_offset, stride, \
+        color_on, color_off, get_pixels)) \
+        return true; \
+      if (display_convert_draw<Pixel##dest_format>( \
+        min_x, min_y, max_x - min_x, max_y - min_y, \
+        src_data, src_pixel_offset, stride, \
+        color_on, color_off, draw_pixels)) \
+        return true; \
+      break
+
+  #define CONVERT_SRC_FORMAT(src_format) \
+    case PixelFormat::src_format: \
+      { \
+        auto src_data = offset_buffer((const Pixel##src_format*)data, min_x - x, min_y - y, width); \
+        auto src_pixel_offset = Pixel##src_format::packed_pixel(min_x - x); \
+        auto native_format = this->get_native_pixel_format(); \
+        if (native_format == PixelFormat::src_format) { \
+          if (display_direct_draw( \
+            min_x, min_y, max_x - min_x, max_y - min_y, \
+            src_data, src_pixel_offset, stride, \
+            draw_pixels)) \
+            return true; \
+        } \
+        switch (native_format) { \
+          EXPORT_DEST_PIXEL_FORMAT(CONVERT_DEST_FORMAT, CONVERT_IGNORE_FORMAT); \
+        } \
+      } \
+      break
+
+  switch (data_format) {
+    EXPORT_SRC_PIXEL_FORMAT(CONVERT_SRC_FORMAT, CONVERT_IGNORE_FORMAT);
+  }
+
+  return false;
+}
+
+template<typename Format, typename Fn>
+static bool display_filled_rectangle_alloc(int x, int y, int width, int height, Color color, Fn draw_pixels) {
+  auto width_stride = Format::array_stride(width + Format::packed_pixel(x));
+  auto dest = new Format[width_stride];
+  auto pixel_color = from_color<Format>(color);
+
+  fill(dest, x, width_stride * Format::PACKED_PIXELS, pixel_color);
+
+  bool done = draw_pixels(
+    x, y, width, height,
+    (const uint8_t*)dest, width_stride, 0
+  );
+
+  delete [] dest;
+  return done;
+}
+
+template<typename Format, typename Fn>
+static bool display_filled_rectangle_buffer(int x, int y, int width, int height, Color color, Fn get_pixels) {
+  auto pixel_color = from_color<Format>(color);
+
+  for (int j = 0; j < height; j++) {
+    auto dest = (Format*)get_pixels(y + j);
+    if (!dest)
+      return false;
+
+    fill(dest, x, width, pixel_color);
+  }
+
+  return true;
+}
+
+bool Display::filled_rectangle_(int x, int y, int width, int height, Color color) {
+  int min_x, max_x, min_y, max_y;
+
+  if (!this->clamp_x_(x, width, min_x, max_x))
+    return true;
+  if (!this->clamp_y_(y, height, min_y, max_y))
+    return true;
+
+  auto get_pixels = [this](int y) {
+    return this->get_native_pixels_(y);
+  };
+  auto draw_pixels = [this](int x, int y, int w, int h,
+    const uint8_t *data, int data_line_size, int data_stride) {
+    return this->draw_pixels_(x, y, w, h, data, data_line_size, data_stride);
+  };
+
+  #define FILLED_RECT_FORMAT(format) \
+    case PixelFormat::format: \
+      if (display_filled_rectangle_buffer<Pixel##format>( \
+          min_x, min_y, max_x - min_x, max_y - min_y, \
+          color, get_pixels)) \
+        return true; \
+      if (display_filled_rectangle_alloc<Pixel##format>( \
+          min_x, min_y, max_x - min_x, max_y - min_y, \
+          color, draw_pixels)) \
+        return true; \
+      break
+
+  #define FILLED_RECT_IGNORE(format) \
+    case PixelFormat::format: \
+      break
+
+  switch (this->get_native_pixel_format()) {
+    EXPORT_DEST_PIXEL_FORMAT(FILLED_RECT_FORMAT, FILLED_RECT_IGNORE);
+  }
+
+  return false;
+}
+
+} // display
+} // esphome

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -19,6 +19,8 @@ class DisplayBuffer : public Display {
   /// Get the height of the image in pixels with rotation applied.
   int get_height() override;
 
+  PixelFormat get_native_pixel_format() override { return PixelFormat::Unknown; }
+
   /// Set a single pixel at the specified coordinates to the given color.
   void draw_pixel_at(int x, int y, Color color) override;
 

--- a/esphome/components/display/pixel_bitblt.cpp
+++ b/esphome/components/display/pixel_bitblt.cpp
@@ -1,3 +1,4 @@
+#include "pixel_bitblt.h"
 #include "pixel_helpers.h"
 
 #include <utility>

--- a/esphome/components/display/pixel_bitblt.h
+++ b/esphome/components/display/pixel_bitblt.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdarg>
+#include <vector>
+
+#include "pixel_formats.h"
+
+#include "esphome/core/color.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace display {
+
+template<typename SrcPixelFormat, typename DestPixelFormat, bool Transparency>
+void bitblt(DestPixelFormat *dest, int dest_x, const SrcPixelFormat *src, int src_x, int width, DestPixelFormat color_on, DestPixelFormat color_off);
+
+template<typename PixelFormat>
+void fill(PixelFormat *dest, int x, int width, const PixelFormat &color);
+
+} // display
+} // esphome

--- a/esphome/components/display/pixel_formats.h
+++ b/esphome/components/display/pixel_formats.h
@@ -1,0 +1,314 @@
+#pragma once
+
+#include <cstdarg>
+#include <vector>
+
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace display {
+
+enum class PixelFormat {
+  Unknown,
+  A1,
+  W1,
+  W2,
+  W4,
+  W8,
+  W8_KEY,
+  RGB332,
+  RGB565_LE,
+  RGB565_BE,
+  RGB888,
+  RGBA4444,
+  RGBA8888
+};
+
+#define EXPORT_SRC_PIXEL_FORMAT(MACRO, IGNORE_MACRO, ...) \
+  IGNORE_MACRO(Unknown, ##__VA_ARGS__); \
+  MACRO(A1, ##__VA_ARGS__); \
+  MACRO(W1, ##__VA_ARGS__); \
+  MACRO(W2, ##__VA_ARGS__); \
+  MACRO(W4, ##__VA_ARGS__); \
+  MACRO(W8, ##__VA_ARGS__); \
+  MACRO(W8_KEY, ##__VA_ARGS__); \
+  MACRO(RGB332, ##__VA_ARGS__); \
+  MACRO(RGB565_LE, ##__VA_ARGS__); \
+  MACRO(RGB565_BE, ##__VA_ARGS__); \
+  MACRO(RGB888, ##__VA_ARGS__); \
+  MACRO(RGBA4444, ##__VA_ARGS__); \
+  MACRO(RGBA8888, ##__VA_ARGS__);
+
+#define EXPORT_DEST_PIXEL_FORMAT(MACRO, IGNORE_MACRO, ...) \
+  IGNORE_MACRO(Unknown, ##__VA_ARGS__); \
+  IGNORE_MACRO(A1, ##__VA_ARGS__); \
+  MACRO(W1, ##__VA_ARGS__); \
+  MACRO(W2, ##__VA_ARGS__); \
+  MACRO(W4, ##__VA_ARGS__); \
+  MACRO(W8, ##__VA_ARGS__); \
+  IGNORE_MACRO(W8_KEY, ##__VA_ARGS__); \
+  MACRO(RGB332, ##__VA_ARGS__); \
+  MACRO(RGB565_LE, ##__VA_ARGS__); \
+  MACRO(RGB565_BE, ##__VA_ARGS__); \
+  MACRO(RGB888, ##__VA_ARGS__); \
+  MACRO(RGBA4444, ##__VA_ARGS__); \
+  MACRO(RGBA8888, ##__VA_ARGS__);
+
+template<PixelFormat FF, int RR, int GG, int BB, int AA, int WW, int NN, int PP = 1, bool CCOLOR_KEY = 0>
+struct PixelDetails {
+  static const PixelFormat FORMAT = FF;
+  static const int R = RR;
+  static const int G = GG;
+  static const int B = BB;
+  static const int A = AA;
+  static const int W = WW;
+  static const int BYTES = NN;
+  static const int PACKED_PIXELS = PP;
+  static const bool COLOR_KEY = CCOLOR_KEY;
+
+  static inline ALWAYS_INLINE int packed_pixel(int x) {
+    return x % PACKED_PIXELS;
+  }
+  static inline ALWAYS_INLINE int array_offset(int x) {
+    return x / PACKED_PIXELS;
+  }
+  static inline ALWAYS_INLINE int array_stride(int width) {
+    return (width + PACKED_PIXELS - 1) / PACKED_PIXELS;
+  }
+  static inline ALWAYS_INLINE int array_stride(int width, int height) {
+    return array_stride(width) * height;
+  }
+  static inline ALWAYS_INLINE int bytes_stride(int width) {
+    return array_stride(width) * BYTES;
+  }
+  static inline ALWAYS_INLINE int bytes_stride(int width, int height) {
+    return array_stride(width, height) * BYTES;
+  }
+};
+
+struct PixelRGB332 : PixelDetails<PixelFormat::RGB332, 3,3,2,0,0,1> {
+  uint8_t raw_8;
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return false;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    this->raw_8 = r << (3+2) | g << (2) | b;
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = this->raw_8 >> (3+2);
+    g = (this->raw_8 >> (2)) & ((1<<3) - 1);
+    b = (this->raw_8 >> 0) & ((1<<2) - 1);
+    w = 0; a = 0;
+  }
+} PACKED;
+
+template<PixelFormat Format, bool BigEndian>
+struct PixelRGB565_Endiness : PixelDetails<Format,5,6,5,0,0,2> {
+  uint16_t raw_16;
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return false;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    uint16_t value = r << (6+5) | g << (5) | b;
+    this->raw_16 = BigEndian ? convert_big_endian(value) : convert_little_endian(value);
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    uint16_t value = BigEndian ? convert_big_endian(this->raw_16) : convert_little_endian(this->raw_16);
+    r = value >> (6+5);
+    g = (value >> (5)) & ((1<<6) - 1);
+    b = (value >> 0) & ((1<<5) - 1);
+    w = 0; a = 0;
+  }
+} PACKED;
+
+typedef PixelRGB565_Endiness<PixelFormat::RGB565_LE, false> PixelRGB565_LE;
+typedef PixelRGB565_Endiness<PixelFormat::RGB565_BE, true> PixelRGB565_BE;
+
+struct PixelRGB888 : PixelDetails<PixelFormat::RGB888,8,8,8,0,0,3> {
+  uint8_t raw_8[3];
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return false;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    this->raw_8[0] = r;
+    this->raw_8[1] = g;
+    this->raw_8[2] = b;
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = this->raw_8[0];
+    g = this->raw_8[1];
+    b = this->raw_8[2];
+    a = w = 0;
+  }
+} PACKED;
+
+struct PixelRGBA4444 : PixelDetails<PixelFormat::RGBA4444,4,4,4,4,0,2> {
+  uint8_t raw_8[2];
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return (this->raw_8[1] & 0xF) < 0x8;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    this->raw_8[0] = r << 4 | g;
+    this->raw_8[1] = b << 4 | a;
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = this->raw_8[0] >> 4;
+    g = this->raw_8[0] & 0xF;
+    b = this->raw_8[1] >> 4;
+    a = this->raw_8[1] & 0xF;
+    w = 0;
+  }
+} PACKED;
+
+struct PixelRGBA8888 : PixelDetails<PixelFormat::RGBA8888,8,8,8,8,0,4> {
+  uint8_t raw_8[4];
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return this->raw_8[3] < 0x80;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    this->raw_8[0] = r;
+    this->raw_8[1] = g;
+    this->raw_8[2] = b;
+    this->raw_8[3] = a;
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = this->raw_8[0];
+    g = this->raw_8[1];
+    b = this->raw_8[2];
+    a = this->raw_8[3];
+    w = 0;
+  }
+} PACKED;
+
+struct PixelW1 : PixelDetails<PixelFormat::W1,0,0,0,0,1,1,8,true> {
+  uint8_t raw_8;
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return (this->raw_8 & (1<<(7-pixel))) ? true : false;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return false;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    const int mask = 1<<(7-pixel);
+    this->raw_8 &= ~mask;
+    if (w)
+      this->raw_8 |= mask;
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = 0; g = 0; b = 0; a = 0;
+    w = (this->raw_8 & (1<<(7-pixel))) ? 1 : 0;
+  }
+} PACKED;
+
+struct PixelA1 : PixelDetails<PixelFormat::A1,0,0,0,1,0,1,8,true> {
+  uint8_t raw_8;
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return (this->raw_8 & (1<<(7-pixel))) ? true : false;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return (this->raw_8 & (1<<(7-pixel))) ? false : true;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    const int mask = 1<<(7-pixel);
+    this->raw_8 &= ~mask;
+    if (a)
+      this->raw_8 |= mask;
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = 0; g = 0; b = 0; w = 0;
+    a = (this->raw_8 & (1<<(7-pixel))) ? 1 : 0;
+  }
+} PACKED;
+
+struct PixelW2 : PixelDetails<PixelFormat::W2,0,0,0,0,2,1,4> {
+  uint8_t raw_8;
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return false;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    this->raw_8 &= ~(3 << (pixel*2));
+    this->raw_8 |= w << (pixel*2);
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = 0; g = 0; b = 0; a = 0;
+    w = (this->raw_8 >> (pixel*2)) & 0x3;
+  }
+} PACKED;
+
+struct PixelW4 : PixelDetails<PixelFormat::W4,0,0,0,0,4,1,2> {
+  uint8_t raw_8;
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return false;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    if (pixel) {
+      this->raw_8 &= ~0xF0;
+      this->raw_8 |= w << 4;
+    } else {
+      this->raw_8 &= ~0x0F;
+      this->raw_8 |= w;
+    }
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = 0; g = 0; b = 0; a = 0;
+    if (pixel)
+      w = this->raw_8 >> 4;
+    else
+      w = this->raw_8 & 0xF;
+  }
+} PACKED;
+
+template<PixelFormat Format, bool Key>
+struct PixelW8_Keyed : PixelDetails<Format,0,0,0,0,8,1> {
+  uint8_t raw_8;
+
+  inline ALWAYS_INLINE bool is_on(int pixel = 0) const {
+    return true;
+  }
+  inline ALWAYS_INLINE bool is_transparent(int pixel = 0) const {
+    return Key ? this->raw_8 == 1 : false;
+  }
+  inline ALWAYS_INLINE void encode(uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t w, int pixel = 0) {
+    this->raw_8 = w;
+  }
+  inline ALWAYS_INLINE void decode(uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a, uint8_t &w, int pixel = 0) const {
+    r = 0; g = 0; b = 0; a = 0;
+    w = this->raw_8;
+  }
+} PACKED;
+
+typedef PixelW8_Keyed<PixelFormat::W8, false> PixelW8;
+typedef PixelW8_Keyed<PixelFormat::W8_KEY, true> PixelW8_KEY;
+
+} // display
+} // esphome

--- a/esphome/components/display/pixel_helpers.cpp
+++ b/esphome/components/display/pixel_helpers.cpp
@@ -1,0 +1,210 @@
+#include "pixel_helpers.h"
+
+#include <utility>
+
+namespace esphome {
+namespace display {
+
+template<typename PixelFormat>
+inline ALWAYS_INLINE void bitblt_copy(
+  PixelFormat *dest_p, const PixelFormat *src_p, int p_pixel, int width)
+{
+  auto dest_end_p = offset_end_buffer(dest_p, p_pixel + width);
+  if (dest_p == dest_end_p)
+    return;
+  auto src_end_p = offset_end_buffer(src_p, p_pixel + width);
+
+  // copy starting pixels
+  if (p_pixel > 0) {
+    copy_pixel(*dest_p++, *src_p++, p_pixel);
+    if (dest_p == dest_end_p)
+      return;
+  }
+
+  // copy ending pixels
+  int end_packed_pixels = PixelFormat::packed_pixel(p_pixel + width);
+  if (end_packed_pixels > 0) {
+    copy_pixel(*--dest_end_p, *--src_end_p, 0, end_packed_pixels);
+    if (dest_p == dest_end_p)
+      return;
+  }
+
+  memcpy(dest_p, src_p, (dest_end_p - dest_p) * PixelFormat::BYTES);
+}
+
+template<bool Transparency, typename SrcPixelFormat, typename DestPixelFormat>
+inline ALWAYS_INLINE void bitblt_fast(
+  DestPixelFormat *dest_p, const SrcPixelFormat *src_p, int width,
+  DestPixelFormat color_on, DestPixelFormat color_off)
+{
+  auto dest_end_p = offset_end_buffer(dest_p, width);
+
+  for ( ; dest_p < dest_end_p; dest_p++, src_p++) {
+    if (Transparency && src_p->is_transparent(0)) {
+      continue;
+    }
+
+    if (SrcPixelFormat::COLOR_KEY) {
+      if (src_p->is_on(0))
+        *dest_p = color_on;
+      else
+        *dest_p = color_off;
+    } else {
+      from_pixel_format(*dest_p, 0, *src_p, 0);
+    }
+  }
+}
+
+template<bool Transparency, typename SrcPixelFormat, typename DestPixelFormat>
+inline ALWAYS_INLINE void bitblt_semi_fast_src_packed_pixels(
+  DestPixelFormat *dest_p, const SrcPixelFormat *src_p, int src_p_pixel, int width,
+  DestPixelFormat color_on, DestPixelFormat color_off)
+{
+  auto dest_end_p = offset_end_buffer(dest_p, width);
+
+  for ( ; dest_p < dest_end_p; src_p++, src_p_pixel = 0) {
+    for ( ; src_p_pixel < SrcPixelFormat::PACKED_PIXELS && dest_p < dest_end_p; src_p_pixel++, dest_p++) {
+      if (Transparency && src_p->is_transparent(src_p_pixel)) {
+        continue;
+      }
+
+      if (SrcPixelFormat::COLOR_KEY) {
+        if (src_p->is_on(src_p_pixel))
+          *dest_p = color_on;
+        else
+          *dest_p = color_off;
+      } else {
+        from_pixel_format(*dest_p, 0, *src_p, src_p_pixel);
+      }
+    }
+  }
+}
+
+template<bool Transparency, typename SrcPixelFormat, typename DestPixelFormat>
+inline ALWAYS_INLINE void bitblt_semi_fast_dest_packed_pixels(
+  DestPixelFormat *dest_p, int dest_p_pixel, const SrcPixelFormat *src_p, int width,
+  DestPixelFormat color_on, DestPixelFormat color_off)
+{
+  auto src_end_p = offset_end_buffer(src_p, width);
+
+  for ( ; src_p < src_end_p; dest_p++, dest_p_pixel = 0) {
+    for ( ; dest_p_pixel < DestPixelFormat::PACKED_PIXELS && src_p < src_end_p; dest_p_pixel++, src_p++) {
+      if (Transparency && src_p->is_transparent(0)) {
+        continue;
+      }
+
+      if (SrcPixelFormat::COLOR_KEY) {
+        if (src_p->is_on(0))
+          from_pixel_format(*dest_p, dest_p_pixel, color_on);
+        else
+          from_pixel_format(*dest_p, dest_p_pixel, color_off);
+      } else {
+        from_pixel_format(*dest_p, dest_p_pixel, *src_p);
+      }
+    }
+  }
+}
+
+template<bool Transparency, typename SrcPixelFormat, typename DestPixelFormat>
+inline ALWAYS_INLINE void bitblt_slow_src_dest_packed_pixels(
+  DestPixelFormat *dest_p, int dest_p_pixel,
+  const SrcPixelFormat *src_p, int src_p_pixel, int width,
+  DestPixelFormat color_on, DestPixelFormat color_off)
+{
+  for (int pixels = 0; pixels < width; src_p++, src_p_pixel = 0) {
+    for ( ; src_p_pixel < DestPixelFormat::PACKED_PIXELS && pixels < width; src_p_pixel++, dest_p_pixel++, pixels++) {
+      assert(dest_p_pixel <= DestPixelFormat::PACKED_PIXELS);
+
+      if (dest_p_pixel == DestPixelFormat::PACKED_PIXELS) {
+        dest_p++;
+        dest_p_pixel = 0;
+      }
+
+      if (Transparency && src_p->is_transparent(src_p_pixel)) {
+        continue;
+      }
+
+      if (SrcPixelFormat::COLOR_KEY) {
+        if (src_p->is_on(src_p_pixel))
+          from_pixel_format(*dest_p, dest_p_pixel, color_on);
+        else
+          from_pixel_format(*dest_p, dest_p_pixel, color_off);
+      } else {
+        from_pixel_format(*dest_p, dest_p_pixel, *src_p, src_p_pixel);
+      }
+    }
+  }
+}
+
+template<typename SrcPixelFormat, typename DestPixelFormat, bool Transparency>
+void bitblt(DestPixelFormat *dest, int dest_x, const SrcPixelFormat *src, int src_x, int width, DestPixelFormat color_on, DestPixelFormat color_off)
+{
+  auto dest_p = offset_buffer(dest, dest_x);
+  auto src_p = offset_buffer(src, src_x);
+
+  if (SrcPixelFormat::FORMAT == DestPixelFormat::FORMAT && DestPixelFormat::packed_pixel(dest_x) == SrcPixelFormat::packed_pixel(src_x)) {
+    bitblt_copy(dest_p, (DestPixelFormat*)src_p, SrcPixelFormat::packed_pixel(src_x), width);
+  } else if (SrcPixelFormat::PACKED_PIXELS == 1 && DestPixelFormat::PACKED_PIXELS == 1) {
+    bitblt_fast<Transparency>(dest_p, src_p, width, color_on, color_off);
+  } else if (SrcPixelFormat::PACKED_PIXELS != 1) {
+    bitblt_semi_fast_src_packed_pixels<Transparency>(dest_p, src_p, SrcPixelFormat::packed_pixel(src_x), width, color_on, color_off);
+  } else if (DestPixelFormat::PACKED_PIXELS != 1) {
+    bitblt_semi_fast_dest_packed_pixels<Transparency>(dest_p, DestPixelFormat::packed_pixel(dest_x), src_p, width, color_on, color_off);
+  } else {
+    bitblt_slow_src_dest_packed_pixels<Transparency>(dest_p, DestPixelFormat::packed_pixel(dest_x), src_p, SrcPixelFormat::packed_pixel(src_x), width, color_on, color_off);
+  }
+}
+
+template<typename PixelFormat>
+void fill(PixelFormat *dest, int x, int width, const PixelFormat &color)
+{
+  auto destp = offset_buffer(dest, x);
+  auto endp = offset_end_buffer(dest, x + width);
+  if (destp == endp)
+    return;
+
+  // handle packed pixels
+  if (PixelFormat::PACKED_PIXELS > 1) {
+    auto packed_pixel = PixelFormat::packed_pixel(x);
+
+    // copy start pixels
+    if (packed_pixel > 0) {
+      copy_pixel(*destp, color, packed_pixel);
+      destp++;
+    }
+
+    // copy end pixels
+    auto end_packed_pixel = PixelFormat::packed_pixel(x + width);
+    if (end_packed_pixel > 0 && destp < endp) {
+      --endp;
+      copy_pixel(*endp, color, 0, end_packed_pixel);
+    }
+  }
+
+  for (auto p = destp; p < endp; p++)
+    *p = color;
+}
+
+#define EXPORT_IGNORE(...)
+#define EXPORT_SRC_DEST_BITBLT(src_format, dest_format, ...) \
+  template void bitblt<Pixel##src_format, Pixel##dest_format, ##__VA_ARGS__>( \
+    Pixel##dest_format *dest, int dest_x, \
+    const Pixel##src_format *src, int src_x, int width, \
+    Pixel##dest_format color_on, Pixel##dest_format color_off)
+
+#define EXPORT_DEST_BITBLT(src_format, dest_format) \
+  EXPORT_SRC_DEST_BITBLT(src_format, dest_format, false); \
+  EXPORT_SRC_DEST_BITBLT(src_format, dest_format, true)
+
+#define EXPORT_FILL(dest_format) \
+  template void fill( \
+    Pixel##dest_format *dest, int x, int width, \
+    const Pixel##dest_format &color)
+
+#define EXPORT_BITBLT(dest_format) EXPORT_SRC_PIXEL_FORMAT(EXPORT_DEST_BITBLT, EXPORT_IGNORE, dest_format)
+
+EXPORT_DEST_PIXEL_FORMAT(EXPORT_BITBLT, EXPORT_IGNORE);
+EXPORT_DEST_PIXEL_FORMAT(EXPORT_FILL, EXPORT_IGNORE);
+
+}  // namespace display
+}  // namespace esphome

--- a/esphome/components/display/pixel_helpers.h
+++ b/esphome/components/display/pixel_helpers.h
@@ -15,10 +15,12 @@ template<int In, int Out>
 inline ALWAYS_INLINE uint8_t shift_bits(uint8_t src) {
   if (!In || !Out) {
     return 0;
+#if 0
   } else if (In == 1 && In < Out) {
     // expand: fast expand
     //return src ? (0xFF >> (8 - Out)) : 0x00;
     return -src >> (8 - Out);
+#endif
 #if 1
   } else if (In < Out) {
     return src * ((255 / ((1<<In)-1)) >> (8 - Out));

--- a/esphome/components/display/pixel_helpers.h
+++ b/esphome/components/display/pixel_helpers.h
@@ -17,13 +17,19 @@ inline ALWAYS_INLINE uint8_t shift_bits(uint8_t src) {
     return 0;
   } else if (In == 1 && In < Out) {
     // expand: fast expand
-    return (src ? 0xFF : 0x00) >> (8 - Out);
+    //return src ? (0xFF >> (8 - Out)) : 0x00;
+    return -src >> (8 - Out);
+#if 1
+  } else if (In < Out) {
+    return src * ((255 / ((1<<In)-1)) >> (8 - Out));
+#else
   } else if (In == 2 && In < Out) {
     // expand: fast expand
     uint8_t out = 0;
-    out |= src & 0x02 ? 0xAA : 0;
-    out |= src & 0x01 ? 0x55 : 0;
-    return out >> (8 - Out);
+    // out |= src & 0x02 ? (0xAA >> (8 - Out)) : 0;
+    // out |= src & 0x01 ? (0x55 >> (8 - Out)) : 0;
+    out = src * (0x55 >> (8 - Out));
+    return out;
   } else if (In < Out) {
     // expand: In=5 => Out=8
     // src << (8-5) + src >> (5 - (8-5))
@@ -40,6 +46,7 @@ inline ALWAYS_INLINE uint8_t shift_bits(uint8_t src) {
     }
 
     return out;
+#endif
   } else if (In > Out) {
     // reduce: In=8 => Out=5
     // (src + (1<<(8-5) - 1)) >> (8-5)
@@ -48,6 +55,39 @@ inline ALWAYS_INLINE uint8_t shift_bits(uint8_t src) {
     return src;
   }
 }
+
+template<typename Out, typename In>
+struct PixelConverter
+{
+  static inline ALWAYS_INLINE Out &convert(Out &out, int out_packed_pixel, const In &in, int in_packed_pixel = 0) {
+    uint8_t r, g, b, a, w;
+    in.decode(r, g, b, a, w, in_packed_pixel);
+
+    uint8_t approx_w = shift_bits<In::R, 6>(r) + shift_bits<In::G, 7>(g) + shift_bits<In::B, 6>(b);
+
+    out.encode(
+      In::R ? shift_bits<In::R, Out::R>(r) : In::W ? shift_bits<In::W, Out::R>(w) : shift_bits<In::A, Out::R>(a),
+      In::G ? shift_bits<In::G, Out::G>(g) : In::W ? shift_bits<In::W, Out::G>(w) : shift_bits<In::A, Out::G>(a),
+      In::B ? shift_bits<In::B, Out::B>(b) : In::W ? shift_bits<In::W, Out::B>(w) : shift_bits<In::A, Out::B>(a),
+      In::A ? shift_bits<In::A, Out::A>(a) : shift_bits<In::W, Out::A>(w),
+      In::W ? shift_bits<In::W, Out::W>(w) : shift_bits<8, Out::W>(approx_w),
+      out_packed_pixel
+    );
+    return out;
+  }
+};
+
+template<PixelFormat OutFormat, bool OutBigEndian, PixelFormat InFormat, bool InBigEndian>
+struct PixelConverter<PixelRGB565_Endiness<OutFormat, OutBigEndian>, PixelRGB565_Endiness<InFormat, InBigEndian> >
+{
+  typedef PixelRGB565_Endiness<OutFormat, OutBigEndian> Out;
+  typedef PixelRGB565_Endiness<InFormat, InBigEndian> In;
+
+  static inline ALWAYS_INLINE Out &convert(Out &out, int out_packed_pixel, const In &in, int in_packed_pixel = 0) {
+    out.raw_16 = OutBigEndian == InBigEndian ? in.raw_16 : byteswap(in.raw_16);
+    return out;
+  }
+};
 
 template<typename Out>
 static inline ALWAYS_INLINE Out from_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 0xFF) {
@@ -132,21 +172,8 @@ static inline ALWAYS_INLINE Out *offset_end_buffer(Out *buffer, int x) {
 
 template<typename Out, typename In>
 static inline ALWAYS_INLINE Out &from_pixel_format(Out &out, int out_packed_pixel, const In &in, int in_packed_pixel = 0) {
-  uint8_t r, g, b, a, w;
-  in.decode(r, g, b, a, w, in_packed_pixel);
-
-  uint8_t approx_w = shift_bits<In::R, 6>(r) + shift_bits<In::G, 7>(g) + shift_bits<In::B, 6>(b);
-
-  out.encode(
-    In::R ? shift_bits<In::R, Out::R>(r) : In::W ? shift_bits<In::W, Out::R>(w) : shift_bits<In::A, Out::R>(a),
-    In::G ? shift_bits<In::G, Out::G>(g) : In::W ? shift_bits<In::W, Out::G>(w) : shift_bits<In::A, Out::G>(a),
-    In::B ? shift_bits<In::B, Out::B>(b) : In::W ? shift_bits<In::W, Out::B>(w) : shift_bits<In::A, Out::B>(a),
-    In::A ? shift_bits<In::A, Out::A>(a) : shift_bits<In::W, Out::A>(w),
-    In::W ? shift_bits<In::W, Out::W>(w) : shift_bits<8, Out::W>(approx_w),
-    out_packed_pixel
-  );
-  return out;
-}
+  return PixelConverter<Out, In>::convert(out, out_packed_pixel, in, in_packed_pixel);
+};
 
 template<typename Out, typename In>
 static inline ALWAYS_INLINE Out from_pixel_format(const In &in, int in_packed_pixel = 0) {
@@ -161,12 +188,6 @@ static inline ALWAYS_INLINE Out &copy_pixel(Out &out, const Out &in, int start_p
   }
   return out;
 }
-
-template<typename SrcPixelFormat, typename DestPixelFormat, bool Transparency>
-void bitblt(DestPixelFormat *dest, int dest_x, const SrcPixelFormat *src, int src_x, int width, DestPixelFormat color_on, DestPixelFormat color_off);
-
-template<typename PixelFormat>
-void fill(PixelFormat *dest, int x, int width, const PixelFormat &color);
 
 } // display
 } // esphome

--- a/esphome/components/display/pixel_helpers.h
+++ b/esphome/components/display/pixel_helpers.h
@@ -15,7 +15,7 @@ template<int In, int Out>
 inline ALWAYS_INLINE uint8_t shift_bits(uint8_t src) {
   if (!In || !Out) {
     return 0;
-#if 0
+#if 1
   } else if (In == 1 && In < Out) {
     // expand: fast expand
     //return src ? (0xFF >> (8 - Out)) : 0x00;

--- a/esphome/components/display/pixel_helpers.h
+++ b/esphome/components/display/pixel_helpers.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <cstdarg>
+#include <vector>
+
+#include "pixel_formats.h"
+
+#include "esphome/core/color.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace display {
+
+template<int In, int Out>
+inline ALWAYS_INLINE uint8_t shift_bits(uint8_t src) {
+  if (!In || !Out) {
+    return 0;
+  } else if (In == 1 && In < Out) {
+    // expand: fast expand
+    return (src ? 0xFF : 0x00) >> (8 - Out);
+  } else if (In == 2 && In < Out) {
+    // expand: fast expand
+    uint8_t out = 0;
+    out |= src & 0x02 ? 0xAA : 0;
+    out |= src & 0x01 ? 0x55 : 0;
+    return out >> (8 - Out);
+  } else if (In < Out) {
+    // expand: In=5 => Out=8
+    // src << (8-5) + src >> (5 - (8-5))
+    // src << (8-5) + src >> (5 - 8 + 5)
+    uint8_t out = src << (Out-In);
+
+    for (int i = 2; i < 8; i++) {
+      if (Out-i*In >= 0)
+        out += src << (Out-i*In);
+      else if (Out-i*In >= -In)
+        out += src >> -(Out-i*In);
+      else
+        break;
+    }
+
+    return out;
+  } else if (In > Out) {
+    // reduce: In=8 => Out=5
+    // (src + (1<<(8-5) - 1)) >> (8-5)
+    return src >> (In-Out);
+  } else {
+    return src;
+  }
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out from_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 0xFF) {
+  Out out;
+  const uint8_t approx_w = (r >> 2) + (g >> 1) + (b >> 2);
+  out.encode(
+    shift_bits<8, Out::R>(r),
+    shift_bits<8, Out::G>(g),
+    shift_bits<8, Out::B>(b),
+    shift_bits<8, Out::A>(a),
+    shift_bits<8, Out::W>(approx_w)
+  );
+  return out;
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out from_w(uint8_t w, uint8_t a = 0xFF) {
+  Out out;
+  out.encode(
+    shift_bits<8, Out::R>(w),
+    shift_bits<8, Out::G>(w),
+    shift_bits<8, Out::B>(w),
+    shift_bits<8, Out::A>(a),
+    shift_bits<8, Out::W>(w)
+  );
+  return out;
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out from_color(Out &out, const Color &in, int out_pixel = 0) {
+  const uint8_t approx_w = (in.r >> 2) + (in.g >> 1) + (in.b >> 2);
+  out.encode(
+    shift_bits<8, Out::R>(in.r),
+    shift_bits<8, Out::G>(in.g),
+    shift_bits<8, Out::B>(in.b),
+    shift_bits<8, Out::A>(in.w),
+    shift_bits<8, Out::W>(approx_w),
+    out_pixel
+  );
+  return out;
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out from_color(const Color &in, bool expand_packed = true) {
+  Out out;
+  from_color(out, in);
+  if (expand_packed) {
+    for (int i = 1; i < Out::PACKED_PIXELS; i++) {
+      from_pixel_format(out, i, out, 0);
+    }
+  }
+  return out;
+}
+
+template<typename In>
+static inline ALWAYS_INLINE Color to_color(const In &in, int pixel = 0) {
+  uint8_t r, g, b, a, w;
+  in.decode(r, g, b, a, w, pixel);
+
+  return Color(
+    In::R ? r : In::W ? w : a,
+    In::G ? g : In::W ? w : a,
+    In::B ? b : In::W ? w : a,
+    In::W ? w : In::A ? a : 0xFF
+  );
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out *offset_buffer(Out *buffer, int x, int y, int width) {
+  return &buffer[y * Out::array_stride(width) + Out::array_offset(x)];
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out *offset_buffer(Out *buffer, int x) {
+  return &buffer[Out::array_offset(x)];
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out *offset_end_buffer(Out *buffer, int x) {
+  return &buffer[Out::array_stride(x)];
+}
+
+template<typename Out, typename In>
+static inline ALWAYS_INLINE Out &from_pixel_format(Out &out, int out_packed_pixel, const In &in, int in_packed_pixel = 0) {
+  uint8_t r, g, b, a, w;
+  in.decode(r, g, b, a, w, in_packed_pixel);
+
+  uint8_t approx_w = shift_bits<In::R, 6>(r) + shift_bits<In::G, 7>(g) + shift_bits<In::B, 6>(b);
+
+  out.encode(
+    In::R ? shift_bits<In::R, Out::R>(r) : In::W ? shift_bits<In::W, Out::R>(w) : shift_bits<In::A, Out::R>(a),
+    In::G ? shift_bits<In::G, Out::G>(g) : In::W ? shift_bits<In::W, Out::G>(w) : shift_bits<In::A, Out::G>(a),
+    In::B ? shift_bits<In::B, Out::B>(b) : In::W ? shift_bits<In::W, Out::B>(w) : shift_bits<In::A, Out::B>(a),
+    In::A ? shift_bits<In::A, Out::A>(a) : shift_bits<In::W, Out::A>(w),
+    In::W ? shift_bits<In::W, Out::W>(w) : shift_bits<8, Out::W>(approx_w),
+    out_packed_pixel
+  );
+  return out;
+}
+
+template<typename Out, typename In>
+static inline ALWAYS_INLINE Out from_pixel_format(const In &in, int in_packed_pixel = 0) {
+  Out out;
+  return from_pixel_format(out, 0, in, in_packed_pixel);
+}
+
+template<typename Out>
+static inline ALWAYS_INLINE Out &copy_pixel(Out &out, const Out &in, int start_packed_pixel = 0, int end_packed_pixel = Out::PACKED_PIXELS) {
+  for (int i = start_packed_pixel; i < end_packed_pixel; i++) {
+    from_pixel_format(out, i, in, i);
+  }
+  return out;
+}
+
+template<typename SrcPixelFormat, typename DestPixelFormat, bool Transparency>
+void bitblt(DestPixelFormat *dest, int dest_x, const SrcPixelFormat *src, int src_x, int width, DestPixelFormat color_on, DestPixelFormat color_off);
+
+template<typename PixelFormat>
+void fill(PixelFormat *dest, int x, int width, const PixelFormat &color);
+
+} // display
+} // esphome

--- a/esphome/components/display_buffer/buffer.cpp
+++ b/esphome/components/display_buffer/buffer.cpp
@@ -1,0 +1,100 @@
+#include "buffer.h"
+
+#include <utility>
+#include "esphome/core/application.h"
+#include "esphome/core/color.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "esphome/components/display/pixel_helpers.h"
+
+namespace esphome {
+namespace display_buffer {
+
+static const char *const TAG = "display";
+
+template<typename PixelFormat>
+void Buffer<PixelFormat>::setup() {
+  ExternalRAMAllocator<PixelFormat> allocator(ExternalRAMAllocator<PixelFormat>::ALLOW_FAILURE);
+
+  this->buffer_length_ = PixelFormat::bytes_stride(this->width_, this->height_);
+  this->buffer_ = allocator.allocate(PixelFormat::array_stride(this->width_, this->height_));
+
+  if (this->buffer_ == nullptr) {
+    ESP_LOGE(TAG, "Could not allocate buffer for framebuffer!");
+    this->mark_failed();
+    return;
+  }
+}
+
+template<typename PixelFormat>
+void Buffer<PixelFormat>::dump_config() {
+  LOG_DISPLAY("", "Buffer", this);
+  ESP_LOGD(TAG, "  Format: %d", PixelFormat::FORMAT);
+  ESP_LOGD(TAG, "  Height: %d", this->height_);
+  ESP_LOGD(TAG, "  Width: %d", this->width_);
+}
+
+template<typename PixelFormat>
+display::DisplayType Buffer<PixelFormat>::get_display_type() {
+  if (PixelFormat::R || PixelFormat::G || PixelFormat::B) {
+    return display::DISPLAY_TYPE_COLOR;
+  } else if (PixelFormat::W > 1) {
+    return display::DISPLAY_TYPE_GRAYSCALE;
+  } else {
+    return display::DISPLAY_TYPE_BINARY;
+  }
+}
+
+template<typename PixelFormat>
+void Buffer<PixelFormat>::update() {
+  this->do_update_();
+}
+
+template<typename PixelFormat>
+void HOT Buffer<PixelFormat>::draw_pixel_at(int x, int y, Color color) {
+  if (!this->clip(x, y))
+    return;
+
+  auto dest = this->get_native_pixels_(x, y);
+  if (!dest)
+    return;
+
+  display::from_color<PixelFormat>(*dest, color, PixelFormat::packed_pixel(x));
+  App.feed_wdt();
+}
+
+template<typename PixelFormat>
+uint8_t *Buffer<PixelFormat>::get_native_pixels_(int y) {
+  if (y < 0 || y >= this->height_)
+    return nullptr;
+  return (uint8_t *)this->get_native_pixels_(0, y);
+}
+
+template<typename PixelFormat>
+PixelFormat *Buffer<PixelFormat>::get_native_pixels_(int x, int y) {
+  if (!this->buffer_)
+    return nullptr;
+
+  return offset_buffer(this->buffer_, x, y, this->width_);
+}
+
+template<typename PixelFormat>
+void Buffer<PixelFormat>::draw(display::Display *display) {
+  ESP_LOGV(TAG, "Swap buffer: %dx%d, stride=%d, format=%d",
+    width_, height_, PixelFormat::bytes_stride(this->width_), PixelFormat::FORMAT);
+  display->draw_pixels_at(
+    0, 0, this->width_, this->height_,
+    (const uint8_t *)this->buffer_,
+    PixelFormat::bytes_stride(this->width_),
+    PixelFormat::FORMAT);
+}
+
+#define EXPORT_FRAMEBUFFER_TEMPLATE(name) \
+  template class Buffer<display::Pixel##name>
+#define IGNORE_FRAMEBUFFER_TEMPLATE(name)
+
+EXPORT_DEST_PIXEL_FORMAT(EXPORT_FRAMEBUFFER_TEMPLATE, IGNORE_FRAMEBUFFER_TEMPLATE);
+
+}  // namespace display_buffer
+}  // namespace esphome

--- a/esphome/components/display_buffer/buffer.h
+++ b/esphome/components/display_buffer/buffer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/display/display.h"
+
+namespace esphome {
+namespace display_buffer {
+
+template<typename PixelFormat>
+class Buffer : public PollingComponent,
+                    public display::Display {
+ public:
+  void dump_config() override;
+  void setup() override;
+  void update() override;
+
+  int get_width() override { return this->width_; }
+  int get_height() override { return this->height_; }
+  display::DisplayType get_display_type() override;
+  display::PixelFormat get_native_pixel_format() override { return PixelFormat::FORMAT; }
+
+  void set_width(int width) { this->width_ = width; }
+  void set_height(int height) { this->height_ = height; }
+  void set_output(display::Display *output) { this->output_ = output; }
+
+  void draw_pixel_at(int x, int y, Color color) override;
+  void draw(display::Display *display);
+
+ protected:
+  uint8_t *get_native_pixels_(int y) override;
+  PixelFormat *get_native_pixels_(int x, int y);
+
+ protected:
+  display::Display *output_{nullptr};
+  PixelFormat *buffer_{nullptr};
+  int buffer_length_{0};
+  int width_{0}, height_{0};
+};
+
+}  // namespace display_buffer
+}  // namespace esphome

--- a/esphome/components/display_buffer/display.py
+++ b/esphome/components/display_buffer/display.py
@@ -1,0 +1,54 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import display
+from esphome.const import (
+    CONF_ID,
+    CONF_LAMBDA,
+    CONF_PAGES,
+    CONF_FORMAT,
+    CONF_WIDTH,
+    CONF_HEIGHT,
+    CONF_OUTPUT,
+)
+
+DEPENDENCIES = ["display"]
+
+display_framebuffer_ns = cg.esphome_ns.namespace("display_buffer")
+Buffer = display_framebuffer_ns.class_(
+    "Buffer", cg.PollingComponent, display.DisplayBuffer
+)
+
+CONFIG_SCHEMA = cv.All(
+    display.FULL_DISPLAY_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(Buffer),
+            cv.Optional(CONF_WIDTH): cv.int_,
+            cv.Optional(CONF_HEIGHT): cv.int_,
+            cv.Required(CONF_FORMAT): cv.enum(display.PIXEL_TYPES, upper=True),
+            cv.Optional(CONF_OUTPUT): cv.use_id(display.DisplayBuffer),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.polling_component_schema("5s")),
+    cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
+    cv.has_at_least_one_key(CONF_OUTPUT, CONF_WIDTH),
+    cv.has_none_or_all_keys(CONF_WIDTH, CONF_HEIGHT),
+)
+
+
+async def to_code(config):
+    template_args = cg.TemplateArguments(config[CONF_FORMAT])
+    var = cg.new_Pvariable(config[CONF_ID], template_args)
+    cg.add(var.set_width(config[CONF_WIDTH]))
+    cg.add(var.set_height(config[CONF_HEIGHT]))
+    if CONF_OUTPUT in config:
+        cg.add(var.set_output(config[CONF_OUTPUT]))
+
+    await cg.register_component(var, config)
+    await display.register_display(var, config)
+
+    if CONF_LAMBDA in config:
+        lambda_ = await cg.process_lambda(
+            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+        )
+        cg.add(var.set_writer(lambda_))

--- a/esphome/components/display_gc9a01/display.py
+++ b/esphome/components/display_gc9a01/display.py
@@ -1,0 +1,78 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import spi
+from esphome.components import display
+from esphome.const import (
+    CONF_DC_PIN,
+    CONF_ID,
+    CONF_LAMBDA,
+    CONF_RESET_PIN,
+    CONF_PAGES,
+    CONF_WIDTH,
+    CONF_HEIGHT,
+)
+
+CODEOWNERS = ["@4cello"]
+# adapted from https://github.com/PaintYourDragon/Adafruit_GC9A01A
+
+DEPENDENCIES = ["spi"]
+
+CONF_OFFSET_X = "offset_x"
+CONF_OFFSET_Y = "offset_y"
+
+gc9a01_ns = cg.esphome_ns.namespace("gc9a01")
+SPIGC9A01 = gc9a01_ns.class_(
+    "GC9A01", cg.PollingComponent, display.DisplayBuffer, spi.SPIDevice
+)
+
+GC9A01_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
+    {
+        cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+    }
+).extend(cv.polling_component_schema("5s"))
+
+CONFIG_SCHEMA = cv.All(
+    GC9A01_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(SPIGC9A01),
+            cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_WIDTH, default=240): cv.int_,
+            cv.Optional(CONF_HEIGHT, default=240): cv.int_,
+            cv.Optional(CONF_OFFSET_Y, default=0): cv.int_,
+            cv.Optional(CONF_OFFSET_X, default=0): cv.int_,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(spi.spi_device_schema()),
+    cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
+)
+
+
+async def setup_gc9a01(var, config):
+    await cg.register_component(var, config)
+    await display.register_display(var, config)
+
+    if CONF_RESET_PIN in config:
+        reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
+        cg.add(var.set_reset_pin(reset))
+    if CONF_LAMBDA in config:
+        lambda_ = await cg.process_lambda(
+            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+        )
+        cg.add(var.set_writer(lambda_))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        config[CONF_WIDTH],
+        config[CONF_HEIGHT],
+        config[CONF_OFFSET_Y],
+        config[CONF_OFFSET_X],
+    )
+    await setup_gc9a01(var, config)
+    await spi.register_spi_device(var, config)
+
+    dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
+    cg.add(var.set_dc_pin(dc))

--- a/esphome/components/display_gc9a01/gc9a01.cpp
+++ b/esphome/components/display_gc9a01/gc9a01.cpp
@@ -1,0 +1,251 @@
+#include "gc9a01.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/hal.h"
+
+#include "gc9a01_defines.h"
+
+namespace esphome {
+namespace gc9a01 {
+
+static const uint8_t MADCTL_MY = 0x80;   ///< Bottom to top
+static const uint8_t MADCTL_MX = 0x40;   ///< Right to left
+static const uint8_t MADCTL_MV = 0x20;   ///< Reverse Mode
+static const uint8_t MADCTL_ML = 0x10;   ///< LCD refresh Bottom to top
+static const uint8_t MADCTL_RGB = 0x00;  ///< Red-Green-Blue pixel order
+static const uint8_t MADCTL_BGR = 0x08;  ///< Blue-Green-Red pixel order
+static const uint8_t MADCTL_MH = 0x04;   ///< LCD refresh right to left
+
+// clang-format off
+static const uint8_t PROGMEM INITCMD[] = {
+  GC9A01_INREGEN2, 0,
+  0xEB, 1, 0x14,
+  GC9A01_INREGEN1, 0,
+  GC9A01_INREGEN2, 0,
+  0xEB, 1, 0x14,
+  0x84, 1, 0x40,
+  0x85, 1, 0xFF,
+  0x86, 1, 0xFF,
+  0x87, 1, 0xFF,
+  0x88, 1, 0x0A,
+  0x89, 1, 0x21,
+  0x8A, 1, 0x00,
+  0x8B, 1, 0x80,
+  0x8C, 1, 0x01,
+  0x8D, 1, 0x01,
+  0x8E, 1, 0xFF,
+  0x8F, 1, 0xFF,
+  0xB6, 2, 0x00, 0x00,
+  GC9A01_MADCTL, 1, MADCTL_MX | MADCTL_BGR,
+  GC9A01_PIXFMT, 1, 0x05,
+  0x90, 4, 0x08, 0x08, 0x08, 0x08,
+  0xBD, 1, 0x06,
+  0xBC, 1, 0x00,
+  0xFF, 3, 0x60, 0x01, 0x04,
+  GC9A011_VREG1A, 0x13,
+  GC9A011_VREG1B, 0x13,
+  GC9A011_VREG2A, 0x22,
+  0xBE, 1, 0x11,
+  GC9A01_GMCTRN1, 2, 0x10, 0x0E,
+  0xDF, 3, 0x21, 0x0c, 0x02,
+  GC9A01_GAMMA1, 6, 0x45, 0x09, 0x08, 0x08, 0x26, 0x2A,
+  GC9A01_GAMMA2, 6, 0x43, 0x70, 0x72, 0x36, 0x37, 0x6F,
+  GC9A01_GAMMA3, 6, 0x45, 0x09, 0x08, 0x08, 0x26, 0x2A,
+  GC9A01_GAMMA4, 6, 0x43, 0x70, 0x72, 0x36, 0x37, 0x6F,
+  0xED, 2, 0x1B, 0x0B,
+  0xAE, 1, 0x77,
+  0xCD, 1, 0x63,
+  0x70, 9, 0x07, 0x07, 0x04, 0x0E, 0x0F, 0x09, 0x07, 0x08, 0x03,
+  GC9A01_FRAMERATE, 1, 0x34,
+  0x62, 12, 0x18, 0x0D, 0x71, 0xED, 0x70, 0x70,
+            0x18, 0x0F, 0x71, 0xEF, 0x70, 0x70,
+  0x63, 12, 0x18, 0x11, 0x71, 0xF1, 0x70, 0x70,
+            0x18, 0x13, 0x71, 0xF3, 0x70, 0x70,
+  0x64, 7, 0x28, 0x29, 0xF1, 0x01, 0xF1, 0x00, 0x07,
+  0x66, 10, 0x3C, 0x00, 0xCD, 0x67, 0x45, 0x45, 0x10, 0x00, 0x00, 0x00,
+  0x67, 10, 0x00, 0x3C, 0x00, 0x00, 0x00, 0x01, 0x54, 0x10, 0x32, 0x98,
+  0x74, 7, 0x10, 0x85, 0x80, 0x00, 0x00, 0x4E, 0x00,
+  0x98, 2, 0x3e, 0x07,
+  GC9A01_TEON, 0,
+  GC9A01_INVON, 0,
+  GC9A01_SLPOUT, 0x80, // Exit sleep
+  GC9A01_DISPON, 0x80, // Display on
+  0x00                  // End of list
+};
+// clang-format on
+
+static const char *const TAG = "gc9a01";
+
+static const uint8_t PROGMEM gc9a01_rotations[] = {
+  MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR, // display::DISPLAY_ROTATION_0_DEGREES
+  MADCTL_MX | MADCTL_BGR, // display::DISPLAY_ROTATION_90_DEGREES
+  MADCTL_MV | MADCTL_BGR, // display::DISPLAY_ROTATION_180_DEGREES
+  MADCTL_MY | MADCTL_BGR, // display::DISPLAY_ROTATION_270_DEGREES
+};
+
+GC9A01::GC9A01(int width, int height, int colstart, int rowstart)
+    : colstart_(colstart), rowstart_(rowstart), width_(width), height_(height) {}
+
+void GC9A01::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up GC9A01...");
+  this->spi_setup();
+
+  this->dc_pin_->setup();  // OUTPUT
+  this->cs_->setup();      // OUTPUT
+
+  this->dc_pin_->digital_write(true);
+  this->cs_->digital_write(true);
+
+  this->init_reset_();
+  delay(100);  // NOLINT
+
+  ESP_LOGD(TAG, "  START");
+  dump_config();
+  ESP_LOGD(TAG, "  END");
+
+  display_init_(INITCMD);
+
+  ESP_LOGI(TAG, "Rotation: %d, %02x", this->rotation_, gc9a01_rotations[this->rotation_ / 90]);
+
+  this->sendcommand_(GC9A01_MADCTL, &gc9a01_rotations[this->rotation_ / 90], 1);
+}
+
+void GC9A01::update() {
+  this->do_update_();
+}
+
+void HOT GC9A01::draw_pixel_at(int x, int y, Color color) {
+  if (x >= this->width_ || x < 0 || y >= this->height_ || y < 0)
+    return;
+
+  const uint32_t color565 = display::ColorUtil::color_to_565(color);
+
+  uint8_t data[] = {
+    uint8_t(color565 >> 8),
+    uint8_t(color565)
+  };
+
+  this->draw_pixels_(x, y, 1, 1, data, sizeof(data), sizeof(data));
+}
+
+bool HOT GC9A01::draw_pixels_(int x, int y, int w, int h, const uint8_t *data, int data_line_size, int data_stride) {
+  uint16_t x1 = this->colstart_ + x;
+  uint16_t x2 = x1 + w - 1;
+  uint16_t y1 = this->rowstart_ + y;
+  uint16_t y2 = y1 + h - 1;
+
+#if 0
+  ESP_LOGI(TAG, "GC9A01 Draw Pixels: %dx%d/%dx%d, line_size=%d, stride=%d",
+    x, y, w, h,
+    data_line_size, data_stride);
+#endif
+
+  this->enable();
+
+  // set column(x) address
+  this->dc_pin_->digital_write(false);
+  this->write_byte(GC9A01_CASET);
+  this->dc_pin_->digital_write(true);
+  this->spi_master_write_addr_(x1, x2);
+
+  // set Page(y) address
+  this->dc_pin_->digital_write(false);
+  this->write_byte(GC9A01_PASET);
+  this->dc_pin_->digital_write(true);
+  this->spi_master_write_addr_(y1, y2);
+
+  //  Memory Write
+  this->dc_pin_->digital_write(false);
+  this->write_byte(GC9A01_RAMWR);
+  this->dc_pin_->digital_write(true);
+
+  for (int i = 0; i < h; i++) {
+    this->write_array(data + data_stride * i, data_line_size);
+  }
+  this->disable();
+
+  return true;
+}
+
+void GC9A01::init_reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();
+    this->reset_pin_->digital_write(true);
+    delay(1);
+    // Trigger Reset
+    this->reset_pin_->digital_write(false);
+    delay(10);
+    // Wake up
+    this->reset_pin_->digital_write(true);
+  }
+}
+
+void GC9A01::display_init_(const uint8_t *addr) {
+  uint8_t cmd, x, num_args;
+  while ((cmd = progmem_read_byte(addr++)) > 0) {
+    x = progmem_read_byte(addr++);
+    num_args = x & 0x7F;
+    this->sendcommand_(cmd, addr, num_args);
+    addr += num_args;
+    if (x & 0x80) {
+      delay(150);  // NOLINT
+    }
+  }
+}
+
+void GC9A01::dump_config() {
+  LOG_DISPLAY("", "GC9A01", this);
+  LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  ESP_LOGD(TAG, "  Height: %d", this->height_);
+  ESP_LOGD(TAG, "  Width: %d", this->width_);
+  ESP_LOGD(TAG, "  OffsetX: %d", this->colstart_);
+  ESP_LOGD(TAG, "  OffsetY: %d", this->rowstart_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void HOT GC9A01::writecommand_(uint8_t value) {
+  this->enable();
+  this->dc_pin_->digital_write(false);
+  this->write_byte(value);
+  this->dc_pin_->digital_write(true);
+  this->disable();
+}
+
+void HOT GC9A01::writedata_(uint8_t value) {
+  this->dc_pin_->digital_write(true);
+  this->enable();
+  this->write_byte(value);
+  this->disable();
+}
+
+void HOT GC9A01::sendcommand_(uint8_t cmd, const uint8_t *data_bytes, uint8_t num_data_bytes) {
+  this->writecommand_(cmd);
+  this->senddata_(data_bytes, num_data_bytes);
+}
+
+void HOT GC9A01::senddata_(const uint8_t *data_bytes, uint8_t num_data_bytes) {
+  this->dc_pin_->digital_write(true);  // pull DC high to indicate data
+  this->cs_->digital_write(false);
+  this->enable();
+  for (uint8_t i = 0; i < num_data_bytes; i++) {
+    this->write_byte(progmem_read_byte(data_bytes++));  // write byte - SPI library
+  }
+  this->cs_->digital_write(true);
+  this->disable();
+}
+
+void GC9A01::spi_master_write_addr_(uint16_t addr1, uint16_t addr2) {
+  static uint8_t byte[4];
+  byte[0] = (addr1 >> 8) & 0xFF;
+  byte[1] = addr1 & 0xFF;
+  byte[2] = (addr2 >> 8) & 0xFF;
+  byte[3] = addr2 & 0xFF;
+
+  this->dc_pin_->digital_write(true);
+  this->write_array(byte, 4);
+}
+
+}  // namespace gc9a01
+}  // namespace esphome

--- a/esphome/components/display_gc9a01/gc9a01.cpp
+++ b/esphome/components/display_gc9a01/gc9a01.cpp
@@ -3,6 +3,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/hal.h"
 
+#include "esphome/components/display/display_color_utils.h"
+
 #include "gc9a01_defines.h"
 
 namespace esphome {

--- a/esphome/components/display_gc9a01/gc9a01.h
+++ b/esphome/components/display_gc9a01/gc9a01.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+#include "esphome/components/display/display.h"
+
+namespace esphome {
+namespace gc9a01 {
+
+class GC9A01 : public PollingComponent,
+               public display::Display,
+               public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                                     spi::DATA_RATE_40MHZ> {
+ public:
+  GC9A01(int width, int height, int colstart, int rowstart);
+  void dump_config() override;
+  void setup() override;
+
+  void update() override;
+
+  float get_setup_priority() const override { return setup_priority::PROCESSOR; }
+
+  void set_reset_pin(GPIOPin *value) { this->reset_pin_ = value; }
+  void set_dc_pin(GPIOPin *value) { dc_pin_ = value; }
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+  int get_width() override { return this->width_; }
+  int get_height() override { return this->height_; }
+
+  display::PixelFormat get_native_pixel_format() override { return display::PixelFormat::RGB565_BE; }
+  bool draw_pixels_(int x, int y, int w, int h, const uint8_t *data, int data_line_size, int data_stride) override;
+  void draw_pixel_at(int x, int y, Color color) override;
+
+ public:
+  void sendcommand_(uint8_t cmd, const uint8_t *data_bytes, uint8_t num_data_bytes);
+  void senddata_(const uint8_t *data_bytes, uint8_t num_data_bytes);
+
+  void writecommand_(uint8_t value);
+  void writedata_(uint8_t value);
+
+  void init_reset_();
+  void display_init_(const uint8_t *addr);
+  void set_addr_window_(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  void spi_master_write_addr_(uint16_t addr1, uint16_t addr2);
+
+  uint8_t colstart_ = 0, rowstart_ = 0;
+  int16_t width_ = 240, height_ = 240;
+
+  GPIOPin *reset_pin_{nullptr};
+  GPIOPin *dc_pin_{nullptr};
+};
+
+}  // namespace gc9a01
+}  // namespace esphome

--- a/esphome/components/display_gc9a01/gc9a01_defines.h
+++ b/esphome/components/display_gc9a01/gc9a01_defines.h
@@ -1,0 +1,67 @@
+#pragma once
+
+namespace esphome {
+namespace gc9a01 {
+
+static const uint8_t GC9A01_TFTWIDTH = 240;   ///< Display width in pixels
+static const uint8_t GC9A01_TFTHEIGHT = 240;  ///< Display height in pixels
+
+// NOTE: ILI9341 registers defined (but commented out) are ones that
+// *might* be compatible with the GC9A01, but aren't documented in
+// the device datasheet. A couple are defined (with ILI name) and NOT
+// commented out because they appeared in the manufacturer example code
+// as raw register addresses, no documentation in datasheet, they SEEM
+// to do the same thing as their ILI equivalents but this is not 100%
+// confirmed so they've not been assigned GC9A01 register defines.
+
+// static const uint8_t ILI9341_NOP = 0x00;     ///< No-op register
+static const uint8_t GC9A01_SWRESET = 0x01;  ///< Software reset register
+
+// static const uint8_t GC9A01 = 0x04;   ///< Read display identification information
+static const uint8_t GC9A01_STATUS = 0x09;  ///< Read Display Status
+
+static const uint8_t GC9A01_SLPIN = 0x10;   ///< Enter Sleep Mode
+static const uint8_t GC9A01_SLPOUT = 0x11;  ///< Sleep Out
+static const uint8_t GC9A01_PTLON = 0x12;   ///< Partial Mode ON
+static const uint8_t GC9A01_NORON = 0x13;   ///< Normal Display Mode ON
+
+static const uint8_t GC9A01_INVOFF = 0x20;   ///< Display Inversion OFF
+static const uint8_t GC9A01_INVON = 0x21;    ///< Display Inversion ON
+static const uint8_t GC9A01_DISPOFF = 0x28;  ///< Display OFF
+static const uint8_t GC9A01_DISPON = 0x29;   ///< Display ON
+
+static const uint8_t GC9A01_CASET = 0x2A;  ///< Column Address Set
+static const uint8_t GC9A01_PASET = 0x2B;  ///< Page Address Set
+static const uint8_t GC9A01_RAMWR = 0x2C;  ///< Memory Write
+// static const uint8_t ILI9341_RAMRD = 0x2E; ///< Memory Read
+
+static const uint8_t GC9A01_PTLAR = 0x30;     ///< Partial Area
+static const uint8_t GC9A01_VSCRDEF = 0x33;   ///< Vertical Scrolling Definition
+static const uint8_t GC9A01_TEOFF = 0x34;     ///< Tearing effect line off
+static const uint8_t GC9A01_TEON = 0x35;      ///< Tearing effect line on
+static const uint8_t GC9A01_MADCTL = 0x36;    ///< Memory Access Control
+static const uint8_t GC9A01_VSCRSADD = 0x37;  ///< Vertical Scrolling Start Address
+static const uint8_t GC9A01_PIXFMT = 0x3A;    ///< COLMOD: Pixel Format Set
+
+static const uint8_t GC9A011_DFUNCTR = 0xB6;  ///< Display Function Control
+
+static const uint8_t GC9A011_VREG1A = 0xC3;  ///< Vreg1a voltage control
+static const uint8_t GC9A011_VREG1B = 0xC4;  ///< Vreg1b voltage control
+static const uint8_t GC9A011_VREG2A = 0xC9;  ///< Vreg2a voltage control
+
+static const uint8_t GC9A01_RDID1 = 0xDA;  ///< Read ID 1
+static const uint8_t GC9A01_RDID2 = 0xDB;  ///< Read ID 2
+static const uint8_t GC9A01_RDID3 = 0xDC;  ///< Read ID 3
+
+// static const uint8_t ILI9341_GMCTRP1 = 0xE0; ///< Positive Gamma Correction
+static const uint8_t GC9A01_GMCTRN1 = 0xE1;    ///< Negative Gamma Correction
+static const uint8_t GC9A01_FRAMERATE = 0xE8;  ///< Frame rate control
+static const uint8_t GC9A01_INREGEN2 = 0xEF;   ///< Inter register enable 2
+static const uint8_t GC9A01_GAMMA1 = 0xF0;     ///< Set gamma 1
+static const uint8_t GC9A01_GAMMA2 = 0xF1;     ///< Set gamma 2
+static const uint8_t GC9A01_GAMMA3 = 0xF2;     ///< Set gamma 3
+static const uint8_t GC9A01_GAMMA4 = 0xF3;     ///< Set gamma 4
+static const uint8_t GC9A01_INREGEN1 = 0xFE;   ///< Inter register enable 1
+
+}  // namespace gc9a01
+}  // namespace esphome

--- a/esphome/components/font/font.cpp
+++ b/esphome/components/font/font.cpp
@@ -15,6 +15,19 @@ void Glyph::draw(int x_at, int y_start, display::Display *display, Color color) 
   this->scan_area(&scan_x1, &scan_y1, &scan_width, &scan_height);
 
   const unsigned char *data = this->glyph_data_->data;
+
+  bool done = display->draw_pixels_at(
+    x_at + scan_x1, y_start + scan_y1,
+    scan_width, scan_height,
+    data,
+    display::PixelA1::bytes_stride(scan_width),
+    display::PixelFormat::A1,
+    color
+  );
+  if (done) {
+    return;
+  }
+
   const int max_x = x_at + scan_x1 + scan_width;
   const int max_y = y_start + scan_y1 + scan_height;
 

--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -94,7 +94,8 @@ void Image::draw(int x, int y, display::Display *display, Color color_on, Color 
       if (display->draw_pixels_at(
         x, y,
         width_, height_,
-        data_start_, data_size_,
+        data_start_,
+        display::PixelRGBA8888::bytes_stride(width_),
         display::PixelFormat::RGBA8888)) {
         return;
       }
@@ -178,23 +179,45 @@ Color Image::get_grayscale_pixel_(int x, int y) const {
 }
 
 #ifdef USE_JPEGDEC
-static int jpeg_draw(JPEGDRAW *pDraw) {
-  display::Display *display = (display::Display *) pDraw->pUser;
+struct JpegData {
+  display::Display *display{nullptr};
+  int jpeg_format{-1};
+  display::PixelFormat pixel_format{display::PixelFormat::Unknown};
+  bool transparent{false};
+};
 
-  const uint16_t *data = pDraw->pPixels;
+static int jpeg_draw(JPEGDRAW *pDraw) {
+  JpegData *data = (JpegData*)pDraw->pUser;
+  display::Display *display = data->display;
+
+  if (display->draw_pixels_at(
+    pDraw->x, pDraw->y,
+    pDraw->iWidth, pDraw->iHeight,
+    (const uint8_t*)pDraw->pPixels,
+    pDraw->iBpp * pDraw->iWidth / 8,
+    data->pixel_format
+  )) {
+    return 1;
+  }
+
+  if (data->pixel_format != display::PixelFormat::RGB565_BE) {
+    return 0;
+  }
+
+  const uint16_t *pixelData = pDraw->pPixels;
   for (int y = 0; y < pDraw->iHeight; y++) {
-    for (int x = 0; x < pDraw->iWidth; x++, data++) {
+    for (int x = 0; x < pDraw->iWidth; x++, pixelData++) {
       // TODO: this is not very fast.
-      auto r = (*data & 0xF800) >> 11;
-      auto g = (*data & 0x07E0) >> 5;
-      auto b = *data & 0x001F;
+      auto r = (*pixelData & 0xF800) >> 11;
+      auto g = (*pixelData & 0x07E0) >> 5;
+      auto b = *pixelData & 0x001F;
       Color color = Color((r << 3) | (r >> 2), (g << 2) | (g >> 4), (b << 3) | (b >> 2));
-      // if (rgb565 == 0x0020 && transparent_) {
-      //   // darkest green has been defined as transparent color for transparent RGB565 images.
-      //   color.w = 0;
-      // } else {
-      color.w = 0xFF;
-      // }
+      if (*pixelData == 0x0020 && data->transparent) {
+        // darkest green has been defined as transparent color for transparent RGB565 images.
+        color.w = 0;
+      } else {
+        color.w = 0xFF;
+      }
       display->draw_pixel_at(pDraw->x + x, pDraw->y + y, color);
     }
   }
@@ -204,11 +227,37 @@ static int jpeg_draw(JPEGDRAW *pDraw) {
 
 void Image::draw_jpeg(int x, int y, display::Display *display) {
 #ifdef USE_JPEGDEC
-  JPEGDEC *jpeg = new JPEGDEC();
+  JPEGDEC* jpeg = new JPEGDEC();
+  JpegData data;
+  int nativeFormat = -1;
 
-  if (jpeg->openFLASH((uint8_t *) this->data_start_, this->data_size_, jpeg_draw)) {
-    jpeg->setUserPointer(display);
-    jpeg->setPixelType(RGB565_LITTLE_ENDIAN);
+  data.display = display;
+  data.pixel_format = display->get_native_pixel_format();
+  data.transparent = this->transparent_;
+
+  switch (data.pixel_format) {
+    case display::PixelFormat::RGB565_LE:
+      data.jpeg_format = RGB565_LITTLE_ENDIAN;
+      break;
+
+    case display::PixelFormat::RGB565_BE:
+      data.jpeg_format = RGB565_BIG_ENDIAN;
+      break;
+
+    case display::PixelFormat::W8:
+      data.jpeg_format = EIGHT_BIT_GRAYSCALE;
+      break;
+
+      // Pixel Format is not supported, fallback to RGB565_BE
+    default:
+      data.jpeg_format = RGB565_LITTLE_ENDIAN;
+      data.pixel_format = display::PixelFormat::RGB565_LE;
+      break;
+  }
+
+  if (jpeg->openFLASH((uint8_t*) this->data_start_, this->data_size_, jpeg_draw)) {
+    jpeg->setUserPointer(&data);
+    jpeg->setPixelType(data.jpeg_format);
     if (jpeg->decode(x, y, 0)) {
       ESP_LOGV("jpeg", "Decode succeeded");
     }

--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -15,6 +15,16 @@ static const char *TAG = "image";
 void Image::draw(int x, int y, display::Display *display, Color color_on, Color color_off) {
   switch (type_) {
     case IMAGE_TYPE_BINARY: {
+      if (display->draw_pixels_at(
+        x, y,
+        width_, height_,
+        data_start_,
+        display::PixelW1::bytes_stride(width_),
+        this->transparent_ ? display::PixelFormat::A1 : display::PixelFormat::W1,
+        color_on, color_off)) {
+        return;
+      }
+
       for (int img_x = 0; img_x < width_; img_x++) {
         for (int img_y = 0; img_y < height_; img_y++) {
           if (this->get_binary_pixel_(img_x, img_y)) {
@@ -27,6 +37,14 @@ void Image::draw(int x, int y, display::Display *display, Color color_on, Color 
       break;
     }
     case IMAGE_TYPE_GRAYSCALE:
+      if (display->draw_pixels_at(
+        x, y,
+        width_, height_,
+        data_start_,
+        display::PixelW8::bytes_stride(width_),
+        this->transparent_ ? display::PixelFormat::W8_KEY : display::PixelFormat::W8)) {
+        return;
+      }
       for (int img_x = 0; img_x < width_; img_x++) {
         for (int img_y = 0; img_y < height_; img_y++) {
           auto color = this->get_grayscale_pixel_(img_x, img_y);
@@ -37,6 +55,14 @@ void Image::draw(int x, int y, display::Display *display, Color color_on, Color 
       }
       break;
     case IMAGE_TYPE_RGB565:
+      if (display->draw_pixels_at(
+        x, y,
+        width_, height_,
+        data_start_,
+        display::PixelRGB565_BE::bytes_stride(width_),
+        display::PixelFormat::RGB565_BE)) {
+        return;
+      }
       for (int img_x = 0; img_x < width_; img_x++) {
         for (int img_y = 0; img_y < height_; img_y++) {
           auto color = this->get_rgb565_pixel_(img_x, img_y);
@@ -47,6 +73,14 @@ void Image::draw(int x, int y, display::Display *display, Color color_on, Color 
       }
       break;
     case IMAGE_TYPE_RGB24:
+      if (display->draw_pixels_at(
+        x, y,
+        width_, height_,
+        data_start_,
+        display::PixelRGB888::bytes_stride(width_),
+        display::PixelFormat::RGB888)) {
+        return;
+      }
       for (int img_x = 0; img_x < width_; img_x++) {
         for (int img_y = 0; img_y < height_; img_y++) {
           auto color = this->get_rgb24_pixel_(img_x, img_y);
@@ -57,6 +91,13 @@ void Image::draw(int x, int y, display::Display *display, Color color_on, Color 
       }
       break;
     case IMAGE_TYPE_RGBA:
+      if (display->draw_pixels_at(
+        x, y,
+        width_, height_,
+        data_start_, data_size_,
+        display::PixelFormat::RGBA8888)) {
+        return;
+      }
       for (int img_x = 0; img_x < width_; img_x++) {
         for (int img_y = 0; img_y < height_; img_y++) {
           auto color = this->get_rgba_pixel_(img_x, img_y);

--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -1,9 +1,16 @@
 #include "image.h"
 
 #include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_JPEGDEC
+#include "JPEGDEC.h"
+#endif  // USE_JPEGDEC
 
 namespace esphome {
 namespace image {
+
+static const char *TAG = "image";
 
 void Image::draw(int x, int y, display::Display *display, Color color_on, Color color_off) {
   switch (type_) {
@@ -58,6 +65,10 @@ void Image::draw(int x, int y, display::Display *display, Color color_on, Color 
           }
         }
       }
+      break;
+
+    case IMAGE_TYPE_JPEG:
+      this->draw_jpeg(x, y, display);
       break;
   }
 }
@@ -124,11 +135,54 @@ Color Image::get_grayscale_pixel_(int x, int y) const {
   uint8_t alpha = (gray == 1 && transparent_) ? 0 : 0xFF;
   return Color(gray, gray, gray, alpha);
 }
+
+#ifdef USE_JPEGDEC
+static int jpeg_draw(JPEGDRAW *pDraw) {
+  display::Display *display = (display::Display *) pDraw->pUser;
+
+  const uint16_t *data = pDraw->pPixels;
+  for (int y = 0; y < pDraw->iHeight; y++) {
+    for (int x = 0; x < pDraw->iWidth; x++, data++) {
+      // TODO: this is not very fast.
+      auto r = (*data & 0xF800) >> 11;
+      auto g = (*data & 0x07E0) >> 5;
+      auto b = *data & 0x001F;
+      Color color = Color((r << 3) | (r >> 2), (g << 2) | (g >> 4), (b << 3) | (b >> 2));
+      // if (rgb565 == 0x0020 && transparent_) {
+      //   // darkest green has been defined as transparent color for transparent RGB565 images.
+      //   color.w = 0;
+      // } else {
+      color.w = 0xFF;
+      // }
+      display->draw_pixel_at(pDraw->x + x, pDraw->y + y, color);
+    }
+  }
+  return 1;
+}
+#endif  // USE_JPEGDEC
+
+void Image::draw_jpeg(int x, int y, display::Display *display) {
+#ifdef USE_JPEGDEC
+  JPEGDEC *jpeg = new JPEGDEC();
+
+  if (jpeg->openFLASH((uint8_t *) this->data_start_, this->data_size_, jpeg_draw)) {
+    jpeg->setUserPointer(display);
+    jpeg->setPixelType(RGB565_LITTLE_ENDIAN);
+    if (jpeg->decode(x, y, 0)) {
+      ESP_LOGV("jpeg", "Decode succeeded");
+    }
+    jpeg->close();
+  }
+  delete jpeg;
+#else   // USE_JPEGDEC
+  ESP_LOGE(TAG, "JPEGDEC is not compiled in.");
+#endif  // USE_JPEGDEC
+}
 int Image::get_width() const { return this->width_; }
 int Image::get_height() const { return this->height_; }
 ImageType Image::get_type() const { return this->type_; }
-Image::Image(const uint8_t *data_start, int width, int height, ImageType type)
-    : width_(width), height_(height), type_(type), data_start_(data_start) {}
+Image::Image(const uint8_t *data_start, int data_size, int width, int height, ImageType type)
+    : data_size_(data_size), width_(width), height_(height), type_(type), data_start_(data_start) {}
 
 }  // namespace image
 }  // namespace esphome

--- a/esphome/components/image/image.h
+++ b/esphome/components/image/image.h
@@ -11,6 +11,7 @@ enum ImageType {
   IMAGE_TYPE_RGB24 = 2,
   IMAGE_TYPE_RGB565 = 3,
   IMAGE_TYPE_RGBA = 4,
+  IMAGE_TYPE_JPEG = 5,
 };
 
 inline int image_type_to_bpp(ImageType type) {
@@ -25,6 +26,8 @@ inline int image_type_to_bpp(ImageType type) {
       return 24;
     case IMAGE_TYPE_RGBA:
       return 32;
+    case IMAGE_TYPE_JPEG:
+      return 0;
   }
   return 0;
 }
@@ -33,7 +36,7 @@ inline int image_type_to_width_stride(int width, ImageType type) { return (width
 
 class Image : public display::BaseImage {
  public:
-  Image(const uint8_t *data_start, int width, int height, ImageType type);
+  Image(const uint8_t *data_start, int data_size, int width, int height, ImageType type);
   Color get_pixel(int x, int y, Color color_on = display::COLOR_ON, Color color_off = display::COLOR_OFF) const;
   int get_width() const override;
   int get_height() const override;
@@ -50,7 +53,9 @@ class Image : public display::BaseImage {
   Color get_rgba_pixel_(int x, int y) const;
   Color get_rgb565_pixel_(int x, int y) const;
   Color get_grayscale_pixel_(int x, int y) const;
+  void draw_jpeg(int x, int y, display::Display *display);
 
+  int data_size_;
   int width_;
   int height_;
   ImageType type_;

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -169,7 +169,7 @@ float Component::get_actual_setup_priority() const {
 void Component::set_setup_priority(float priority) { this->setup_priority_override_ = priority; }
 
 bool Component::has_overridden_loop() const {
-#ifdef CLANG_TIDY
+#if defined(CLANG_TIDY) || defined(__APPLE_CC__)
   bool loop_overridden = true;
   bool call_loop_overridden = true;
 #else


### PR DESCRIPTION
# What does this implement/fix?

The purpose of this to provide a new way of writing display drivers:

### Design goals

- All existing display should continue working, but their implementation should be marked as deprecated
- Display driver should not manage framebuffer, only send data directly to the target device
- Display driver should use native device rotation where-is possible
- Display driver should declare what is native buffer format for buffer transfer
- Framebuffer should provide an allocated buffer of choice
- Image/Font and all other functions should prefer to use `draw_pixels` or `draw_pixels_format` in all cases which would convert if needed from non-native format to native and render by lines
- Pixel formats should provide a uniform and convenient pixel mapping between all pixel formats
- Transparancy should be implemented using Pixel Format, where the color key should part of Pixel Format implementation, similar to how `PixelA1` and `PixelW1` are implemented

### Performance

- previously took 170ms to render 240x240/RGB565
- framebuffer: with direct blit to framebuffer, it takes 8ms
- framebuffer: with conversion from RGB888 to RGB565, it takes 21ms
- direct to display: with conversion from RGB888 over SPI to RGB565, it takes 56ms
- direct to display: RGB565 to SPI RGB565 it takes 30ms
- displaying framebuffer, it takes around 30ms to be transfered over SPI

- previously took 1700us to render the front from example
- framebuffer: it takes around 400ms now

> The routines for pixel conversion are not yet optimised.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```yaml
display:
  - id: lcd_display
    platform: display_gc9a01
    reset_pin: GPIO13
    cs_pin: GPIO10
    dc_pin: GPIO9
    rotation: 0
    auto_clear_enabled: false

  - id: framebuffer
    platform: display_buffer
    width: 240
    height: 240
    format: RGB565
    auto_clear_enabled: true
    lambda: |-
      start_us = micros();
      it.image(120, 120, id(logo), ImageAlign::CENTER);
      ESP_LOGE("logo_page", "mellow_logo2: %ld", micros() - start_us);

      start_us = micros();
      it.print(120, 120, id(roboto), TextAlign::TOP_CENTER, "Hello World!");
      ESP_LOGE("logo_page", "roboto: %ld", micros() - start_us);

      start_us = micros();
      id(framebuffer).draw(id(lcd_display));
      ESP_LOGE("logo_page", "send: %ld", micros() - start_us);

      ESP_LOGE("logo_page", "refresh: %ld", micros() - refresh_us);
      refresh_us = micros();
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
