### PR TITLE
Swap ADC back to use 'int' because C3

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -32,8 +32,8 @@ static const int32_t SOC_ADC_RTC_MAX_BITWIDTH = 12;
 #endif
 #endif
 
-static const int32_t ADC_MAX = (1 << SOC_ADC_RTC_MAX_BITWIDTH) - 1;    // 4095 (12 bit) or 8191 (13 bit)
-static const int32_t ADC_HALF = (1 << SOC_ADC_RTC_MAX_BITWIDTH) >> 1;  // 2048 (12 bit) or 4096 (13 bit)
+static const int ADC_MAX = (1 << SOC_ADC_RTC_MAX_BITWIDTH) - 1;    // 4095 (12 bit) or 8191 (13 bit)
+static const int ADC_HALF = (1 << SOC_ADC_RTC_MAX_BITWIDTH) >> 1;  // 2048 (12 bit) or 4096 (13 bit)
 #endif
 
 #ifdef USE_RP2040
@@ -59,7 +59,7 @@ extern "C"
   }
 
   // load characteristics for each attenuation
-  for (int32_t i = 0; i < (int32_t) ADC_ATTEN_MAX; i++) {
+  for (int32_t i = 0; i <= ADC_ATTEN_DB_11; i++) {
     auto adc_unit = channel1_ != ADC1_CHANNEL_MAX ? ADC_UNIT_1 : ADC_UNIT_2;
     auto cal_value = esp_adc_cal_characterize(adc_unit, (adc_atten_t) i, ADC_WIDTH_MAX_SOC_BITS,
                                               1100,  // default vref
@@ -157,7 +157,7 @@ float ADCSensor::sample() {
 #ifdef USE_ESP32
 float ADCSensor::sample() {
   if (!autorange_) {
-    int32_t raw = -1;
+    int raw = -1;
     if (channel1_ != ADC1_CHANNEL_MAX) {
       raw = adc1_get_raw(channel1_);
     } else if (channel2_ != ADC2_CHANNEL_MAX) {
@@ -174,7 +174,7 @@ float ADCSensor::sample() {
     return mv / 1000.0f;
   }
 
-  int32_t raw11 = ADC_MAX, raw6 = ADC_MAX, raw2 = ADC_MAX, raw0 = ADC_MAX;
+  int raw11 = ADC_MAX, raw6 = ADC_MAX, raw2 = ADC_MAX, raw0 = ADC_MAX;
 
   if (channel1_ != ADC1_CHANNEL_MAX) {
     adc1_config_channel_atten(channel1_, ADC_ATTEN_DB_11);

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -62,7 +62,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   adc1_channel_t channel1_{ADC1_CHANNEL_MAX};
   adc2_channel_t channel2_{ADC2_CHANNEL_MAX};
   bool autorange_{false};
-  esp_adc_cal_characteristics_t cal_characteristics_[(int32_t) ADC_ATTEN_MAX] = {};
+  esp_adc_cal_characteristics_t cal_characteristics_[ADC_ATTEN_MAX] = {};
 #endif
 };
 

--- a/tests/test7.yaml
+++ b/tests/test7.yaml
@@ -31,3 +31,11 @@ logger:
 http_request:
   useragent: esphome/tagreader
   timeout: 10s
+
+sensor:
+  - platform: adc
+    id: adc_sensor_p4
+    name: ADC pin 4
+    pin: 4
+    attenuation: 11db
+    update_interval: 1s


### PR DESCRIPTION
# What does this implement/fix?

Fixes https://github.com/esphome/issues/issues/4711

...also adds a test for the ADC on the C3.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4711

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (ESP32 + ESP32-C3)
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
