### PR TITLE
update "Can't convert" warning to match others in homeassistant_sensor

### DIFF
--- a/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
+++ b/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
@@ -12,7 +12,7 @@ void HomeassistantSensor::setup() {
       this->entity_id_, this->attribute_, [this](const std::string &state) {
         auto val = parse_number<float>(state);
         if (!val.has_value()) {
-          ESP_LOGW(TAG, "Can't convert '%s' to number!", state.c_str());
+          ESP_LOGW(TAG, "'%s': Can't convert '%s' to number!", this->entity_id_.c_str(), state.c_str());
           this->publish_state(NAN);
           return;
         }


### PR DESCRIPTION
# What does this implement/fix?

This change includes the entity_id in warning log messages when the value can't be converted to a number. This matches the inclusion of the entity_id with the other log messages from the component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - NA [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
