### PR TITLE
fix template binary_sensor publish_initial_state option

### DIFF
--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -6,11 +6,21 @@ namespace template_ {
 
 static const char *const TAG = "template.binary_sensor";
 
-void TemplateBinarySensor::loop() {
-  if (!this->f_.has_value())
+void TemplateBinarySensor::setup() {
+  if (!this->publish_initial_state_)
     return;
 
-  auto s = (*this->f_)();
+  if (this->f_ != nullptr) {
+    this->publish_initial_state(this->f_().value_or(false));
+  } else {
+    this->publish_initial_state(false);
+  }
+}
+void TemplateBinarySensor::loop() {
+  if (this->f_ == nullptr)
+    return;
+
+  auto s = this->f_();
   if (s.has_value()) {
     this->publish_state(*s);
   }

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -11,7 +11,7 @@ void TemplateBinarySensor::setup() {
     return;
 
   if (this->f_ != nullptr) {
-    this->publish_initial_state(this->f_().value_or(false));
+    this->publish_initial_state(*this->f_());
   } else {
     this->publish_initial_state(false);
   }

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -10,13 +10,14 @@ class TemplateBinarySensor : public Component, public binary_sensor::BinarySenso
  public:
   void set_template(std::function<optional<bool>()> &&f) { this->f_ = f; }
 
+  void setup() override;
   void loop() override;
   void dump_config() override;
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
  protected:
-  optional<std::function<optional<bool>()>> f_{};
+  std::function<optional<bool>()> f_{nullptr};
 };
 
 }  // namespace template_


### PR DESCRIPTION
# What does this implement/fix?

1. Fixed/implemented support for `publish_initial_state` option;
2. Template class `optional<T>` has been replaced with a `nullptr`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
binary_sensor:
  - platform: template
    id: condensate_sensor
    publish_initial_state: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
