### PR TITLE
image: allow the image to by auto-loaded by animation

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -12,7 +12,7 @@ import argcomplete
 
 from esphome import const, writer, yaml_util
 import esphome.codegen as cg
-from esphome.config import iter_components, read_config, strip_default_ids
+from esphome.config import iter_component_configs, read_config, strip_default_ids
 from esphome.const import (
     ALLOWED_NAME_CHARS,
     CONF_BAUD_RATE,
@@ -196,7 +196,7 @@ def write_cpp(config):
 def generate_cpp_contents(config):
     _LOGGER.info("Generating C++ source...")
 
-    for name, component, conf in iter_components(CORE.config):
+    for name, component, conf in iter_component_configs(CORE.config):
         if component.to_code is not None:
             coro = wrap_to_code(name, component)
             CORE.add_job(coro, conf)

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -36,6 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "image"
 DEPENDENCIES = ["display"]
 MULTI_CONF = True
+MULTI_CONF_NO_DEFAULT = True
 
 image_ns = cg.esphome_ns.namespace("image")
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -41,6 +41,17 @@ _LOGGER = logging.getLogger(__name__)
 def iter_components(config):
     for domain, conf in config.items():
         component = get_component(domain)
+        yield domain, component
+        if component.is_platform_component:
+            for p_config in conf:
+                p_name = f"{domain}.{p_config[CONF_PLATFORM]}"
+                platform = get_platform(domain, p_config[CONF_PLATFORM])
+                yield p_name, platform
+
+
+def iter_component_configs(config):
+    for domain, conf in config.items():
+        component = get_component(domain)
         if component.multi_conf:
             for conf_ in conf:
                 yield domain, component, conf_
@@ -303,8 +314,10 @@ class LoadValidationStep(ConfigValidationStep):
             # Ignore top-level keys starting with a dot
             return
         result.add_output_path([self.domain], self.domain)
-        result[self.domain] = self.conf
         component = get_component(self.domain)
+        if component.multi_conf_no_default and isinstance(self.conf, core.AutoLoad):
+            self.conf = []
+        result[self.domain] = self.conf
         path = [self.domain]
         if component is None:
             result.add_str_error(f"Component not found: {self.domain}", path)
@@ -424,7 +437,10 @@ class MetadataValidationStep(ConfigValidationStep):
 
     def run(self, result: Config) -> None:
         if self.conf is None:
-            result[self.domain] = self.conf = {}
+            if self.comp.multi_conf and self.comp.multi_conf_no_default:
+                result[self.domain] = self.conf = []
+            else:
+                result[self.domain] = self.conf = {}
 
         success = True
         for dependency in self.comp.dependencies:

--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -58,6 +58,10 @@ class ComponentManifest:
         return getattr(self.module, "MULTI_CONF", False)
 
     @property
+    def multi_conf_no_default(self) -> bool:
+        return getattr(self.module, "MULTI_CONF_NO_DEFAULT", False)
+
+    @property
     def to_code(self) -> Optional[Callable[[Any], None]]:
         return getattr(self.module, "to_code", None)
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Union
 
-from esphome.config import iter_components
+from esphome.config import iter_components, iter_component_configs
 from esphome.const import (
     HEADER_FILE_EXTENSIONS,
     SOURCE_FILE_EXTENSIONS,
@@ -70,14 +70,14 @@ UPLOAD_SPEED_OVERRIDE = {
 
 def get_flags(key):
     flags = set()
-    for _, component, conf in iter_components(CORE.config):
+    for _, component, conf in iter_component_configs(CORE.config):
         flags |= getattr(component, key)(conf)
     return flags
 
 
 def get_include_text():
     include_text = '#include "esphome.h"\nusing namespace esphome;\n'
-    for _, component, conf in iter_components(CORE.config):
+    for _, component, conf in iter_component_configs(CORE.config):
         if not hasattr(component, "includes"):
             continue
         includes = component.includes
@@ -232,7 +232,7 @@ the custom_components folder or the external_components feature.
 
 def copy_src_tree():
     source_files: list[loader.FileResource] = []
-    for _, component, _ in iter_components(CORE.config):
+    for _, component in iter_components(CORE.config):
         source_files += component.resources
     source_files_map = {
         Path(x.package.replace(".", "/") + "/" + x.resource): x for x in source_files

--- a/tests/test8.yaml
+++ b/tests/test8.yaml
@@ -92,3 +92,13 @@ sensor:
       name: "Loop Time"
     psram:
       name: "PSRAM Free"
+
+# Purposely test that `animation:` does auto-load `image:`
+# Keep the `image:` undefined.
+# image:
+
+animation:
+  - id: rgb565_animation
+    file: pnglogo.png
+    type: RGB565
+    use_transparency: no


### PR DESCRIPTION
This fixes the case where only `animation:` is present and `image:` is auto-loaded.

This introduces `MULTI_CONF_NO_DEFAULT=True` that allows to include image source code only without initialising a default object.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

Per `test8.yaml` included in PR.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
