### PR TITLE
Fix binary_sensor initial publish

### DIFF
--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -21,7 +21,7 @@ void Filter::output(bool value, bool is_initial) {
 }
 void Filter::input(bool value, bool is_initial) {
   auto b = this->new_value(value, is_initial);
-  if (b.has_value()) {
+  if (b.has_value() | !this->dedup_.has_value()) {
     this->output(*b, is_initial);
   }
 }

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -22,7 +22,7 @@ void Filter::output(bool value, bool is_initial) {
 void Filter::input(bool value, bool is_initial) {
   auto b = this->new_value(value, is_initial);
   if (b.has_value() || !this->dedup_.has_value()) {
-    this->output(*b, is_initial);
+    this->output(b.value_or(false), is_initial);
   }
 }
 

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -21,7 +21,7 @@ void Filter::output(bool value, bool is_initial) {
 }
 void Filter::input(bool value, bool is_initial) {
   auto b = this->new_value(value, is_initial);
-  if (b.has_value() | !this->dedup_.has_value()) {
+  if (b.has_value() || !this->dedup_.has_value()) {
     this->output(*b, is_initial);
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes an error in the initial publication of the state of the binary sensor during the use of filters.

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2537

https://community.home-assistant.io/t/esphome-fails-to-update-sensor-state-in-ha-when-using-4-second-delay-filters-workaround/347541

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
