### PR TITLE
Allow BTM and RRM to be explicitly disabled on Arduino framework

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -78,6 +78,12 @@ def validate_channel(value):
     return value
 
 
+def validate_esp_idf_feature(value):
+    if value:
+        return cv.only_with_esp_idf(value)
+    return value
+
+
 AP_MANUAL_IP_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_STATIC_IP): cv.ipv4,
@@ -280,10 +286,10 @@ CONFIG_SCHEMA = cv.All(
                 cv.decibel, cv.float_range(min=8.5, max=20.5)
             ),
             cv.SplitDefault(CONF_ENABLE_BTM, esp32_idf=False): cv.All(
-                cv.boolean, cv.only_with_esp_idf
+                cv.boolean, validate_esp_idf_feature
             ),
             cv.SplitDefault(CONF_ENABLE_RRM, esp32_idf=False): cv.All(
-                cv.boolean, cv.only_with_esp_idf
+                cv.boolean, validate_esp_idf_feature
             ),
             cv.Optional(CONF_PASSIVE_SCAN, default=False): cv.boolean,
             cv.Optional("enable_mdns"): cv.invalid(


### PR DESCRIPTION
# What does this implement/fix?

Currently the following configuration fails when using the Arduino framework:

```yaml
---
substitutions:
  enable_btm: 'false'
  enable_rrm: 'false'

esphome:
  name: 'test'

esp8266:
  board: 'esp01_1m'

wifi:
  enable_btm: '${enable_btm}'
  enable_rrm: '${enable_rrm}'
```

The intention of the code is to only allow `enable_btm` and `enable_rrm` to be set to `true` when using ESP-IDF, but this isn't consistent with the actual behaviour of the code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Fixes esphome/issues#4725.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
---
substitutions:
  enable_btm: 'false'
  enable_rrm: 'false'

esphome:
  name: 'test'

esp8266:
  board: 'esp01_1m'

wifi:
  enable_btm: '${enable_btm}'
  enable_rrm: '${enable_rrm}'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
