### PR TITLE
Add optional relative_color_temp parameter to light.dim_relative service

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -83,12 +83,11 @@ template<typename... Ts> class DimRelativeAction : public Action<Ts...> {
     float rel_ct = this->relative_color_temp_.value(x...);
     float cur_ct = this->parent_->remote_values.get_color_temperature();
     float target_ct = cur_ct;
-    if(this->relative_color_temp_.has_value())
-    {
-        float cold_ct = this->parent_->remote_values.get_cold_white();
-        float warm_ct = this->parent_->remote_values.get_warm_white();
-        if(warm_ct - cold_ct > 0)
-            target_ct = clamp((warm_ct-cold_ct)*rel_ct + cur_ct, cold_ct, warm_ct);
+    if (this->relative_color_temp_.has_value()) {
+      float cold_ct = this->parent_->remote_values.get_cold_white();
+      float warm_ct = this->parent_->remote_values.get_warm_white();
+      if (warm_ct - cold_ct > 0)
+        target_ct = clamp((warm_ct - cold_ct) * rel_ct + cur_ct, cold_ct, warm_ct);
     }
 
     call.set_state(new_brightness != 0.0f);

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -158,10 +158,14 @@ async def light_control_to_code(config, action_id, template_arg, args):
 
 
 CONF_RELATIVE_BRIGHTNESS = "relative_brightness"
+CONF_RELATIVE_COLOR_TEMP = "relative_color_temp"
 LIGHT_DIM_RELATIVE_ACTION_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_ID): cv.use_id(LightState),
         cv.Required(CONF_RELATIVE_BRIGHTNESS): cv.templatable(
+            cv.possibly_negative_percentage
+        ),
+        cv.Optional(CONF_RELATIVE_COLOR_TEMP): cv.templatable(
             cv.possibly_negative_percentage
         ),
         cv.Optional(CONF_TRANSITION_LENGTH): cv.templatable(
@@ -179,6 +183,9 @@ async def light_dim_relative_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, paren)
     templ = await cg.templatable(config[CONF_RELATIVE_BRIGHTNESS], args, float)
     cg.add(var.set_relative_brightness(templ))
+    if CONF_RELATIVE_COLOR_TEMP in config:
+        templ = await cg.templatable(config[CONF_RELATIVE_COLOR_TEMP], args, float)
+        cg.add(var.set_relative_color_temp(templ))
     if CONF_TRANSITION_LENGTH in config:
         templ = await cg.templatable(config[CONF_TRANSITION_LENGTH], args, cg.uint32)
         cg.add(var.set_transition_length(templ))


### PR DESCRIPTION
# What does this implement/fix?

Extends the light.dim_relative service to enable relative adjustments to color temperature.

New parameter name: relative_color_temp
Type: Percentage, optional, can be negative

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
This is an idea that came up as a result of discussions in esphome/feature-requests#2186

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3021
## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:

```yaml
esphome:
  name: lamp_01
  comment: "Lamp"
 
rp2040:
  board: rpipicow
  framework:
    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
  
wifi:
  networks:
    - ssid: !secret wifi_ssid
      password: !secret wifi_password
      
api:
  encryption:
    key: !secret haas_api


light:
  - platform: cwww
    name: 'CWWW Lamp'
    id: cwww_lamp
    cold_white: cool_pin
    warm_white: warm_pin
    cold_white_color_temperature: 6000 K
    warm_white_color_temperature: 3000 K 
    constant_brightness: true

binary_sensor:
   - platform: gpio
     pin: 
       number: 6
       mode: INPUT_PULLDOWN
     id: button_temp_up
     internal: false
     on_click:
       then:
         - if:
             condition:
               light.is_on: cwww_lamp
             then:
               - light.dim_relative:
                   id: cwww_lamp
                   relative_brightness: 0%
                   relative_color_temp: 10%
                   transition_length: 0.5s

   - platform: gpio
     pin: 
       number: 7
       mode: INPUT_PULLDOWN
    
     id: button_temp_down
     on_click:
       then:
         - if:
             condition:
               light.is_on: lamp_01
             then:
               - light.dim_relative:
                   id: cwww_lamp
                   relative_brightness: 0%
                   relative_color_temp: -10%
                   transition_length: 0.5s

output:
  - platform: rp2040_pwm
    pin: 10
    id: warm_pin
    frequency: 1000Hz
 
  - platform: rp2040_pwm
    pin: 21
    id: cool_pin
    frequency: 1000Hz

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
