### PR TITLE
Handle Nextion displays that are in Protocol Reparse Mode

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -46,7 +46,8 @@ bool Nextion::check_connect_() {
     this->reset_(false);
 
     this->ignore_is_setup_ = true;
-    this->send_command_("boguscommand=0");  // bogus command. needed sometimes after updating
+    this->send_command_("boguscommand=0");            // bogus command. needed sometimes after updating
+    this->send_command_("DRAKJHSUYDGBNCJHGJKSHBDN");  // escape Protocol Reparse mode if we're in it
     this->send_command_("connect");
 
     this->comok_sent_ = millis();
@@ -61,6 +62,11 @@ bool Nextion::check_connect_() {
   std::string response;
 
   this->recv_ret_string_(response, 0, false);
+  if (!response.empty() && response[0] == 0x1A) {
+    // Swallow invalid variable name responses that may be caused by the above commands
+    ESP_LOGD(TAG, "0x1A error ignored during setup");
+    return false;
+  }
   if (response.empty() || response.find("comok") == std::string::npos) {
 #ifdef NEXTION_PROTOCOL_LOG
     ESP_LOGN(TAG, "Bad connect request %s", response.c_str());


### PR DESCRIPTION
This is an update of https://github.com/esphome/esphome/pull/2956 (from @masto) as the proposed workaround in the comments there is not solving the problem in many cases and that PR is failing compiling since ESPHome v2023.6.0.

# What does this implement/fix?

If a Nextion display is in Protocol Reparse Mode, the standard communication protocol doesn't work, and it's necessary to send an escape sequence to get out of it.

This makes it possible to communicate with a Sonoff NSPanel (and presumably other devices in the same state).

Tip from fvanroie via
https://community.home-assistant.io/t/sonoff-nspanel-smart-scene-wall-switch-by-itead-coming-soon-on-kickstarter/332962/27

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Please take a look at #2956 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
