### PR TITLE
display: Add helper methods to `Display::clip` and `Display::clamp_x/y_`

### DIFF
--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -472,14 +472,21 @@ class Display {
    *
    * return rect for active clipping region
    */
-  Rect get_clipping();
+  Rect get_clipping() const;
 
   bool is_clipping() const { return !this->clipping_rectangle_.empty(); }
 
+  /** Check if pixel is within region of display.
+   */
+  bool clip(int x, int y);
+
  protected:
+  bool clamp_x_(int x, int w, int &min_x, int &max_x);
+  bool clamp_y_(int y, int h, int &min_y, int &max_y);
   void vprintf_(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, va_list arg);
 
   void do_update_();
+  void clear_clipping_();
 
   DisplayRotation rotation_{DISPLAY_ROTATION_0_DEGREES};
   optional<display_writer_t> writer_{};

--- a/esphome/components/display/rect.cpp
+++ b/esphome/components/display/rect.cpp
@@ -60,11 +60,11 @@ void Rect::shrink(Rect rect) {
   }
 }
 
-bool Rect::equal(Rect rect) {
+bool Rect::equal(Rect rect) const {
   return (rect.x == this->x) && (rect.w == this->w) && (rect.y == this->y) && (rect.h == this->h);
 }
 
-bool Rect::inside(int16_t test_x, int16_t test_y, bool absolute) {  // NOLINT
+bool Rect::inside(int16_t test_x, int16_t test_y, bool absolute) const {  // NOLINT
   if (!this->is_set()) {
     return true;
   }
@@ -75,7 +75,7 @@ bool Rect::inside(int16_t test_x, int16_t test_y, bool absolute) {  // NOLINT
   }
 }
 
-bool Rect::inside(Rect rect, bool absolute) {
+bool Rect::inside(Rect rect, bool absolute) const {
   if (!this->is_set() || !rect.is_set()) {
     return true;
   }

--- a/esphome/components/display/rect.h
+++ b/esphome/components/display/rect.h
@@ -16,19 +16,19 @@ class Rect {
 
   Rect() : x(VALUE_NO_SET), y(VALUE_NO_SET), w(VALUE_NO_SET), h(VALUE_NO_SET) {}  // NOLINT
   inline Rect(int16_t x, int16_t y, int16_t w, int16_t h) ALWAYS_INLINE : x(x), y(y), w(w), h(h) {}
-  inline int16_t x2() { return this->x + this->w; };  ///< X coordinate of corner
-  inline int16_t y2() { return this->y + this->h; };  ///< Y coordinate of corner
+  inline int16_t x2() const { return this->x + this->w; };  ///< X coordinate of corner
+  inline int16_t y2() const { return this->y + this->h; };  ///< Y coordinate of corner
 
-  inline bool is_set() ALWAYS_INLINE { return (this->h != VALUE_NO_SET) && (this->w != VALUE_NO_SET); }
+  inline bool is_set() const ALWAYS_INLINE { return (this->h != VALUE_NO_SET) && (this->w != VALUE_NO_SET); }
 
   void expand(int16_t horizontal, int16_t vertical);
 
   void extend(Rect rect);
   void shrink(Rect rect);
 
-  bool inside(Rect rect, bool absolute = true);
-  bool inside(int16_t test_x, int16_t test_y, bool absolute = true);
-  bool equal(Rect rect);
+  bool inside(Rect rect, bool absolute = true) const;
+  bool inside(int16_t test_x, int16_t test_y, bool absolute = true) const;
+  bool equal(Rect rect) const;
   void info(const std::string &prefix = "rect info:");
 };
 


### PR DESCRIPTION
# What does this implement/fix?

This is a change taken from the https://github.com/esphome/esphome/pull/4996. 
This requires changes from: https://github.com/esphome/esphome/pull/5001.

It is additive change adding `clip` and `clamp_x/y_` methods:

- `clip` checks if `x/y` is within display boundaries, and clipping region
- `clamp_x/y_` clamps `x/x+w` to display boundaries and clipping region, returning `min_x (inclusive)` and `max_x (exclusive)`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32S3
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
