### PR TITLE
Change datatype in e131 addressable light

### DIFF
--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -51,7 +51,7 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
   if (universe < first_universe_ || universe > get_last_universe())
     return false;
 
-  int output_offset = (universe - first_universe_) * get_lights_per_universe();
+  int32_t output_offset = (universe - first_universe_) * get_lights_per_universe();
   // limit amount of lights per universe and received
   int output_end =
       std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + packet.count - 1));


### PR DESCRIPTION
# What does this implement/fix?

Comparsion failed due to incompatible datatypes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4686

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: i4686

esp32:
  board: esp32-c3-devkitm-1

wifi:
  ssid: wifiname
  password: !secret wifipwd

e131:
  method: unicast

light:
  - platform: neopixelbus
    type: BRG
    variant: WS2811
    pin: GPIO9
    num_leds: 66
    name: "NeoPixel Light"
    effects:
      - e131:
          universe: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
