### PR TITLE
Fix typo in mpu6050.cpp

### DIFF
--- a/esphome/components/mpu6050/mpu6050.cpp
+++ b/esphome/components/mpu6050/mpu6050.cpp
@@ -77,7 +77,7 @@ void MPU6050Component::setup() {
   accel_config &= 0b11100111;
   accel_config |= (MPU6050_RANGE_2G << 3);
   ESP_LOGV(TAG, "    Output accel_config: 0b" BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(accel_config));
-  if (!this->write_byte(MPU6050_REGISTER_GYRO_CONFIG, gyro_config)) {
+  if (!this->write_byte(MPU6050_REGISTER_ACCEL_CONFIG, accel_config)) {
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
MPU6050_REGISTER_ACCEL_CONFIG was never written and MPU6050_REGISTER_GYRO_CONFIG was written twice.

# What does this implement/fix?

MPU6050_REGISTER_ACCEL_CONFIG was never written (although the code indicates that)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
