### PR TITLE
Fix bulk and single Bluetooth parser coexistence

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -275,10 +275,8 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
   return ESP_OK;
 }
 
-esp32_ble_tracker::AdvertisementParserType BluetoothProxy::get_advertisement_parser_type() {
-  if (this->proxy_->raw_advertisements_)
-    return esp32_ble_tracker::AdvertisementParserType::RAW_ADVERTISEMENTS;
-  return esp32_ble_tracker::AdvertisementParserType::PARSED_ADVERTISEMENTS;
+esp32_ble_tracker::AdvertisementParserType BluetoothConnection::get_advertisement_parser_type() {
+  return this->proxy_->get_advertisement_parser_type();
 }
 
 }  // namespace bluetooth_proxy

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -275,6 +275,12 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
   return ESP_OK;
 }
 
+esp32_ble_tracker::AdvertisementParserType BluetoothProxy::get_advertisement_parser_type() {
+  if (this->proxy_->raw_advertisements_)
+    return esp32_ble_tracker::AdvertisementParserType::RAW_ADVERTISEMENTS;
+  return esp32_ble_tracker::AdvertisementParserType::PARSED_ADVERTISEMENTS;
+}
+
 }  // namespace bluetooth_proxy
 }  // namespace esphome
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -14,6 +14,7 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
+  esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
 
   esp_err_t read_characteristic(uint16_t handle);
   esp_err_t write_characteristic(uint16_t handle, const std::string &data, bool response);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -441,6 +441,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
   }
   this->api_connection_ = api_connection;
   this->raw_advertisements_ = flags & BluetoothProxySubscriptionFlag::SUBSCRIPTION_RAW_ADVERTISEMENTS;
+  this->parent_->recalculate_advertisement_parser_types();
 }
 
 void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connection) {
@@ -450,6 +451,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
   }
   this->api_connection_ = nullptr;
   this->raw_advertisements_ = false;
+  this->parent_->recalculate_advertisement_parser_types();
 }
 
 void BluetoothProxy::send_device_connection(uint64_t address, bool connected, uint16_t mtu, esp_err_t error) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -198,10 +198,10 @@ void BluetoothProxy::loop() {
   }
 }
 
-AdvertisementParserType BluetoothProxy::get_advertisement_parser_type() {
+esp32_ble_tracker::AdvertisementParserType BluetoothProxy::get_advertisement_parser_type() {
   if (this->raw_advertisements_)
-    return AdvertisementParserType::RAW_ADVERTISEMENTS;
-  return AdvertisementParserType::PARSED_ADVERTISEMENTS;
+    return esp32_ble_tracker::AdvertisementParserType::RAW_ADVERTISEMENTS;
+  return esp32_ble_tracker::AdvertisementParserType::PARSED_ADVERTISEMENTS;
 }
 
 BluetoothConnection *BluetoothProxy::get_connection_(uint64_t address, bool reserve) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -198,6 +198,12 @@ void BluetoothProxy::loop() {
   }
 }
 
+AdvertisementParserType BluetoothProxy::get_advertisement_parser_type() {
+  if (this->raw_advertisements_)
+    return AdvertisementParserType::RAW_ADVERTISEMENTS;
+  return AdvertisementParserType::PARSED_ADVERTISEMENTS;
+}
+
 BluetoothConnection *BluetoothProxy::get_connection_(uint64_t address, bool reserve) {
   for (auto *connection : this->connections_) {
     if (connection->get_address() == address)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -51,7 +51,7 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
   bool parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_param *advertisements, size_t count) override;
   void dump_config() override;
   void loop() override;
-  AdvertisementParserType get_advertisement_parser_type() override;
+  esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
 
   void register_connection(BluetoothConnection *connection) {
     this->connections_.push_back(connection);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -51,6 +51,7 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
   bool parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_param *advertisements, size_t count) override;
   void dump_config() override;
   void loop() override;
+  AdvertisementParserType get_advertisement_parser_type() override;
 
   void register_connection(BluetoothConnection *connection) {
     this->connections_.push_back(connection);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -108,16 +108,18 @@ void ESP32BLETracker::loop() {
       }
 
       if (this->raw_advertisements_) {
+        ESP_LOGD(TAG, "raw_advertisements_");
         for (auto *listener : this->listeners_) {
           listener->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
         }
         for (auto *client : this->clients_) {
           client->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
         }
+        ESP_LOGD(TAG, "done raw_advertisements_");
       }
 
       if (this->parse_advertisements_) {
-        ESP_LOGD(TAG, "Parsing BLE devices");
+        ESP_LOGD(TAG, "parse_advertisements_");
         for (size_t i = 0; i < index; i++) {
           ESPBTDevice device;
           device.parse_scan_rst(this->scan_result_buffer_[i]);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -289,13 +289,13 @@ void ESP32BLETracker::end_of_scan_() {
 void ESP32BLETracker::register_client(ESPBTClient *client) {
   client->app_id = ++this->app_id_;
   this->clients_.push_back(client);
-  this->_recalculate_advertisement_parser_types();
+  this->recalculate_advertisement_parser_types();
 }
 
 void ESP32BLETracker::register_listener(ESPBTDeviceListener *listener) {
   listener->set_parent(this);
   this->listeners_.push_back(listener);
-  this->_recalculate_advertisement_parser_types();
+  this->recalculate_advertisement_parser_types();
 }
 
 void ESP32BLETracker::recalculate_advertisement_parser_types() {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -303,19 +303,15 @@ void ESP32BLETracker::recalculate_advertisement_parser_types() {
   this->parse_advertisements_ = false;
   for (auto *listener : this->listeners_) {
     if (listener->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
-      ESP_LOGW(TAG, "listener->parse_advertisements_ = true");
       this->parse_advertisements_ = true;
     } else {
-      ESP_LOGW(TAG, "listener->raw_advertisements_ = true");
       this->raw_advertisements_ = true;
     }
   }
   for (auto *client : this->clients_) {
     if (client->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
-      ESP_LOGW(TAG, "client->parse_advertisements_ = true");
       this->parse_advertisements_ = true;
     } else {
-      ESP_LOGW(TAG, "client->raw_advertisements_ = true");
       this->raw_advertisements_ = true;
     }
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -108,18 +108,15 @@ void ESP32BLETracker::loop() {
       }
 
       if (this->raw_advertisements_) {
-        ESP_LOGD(TAG, "raw_advertisements_");
         for (auto *listener : this->listeners_) {
           listener->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
         }
         for (auto *client : this->clients_) {
           client->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
         }
-        ESP_LOGD(TAG, "done raw_advertisements_");
       }
 
       if (this->parse_advertisements_) {
-        ESP_LOGD(TAG, "parse_advertisements_");
         for (size_t i = 0; i < index; i++) {
           ESPBTDevice device;
           device.parse_scan_rst(this->scan_result_buffer_[i]);
@@ -143,8 +140,6 @@ void ESP32BLETracker::loop() {
             this->print_bt_device_info(device);
           }
         }
-      } else {
-        ESP_LOGD(TAG, "Skipping BLE device parsing");
       }
       this->scan_result_index_ = 0;
       xSemaphoreGive(this->scan_result_lock_);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -107,16 +107,16 @@ void ESP32BLETracker::loop() {
         ESP_LOGW(TAG, "Too many BLE events to process. Some devices may not show up.");
       }
 
-      bool bulk_parsed = false;
+      bool needs_single_parse = false;
 
       for (auto *listener : this->listeners_) {
-        bulk_parsed |= listener->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
+        needs_single_parse |= !listener->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
       }
       for (auto *client : this->clients_) {
-        bulk_parsed |= client->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
+        needs_single_parse |= !client->parse_devices(this->scan_result_buffer_, this->scan_result_index_);
       }
 
-      if (!bulk_parsed) {
+      if (needs_single_parse) {
         for (size_t i = 0; i < index; i++) {
           ESPBTDevice device;
           device.parse_scan_rst(this->scan_result_buffer_[i]);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -298,7 +298,7 @@ void ESP32BLETracker::register_listener(ESPBTDeviceListener *listener) {
   this->_recalculate_advertisement_parser_types();
 }
 
-void ESP32BLETracker::_recalculate_advertisement_parser_types() {
+void ESP32BLETracker::recalculate_advertisement_parser_types() {
   this->raw_advertisements_ = false;
   this->parse_advertisements_ = false;
   for (auto *listener : this->listeners_) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -303,15 +303,19 @@ void ESP32BLETracker::_recalculate_advertisement_parser_types() {
   this->parse_advertisements_ = false;
   for (auto *listener : this->listeners_) {
     if (listener->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
+      ESP_LOGW(TAG, "listener->parse_advertisements_ = true");
       this->parse_advertisements_ = true;
     } else {
+      ESP_LOGW(TAG, "listener->raw_advertisements_ = true");
       this->raw_advertisements_ = true;
     }
   }
   for (auto *client : this->clients_) {
     if (client->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
+      ESP_LOGW(TAG, "client->parse_advertisements_ = true");
       this->parse_advertisements_ = true;
     } else {
+      ESP_LOGW(TAG, "client->raw_advertisements_ = true");
       this->raw_advertisements_ = true;
     }
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -305,18 +305,16 @@ void ESP32BLETracker::_recalculate_advertisement_parser_types() {
     if (listener->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
       this->parse_advertisements_ = true;
     } else {
+      this->raw_advertisements_ = true;
     }
-    this->raw_advertisements_ = true;
   }
-}
-for (auto *client : this->clients_) {
-  if (client->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
-    this->parse_advertisements_ = true;
-  } else {
+  for (auto *client : this->clients_) {
+    if (client->get_advertisement_parser_type() == AdvertisementParserType::PARSED_ADVERTISEMENTS) {
+      this->parse_advertisements_ = true;
+    } else {
+      this->raw_advertisements_ = true;
+    }
   }
-  this->raw_advertisements_ = true;
-}
-}
 }
 
 void ESP32BLETracker::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -194,7 +194,7 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
 
   void register_listener(ESPBTDeviceListener *listener);
   void register_client(ESPBTClient *client);
-  void _recalculate_advertisement_parser_types();
+  void recalculate_advertisement_parser_types();
 
   void print_bt_device_info(const ESPBTDevice &device);
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -27,6 +27,11 @@ using namespace esp32_ble;
 
 using adv_data_t = std::vector<uint8_t>;
 
+enum AdvertisementParserType {
+  PARSED_ADVERTISEMENTS,
+  RAW_ADVERTISEMENTS,
+};
+
 struct ServiceData {
   ESPBTUUID uuid;
   adv_data_t data;
@@ -116,6 +121,9 @@ class ESPBTDeviceListener {
   virtual bool parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_param *advertisements, size_t count) {
     return false;
   };
+  virtual AdvertisementParserType get_advertisement_parser_type() {
+    return AdvertisementParserType::PARSED_ADVERTISEMENTS;
+  };
   void set_parent(ESP32BLETracker *parent) { parent_ = parent; }
 
  protected:
@@ -184,11 +192,7 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
 
   void loop() override;
 
-  void register_listener(ESPBTDeviceListener *listener) {
-    listener->set_parent(this);
-    this->listeners_.push_back(listener);
-  }
-
+  void register_listener(ESPBTDeviceListener *listener);
   void register_client(ESPBTClient *client);
 
   void print_bt_device_info(const ESPBTDevice &device);
@@ -231,6 +235,8 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   bool scan_continuous_;
   bool scan_active_;
   bool scanner_idle_;
+  bool raw_advertisements_{false};
+  bool parse_advertisements_{false};
   SemaphoreHandle_t scan_result_lock_;
   SemaphoreHandle_t scan_end_lock_;
   size_t scan_result_index_{0};

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -194,6 +194,7 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
 
   void register_listener(ESPBTDeviceListener *listener);
   void register_client(ESPBTClient *client);
+  void _recalculate_advertisement_parser_types();
 
   void print_bt_device_info(const ESPBTDevice &device);
 


### PR DESCRIPTION
# What does this implement/fix?

fixes https://github.com/esphome/issues/issues/4641 fixes https://github.com/esphome/issues/issues/4667 fixes https://github.com/esphome/issues/issues/4680
<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
