### PR TITLE
ESP-IDF SPI LED strip (APA102/SK9822)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -90,6 +90,7 @@ esphome/components/esp32_camera_web_server/* @ayufan
 esphome/components/esp32_can/* @Sympatron
 esphome/components/esp32_improv/* @jesserockz
 esphome/components/esp32_rmt_led_strip/* @jesserockz
+esphome/components/esp32_spi_led_strip/* @dentra
 esphome/components/esp8266/* @esphome/core
 esphome/components/ethernet_info/* @gtjadsonsantos
 esphome/components/exposure_notifications/* @OttoWinter

--- a/esphome/components/esp32_spi_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_spi_led_strip/led_strip.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_ESP_IDF
 #include "esphome/core/log.h"
 
 #include "led_strip.h"
@@ -71,7 +72,7 @@ void LedStripSpi::setup() {
 
   // clear all pixels and set brightness to maximum, skipping start frame
   for (int i = 1; i <= this->num_leds_; i++) {
-    this->buf_[i * this->frame_size_] = 0xFF;
+    this->buf_[i * FRAME_SIZE] = 0xFF;
   }
   this->spi_flush_();
 }
@@ -174,7 +175,7 @@ light::ESPColorView LedStripSpi::get_view_internal(int32_t index) const {
       b = OFFSET_B;
       break;
   }
-  auto offset = (index + 1) * this->frame_size_;  // skip start frame
+  auto offset = (index + 1) * FRAME_SIZE;  // skip start frame
   return {
       this->buf_ + offset + r,     // red
       this->buf_ + offset + g,     // green
@@ -187,3 +188,4 @@ light::ESPColorView LedStripSpi::get_view_internal(int32_t index) const {
 
 }  // namespace esp32_spi_led_strip
 }  // namespace esphome
+#endif

--- a/esphome/components/esp32_spi_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_spi_led_strip/led_strip.cpp
@@ -33,7 +33,7 @@ void LedStripSpi::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 SPI LED Strip:");
   ESP_LOGCONFIG(TAG, "  Data Pin: GPIO%d", this->data_pin_);
   ESP_LOGCONFIG(TAG, "  Clock Pin: GPIO%d", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Number of LEDs: %d" PRId16, this->num_leds_);
+  ESP_LOGCONFIG(TAG, "  Number of LEDs: %d", this->num_leds_);
   ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order_to_string(this->rgb_order_));
   if (this->max_refresh_rate_) {
     ESP_LOGCONFIG(TAG, "  Max Refresh Rate: %" PRIu32 " Hz", this->max_refresh_rate_);

--- a/esphome/components/esp32_spi_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_spi_led_strip/led_strip.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 #include "esphome/core/log.h"
 
 #include "led_strip.h"
@@ -28,7 +28,7 @@ inline static const char *rgb_order_to_string(RGBOrder order) {
 }
 
 void LedStripSpi::dump_config() {
-  ESP_LOGCONFIG(TAG, "ESP-IDF SPI LED Strip:");
+  ESP_LOGCONFIG(TAG, "ESP32 SPI LED Strip:");
   ESP_LOGCONFIG(TAG, "  Data Pin: GPIO%d", this->data_pin_);
   ESP_LOGCONFIG(TAG, "  Clock Pin: GPIO%d", this->clock_pin_);
   ESP_LOGCONFIG(TAG, "  Number of LEDs: %d", this->num_leds_);
@@ -39,7 +39,7 @@ void LedStripSpi::dump_config() {
 }
 
 void LedStripSpi::setup() {
-  ESP_LOGD(TAG, "Setting up ESP-IDF SPI LED Strip...");
+  ESP_LOGD(TAG, "Setting up ESP32 SPI LED Strip...");
 
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
 

--- a/esphome/components/esp32_spi_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_spi_led_strip/led_strip.cpp
@@ -54,7 +54,7 @@ void LedStripSpi::setup() {
   this->buf_ = allocator.allocate(this->buf_size_());
   if (this->buf_ == nullptr) {
     ESP_LOGE(TAG, "Failed allocate LED buffer");
-    free(this->effect_data_);
+    allocator.deallocate(this->effect_data_, this->num_leds_);
     this->effect_data_ = nullptr;
     this->mark_failed();
     return;
@@ -62,9 +62,9 @@ void LedStripSpi::setup() {
   memset(this->buf_, 0, this->buf_size_());
 
   if (!this->spi_init_()) {
-    free(this->effect_data_);
+    allocator.deallocate(this->effect_data_, this->num_leds_);
     this->effect_data_ = nullptr;
-    free(this->buf_);
+    allocator.deallocate(this->buf_, this->buf_size_());
     this->buf_ = nullptr;
     this->mark_failed();
     return;

--- a/esphome/components/esp32_spi_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_spi_led_strip/led_strip.cpp
@@ -141,51 +141,54 @@ void LedStripSpi::write_state(light::LightState *state) {
   this->spi_flush_();
 }
 
-enum : size_t { OFFSET_BRIGHTNESS = 0, OFFSET_B = 1, OFFSET_G = 2, OFFSET_R = 3 };
-
 light::ESPColorView LedStripSpi::get_view_internal(int32_t index) const {
-  size_t r, g, b;
+  auto offset = (index + 1) * FRAME_SIZE;  // skip start frame
+  auto *frame = this->buf_ + offset;
+  return {
+      frame + this->rgb_offset_r_,  // red
+      frame + this->rgb_offset_g_,  // green
+      frame + this->rgb_offset_b_,  // blue
+      nullptr,                      // white
+      &this->effect_data_[index],   // effect data
+      &this->correction_,           // color correction
+  };
+}
+
+void LedStripSpi::set_rgb_order(RGBOrder rgb_order) {
+  this->rgb_order_ = rgb_order;
+
   switch (this->rgb_order_) {
     case RGBOrder::ORDER_RBG:
-      r = OFFSET_R;
-      g = OFFSET_B;
-      b = OFFSET_G;
+      this->rgb_offset_r_ = OFFSET_R;
+      this->rgb_offset_g_ = OFFSET_B;
+      this->rgb_offset_b_ = OFFSET_G;
       break;
     case RGBOrder::ORDER_GRB:
-      r = OFFSET_G;
-      g = OFFSET_R;
-      b = OFFSET_B;
+      this->rgb_offset_r_ = OFFSET_G;
+      this->rgb_offset_g_ = OFFSET_R;
+      this->rgb_offset_b_ = OFFSET_B;
       break;
     case RGBOrder::ORDER_GBR:
-      r = OFFSET_G;
-      g = OFFSET_B;
-      b = OFFSET_R;
+      this->rgb_offset_r_ = OFFSET_G;
+      this->rgb_offset_g_ = OFFSET_B;
+      this->rgb_offset_b_ = OFFSET_R;
       break;
     case RGBOrder::ORDER_BGR:
-      r = OFFSET_B;
-      g = OFFSET_G;
-      b = OFFSET_R;
+      this->rgb_offset_r_ = OFFSET_B;
+      this->rgb_offset_g_ = OFFSET_G;
+      this->rgb_offset_b_ = OFFSET_R;
       break;
     case RGBOrder::ORDER_BRG:
-      r = OFFSET_B;
-      g = OFFSET_R;
-      b = OFFSET_G;
+      this->rgb_offset_r_ = OFFSET_B;
+      this->rgb_offset_g_ = OFFSET_R;
+      this->rgb_offset_b_ = OFFSET_G;
       break;
     default:  // RGBOrder::ORDER_RGB
-      r = OFFSET_R;
-      g = OFFSET_G;
-      b = OFFSET_B;
+      this->rgb_offset_r_ = OFFSET_R;
+      this->rgb_offset_g_ = OFFSET_G;
+      this->rgb_offset_b_ = OFFSET_B;
       break;
   }
-  auto offset = (index + 1) * FRAME_SIZE;  // skip start frame
-  return {
-      this->buf_ + offset + r,     // red
-      this->buf_ + offset + g,     // green
-      this->buf_ + offset + b,     // blue
-      nullptr,                     // white
-      &this->effect_data_[index],  // effect data
-      &this->correction_,          // color correction
-  };
 }
 
 }  // namespace esp32_spi_led_strip

--- a/esphome/components/esp32_spi_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_spi_led_strip/led_strip.cpp
@@ -1,4 +1,6 @@
 #ifdef USE_ESP32
+#include <cinttypes>
+
 #include "esphome/core/log.h"
 
 #include "led_strip.h"
@@ -31,10 +33,10 @@ void LedStripSpi::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 SPI LED Strip:");
   ESP_LOGCONFIG(TAG, "  Data Pin: GPIO%d", this->data_pin_);
   ESP_LOGCONFIG(TAG, "  Clock Pin: GPIO%d", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Number of LEDs: %d", this->num_leds_);
+  ESP_LOGCONFIG(TAG, "  Number of LEDs: %d" PRId16, this->num_leds_);
   ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order_to_string(this->rgb_order_));
   if (this->max_refresh_rate_) {
-    ESP_LOGCONFIG(TAG, "  Max Refresh Rate: %u Hz", this->max_refresh_rate_);
+    ESP_LOGCONFIG(TAG, "  Max Refresh Rate: %" PRIu32 " Hz", this->max_refresh_rate_);
   }
 }
 

--- a/esphome/components/esp32_spi_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_spi_led_strip/led_strip.cpp
@@ -1,0 +1,189 @@
+#include "esphome/core/log.h"
+
+#include "led_strip.h"
+
+namespace esphome {
+namespace esp32_spi_led_strip {
+
+static const char *const TAG = "esp32_spi_led_strip";
+
+inline static const char *rgb_order_to_string(RGBOrder order) {
+  switch (order) {
+    case RGBOrder::ORDER_RGB:
+      return "RGB";
+    case RGBOrder::ORDER_RBG:
+      return "RBG";
+    case RGBOrder::ORDER_GRB:
+      return "GRB";
+    case RGBOrder::ORDER_GBR:
+      return "GBR";
+    case RGBOrder::ORDER_BGR:
+      return "BGR";
+    case RGBOrder::ORDER_BRG:
+      return "BRG";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+void LedStripSpi::dump_config() {
+  ESP_LOGCONFIG(TAG, "ESP-IDF SPI LED Strip:");
+  ESP_LOGCONFIG(TAG, "  Data Pin: GPIO%d", this->data_pin_);
+  ESP_LOGCONFIG(TAG, "  Clock Pin: GPIO%d", this->clock_pin_);
+  ESP_LOGCONFIG(TAG, "  Number of LEDs: %d", this->num_leds_);
+  ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order_to_string(this->rgb_order_));
+  if (this->max_refresh_rate_) {
+    ESP_LOGCONFIG(TAG, "  Max Refresh Rate: %u Hz", this->max_refresh_rate_);
+  }
+}
+
+void LedStripSpi::setup() {
+  ESP_LOGD(TAG, "Setting up ESP-IDF SPI LED Strip...");
+
+  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+
+  this->effect_data_ = allocator.allocate(this->num_leds_);
+  if (this->effect_data_ == nullptr) {
+    ESP_LOGE(TAG, "Failed allocate effect data");
+    this->mark_failed();
+    return;
+  }
+  memset(this->effect_data_, 0, this->num_leds_);
+
+  this->buf_ = allocator.allocate(this->buf_size_());
+  if (this->buf_ == nullptr) {
+    ESP_LOGE(TAG, "Failed allocate LED buffer");
+    free(this->effect_data_);
+    this->effect_data_ = nullptr;
+    this->mark_failed();
+    return;
+  }
+  memset(this->buf_, 0, this->buf_size_());
+
+  if (!this->spi_init_()) {
+    free(this->effect_data_);
+    this->effect_data_ = nullptr;
+    free(this->buf_);
+    this->buf_ = nullptr;
+    this->mark_failed();
+    return;
+  }
+
+  // clear all pixels and set brightness to maximum, skipping start frame
+  for (int i = 1; i <= this->num_leds_; i++) {
+    this->buf_[i * this->frame_size_] = 0xFF;
+  }
+  this->spi_flush_();
+}
+
+bool LedStripSpi::spi_init_() {
+  spi_bus_config_t bus_cfg = {
+      .mosi_io_num = this->data_pin_,
+      .miso_io_num = -1,
+      .sclk_io_num = this->clock_pin_,
+      .data2_io_num = -1,
+      .data3_io_num = -1,
+      .data4_io_num = -1,
+      .data5_io_num = -1,
+      .data6_io_num = -1,
+      .data7_io_num = -1,
+      .max_transfer_sz = this->buf_size_(),
+      .flags = SPICOMMON_BUSFLAG_MASTER,
+      .intr_flags = 0,
+  };
+
+  auto err = spi_bus_initialize(SPI2_HOST, &bus_cfg, SPI_DMA_CH_AUTO);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed initialize SPI bus: %d, %s", err, esp_err_to_name(err));
+    return false;
+  }
+
+  spi_device_interface_config_t dev_cfg = {};
+  dev_cfg.clock_speed_hz = 1000000 * 10;  // 10Mhz
+  dev_cfg.queue_size = 1;
+  dev_cfg.spics_io_num = -1;
+  dev_cfg.mode = 3;
+
+  err = spi_bus_add_device(SPI2_HOST, &dev_cfg, &this->spi_device_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed add SPI bus device: %d, %s", err, esp_err_to_name(err));
+    return false;
+  }
+
+  return true;
+}
+
+void LedStripSpi::spi_flush_() {
+  spi_transaction_t tx{};
+  tx.length = this->buf_size_() * 8;
+  tx.tx_buffer = this->buf_;
+  spi_device_queue_trans(this->spi_device_, &tx, portMAX_DELAY);
+}
+
+void LedStripSpi::write_state(light::LightState *state) {
+  // protect from refreshing too often
+  if (this->max_refresh_rate_) {
+    uint32_t now = micros();
+    if ((now - this->last_refresh_) < this->max_refresh_rate_) {
+      // try again next loop iteration, so that this change won't get lost
+      this->schedule_show();
+      return;
+    }
+    this->last_refresh_ = now;
+  }
+
+  this->mark_shown_();
+
+  ESP_LOGVV(TAG, "Writing RGB values to bus...");
+  this->spi_flush_();
+}
+
+enum : size_t { OFFSET_BRIGHTNESS = 0, OFFSET_B = 1, OFFSET_G = 2, OFFSET_R = 3 };
+
+light::ESPColorView LedStripSpi::get_view_internal(int32_t index) const {
+  size_t r, g, b;
+  switch (this->rgb_order_) {
+    case RGBOrder::ORDER_RBG:
+      r = OFFSET_R;
+      g = OFFSET_B;
+      b = OFFSET_G;
+      break;
+    case RGBOrder::ORDER_GRB:
+      r = OFFSET_G;
+      g = OFFSET_R;
+      b = OFFSET_B;
+      break;
+    case RGBOrder::ORDER_GBR:
+      r = OFFSET_G;
+      g = OFFSET_B;
+      b = OFFSET_R;
+      break;
+    case RGBOrder::ORDER_BGR:
+      r = OFFSET_B;
+      g = OFFSET_G;
+      b = OFFSET_R;
+      break;
+    case RGBOrder::ORDER_BRG:
+      r = OFFSET_B;
+      g = OFFSET_R;
+      b = OFFSET_G;
+      break;
+    default:  // RGBOrder::ORDER_RGB
+      r = OFFSET_R;
+      g = OFFSET_G;
+      b = OFFSET_B;
+      break;
+  }
+  auto offset = (index + 1) * this->frame_size_;  // skip start frame
+  return {
+      this->buf_ + offset + r,     // red
+      this->buf_ + offset + g,     // green
+      this->buf_ + offset + b,     // blue
+      nullptr,                     // white
+      &this->effect_data_[index],  // effect data
+      &this->correction_,          // color correction
+  };
+}
+
+}  // namespace esp32_spi_led_strip
+}  // namespace esphome

--- a/esphome/components/esp32_spi_led_strip/led_strip.h
+++ b/esphome/components/esp32_spi_led_strip/led_strip.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <driver/spi_master.h>
+
+#include "esphome/components/light/addressable_light.h"
+
+namespace esphome {
+namespace esp32_spi_led_strip {
+
+enum RGBOrder : uint8_t {
+  ORDER_RGB = 0,
+  ORDER_RBG,
+  ORDER_GRB,
+  ORDER_GBR,
+  ORDER_BGR,
+  ORDER_BRG,
+};
+
+class LedStripSpi : public light::AddressableLight {
+ public:
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void setup() override;
+  void write_state(light::LightState *state) override;
+  void dump_config() override;
+  int32_t size() const override { return this->num_leds_; }
+
+  light::LightTraits get_traits() override {
+    auto traits = light::LightTraits();
+    traits.set_supported_color_modes({
+        light::ColorMode::RGB,
+        light::ColorMode::BRIGHTNESS,
+    });
+    return traits;
+  }
+
+  void set_data_pin(uint8_t data_pin) { this->data_pin_ = data_pin; }
+  void set_clock_pin(uint8_t clock_pin) { this->clock_pin_ = clock_pin; }
+  void set_num_leds(uint16_t num_leds) { this->num_leds_ = num_leds; }
+  void set_rgb_order(RGBOrder rgb_order) { this->rgb_order_ = rgb_order; }
+  /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
+  void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
+
+  void clear_effect_data() override {
+    for (int32_t i = 0; i < this->size(); i++)
+      this->effect_data_[i] = 0;
+  }
+
+ protected:
+  uint8_t data_pin_{};
+  uint8_t clock_pin_{};
+  uint16_t num_leds_{};
+  RGBOrder rgb_order_{RGBOrder::ORDER_RGB};
+  uint32_t max_refresh_rate_{};
+  uint32_t last_refresh_{};
+
+  uint8_t *effect_data_{};
+  uint8_t *buf_{};
+  spi_device_handle_t spi_device_{};
+
+  light::ESPColorView get_view_internal(int32_t index) const override;
+
+  bool spi_init_();
+  void spi_flush_();
+  static constexpr size_t frame_size_ = 4;  // The size of a LED frame
+  int buf_size_() const {
+    return 0                                        //
+           + (this->frame_size_)                    // Start frame
+           + (this->frame_size_ * this->num_leds_)  // LED frames
+           + (this->frame_size_)                    // Reset frame
+           + (this->num_leds_ / 16 + 1)             // Last frame
+        ;
+  };
+};
+
+}  // namespace esp32_spi_led_strip
+}  // namespace esphome

--- a/esphome/components/esp32_spi_led_strip/led_strip.h
+++ b/esphome/components/esp32_spi_led_strip/led_strip.h
@@ -1,5 +1,5 @@
 #pragma once
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 #include <driver/spi_master.h>
 
 #include "esphome/components/light/addressable_light.h"

--- a/esphome/components/esp32_spi_led_strip/led_strip.h
+++ b/esphome/components/esp32_spi_led_strip/led_strip.h
@@ -36,7 +36,7 @@ class LedStripSpi : public light::AddressableLight {
   void set_data_pin(uint8_t data_pin) { this->data_pin_ = data_pin; }
   void set_clock_pin(uint8_t clock_pin) { this->clock_pin_ = clock_pin; }
   void set_num_leds(uint16_t num_leds) { this->num_leds_ = num_leds; }
-  void set_rgb_order(RGBOrder rgb_order) { this->rgb_order_ = rgb_order; }
+  void set_rgb_order(RGBOrder rgb_order);
   /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
   void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
 
@@ -49,9 +49,14 @@ class LedStripSpi : public light::AddressableLight {
   uint8_t data_pin_{};
   uint8_t clock_pin_{};
   uint16_t num_leds_{};
-  RGBOrder rgb_order_{RGBOrder::ORDER_RGB};
+  RGBOrder rgb_order_{RGBOrder::ORDER_BGR};
   uint32_t max_refresh_rate_{};
   uint32_t last_refresh_{};
+
+  enum : size_t { OFFSET_BRIGHTNESS = 0, OFFSET_R = 1, OFFSET_G = 2, OFFSET_B = 3 };
+  size_t rgb_offset_r_{OFFSET_R};
+  size_t rgb_offset_g_{OFFSET_G};
+  size_t rgb_offset_b_{OFFSET_B};
 
   uint8_t *effect_data_{};
   uint8_t *buf_{};

--- a/esphome/components/esp32_spi_led_strip/led_strip.h
+++ b/esphome/components/esp32_spi_led_strip/led_strip.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#ifdef USE_ESP_IDF
 #include <driver/spi_master.h>
 
 #include "esphome/components/light/addressable_light.h"
@@ -61,16 +61,18 @@ class LedStripSpi : public light::AddressableLight {
 
   bool spi_init_();
   void spi_flush_();
-  static constexpr size_t frame_size_ = 4;  // The size of a LED frame
+  static constexpr size_t FRAME_SIZE = 4;  // The size of a LED frame
   int buf_size_() const {
-    return 0                                        //
-           + (this->frame_size_)                    // Start frame
-           + (this->frame_size_ * this->num_leds_)  // LED frames
-           + (this->frame_size_)                    // Reset frame
-           + (this->num_leds_ / 16 + 1)             // Last frame
+    return 0                                 //
+           + (FRAME_SIZE)                    // Start frame
+           + (FRAME_SIZE * this->num_leds_)  // LED frames
+           + (FRAME_SIZE)                    // Reset frame
+           + (this->num_leds_ / 16 + 1)      // Last frame
         ;
   };
 };
 
 }  // namespace esp32_spi_led_strip
 }  // namespace esphome
+
+#endif

--- a/esphome/components/esp32_spi_led_strip/light.py
+++ b/esphome/components/esp32_spi_led_strip/light.py
@@ -34,7 +34,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_DATA_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
-            cv.Optional(CONF_RGB_ORDER, default="RGB"): cv.enum(RGB_ORDERS, upper=True),
+            cv.Optional(CONF_RGB_ORDER, default="BGR"): cv.enum(RGB_ORDERS, upper=True),
             cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
         }
     ),

--- a/esphome/components/esp32_spi_led_strip/light.py
+++ b/esphome/components/esp32_spi_led_strip/light.py
@@ -12,10 +12,11 @@ from esphome.const import (
 )
 
 CODEOWNERS = ["@dentra"]
+DEPENDENCIES = ["esp32"]
 
-led_strip_spi_ns = cg.esphome_ns.namespace("esp32_spi_led_strip")
-LedStripSpi = led_strip_spi_ns.class_("LedStripSpi", light.AddressableLight)
-RGBOrder = led_strip_spi_ns.enum("RGBOrder")
+esp32_spi_led_strip_ns = cg.esphome_ns.namespace("esp32_spi_led_strip")
+LedStripSpi = esp32_spi_led_strip_ns.class_("LedStripSpi", light.AddressableLight)
+RGBOrder = esp32_spi_led_strip_ns.enum("RGBOrder")
 
 RGB_ORDERS = {
     "RGB": RGBOrder.ORDER_RGB,
@@ -37,7 +38,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
         }
     ),
-    cv.only_with_esp_idf,
+    cv.only_on_esp32,
 )
 
 

--- a/esphome/components/esp32_spi_led_strip/light.py
+++ b/esphome/components/esp32_spi_led_strip/light.py
@@ -1,0 +1,55 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import light
+from esphome.const import (
+    CONF_MAX_REFRESH_RATE,
+    CONF_NUM_LEDS,
+    CONF_OUTPUT_ID,
+    CONF_CLOCK_PIN,
+    CONF_DATA_PIN,
+    CONF_RGB_ORDER,
+)
+
+CODEOWNERS = ["@dentra"]
+
+led_strip_spi_ns = cg.esphome_ns.namespace("esp32_spi_led_strip")
+LedStripSpi = led_strip_spi_ns.class_("LedStripSpi", light.AddressableLight)
+RGBOrder = led_strip_spi_ns.enum("RGBOrder")
+
+RGB_ORDERS = {
+    "RGB": RGBOrder.ORDER_RGB,
+    "RBG": RGBOrder.ORDER_RBG,
+    "GRB": RGBOrder.ORDER_GRB,
+    "GBR": RGBOrder.ORDER_GBR,
+    "BGR": RGBOrder.ORDER_BGR,
+    "BRG": RGBOrder.ORDER_BRG,
+}
+
+CONFIG_SCHEMA = cv.All(
+    light.ADDRESSABLE_LIGHT_SCHEMA.extend(
+        {
+            cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(LedStripSpi),
+            cv.Required(CONF_DATA_PIN): pins.internal_gpio_output_pin_number,
+            cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
+            cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
+            cv.Optional(CONF_RGB_ORDER, default="RGB"): cv.enum(RGB_ORDERS, upper=True),
+            cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
+        }
+    ),
+    cv.only_with_esp_idf,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    await light.register_light(var, config)
+    await cg.register_component(var, config)
+
+    cg.add(var.set_data_pin(config[CONF_DATA_PIN]))
+    cg.add(var.set_clock_pin(config[CONF_CLOCK_PIN]))
+    cg.add(var.set_num_leds(config[CONF_NUM_LEDS]))
+    cg.add(var.set_rgb_order(config[CONF_RGB_ORDER]))
+
+    if CONF_MAX_REFRESH_RATE in config:
+        cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -665,3 +665,10 @@ light:
     bit0_low: 100us
     bit1_high: 100us
     bit1_low: 100us
+  - platform: esp32_spi_led_strip
+    id: led_stripp_spi
+    data_pin: GPIO40
+    clock_pin: GPIO39
+    num_leds: 1
+    rgb_order: RGB
+    max_refresh_rate: 50us

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -666,9 +666,9 @@ light:
     bit1_high: 100us
     bit1_low: 100us
   - platform: esp32_spi_led_strip
-    id: led_stripp_spi
-    data_pin: GPIO40
-    clock_pin: GPIO39
+    id: led_strip_spi
+    data_pin: GPIO23
+    clock_pin: GPIO22
     num_leds: 1
     rgb_order: RGB
     max_refresh_rate: 50us


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for SPI LED strips on APA102 and SK9822 chips. This is especially true for the ESP-IDF platform.
Tested with my Lilygo Dongle S3 with one led.

~~I will do PR in the docs a little later.~~

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3064

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
light:
  - platform: esp32_spi_led_strip
    name: "Led Light"
    data_pin: GPIO40
    clock_pin: GPIO39
    num_leds: 1
    rgb_order: RGB
    max_refresh_rate: 50us
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
