### PR TITLE
Increase maximum number of BLE notifications

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -263,6 +263,7 @@ async def to_code(config):
         # Match arduino CONFIG_BTU_TASK_STACK_SIZE
         # https://github.com/espressif/arduino-esp32/blob/fd72cf46ad6fc1a6de99c1d83ba8eba17d80a4ee/tools/sdk/esp32/sdkconfig#L1866
         add_idf_sdkconfig_option("CONFIG_BTU_TASK_STACK_SIZE", 8192)
+        add_idf_sdkconfig_option("CONFIG_BT_ACL_CONNECTIONS", 9)
 
     cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts
     cg.add_define("USE_ESP32_BLE_CLIENT")


### PR DESCRIPTION
# What does this implement/fix?

Sets CONFIG_BT_ACL_CONNECTIONS to 9 to allow more notifications (only 4 allowed by default). For some reason espressif decided to make this the configuration option to increase `BTA_GATTC_NOTIF_REG_MAX` 🤷 

This appears to use ~400 bytes more memory, but testing is within the margin of error

This fixes many HomeKit BLE devices (any device that uses more than 4 notifications)  like the `Onvis CS1` and `Qingping Temp RH H` which have more than 4 chars with thh `ev` perm (it would previous fail after trying to enable notify on the 5th). If someone did manage to get it to pair and than moved it closer to a proxy, the symptoms would be stale state when it switched to the proxy.


For testing:

```yaml
external_components:
  - source: github://pr#5155
    components: [ esp32_ble_tracker ]
```

recommended as well

```yaml
esp32:
  board: [ADJUST THIS]
  framework:
    type: esp-idf
    version: 4.4.5
    platform_version: 5.4.0
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
