### PR TITLE
Speaker return bytes written and do not wait for queue

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -185,7 +185,7 @@ void I2SAudioSpeaker::loop() {
   }
 }
 
-bool I2SAudioSpeaker::play(const uint8_t *data, size_t length) {
+size_t I2SAudioSpeaker::play(const uint8_t *data, size_t length) {
   if (this->state_ != speaker::STATE_RUNNING && this->state_ != speaker::STATE_STARTING) {
     this->start();
   }
@@ -197,13 +197,13 @@ bool I2SAudioSpeaker::play(const uint8_t *data, size_t length) {
     size_t to_send_length = std::min(remaining, BUFFER_SIZE);
     event.len = to_send_length;
     memcpy(event.data, data + index, to_send_length);
-    if (xQueueSend(this->buffer_queue_, &event, 100 / portTICK_PERIOD_MS) == pdTRUE) {
-      remaining -= to_send_length;
-      index += to_send_length;
+    if (xQueueSend(this->buffer_queue_, &event, 0) != pdTRUE) {
+      return index;
     }
-    App.feed_wdt();
+    remaining -= to_send_length;
+    index += to_send_length;
   }
-  return true;
+  return index;
 }
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -54,7 +54,7 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
   void start();
   void stop() override;
 
-  bool play(const uint8_t *data, size_t length) override;
+  size_t play(const uint8_t *data, size_t length) override;
 
  protected:
   void start_();

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -12,8 +12,8 @@ enum State : uint8_t {
 
 class Speaker {
  public:
-  virtual bool play(const uint8_t *data, size_t length) = 0;
-  virtual bool play(const std::vector<uint8_t> &data) { return this->play(data.data(), data.size()); }
+  virtual size_t play(const uint8_t *data, size_t length) = 0;
+  virtual size_t play(const std::vector<uint8_t> &data) { return this->play(data.data(), data.size()); }
 
   virtual void stop() = 0;
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
