### PR TITLE
socket: udp support for esp8266

### DIFF
--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -5,6 +5,10 @@
 #include "esphome/core/optional.h"
 #include "headers.h"
 
+#if defined(USE_SOCKET_IMPL_LWIP_TCP) && !defined(MSG_PEEK)
+#define MSG_PEEK       0x01    /* Peeks at an incoming message */
+#endif
+
 namespace esphome {
 namespace socket {
 

--- a/esphome/components/socket_shd/__init__.py
+++ b/esphome/components/socket_shd/__init__.py
@@ -1,0 +1,26 @@
+import esphome.config_validation as cv
+import esphome.codegen as cg
+
+CODEOWNERS = ["@esphome/core"]
+AUTO_LOAD = ["socket"]
+
+CONF_IMPLEMENTATION = "implementation"
+IMPLEMENTATION_LWIP_TCP = "lwip_tcp"
+IMPLEMENTATION_BSD_SOCKETS = "bsd_sockets"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.SplitDefault(
+            CONF_IMPLEMENTATION,
+            esp8266=IMPLEMENTATION_LWIP_TCP,
+            esp32=IMPLEMENTATION_BSD_SOCKETS,
+            rp2040=IMPLEMENTATION_LWIP_TCP,
+            host=IMPLEMENTATION_BSD_SOCKETS,
+        ): cv.one_of(
+            IMPLEMENTATION_LWIP_TCP, IMPLEMENTATION_BSD_SOCKETS, lower=True, space="_"
+        ),
+    }
+)
+
+async def to_code(config):
+    cg.add_define("USE_SOCKET_SHD")

--- a/esphome/components/socket_shd/bsd_sockets_impl.cpp
+++ b/esphome/components/socket_shd/bsd_sockets_impl.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace esphome {
-namespace socket {
+namespace socket_shd {
 
 std::string format_sockaddr(const struct sockaddr_storage &storage) {
   if (storage.ss_family == AF_INET) {
@@ -181,7 +181,7 @@ std::unique_ptr<Socket> socket(int domain, int type, int protocol) {
   return std::unique_ptr<Socket>{new BSDSocketImpl(ret)};
 }
 
-}  // namespace socket
+}  // namespace socket_shd
 }  // namespace esphome
 
 #endif  // USE_SOCKET_IMPL_BSD_SOCKETS

--- a/esphome/components/socket_shd/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket_shd/lwip_raw_tcp_impl.cpp
@@ -16,7 +16,7 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace socket {
+namespace socket_shd {
 
 static const char *const TAG = "socket.lwip";
 
@@ -951,7 +951,7 @@ std::unique_ptr<Socket> socket(int domain, int type, int protocol) {
   return std::unique_ptr<Socket>{sock};
 }
 
-}  // namespace socket
+}  // namespace socket_shd
 }  // namespace esphome
 
 #endif  // USE_SOCKET_IMPL_LWIP_TCP

--- a/esphome/components/socket_shd/socket.cpp
+++ b/esphome/components/socket_shd/socket.cpp
@@ -1,0 +1,21 @@
+#include "socket.h"
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace socket_shd {
+
+Socket::~Socket() {}
+
+std::unique_ptr<Socket> socket_ip(int type, int protocol) {
+#if LWIP_IPV6
+  return socket(AF_INET6, type, protocol);
+#else
+  return socket(AF_INET, type, protocol);
+#endif
+}
+
+}  // namespace socket_shd
+}  // namespace esphome

--- a/esphome/components/socket_shd/socket.h
+++ b/esphome/components/socket_shd/socket.h
@@ -5,6 +5,10 @@
 #include "esphome/core/optional.h"
 #include "esphome/components/socket/headers.h"
 
+#if defined(USE_SOCKET_IMPL_LWIP_TCP) && !defined(MSG_PEEK)
+#define MSG_PEEK       0x01    /* Peeks at an incoming message */
+#endif
+
 namespace esphome {
 namespace socket_shd {
 

--- a/esphome/components/socket_shd/socket.h
+++ b/esphome/components/socket_shd/socket.h
@@ -3,10 +3,10 @@
 #include <string>
 
 #include "esphome/core/optional.h"
-#include "headers.h"
+#include "esphome/components/socket/headers.h"
 
 namespace esphome {
-namespace socket {
+namespace socket_shd {
 
 class Socket {
  public:
@@ -48,11 +48,5 @@ std::unique_ptr<Socket> socket(int domain, int type, int protocol);
 /// Create a socket in the newest available IP domain (IPv6 or IPv4) of the given type and protocol.
 std::unique_ptr<Socket> socket_ip(int type, int protocol);
 
-/// Set a sockaddr to the specified address and port for the IP version used by socket_ip().
-socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port);
-
-/// Set a sockaddr to the any address and specified port for the IP version used by socket_ip().
-socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port);
-
-}  // namespace socket
+}  // namespace socket_shd
 }  // namespace esphome

--- a/esphome/components/socket_shd/test/test-tcp-sock.h
+++ b/esphome/components/socket_shd/test/test-tcp-sock.h
@@ -1,0 +1,79 @@
+#include "esphome/components/socket/socket.h"
+#include "esphome/components/socket_shd/socket.h"
+
+// NB!!!
+// A (VERY!!) simple tcp server!
+// connections will be closed and removed (I think) 10s after last received message
+// ... if test_tcp_read() is being called often
+
+struct tcp_client {
+  std::unique_ptr<socket_shd::Socket> sock;
+  uint32_t msec;
+};
+
+std::unique_ptr<socket_shd::Socket> sock_tcp;
+struct sockaddr_storage srv_tcp;
+uint8_t buff_tcp_recv[1024];
+std::vector<std::unique_ptr<struct tcp_client>> tcp_clients;
+
+void test_tcp_read() {
+  if(!sock_tcp) return;
+
+  // Partition clients into remove and active
+  auto new_end = std::partition(
+    tcp_clients.begin(), tcp_clients.end(),
+    [](const std::unique_ptr<struct tcp_client> &conn) {
+      bool close = (millis() - conn->msec) < 10000;
+      return close;
+    }
+  );
+  // print disconnection messages
+  for (auto it = new_end; it != tcp_clients.end(); ++it) {
+    ESP_LOGD("tcp_serv", "Removing connection to %s", (*it)->sock->getpeername().c_str());
+  }
+  // resize vector
+  tcp_clients.erase(new_end, tcp_clients.end());
+
+  for (auto &client : tcp_clients) {
+    std::string addr;
+    ssize_t len = client->sock->recvfrom(buff_tcp_recv, sizeof(buff_tcp_recv), 0, addr);
+    if (len <= 0) continue;
+
+    client->msec = millis();
+    ESP_LOGD("tcp_recv", "From: %s", addr.c_str());
+    ESP_LOGD("tcp_recv", "Data: %s", std::string((const char *) buff_tcp_recv, len).c_str());
+  }
+}
+
+void test_tcp_accept() {
+  if(!sock_tcp) return;
+
+  while (true) {
+    struct sockaddr_storage source_addr;
+    socklen_t addr_len = sizeof(source_addr);
+    auto sock = sock_tcp->accept((struct sockaddr *) &source_addr, &addr_len);
+    if (!sock) break;
+    sock->setblocking(false);
+    ESP_LOGD("tcp_serv", "Accepted %s", sock->getpeername().c_str());
+
+    auto *client = new tcp_client {std::move(sock), millis()};
+    tcp_clients.emplace_back(client);
+
+    std::string str = "hello client";
+    client->sock->write(str.data(), str.size());
+  }
+}
+
+void test_tcp_setup() {
+  if(sock_tcp) return;
+
+  socket::set_sockaddr_any((struct sockaddr *) &srv_tcp, sizeof(srv_tcp), 25588);
+  
+  int enable = 1;
+  sock_tcp = socket_shd::socket_ip(SOCK_STREAM, IPPROTO_IP);
+  sock_tcp->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+  sock_tcp->setblocking(false);
+
+  sock_tcp->bind((struct sockaddr *) &srv_tcp, sizeof(srv_tcp));
+  sock_tcp->listen(4);
+}

--- a/esphome/components/socket_shd/test/test-tcp-sock.h
+++ b/esphome/components/socket_shd/test/test-tcp-sock.h
@@ -36,11 +36,18 @@ void test_tcp_read() {
 
   for (auto &client : tcp_clients) {
     std::string addr;
-    ssize_t len = client->sock->recvfrom(buff_tcp_recv, sizeof(buff_tcp_recv), 0, addr);
+    ssize_t len;
+
+    len = client->sock->recvfrom(buff_tcp_recv, 3, MSG_PEEK, addr);
     if (len <= 0) continue;
 
     client->msec = millis();
     ESP_LOGD("tcp_recv", "From: %s", addr.c_str());
+    ESP_LOGD("tcp_recv", "Data: %s", std::string((const char *) buff_tcp_recv, len).c_str());
+
+    len = client->sock->read(buff_tcp_recv, sizeof(buff_tcp_recv));
+    if (len <= 0) continue;
+
     ESP_LOGD("tcp_recv", "Data: %s", std::string((const char *) buff_tcp_recv, len).c_str());
   }
 }

--- a/esphome/components/socket_shd/test/test-udp-sock.h
+++ b/esphome/components/socket_shd/test/test-udp-sock.h
@@ -1,0 +1,36 @@
+#include "esphome/components/socket/socket.h"
+#include "esphome/components/socket_shd/socket.h"
+
+std::unique_ptr<socket_shd::Socket> sock_udp;
+struct sockaddr dest_bcast;
+struct sockaddr_storage srv_udp;
+uint8_t buff_udb_recv[1024];
+
+void test_udp_read() {
+  if(!sock_udp) return;
+  
+  std::string addr;
+  ssize_t len = sock_udp->recvfrom(buff_udb_recv, sizeof(buff_udb_recv), 0, addr);
+  if (len <= 0) return;
+
+  ESP_LOGD("udp_recv", "From: %s", addr.c_str());
+  ESP_LOGD("udp_recv", "Data: %s", std::string((const char *) buff_udb_recv, len).c_str());
+}
+
+void test_udp_send(const void *data, size_t len) {
+	if (!sock_udp) return;
+	sock_udp->sendto(data, len, 0, &dest_bcast, sizeof(dest_bcast));
+}
+
+void test_udp_setup() {
+  socket::set_sockaddr(&dest_bcast, sizeof(dest_bcast), "255.255.255.255", 25577);
+  socket::set_sockaddr_any((struct sockaddr *) &srv_udp, sizeof(srv_udp), 25577);
+  
+  int enable = 1;
+  sock_udp = socket_shd::socket_ip(SOCK_DGRAM, IPPROTO_IP);
+  sock_udp->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+  sock_udp->setsockopt(SOL_SOCKET, SO_BROADCAST, &enable, sizeof(int));
+  sock_udp->setblocking(false);
+  
+  sock_udp->bind((struct sockaddr *) &srv_udp, sizeof(srv_udp));
+}

--- a/esphome/components/socket_shd/test/test-udp-sock.h
+++ b/esphome/components/socket_shd/test/test-udp-sock.h
@@ -10,10 +10,17 @@ void test_udp_read() {
   if(!sock_udp) return;
   
   std::string addr;
-  ssize_t len = sock_udp->recvfrom(buff_udb_recv, sizeof(buff_udb_recv), 0, addr);
+  ssize_t len;
+
+  len = sock_udp->recvfrom(buff_udb_recv, 3, MSG_PEEK, addr);
   if (len <= 0) return;
 
   ESP_LOGD("udp_recv", "From: %s", addr.c_str());
+  ESP_LOGD("udp_recv", "Data: %s", std::string((const char *) buff_udb_recv, len).c_str());
+
+  len = sock_udp->read(buff_udb_recv, sizeof(buff_udb_recv));
+  if (len <= 0) return;
+
   ESP_LOGD("udp_recv", "Data: %s", std::string((const char *) buff_udb_recv, len).c_str());
 }
 

--- a/esphome/components/socket_shd/test/test.yaml
+++ b/esphome/components/socket_shd/test/test.yaml
@@ -1,0 +1,32 @@
+esphome:
+  name: "my-esp-test-1"
+  friendly_name: "my-esp-test-1"
+  includes:
+    - test-udp-sock.h
+    - test-tcp-sock.h
+  on_boot:
+    priority: 250
+    then:
+      - lambda: |-
+          test_udp_setup();
+          test_tcp_setup();
+  on_loop:
+    - lambda: |-
+        test_udp_read();
+        test_tcp_accept();
+        test_tcp_read();
+
+external_components:
+  - source: github://pr#0000
+    components: [ socket_shd ]
+
+socket_shd:
+
+button:
+  - platform: template
+    id: test_udp_send
+    name: "Test UDP Send"
+    on_press:
+      - lambda: |-
+          std::string str = "hello from my-esp-test-1";
+          test_udp_send(str.data(), str.size());


### PR DESCRIPTION
# What does this implement/fix?

**Testing!!!**

Add support on esp8266 for UDP in socket component.

`socket_shd` is a copy of the socket component in a different namespace, so one would be able to test this without breaking `api` and `ota` if something goes wrong.

Just don't load `socket` as external component from this PR, only `socket_shd` as in example bellow.

When/if deemed worthy of merging, `socket_shd` will be removed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: "my-esp-test-1"
  friendly_name: "my-esp-test-1"
  includes:
    # files in socket_shd/test folder
    - test-udp-sock.h
    - test-tcp-sock.h
  on_boot:
    priority: 250
    then:
      - lambda: |-
          test_udp_setup();
          test_tcp_setup();
  on_loop:
    - lambda: |-
        test_udp_read();
        test_tcp_accept();
        test_tcp_read();

external_components:
  - source: github://pr#5063
    components: [ socket_shd ]

socket_shd:

button:
  - platform: template
    id: test_udp_send
    name: "Test UDP Send"
    on_press:
      - lambda: |-
          std::string str = "hello from my-esp-test-1";
          test_udp_send(str.data(), str.size());
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
