### PR TITLE
core: read ESP32 MAC address from eFuse if IEEE802.15.4 is supported

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -38,7 +38,7 @@
 #include "esp32/rom/crc.h"
 #endif
 
-#ifdef USE_ESP32_IGNORE_EFUSE_MAC_CRC
+#if defined(CONFIG_SOC_IEEE802154_SUPPORTED) || defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
 #endif
@@ -540,7 +540,9 @@ bool HighFrequencyLoopRequester::is_high_frequency() { return num_requests > 0; 
 
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
 #if defined(USE_ESP32)
-#if defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
+#if defined(CONFIG_SOC_IEEE802154_SUPPORTED) || defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
+  // When CONFIG_SOC_IEEE802154_SUPPORTED is defined, esp_efuse_mac_get_default
+  // returns the 802.15.4 EUI-64 address. Read directly from eFuse instead.
   // On some devices, the MAC address that is burnt into EFuse does not
   // match the CRC that goes along with it. For those devices, this
   // work-around reads and uses the MAC address as-is from EFuse,


### PR DESCRIPTION
# What does this implement/fix?

As of ESP-IDF 5.1, support for 802.15.4 was added. On devices supporting this (ESP32-C6, ESP32-H2), CONFIG_SOC_IEEE802154_SUPPORTED will be enabled in sdkconfig.

Unfortunately having CONFIG_SOC_IEEE802154_SUPPORTED enabled, changes the behavior of esp_efuse_mac_get_default(). It will return 8 bytes containing the EUI-64 MAC address used for IEEE802.15.4.

This in turn results in multiple devices having a wrong local MAC address. In some cases this might even lead to a duplicate MAC address. Duplicate MAC addresses lead to weird behaviour in Home Assistant, where one device would use the friendly name of the other, or adding a new device would fail with an error that it already exists.

Reading the MAC address from the eFuse makes it clear why this happens:

Device 1:

```
Mac fuses:
MAC (BLOCK1)                                       MAC address
   = 60:55:f9:f6:fa:3c (OK) R/W
MAC_EXT (BLOCK1)                                   Stores the extended bits of MAC address            = 00:00 (OK) R/W
CUSTOM_MAC (BLOCK3)                                Custom MAC
   = 00:00:00:00:00:00 (OK) R/W
MAC_EUI64 (BLOCK1)                                 calc MAC_EUI64 = MAC[0]:MAC[1]:MAC[2]:MAC_EXT[0]:M
   = 60:55:f9:00:00:f6:fa:3c (OK) R/W
                                                   AC_EXT[1]:MAC[3]:MAC[4]:MAC[5]
```

Device 2:

```
Mac fuses:
MAC (BLOCK1)                                       MAC address
   = 60:55:f9:f6:fd:b8 (OK) R/W
MAC_EXT (BLOCK1)                                   Stores the extended bits of MAC address            = 00:00 (OK) R/W
CUSTOM_MAC (BLOCK3)                                Custom MAC
   = 00:00:00:00:00:00 (OK) R/W
MAC_EUI64 (BLOCK1)                                 calc MAC_EUI64 = MAC[0]:MAC[1]:MAC[2]:MAC_EXT[0]:M
   = 60:55:f9:00:00:f6:fd:b8 (OK) R/W
                                                   AC_EXT[1]:MAC[3]:MAC[4]:MAC[5]
```

As the get_mac_address helpers use an uint8 array of length 6, only the first 6 bytes will be read, cutting off the last 2 bytes that make it unique.

Read the MAC address from eFuse directly to fix this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
