### PR TITLE
duty_time: fix build without binary_sensor. Parented in automations.

### DIFF
--- a/esphome/components/duty_time/duty_time_sensor.cpp
+++ b/esphome/components/duty_time/duty_time_sensor.cpp
@@ -6,9 +6,11 @@ namespace duty_time_sensor {
 
 static const char *const TAG = "duty_time_sensor";
 
+#ifdef USE_BINARY_SENSOR
 void DutyTimeSensor::set_sensor(binary_sensor::BinarySensor *const sensor) {
   sensor->add_on_state_callback([this](bool state) { this->process_state_(state); });
 }
+#endif
 
 void DutyTimeSensor::start() {
   if (!this->last_state_)

--- a/esphome/components/duty_time/sensor.py
+++ b/esphome/components/duty_time/sensor.py
@@ -19,6 +19,7 @@ from esphome.const import (
     DEVICE_CLASS_DURATION,
     ENTITY_CATEGORY_DIAGNOSTIC,
 )
+from esphome.cpp_helpers import register_parented
 
 CONF_LAST_TIME = "last_time"
 
@@ -26,11 +27,14 @@ duty_time_sensor_ns = cg.esphome_ns.namespace("duty_time_sensor")
 DutyTimeSensor = duty_time_sensor_ns.class_(
     "DutyTimeSensor", sensor.Sensor, cg.PollingComponent
 )
-StartAction = duty_time_sensor_ns.class_("StartAction", Action)
-StopAction = duty_time_sensor_ns.class_("StopAction", Action)
-ResetAction = duty_time_sensor_ns.class_("ResetAction", Action)
-SetAction = duty_time_sensor_ns.class_("SetAction", Action)
-RunningCondition = duty_time_sensor_ns.class_("RunningCondition", Condition)
+BaseAction = duty_time_sensor_ns.class_("BaseAction", Action, cg.Parented)
+StartAction = duty_time_sensor_ns.class_("StartAction", BaseAction)
+StopAction = duty_time_sensor_ns.class_("StopAction", BaseAction)
+ResetAction = duty_time_sensor_ns.class_("ResetAction", BaseAction)
+SetAction = duty_time_sensor_ns.class_("SetAction", BaseAction)
+RunningCondition = duty_time_sensor_ns.class_(
+    "RunningCondition", Condition, cg.Parented
+)
 
 
 CONFIG_SCHEMA = cv.All(
@@ -89,20 +93,23 @@ DUTY_TIME_ID_SCHEMA = maybe_simple_id(
 
 @register_action("sensor.duty_time.start", StartAction, DUTY_TIME_ID_SCHEMA)
 async def sensor_runtime_start_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
+    var = cg.new_Pvariable(action_id, template_arg)
+    await register_parented(var, config[CONF_ID])
+    return var
 
 
 @register_action("sensor.duty_time.stop", StopAction, DUTY_TIME_ID_SCHEMA)
 async def sensor_runtime_stop_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
+    var = cg.new_Pvariable(action_id, template_arg)
+    await register_parented(var, config[CONF_ID])
+    return var
 
 
 @register_action("sensor.duty_time.reset", ResetAction, DUTY_TIME_ID_SCHEMA)
 async def sensor_runtime_reset_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
+    var = cg.new_Pvariable(action_id, template_arg)
+    await register_parented(var, config[CONF_ID])
+    return var
 
 
 @register_condition(

--- a/esphome/components/duty_time/sensor.py
+++ b/esphome/components/duty_time/sensor.py
@@ -100,7 +100,7 @@ async def sensor_runtime_start_to_code(config, action_id, template_arg, args):
 @register_action("sensor.duty_time.stop", StopAction, DUTY_TIME_ID_SCHEMA)
 async def sensor_runtime_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
-    await register_parented(var, config[CONF_ID])
+    await cg.register_parented(var, config[CONF_ID])
     return var
 
 

--- a/esphome/components/duty_time/sensor.py
+++ b/esphome/components/duty_time/sensor.py
@@ -19,7 +19,6 @@ from esphome.const import (
     DEVICE_CLASS_DURATION,
     ENTITY_CATEGORY_DIAGNOSTIC,
 )
-from esphome.cpp_helpers import register_parented
 
 CONF_LAST_TIME = "last_time"
 

--- a/esphome/components/duty_time/sensor.py
+++ b/esphome/components/duty_time/sensor.py
@@ -93,7 +93,7 @@ DUTY_TIME_ID_SCHEMA = maybe_simple_id(
 @register_action("sensor.duty_time.start", StartAction, DUTY_TIME_ID_SCHEMA)
 async def sensor_runtime_start_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
-    await register_parented(var, config[CONF_ID])
+    await cg.register_parented(var, config[CONF_ID])
     return var
 
 

--- a/esphome/components/duty_time/sensor.py
+++ b/esphome/components/duty_time/sensor.py
@@ -107,7 +107,7 @@ async def sensor_runtime_stop_to_code(config, action_id, template_arg, args):
 @register_action("sensor.duty_time.reset", ResetAction, DUTY_TIME_ID_SCHEMA)
 async def sensor_runtime_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
-    await register_parented(var, config[CONF_ID])
+    await cg.register_parented(var, config[CONF_ID])
     return var
 
 


### PR DESCRIPTION
# What does this implement/fix?

1. Fixed building then `binary_sensor` is not loaded. Preferred preprocessor directives to `AUTO_LOAD` since use is optional;
2. Automation used `Parented<T>`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
