### PR TITLE
Slightly lower template switch setup priority

### DIFF
--- a/esphome/components/template/switch/template_switch.cpp
+++ b/esphome/components/template/switch/template_switch.cpp
@@ -36,7 +36,7 @@ void TemplateSwitch::write_state(bool state) {
 void TemplateSwitch::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 bool TemplateSwitch::assumed_state() { return this->assumed_state_; }
 void TemplateSwitch::set_state_lambda(std::function<optional<bool>()> &&f) { this->f_ = f; }
-float TemplateSwitch::get_setup_priority() const { return setup_priority::HARDWARE; }
+float TemplateSwitch::get_setup_priority() const { return setup_priority::HARDWARE - 2.0f; }
 Trigger<> *TemplateSwitch::get_turn_on_trigger() const { return this->turn_on_trigger_; }
 Trigger<> *TemplateSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
 void TemplateSwitch::setup() {


### PR DESCRIPTION
Template switches may be used to influence hardware, but the hardware needs to be initialized before the template switch comes into action.

# What does this implement/fix?

When a template switch operates hardware, the hardware needs to be initialized before the switch can be set up.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes an issue I had with template switches. I didn't create a bug report for it...

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

script:
  - id: draw_tree
    then:
      - light.turn_off:
          id: tree
      - if:
          condition:
            switch.is_on: sw_pos_1
          then:
          - light.turn_on:
              id: position_1
          else:
          - light.turn_off:
              id: position_1
      - if:
          condition:
            switch.is_on: sw_pos_4
          then:
          - light.turn_on:
              id: position_4
          else:
          - light.turn_off:
              id: position_4
      - if:
          condition:
            or:
              - switch.is_on: sw_pos_4
              - switch.is_on: sw_pos_1
          then:
          - light.turn_on:
              id: position_14
          else:
          - light.turn_off:
              id: position_14

switch:
  - platform: template
    name: "Position 1"
    id: sw_pos_1
    optimistic: true
    on_state:
      - script.execute: draw_tree

  - platform: template
    name: "Position 4"
    id: sw_pos_4
    optimistic: true
    on_state:
      - script.execute: draw_tree

light:
  - platform: neopixelbus
    id: tree
    type: GRB
    variant: WS2812
    pin: D3
    num_leds: 450
    name: "NeoPixel Light"
    default_transition_length: 0ms
    internal: true
    restore_mode: ALWAYS_OFF

  - platform: partition
    internal: true
    id: position_1
    name: "Position 1 internal"
    segments:
    - id: tree
      from: 38
      to: 61

  - platform: partition
    internal: true
    id: position_14
    name: "Position 14 internal"
    segments:
    - id: tree
      from: 237
      to: 260

  - platform: partition
    internal: true
    id: position_4
    name: "Position 4 internal"
    segments:
    - id: tree
      from: 338
      to: 361
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
