### PR TITLE
binary_sensor removed unused filter

### DIFF
--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -114,15 +114,6 @@ LambdaFilter::LambdaFilter(std::function<optional<bool>(bool)> f) : f_(std::move
 
 optional<bool> LambdaFilter::new_value(bool value, bool is_initial) { return this->f_(value); }
 
-optional<bool> UniqueFilter::new_value(bool value, bool is_initial) {
-  if (this->last_value_.has_value() && *this->last_value_ == value) {
-    return {};
-  } else {
-    this->last_value_ = value;
-    return value;
-  }
-}
-
 }  // namespace binary_sensor
 
 }  // namespace esphome

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -105,14 +105,6 @@ class LambdaFilter : public Filter {
   std::function<optional<bool>(bool)> f_;
 };
 
-class UniqueFilter : public Filter {
- public:
-  optional<bool> new_value(bool value, bool is_initial) override;
-
- protected:
-  optional<bool> last_value_{};
-};
-
 }  // namespace binary_sensor
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Removed the unused and essentially unnecessary `UniqueFilter`. Its function is performed by a deduplicator.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
