### PR TITLE
Add Graphical menu

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -100,6 +100,7 @@ esphome/components/gp8403/* @jesserockz
 esphome/components/gpio/* @esphome/core
 esphome/components/gps/* @coogle
 esphome/components/graph/* @synco
+esphome/components/graphical_menu/* @silverchris
 esphome/components/growatt_solar/* @leeuwte
 esphome/components/haier/* @Yarikx
 esphome/components/havells_solar/* @sourabhjaiswal

--- a/esphome/components/graphical_menu/__init__.py
+++ b/esphome/components/graphical_menu/__init__.py
@@ -1,0 +1,66 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_COLOR,
+)
+from esphome.components import display, font, color
+from esphome.components.display_menu_base import (
+    DISPLAY_MENU_BASE_SCHEMA,
+    DisplayMenuComponent,
+    display_menu_to_code,
+)
+
+CODEOWNERS = ["@silverchris"]
+
+AUTO_LOAD = ["display_menu_base"]
+
+graphical_menu_ns = cg.esphome_ns.namespace("graphical_menu")
+
+CONF_DISPLAY_ID = "display_id"
+
+CONF_MARK_SELECTED = "mark_selected"
+CONF_MARK_EDITING = "mark_editing"
+CONF_MARK_SUBMENU = "mark_submenu"
+CONF_MARK_BACK = "mark_back"
+CONF_FONT = "font"
+
+MINIMUM_COLUMNS = 12
+
+GraphicalMenuComponent = graphical_menu_ns.class_(
+    "GraphicalMenuComponent", DisplayMenuComponent
+)
+
+MULTI_CONF = True
+
+CONFIG_SCHEMA = DISPLAY_MENU_BASE_SCHEMA.extend(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(GraphicalMenuComponent),
+            cv.GenerateID(CONF_DISPLAY_ID): cv.use_id(display.DisplayBuffer),
+            cv.Required(CONF_FONT): cv.use_id(font.Font),
+            cv.Optional(CONF_MARK_SELECTED, default=0x3E): cv.uint8_t,
+            cv.Optional(CONF_MARK_EDITING, default=0x2A): cv.uint8_t,
+            cv.Optional(CONF_MARK_SUBMENU, default=0x7E): cv.uint8_t,
+            cv.Optional(CONF_MARK_BACK, default=0x5E): cv.uint8_t,
+            cv.Optional(CONF_COLOR): cv.use_id(color.ColorStruct),
+        }
+    )
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    disp = await cg.get_variable(config[CONF_DISPLAY_ID])
+    cg.add(var.set_display(disp))
+    await display_menu_to_code(var, config)
+    cg.add(var.set_mark_selected(config[CONF_MARK_SELECTED]))
+    cg.add(var.set_mark_editing(config[CONF_MARK_EDITING]))
+    cg.add(var.set_mark_submenu(config[CONF_MARK_SUBMENU]))
+    cg.add(var.set_mark_back(config[CONF_MARK_BACK]))
+    menu_font = await cg.get_variable(config[CONF_FONT])
+    cg.add(var.set_font(menu_font))
+    if CONF_COLOR in config:
+        c = await cg.get_variable(config[CONF_COLOR])
+        cg.add(var.set_color(c))

--- a/esphome/components/graphical_menu/graphical_menu.cpp
+++ b/esphome/components/graphical_menu/graphical_menu.cpp
@@ -1,0 +1,80 @@
+#include "graphical_menu.h"
+#include "esphome/core/log.h"
+#include <algorithm>
+
+namespace esphome {
+namespace graphical_menu {
+
+static const char *const TAG = "graphical_menu";
+
+void GraphicalMenuComponent::setup() {
+  int width;
+  int x_offset;
+  int x_baseline;
+  int height;
+  char test_string[2] = "A";
+  this->font_->measure(test_string, &width, &x_offset, &x_baseline, &height);
+  set_rows(this->display_->get_height() / height);
+  this->columns_ = this->display_->get_width() / width;  // Assumes monospaced font
+  ESP_LOGD(TAG, "Character Width: %u, Height: %u", width, height);
+  display_menu_base::DisplayMenuComponent::setup();
+}
+
+float GraphicalMenuComponent::get_setup_priority() const { return setup_priority::PROCESSOR - 1.0f; }
+
+void GraphicalMenuComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "LCD Menu");
+  ESP_LOGCONFIG(TAG, "  Rows: %u Colums: %u", this->rows_, this->columns_);
+  ESP_LOGCONFIG(TAG, "  Mark characters: %02x, %02x, %02x, %02x", this->mark_selected_, this->mark_editing_,
+                this->mark_submenu_, this->mark_back_);
+}
+
+void GraphicalMenuComponent::draw_item(const display_menu_base::MenuItem *item, uint8_t row, bool selected) {
+  char data[this->columns_ + 1];
+
+  int editing_width;
+  int selected_width;
+  int x_offset;
+  int x_baseline;
+  int height;
+  char editing_string[2] = {this->mark_editing_, '\0'};
+  char selected_string[2] = {this->mark_selected_, '\0'};
+  this->font_->measure(editing_string, &editing_width, &x_offset, &x_baseline, &height);
+  this->font_->measure(selected_string, &selected_width, &x_offset, &x_baseline, &height);
+
+  int es_width = editing_width >= selected_width ? editing_width : selected_width;
+
+  memset(data, ' ', this->columns_);
+
+  if (selected) {
+    char c = (this->editing_ || (this->mode_ == display_menu_base::MENU_MODE_JOYSTICK && item->get_immediate_edit()))
+                 ? this->mark_editing_
+                 : this->mark_selected_;
+    this->display_->printf(0, row * this->font_->get_height(), this->font_, this->color_, "%c", c);
+  }
+
+  switch (item->get_type()) {
+    case display_menu_base::MENU_ITEM_MENU:
+      data[this->columns_ - 1] = this->mark_submenu_;
+      break;
+    case display_menu_base::MENU_ITEM_BACK:
+      data[this->columns_ - 1] = this->mark_back_;
+      break;
+    default:
+      break;
+  }
+
+  auto text = item->get_text();
+
+  this->display_->print(es_width, row * this->font_->get_height(), this->font_, this->color_, item->get_text().c_str());
+
+  if (item->has_value()) {
+    std::string value = item->get_value_text();
+
+    this->display_->printf(this->display_->get_width(), row * this->font_->get_height(), this->font_, this->color_,
+                           display::TextAlign::TOP_RIGHT, "[%s]", value.c_str());
+  }
+}
+
+}  // namespace graphical_menu
+}  // namespace esphome

--- a/esphome/components/graphical_menu/graphical_menu.h
+++ b/esphome/components/graphical_menu/graphical_menu.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "esphome/components/display/display_buffer.h"
+#include "esphome/components/ssd1306_base/ssd1306_base.h"
+#include "esphome/components/display_menu_base/display_menu_base.h"
+#include "esphome/core/color.h"
+
+#include <forward_list>
+#include <vector>
+
+namespace esphome {
+namespace graphical_menu {
+
+/** Class to display a hierarchical menu.
+ *
+ */
+class GraphicalMenuComponent : public display_menu_base::DisplayMenuComponent {
+ public:
+  void set_display(ssd1306_base::SSD1306 *display) { this->display_ = display; }
+  void set_dimensions(uint8_t columns, uint8_t rows) {
+    this->columns_ = columns;
+    set_rows(rows);
+  }
+  void set_mark_selected(uint8_t c) { this->mark_selected_ = c; }
+  void set_mark_editing(uint8_t c) { this->mark_editing_ = c; }
+  void set_mark_submenu(uint8_t c) { this->mark_submenu_ = c; }
+  void set_mark_back(uint8_t c) { this->mark_back_ = c; }
+  void set_font(display::Font *font) { this->font_ = font; }
+  void set_color(Color val) { this->color_ = val; }
+
+  void setup() override;
+  float get_setup_priority() const override;
+
+  void dump_config() override;
+
+ protected:
+  void draw_item(const display_menu_base::MenuItem *item, uint8_t row, bool selected) override;
+  void update() override { this->display_->update(); }
+
+  ssd1306_base::SSD1306 *display_;
+  uint8_t columns_;
+  char mark_selected_;
+  char mark_editing_;
+  char mark_submenu_;
+  char mark_back_;
+  display::Font *font_;
+  Color color_{Color::BLACK};
+};
+
+}  // namespace graphical_menu
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Emulates `lcd_menu` for graphical LCDs, allowing for simple menus on graphical LCDs

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3074

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
graphical_menu:
  id: oled_menu
  font: roboto
  display_id: oled
  active: false
  mode: rotary
  items:
    - type: command
      text: "Exit"
      on_value:
        - display_menu.hide:


```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
