### PR TITLE
Add alarm to reserved ids

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -108,6 +108,7 @@ ROOT_CONFIG_PATH = object()
 
 RESERVED_IDS = [
     # C++ keywords http://en.cppreference.com/w/cpp/keyword
+    "alarm",
     "alignas",
     "alignof",
     "and",


### PR DESCRIPTION
# What does this implement/fix?

Add `alarm` to `RESERVED_IDS` as somewhere in the PlatformIO xtensa toolchain for ESP32 `alarm` is defined and if you use that as an id then you get compilation errors...
```
src/main.cpp:21:39: error: 'esphome::template_::TemplateAlarmControlPanel* alarm' redeclared as different kind of symbol
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

fixes esphome/issues#4636

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
