### PR TITLE
Initial debug component support for rp2040

### DIFF
--- a/esphome/components/debug/__init__.py
+++ b/esphome/components/debug/__init__.py
@@ -38,7 +38,6 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     ).extend(cv.polling_component_schema("60s")),
-    cv.only_on(["esp32", "esp8266"]),
 )
 
 

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -22,7 +22,11 @@
 #endif  // USE_ESP32
 
 #ifdef USE_ARDUINO
+#ifdef USE_RP2040
+#include <Arduino.h>
+#else
 #include <Esp.h>
+#endif
 #endif
 
 namespace esphome {
@@ -35,6 +39,8 @@ static uint32_t get_free_heap() {
   return ESP.getFreeHeap();  // NOLINT(readability-static-accessed-through-instance)
 #elif defined(USE_ESP32)
   return heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+#elif defined(USE_RP2040)
+  return rp2040.getFreeHeap();
 #endif
 }
 
@@ -65,7 +71,7 @@ void DebugComponent::dump_config() {
   this->free_heap_ = get_free_heap();
   ESP_LOGD(TAG, "Free Heap Size: %" PRIu32 " bytes", this->free_heap_);
 
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) && !defined(USE_RP2040)
   const char *flash_mode;
   switch (ESP.getFlashChipMode()) {  // NOLINT(readability-static-accessed-through-instance)
     case FM_QIO:
@@ -273,6 +279,11 @@ void DebugComponent::dump_config() {
 
   reset_reason = ESP.getResetReason().c_str();
 #endif
+
+#ifdef USE_RP2040
+  ESP_LOGD(TAG, "CPU Frequency: %u", rp2040.f_cpu());
+  device_info += "CPU Frequency: " + to_string(rp2040.f_cpu());
+#endif  // USE_RP2040
 
 #ifdef USE_TEXT_SENSOR
   if (this->device_info_ != nullptr) {


### PR DESCRIPTION
# What does this implement/fix?

This adds initial support for `debug`-component for RP2040

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: rpidebug

rp2040:
  board: rpipicow
  framework:
    # Required until https://github.com/platformio/platform-raspberrypi/pull/36 is merged
    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git


wifi:
  ssid: wireless
  password: !secret wifipwd

debug:

logger:
  level: VERY_VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
