### PR TITLE
2023.7.1

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -32,8 +32,8 @@ static const int32_t SOC_ADC_RTC_MAX_BITWIDTH = 12;
 #endif
 #endif
 
-static const int32_t ADC_MAX = (1 << SOC_ADC_RTC_MAX_BITWIDTH) - 1;    // 4095 (12 bit) or 8191 (13 bit)
-static const int32_t ADC_HALF = (1 << SOC_ADC_RTC_MAX_BITWIDTH) >> 1;  // 2048 (12 bit) or 4096 (13 bit)
+static const int ADC_MAX = (1 << SOC_ADC_RTC_MAX_BITWIDTH) - 1;    // 4095 (12 bit) or 8191 (13 bit)
+static const int ADC_HALF = (1 << SOC_ADC_RTC_MAX_BITWIDTH) >> 1;  // 2048 (12 bit) or 4096 (13 bit)
 #endif
 
 #ifdef USE_RP2040
@@ -59,7 +59,7 @@ extern "C"
   }
 
   // load characteristics for each attenuation
-  for (int32_t i = 0; i < (int32_t) ADC_ATTEN_MAX; i++) {
+  for (int32_t i = 0; i <= ADC_ATTEN_DB_11; i++) {
     auto adc_unit = channel1_ != ADC1_CHANNEL_MAX ? ADC_UNIT_1 : ADC_UNIT_2;
     auto cal_value = esp_adc_cal_characterize(adc_unit, (adc_atten_t) i, ADC_WIDTH_MAX_SOC_BITS,
                                               1100,  // default vref
@@ -157,7 +157,7 @@ float ADCSensor::sample() {
 #ifdef USE_ESP32
 float ADCSensor::sample() {
   if (!autorange_) {
-    int32_t raw = -1;
+    int raw = -1;
     if (channel1_ != ADC1_CHANNEL_MAX) {
       raw = adc1_get_raw(channel1_);
     } else if (channel2_ != ADC2_CHANNEL_MAX) {
@@ -174,7 +174,7 @@ float ADCSensor::sample() {
     return mv / 1000.0f;
   }
 
-  int32_t raw11 = ADC_MAX, raw6 = ADC_MAX, raw2 = ADC_MAX, raw0 = ADC_MAX;
+  int raw11 = ADC_MAX, raw6 = ADC_MAX, raw2 = ADC_MAX, raw0 = ADC_MAX;
 
   if (channel1_ != ADC1_CHANNEL_MAX) {
     adc1_config_channel_atten(channel1_, ADC_ATTEN_DB_11);

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -62,7 +62,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   adc1_channel_t channel1_{ADC1_CHANNEL_MAX};
   adc2_channel_t channel2_{ADC2_CHANNEL_MAX};
   bool autorange_{false};
-  esp_adc_cal_characteristics_t cal_characteristics_[(int32_t) ADC_ATTEN_MAX] = {};
+  esp_adc_cal_characteristics_t cal_characteristics_[ADC_ATTEN_MAX] = {};
 #endif
 };
 

--- a/esphome/components/ble_presence/binary_sensor.py
+++ b/esphome/components/ble_presence/binary_sensor.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_IBEACON_MINOR): cv.uint16_t,
             cv.Optional(CONF_IBEACON_UUID): cv.uuid,
             cv.Optional(CONF_MIN_RSSI): cv.All(
-                cv.decibel, cv.int_range(min=-90, max=-30)
+                cv.decibel, cv.int_range(min=-100, max=-30)
             ),
         }
     )

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -51,7 +51,7 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
     this->found_ = false;
   }
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
-    if (this->check_minimum_rssi_ && this->minimum_rssi_ <= device.get_rssi()) {
+    if (this->check_minimum_rssi_ && this->minimum_rssi_ > device.get_rssi()) {
       return false;
     }
     switch (this->match_by_) {

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -263,6 +263,7 @@ async def to_code(config):
         # Match arduino CONFIG_BTU_TASK_STACK_SIZE
         # https://github.com/espressif/arduino-esp32/blob/fd72cf46ad6fc1a6de99c1d83ba8eba17d80a4ee/tools/sdk/esp32/sdkconfig#L1866
         add_idf_sdkconfig_option("CONFIG_BTU_TASK_STACK_SIZE", 8192)
+        add_idf_sdkconfig_option("CONFIG_BT_ACL_CONNECTIONS", 9)
 
     cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts
     cg.add_define("USE_ESP32_BLE_CLIENT")

--- a/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
+++ b/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
@@ -12,7 +12,7 @@ void HomeassistantSensor::setup() {
       this->entity_id_, this->attribute_, [this](const std::string &state) {
         auto val = parse_number<float>(state);
         if (!val.has_value()) {
-          ESP_LOGW(TAG, "Can't convert '%s' to number!", state.c_str());
+          ESP_LOGW(TAG, "'%s': Can't convert '%s' to number!", this->entity_id_.c_str(), state.c_str());
           this->publish_state(NAN);
           return;
         }

--- a/esphome/components/template/switch/template_switch.cpp
+++ b/esphome/components/template/switch/template_switch.cpp
@@ -36,7 +36,7 @@ void TemplateSwitch::write_state(bool state) {
 void TemplateSwitch::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 bool TemplateSwitch::assumed_state() { return this->assumed_state_; }
 void TemplateSwitch::set_state_lambda(std::function<optional<bool>()> &&f) { this->f_ = f; }
-float TemplateSwitch::get_setup_priority() const { return setup_priority::HARDWARE; }
+float TemplateSwitch::get_setup_priority() const { return setup_priority::HARDWARE - 2.0f; }
 Trigger<> *TemplateSwitch::get_turn_on_trigger() const { return this->turn_on_trigger_; }
 Trigger<> *TemplateSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
 void TemplateSwitch::setup() {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1492,11 +1492,10 @@ void WaveshareEPaper7P5InV2alt::initialize() {
   this->command(0x01);
 
   // 1-0=11: internal power
-  this->data(0x17);
-
+  this->data(0x07);
   this->data(0x17);  // VGH&VGL
   this->data(0x3F);  // VSH
-  this->data(0x3F);  // VSL
+  this->data(0x26);  // VSL
   this->data(0x11);  // VSHR
 
   // VCOM DC Setting
@@ -1509,10 +1508,6 @@ void WaveshareEPaper7P5InV2alt::initialize() {
   this->data(0x27);
   this->data(0x2F);
   this->data(0x17);
-
-  // OSC Setting
-  this->command(0x30);
-  this->data(0x06);  // 2-0=100: N=4  ; 5-3=111: M=7  ;  3C=50Hz     3A=100HZ
 
   // POWER ON
   this->command(0x04);
@@ -1535,7 +1530,7 @@ void WaveshareEPaper7P5InV2alt::initialize() {
   // COMMAND VCOM AND DATA INTERVAL SETTING
   this->command(0x50);
   this->data(0x10);
-  this->data(0x07);
+  this->data(0x00);
   // COMMAND TCON SETTING
   this->command(0x60);
   this->data(0x22);

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -569,6 +569,8 @@ const char *get_disconnect_reason_str(uint8_t reason) {
       return "Handshake Failed";
     case WIFI_REASON_CONNECTION_FAIL:
       return "Connection Failed";
+    case WIFI_REASON_ROAMING:
+      return "Station Roaming";
     case WIFI_REASON_UNSPECIFIED:
     default:
       return "Unspecified";
@@ -631,7 +633,9 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     if (it.reason == WIFI_REASON_NO_AP_FOUND) {
       ESP_LOGW(TAG, "Event: Disconnected ssid='%s' reason='Probe Request Unsuccessful'", buf);
       s_sta_connect_not_found = true;
-
+    } else if (it.reason == WIFI_REASON_ROAMING) {
+      ESP_LOGI(TAG, "Event: Disconnected ssid='%s' reason='Station Roaming'", buf);
+      return;
     } else {
       ESP_LOGW(TAG, "Event: Disconnected ssid='%s' bssid=" LOG_SECRET("%s") " reason='%s'", buf,
                format_mac_addr(it.bssid).c_str(), get_disconnect_reason_str(it.reason));

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.7.0"
+__version__ = "2023.7.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/tests/test7.yaml
+++ b/tests/test7.yaml
@@ -31,3 +31,11 @@ logger:
 http_request:
   useragent: esphome/tagreader
   timeout: 10s
+
+sensor:
+  - platform: adc
+    id: adc_sensor_p4
+    name: ADC pin 4
+    pin: 4
+    attenuation: 11db
+    update_interval: 1s


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Dashboard: use Popen() on Windows [esphome#5110](https://github.com/esphome/esphome/pull/5110)
- Swap ADC back to use 'int' because C3 [esphome#5151](https://github.com/esphome/esphome/pull/5151)
- wifi: handle WIFI_REASON_ROAMING reason in event [esphome#5153](https://github.com/esphome/esphome/pull/5153)
- Slightly lower template switch setup priority [esphome#5163](https://github.com/esphome/esphome/pull/5163)
- update "Can't convert" warning to match others in homeassistant_sensor [esphome#5162](https://github.com/esphome/esphome/pull/5162)
- Increase maximum number of BLE notifications [esphome#5155](https://github.com/esphome/esphome/pull/5155)
- invert min_rssi check [esphome#5150](https://github.com/esphome/esphome/pull/5150)
- Fix graininess & streaks for 7.50inV2alt Waveshare e-paper [esphome#5168](https://github.com/esphome/esphome/pull/5168)
