### PR TITLE
Coolix IR protocol improvements

### DIFF
--- a/esphome/components/coolix/coolix.cpp
+++ b/esphome/components/coolix/coolix.cpp
@@ -114,7 +114,7 @@ bool CoolixClimate::on_coolix(climate::Climate *parent, remote_base::RemoteRecei
   if (!decoded.has_value())
     return false;
   // Decoded remote state y 3 bytes long code.
-  uint32_t remote_state = *decoded;
+  uint32_t remote_state = (*decoded).second;
   ESP_LOGV(TAG, "Decoded 0x%06X", remote_state);
   if ((remote_state & 0xFF0000) != 0xB20000)
     return false;

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -358,7 +358,7 @@ COOLIX_BASE_SCHEMA = cv.Schema(
         cv.Required(CONF_FIRST): cv.hex_int_range(0, 16777215),
         cv.Optional(CONF_SECOND, default=0): cv.hex_int_range(0, 16777215),
         cv.Optional(CONF_DATA): cv.invalid(
-            "'data' option has been removed in ESPHome 2023.7. "
+            "'data' option has been removed in ESPHome 2023.8. "
             "Use the 'first' and 'second' options instead."
         ),
     }

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -355,8 +355,8 @@ async def canalsatld_action(var, config, args):
 
 COOLIX_BASE_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_FIRST): cv.hex_uint32_t,
-        cv.Optional(CONF_SECOND, default=0): cv.hex_uint32_t,
+        cv.Required(CONF_FIRST): cv.hex_int_range(0, 16777215),
+        cv.Optional(CONF_SECOND, default=0): cv.hex_int_range(0, 16777215),
         cv.Optional(CONF_DATA): cv.invalid(
             "'data' option has been removed in ESPHome 2023.7. "
             "Use the 'first' and 'second' options instead."
@@ -364,7 +364,7 @@ COOLIX_BASE_SCHEMA = cv.Schema(
     }
 )
 
-COOLIX_SENSOR_SCHEMA = cv.Any(cv.hex_uint32_t, COOLIX_BASE_SCHEMA)
+COOLIX_SENSOR_SCHEMA = cv.Any(cv.hex_int_range(0, 16777215), COOLIX_BASE_SCHEMA)
 
 
 @register_binary_sensor("coolix", CoolixBinarySensor, COOLIX_SENSOR_SCHEMA)

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -17,6 +17,7 @@ from esphome.const import (
     CONF_PROTOCOL,
     CONF_GROUP,
     CONF_DEVICE,
+    CONF_SECOND,
     CONF_STATE,
     CONF_CHANNEL,
     CONF_FAMILY,
@@ -39,6 +40,7 @@ AUTO_LOAD = ["binary_sensor"]
 
 CONF_RECEIVER_ID = "receiver_id"
 CONF_TRANSMITTER_ID = "transmitter_id"
+CONF_FIRST = "first"
 
 ns = remote_base_ns = cg.esphome_ns.namespace("remote_base")
 RemoteProtocol = ns.class_("RemoteProtocol")
@@ -349,19 +351,48 @@ async def canalsatld_action(var, config, args):
     CoolixAction,
     CoolixDumper,
 ) = declare_protocol("Coolix")
-COOLIX_SCHEMA = cv.Schema({cv.Required(CONF_DATA): cv.hex_uint32_t})
 
 
-@register_binary_sensor("coolix", CoolixBinarySensor, COOLIX_SCHEMA)
+COOLIX_BASE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_FIRST): cv.hex_uint32_t,
+        cv.Optional(CONF_SECOND, default=0): cv.hex_uint32_t,
+        cv.Optional(CONF_DATA): cv.invalid(
+            "'data' option has been removed in ESPHome 2023.7. "
+            "Use the 'first' and 'second' options instead."
+        ),
+    }
+)
+
+COOLIX_SENSOR_SCHEMA = cv.Any(cv.hex_uint32_t, COOLIX_BASE_SCHEMA)
+
+
+@register_binary_sensor("coolix", CoolixBinarySensor, COOLIX_SENSOR_SCHEMA)
 def coolix_binary_sensor(var, config):
-    cg.add(
-        var.set_data(
-            cg.StructInitializer(
-                CoolixData,
-                ("data", config[CONF_DATA]),
+    if isinstance(config, dict):
+        cg.add(
+            var.set_data(
+                cg.StructInitializer(
+                    CoolixData,
+                    ("first", config[CONF_FIRST]),
+                    ("second", config[CONF_SECOND]),
+                )
             )
         )
-    )
+    else:
+        cg.add(
+            var.set_data(
+                cg.StructInitializer(CoolixData, ("first", 0), ("second", config))
+            )
+        )
+
+
+@register_action("coolix", CoolixAction, COOLIX_BASE_SCHEMA)
+async def coolix_action(var, config, args):
+    template_ = await cg.templatable(config[CONF_FIRST], args, cg.uint32)
+    cg.add(var.set_first(template_))
+    template_ = await cg.templatable(config[CONF_SECOND], args, cg.uint32)
+    cg.add(var.set_second(template_))
 
 
 @register_trigger("coolix", CoolixTrigger, CoolixData)
@@ -372,12 +403,6 @@ def coolix_trigger(var, config):
 @register_dumper("coolix", CoolixDumper)
 def coolix_dumper(var, config):
     pass
-
-
-@register_action("coolix", CoolixAction, COOLIX_SCHEMA)
-async def coolix_action(var, config, args):
-    template_ = await cg.templatable(config[CONF_DATA], args, cg.uint32)
-    cg.add(var.set_data(template_))
 
 
 # Dish

--- a/esphome/components/remote_base/coolix_protocol.cpp
+++ b/esphome/components/remote_base/coolix_protocol.cpp
@@ -91,9 +91,10 @@ static bool decode_frame(RemoteReceiveData &src, uint32_t &dst) {
 
 optional<CoolixData> CoolixProtocol::decode(RemoteReceiveData data) {
   CoolixData result;
-  if ((data.size() != 200 && data.size() != 100) || !decode_frame(data, result.first))
+  const auto size = data.size();
+  if ((size != 200 && size != 100) || !decode_frame(data, result.first))
     return {};
-  if (data.size() == 100 || !data.expect_space(FOOTER_SPACE_US) || !decode_frame(data, result.second))
+  if (size == 100 || !data.expect_space(FOOTER_SPACE_US) || !decode_frame(data, result.second))
     result.second = 0;
   return result;
 }

--- a/esphome/components/remote_base/coolix_protocol.cpp
+++ b/esphome/components/remote_base/coolix_protocol.cpp
@@ -93,7 +93,7 @@ optional<CoolixData> CoolixProtocol::decode(RemoteReceiveData data) {
   CoolixData result;
   if ((data.size() != 200 && data.size() != 100) || !decode_frame(data, result.first))
     return {};
-  if (!data.expect_space(FOOTER_SPACE_US) || !decode_frame(data, result.second))
+  if (data.size() == 100 || !data.expect_space(FOOTER_SPACE_US) || !decode_frame(data, result.second))
     result.second = 0;
   return result;
 }

--- a/esphome/components/remote_base/coolix_protocol.h
+++ b/esphome/components/remote_base/coolix_protocol.h
@@ -7,7 +7,16 @@
 namespace esphome {
 namespace remote_base {
 
-using CoolixData = uint32_t;
+struct CoolixData {
+  CoolixData() {}
+  CoolixData(uint32_t a) : first(a), second(a) {}
+  CoolixData(uint32_t a, uint32_t b) : first(a), second(b) {}
+  bool operator==(const CoolixData &other) const;
+  bool is_strict() const { return this->first == this->second; }
+  bool has_second() const { return this->second != 0; }
+  uint32_t first;
+  uint32_t second;
+};
 
 class CoolixProtocol : public RemoteProtocol<CoolixData> {
  public:
@@ -19,10 +28,10 @@ class CoolixProtocol : public RemoteProtocol<CoolixData> {
 DECLARE_REMOTE_PROTOCOL(Coolix)
 
 template<typename... Ts> class CoolixAction : public RemoteTransmitterActionBase<Ts...> {
-  TEMPLATABLE_VALUE(CoolixData, data)
+  TEMPLATABLE_VALUE(uint32_t, first)
+  TEMPLATABLE_VALUE(uint32_t, second)
   void encode(RemoteTransmitData *dst, Ts... x) override {
-    CoolixData data = this->data_.value(x...);
-    CoolixProtocol().encode(dst, data);
+    CoolixProtocol().encode(dst, {this->first_.value(x...), this->second_.value(x...)});
   }
 };
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1594,6 +1594,18 @@ binary_sensor:
           -2267,
           1709,
         ]
+  - platform: remote_receiver
+    name: Coolix Test 1
+    coolix: 0xB21F98
+  - platform: remote_receiver
+    name: Coolix Test 2
+    coolix:
+      first: 0xB2E003
+  - platform: remote_receiver
+    name: Coolix Test 3
+    coolix:
+      first: 0xB2E003
+      second: 0xB21F98
   - platform: as3935
     name: Storm Alert
   - platform: analog_threshold
@@ -2265,8 +2277,16 @@ switch:
   - platform: template
     name: MIDEA_RAW
     turn_on_action:
-      remote_transmitter.transmit_midea:
-        code: [0xA2, 0x08, 0xFF, 0xFF, 0xFF]
+      - remote_transmitter.transmit_coolix:
+          first: 0xB21F98
+      - remote_transmitter.transmit_coolix:
+          first: 0xB21F98
+          second: 0xB21F98
+      - remote_transmitter.transmit_coolix:
+          first: !lambda "return 0xB21F98;"
+          second: !lambda "return 0xB21F98;"
+      - remote_transmitter.transmit_midea:
+          code: [0xA2, 0x08, 0xFF, 0xFF, 0xFF]
   - platform: gpio
     name: "MCP23S08 Pin #0"
     pin:
@@ -2848,6 +2868,9 @@ tm1651:
 remote_receiver:
   pin: GPIO32
   dump: all
+  on_coolix:
+    then:
+      delay: !lambda "return x.first + x.second;"
 
 status_led:
   pin: GPIO2


### PR DESCRIPTION
# What does this implement/fix?

The `coolix` protocol in many air conditioners _does not follow strict rules_, resulting in the `climate_ir` `coolix` component not being further developed to provide advanced control and feedback capabilities. **This PR marks the beginning of this work.**

For example, in my air conditioner, the `SLEEP` command is sent in two different packets: the first is the `SLEEP` command, and the second sends the standard state. Before this changes, the decoder ignored the data, and now it outputs:

`[remote.coolix:093]: Received unstrict Coolix: [0xB2E003, 0xB21F98]`

Some commands consist even of one packet, for example, `SWING_STEP`. Now the decoder processes it correctly and outputs:

`[remote.coolix:095]: Received unstrict Coolix: [0xB20FE0]`

As for the breakdown of automation compatibility, I can assume that it is used by an extremely small number of users, since the protocol is specific and is used mainly as part of the `climate_ir` `coolix` component. Actually, not so long ago I removed it from the component to `remote_base` _without any issue_.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3071

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
binary_sensor:
 - platform: remote_receiver
    coolix: 0xB21F98 # in first or second packet
 - platform: remote_receiver
    coolix:
      first: 0xB2E003
      second: 0xB21F98 # optional. if none - event generated only on one packet commands

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
