### PR TITLE
Fix PIDController::in_deadband() to give correct result when error is zero

### DIFF
--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -29,7 +29,7 @@ float PIDController::update(float setpoint, float process_value) {
 bool PIDController::in_deadband() {
   // return (fabs(error) < deadband_threshold);
   float err = -error_;
-  return ((err > 0 && err < threshold_high_) || (err < 0 && err > threshold_low_));
+  return (threshold_low_ < err && err < threshold_high_);
 }
 
 void PIDController::calculate_proportional_term_() {


### PR DESCRIPTION
# What does this implement/fix?

The previous logic checked that the error was less than high threshold if `err > 0` or that error was greater than low threshold if `err < 0`, but this excluded the case where error values were exactly zero and would result in `in_deadband()` returning `false` in this case.

This would then cause the logic in `calculate_proportional_term_()` to apply a compensation offset as if the error was at the low threshold, resulting in a large jump in p-term if the process value exactly matches the setpoint when a deadband range is enabled.

Now just check that err value is between low threshold and high threshold.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

Fixes https://github.com/esphome/issues/issues/4483

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

