### PR TITLE
Allow esp32 idf components to specify submodules and specific components

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import Union, Optional
 from pathlib import Path
 import logging
 import os
@@ -127,12 +127,14 @@ def add_idf_component(
     ref: str = None,
     path: str = None,
     refresh: TimePeriod = None,
-    components: list[str] = [],
-    submodules: list[str] = [],
+    components: Optional[list[str]] = None,
+    submodules: Optional[list[str]] = None,
 ):
     """Add an esp-idf component to the project."""
     if not CORE.using_esp_idf:
         raise ValueError("Not an esp-idf project")
+    if components is None:
+        components = []
     if name not in CORE.data[KEY_ESP32][KEY_COMPONENTS]:
         CORE.data[KEY_ESP32][KEY_COMPONENTS][name] = {
             KEY_REPO: repo,

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -9,6 +9,7 @@ KEY_REPO = "repo"
 KEY_REF = "ref"
 KEY_REFRESH = "refresh"
 KEY_PATH = "path"
+KEY_SUBMODULES = "submodules"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32S2 = "ESP32S2"

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -86,10 +86,10 @@ async def to_code(config):
         5, 0, 0
     ):
         add_idf_component(
-            "mdns",
-            "https://github.com/espressif/esp-protocols.git",
-            "mdns-v1.0.9",
-            "components/mdns",
+            name="mdns",
+            repo="https://github.com/espressif/esp-protocols.git",
+            ref="mdns-v1.0.9",
+            path="components/mdns",
         )
 
     if config[CONF_DISABLED]:

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -49,7 +49,7 @@ def clone_or_update(
     domain: str,
     username: str = None,
     password: str = None,
-    submodules: list[str] = [],
+    submodules: Optional[list[str]] = None,
 ) -> tuple[Path, Optional[Callable[[], None]]]:
     key = f"{url}@{ref}"
 
@@ -76,7 +76,7 @@ def clone_or_update(
             run_git_command(["git", "fetch", "--", "origin", ref], str(repo_dir))
             run_git_command(["git", "reset", "--hard", "FETCH_HEAD"], str(repo_dir))
 
-        if submodules:
+        if submodules is not None:
             _LOGGER.info(
                 "Initialising submodules (%s) for %s", ", ".join(submodules), key
             )
@@ -107,7 +107,7 @@ def clone_or_update(
             # Hard reset to FETCH_HEAD (short-lived git ref corresponding to most recent fetch)
             run_git_command(["git", "reset", "--hard", "FETCH_HEAD"], str(repo_dir))
 
-            if submodules:
+            if submodules is not None:
                 _LOGGER.info(
                     "Updating submodules (%s) for %s", ", ".join(submodules), key
                 )

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def run_git_command(cmd, cwd=None) -> str:
+    _LOGGER.debug("Running git command: %s", " ".join(cmd))
     try:
         ret = subprocess.run(cmd, cwd=cwd, capture_output=True, check=False)
     except FileNotFoundError as err:
@@ -48,6 +49,7 @@ def clone_or_update(
     domain: str,
     username: str = None,
     password: str = None,
+    submodules: list[str] = [],
 ) -> tuple[Path, Optional[Callable[[], None]]]:
     key = f"{url}@{ref}"
 
@@ -74,6 +76,14 @@ def clone_or_update(
             run_git_command(["git", "fetch", "--", "origin", ref], str(repo_dir))
             run_git_command(["git", "reset", "--hard", "FETCH_HEAD"], str(repo_dir))
 
+        if submodules:
+            _LOGGER.info(
+                "Initialising submodules (%s) for %s", ", ".join(submodules), key
+            )
+            run_git_command(
+                ["git", "submodule", "update", "--init"] + submodules, str(repo_dir)
+            )
+
     else:
         # Check refresh needed
         file_timestamp = Path(repo_dir / ".git" / "FETCH_HEAD")
@@ -96,6 +106,14 @@ def clone_or_update(
             run_git_command(cmd, str(repo_dir))
             # Hard reset to FETCH_HEAD (short-lived git ref corresponding to most recent fetch)
             run_git_command(["git", "reset", "--hard", "FETCH_HEAD"], str(repo_dir))
+
+            if submodules:
+                _LOGGER.info(
+                    "Updating submodules (%s) for %s", ", ".join(submodules), key
+                )
+                run_git_command(
+                    ["git", "submodule", "update", "--init"] + submodules, str(repo_dir)
+                )
 
             def revert():
                 _LOGGER.info("Reverting changes to %s -> %s", key, old_sha)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
