### PR TITLE
wifi: handle WIFI_REASON_ROAMING reason in event

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -569,6 +569,8 @@ const char *get_disconnect_reason_str(uint8_t reason) {
       return "Handshake Failed";
     case WIFI_REASON_CONNECTION_FAIL:
       return "Connection Failed";
+    case WIFI_REASON_ROAMING:
+      return "Station Roaming";
     case WIFI_REASON_UNSPECIFIED:
     default:
       return "Unspecified";
@@ -631,7 +633,9 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     if (it.reason == WIFI_REASON_NO_AP_FOUND) {
       ESP_LOGW(TAG, "Event: Disconnected ssid='%s' reason='Probe Request Unsuccessful'", buf);
       s_sta_connect_not_found = true;
-
+    } else if (it.reason == WIFI_REASON_ROAMING) {
+      ESP_LOGI(TAG, "Event: Disconnected ssid='%s' reason='Station Roaming'", buf);
+      return;
     } else {
       ESP_LOGW(TAG, "Event: Disconnected ssid='%s' bssid=" LOG_SECRET("%s") " reason='%s'", buf,
                format_mac_addr(it.bssid).c_str(), get_disconnect_reason_str(it.reason));


### PR DESCRIPTION
# What does this implement/fix?

When a WIFI_EVENT_STA_DISCONNECTED event is received with reason WIFI_REASON_ROAMING, we currently disconnect from the Wi-Fi network. This causes the client to disconnect and reconnect, most likely to the same BSSID. Instead, this event should be ignored, to let the driver handle it.

When sending an 802.11v BSS Transition Request, this often results in the client connecting to the AP it was currently connected to.

Without this change:
```
root@ap0:~# logread -e 7c:df:a1:66:b3:f0 -f
Wed Jul 26 15:34:16 2023 daemon.notice hostapd: wl24-iot: BSS-TM-RESP 7c:df:a1:66:b3:f0 status_code=0 bss_termination_delay=0 target_bssid=b6:a7:b9:cb:ee:bc
Wed Jul 26 15:34:16 2023daemon.notice hostapd: wl24-iot: AP-STA-DISCONNECTED 7c:df:a1:66:b3:f0
Wed Jul 26 15:34:17 2023 user.info usteer: station 7c:df:a1:66:b3:f0 disconnected from node hostapd.wl24-iot
Wed Jul 26 15:34:17 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:b3:f0 IEEE 802.11: authenticated
Wed Jul 26 15:34:17 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:b3:f0 IEEE 802.11: associated (aid 1)
Wed Jul 26 15:34:17 2023 daemon.notice hostapd: wl24-iot: AP-STA-CONNECTED 7c:df:a1:66:b3:f0 auth_alg=open
Wed Jul 26 15:34:17 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:b3:f0 RADIUS: starting accounting session 99A5663904E9D032
Wed Jul 26 15:34:17 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:b3:f0 WPA: pairwise key handshake completed (RSN)
Wed Jul 26 15:34:17 2023 daemon.notice hostapd: wl24-iot: EAPOL-4WAY-HS-COMPLETED 7c:df:a1:66:b3:f0
```

With this change:
```
root@ap0:~# logread -e 7c:df:a1:66:dc:68 -f
Wed Jul 26 15:42:02 2023 daemon.notice hostapd: wl24-iot: BSS-TM-RESP 7c:df:a1:66:dc:68 status_code=0 bss_termination_delay=0 target_bssid=b6:a7:b9:cb:ee:bc
Wed Jul 26 15:42:02 2023 daemon.notice hostapd: wl24-iot: AP-STA-DISCONNECTED 7c:df:a1:66:dc:68
```
```
root@ap1:~# logread -e 7c:df:a1:66:dc:68 -f
Wed Jul 26 15:42:03 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:dc:68 IEEE 802.11: authenticated
Wed Jul 26 15:42:03 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:dc:68 IEEE 802.11: associated (aid 2)
Wed Jul 26 15:42:03 2023 daemon.notice hostapd: wl24-iot: AP-STA-CONNECTED 7c:df:a1:66:dc:68 auth_alg=open
Wed Jul 26 15:42:03 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:dc:68 RADIUS: starting accounting session DAA5B468DD7DE4BD
Wed Jul 26 15:42:03 2023 daemon.info hostapd: wl24-iot: STA 7c:df:a1:66:dc:68 WPA: pairwise key handshake completed (RSN)
Wed Jul 26 15:42:03 2023 daemon.notice hostapd: wl24-iot: EAPOL-4WAY-HS-COMPLETED 7c:df:a1:66:dc:68
```
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
---
esphome:
  name: "bug"
  platformio_options:
    board_build.flash_mode: dio

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: esp-idf

wifi:
  ssid: !secret ssid_iot
  password: !secret pass_wifi_iot
  power_save_mode: none
  reboot_timeout: 1h
  enable_btm: true
  enable_rrm: true

logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
