### PR TITLE
Init colorama in ESPHome main

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -670,7 +670,6 @@ POST_CONFIG_ACTIONS = {
 
 
 def parse_args(argv):
-    colorama.init()
     options_parser = argparse.ArgumentParser(add_help=False)
     options_parser.add_argument(
         "-v", "--verbose", help="Enable verbose ESPHome logs.", action="store_true"
@@ -954,6 +953,8 @@ def parse_args(argv):
 
 
 def run_esphome(argv):
+    colorama.init()
+
     args = parse_args(argv)
     CORE.dashboard = args.dashboard
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -7,8 +7,6 @@ import sys
 import time
 from datetime import datetime
 
-import colorama
-
 from esphome import const, writer, yaml_util
 import esphome.codegen as cg
 from esphome.config import iter_components, read_config, strip_default_ids
@@ -953,8 +951,6 @@ def parse_args(argv):
 
 
 def run_esphome(argv):
-    colorama.init()
-
     args = parse_args(argv)
     CORE.dashboard = args.dashboard
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -7,6 +7,8 @@ import sys
 import time
 from datetime import datetime
 
+import colorama
+
 from esphome import const, writer, yaml_util
 import esphome.codegen as cg
 from esphome.config import iter_components, read_config, strip_default_ids
@@ -668,6 +670,7 @@ POST_CONFIG_ACTIONS = {
 
 
 def parse_args(argv):
+    colorama.init()
     options_parser = argparse.ArgumentParser(add_help=False)
     options_parser.add_argument(
         "-v", "--verbose", help="Enable verbose ESPHome logs.", action="store_true"

--- a/esphome/log.py
+++ b/esphome/log.py
@@ -69,6 +69,10 @@ class ESPHomeLogFormatter(logging.Formatter):
 def setup_log(
     debug: bool = False, quiet: bool = False, include_timestamp: bool = False
 ) -> None:
+    import colorama
+
+    colorama.init()
+
     if debug:
         log_level = logging.DEBUG
         CORE.verbose = True

--- a/esphome/log.py
+++ b/esphome/log.py
@@ -69,8 +69,6 @@ class ESPHomeLogFormatter(logging.Formatter):
 def setup_log(
     debug: bool = False, quiet: bool = False, include_timestamp: bool = False
 ) -> None:
-    import colorama
-
     if debug:
         log_level = logging.DEBUG
         CORE.verbose = True
@@ -82,7 +80,6 @@ def setup_log(
 
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 
-    colorama.init()
     logging.getLogger().handlers[0].setFormatter(
         ESPHomeLogFormatter(include_timestamp=include_timestamp)
     )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Call `colorama.init()` in ESPHome CLI tools, to fix terminal color support on Windows (especially in editors such as VSCode, having their own terminal support).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).