### PR TITLE
Bump clang-tidy from 11 to 14

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,9 +5,12 @@ Checks: >-
   -altera-*,
   -android-*,
   -boost-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
   -cert-dcl50-cpp,
+  -cert-err33-c,
   -cert-err58-cpp,
   -cert-oop57-cpp,
   -cert-str34-c,
@@ -15,6 +18,7 @@ Checks: >-
   -clang-analyzer-osx.*,
   -clang-diagnostic-delete-abstract-non-virtual-dtor,
   -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
+  -clang-diagnostic-ignored-optimization-argument,
   -clang-diagnostic-shadow-field,
   -clang-diagnostic-unused-const-variable,
   -clang-diagnostic-unused-parameter,
@@ -25,6 +29,7 @@ Checks: >-
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-prefer-member-initializer,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
@@ -36,6 +41,7 @@ Checks: >-
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-virtual-class-destructor,
   -fuchsia-multiple-inheritance,
   -fuchsia-overloaded-operator,
   -fuchsia-statically-constructed-objects,
@@ -68,6 +74,7 @@ Checks: >-
   -modernize-use-nodiscard,
   -mpi-*,
   -objc-*,
+  -readability-container-data-pointer,
   -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
@@ -82,8 +89,6 @@ WarningsAsErrors: '*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     google
 CheckOptions:
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
   - key:             google-readability-function-size.StatementThreshold
     value:           '800'
   - key:             google-runtime-int.TypeSuffix
@@ -157,4 +162,10 @@ CheckOptions:
   - key:             readability-identifier-naming.VirtualMethodSuffix
     value:           ''
   - key:             readability-qualified-auto.AddConstToQualified
+    value:           0
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumLoopCounterNameLength
     value:           0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
           key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
 
       - name: Install clang-tidy
-        run: sudo apt-get install clang-tidy-11
+        run: sudo apt-get install clang-tidy-14
 
       - name: Register problem matchers
         run: |

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -125,7 +125,7 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
 #elif defined(USE_ESP32_VARIANT_ESP32S3)
         uart_ == UART_SELECTION_USB_CDC || uart_ == UART_SELECTION_USB_SERIAL_JTAG
 #else
-        /* DISABLES CODE */ (false)
+        /* DISABLES CODE */ (false)  // NOLINT
 #endif
     ) {
       puts(msg);

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -89,11 +89,13 @@ void MatrixKeypad::loop() {
 void MatrixKeypad::dump_config() {
   ESP_LOGCONFIG(TAG, "Matrix Keypad:");
   ESP_LOGCONFIG(TAG, " Rows:");
-  for (auto &pin : this->rows_)
+  for (auto &pin : this->rows_) {
     LOG_PIN("  Pin: ", pin);
+  }
   ESP_LOGCONFIG(TAG, " Cols:");
-  for (auto &pin : this->columns_)
+  for (auto &pin : this->columns_) {
     LOG_PIN("  Pin: ", pin);
+  }
 }
 
 void MatrixKeypad::register_listener(MatrixKeypadListener *listener) { this->listeners_.push_back(listener); }

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -22,8 +22,6 @@ class MideaData {
   MideaData(const std::vector<uint8_t> &data) {
     std::copy_n(data.begin(), std::min(data.size(), this->data_.size()), this->data_.begin());
   }
-  // Default copy constructor
-  MideaData(const MideaData &) = default;
 
   uint8_t *data() { return this->data_.data(); }
   const uint8_t *data() const { return this->data_.data(); }

--- a/esphome/components/ssd1322_spi/ssd1322_spi.cpp
+++ b/esphome/components/ssd1322_spi/ssd1322_spi.cpp
@@ -21,8 +21,7 @@ void SPISSD1322::setup() {
 void SPISSD1322::dump_config() {
   LOG_DISPLAY("", "SPI SSD1322", this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
-  if (this->cs_)
-    LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   ESP_LOGCONFIG(TAG, "  Initial Brightness: %.2f", this->brightness_);

--- a/esphome/components/ssd1325_spi/ssd1325_spi.cpp
+++ b/esphome/components/ssd1325_spi/ssd1325_spi.cpp
@@ -21,8 +21,7 @@ void SPISSD1325::setup() {
 void SPISSD1325::dump_config() {
   LOG_DISPLAY("", "SPI SSD1325", this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
-  if (this->cs_)
-    LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   ESP_LOGCONFIG(TAG, "  Initial Brightness: %.2f", this->brightness_);

--- a/esphome/components/ssd1327_spi/ssd1327_spi.cpp
+++ b/esphome/components/ssd1327_spi/ssd1327_spi.cpp
@@ -21,8 +21,7 @@ void SPISSD1327::setup() {
 void SPISSD1327::dump_config() {
   LOG_DISPLAY("", "SPI SSD1327", this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
-  if (this->cs_)
-    LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   ESP_LOGCONFIG(TAG, "  Initial Brightness: %.2f", this->brightness_);

--- a/esphome/components/ssd1331_spi/ssd1331_spi.cpp
+++ b/esphome/components/ssd1331_spi/ssd1331_spi.cpp
@@ -20,8 +20,7 @@ void SPISSD1331::setup() {
 }
 void SPISSD1331::dump_config() {
   LOG_DISPLAY("", "SPI SSD1331", this);
-  if (this->cs_)
-    LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   ESP_LOGCONFIG(TAG, "  Initial Brightness: %.2f", this->brightness_);

--- a/esphome/components/ssd1351_spi/ssd1351_spi.cpp
+++ b/esphome/components/ssd1351_spi/ssd1351_spi.cpp
@@ -21,8 +21,7 @@ void SPISSD1351::setup() {
 void SPISSD1351::dump_config() {
   LOG_DISPLAY("", "SPI SSD1351", this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
-  if (this->cs_)
-    LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   ESP_LOGCONFIG(TAG, "  Initial Brightness: %.2f", this->brightness_);

--- a/esphome/components/tlc5947/tlc5947.cpp
+++ b/esphome/components/tlc5947/tlc5947.cpp
@@ -27,8 +27,7 @@ void TLC5947::dump_config() {
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
   LOG_PIN("  LAT Pin: ", this->lat_pin_);
-  if (this->outenable_pin_ != nullptr)
-    LOG_PIN("  OE Pin: ", this->outenable_pin_);
+  LOG_PIN("  OE Pin: ", this->outenable_pin_);
   ESP_LOGCONFIG(TAG, "  Number of chips: %u", this->num_chips_);
 }
 

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
@@ -147,8 +147,9 @@ void VBusCustomBSensor::dump_config() {
     ESP_LOGCONFIG(TAG, "  Command: 0x%04x", this->command_);
   }
   ESP_LOGCONFIG(TAG, "  Binary Sensors:");
-  for (VBusCustomSubBSensor *bsensor : this->bsensors_)
+  for (VBusCustomSubBSensor *bsensor : this->bsensors_) {
     LOG_BINARY_SENSOR("  ", "-", bsensor);
+  }
 }
 
 void VBusCustomBSensor::handle_message(std::vector<uint8_t> &message) {

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -232,8 +232,9 @@ void VBusCustomSensor::dump_config() {
     ESP_LOGCONFIG(TAG, "  Command: 0x%04x", this->command_);
   }
   ESP_LOGCONFIG(TAG, "  Sensors:");
-  for (VBusCustomSubSensor *sensor : this->sensors_)
+  for (VBusCustomSubSensor *sensor : this->sensors_) {
     LOG_SENSOR("  ", "-", sensor);
+  }
 }
 
 void VBusCustomSensor::handle_message(std::vector<uint8_t> &message) {

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -6,7 +6,6 @@
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
-#include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 
 #include "esphome/components/api/api_pb2.h"

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -220,7 +220,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   esp_err_t err;
   esp_wifi_get_config(WIFI_IF_STA, &current_conf);
 
-  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {  // NOLINT(bugprone-suspicious-memory-comparison)
+  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {  // NOLINT
     err = esp_wifi_disconnect();
     if (err != ESP_OK) {
       ESP_LOGV(TAG, "esp_wifi_disconnect failed! %d", err);

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -220,7 +220,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   esp_err_t err;
   esp_wifi_get_config(WIFI_IF_STA, &current_conf);
 
-  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {
+  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {  // NOLINT(bugprone-suspicious-memory-comparison)
     err = esp_wifi_disconnect();
     if (err != ESP_OK) {
       ESP_LOGV(TAG, "esp_wifi_disconnect failed! %d", err);

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -333,7 +333,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     // can continue
   }
 
-  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {  // NOLINT(bugprone-suspicious-memory-comparison)
+  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {  // NOLINT
     err = esp_wifi_disconnect();
     if (err != ESP_OK) {
       ESP_LOGV(TAG, "esp_wifi_disconnect failed: %s", esp_err_to_name(err));

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -333,7 +333,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     // can continue
   }
 
-  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {
+  if (memcmp(&current_conf, &conf, sizeof(wifi_config_t)) != 0) {  // NOLINT(bugprone-suspicious-memory-comparison)
     err = esp_wifi_disconnect();
     if (err != ESP_OK) {
       ESP_LOGV(TAG, "esp_wifi_disconnect failed: %s", esp_err_to_name(err));

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -113,7 +113,7 @@ def clang_options(idedata):
 def run_tidy(args, options, tmpdir, queue, lock, failed_files):
     while True:
         path = queue.get()
-        invocation = ["clang-tidy-11"]
+        invocation = ["clang-tidy-14"]
 
         if tmpdir is not None:
             invocation.append("--export-fixes")
@@ -194,14 +194,14 @@ def main():
     args = parser.parse_args()
 
     try:
-        get_output("clang-tidy-11", "-version")
+        get_output("clang-tidy-14", "-version")
     except:
         print(
             """
-        Oops. It looks like clang-tidy-11 is not installed.
+        Oops. It looks like clang-tidy-14 is not installed.
 
-        Please check you can run "clang-tidy-11 -version" in your terminal and install
-        clang-tidy (v11) if necessary.
+        Please check you can run "clang-tidy-14 -version" in your terminal and install
+        clang-tidy (v14) if necessary.
 
         Note you can also upload your code as a pull request on GitHub and see the CI check
         output to apply clang-tidy.
@@ -272,7 +272,7 @@ def main():
     if args.fix and failed_files:
         print("Applying fixes ...")
         try:
-            subprocess.call(["clang-apply-replacements-11", tmpdir])
+            subprocess.call(["clang-apply-replacements-14", tmpdir])
         except:
             print("Error applying fixes.\n", file=sys.stderr)
             raise


### PR DESCRIPTION
# What does this implement/fix?

In view of the discovered bug described [here](https://discordapp.com/channels/429907082951524364/1134049872681644063), I bump `clang-tidy` from `11` to `14` in this PR. For example, [this job](https://github.com/esphome/esphome/actions/runs/5685343905/job/15410065527) failed due to this bug.
I disabled many new default tests and made only the most significant changes to the source code.
New tests are very useful, but due to the many rather significant changes, checking the PR would take too much time.

Let me explain the issue using [this example](https://github.com/esphome/esphome/actions/runs/5685343905/job/15410065527): the `Action<Ts>` class has a `protected` `pure virtual` method `virtual void play(Ts... x) = 0;`. Its name is subject to the rule `readability-identifier-naming.VirtualMethodSuffix = ''`, that is, it __does not require a suffix for any type of access__, in this case `protected`. In a derived class, we are must to `override` a `purely virtual` method and we do it, but due to a bug `clang-tidy-11` __does not apply the virtual method naming rule to this method__, `clang-tidy` forces the name to be changed with the `_` suffix, since the method is `private` and enters into effect the rule `readability-identifier-naming.PrivateMethodSuffix = '_'`. To workaround the problem, we are forced to make the overridden method `public`, since the naming rules for public methods not defined and __do not require a suffix__ `_`. Adding the `virtual` keyword doesn't work, because `clang-tidy` will already __require to remove it, since it's redundant when used with an overridden method__.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
