### PR TITLE
[Sprinkler] Resume fixes

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -954,10 +954,18 @@ void Sprinkler::pause() {
 }
 
 void Sprinkler::resume() {
-  if (this->paused_valve_.has_value() && (this->resume_duration_.has_value())) {
-    ESP_LOGD(TAG, "Resuming valve %u with %u seconds remaining", this->paused_valve_.value_or(0),
-             this->resume_duration_.value_or(0));
-    this->fsm_request_(this->paused_valve_.value(), this->resume_duration_.value());
+  if (this->standby()) {
+    ESP_LOGD(TAG, "resume called but standby is enabled; no action taken");
+    return;
+  }
+
+  if (this->paused_valve_.has_value()) {
+    // Resume only if valve has not been completed yet
+    if (!this->valve_cycle_complete_(this->paused_valve_.value())) {
+        ESP_LOGD(TAG, "Resuming valve %u with %u seconds remaining", this->paused_valve_.value_or(0),
+                 this->resume_duration_.value_or(0));
+        this->fsm_request_(this->paused_valve_.value(), this->resume_duration_.value());
+    }
     this->reset_resume();
   } else {
     ESP_LOGD(TAG, "No valve to resume!");

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -959,7 +959,7 @@ void Sprinkler::resume() {
     return;
   }
 
-  if (this->paused_valve_.has_value()) {
+  if (this->paused_valve_.has_value() && (this->resume_duration_.has_value())) {
     // Resume only if valve has not been completed yet
     if (!this->valve_cycle_complete_(this->paused_valve_.value())) {
       ESP_LOGD(TAG, "Resuming valve %u with %u seconds remaining", this->paused_valve_.value_or(0),

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -962,9 +962,9 @@ void Sprinkler::resume() {
   if (this->paused_valve_.has_value()) {
     // Resume only if valve has not been completed yet
     if (!this->valve_cycle_complete_(this->paused_valve_.value())) {
-        ESP_LOGD(TAG, "Resuming valve %u with %u seconds remaining", this->paused_valve_.value_or(0),
-                 this->resume_duration_.value_or(0));
-        this->fsm_request_(this->paused_valve_.value(), this->resume_duration_.value());
+      ESP_LOGD(TAG, "Resuming valve %u with %u seconds remaining", this->paused_valve_.value_or(0),
+               this->resume_duration_.value_or(0));
+      this->fsm_request_(this->paused_valve_.value(), this->resume_duration_.value());
     }
     this->reset_resume();
   } else {


### PR DESCRIPTION
# What does this implement/fix?

1.  `Sprinkler::resume()`: Skip resuming if controller is in standby

     Please note the configuration example below doesn't illustrate the issue - replicating it is very simple: pause controller with active cycle (e.g. with `sprinkler.pause` action), put it on standby via corresponding switch and then attempt to resume (e.g. with `sprinkler.resume` action).
    Expected behaviour: controller takes no action
    Actual behaviour: controller resumes the cycle 

2. `Sprinkler::resume()`: Skip resuming when valve has been marked as complete

    I have a specific need to trigger water tank refill upon each valve completes - that is achieved by enabling dedicated switch (not part of controller configuration) for several seconds. The issue manifests itself as controller enters into loop over last controller's valve repeating its operation over and over again. Seemingly that is because extra processing at each valve that has `pause` action pauses the valve with `0` seconds remaining thus on `resume` it will pick the valve up again (seems `next_req_` is picked and reset to valve duration when the issue occurs).
   Please see below for sample configuration and corresponding log entries.

    Expected behaviour: controller processes the valves and ends the cycle
    Actual behaviour: controller enters a loop over last valve
   
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:


```yaml
# Example config.yaml
---
# Initiate sprinkler full cycle in 30 seconds upon boot,
# only to have no dependency on API/HASS to trigger
esphome:
  on_boot:
    priority: -100
    then:
      - delay: 30s
      - sprinkler.start_full_cycle: lawn_sprinkler_ctrlr

logger:
  level: VERY_VERBOSE
  logs:
    sensor: INFO
    text_sensor: INFO
    switch: DEBUG
    scheduler: INFO

# Basic configuration with single controller and two valves
# (template switches for illustration purposes)
sprinkler:
  - id: lawn_sprinkler_ctrlr
    main_switch: "Lawn Sprinklers"
    auto_advance_switch: "Lawn Sprinklers Auto Advance"

    valves:
      - valve_switch:
          name: "Lawn #1"
          # Upon valve completes, trigger tank refill over corresponding switch
          # (not part of controller valve configuration) by turning dedicated switch for 3 seconds
          # and then proceeding to next valve in cycle if any
          on_turn_off:
            - sprinkler.pause: lawn_sprinkler_ctrlr
            - switch.turn_on: tank_refill_sw
            - delay: 3s
            - switch.turn_off: tank_refill_sw
            - sprinkler.resume: lawn_sprinkler_ctrlr
        pump_switch_id: sprinkler_pump_sw
        run_duration: 5s
        valve_switch_id: lawn_sprinkler_valve_sw1
      - valve_switch:
          name: "Lawn #2"
          # See comment above 
          on_turn_off:
            - sprinkler.pause: lawn_sprinkler_ctrlr
            - switch.turn_on: tank_refill_sw
            - delay: 3s
            - switch.turn_off: tank_refill_sw
            - sprinkler.resume: lawn_sprinkler_ctrlr
        pump_switch_id: sprinkler_pump_sw
        run_duration: 5s
        valve_switch_id: lawn_sprinkler_valve_sw2

switch:
  - platform: template
    id: sprinkler_pump_sw
    optimistic: true
  - platform: template
    id: tank_refill_sw
    optimistic: true
  - platform: template
    id: lawn_sprinkler_valve_sw1
    optimistic: true
  - platform: template
    id: lawn_sprinkler_valve_sw2
    optimistic: true
```

## Corresponding logs

Taken from ESP12F, although RP2040 shows very similar behaviour.

```
...
[11:43:02][D][switch:012]: 'Lawn Sprinklers Auto Advance' Turning ON.
[11:43:02][D][switch:055]: 'Lawn Sprinklers Auto Advance': Sending state ON
[11:43:02][VV][sprinkler:1473]: fsm_transition_ called; state is IDLE
[11:43:02][VV][sprinkler:1635]: Timer 0 started for 5 sec
[11:43:02][D][sprinkler:1410]: CYCLE is starting valve 0 for 5 seconds, cycle 1 of 1
[11:43:02][D][switch:012]: 'lawn_sprinkler_valve_sw1' Turning ON.
[11:43:02][D][switch:055]: 'lawn_sprinkler_valve_sw1': Sending state ON
[11:43:02][D][switch:012]: 'sprinkler_pump_sw' Turning ON.
[11:43:02][D][switch:055]: 'sprinkler_pump_sw': Sending state ON
[11:43:02][VV][sprinkler:1516]: fsm_transition_ complete; new state is ACTIVE
[11:43:02][V][component:204]: Component esphome.coroutine took a long time for an operation (0.05 s).
[11:43:02][V][component:205]: Components should block for at most 20-30ms.
[11:43:02][D][switch:055]: 'Lawn Sprinklers': Sending state ON
[11:43:02][D][switch:055]: 'Lawn #1': Sending state ON
[11:43:07][VV][sprinkler:1667]: State machine timer expired
[11:43:07][VV][sprinkler:1473]: fsm_transition_ called; state is ACTIVE
[11:43:07][D][sprinkler:1282]: Marking valve 0 complete
[11:43:07][VV][sprinkler:1635]: Timer 0 started for 5 sec
[11:43:07][D][sprinkler:1410]: CYCLE is starting valve 1 for 5 seconds, cycle 1 of 1
[11:43:07][D][switch:012]: 'lawn_sprinkler_valve_sw2' Turning ON.
[11:43:07][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state ON
[11:43:07][VV][sprinkler:1516]: fsm_transition_ complete; new state is ACTIVE
[11:43:07][D][switch:055]: 'Lawn #2': Sending state ON
[11:43:07][D][switch:016]: 'lawn_sprinkler_valve_sw1' Turning OFF.
[11:43:07][D][switch:055]: 'lawn_sprinkler_valve_sw1': Sending state OFF
[11:43:07][D][switch:055]: 'Lawn #1': Sending state OFF
[11:43:07][D][switch:016]: 'lawn_sprinkler_valve_sw2' Turning OFF.
[11:43:07][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state OFF
[11:43:07][D][switch:016]: 'sprinkler_pump_sw' Turning OFF.
[11:43:07][D][switch:055]: 'sprinkler_pump_sw': Sending state OFF
[11:43:07][VV][sprinkler:1635]: Timer 0 started for 1 sec
[11:43:07][D][sprinkler:952]: Paused valve 1 with 4 seconds remaining
[11:43:07][D][switch:012]: 'tank_refill_sw' Turning ON.
[11:43:07][D][switch:055]: 'tank_refill_sw': Sending state ON
[11:43:07][D][switch:055]: 'Lawn #2': Sending state OFF
[11:43:07][D][switch:012]: 'tank_refill_sw' Turning ON.
[11:43:07][D][switch:055]: 'Lawn Sprinklers': Sending state OFF
[11:43:08][VV][sprinkler:1667]: State machine timer expired
[11:43:08][VV][sprinkler:1473]: fsm_transition_ called; state is STOPPING
[11:43:08][D][sprinkler:1434]: All valves stopped, including pumps
[11:43:08][VV][sprinkler:1516]: fsm_transition_ complete; new state is IDLE
[11:43:10][D][switch:016]: 'tank_refill_sw' Turning OFF.
[11:43:10][D][switch:055]: 'tank_refill_sw': Sending state OFF
[11:43:10][D][sprinkler:958]: Resuming valve 1 with 4 seconds remaining
[11:43:10][VV][sprinkler:1473]: fsm_transition_ called; state is IDLE
[11:43:10][VV][sprinkler:1635]: Timer 0 started for 4 sec
[11:43:10][D][sprinkler:1410]: USER is starting valve 1 for 4 seconds, cycle 1 of 1
[11:43:10][D][switch:012]: 'lawn_sprinkler_valve_sw2' Turning ON.
[11:43:10][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state ON
[11:43:10][D][switch:012]: 'sprinkler_pump_sw' Turning ON.
[11:43:10][D][switch:055]: 'sprinkler_pump_sw': Sending state ON
[11:43:10][VV][sprinkler:1516]: fsm_transition_ complete; new state is ACTIVE
[11:43:10][V][component:204]: Component switch took a long time for an operation (0.06 s).
[11:43:10][V][component:205]: Components should block for at most 20-30ms.
[11:43:10][D][switch:055]: 'Lawn Sprinklers': Sending state ON
[11:43:10][D][switch:055]: 'Lawn #2': Sending state ON
[11:43:10][D][switch:016]: 'tank_refill_sw' Turning OFF.
[11:43:10][D][sprinkler:963]: No valve to resume!
[11:43:12][D][esp8266.preferences:238]: Saving preferences to flash...
[11:43:14][VV][sprinkler:1667]: State machine timer expired
[11:43:14][VV][sprinkler:1473]: fsm_transition_ called; state is ACTIVE
[11:43:14][D][sprinkler:1282]: Marking valve 1 complete
[11:43:14][VV][sprinkler:1635]: Timer 0 started for 1 sec
[11:43:14][VV][sprinkler:1516]: fsm_transition_ complete; new state is STOPPING
[11:43:14][D][switch:016]: 'lawn_sprinkler_valve_sw2' Turning OFF.
[11:43:14][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state OFF
[11:43:14][D][switch:016]: 'sprinkler_pump_sw' Turning OFF.
[11:43:14][D][switch:055]: 'sprinkler_pump_sw': Sending state OFF
[11:43:14][D][switch:055]: 'Lawn #2': Sending state OFF
[11:43:14][VV][sprinkler:1635]: Timer 0 started for 1 sec
[11:43:14][D][sprinkler:952]: Paused valve 1 with 0 seconds remaining
[11:43:14][D][switch:012]: 'tank_refill_sw' Turning ON.
[11:43:14][D][switch:055]: 'tank_refill_sw': Sending state ON
[11:43:14][D][switch:055]: 'Lawn Sprinklers': Sending state OFF
[11:43:15][VV][sprinkler:1667]: State machine timer expired
[11:43:15][VV][sprinkler:1473]: fsm_transition_ called; state is STOPPING
[11:43:15][D][sprinkler:1434]: All valves stopped, including pumps
[11:43:15][VV][sprinkler:1516]: fsm_transition_ complete; new state is IDLE
[11:43:17][D][switch:016]: 'tank_refill_sw' Turning OFF.
[11:43:17][D][switch:055]: 'tank_refill_sw': Sending state OFF
[11:43:17][D][sprinkler:958]: Resuming valve 1 with 0 seconds remaining
[11:43:17][VV][sprinkler:1473]: fsm_transition_ called; state is IDLE
[11:43:17][VV][sprinkler:1635]: Timer 0 started for 5 sec
[11:43:17][D][sprinkler:1410]: USER is starting valve 1 for 5 seconds, cycle 2 of 1
[11:43:17][D][switch:012]: 'lawn_sprinkler_valve_sw2' Turning ON.
[11:43:17][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state ON
[11:43:17][D][switch:012]: 'sprinkler_pump_sw' Turning ON.
[11:43:17][D][switch:055]: 'sprinkler_pump_sw': Sending state ON
[11:43:17][VV][sprinkler:1516]: fsm_transition_ complete; new state is ACTIVE
[11:43:17][V][component:204]: Component switch took a long time for an operation (0.06 s).
[11:43:17][V][component:205]: Components should block for at most 20-30ms.
[11:43:17][D][switch:055]: 'Lawn Sprinklers': Sending state ON
[11:43:17][D][switch:055]: 'Lawn #2': Sending state ON
[11:43:22][VV][sprinkler:1667]: State machine timer expired
[11:43:22][VV][sprinkler:1473]: fsm_transition_ called; state is ACTIVE
[11:43:22][D][sprinkler:1282]: Marking valve 1 complete
[11:43:22][VV][sprinkler:1635]: Timer 0 started for 1 sec
[11:43:22][VV][sprinkler:1516]: fsm_transition_ complete; new state is STOPPING
[11:43:22][D][switch:016]: 'lawn_sprinkler_valve_sw2' Turning OFF.
[11:43:22][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state OFF
[11:43:22][D][switch:016]: 'sprinkler_pump_sw' Turning OFF.
[11:43:22][D][switch:055]: 'sprinkler_pump_sw': Sending state OFF
[11:43:22][D][switch:055]: 'Lawn #2': Sending state OFF
[11:43:22][VV][sprinkler:1635]: Timer 0 started for 1 sec
[11:43:22][D][sprinkler:952]: Paused valve 1 with 0 seconds remaining
[11:43:22][D][switch:012]: 'tank_refill_sw' Turning ON.
[11:43:22][D][switch:055]: 'tank_refill_sw': Sending state ON
[11:43:22][D][switch:055]: 'Lawn Sprinklers': Sending state OFF
[11:43:23][VV][sprinkler:1667]: State machine timer expired
[11:43:23][VV][sprinkler:1473]: fsm_transition_ called; state is STOPPING
[11:43:23][D][sprinkler:1434]: All valves stopped, including pumps
[11:43:23][VV][sprinkler:1516]: fsm_transition_ complete; new state is IDLE
[11:43:25][D][switch:016]: 'tank_refill_sw' Turning OFF.
[11:43:25][D][switch:055]: 'tank_refill_sw': Sending state OFF
[11:43:25][D][sprinkler:958]: Resuming valve 1 with 0 seconds remaining
[11:43:25][VV][sprinkler:1473]: fsm_transition_ called; state is IDLE
[11:43:25][VV][sprinkler:1635]: Timer 0 started for 5 sec
[11:43:25][D][sprinkler:1410]: USER is starting valve 1 for 5 seconds, cycle 3 of 1
[11:43:25][D][switch:012]: 'lawn_sprinkler_valve_sw2' Turning ON.
[11:43:25][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state ON
[11:43:25][D][switch:012]: 'sprinkler_pump_sw' Turning ON.
[11:43:25][D][switch:055]: 'sprinkler_pump_sw': Sending state ON
[11:43:25][VV][sprinkler:1516]: fsm_transition_ complete; new state is ACTIVE
[11:43:25][V][component:204]: Component switch took a long time for an operation (0.05 s).
[11:43:25][V][component:205]: Components should block for at most 20-30ms.
[11:43:25][D][switch:055]: 'Lawn Sprinklers': Sending state ON
[11:43:25][D][switch:055]: 'Lawn #2': Sending state ON
[11:43:30][VV][sprinkler:1667]: State machine timer expired
[11:43:30][VV][sprinkler:1473]: fsm_transition_ called; state is ACTIVE
[11:43:30][D][sprinkler:1282]: Marking valve 1 complete
[11:43:30][VV][sprinkler:1635]: Timer 0 started for 1 sec
[11:43:30][VV][sprinkler:1516]: fsm_transition_ complete; new state is STOPPING
[11:43:30][D][switch:016]: 'lawn_sprinkler_valve_sw2' Turning OFF.
[11:43:30][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state OFF
[11:43:30][D][switch:016]: 'sprinkler_pump_sw' Turning OFF.
[11:43:30][D][switch:055]: 'sprinkler_pump_sw': Sending state OFF
[11:43:30][D][switch:055]: 'Lawn #2': Sending state OFF
[11:43:30][VV][sprinkler:1635]: Timer 0 started for 1 sec
[11:43:30][D][sprinkler:952]: Paused valve 1 with 0 seconds remaining
[11:43:30][D][switch:012]: 'tank_refill_sw' Turning ON.
[11:43:30][D][switch:055]: 'tank_refill_sw': Sending state ON
[11:43:30][D][switch:055]: 'Lawn Sprinklers': Sending state OFF
[11:43:31][VV][sprinkler:1667]: State machine timer expired
[11:43:31][VV][sprinkler:1473]: fsm_transition_ called; state is STOPPING
[11:43:31][D][sprinkler:1434]: All valves stopped, including pumps
[11:43:31][VV][sprinkler:1516]: fsm_transition_ complete; new state is IDLE
[11:43:33][D][switch:016]: 'tank_refill_sw' Turning OFF.
[11:43:33][D][switch:055]: 'tank_refill_sw': Sending state OFF
[11:43:33][D][sprinkler:958]: Resuming valve 1 with 0 seconds remaining
[11:43:33][VV][sprinkler:1473]: fsm_transition_ called; state is IDLE
[11:43:33][VV][sprinkler:1635]: Timer 0 started for 5 sec
[11:43:33][D][sprinkler:1410]: USER is starting valve 1 for 5 seconds, cycle 4 of 1
[11:43:33][D][switch:012]: 'lawn_sprinkler_valve_sw2' Turning ON.
[11:43:33][D][switch:055]: 'lawn_sprinkler_valve_sw2': Sending state ON
[11:43:34][D][switch:012]: 'sprinkler_pump_sw' Turning ON.
[11:43:34][D][switch:055]: 'sprinkler_pump_sw': Sending state ON
[11:43:34][VV][sprinkler:1516]: fsm_transition_ complete; new state is ACTIVE
[11:43:34][V][component:204]: Component switch took a long time for an operation (0.05 s).
[11:43:34][V][component:205]: Components should block for at most 20-30ms.
[11:43:34][D][switch:055]: 'Lawn Sprinklers': Sending state ON
[11:43:34][D][switch:055]: 'Lawn #2': Sending state ON
...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
