### PR TITLE
Add Zio Ultrasonic Distance Sensor Component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -103,13 +103,12 @@ esphome/components/gpio/* @esphome/core
 esphome/components/gps/* @coogle
 esphome/components/graph/* @synco
 esphome/components/growatt_solar/* @leeuwte
-esphome/components/haier/* @paveldn
+esphome/components/haier/* @Yarikx
 esphome/components/havells_solar/* @sourabhjaiswal
 esphome/components/hbridge/fan/* @WeekendWarrior
 esphome/components/hbridge/light/* @DotNetDann
 esphome/components/heatpumpir/* @rob-deutsch
 esphome/components/hitachi_ac424/* @sourabhjaiswal
-esphome/components/hm3301/* @freekode
 esphome/components/homeassistant/* @OttoWinter
 esphome/components/honeywellabp/* @RubyBailey
 esphome/components/host/* @esphome/core
@@ -286,7 +285,6 @@ esphome/components/tlc5947/* @rnauber
 esphome/components/tm1621/* @Philippe12
 esphome/components/tm1637/* @glmnet
 esphome/components/tm1638/* @skykingjwc
-esphome/components/tm1651/* @freekode
 esphome/components/tmp102/* @timsavage
 esphome/components/tmp1075/* @sybrenstuvel
 esphome/components/tmp117/* @Azimath
@@ -321,3 +319,4 @@ esphome/components/xiaomi_mhoc401/* @vevsvevs
 esphome/components/xiaomi_rtcgq02lm/* @jesserockz
 esphome/components/xl9535/* @mreditor97
 esphome/components/xpt2046/* @nielsnl68 @numo68
+esphome/components/zio_ultrasonic/* @kahrendt

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -103,12 +103,13 @@ esphome/components/gpio/* @esphome/core
 esphome/components/gps/* @coogle
 esphome/components/graph/* @synco
 esphome/components/growatt_solar/* @leeuwte
-esphome/components/haier/* @Yarikx
+esphome/components/haier/* @paveldn
 esphome/components/havells_solar/* @sourabhjaiswal
 esphome/components/hbridge/fan/* @WeekendWarrior
 esphome/components/hbridge/light/* @DotNetDann
 esphome/components/heatpumpir/* @rob-deutsch
 esphome/components/hitachi_ac424/* @sourabhjaiswal
+esphome/components/hm3301/* @freekode
 esphome/components/homeassistant/* @OttoWinter
 esphome/components/honeywellabp/* @RubyBailey
 esphome/components/host/* @esphome/core
@@ -285,6 +286,7 @@ esphome/components/tlc5947/* @rnauber
 esphome/components/tm1621/* @Philippe12
 esphome/components/tm1637/* @glmnet
 esphome/components/tm1638/* @skykingjwc
+esphome/components/tm1651/* @freekode
 esphome/components/tmp102/* @timsavage
 esphome/components/tmp1075/* @sybrenstuvel
 esphome/components/tmp117/* @Azimath

--- a/esphome/components/zio_ultrasonic/sensor.py
+++ b/esphome/components/zio_ultrasonic/sensor.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    DEVICE_CLASS_DISTANCE,
+    STATE_CLASS_MEASUREMENT,
+)
+
+DEPENDENCIES = ["i2c"]
+CODEOWNERS = ["@kahrendt"]
+
+zio_ultrasonic_ns = cg.esphome_ns.namespace("zio_ultrasonic")
+
+ZioUltrasonicComponent = zio_ultrasonic_ns.class_(
+    "ZioUltrasonicComponent", cg.PollingComponent, i2c.I2CDevice, sensor.Sensor
+)
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        ZioUltrasonicComponent,
+        unit_of_measurement="mm",
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_DISTANCE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x00))
+)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/zio_ultrasonic/zio_ultrasonic.cpp
+++ b/esphome/components/zio_ultrasonic/zio_ultrasonic.cpp
@@ -1,0 +1,31 @@
+
+#include "zio_ultrasonic.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace zio_ultrasonic {
+
+static const char *const TAG = "Zio Ultrasonic";
+
+void ZioUltrasonicComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "Zio Ultrasonic:");
+  LOG_I2C_DEVICE(this);
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "Distance", this);
+}
+
+void ZioUltrasonicComponent::update() {
+  uint16_t distance;
+
+  // Read an unsigned two byte integerfrom register 0x01 which gives distance in mm
+  if (!this->read_byte_16(0x01, &distance)) {
+    ESP_LOGE(TAG, "Error reading data from Zio Ultrasonic");
+    this->publish_state(NAN);
+  } else {
+    this->publish_state(distance);
+  }
+}
+
+}  // namespace zio_ultrasonic
+}  // namespace esphome

--- a/esphome/components/zio_ultrasonic/zio_ultrasonic.cpp
+++ b/esphome/components/zio_ultrasonic/zio_ultrasonic.cpp
@@ -6,13 +6,13 @@
 namespace esphome {
 namespace zio_ultrasonic {
 
-static const char *const TAG = "Zio Ultrasonic";
+static const char *const TAG = "zio_ultrasonic";
 
 void ZioUltrasonicComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Zio Ultrasonic:");
+  ESP_LOGCONFIG(TAG, "Zio Ultrasonic Sensor:");
   LOG_I2C_DEVICE(this);
   LOG_UPDATE_INTERVAL(this);
-  LOG_SENSOR("  ", "Distance", this);
+  LOG_SENSOR("  ", "Sensor:", this);
 }
 
 void ZioUltrasonicComponent::update() {

--- a/esphome/components/zio_ultrasonic/zio_ultrasonic.h
+++ b/esphome/components/zio_ultrasonic/zio_ultrasonic.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+static const char *const TAG = "Zio Ultrasonic";
+
+namespace esphome {
+namespace zio_ultrasonic {
+
+class ZioUltrasonicComponent : public i2c::I2CDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void dump_config() override;
+
+  void update() override;
+};
+
+}  // namespace zio_ultrasonic
+}  // namespace esphome

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1310,6 +1310,10 @@ sensor:
       fault_count: 1
       polarity: active_high
       function: comparator
+  - platform: zio_ultrasonic
+    name: "Distance"
+    update_interval: 60s
+    i2c_id: i2c_bus
 
 esp32_touch:
   setup_mode: false


### PR DESCRIPTION
# What does this implement/fix?

This component adds support for Zio Ultrasonic Distance Sensors. They are based on the HC-SR04 ultrasonic sensors, but they communicate over the I2C bus. The sensor is very basic and does not require significant code to implement support.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3043

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

    sensor:
      - platform: zio_ultrasonic
        name: "Distance"
        update_interval: 60s

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
