### PR TITLE
display: Rename `display.DisplayBufferRef` to `display.DisplayRef` used by lambda

### DIFF
--- a/esphome/components/addressable_light/display.py
+++ b/esphome/components/addressable_light/display.py
@@ -58,6 +58,6 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -18,10 +18,11 @@ from esphome.core import coroutine_with_priority
 IS_PLATFORM_COMPONENT = True
 
 display_ns = cg.esphome_ns.namespace("display")
+Display = display_ns.class_("Display")
 DisplayBuffer = display_ns.class_("DisplayBuffer")
 DisplayPage = display_ns.class_("DisplayPage")
 DisplayPagePtr = DisplayPage.operator("ptr")
-DisplayBufferRef = DisplayBuffer.operator("ref")
+DisplayRef = Display.operator("ref")
 DisplayPageShowAction = display_ns.class_("DisplayPageShowAction", automation.Action)
 DisplayPageShowNextAction = display_ns.class_(
     "DisplayPageShowNextAction", automation.Action
@@ -96,7 +97,7 @@ async def setup_display_core_(var, config):
         pages = []
         for conf in config[CONF_PAGES]:
             lambda_ = await cg.process_lambda(
-                conf[CONF_LAMBDA], [(DisplayBufferRef, "it")], return_type=cg.void
+                conf[CONF_LAMBDA], [(DisplayRef, "it")], return_type=cg.void
             )
             page = cg.new_Pvariable(conf[CONF_ID], lambda_)
             pages.append(page)

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -133,12 +133,10 @@ enum DisplayRotation {
 };
 
 class Display;
-class DisplayBuffer;
 class DisplayPage;
 class DisplayOnPageChangeTrigger;
 
 using display_writer_t = std::function<void(Display &)>;
-using display_buffer_writer_t = std::function<void(DisplayBuffer &)>;
 
 #define LOG_DISPLAY(prefix, type, obj) \
   if ((obj) != nullptr) { \
@@ -411,10 +409,6 @@ class Display {
 
   /// Internal method to set the display writer lambda.
   void set_writer(display_writer_t &&writer);
-  void set_writer(const display_buffer_writer_t &writer) {
-    // Temporary mapping to be removed once all lambdas are changed to use `display.DisplayRef`
-    this->set_writer([writer](Display &display) { return writer((display::DisplayBuffer &) display); });
-  }
 
   void show_page(DisplayPage *page);
   void show_next_page();
@@ -499,9 +493,6 @@ class Display {
 class DisplayPage {
  public:
   DisplayPage(display_writer_t writer);
-  // Temporary mapping to be removed once all lambdas are changed to use `display.DisplayRef`
-  DisplayPage(const display_buffer_writer_t &writer)
-      : DisplayPage([writer](Display &display) { return writer((display::DisplayBuffer &) display); }) {}
   void show();
   void show_next();
   void show_prev();

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -121,7 +121,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 

--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -115,7 +115,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 

--- a/esphome/components/pcd8544/display.py
+++ b/esphome/components/pcd8544/display.py
@@ -52,6 +52,6 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/ssd1306_base/__init__.py
+++ b/esphome/components/ssd1306_base/__init__.py
@@ -96,6 +96,6 @@ async def setup_ssd1306(var, config):
         cg.add(var.init_invert(config[CONF_INVERT]))
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/ssd1322_base/__init__.py
+++ b/esphome/components/ssd1322_base/__init__.py
@@ -46,6 +46,6 @@ async def setup_ssd1322(var, config):
         cg.add(var.set_external_vcc(config[CONF_EXTERNAL_VCC]))
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/ssd1325_base/__init__.py
+++ b/esphome/components/ssd1325_base/__init__.py
@@ -50,6 +50,6 @@ async def setup_ssd1325(var, config):
         cg.add(var.set_external_vcc(config[CONF_EXTERNAL_VCC]))
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/ssd1327_base/__init__.py
+++ b/esphome/components/ssd1327_base/__init__.py
@@ -37,6 +37,6 @@ async def setup_ssd1327(var, config):
         cg.add(var.init_brightness(config[CONF_BRIGHTNESS]))
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/ssd1331_base/__init__.py
+++ b/esphome/components/ssd1331_base/__init__.py
@@ -28,6 +28,6 @@ async def setup_ssd1331(var, config):
         cg.add(var.init_brightness(config[CONF_BRIGHTNESS]))
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/ssd1351_base/__init__.py
+++ b/esphome/components/ssd1351_base/__init__.py
@@ -38,6 +38,6 @@ async def setup_ssd1351(var, config):
         cg.add(var.init_brightness(config[CONF_BRIGHTNESS]))
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))

--- a/esphome/components/st7735/display.py
+++ b/esphome/components/st7735/display.py
@@ -77,7 +77,7 @@ async def setup_st7735(var, config):
         cg.add(var.set_reset_pin(reset))
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -121,7 +121,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -153,7 +153,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
     if CONF_RESET_PIN in config:


### PR DESCRIPTION
# What does this implement/fix?

This is a change taken from the https://github.com/esphome/esphome/pull/4996.
This requires changes from: https://github.com/esphome/esphome/pull/5001.

It is interface breaking change to finish move from `display::DisplayBuffer` to `display::Display`:

- this does change `lambda:` (for display and pages) to be based on `display::Display&`
- this is breaking change for external display components, as they have to change to use `displays.DisplayRef`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32S3
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
