### PR TITLE
Remove template switch restore_state

### DIFF
--- a/esphome/components/template/switch/__init__.py
+++ b/esphome/components/template/switch/__init__.py
@@ -43,7 +43,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_TURN_ON_ACTION): automation.validate_automation(
                 single=True
             ),
-            cv.Optional(CONF_RESTORE_STATE, default=False): cv.boolean,
+            cv.Optional(CONF_RESTORE_STATE): cv.invalid(
+                "The restore_state option has been removed in 2023.7.0. Use the restore_mode option instead"
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA),
@@ -70,7 +72,6 @@ async def to_code(config):
         )
     cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
     cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))
-    cg.add(var.set_restore_state(config[CONF_RESTORE_STATE]))
 
 
 @automation.register_action(

--- a/esphome/components/template/switch/template_switch.cpp
+++ b/esphome/components/template/switch/template_switch.cpp
@@ -40,9 +40,6 @@ float TemplateSwitch::get_setup_priority() const { return setup_priority::HARDWA
 Trigger<> *TemplateSwitch::get_turn_on_trigger() const { return this->turn_on_trigger_; }
 Trigger<> *TemplateSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
 void TemplateSwitch::setup() {
-  if (!this->restore_state_)
-    return;
-
   optional<bool> initial_state = this->get_initial_state_with_restore_mode();
 
   if (initial_state.has_value()) {
@@ -57,10 +54,8 @@ void TemplateSwitch::setup() {
 }
 void TemplateSwitch::dump_config() {
   LOG_SWITCH("", "Template Switch", this);
-  ESP_LOGCONFIG(TAG, "  Restore State: %s", YESNO(this->restore_state_));
   ESP_LOGCONFIG(TAG, "  Optimistic: %s", YESNO(this->optimistic_));
 }
-void TemplateSwitch::set_restore_state(bool restore_state) { this->restore_state_ = restore_state; }
 void TemplateSwitch::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 
 }  // namespace template_

--- a/esphome/components/template/switch/template_switch.h
+++ b/esphome/components/template/switch/template_switch.h
@@ -15,7 +15,6 @@ class TemplateSwitch : public switch_::Switch, public Component {
   void dump_config() override;
 
   void set_state_lambda(std::function<optional<bool>()> &&f);
-  void set_restore_state(bool restore_state);
   Trigger<> *get_turn_on_trigger() const;
   Trigger<> *get_turn_off_trigger() const;
   void set_optimistic(bool optimistic);
@@ -35,7 +34,6 @@ class TemplateSwitch : public switch_::Switch, public Component {
   Trigger<> *turn_on_trigger_;
   Trigger<> *turn_off_trigger_;
   Trigger<> *prev_trigger_{nullptr};
-  bool restore_state_{false};
 };
 
 }  // namespace template_

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2475,7 +2475,6 @@ switch:
           level: !lambda "return 0.5;"
     turn_off_action:
       - switch.turn_on: living_room_lights_off
-    restore_state: false
     on_turn_on:
       - switch.template.publish:
           id: livingroom_lights
@@ -2511,7 +2510,6 @@ switch:
       }
     optimistic: true
     assumed_state: false
-    restore_state: true
     on_turn_off:
       - switch.template.publish:
           id: my_switch


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This removes `restore_state` on a template switch which was replaced with `restore_mode` on the switch core config and having both is just confusing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3070

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
