### PR TITLE
climate triggers Climate and ClimateCall references

### DIFF
--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -127,8 +127,12 @@ def single_visual_temperature(value):
 
 # Actions
 ControlAction = climate_ns.class_("ControlAction", automation.Action)
-StateTrigger = climate_ns.class_("StateTrigger", automation.Trigger.template())
-ControlTrigger = climate_ns.class_("ControlTrigger", automation.Trigger.template())
+StateTrigger = climate_ns.class_(
+    "StateTrigger", automation.Trigger.template(Climate.operator("ref"))
+)
+ControlTrigger = climate_ns.class_(
+    "ControlTrigger", automation.Trigger.template(ClimateCall.operator("ref"))
+)
 
 VISUAL_TEMPERATURE_STEP_SCHEMA = cv.Any(
     single_visual_temperature,
@@ -322,11 +326,15 @@ async def setup_climate_core_(var, config):
 
     for conf in config.get(CONF_ON_STATE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_automation(
+            trigger, [(Climate.operator("ref"), "x")], conf
+        )
 
     for conf in config.get(CONF_ON_CONTROL, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_automation(
+            trigger, [(ClimateCall.operator("ref"), "x")], conf
+        )
 
 
 async def register_climate(var, config):

--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -42,17 +42,17 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
   Climate *climate_;
 };
 
-class ControlTrigger : public Trigger<> {
+class ControlTrigger : public Trigger<ClimateCall &> {
  public:
   ControlTrigger(Climate *climate) {
-    climate->add_on_control_callback([this]() { this->trigger(); });
+    climate->add_on_control_callback([this](ClimateCall &x) { this->trigger(x); });
   }
 };
 
-class StateTrigger : public Trigger<> {
+class StateTrigger : public Trigger<Climate &> {
  public:
   StateTrigger(Climate *climate) {
-    climate->add_on_state_callback([this]() { this->trigger(); });
+    climate->add_on_state_callback([this](Climate &x) { this->trigger(x); });
   }
 };
 

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -7,6 +7,7 @@ namespace climate {
 static const char *const TAG = "climate";
 
 void ClimateCall::perform() {
+  this->parent_->control_callback_.call(*this);
   ESP_LOGD(TAG, "'%s' - Setting", this->parent_->get_name().c_str());
   this->validate_();
   if (this->mode_.has_value()) {
@@ -44,7 +45,6 @@ void ClimateCall::perform() {
   if (this->target_temperature_high_.has_value()) {
     ESP_LOGD(TAG, "  Target Temperature High: %.2f", *this->target_temperature_high_);
   }
-  this->parent_->control_callback_.call();
   this->parent_->control(*this);
 }
 void ClimateCall::validate_() {
@@ -300,11 +300,11 @@ ClimateCall &ClimateCall::set_swing_mode(optional<ClimateSwingMode> swing_mode) 
   return *this;
 }
 
-void Climate::add_on_state_callback(std::function<void()> &&callback) {
+void Climate::add_on_state_callback(std::function<void(Climate &)> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 
-void Climate::add_on_control_callback(std::function<void()> &&callback) {
+void Climate::add_on_control_callback(std::function<void(ClimateCall &)> &&callback) {
   this->control_callback_.add(std::move(callback));
 }
 
@@ -408,7 +408,7 @@ void Climate::publish_state() {
   }
 
   // Send state to frontend
-  this->state_callback_.call();
+  this->state_callback_.call(*this);
   // Save state
   this->save_state_();
 }

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -198,7 +198,7 @@ class Climate : public EntityBase {
    *
    * @param callback The callback to call.
    */
-  void add_on_state_callback(std::function<void()> &&callback);
+  void add_on_state_callback(std::function<void(Climate &)> &&callback);
 
   /**
    * Add a callback for the climate device configuration; each time the configuration parameters of a climate device
@@ -206,7 +206,7 @@ class Climate : public EntityBase {
    *
    * @param callback The callback to call.
    */
-  void add_on_control_callback(std::function<void()> &&callback);
+  void add_on_control_callback(std::function<void(ClimateCall &)> &&callback);
 
   /** Make a climate device control call, this is used to control the climate device, see the ClimateCall description
    * for more info.
@@ -273,8 +273,8 @@ class Climate : public EntityBase {
 
   void dump_traits_(const char *tag);
 
-  CallbackManager<void()> state_callback_{};
-  CallbackManager<void()> control_callback_{};
+  CallbackManager<void(Climate &)> state_callback_{};
+  CallbackManager<void(ClimateCall &)> control_callback_{};
   ESPPreferenceObject rtc_;
   optional<float> visual_min_temperature_override_{};
   optional<float> visual_max_temperature_override_{};

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -216,7 +216,7 @@ void MQTTClimateComponent::setup() {
     });
   }
 
-  this->device_->add_on_state_callback([this]() { this->publish_state_(); });
+  this->device_->add_on_state_callback([this](Climate & /*unused*/) { this->publish_state_(); });
 }
 MQTTClimateComponent::MQTTClimateComponent(Climate *device) : device_(device) {}
 bool MQTTClimateComponent::send_initial_state() { return this->publish_state_(); }

--- a/esphome/core/controller.cpp
+++ b/esphome/core/controller.cpp
@@ -50,7 +50,7 @@ void Controller::setup_controller(bool include_internal) {
 #ifdef USE_CLIMATE
   for (auto *obj : App.get_climates()) {
     if (include_internal || !obj->is_internal())
-      obj->add_on_state_callback([this, obj]() { this->on_climate_update(obj); });
+      obj->add_on_state_callback([this, obj](climate::Climate & /*unused*/) { this->on_climate_update(obj); });
   }
 #endif
 #ifdef USE_NUMBER

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2147,9 +2147,14 @@ climate:
     use_fahrenheit: true
   - platform: midea
     on_control:
-      logger.log: Control message received!
+      - logger.log: Control message received!
+      - lambda: |-
+          x.set_mode(CLIMATE_MODE_FAN_ONLY);
     on_state:
-      logger.log: State changed!
+      - logger.log: State changed!
+      - lambda: |-
+          if (x.mode == CLIMATE_MODE_FAN_ONLY)
+            id(binary_sensor1).publish_state(true);
     id: midea_unit
     uart_id: uart_0
     name: Midea Climate


### PR DESCRIPTION
# What does this implement/fix?

1. Lambda functions in a trigger `climate.on_control` now get a reference to the control object `ClimateCall`, which can be modified. It useful, for example, implement automatic condensate purge at shutdown.
2. Lambda functions in a trigger `climate.on_state` now get a reference to the `Climate`. It makes properties access shorter.

```yaml
climate:
  - platform: ...
    on_control:
      - lambda: |-
          if (x.get_mode() != CLIMATE_MODE_OFF) {
              id(turnoff_script).stop();
              return;
          }
          if (id(condensate_sensor).state) {
              id(turnoff_script).execute();
              x.set_mode(CLIMATE_MODE_FAN_ONLY);
          }
    on_state:
      - lambda: |-
          if (x.mode == CLIMATE_MODE_FAN_ONLY)
            id(binary_sensor1).publish_state(true);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3033

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
