### PR TITLE
Update docker to use Debian 12 and clang to 14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,9 @@
 ARG BASEIMGTYPE=docker
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ghcr.io/hassio-addons/debian-base:6.2.3 AS base-hassio
+FROM ghcr.io/hassio-addons/debian-base:7.0.0 AS base-hassio
 # https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye
-FROM debian:bullseye-20230208-slim AS base-docker
+FROM debian:bookworm-20230703-slim AS base-docker
 
 FROM base-${BASEIMGTYPE} AS base
 
@@ -19,18 +19,24 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        python3=3.9.2-3 \
-        python3-pip=20.3.4-4+deb11u1 \
-        python3-setuptools=52.0.0-4 \
-        python3-pil=8.1.2+dfsg-0.3+deb11u1 \
-        python3-cryptography=3.3.2-1 \
-        python3-venv=3.9.2-3 \
-        iputils-ping=3:20210202-1 \
-        git=1:2.30.2-1+deb11u2 \
-        curl=7.74.0-1.3+deb11u7 \
-        openssh-client=1:8.4p1-5+deb11u1 \
-        libcairo2=1.16.0-5 \
-        python3-cffi=1.14.5-1 \
+        python3=3.11.2-1+b1 \
+        python3-pip=23.0.1+dfsg-1 \
+        python3-setuptools=66.1.1-1 \
+        python3-venv=3.11.2-1+b1 \
+        iputils-ping=3:20221126-1 \
+        git=1:2.39.2-1.1 \
+        curl=7.88.1-10 \
+        build-essential=12.9 \
+        libffi-dev=3.4.4-1 \
+        libssl-dev=3.0.9-1 \
+        python3-dev=3.11.2-1+b1 \
+        cargo=0.66.0+ds1-1 \
+        pkg-config \
+        zlib1g-dev=1:1.2.13.dfsg-1 \
+        libjpeg-dev=1:2.1.5-2 \
+        openssh-client=1:9.2p1-2 \
+        libcairo2=1.16.0-7 \
+        python3-cffi=1.15.1-5 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \
@@ -40,7 +46,9 @@ ENV \
   # Fix click python3 lang warning https://click.palletsprojects.com/en/7.x/python3/
   LANG=C.UTF-8 LC_ALL=C.UTF-8 \
   # Store globally installed pio libs in /piolibs
-  PLATFORMIO_GLOBALLIB_DIR=/piolibs
+  PLATFORMIO_GLOBALLIB_DIR=/piolibs \
+  # Path for virtual env
+  VIRTUAL_ENV=/opt/venv
 
 # Support legacy binaries on Debian multiarch system. There is no "correct" way
 # to do this, other than using properly built toolchains...
@@ -50,10 +58,13 @@ RUN \
         ln -s /lib/arm-linux-gnueabihf/ld-linux.so.3 /lib/ld-linux.so.3; \
     fi
 
+
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --no-cache-dir \
-        wheel==0.37.1 \
+        wheel==0.40.0 \
         platformio==6.1.7 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
@@ -65,7 +76,7 @@ RUN \
 COPY requirements.txt requirements_optional.txt script/platformio_install_deps.py platformio.ini /
 RUN \
     pip3 install --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
-    && /platformio_install_deps.py /platformio.ini --libraries
+    && python3 /platformio_install_deps.py /platformio.ini --libraries
 
 
 # ======================= docker-type image =======================
@@ -102,7 +113,7 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        nginx-light=1.18.0-6.1+deb11u3 \
+        nginx-light=1.22.1-9 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \
@@ -138,13 +149,13 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        clang-format-13=1:13.0.1-6~deb11u1 \
-        clang-tidy-11=1:11.0.1-2 \
+        clang-format=1:14.0-55.6 \
+        clang-tidy=1:14.0-55.6 \
         patch=2.7.6-7 \
-        software-properties-common=0.96.20.2-2.1 \
-        nano=5.4-2+deb11u2 \
+        software-properties-common=0.99.30-4 \
+        nano=7.2-1 \
         build-essential=12.9 \
-        python3-dev=3.9.2-3 \
+        python3-dev=3.11.2-1+b1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \
@@ -153,5 +164,6 @@ RUN \
 COPY requirements_test.txt /
 RUN pip3 install --no-cache-dir -r /requirements_test.txt
 
+RUN git config --global --add safe.directory /esphome
 VOLUME ["/esphome"]
 WORKDIR /esphome

--- a/script/clang-format
+++ b/script/clang-format
@@ -17,7 +17,7 @@ def run_format(args, queue, lock, failed_files):
     """Takes filenames out of queue and runs clang-format on them."""
     while True:
         path = queue.get()
-        invocation = ["clang-format-13"]
+        invocation = ["clang-format-14"]
         if args.inplace:
             invocation.append("-i")
         else:
@@ -59,14 +59,14 @@ def main():
     args = parser.parse_args()
 
     try:
-        get_output("clang-format-13", "-version")
+        get_output("clang-format-14", "-version")
     except:
         print(
             """
         Oops. It looks like clang-format is not installed. 
         
-        Please check you can run "clang-format-13 -version" in your terminal and install
-        clang-format (v13) if necessary.
+        Please check you can run "clang-format-14 -version" in your terminal and install
+        clang-format (v14) if necessary.
         
         Note you can also upload your code as a pull request on GitHub and see the CI check
         output to apply clang-format.

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -113,7 +113,7 @@ def clang_options(idedata):
 def run_tidy(args, options, tmpdir, queue, lock, failed_files):
     while True:
         path = queue.get()
-        invocation = ["clang-tidy-11"]
+        invocation = ["clang-tidy-14"]
 
         if tmpdir is not None:
             invocation.append("--export-fixes")
@@ -194,14 +194,14 @@ def main():
     args = parser.parse_args()
 
     try:
-        get_output("clang-tidy-11", "-version")
+        get_output("clang-tidy-14", "-version")
     except:
         print(
             """
-        Oops. It looks like clang-tidy-11 is not installed.
+        Oops. It looks like clang-tidy-14 is not installed.
 
-        Please check you can run "clang-tidy-11 -version" in your terminal and install
-        clang-tidy (v11) if necessary.
+        Please check you can run "clang-tidy-14 -version" in your terminal and install
+        clang-tidy (v14) if necessary.
 
         Note you can also upload your code as a pull request on GitHub and see the CI check
         output to apply clang-tidy.
@@ -272,7 +272,7 @@ def main():
     if args.fix and failed_files:
         print("Applying fixes ...")
         try:
-            subprocess.call(["clang-apply-replacements-11", tmpdir])
+            subprocess.call(["clang-apply-replacements-14", tmpdir])
         except:
             print("Error applying fixes.\n", file=sys.stderr)
             raise


### PR DESCRIPTION
# What does this implement/fix?

Updates docker to use Debian 12 (bookworm) and clang-tidy and clang-format to version 14.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
