### PR TITLE
Add timeout filter

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -217,6 +217,7 @@ OffsetFilter = sensor_ns.class_("OffsetFilter", Filter)
 MultiplyFilter = sensor_ns.class_("MultiplyFilter", Filter)
 FilterOutValueFilter = sensor_ns.class_("FilterOutValueFilter", Filter)
 ThrottleFilter = sensor_ns.class_("ThrottleFilter", Filter)
+TimeoutFilter = sensor_ns.class_("TimeoutFilter", Filter, cg.Component)
 DebounceFilter = sensor_ns.class_("DebounceFilter", Filter, cg.Component)
 HeartbeatFilter = sensor_ns.class_("HeartbeatFilter", Filter, cg.Component)
 DeltaFilter = sensor_ns.class_("DeltaFilter", Filter)
@@ -531,6 +532,15 @@ async def throttle_filter_to_code(config, filter_id):
     "heartbeat", HeartbeatFilter, cv.positive_time_period_milliseconds
 )
 async def heartbeat_filter_to_code(config, filter_id):
+    var = cg.new_Pvariable(filter_id, config)
+    await cg.register_component(var, {})
+    return var
+
+
+@FILTER_REGISTRY.register(
+    "timeout", TimeoutFilter, cv.positive_time_period_milliseconds
+)
+async def timeout_filter_to_code(config, filter_id):
     var = cg.new_Pvariable(filter_id, config)
     await cg.register_component(var, {})
     return var

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -373,6 +373,17 @@ void OrFilter::initialize(Sensor *parent, Filter *next) {
   this->phi_.initialize(parent, nullptr);
 }
 
+// TimeoutFilter
+optional<float> TimeoutFilter::new_value(float value) {
+  this->set_timeout("timeout", this->time_period_, [this]() { this->output(NAN); });
+  this->output(value);
+
+  return {};
+}
+
+TimeoutFilter::TimeoutFilter(uint32_t time_period) : time_period_(time_period) {}
+float TimeoutFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
+
 // DebounceFilter
 optional<float> DebounceFilter::new_value(float value) {
   this->set_timeout("debounce", this->time_period_, [this, value]() { this->output(value); });

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -313,6 +313,18 @@ class ThrottleFilter : public Filter {
   uint32_t min_time_between_inputs_;
 };
 
+class TimeoutFilter : public Filter, public Component {
+ public:
+  explicit TimeoutFilter(uint32_t time_period);
+
+  optional<float> new_value(float value) override;
+
+  float get_setup_priority() const override;
+
+ protected:
+  uint32_t time_period_;
+};
+
 class DebounceFilter : public Filter, public Component {
  public:
   explicit DebounceFilter(uint32_t time_period);

--- a/tests/test3.1.yaml
+++ b/tests/test3.1.yaml
@@ -86,6 +86,7 @@ sensor:
       - delta: 100
       - throttle: 100ms
       - debounce: 500s
+      - timeout: 10min
       - calibrate_linear:
           - 0 -> 0
           - 100 -> 100


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add a new filter to publish `NaN` when no data is provided within a specified time window.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3068

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: vbus
    model: deltasol_bs_2009
    temperature_1:
      name: Collector Temp
      filters:
        timeout: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
