### PR TITLE
Mk2 to prepare color.h for idf >= 5

### DIFF
--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -57,21 +57,6 @@ struct Color {
   inline bool operator!=(uint32_t colorcode) {  // NOLINT
     return this->raw_32 != colorcode;
   }
-
-  inline Color &operator=(const Color &rhs) ALWAYS_INLINE {  // NOLINT
-    this->r = rhs.r;
-    this->g = rhs.g;
-    this->b = rhs.b;
-    this->w = rhs.w;
-    return *this;
-  }
-  inline Color &operator=(uint32_t colorcode) ALWAYS_INLINE {
-    this->w = (colorcode >> 24) & 0xFF;
-    this->r = (colorcode >> 16) & 0xFF;
-    this->g = (colorcode >> 8) & 0xFF;
-    this->b = (colorcode >> 0) & 0xFF;
-    return *this;
-  }
   inline uint8_t &operator[](uint8_t x) ALWAYS_INLINE { return this->raw[x]; }
   inline Color operator*(uint8_t scale) const ALWAYS_INLINE {
     return Color(esp_scale8(this->red, scale), esp_scale8(this->green, scale), esp_scale8(this->blue, scale),


### PR DESCRIPTION
# What does this implement/fix?

Compiler started to give warnings about operator= in color.h when preparing other components for IDF >= 5. The simple solution is to remove both `operator=`'s.

This is an alternative to #5051 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
