### PR TITLE
Fix binary_sensor initial state filters bug

### DIFF
--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -23,6 +23,8 @@ void Filter::input(bool value, bool is_initial) {
   auto b = this->new_value(value, is_initial);
   if (b.has_value()) {
     this->output(*b, is_initial);
+  } else if (is_initial) {
+    this->parent_->send_state_internal(value, is_initial);
   }
 }
 

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -6,11 +6,21 @@ namespace template_ {
 
 static const char *const TAG = "template.binary_sensor";
 
-void TemplateBinarySensor::loop() {
-  if (!this->f_.has_value())
+void TemplateBinarySensor::setup() {
+  if (!this->publish_initial_state_)
     return;
 
-  auto s = (*this->f_)();
+  if (this->f_ != nullptr) {
+    this->publish_initial_state(this->f_().value_or(false));
+  } else {
+    this->publish_initial_state(false);
+  }
+}
+void TemplateBinarySensor::loop() {
+  if (this->f_ == nullptr)
+    return;
+
+  auto s = this->f_();
   if (s.has_value()) {
     this->publish_state(*s);
   }

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -10,13 +10,14 @@ class TemplateBinarySensor : public Component, public binary_sensor::BinarySenso
  public:
   void set_template(std::function<optional<bool>()> &&f) { this->f_ = f; }
 
+  void setup() override;
   void loop() override;
   void dump_config() override;
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
  protected:
-  optional<std::function<optional<bool>()>> f_{};
+  std::function<optional<bool>()> f_{nullptr};
 };
 
 }  // namespace template_


### PR DESCRIPTION
# What does this implement/fix?

1. Fixed operation of the `publish_initial_state` option for `binary_sensor` when using filters;
2. Fixed/implemented support for this option for template `binary_sensor` component;
3. `optional<T>` has been replaced with a null pointer in template `binary_sensor` component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
