### PR TITLE
[ILI9xxx] Add ili9488_a (alternative gamma configuration for ILI9488)

### DIFF
--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -43,6 +43,7 @@ MODELS = {
     "ILI9481": ili9XXX_ns.class_("ILI9XXXILI9481", ili9XXXSPI),
     "ILI9486": ili9XXX_ns.class_("ILI9XXXILI9486", ili9XXXSPI),
     "ILI9488": ili9XXX_ns.class_("ILI9XXXILI9488", ili9XXXSPI),
+    "ILI9488_A": ili9XXX_ns.class_("ILI9XXXILI9488_A", ili9XXXSPI),
     "ST7796": ili9XXX_ns.class_("ILI9XXXST7796", ili9XXXSPI),
     "S3BOX": ili9XXX_ns.class_("ILI9XXXS3Box", ili9XXXSPI),
     "S3BOX_LITE": ili9XXX_ns.class_("ILI9XXXS3BoxLite", ili9XXXSPI),

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -43,7 +43,7 @@ MODELS = {
     "ILI9481": ili9XXX_ns.class_("ILI9XXXILI9481", ili9XXXSPI),
     "ILI9486": ili9XXX_ns.class_("ILI9XXXILI9486", ili9XXXSPI),
     "ILI9488": ili9XXX_ns.class_("ILI9XXXILI9488", ili9XXXSPI),
-    "ILI9488_A": ili9XXX_ns.class_("ILI9XXXILI9488_A", ili9XXXSPI),
+    "ILI9488_A": ili9XXX_ns.class_("ILI9XXXILI9488A", ili9XXXSPI),
     "ST7796": ili9XXX_ns.class_("ILI9XXXST7796", ili9XXXSPI),
     "S3BOX": ili9XXX_ns.class_("ILI9XXXS3Box", ili9XXXSPI),
     "S3BOX_LITE": ili9XXX_ns.class_("ILI9XXXS3BoxLite", ili9XXXSPI),

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -411,6 +411,17 @@ void ILI9XXXILI9488::initialize() {
   this->is_18bitdisplay_ = true;
 }
 //    40_TFT display
+void ILI9XXXILI9488_A::initialize() {
+  this->init_lcd_(INITCMD_ILI9488_A);
+  if (this->width_ == 0) {
+    this->width_ = 480;
+  }
+  if (this->height_ == 0) {
+    this->height_ = 320;
+  }
+  this->is_18bitdisplay_ = true;
+}
+//    40_TFT display
 void ILI9XXXST7796::initialize() {
   this->init_lcd_(INITCMD_ST7796);
   if (this->width_ == 0) {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -411,7 +411,7 @@ void ILI9XXXILI9488::initialize() {
   this->is_18bitdisplay_ = true;
 }
 //    40_TFT display
-void ILI9XXXILI9488_A::initialize() {
+void ILI9XXXILI9488A::initialize() {
   this->init_lcd_(INITCMD_ILI9488_A);
   if (this->width_ == 0) {
     this->width_ = 480;

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -129,7 +129,7 @@ class ILI9XXXILI9488 : public ILI9XXXDisplay {
 };
 
 //-----------   ILI9XXX_35_TFT origin colors rotated display --------------
-class ILI9XXXILI9488_A : public ILI9XXXDisplay {
+class ILI9XXXILI9488A : public ILI9XXXDisplay {
  protected:
   void initialize() override;
 };

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -128,6 +128,12 @@ class ILI9XXXILI9488 : public ILI9XXXDisplay {
   void initialize() override;
 };
 
+//-----------   ILI9XXX_35_TFT origin colors rotated display --------------
+class ILI9XXXILI9488_A : public ILI9XXXDisplay {
+ protected:
+  void initialize() override;
+};
+
 //-----------   ILI9XXX_35_TFT rotated display --------------
 class ILI9XXXST7796 : public ILI9XXXDisplay {
  protected:

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -149,6 +149,40 @@ static const uint8_t PROGMEM INITCMD_ILI9488[] = {
   0x00 // end
 };
 
+static const uint8_t PROGMEM INITCMD_ILI9488_A[] = {
+  ILI9XXX_GMCTRP1,15, 0x00, 0x03, 0x09, 0x08, 0x16, 0x0A, 0x3F, 0x78, 0x4C, 0x09, 0x0A, 0x08, 0x16, 0x1A, 0x0F,
+  ILI9XXX_GMCTRN1,15, 0x00, 0x16, 0x19, 0x03, 0x0F, 0x05, 0x32, 0x45, 0x46, 0x04, 0x0E, 0x0D, 0x35, 0x37, 0x0F,
+
+  ILI9XXX_PWCTR1,  2, 0x17, 0x15,  // VRH1 VRH2
+  ILI9XXX_PWCTR2,  1, 0x41,  // VGH, VGL
+  ILI9XXX_VMCTR1,  3, 0x00, 0x12, 0x80,    // nVM VCM_REG VCM_REG_EN
+
+  ILI9XXX_IFMODE,  1, 0x00,
+  ILI9XXX_FRMCTR1, 1, 0xA0,  // Frame rate = 60Hz
+  ILI9XXX_INVCTR,  1, 0x02,  // Display Inversion Control = 2dot
+
+  ILI9XXX_DFUNCTR, 2, 0x02, 0x02, // Nomal scan
+
+  0xE9, 1, 0x00,   // Set Image Functio. Disable 24 bit data
+
+  ILI9XXX_ADJCTL3, 4, 0xA9, 0x51, 0x2C, 0x82,  // Adjust Control 3
+
+  ILI9XXX_MADCTL,  1, 0x28,
+  //ILI9XXX_PIXFMT,  1, 0x55,  // Interface Pixel Format = 16bit
+  ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
+
+
+
+  // 5 frames
+  //ILI9XXX_ETMOD,   1, 0xC6,  //
+
+
+  ILI9XXX_SLPOUT,  0x80,    // Exit sleep mode
+  //ILI9XXX_INVON  , 0,
+  ILI9XXX_DISPON,  0x80,    // Set display on
+  0x00 // end
+};
+
 static const uint8_t PROGMEM INITCMD_ST7796[] = {
   // This ST7796S initilization routine was copied from https://github.com/prenticedavid/Adafruit_ST7796S_kbv/blob/master/Adafruit_ST7796S_kbv.cpp
   ILI9XXX_SWRESET, 0x80,         // Soft reset, then delay 150 ms


### PR DESCRIPTION
# What does this implement/fix?

Add model "ili9488_A" so that some screens that had the correct colors before PR #4849 can continue to work as before.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4603

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/3031

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: ili9xxx
    model: ili9488_A
    id: my_display
    cs_pin: GPIO14
    dc_pin: 10
    reset_pin: 9
    spi_id: spi_display
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
