### PR TITLE
Mqtt unique

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -247,6 +247,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_QOS, default=0): cv.mqtt_qos,
                 }
             ),
+            cv.Optional("is_unique_topic", default=False): cv.boolean,
         }
     ),
     validate_config,
@@ -355,6 +356,9 @@ async def to_code(config):
     cg.add(var.set_keep_alive(config[CONF_KEEPALIVE]))
 
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
+
+    if "is_unique_topic" in config:
+        cg.add(var.set_is_unique_topic(config["is_unique_topic"]))
 
     # esp-idf only
     if CONF_CERTIFICATE_AUTHORITY in config:

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -37,14 +37,22 @@ void MQTTClientComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MQTT...");
 
   // replace a special topic
-  MQTTMessage message;
-  message.topic = get_mac_address() + "/status";
-  message.payload = "online";
-  message.qos = 0;
-  message.retain = true;
-  global_mqtt_client->set_birth_message(std::move(message));
-  message.payload = "online";
-  global_mqtt_client->set_last_will(std::move(message));
+  if (global_mqtt_client->get_is_unique_topic()) {
+    MQTTMessage message = MQTTMessage{
+        .topic = get_mac_address() + "/status",
+        .payload = "online",
+        .qos = 0,
+        .retain = true,
+    };
+    global_mqtt_client->set_birth_message(std::move(message));
+    MQTTMessage messageWill = MQTTMessage{
+        .topic = get_mac_address() + "/status",
+        .payload = "offline",
+        .qos = 0,
+        .retain = true,
+    };
+    global_mqtt_client->set_last_will(std::move(messageWill));
+  }
 
   this->mqtt_backend_.set_on_message(
       [this](const char *topic, const char *payload, size_t len, size_t index, size_t total) {

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -35,6 +35,17 @@ MQTTClientComponent::MQTTClientComponent() {
 // Connection
 void MQTTClientComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MQTT...");
+
+  // replace a special topic
+  MQTTMessage message;
+  message.topic = get_mac_address() + "/status";
+  message.payload = "online";
+  message.qos = 0;
+  message.retain = true;
+  global_mqtt_client->set_birth_message(std::move(message));
+  message.payload = "online";
+  global_mqtt_client->set_last_will(std::move(message));
+
   this->mqtt_backend_.set_on_message(
       [this](const char *topic, const char *payload, size_t len, size_t index, size_t total) {
         if (index == 0)

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -250,6 +250,10 @@ class MQTTClientComponent : public Component {
   void set_on_connect(mqtt_on_connect_callback_t &&callback);
   void set_on_disconnect(mqtt_on_disconnect_callback_t &&callback);
 
+
+  void set_is_unique_topic(bool is_unique_topic) { this->is_unique_topic = is_unique_topic; }
+  bool get_is_unique_topic() { return is_unique_topic; }
+
  protected:
   void send_device_info_();
 
@@ -294,6 +298,9 @@ class MQTTClientComponent : public Component {
   MQTTMessage log_message_;
   std::string payload_buffer_;
   int log_level_{ESPHOME_LOG_LEVEL};
+
+  // unique topic by mac adress
+  bool is_unique_topic{false};
 
   std::vector<MQTTSubscription> subscriptions_;
 #if defined(USE_ESP_IDF)

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -18,7 +18,7 @@ void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
   std::string sanitized_name = str_sanitize(App.get_name());
-  return discovery_info.prefix + "/" + this->component_type() + "/" + sanitized_name + "/" +
+  return discovery_info.prefix + "/" + this->component_type() + "/" + get_mac_address() + "/" + sanitized_name + "/" +
          this->get_default_object_id_() + "/config";
 }
 
@@ -183,6 +183,12 @@ void MQTTComponent::disable_availability() { this->set_availability("", "", "");
 void MQTTComponent::call_setup() {
   if (this->is_internal())
     return;
+
+  // replace a special topic
+  this->set_custom_state_topic(global_mqtt_client->get_topic_prefix() + "/" + get_mac_address() + "/" + this->get_default_object_id_() +
+         "/" + "state");
+  this->set_custom_command_topic(global_mqtt_client->get_topic_prefix() + "/" + get_mac_address() + "/" + this->get_default_object_id_() +
+         "/" + "command");
 
   this->setup();
 

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -18,8 +18,13 @@ void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
   std::string sanitized_name = str_sanitize(App.get_name());
-  return discovery_info.prefix + "/" + this->component_type() + "/" + get_mac_address() + "/" + sanitized_name + "/" +
-         this->get_default_object_id_() + "/config";
+  if (global_mqtt_client->get_is_unique_topic()) {
+    return discovery_info.prefix + "/" + this->component_type() + "/" + get_mac_address() + "_" + sanitized_name + "/" +
+           this->get_default_object_id_() + "/config";
+  } else {
+    return discovery_info.prefix + "/" + this->component_type() + "/" + sanitized_name + "/" +
+           this->get_default_object_id_() + "/config";
+  }
 }
 
 std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) const {


### PR DESCRIPTION
# What does this implement/fix?

This pull request implements a new feature that allows for generating unique MQTT topics for each ESP device, even if the ESPHome configuration files are the same. This feature enables batch flashing of different ESP devices with the same configuration.
<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
mqtt:
  broker: mqtt.host
  port: 1883
  discovery_unique_id_generator: mac
  is_unique_topic: true # new of this request
```

## Checklist:
- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
