### PR TITLE
[LD2410] Remove baud_rate check

### DIFF
--- a/esphome/components/ld2410/__init__.py
+++ b/esphome/components/ld2410/__init__.py
@@ -112,7 +112,6 @@ CONFIG_SCHEMA = cv.All(
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     "ld2410",
-    baud_rate=256000,
     require_tx=True,
     require_rx=True,
     parity="NONE",


### PR DESCRIPTION


# What does this implement/fix?

According to LD2410's documentation, the baud rate can be changed. Using 256000 speed on software uart causing bootloop, 115200 works fine, but because of this check we cannot change it.

## Types of changes
New feature (non-breaking change which adds functionality)


## Test Environment
ESP8266

## Example entry for `config.yaml`:
``` yaml
uart:
  tx_pin: D2
  rx_pin: D1
  baud_rate: 115200
  parity: NONE
  stop_bits: 1
  data_bits: 8
```


## Checklist:
The code change is tested and works locally.
