### PR TITLE
binary_sensor filters templatable delays

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -138,35 +138,49 @@ FILTER_REGISTRY = Registry()
 validate_filters = cv.validate_registry("filter", FILTER_REGISTRY)
 
 
-@FILTER_REGISTRY.register("invert", InvertFilter, {})
+def register_filter(name, filter_type, schema):
+    return FILTER_REGISTRY.register(name, filter_type, schema)
+
+
+@register_filter("invert", InvertFilter, {})
 async def invert_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id)
 
 
-@FILTER_REGISTRY.register(
-    "delayed_on_off", DelayedOnOffFilter, cv.positive_time_period_milliseconds
+@register_filter(
+    "delayed_on_off",
+    DelayedOnOffFilter,
+    cv.templatable(cv.positive_time_period_milliseconds),
 )
 async def delayed_on_off_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
+    var = cg.new_Pvariable(filter_id)
     await cg.register_component(var, {})
+    template_ = await cg.templatable(config, [], cg.uint32)
+    cg.add(var.set_delay(template_))
     return var
 
 
-@FILTER_REGISTRY.register(
-    "delayed_on", DelayedOnFilter, cv.positive_time_period_milliseconds
+@register_filter(
+    "delayed_on", DelayedOnFilter, cv.templatable(cv.positive_time_period_milliseconds)
 )
 async def delayed_on_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
+    var = cg.new_Pvariable(filter_id)
     await cg.register_component(var, {})
+    template_ = await cg.templatable(config, [], cg.uint32)
+    cg.add(var.set_delay(template_))
     return var
 
 
-@FILTER_REGISTRY.register(
-    "delayed_off", DelayedOffFilter, cv.positive_time_period_milliseconds
+@register_filter(
+    "delayed_off",
+    DelayedOffFilter,
+    cv.templatable(cv.positive_time_period_milliseconds),
 )
 async def delayed_off_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
+    var = cg.new_Pvariable(filter_id)
     await cg.register_component(var, {})
+    template_ = await cg.templatable(config, [], cg.uint32)
+    cg.add(var.set_delay(template_))
     return var
 
 
@@ -178,7 +192,7 @@ DEFAULT_TIME_OFF = "100ms"
 DEFAULT_TIME_ON = "900ms"
 
 
-@FILTER_REGISTRY.register(
+@register_filter(
     "autorepeat",
     AutorepeatFilter,
     cv.All(
@@ -215,7 +229,7 @@ async def autorepeat_filter_to_code(config, filter_id):
     return var
 
 
-@FILTER_REGISTRY.register("lambda", LambdaFilter, cv.returning_lambda)
+@register_filter("lambda", LambdaFilter, cv.returning_lambda)
 async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(bool, "x")], return_type=cg.optional.template(bool)

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -27,11 +27,10 @@ void Filter::input(bool value, bool is_initial) {
 }
 
 optional<bool> DelayedOnOffFilter::new_value(bool value, bool is_initial) {
-  uint32_t delay = this->delay_.value();
   if (value) {
-    this->set_timeout("ON_OFF", delay, [this, is_initial]() { this->output(true, is_initial); });
+    this->set_timeout("ON_OFF", this->on_delay_.value(), [this, is_initial]() { this->output(true, is_initial); });
   } else {
-    this->set_timeout("ON_OFF", delay, [this, is_initial]() { this->output(false, is_initial); });
+    this->set_timeout("ON_OFF", this->off_delay_.value(), [this, is_initial]() { this->output(false, is_initial); });
   }
   return {};
 }

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -26,22 +26,21 @@ void Filter::input(bool value, bool is_initial) {
   }
 }
 
-DelayedOnOffFilter::DelayedOnOffFilter(uint32_t delay) : delay_(delay) {}
 optional<bool> DelayedOnOffFilter::new_value(bool value, bool is_initial) {
+  uint32_t delay = this->delay_.value();
   if (value) {
-    this->set_timeout("ON_OFF", this->delay_, [this, is_initial]() { this->output(true, is_initial); });
+    this->set_timeout("ON_OFF", delay, [this, is_initial]() { this->output(true, is_initial); });
   } else {
-    this->set_timeout("ON_OFF", this->delay_, [this, is_initial]() { this->output(false, is_initial); });
+    this->set_timeout("ON_OFF", delay, [this, is_initial]() { this->output(false, is_initial); });
   }
   return {};
 }
 
 float DelayedOnOffFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-DelayedOnFilter::DelayedOnFilter(uint32_t delay) : delay_(delay) {}
 optional<bool> DelayedOnFilter::new_value(bool value, bool is_initial) {
   if (value) {
-    this->set_timeout("ON", this->delay_, [this, is_initial]() { this->output(true, is_initial); });
+    this->set_timeout("ON", this->delay_.value(), [this, is_initial]() { this->output(true, is_initial); });
     return {};
   } else {
     this->cancel_timeout("ON");
@@ -51,10 +50,9 @@ optional<bool> DelayedOnFilter::new_value(bool value, bool is_initial) {
 
 float DelayedOnFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-DelayedOffFilter::DelayedOffFilter(uint32_t delay) : delay_(delay) {}
 optional<bool> DelayedOffFilter::new_value(bool value, bool is_initial) {
   if (!value) {
-    this->set_timeout("OFF", this->delay_, [this, is_initial]() { this->output(false, is_initial); });
+    this->set_timeout("OFF", this->delay_.value(), [this, is_initial]() { this->output(false, is_initial); });
     return {};
   } else {
     this->cancel_timeout("OFF");

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
@@ -29,38 +30,38 @@ class Filter {
 
 class DelayedOnOffFilter : public Filter, public Component {
  public:
-  explicit DelayedOnOffFilter(uint32_t delay);
-
   optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
+  template<typename T> void set_delay(T delay) { this->delay_ = delay; }
+
  protected:
-  uint32_t delay_;
+  TemplatableValue<uint32_t> delay_{};
 };
 
 class DelayedOnFilter : public Filter, public Component {
  public:
-  explicit DelayedOnFilter(uint32_t delay);
-
   optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
+  template<typename T> void set_delay(T delay) { this->delay_ = delay; }
+
  protected:
-  uint32_t delay_;
+  TemplatableValue<uint32_t> delay_{};
 };
 
 class DelayedOffFilter : public Filter, public Component {
  public:
-  explicit DelayedOffFilter(uint32_t delay);
-
   optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
+  template<typename T> void set_delay(T delay) { this->delay_ = delay; }
+
  protected:
-  uint32_t delay_;
+  TemplatableValue<uint32_t> delay_{};
 };
 
 class InvertFilter : public Filter {

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -34,10 +34,12 @@ class DelayedOnOffFilter : public Filter, public Component {
 
   float get_setup_priority() const override;
 
-  template<typename T> void set_delay(T delay) { this->delay_ = delay; }
+  template<typename T> void set_on_delay(T delay) { this->on_delay_ = delay; }
+  template<typename T> void set_off_delay(T delay) { this->off_delay_ = delay; }
 
  protected:
-  TemplatableValue<uint32_t> delay_{};
+  TemplatableValue<uint32_t> on_delay_{};
+  TemplatableValue<uint32_t> off_delay_{};
 };
 
 class DelayedOnFilter : public Filter, public Component {

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1356,6 +1356,9 @@ binary_sensor:
     filters:
       - invert:
       - delayed_on_off: 40ms
+      - delayed_on_off:
+          time_on: 10s
+          time_off: !lambda "return 1000;"
       - delayed_on: 40ms
       - delayed_off: 40ms
       - delayed_on_off: !lambda "return 10;"

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1355,8 +1355,12 @@ binary_sensor:
     device_class: window
     filters:
       - invert:
+      - delayed_on_off: 40ms
       - delayed_on: 40ms
       - delayed_off: 40ms
+      - delayed_on_off: !lambda "return 10;"
+      - delayed_on: !lambda "return 1000;"
+      - delayed_off: !lambda "return 0;"
     on_press:
       then:
         - lambda: >-


### PR DESCRIPTION
# What does this implement/fix?

1. Binary sensors delay filters can be configured with template parameters similar to the `delay` action:

```yaml
binary_sensor:
  - platform: ...
    filters:
      - delayed_on_off: !lambda "return id(drying_delay).state * 1000;"
      - delayed_on: !lambda "return 1000;"
      - delayed_off: !lambda "return 2000;"
``` 

2. `delayed_on_off` filter *can* take the turn-on and turn-off delay times as separate parameters `time_on` and `time_off` if required, which is simply irreplaceable for many automations (it is impossible to replace it with a chain of `delayed_on` and `delayed_off`). Of course, backward compatibility is preserved. Moreover, the old one-line notation is shorter and it is better to use it if the delays are the same.

```yaml
binary_sensor:
  - platform: ...
    filters:
      - delayed_on_off:
          time_on: 2min
          time_off: !lambda "return id(drying_delay).state * 1000;"
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3034

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
