### PR TITLE
Make docker use pip installed pillow

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,16 +22,22 @@ RUN \
         python3=3.9.2-3 \
         python3-pip=20.3.4-4+deb11u1 \
         python3-setuptools=52.0.0-4 \
-        python3-pil=8.1.2+dfsg-0.3+deb11u1 \
         python3-cryptography=3.3.2-1 \
         python3-venv=3.9.2-3 \
         iputils-ping=3:20210202-1 \
         git=1:2.30.2-1+deb11u2 \
         curl=7.74.0-1.3+deb11u7 \
         openssh-client=1:8.4p1-5+deb11u1 \
-        libcairo2=1.16.0-5 \
-        python3-cffi=1.14.5-1 \
-    && rm -rf \
+        python3-cffi=1.14.5-1; \
+    if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
+        apt-get install -y --no-install-recommends \
+          build-essential=12.9 \
+          python3-dev=3.9.2-3 \
+          zlib1g-dev=1:1.2.11.dfsg-2+deb11u2 \
+          libjpeg-dev=1:2.0.6-4 \
+          libcairo2=1.16.0-5; \
+    fi; \
+    rm -rf \
         /tmp/* \
         /var/{cache,log}/* \
         /var/lib/apt/lists/*


### PR DESCRIPTION
# What does this implement/fix?

Don't apt install pillow to make docker container use version from requirements_optional.txt

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4398

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
