### PR TITLE
Update RP2040 Aruino framwork and platform to latest

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -62,19 +62,19 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
 # The default/recommended arduino framework version
 #  - https://github.com/earlephilhower/arduino-pico/releases
 #  - https://api.registry.platformio.org/v3/packages/earlephilhower/tool/framework-arduinopico
-RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(2, 6, 4)
+RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(3, 3, 0)
 
 # The platformio/raspberrypi version to use for arduino frameworks
 #  - https://github.com/platformio/platform-raspberrypi/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/platform/raspberrypi
-ARDUINO_PLATFORM_VERSION = cv.Version(1, 7, 0)
+ARDUINO_PLATFORM_VERSION = cv.Version(1, 9, 0)
 
 
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": (cv.Version(2, 6, 4), "https://github.com/earlephilhower/arduino-pico"),
-        "latest": (cv.Version(2, 6, 4), None),
+        "dev": (cv.Version(3, 3, 0), "https://github.com/earlephilhower/arduino-pico"),
+        "latest": (cv.Version(3, 3, 0), None),
         "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -157,7 +157,7 @@ board_build.filesystem_size = 0.5m
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 platform_packages =
     ; earlephilhower/framework-arduinopico@~1.20602.0 ; Cannot use the platformio package until old releases stop getting deleted
-    earlephilhower/framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/2.6.2/rp2040-2.6.2.zip
+    earlephilhower/framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/3.3.0/rp2040-3.3.0.zip
 
 framework = arduino
 lib_deps =


### PR DESCRIPTION
# What does this implement/fix?

Update RP2040 Arduino framework to 3.3.0 and Arduino platform to 1.9.0

Arduino platform changelogs:
- [1.8.0](https://github.com/platformio/platform-raspberrypi/releases/tag/v1.8.0)
- [1.9.0](https://github.com/platformio/platform-raspberrypi/releases/tag/v1.9.0)

Arduino framework changelogs:
- [2.7.0](https://github.com/earlephilhower/arduino-pico/releases/tag/2.7.0)
- [3.0.0](https://github.com/earlephilhower/arduino-pico/releases/tag/3.0.0)
- [3.1.0](https://github.com/earlephilhower/arduino-pico/releases/tag/3.1.0)
- [3.2.0](https://github.com/earlephilhower/arduino-pico/releases/tag/3.2.0)
- [3.3.0](https://github.com/earlephilhower/arduino-pico/releases/tag/3.3.0)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
