### PR TITLE
Preparing color.h for IDF >= 5

### DIFF
--- a/esphome/components/addressable_light/addressable_light_display.cpp
+++ b/esphome/components/addressable_light/addressable_light_display.cpp
@@ -52,7 +52,7 @@ void AddressableLightDisplay::display() {
   }
 }
 
-void HOT AddressableLightDisplay::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT AddressableLightDisplay::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
 

--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -47,7 +47,7 @@ class AddressableLightDisplay : public display::DisplayBuffer, public PollingCom
  protected:
   int get_width_internal() override;
   int get_height_internal() override;
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
   void update() override;
 
   light::LightState *light_state_;

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -12,10 +12,10 @@ static const char *const TAG = "display";
 const Color COLOR_OFF(0, 0, 0, 0);
 const Color COLOR_ON(255, 255, 255, 255);
 
-void Display::fill(Color color) { this->filled_rectangle(0, 0, this->get_width(), this->get_height(), color); }
+void Display::fill(const Color &color) { this->filled_rectangle(0, 0, this->get_width(), this->get_height(), color); }
 void Display::clear() { this->fill(COLOR_OFF); }
 void Display::set_rotation(DisplayRotation rotation) { this->rotation_ = rotation; }
-void HOT Display::line(int x1, int y1, int x2, int y2, Color color) {
+void HOT Display::line(int x1, int y1, int x2, int y2, const Color &color) {
   const int32_t dx = abs(x2 - x1), sx = x1 < x2 ? 1 : -1;
   const int32_t dy = -abs(y2 - y1), sy = y1 < y2 ? 1 : -1;
   int32_t err = dx + dy;
@@ -35,29 +35,29 @@ void HOT Display::line(int x1, int y1, int x2, int y2, Color color) {
     }
   }
 }
-void HOT Display::horizontal_line(int x, int y, int width, Color color) {
+void HOT Display::horizontal_line(int x, int y, int width, const Color &color) {
   // Future: Could be made more efficient by manipulating buffer directly in certain rotations.
   for (int i = x; i < x + width; i++)
     this->draw_pixel_at(i, y, color);
 }
-void HOT Display::vertical_line(int x, int y, int height, Color color) {
+void HOT Display::vertical_line(int x, int y, int height, const Color &color) {
   // Future: Could be made more efficient by manipulating buffer directly in certain rotations.
   for (int i = y; i < y + height; i++)
     this->draw_pixel_at(x, i, color);
 }
-void Display::rectangle(int x1, int y1, int width, int height, Color color) {
+void Display::rectangle(int x1, int y1, int width, int height, const Color &color) {
   this->horizontal_line(x1, y1, width, color);
   this->horizontal_line(x1, y1 + height - 1, width, color);
   this->vertical_line(x1, y1, height, color);
   this->vertical_line(x1 + width - 1, y1, height, color);
 }
-void Display::filled_rectangle(int x1, int y1, int width, int height, Color color) {
+void Display::filled_rectangle(int x1, int y1, int width, int height, const Color &color) {
   // Future: Use vertical_line and horizontal_line methods depending on rotation to reduce memory accesses.
   for (int i = y1; i < y1 + height; i++) {
     this->horizontal_line(x1, i, width, color);
   }
 }
-void HOT Display::circle(int center_x, int center_xy, int radius, Color color) {
+void HOT Display::circle(int center_x, int center_xy, int radius, const Color &color) {
   int dx = -radius;
   int dy = 0;
   int err = 2 - 2 * radius;
@@ -80,7 +80,7 @@ void HOT Display::circle(int center_x, int center_xy, int radius, Color color) {
     }
   } while (dx <= 0);
 }
-void Display::filled_circle(int center_x, int center_y, int radius, Color color) {
+void Display::filled_circle(int center_x, int center_y, int radius, const Color &color) {
   int dx = -int32_t(radius);
   int dy = 0;
   int err = 2 - 2 * radius;
@@ -107,24 +107,25 @@ void Display::filled_circle(int center_x, int center_y, int radius, Color color)
   } while (dx <= 0);
 }
 
-void Display::print(int x, int y, BaseFont *font, Color color, TextAlign align, const char *text) {
+void Display::print(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *text) {
   int x_start, y_start;
   int width, height;
   this->get_text_bounds(x, y, text, font, align, &x_start, &y_start, &width, &height);
   font->print(x_start, y_start, this, color, text);
 }
-void Display::vprintf_(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, va_list arg) {
+void Display::vprintf_(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *format,
+                       va_list arg) {
   char buffer[256];
   int ret = vsnprintf(buffer, sizeof(buffer), format, arg);
   if (ret > 0)
     this->print(x, y, font, color, align, buffer);
 }
 
-void Display::image(int x, int y, BaseImage *image, Color color_on, Color color_off) {
+void Display::image(int x, int y, BaseImage *image, const Color &color_on, const Color &color_off) {
   this->image(x, y, image, ImageAlign::TOP_LEFT, color_on, color_off);
 }
 
-void Display::image(int x, int y, BaseImage *image, ImageAlign align, Color color_on, Color color_off) {
+void Display::image(int x, int y, BaseImage *image, ImageAlign align, const Color &color_on, const Color &color_off) {
   auto x_align = ImageAlign(int(align) & (int(ImageAlign::HORIZONTAL_ALIGNMENT)));
   auto y_align = ImageAlign(int(align) & (int(ImageAlign::VERTICAL_ALIGNMENT)));
 
@@ -156,12 +157,14 @@ void Display::image(int x, int y, BaseImage *image, ImageAlign align, Color colo
 }
 
 #ifdef USE_GRAPH
-void Display::graph(int x, int y, graph::Graph *graph, Color color_on) { graph->draw(this, x, y, color_on); }
-void Display::legend(int x, int y, graph::Graph *graph, Color color_on) { graph->draw_legend(this, x, y, color_on); }
+void Display::graph(int x, int y, graph::Graph *graph, const Color &color_on) { graph->draw(this, x, y, color_on); }
+void Display::legend(int x, int y, graph::Graph *graph, const Color &color_on) {
+  graph->draw_legend(this, x, y, color_on);
+}
 #endif  // USE_GRAPH
 
 #ifdef USE_QR_CODE
-void Display::qr_code(int x, int y, qr_code::QrCode *qr_code, Color color_on, int scale) {
+void Display::qr_code(int x, int y, qr_code::QrCode *qr_code, const Color &color_on, int scale) {
   qr_code->draw(this, x, y, color_on, scale);
 }
 #endif  // USE_QR_CODE
@@ -204,7 +207,7 @@ void Display::get_text_bounds(int x, int y, const char *text, BaseFont *font, Te
       break;
   }
 }
-void Display::print(int x, int y, BaseFont *font, Color color, const char *text) {
+void Display::print(int x, int y, BaseFont *font, const Color &color, const char *text) {
   this->print(x, y, font, color, TextAlign::TOP_LEFT, text);
 }
 void Display::print(int x, int y, BaseFont *font, TextAlign align, const char *text) {
@@ -213,13 +216,13 @@ void Display::print(int x, int y, BaseFont *font, TextAlign align, const char *t
 void Display::print(int x, int y, BaseFont *font, const char *text) {
   this->print(x, y, font, COLOR_ON, TextAlign::TOP_LEFT, text);
 }
-void Display::printf(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, ...) {
+void Display::printf(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *format, ...) {
   va_list arg;
   va_start(arg, format);
   this->vprintf_(x, y, font, color, align, format, arg);
   va_end(arg);
 }
-void Display::printf(int x, int y, BaseFont *font, Color color, const char *format, ...) {
+void Display::printf(int x, int y, BaseFont *font, const Color &color, const char *format, ...) {
   va_list arg;
   va_start(arg, format);
   this->vprintf_(x, y, font, color, TextAlign::TOP_LEFT, format, arg);
@@ -278,13 +281,14 @@ void DisplayOnPageChangeTrigger::process(DisplayPage *from, DisplayPage *to) {
   if ((this->from_ == nullptr || this->from_ == from) && (this->to_ == nullptr || this->to_ == to))
     this->trigger(from, to);
 }
-void Display::strftime(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, ESPTime time) {
+void Display::strftime(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *format,
+                       ESPTime time) {
   char buffer[64];
   size_t ret = time.strftime(buffer, sizeof(buffer), format);
   if (ret > 0)
     this->print(x, y, font, color, align, buffer);
 }
-void Display::strftime(int x, int y, BaseFont *font, Color color, const char *format, ESPTime time) {
+void Display::strftime(int x, int y, BaseFont *font, const Color &color, const char *format, ESPTime time) {
   this->strftime(x, y, font, color, TextAlign::TOP_LEFT, format, time);
 }
 void Display::strftime(int x, int y, BaseFont *font, TextAlign align, const char *format, ESPTime time) {

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -154,21 +154,21 @@ extern const Color COLOR_ON;
 
 class BaseImage {
  public:
-  virtual void draw(int x, int y, Display *display, Color color_on, Color color_off) = 0;
+  virtual void draw(int x, int y, Display *display, const Color &color_on, const Color &color_off) = 0;
   virtual int get_width() const = 0;
   virtual int get_height() const = 0;
 };
 
 class BaseFont {
  public:
-  virtual void print(int x, int y, Display *display, Color color, const char *text) = 0;
+  virtual void print(int x, int y, Display *display, const Color &color, const char *text) = 0;
   virtual void measure(const char *str, int *width, int *x_offset, int *baseline, int *height) = 0;
 };
 
 class Display {
  public:
   /// Fill the entire screen with the given color.
-  virtual void fill(Color color);
+  virtual void fill(const Color &color);
   /// Clear the entire screen by filling it with OFF pixels.
   void clear();
 
@@ -181,29 +181,29 @@ class Display {
   inline void draw_pixel_at(int x, int y) { this->draw_pixel_at(x, y, COLOR_ON); }
 
   /// Set a single pixel at the specified coordinates to the given color.
-  virtual void draw_pixel_at(int x, int y, Color color) = 0;
+  virtual void draw_pixel_at(int x, int y, const Color &color) = 0;
 
   /// Draw a straight line from the point [x1,y1] to [x2,y2] with the given color.
-  void line(int x1, int y1, int x2, int y2, Color color = COLOR_ON);
+  void line(int x1, int y1, int x2, int y2, const Color &color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
-  void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
+  void horizontal_line(int x, int y, int width, const Color &color = COLOR_ON);
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
-  void vertical_line(int x, int y, int height, Color color = COLOR_ON);
+  void vertical_line(int x, int y, int height, const Color &color = COLOR_ON);
 
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].
-  void rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
+  void rectangle(int x1, int y1, int width, int height, const Color &color = COLOR_ON);
 
   /// Fill a rectangle with the top left point at [x1,y1] and the bottom right point at [x1+width,y1+height].
-  void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
+  void filled_rectangle(int x1, int y1, int width, int height, const Color &color = COLOR_ON);
 
   /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given color.
-  void circle(int center_x, int center_xy, int radius, Color color = COLOR_ON);
+  void circle(int center_x, int center_xy, int radius, const Color &color = COLOR_ON);
 
   /// Fill a circle centered around [center_x,center_y] with the radius radius with the given color.
-  void filled_circle(int center_x, int center_y, int radius, Color color = COLOR_ON);
+  void filled_circle(int center_x, int center_y, int radius, const Color &color = COLOR_ON);
 
   /** Print `text` with the anchor point at [x,y] with `font`.
    *
@@ -214,7 +214,7 @@ class Display {
    * @param align The alignment of the text.
    * @param text The text to draw.
    */
-  void print(int x, int y, BaseFont *font, Color color, TextAlign align, const char *text);
+  void print(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *text);
 
   /** Print `text` with the top left at [x,y] with `font`.
    *
@@ -224,7 +224,7 @@ class Display {
    * @param color The color to draw the text with.
    * @param text The text to draw.
    */
-  void print(int x, int y, BaseFont *font, Color color, const char *text);
+  void print(int x, int y, BaseFont *font, const Color &color, const char *text);
 
   /** Print `text` with the anchor point at [x,y] with `font`.
    *
@@ -255,7 +255,7 @@ class Display {
    * @param format The format to use.
    * @param ... The arguments to use for the text formatting.
    */
-  void printf(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, ...)
+  void printf(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *format, ...)
       __attribute__((format(printf, 7, 8)));
 
   /** Evaluate the printf-format `format` and print the result with the top left at [x,y] with `font`.
@@ -267,7 +267,8 @@ class Display {
    * @param format The format to use.
    * @param ... The arguments to use for the text formatting.
    */
-  void printf(int x, int y, BaseFont *font, Color color, const char *format, ...) __attribute__((format(printf, 6, 7)));
+  void printf(int x, int y, BaseFont *font, const Color &color, const char *format, ...)
+      __attribute__((format(printf, 6, 7)));
 
   /** Evaluate the printf-format `format` and print the result with the anchor point at [x,y] with `font`.
    *
@@ -301,7 +302,7 @@ class Display {
    * @param format The strftime format to use.
    * @param time The time to format.
    */
-  void strftime(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, ESPTime time)
+  void strftime(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *format, ESPTime time)
       __attribute__((format(strftime, 7, 0)));
 
   /** Evaluate the strftime-format `format` and print the result with the top left at [x,y] with `font`.
@@ -313,7 +314,7 @@ class Display {
    * @param format The strftime format to use.
    * @param time The time to format.
    */
-  void strftime(int x, int y, BaseFont *font, Color color, const char *format, ESPTime time)
+  void strftime(int x, int y, BaseFont *font, const Color &color, const char *format, ESPTime time)
       __attribute__((format(strftime, 6, 0)));
 
   /** Evaluate the strftime-format `format` and print the result with the anchor point at [x,y] with `font`.
@@ -346,7 +347,7 @@ class Display {
    * @param color_on The color to replace in binary images for the on bits.
    * @param color_off The color to replace in binary images for the off bits.
    */
-  void image(int x, int y, BaseImage *image, Color color_on = COLOR_ON, Color color_off = COLOR_OFF);
+  void image(int x, int y, BaseImage *image, const Color &color_on = COLOR_ON, const Color &color_off = COLOR_OFF);
 
   /** Draw the `image` at [x,y] to the screen.
    *
@@ -357,7 +358,8 @@ class Display {
    * @param color_on The color to replace in binary images for the on bits.
    * @param color_off The color to replace in binary images for the off bits.
    */
-  void image(int x, int y, BaseImage *image, ImageAlign align, Color color_on = COLOR_ON, Color color_off = COLOR_OFF);
+  void image(int x, int y, BaseImage *image, ImageAlign align, const Color &color_on = COLOR_ON,
+             const Color &color_off = COLOR_OFF);
 
 #ifdef USE_GRAPH
   /** Draw the `graph` with the top-left corner at [x,y] to the screen.
@@ -367,7 +369,7 @@ class Display {
    * @param graph The graph id to draw
    * @param color_on The color to replace in binary images for the on bits.
    */
-  void graph(int x, int y, graph::Graph *graph, Color color_on = COLOR_ON);
+  void graph(int x, int y, graph::Graph *graph, const Color &color_on = COLOR_ON);
 
   /** Draw the `legend` for graph with the top-left corner at [x,y] to the screen.
    *
@@ -380,7 +382,7 @@ class Display {
    * @param value_font The font used for the trace value and units
    * @param color_on The color of the border
    */
-  void legend(int x, int y, graph::Graph *graph, Color color_on = COLOR_ON);
+  void legend(int x, int y, graph::Graph *graph, const Color &color_on = COLOR_ON);
 #endif  // USE_GRAPH
 
 #ifdef USE_QR_CODE
@@ -391,7 +393,7 @@ class Display {
    * @param qr_code The qr_code to draw
    * @param color_on The color to replace in binary images for the on bits.
    */
-  void qr_code(int x, int y, qr_code::QrCode *qr_code, Color color_on = COLOR_ON, int scale = 1);
+  void qr_code(int x, int y, qr_code::QrCode *qr_code, const Color &color_on = COLOR_ON, int scale = 1);
 #endif
 
   /** Get the text bounds of the given string.
@@ -483,7 +485,7 @@ class Display {
   bool is_clipping() const { return !this->clipping_rectangle_.empty(); }
 
  protected:
-  void vprintf_(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, va_list arg);
+  void vprintf_(int x, int y, BaseFont *font, const Color &color, TextAlign align, const char *format, va_list arg);
 
   void do_update_();
 

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -44,7 +44,7 @@ int DisplayBuffer::get_height() {
   }
 }
 
-void HOT DisplayBuffer::draw_pixel_at(int x, int y, Color color) {
+void HOT DisplayBuffer::draw_pixel_at(int x, int y, const Color &color) {
   if (!this->get_clipping().inside(x, y))
     return;  // NOLINT
 

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -20,13 +20,13 @@ class DisplayBuffer : public Display {
   int get_height() override;
 
   /// Set a single pixel at the specified coordinates to the given color.
-  void draw_pixel_at(int x, int y, Color color) override;
+  void draw_pixel_at(int x, int y, const Color &color) override;
 
   virtual int get_height_internal() = 0;
   virtual int get_width_internal() = 0;
 
  protected:
-  virtual void draw_absolute_pixel_internal(int x, int y, Color color) = 0;
+  virtual void draw_absolute_pixel_internal(int x, int y, const Color &color) = 0;
 
   void init_internal_(uint32_t buffer_length);
 

--- a/esphome/components/display/display_color_utils.h
+++ b/esphome/components/display/display_color_utils.h
@@ -69,7 +69,7 @@ class ColorUtil {
   static inline Color rgb332_to_color(uint8_t rgb332_color) {
     return to_color((uint32_t) rgb332_color, COLOR_ORDER_RGB, COLOR_BITNESS_332);
   }
-  static uint8_t color_to_332(Color color, ColorOrder color_order = ColorOrder::COLOR_ORDER_RGB) {
+  static uint8_t color_to_332(const Color &color, ColorOrder color_order = ColorOrder::COLOR_ORDER_RGB) {
     uint16_t red_color, green_color, blue_color;
 
     red_color = esp_scale8(color.red, ((1 << 3) - 1));
@@ -86,7 +86,7 @@ class ColorUtil {
     }
     return 0;
   }
-  static uint16_t color_to_565(Color color, ColorOrder color_order = ColorOrder::COLOR_ORDER_RGB) {
+  static uint16_t color_to_565(const Color &color, ColorOrder color_order = ColorOrder::COLOR_ORDER_RGB) {
     uint16_t red_color, green_color, blue_color;
 
     red_color = esp_scale8(color.red, ((1 << 5) - 1));
@@ -103,7 +103,7 @@ class ColorUtil {
     }
     return 0;
   }
-  static uint32_t color_to_grayscale4(Color color) {
+  static uint32_t color_to_grayscale4(const Color &color) {
     uint32_t gs4 = esp_scale8(color.white, 15);
     return gs4;
   }
@@ -117,7 +117,7 @@ class ColorUtil {
    * @return The 8 bit index of the closest color (e.g. for display buffer).
    */
   // static uint8_t color_to_index8_palette888(Color color, uint8_t *palette) {
-  static uint8_t color_to_index8_palette888(Color color, const uint8_t *palette) {
+  static uint8_t color_to_index8_palette888(const Color &color, const uint8_t *palette) {
     uint8_t closest_index = 0;
     uint32_t minimum_dist2 = UINT32_MAX;  // Smallest distance^2 to the target
                                           // so far

--- a/esphome/components/font/font.cpp
+++ b/esphome/components/font/font.cpp
@@ -10,7 +10,7 @@ namespace font {
 
 static const char *const TAG = "font";
 
-void Glyph::draw(int x_at, int y_start, display::Display *display, Color color) const {
+void Glyph::draw(int x_at, int y_start, display::Display *display, const Color &color) const {
   int scan_x1, scan_y1, scan_width, scan_height;
   this->scan_area(&scan_x1, &scan_y1, &scan_width, &scan_height);
 
@@ -118,7 +118,7 @@ void Font::measure(const char *str, int *width, int *x_offset, int *baseline, in
   *x_offset = min_x;
   *width = x - min_x;
 }
-void Font::print(int x_start, int y_start, display::Display *display, Color color, const char *text) {
+void Font::print(int x_start, int y_start, display::Display *display, const Color &color, const char *text) {
   int i = 0;
   int x_at = x_start;
   while (text[i] != '\0') {

--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -22,7 +22,7 @@ class Glyph {
  public:
   Glyph(const GlyphData *data) : glyph_data_(data) {}
 
-  void draw(int x, int y, display::Display *display, Color color) const;
+  void draw(int x, int y, display::Display *display, const Color &color) const;
 
   const char *get_char() const;
 
@@ -50,7 +50,7 @@ class Font : public display::BaseFont {
 
   int match_next_glyph(const char *str, int *match_length);
 
-  void print(int x_start, int y_start, display::Display *display, Color color, const char *text) override;
+  void print(int x_start, int y_start, display::Display *display, const Color &color, const char *text) override;
   void measure(const char *str, int *width, int *x_offset, int *baseline, int *height) override;
   inline int get_baseline() { return this->baseline_; }
   inline int get_height() { return this->height_; }

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -56,7 +56,7 @@ void GraphTrace::init(Graph *g) {
   this->data_.set_update_time_ms(g->get_duration() * 1000 / g->get_width());
 }
 
-void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color color) {
+void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, const Color &color) {
   /// Plot border
   if (this->border_) {
     buff->horizontal_line(x_offset, y_offset, this->width_, color);
@@ -303,7 +303,7 @@ void GraphLegend::init(Graph *g) {
   }
 }
 
-void Graph::draw_legend(display::Display *buff, uint16_t x_offset, uint16_t y_offset, Color color) {
+void Graph::draw_legend(display::Display *buff, uint16_t x_offset, uint16_t y_offset, const Color &color) {
   if (!legend_)
     return;
 

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -115,7 +115,7 @@ class GraphTrace {
   enum LineType get_line_type() { return this->line_type_; }
   void set_line_type(enum LineType val) { this->line_type_ = val; }
   Color get_line_color() { return this->line_color_; }
-  void set_line_color(Color val) { this->line_color_ = val; }
+  void set_line_color(const Color &val) { this->line_color_ = val; }
   std::string get_name() { return name_; }
   const HistoryData *get_tracedata() { return &data_; }
 
@@ -133,8 +133,8 @@ class GraphTrace {
 
 class Graph : public Component {
  public:
-  void draw(display::Display *buff, uint16_t x_offset, uint16_t y_offset, Color color);
-  void draw_legend(display::Display *buff, uint16_t x_offset, uint16_t y_offset, Color color);
+  void draw(display::Display *buff, uint16_t x_offset, uint16_t y_offset, const Color &color);
+  void draw_legend(display::Display *buff, uint16_t x_offset, uint16_t y_offset, const Color &color);
 
   void setup() override;
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -72,7 +72,7 @@ void ILI9XXXDisplay::dump_config() {
 
 float ILI9XXXDisplay::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-void ILI9XXXDisplay::fill(Color color) {
+void ILI9XXXDisplay::fill(const Color &color) {
   uint16_t new_color = 0;
   this->x_low_ = 0;
   this->y_low_ = 0;
@@ -106,7 +106,7 @@ void ILI9XXXDisplay::fill(Color color) {
   memset(this->buffer_, (uint8_t) new_color, this->get_buffer_length_());
 }
 
-void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0) {
     return;
   }

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -40,7 +40,7 @@ class ILI9XXXDisplay : public PollingComponent,
 
   void update() override;
 
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   void dump_config() override;
   void setup() override;
@@ -48,7 +48,7 @@ class ILI9XXXDisplay : public PollingComponent,
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
 
  protected:
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
   void setup_pins_();
   virtual void initialize() = 0;
 

--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace image {
 
-void Image::draw(int x, int y, display::Display *display, Color color_on, Color color_off) {
+void Image::draw(int x, int y, display::Display *display, const Color &color_on, const Color &color_off) {
   switch (type_) {
     case IMAGE_TYPE_BINARY: {
       for (int img_x = 0; img_x < width_; img_x++) {
@@ -61,7 +61,7 @@ void Image::draw(int x, int y, display::Display *display, Color color_on, Color 
       break;
   }
 }
-Color Image::get_pixel(int x, int y, Color color_on, Color color_off) const {
+Color Image::get_pixel(int x, int y, const Color &color_on, const Color &color_off) const {
   if (x < 0 || x >= this->width_ || y < 0 || y >= this->height_)
     return color_off;
   switch (this->type_) {

--- a/esphome/components/image/image.h
+++ b/esphome/components/image/image.h
@@ -34,12 +34,13 @@ inline int image_type_to_width_stride(int width, ImageType type) { return (width
 class Image : public display::BaseImage {
  public:
   Image(const uint8_t *data_start, int width, int height, ImageType type);
-  Color get_pixel(int x, int y, Color color_on = display::COLOR_ON, Color color_off = display::COLOR_OFF) const;
+  Color get_pixel(int x, int y, const Color &color_on = display::COLOR_ON,
+                  const Color &color_off = display::COLOR_OFF) const;
   int get_width() const override;
   int get_height() const override;
   ImageType get_type() const;
 
-  void draw(int x, int y, display::Display *display, Color color_on, Color color_off) override;
+  void draw(int x, int y, display::Display *display, const Color &color_on, const Color &color_off) override;
 
   void set_transparency(bool transparent) { transparent_ = transparent; }
   bool has_transparency() const { return transparent_; }

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -147,7 +147,7 @@ void Inkplate6::update() {
   this->display();
 }
 
-void HOT Inkplate6::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT Inkplate6::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
 
@@ -282,7 +282,7 @@ bool Inkplate6::read_power_status_() {
   return false;
 }
 
-void Inkplate6::fill(Color color) {
+void Inkplate6::fill(const Color &color) {
   ESP_LOGV(TAG, "Fill called");
   uint32_t start_time = millis();
 

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -73,7 +73,7 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
 
   void display();
   void clean();
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   void update() override;
 
@@ -91,7 +91,7 @@ class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public
   }
 
  protected:
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
   void display1b_();
   void display3b_();
   void initialize_();

--- a/esphome/components/light/esp_color_correction.h
+++ b/esphome/components/light/esp_color_correction.h
@@ -11,7 +11,7 @@ class ESPColorCorrection {
   void set_max_brightness(const Color &max_brightness) { this->max_brightness_ = max_brightness; }
   void set_local_brightness(uint8_t local_brightness) { this->local_brightness_ = local_brightness; }
   void calculate_gamma_table(float gamma);
-  inline Color color_correct(Color color) const ALWAYS_INLINE {
+  inline Color color_correct(const Color &color) const ALWAYS_INLINE {
     // corrected = (uncorrected * max_brightness * local_brightness) ^ gamma
     return Color(this->color_correct_red(color.red), this->color_correct_green(color.green),
                  this->color_correct_blue(color.blue), this->color_correct_white(color.white));
@@ -32,7 +32,7 @@ class ESPColorCorrection {
     uint8_t res = esp_scale8(esp_scale8(white, this->max_brightness_.white), this->local_brightness_);
     return this->gamma_table_[res];
   }
-  inline Color color_uncorrect(Color color) const ALWAYS_INLINE {
+  inline Color color_uncorrect(const Color &color) const ALWAYS_INLINE {
     // uncorrected = corrected^(1/gamma) / (max_brightness * local_brightness)
     return Color(this->color_uncorrect_red(color.red), this->color_uncorrect_green(color.green),
                  this->color_uncorrect_blue(color.blue), this->color_uncorrect_white(color.white));

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -154,7 +154,7 @@ int MAX7219Component::get_height_internal() {
 
 int MAX7219Component::get_width_internal() { return this->num_chips_ / this->num_chip_lines_ * 8; }
 
-void HOT MAX7219Component::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT MAX7219Component::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x + 1 > (int) this->max_displaybuffer_[0].size()) {  // Extend the display buffer in case required
     for (int chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
       this->max_displaybuffer_[chip_line].resize(x + 1, this->bckgrnd_);

--- a/esphome/components/max7219digit/max7219digit.h
+++ b/esphome/components/max7219digit/max7219digit.h
@@ -49,7 +49,7 @@ class MAX7219Component : public PollingComponent,
 
   void turn_on_off(bool on_off);
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
   int get_height_internal() override;
   int get_width_internal() override;
 

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -439,7 +439,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * the color of blue. Use this [color picker](https://nodtem66.github.io/nextion-hmi-color-convert/index.html) to
    * convert color codes to Nextion HMI colors
    */
-  void fill_area(int x1, int y1, int width, int height, Color color);
+  void fill_area(int x1, int y1, int width, int height, const Color &color);
   /**
    * Draw a line on the screen.
    * @param x1 The starting x coordinate.
@@ -477,7 +477,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * picker](https://nodtem66.github.io/nextion-hmi-color-convert/index.html) to convert color codes to Nextion HMI
    * colors.
    */
-  void line(int x1, int y1, int x2, int y2, Color color);
+  void line(int x1, int y1, int x2, int y2, const Color &color);
   /**
    * Draw a rectangle outline.
    * @param x1 The starting x coordinate.
@@ -515,7 +515,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * picker](https://nodtem66.github.io/nextion-hmi-color-convert/index.html) to convert color codes to Nextion HMI
    * colors.
    */
-  void rectangle(int x1, int y1, int width, int height, Color color);
+  void rectangle(int x1, int y1, int width, int height, const Color &color);
   /**
    * Draw a circle outline
    * @param center_x The center x coordinate.
@@ -531,7 +531,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * @param radius The circle radius.
    * @param color The color to draw with (as Color).
    */
-  void circle(int center_x, int center_y, int radius, Color color);
+  void circle(int center_x, int center_y, int radius, const Color &color);
   /**
    * Draw a filled circled.
    * @param center_x The center x coordinate.
@@ -565,7 +565,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * Use this [color picker](https://nodtem66.github.io/nextion-hmi-color-convert/index.html) to convert color codes to
    * Nextion HMI colors.
    */
-  void filled_circle(int center_x, int center_y, int radius, Color color);
+  void filled_circle(int center_x, int center_y, int radius, const Color &color);
 
   /** Set the brightness of the backlight.
    *

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -178,7 +178,7 @@ void Nextion::fill_area(int x1, int y1, int width, int height, const char *color
   this->add_no_result_to_queue_with_printf_("fill_area", "fill %d,%d,%d,%d,%s", x1, y1, width, height, color);
 }
 
-void Nextion::fill_area(int x1, int y1, int width, int height, Color color) {
+void Nextion::fill_area(int x1, int y1, int width, int height, const Color &color) {
   this->add_no_result_to_queue_with_printf_("fill_area", "fill %d,%d,%d,%d,%d", x1, y1, width, height,
                                             display::ColorUtil::color_to_565(color));
 }
@@ -187,7 +187,7 @@ void Nextion::line(int x1, int y1, int x2, int y2, const char *color) {
   this->add_no_result_to_queue_with_printf_("line", "line %d,%d,%d,%d,%s", x1, y1, x2, y2, color);
 }
 
-void Nextion::line(int x1, int y1, int x2, int y2, Color color) {
+void Nextion::line(int x1, int y1, int x2, int y2, const Color &color) {
   this->add_no_result_to_queue_with_printf_("line", "line %d,%d,%d,%d,%d", x1, y1, x2, y2,
                                             display::ColorUtil::color_to_565(color));
 }
@@ -196,7 +196,7 @@ void Nextion::rectangle(int x1, int y1, int width, int height, const char *color
   this->add_no_result_to_queue_with_printf_("draw", "draw %d,%d,%d,%d,%s", x1, y1, x1 + width, y1 + height, color);
 }
 
-void Nextion::rectangle(int x1, int y1, int width, int height, Color color) {
+void Nextion::rectangle(int x1, int y1, int width, int height, const Color &color) {
   this->add_no_result_to_queue_with_printf_("draw", "draw %d,%d,%d,%d,%d", x1, y1, x1 + width, y1 + height,
                                             display::ColorUtil::color_to_565(color));
 }
@@ -205,7 +205,7 @@ void Nextion::circle(int center_x, int center_y, int radius, const char *color) 
   this->add_no_result_to_queue_with_printf_("cir", "cir %d,%d,%d,%s", center_x, center_y, radius, color);
 }
 
-void Nextion::circle(int center_x, int center_y, int radius, Color color) {
+void Nextion::circle(int center_x, int center_y, int radius, const Color &color) {
   this->add_no_result_to_queue_with_printf_("cir", "cir %d,%d,%d,%d", center_x, center_y, radius,
                                             display::ColorUtil::color_to_565(color));
 }
@@ -214,7 +214,7 @@ void Nextion::filled_circle(int center_x, int center_y, int radius, const char *
   this->add_no_result_to_queue_with_printf_("cirs", "cirs %d,%d,%d,%s", center_x, center_y, radius, color);
 }
 
-void Nextion::filled_circle(int center_x, int center_y, int radius, Color color) {
+void Nextion::filled_circle(int center_x, int center_y, int radius, const Color &color) {
   this->add_no_result_to_queue_with_printf_("cirs", "cirs %d,%d,%d,%d", center_x, center_y, radius,
                                             display::ColorUtil::color_to_565(color));
 }

--- a/esphome/components/nextion/nextion_component.cpp
+++ b/esphome/components/nextion/nextion_component.cpp
@@ -3,7 +3,7 @@
 namespace esphome {
 namespace nextion {
 
-void NextionComponent::set_background_color(Color bco) {
+void NextionComponent::set_background_color(const Color &bco) {
   if (this->variable_name_ == this->variable_name_to_send_) {
     return;  // This is a variable. no need to set color
   }
@@ -13,7 +13,7 @@ void NextionComponent::set_background_color(Color bco) {
   this->update_component_settings();
 }
 
-void NextionComponent::set_background_pressed_color(Color bco2) {
+void NextionComponent::set_background_pressed_color(const Color &bco2) {
   if (this->variable_name_ == this->variable_name_to_send_) {
     return;  // This is a variable. no need to set color
   }
@@ -24,7 +24,7 @@ void NextionComponent::set_background_pressed_color(Color bco2) {
   this->update_component_settings();
 }
 
-void NextionComponent::set_foreground_color(Color pco) {
+void NextionComponent::set_foreground_color(const Color &pco) {
   if (this->variable_name_ == this->variable_name_to_send_) {
     return;  // This is a variable. no need to set color
   }
@@ -34,7 +34,7 @@ void NextionComponent::set_foreground_color(Color pco) {
   this->update_component_settings();
 }
 
-void NextionComponent::set_foreground_pressed_color(Color pco2) {
+void NextionComponent::set_foreground_pressed_color(const Color &pco2) {
   if (this->variable_name_ == this->variable_name_to_send_) {
     return;  // This is a variable. no need to set color
   }

--- a/esphome/components/nextion/nextion_component.h
+++ b/esphome/components/nextion/nextion_component.h
@@ -13,10 +13,10 @@ class NextionComponent : public NextionComponentBase {
 
   void update_component_settings(bool force_update) override;
 
-  void set_background_color(Color bco);
-  void set_background_pressed_color(Color bco2);
-  void set_foreground_color(Color pco);
-  void set_foreground_pressed_color(Color pco2);
+  void set_background_color(const Color &bco);
+  void set_background_pressed_color(const Color &bco2);
+  void set_foreground_color(const Color &pco);
+  void set_foreground_pressed_color(const Color &pco2);
   void set_font_id(uint8_t font_id);
   void set_visible(bool visible);
 

--- a/esphome/components/pcd8544/pcd_8544.cpp
+++ b/esphome/components/pcd8544/pcd_8544.cpp
@@ -84,7 +84,7 @@ void HOT PCD8544::display() {
   this->command(this->PCD8544_SETYADDR);
 }
 
-void HOT PCD8544::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT PCD8544::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0) {
     return;
   }
@@ -116,7 +116,7 @@ void PCD8544::update() {
   this->display();
 }
 
-void PCD8544::fill(Color color) {
+void PCD8544::fill(const Color &color) {
   uint8_t fill = color.is_on() ? 0xFF : 0x00;
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;

--- a/esphome/components/pcd8544/pcd_8544.h
+++ b/esphome/components/pcd8544/pcd_8544.h
@@ -45,7 +45,7 @@ class PCD8544 : public PollingComponent,
 
   void update() override;
 
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   void setup() override {
     this->setup_pins_();
@@ -55,7 +55,7 @@ class PCD8544 : public PollingComponent,
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
 
  protected:
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   void setup_pins_();
 

--- a/esphome/components/qr_code/qr_code.cpp
+++ b/esphome/components/qr_code/qr_code.cpp
@@ -33,7 +33,7 @@ void QrCode::generate_qr_code() {
   }
 }
 
-void QrCode::draw(display::Display *buff, uint16_t x_offset, uint16_t y_offset, Color color, int scale) {
+void QrCode::draw(display::Display *buff, uint16_t x_offset, uint16_t y_offset, const Color &color, int scale) {
   ESP_LOGV(TAG, "Drawing QR code at (%d, %d)", x_offset, y_offset);
 
   if (this->needs_update_) {

--- a/esphome/components/qr_code/qr_code.h
+++ b/esphome/components/qr_code/qr_code.h
@@ -15,7 +15,7 @@ class Display;
 namespace qr_code {
 class QrCode : public Component {
  public:
-  void draw(display::Display *buff, uint16_t x_offset, uint16_t y_offset, Color color, int scale);
+  void draw(display::Display *buff, uint16_t x_offset, uint16_t y_offset, const Color &color, int scale);
 
   void dump_config() override;
 

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -266,7 +266,7 @@ int SSD1306::get_width_internal() {
 size_t SSD1306::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 8u;
 }
-void HOT SSD1306::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT SSD1306::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
 
@@ -278,7 +278,7 @@ void HOT SSD1306::draw_absolute_pixel_internal(int x, int y, Color color) {
     this->buffer_[pos] &= ~(1 << subpos);
   }
 }
-void SSD1306::fill(Color color) {
+void SSD1306::fill(const Color &color) {
   uint8_t fill = color.is_on() ? 0xFF : 0x00;
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -47,7 +47,7 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void turn_on();
   void turn_off();
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
 
@@ -59,7 +59,7 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   bool is_sh1106_() const;
   bool is_ssd1305_() const;
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   int get_height_internal() override;
   int get_width_internal() override;

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -159,7 +159,7 @@ int SSD1322::get_width_internal() {
 size_t SSD1322::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / SSD1322_PIXELSPERBYTE;
 }
-void HOT SSD1322::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT SSD1322::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
   uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
@@ -173,7 +173,7 @@ void HOT SSD1322::draw_absolute_pixel_internal(int x, int y, Color color) {
   // ...then lay the new nibble back on top. done!
   this->buffer_[pos] |= color4;
 }
-void SSD1322::fill(Color color) {
+void SSD1322::fill(const Color &color) {
   const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
   uint8_t fill = (color4 & SSD1322_COLORMASK) | ((color4 & SSD1322_COLORMASK) << SSD1322_COLORSHIFT);
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)

--- a/esphome/components/ssd1322_base/ssd1322_base.h
+++ b/esphome/components/ssd1322_base/ssd1322_base.h
@@ -28,7 +28,7 @@ class SSD1322 : public PollingComponent, public display::DisplayBuffer {
   void turn_off();
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_GRAYSCALE; }
 
@@ -38,7 +38,7 @@ class SSD1322 : public PollingComponent, public display::DisplayBuffer {
   virtual void write_display_data() = 0;
   void init_reset_();
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   int get_height_internal() override;
   int get_width_internal() override;

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -192,7 +192,7 @@ int SSD1325::get_width_internal() {
 size_t SSD1325::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / SSD1325_PIXELSPERBYTE;
 }
-void HOT SSD1325::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT SSD1325::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
   uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
@@ -206,7 +206,7 @@ void HOT SSD1325::draw_absolute_pixel_internal(int x, int y, Color color) {
   // ...then lay the new nibble back on top. done!
   this->buffer_[pos] |= color4;
 }
-void SSD1325::fill(Color color) {
+void SSD1325::fill(const Color &color) {
   const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
   uint8_t fill = (color4 & SSD1325_COLORMASK) | ((color4 & SSD1325_COLORMASK) << SSD1325_COLORSHIFT);
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)

--- a/esphome/components/ssd1325_base/ssd1325_base.h
+++ b/esphome/components/ssd1325_base/ssd1325_base.h
@@ -33,7 +33,7 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   void turn_off();
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
 
@@ -42,7 +42,7 @@ class SSD1325 : public PollingComponent, public display::DisplayBuffer {
   virtual void write_display_data() = 0;
   void init_reset_();
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   int get_height_internal() override;
   int get_width_internal() override;

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -135,7 +135,7 @@ int SSD1327::get_width_internal() {
 size_t SSD1327::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / SSD1327_PIXELSPERBYTE;
 }
-void HOT SSD1327::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT SSD1327::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
   uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
@@ -149,7 +149,7 @@ void HOT SSD1327::draw_absolute_pixel_internal(int x, int y, Color color) {
   // ...then lay the new nibble back on top. done!
   this->buffer_[pos] |= color4;
 }
-void SSD1327::fill(Color color) {
+void SSD1327::fill(const Color &color) {
   const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
   uint8_t fill = (color4 & SSD1327_COLORMASK) | ((color4 & SSD1327_COLORMASK) << SSD1327_COLORSHIFT);
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)

--- a/esphome/components/ssd1327_base/ssd1327_base.h
+++ b/esphome/components/ssd1327_base/ssd1327_base.h
@@ -28,7 +28,7 @@ class SSD1327 : public PollingComponent, public display::DisplayBuffer {
   void turn_off();
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_GRAYSCALE; }
 
@@ -37,7 +37,7 @@ class SSD1327 : public PollingComponent, public display::DisplayBuffer {
   virtual void write_display_data() = 0;
   void init_reset_();
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   int get_height_internal() override;
   int get_width_internal() override;

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -118,7 +118,7 @@ int SSD1331::get_width_internal() { return 96; }
 size_t SSD1331::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) * size_t(SSD1331_BYTESPERPIXEL);
 }
-void HOT SSD1331::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT SSD1331::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
@@ -127,7 +127,7 @@ void HOT SSD1331::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos++] = (color565 >> 8) & 0xff;
   this->buffer_[pos] = color565 & 0xff;
 }
-void SSD1331::fill(Color color) {
+void SSD1331::fill(const Color &color) {
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
     if (i & 1) {

--- a/esphome/components/ssd1331_base/ssd1331_base.h
+++ b/esphome/components/ssd1331_base/ssd1331_base.h
@@ -23,7 +23,7 @@ class SSD1331 : public PollingComponent, public display::DisplayBuffer {
   void turn_off();
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
 
@@ -32,7 +32,7 @@ class SSD1331 : public PollingComponent, public display::DisplayBuffer {
   virtual void write_display_data() = 0;
   void init_reset_();
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   int get_height_internal() override;
   int get_width_internal() override;

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -147,7 +147,7 @@ int SSD1351::get_width_internal() {
 size_t SSD1351::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) * size_t(SSD1351_BYTESPERPIXEL);
 }
-void HOT SSD1351::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT SSD1351::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
@@ -156,7 +156,7 @@ void HOT SSD1351::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos++] = (color565 >> 8) & 0xff;
   this->buffer_[pos] = color565 & 0xff;
 }
-void SSD1351::fill(Color color) {
+void SSD1351::fill(const Color &color) {
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
     if (i & 1) {

--- a/esphome/components/ssd1351_base/ssd1351_base.h
+++ b/esphome/components/ssd1351_base/ssd1351_base.h
@@ -29,7 +29,7 @@ class SSD1351 : public PollingComponent, public display::DisplayBuffer {
   void turn_off();
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
 
@@ -39,7 +39,7 @@ class SSD1351 : public PollingComponent, public display::DisplayBuffer {
   virtual void write_display_data() = 0;
   void init_reset_();
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   int get_height_internal() override;
   int get_width_internal() override;

--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -307,7 +307,7 @@ size_t ST7735::get_buffer_length() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) * 2;
 }
 
-void HOT ST7735::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT ST7735::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
 

--- a/esphome/components/st7735/st7735.h
+++ b/esphome/components/st7735/st7735.h
@@ -67,7 +67,7 @@ class ST7735 : public PollingComponent,
   void init_reset_();
   void display_init_(const uint8_t *addr);
   void set_addr_window_(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
   void spi_master_write_addr_(uint16_t addr1, uint16_t addr2);
   void spi_master_write_color_(uint16_t color, uint16_t size);
 

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -313,7 +313,7 @@ void ST7789V::draw_filled_rect_(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t 
   this->disable();
 }
 
-void HOT ST7789V::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT ST7789V::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
     return;
 

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -173,7 +173,7 @@ class ST7789V : public PollingComponent,
 
   void draw_filled_rect_(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   const char *model_str_();
 };

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -90,7 +90,9 @@ void HOT ST7920::write_display_data() {
   }
 }
 
-void ST7920::fill(Color color) { memset(this->buffer_, color.is_on() ? 0xFF : 0x00, this->get_buffer_length_()); }
+void ST7920::fill(const Color &color) {
+  memset(this->buffer_, color.is_on() ? 0xFF : 0x00, this->get_buffer_length_());
+}
 
 void ST7920::dump_config() {
   LOG_DISPLAY("", "ST7920", this);
@@ -116,7 +118,7 @@ size_t ST7920::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 8u;
 }
 
-void HOT ST7920::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT ST7920::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0) {
     ESP_LOGW(TAG, "Position out of area: %dx%d", x, y);
     return;

--- a/esphome/components/st7920/st7920.h
+++ b/esphome/components/st7920/st7920.h
@@ -26,13 +26,13 @@ class ST7920 : public PollingComponent,
   void dump_config() override;
   float get_setup_priority() const override;
   void update() override;
-  void fill(Color color) override;
+  void fill(const Color &color) override;
   void write_display_data();
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
 
  protected:
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
   int get_height_internal() override;
   int get_width_internal() override;
   size_t get_buffer_length_();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -127,13 +127,13 @@ void WaveshareEPaper::update() {
   this->do_update_();
   this->display();
 }
-void WaveshareEPaper::fill(Color color) {
+void WaveshareEPaper::fill(const Color &color) {
   // flip logic
   const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;
 }
-void HOT WaveshareEPaper::draw_absolute_pixel_internal(int x, int y, Color color) {
+void HOT WaveshareEPaper::draw_absolute_pixel_internal(int x, int y, const Color &color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -27,7 +27,7 @@ class WaveshareEPaper : public PollingComponent,
 
   void update() override;
 
-  void fill(Color color) override;
+  void fill(const Color &color) override;
 
   void setup() override {
     this->setup_pins_();
@@ -39,7 +39,7 @@ class WaveshareEPaper : public PollingComponent,
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
 
  protected:
-  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void draw_absolute_pixel_internal(int x, int y, const Color &color) override;
 
   bool wait_until_idle_();
 

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -43,7 +43,9 @@ struct Color {
                                                             b((colorcode >> 0) & 0xFF),
                                                             w((colorcode >> 24) & 0xFF) {}
 
-  inline bool is_on() ALWAYS_INLINE { return this->raw_32 != 0; }
+  inline Color(const Color &other) : raw_32(other.raw_32) {}
+
+  inline bool is_on() const ALWAYS_INLINE { return this->raw_32 != 0; }
 
   inline bool operator==(const Color &rhs) {  // NOLINT
     return this->raw_32 == rhs.raw_32;


### PR DESCRIPTION
# What does this implement/fix?

Compiler started to give warnings about operator= in color.h when preparing other components for IDF >= 5. Adding copy constructor and changing is_on to const gave a suggestion from compiler to change argument to const reference on display-classes. It's a breaking change for external modules based on the display class.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
