### PR TITLE
remote_base changes

### DIFF
--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -187,11 +187,10 @@ std::string ProntoProtocol::dump_duration_(uint32_t duration, uint16_t timebase,
   return dump_number_((duration + timebase / 2) / timebase, end);
 }
 
-std::string ProntoProtocol::compensate_and_dump_sequence_(std::vector<int32_t> *data, uint16_t timebase) {
+std::string ProntoProtocol::compensate_and_dump_sequence_(const RawTimings &data, uint16_t timebase) {
   std::string out;
 
-  for (std::vector<int32_t>::size_type i = 0; i < data->size() - 1; i++) {
-    int32_t t_length = data->at(i);
+  for (int32_t t_length : data) {
     uint32_t t_duration;
     if (t_length > 0) {
       // Mark
@@ -212,12 +211,12 @@ optional<ProntoData> ProntoProtocol::decode(RemoteReceiveData src) {
   ProntoData out;
 
   uint16_t frequency = 38000U;
-  std::vector<int32_t> *data = src.get_raw_data();
+  auto &data = src.get_raw_data();
   std::string prontodata;
 
   prontodata += dump_number_(frequency > 0 ? LEARNED_TOKEN : LEARNED_NON_MODULATED_TOKEN);
   prontodata += dump_number_(to_frequency_code_(frequency));
-  prontodata += dump_number_((data->size() + 1) / 2);
+  prontodata += dump_number_((data.size() + 1) / 2);
   prontodata += dump_number_(0);
   uint16_t timebase = to_timebase_(frequency);
   prontodata += compensate_and_dump_sequence_(data, timebase);

--- a/esphome/components/remote_base/pronto_protocol.h
+++ b/esphome/components/remote_base/pronto_protocol.h
@@ -27,7 +27,7 @@ class ProntoProtocol : public RemoteProtocol<ProntoData> {
   std::string dump_digit_(uint8_t x);
   std::string dump_number_(uint16_t number, bool end = false);
   std::string dump_duration_(uint32_t duration, uint16_t timebase, bool end = false);
-  std::string compensate_and_dump_sequence_(std::vector<int32_t> *data, uint16_t timebase);
+  std::string compensate_and_dump_sequence_(const RawTimings &data, uint16_t timebase);
 
  public:
   void encode(RemoteTransmitData *dst, const ProntoData &data) override;

--- a/esphome/components/remote_base/raw_protocol.h
+++ b/esphome/components/remote_base/raw_protocol.h
@@ -31,17 +31,17 @@ class RawBinarySensor : public RemoteReceiverBinarySensorBase {
   size_t len_;
 };
 
-class RawTrigger : public Trigger<std::vector<int32_t>>, public Component, public RemoteReceiverListener {
+class RawTrigger : public Trigger<RawTimings>, public Component, public RemoteReceiverListener {
  protected:
   bool on_receive(RemoteReceiveData src) override {
-    this->trigger(*src.get_raw_data());
+    this->trigger(src.get_raw_data());
     return false;
   }
 };
 
 template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts...> {
  public:
-  void set_code_template(std::function<std::vector<int32_t>(Ts...)> func) { this->code_func_ = func; }
+  void set_code_template(std::function<RawTimings(Ts...)> func) { this->code_func_ = func; }
   void set_code_static(const int32_t *code, size_t len) {
     this->code_static_ = code;
     this->code_static_len_ = len;
@@ -65,7 +65,7 @@ template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts
   }
 
  protected:
-  std::function<std::vector<int32_t>(Ts...)> code_func_{};
+  std::function<RawTimings(Ts...)> code_func_{nullptr};
   const int32_t *code_static_{nullptr};
   int32_t code_static_len_{0};
 };

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -24,11 +24,105 @@ void RemoteRMTChannel::config_rmt(rmt_config_t &rmt) {
 }
 #endif
 
+/* RemoteReceiveData */
+
+bool RemoteReceiveData::peek_mark(uint32_t length, uint32_t offset) const {
+  if (!this->is_valid(offset))
+    return false;
+  const int32_t value = this->peek(offset);
+  const int32_t lo = this->lower_bound_(length);
+  const int32_t hi = this->upper_bound_(length);
+  return value >= 0 && lo <= value && value <= hi;
+}
+
+bool RemoteReceiveData::peek_space(uint32_t length, uint32_t offset) const {
+  if (!this->is_valid(offset))
+    return false;
+  const int32_t value = this->peek(offset);
+  const int32_t lo = this->lower_bound_(length);
+  const int32_t hi = this->upper_bound_(length);
+  return value <= 0 && lo <= -value && -value <= hi;
+}
+
+bool RemoteReceiveData::peek_space_at_least(uint32_t length, uint32_t offset) const {
+  if (!this->is_valid(offset))
+    return false;
+  const int32_t value = this->peek(offset);
+  const int32_t lo = this->lower_bound_(length);
+  return value <= 0 && lo <= -value;
+}
+
+bool RemoteReceiveData::expect_mark(uint32_t length) {
+  if (!this->peek_mark(length))
+    return false;
+  this->advance();
+  return true;
+}
+
+bool RemoteReceiveData::expect_space(uint32_t length) {
+  if (!this->peek_space(length))
+    return false;
+  this->advance();
+  return true;
+}
+
+bool RemoteReceiveData::expect_item(uint32_t mark, uint32_t space) {
+  if (!this->peek_item(mark, space))
+    return false;
+  this->advance(2);
+  return true;
+}
+
+bool RemoteReceiveData::expect_pulse_with_gap(uint32_t mark, uint32_t space) {
+  if (!this->peek_space_at_least(space, 1) || !this->peek_mark(mark))
+    return false;
+  this->advance(2);
+  return true;
+}
+
+/* RemoteReceiverBinarySensorBase */
+
+bool RemoteReceiverBinarySensorBase::on_receive(RemoteReceiveData src) {
+  if (!this->matches(src))
+    return false;
+  this->publish_state(true);
+  yield();
+  this->publish_state(false);
+  return true;
+}
+
+/* RemoteReceiverBase */
+
+void RemoteReceiverBase::register_dumper(RemoteReceiverDumperBase *dumper) {
+  if (dumper->is_secondary()) {
+    this->secondary_dumpers_.push_back(dumper);
+  } else {
+    this->dumpers_.push_back(dumper);
+  }
+}
+
+void RemoteReceiverBase::call_listeners_() {
+  for (auto *listener : this->listeners_)
+    listener->on_receive(RemoteReceiveData(this->temp_, this->tolerance_));
+}
+
+void RemoteReceiverBase::call_dumpers_() {
+  bool success = false;
+  for (auto *dumper : this->dumpers_) {
+    if (dumper->dump(RemoteReceiveData(this->temp_, this->tolerance_)))
+      success = true;
+  }
+  if (!success) {
+    for (auto *dumper : this->secondary_dumpers_)
+      dumper->dump(RemoteReceiveData(this->temp_, this->tolerance_));
+  }
+}
+
 void RemoteReceiverBinarySensorBase::dump_config() { LOG_BINARY_SENSOR("", "Remote Receiver Binary Sensor", this); }
 
 void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-  const std::vector<int32_t> &vec = this->temp_.get_data();
+  const auto &vec = this->temp_.get_data();
   char buffer[256];
   uint32_t buffer_offset = 0;
   buffer_offset += sprintf(buffer, "Sending times=%u wait=%ums: ", send_times, send_wait);

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -48,7 +48,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   esp_err_t error_code_{ESP_OK};
   bool inverted_{false};
 #endif
-  uint8_t carrier_duty_percent_{50};
+  uint8_t carrier_duty_percent_;
 };
 
 }  // namespace remote_transmitter


### PR DESCRIPTION
# What does this implement/fix?

The original goal of this PR was to fix the non-call of dumpers after processing by at least one of the listeners.
But as soon as I started, I could not pass by and not do the following:

1. Add `const` qualifiers to methods that do not change the state of objects;
2. Moved large methods from the header file to the source file, since they are used in all protocols and increase the binary file without a significant need;
3. Removed some default initializers, which are mandatory initialized by the constructor from the YAML configuration.

In fact, there is still a lot of work to clean up the old code. Trust me at least this simple IR subsystem. I'll try to clean it up and keep it up.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
