### PR TITLE
Version bump for ESP32 IDF and Arduino

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -163,23 +163,23 @@ RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(2, 0, 5)
 # The platformio/espressif32 version to use for arduino frameworks
 #  - https://github.com/platformio/platform-espressif32/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/platform/espressif32
-ARDUINO_PLATFORM_VERSION = cv.Version(5, 3, 0)
+ARDUINO_PLATFORM_VERSION = cv.Version(5, 4, 0)
 
 # The default/recommended esp-idf framework version
 #  - https://github.com/espressif/esp-idf/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
-RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(4, 4, 4)
+RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(4, 4, 5)
 # The platformio/espressif32 version to use for esp-idf frameworks
 #  - https://github.com/platformio/platform-espressif32/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/platform/espressif32
-ESP_IDF_PLATFORM_VERSION = cv.Version(5, 3, 0)
+ESP_IDF_PLATFORM_VERSION = cv.Version(5, 4, 0)
 
 
 def _arduino_check_versions(value):
     value = value.copy()
     lookups = {
         "dev": (cv.Version(2, 1, 0), "https://github.com/espressif/arduino-esp32.git"),
-        "latest": (cv.Version(2, 0, 7), None),
+        "latest": (cv.Version(2, 0, 9), None),
         "recommended": (RECOMMENDED_ARDUINO_FRAMEWORK_VERSION, None),
     }
 
@@ -214,7 +214,7 @@ def _esp_idf_check_versions(value):
     value = value.copy()
     lookups = {
         "dev": (cv.Version(5, 1, 0), "https://github.com/espressif/esp-idf.git"),
-        "latest": (cv.Version(5, 0, 1), None),
+        "latest": (cv.Version(5, 1, 0), None),
         "recommended": (RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION, None),
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -104,7 +104,7 @@ extra_scripts = post:esphome/components/esp8266/post_build.py.script
 ; This are common settings for the ESP32 (all variants) using Arduino.
 [common:esp32-arduino]
 extends = common:arduino
-platform = platformio/espressif32@5.3.0
+platform = platformio/espressif32@5.4.0
 platform_packages =
     platformio/framework-arduinoespressif32@~3.20005.0
 
@@ -133,9 +133,9 @@ extra_scripts = post:esphome/components/esp32/post_build.py.script
 ; This are common settings for the ESP32 (all variants) using IDF.
 [common:esp32-idf]
 extends = common:idf
-platform = platformio/espressif32@5.3.0
+platform = platformio/espressif32@5.4.0
 platform_packages =
-    platformio/framework-espidf@~3.40404.0
+    platformio/framework-espidf@~3.40405.0
 
 framework = espidf
 lib_deps =


### PR DESCRIPTION
# What does this implement/fix?

Version bump for Platformio, IDF and Arduino for ESP32
Arduino/idf platform changelog:
- [5.4.0](https://github.com/platformio/platform-espressif32/releases/tag/v5.4.0)

Idf framework changelog:
- [4.4.5](https://github.com/espressif/esp-idf/releases/tag/v4.4.5)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
