### PR TITLE
Climate control trigger, lambdas in binary sensor delay filters, deduplicator helper changes

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -138,35 +138,49 @@ FILTER_REGISTRY = Registry()
 validate_filters = cv.validate_registry("filter", FILTER_REGISTRY)
 
 
-@FILTER_REGISTRY.register("invert", InvertFilter, {})
+def register_filter(name, filter_type, schema):
+    return FILTER_REGISTRY.register(name, filter_type, schema)
+
+
+@register_filter("invert", InvertFilter, {})
 async def invert_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id)
 
 
-@FILTER_REGISTRY.register(
-    "delayed_on_off", DelayedOnOffFilter, cv.positive_time_period_milliseconds
+@register_filter(
+    "delayed_on_off",
+    DelayedOnOffFilter,
+    cv.templatable(cv.positive_time_period_milliseconds),
 )
 async def delayed_on_off_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
+    var = cg.new_Pvariable(filter_id)
     await cg.register_component(var, {})
+    template_ = await cg.templatable(config, [], cg.uint32)
+    cg.add(var.set_delay(template_))
     return var
 
 
-@FILTER_REGISTRY.register(
-    "delayed_on", DelayedOnFilter, cv.positive_time_period_milliseconds
+@register_filter(
+    "delayed_on", DelayedOnFilter, cv.templatable(cv.positive_time_period_milliseconds)
 )
 async def delayed_on_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
+    var = cg.new_Pvariable(filter_id)
     await cg.register_component(var, {})
+    template_ = await cg.templatable(config, [], cg.uint32)
+    cg.add(var.set_delay(template_))
     return var
 
 
-@FILTER_REGISTRY.register(
-    "delayed_off", DelayedOffFilter, cv.positive_time_period_milliseconds
+@register_filter(
+    "delayed_off",
+    DelayedOffFilter,
+    cv.templatable(cv.positive_time_period_milliseconds),
 )
 async def delayed_off_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
+    var = cg.new_Pvariable(filter_id)
     await cg.register_component(var, {})
+    template_ = await cg.templatable(config, [], cg.uint32)
+    cg.add(var.set_delay(template_))
     return var
 
 
@@ -178,7 +192,7 @@ DEFAULT_TIME_OFF = "100ms"
 DEFAULT_TIME_ON = "900ms"
 
 
-@FILTER_REGISTRY.register(
+@register_filter(
     "autorepeat",
     AutorepeatFilter,
     cv.All(
@@ -215,7 +229,7 @@ async def autorepeat_filter_to_code(config, filter_id):
     return var
 
 
-@FILTER_REGISTRY.register("lambda", LambdaFilter, cv.returning_lambda)
+@register_filter("lambda", LambdaFilter, cv.returning_lambda)
 async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(bool, "x")], return_type=cg.optional.template(bool)

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -26,22 +26,21 @@ void Filter::input(bool value, bool is_initial) {
   }
 }
 
-DelayedOnOffFilter::DelayedOnOffFilter(uint32_t delay) : delay_(delay) {}
 optional<bool> DelayedOnOffFilter::new_value(bool value, bool is_initial) {
+  uint32_t delay = this->delay_.value();
   if (value) {
-    this->set_timeout("ON_OFF", this->delay_, [this, is_initial]() { this->output(true, is_initial); });
+    this->set_timeout("ON_OFF", delay, [this, is_initial]() { this->output(true, is_initial); });
   } else {
-    this->set_timeout("ON_OFF", this->delay_, [this, is_initial]() { this->output(false, is_initial); });
+    this->set_timeout("ON_OFF", delay, [this, is_initial]() { this->output(false, is_initial); });
   }
   return {};
 }
 
 float DelayedOnOffFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-DelayedOnFilter::DelayedOnFilter(uint32_t delay) : delay_(delay) {}
 optional<bool> DelayedOnFilter::new_value(bool value, bool is_initial) {
   if (value) {
-    this->set_timeout("ON", this->delay_, [this, is_initial]() { this->output(true, is_initial); });
+    this->set_timeout("ON", this->delay_.value(), [this, is_initial]() { this->output(true, is_initial); });
     return {};
   } else {
     this->cancel_timeout("ON");
@@ -51,10 +50,9 @@ optional<bool> DelayedOnFilter::new_value(bool value, bool is_initial) {
 
 float DelayedOnFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-DelayedOffFilter::DelayedOffFilter(uint32_t delay) : delay_(delay) {}
 optional<bool> DelayedOffFilter::new_value(bool value, bool is_initial) {
   if (!value) {
-    this->set_timeout("OFF", this->delay_, [this, is_initial]() { this->output(false, is_initial); });
+    this->set_timeout("OFF", this->delay_.value(), [this, is_initial]() { this->output(false, is_initial); });
     return {};
   } else {
     this->cancel_timeout("OFF");

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
@@ -29,38 +30,38 @@ class Filter {
 
 class DelayedOnOffFilter : public Filter, public Component {
  public:
-  explicit DelayedOnOffFilter(uint32_t delay);
-
   optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
+  template<typename T> void set_delay(T delay) { this->delay_ = delay; }
+
  protected:
-  uint32_t delay_;
+  TemplatableValue<uint32_t> delay_{};
 };
 
 class DelayedOnFilter : public Filter, public Component {
  public:
-  explicit DelayedOnFilter(uint32_t delay);
-
   optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
+  template<typename T> void set_delay(T delay) { this->delay_ = delay; }
+
  protected:
-  uint32_t delay_;
+  TemplatableValue<uint32_t> delay_{};
 };
 
 class DelayedOffFilter : public Filter, public Component {
  public:
-  explicit DelayedOffFilter(uint32_t delay);
-
   optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
+  template<typename T> void set_delay(T delay) { this->delay_ = delay; }
+
  protected:
-  uint32_t delay_;
+  TemplatableValue<uint32_t> delay_{};
 };
 
 class InvertFilter : public Filter {

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -128,7 +128,9 @@ def single_visual_temperature(value):
 # Actions
 ControlAction = climate_ns.class_("ControlAction", automation.Action)
 StateTrigger = climate_ns.class_("StateTrigger", automation.Trigger.template())
-ControlTrigger = climate_ns.class_("ControlTrigger", automation.Trigger.template())
+ControlTrigger = climate_ns.class_(
+    "ControlTrigger", automation.Trigger.template(ClimateCall)
+)
 
 VISUAL_TEMPERATURE_STEP_SCHEMA = cv.Any(
     single_visual_temperature,
@@ -326,7 +328,7 @@ async def setup_climate_core_(var, config):
 
     for conf in config.get(CONF_ON_CONTROL, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_automation(trigger, [(ClimateCall, "x")], conf)
 
 
 async def register_climate(var, config):

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -129,7 +129,7 @@ def single_visual_temperature(value):
 ControlAction = climate_ns.class_("ControlAction", automation.Action)
 StateTrigger = climate_ns.class_("StateTrigger", automation.Trigger.template())
 ControlTrigger = climate_ns.class_(
-    "ControlTrigger", automation.Trigger.template(ClimateCall)
+    "ControlTrigger", automation.Trigger.template(ClimateCall.operator("ref"))
 )
 
 VISUAL_TEMPERATURE_STEP_SCHEMA = cv.Any(
@@ -328,7 +328,9 @@ async def setup_climate_core_(var, config):
 
     for conf in config.get(CONF_ON_CONTROL, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(ClimateCall, "x")], conf)
+        await automation.build_automation(
+            trigger, [(ClimateCall.operator("ref"), "x")], conf
+        )
 
 
 async def register_climate(var, config):

--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -42,10 +42,10 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
   Climate *climate_;
 };
 
-class ControlTrigger : public Trigger<> {
+class ControlTrigger : public Trigger<ClimateCall> {
  public:
   ControlTrigger(Climate *climate) {
-    climate->add_on_control_callback([this]() { this->trigger(); });
+    climate->add_on_control_callback([this](ClimateCall x) { this->trigger(x); });
   }
 };
 

--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -42,10 +42,10 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
   Climate *climate_;
 };
 
-class ControlTrigger : public Trigger<ClimateCall> {
+class ControlTrigger : public Trigger<ClimateCall &> {
  public:
   ControlTrigger(Climate *climate) {
-    climate->add_on_control_callback([this](ClimateCall x) { this->trigger(x); });
+    climate->add_on_control_callback([this](ClimateCall &x) { this->trigger(x); });
   }
 };
 

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -7,6 +7,7 @@ namespace climate {
 static const char *const TAG = "climate";
 
 void ClimateCall::perform() {
+  this->parent_->control_callback_.call(*this);
   ESP_LOGD(TAG, "'%s' - Setting", this->parent_->get_name().c_str());
   this->validate_();
   if (this->mode_.has_value()) {
@@ -44,7 +45,6 @@ void ClimateCall::perform() {
   if (this->target_temperature_high_.has_value()) {
     ESP_LOGD(TAG, "  Target Temperature High: %.2f", *this->target_temperature_high_);
   }
-  this->parent_->control_callback_.call(*this);
   this->parent_->control(*this);
 }
 void ClimateCall::validate_() {
@@ -304,7 +304,7 @@ void Climate::add_on_state_callback(std::function<void()> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 
-void Climate::add_on_control_callback(std::function<void(ClimateCall)> &&callback) {
+void Climate::add_on_control_callback(std::function<void(ClimateCall &)> &&callback) {
   this->control_callback_.add(std::move(callback));
 }
 

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -44,7 +44,7 @@ void ClimateCall::perform() {
   if (this->target_temperature_high_.has_value()) {
     ESP_LOGD(TAG, "  Target Temperature High: %.2f", *this->target_temperature_high_);
   }
-  this->parent_->control_callback_.call();
+  this->parent_->control_callback_.call(*this);
   this->parent_->control(*this);
 }
 void ClimateCall::validate_() {
@@ -304,7 +304,7 @@ void Climate::add_on_state_callback(std::function<void()> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 
-void Climate::add_on_control_callback(std::function<void()> &&callback) {
+void Climate::add_on_control_callback(std::function<void(ClimateCall)> &&callback) {
   this->control_callback_.add(std::move(callback));
 }
 

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -206,7 +206,7 @@ class Climate : public EntityBase {
    *
    * @param callback The callback to call.
    */
-  void add_on_control_callback(std::function<void()> &&callback);
+  void add_on_control_callback(std::function<void(ClimateCall)> &&callback);
 
   /** Make a climate device control call, this is used to control the climate device, see the ClimateCall description
    * for more info.
@@ -274,7 +274,7 @@ class Climate : public EntityBase {
   void dump_traits_(const char *tag);
 
   CallbackManager<void()> state_callback_{};
-  CallbackManager<void()> control_callback_{};
+  CallbackManager<void(ClimateCall)> control_callback_{};
   ESPPreferenceObject rtc_;
   optional<float> visual_min_temperature_override_{};
   optional<float> visual_max_temperature_override_{};

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -206,7 +206,7 @@ class Climate : public EntityBase {
    *
    * @param callback The callback to call.
    */
-  void add_on_control_callback(std::function<void(ClimateCall)> &&callback);
+  void add_on_control_callback(std::function<void(ClimateCall &)> &&callback);
 
   /** Make a climate device control call, this is used to control the climate device, see the ClimateCall description
    * for more info.
@@ -274,7 +274,7 @@ class Climate : public EntityBase {
   void dump_traits_(const char *tag);
 
   CallbackManager<void()> state_callback_{};
-  CallbackManager<void(ClimateCall)> control_callback_{};
+  CallbackManager<void(ClimateCall &)> control_callback_{};
   ESPPreferenceObject rtc_;
   optional<float> visual_min_temperature_override_{};
   optional<float> visual_max_temperature_override_{};

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1355,8 +1355,12 @@ binary_sensor:
     device_class: window
     filters:
       - invert:
+      - delayed_on_off: 40ms
       - delayed_on: 40ms
       - delayed_off: 40ms
+      - delayed_on_off: !lambda "return false;"
+      - delayed_on: !lambda "return false;"
+      - delayed_off: !lambda "return false;"
     on_press:
       then:
         - lambda: >-
@@ -2147,7 +2151,9 @@ climate:
     use_fahrenheit: true
   - platform: midea
     on_control:
-      logger.log: Control message received!
+      - logger.log: Control message received!
+      - lambda: |-
+          x.set_mode(CLIMATE_MODE_FAN_ONLY);
     on_state:
       logger.log: State changed!
     id: midea_unit

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1358,9 +1358,9 @@ binary_sensor:
       - delayed_on_off: 40ms
       - delayed_on: 40ms
       - delayed_off: 40ms
-      - delayed_on_off: !lambda "return false;"
-      - delayed_on: !lambda "return false;"
-      - delayed_off: !lambda "return false;"
+      - delayed_on_off: !lambda "return 10;"
+      - delayed_on: !lambda "return 1000;"
+      - delayed_off: !lambda "return 0;"
     on_press:
       then:
         - lambda: >-


### PR DESCRIPTION
# What does this implement/fix?

1. Lambda functions in a trigger `climate.on_control` now get a reference to the control object `ClimateCall`, which can be modified. It useful, for example, implement automatic condensate purge at shutdown.
```yaml
climate:
  - platform: ...
    on_control:
      - lambda: |-
          if (x.get_mode() != CLIMATE_MODE_OFF) {
              id(turnoff_script).stop();
              return;
          }
          if (id(condensate_sensor).state) {
              id(turnoff_script).execute();
              x.set_mode(CLIMATE_MODE_FAN_ONLY);
          }
```
2. Binary sensor delay filters now can be configured with template parameters similar to the `delay` action.
```yaml
binary_sensor:
  - platform: ...
    filters:
      - delayed_on_off: !lambda "return id(drying_delay).state * 1000;"
``` 
3. Changed the deduplicator class by applying the `optional<T>` class. Added a method `optional<std::pair<T, T>> next_change(const T &value)` for returning a optional pair of `(previous, current)` values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3030

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
