### PR TITLE
pn532: add support for polling FeliCa NFC cards

### DIFF
--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -45,6 +45,9 @@ static const uint8_t MIFARE_CMD_NAK_CRC_ERROR_XFER_BUFF_VALID = 0x01;
 static const uint8_t MIFARE_CMD_NAK_INVALID_XFER_BUFF_INVALID = 0x04;
 static const uint8_t MIFARE_CMD_NAK_CRC_ERROR_XFER_BUFF_INVALID = 0x05;
 
+// FeliCa Commands
+static const uint8_t FELICA_CMD_REQUEST_SERVICE = 0x02;
+
 static const char *const MIFARE_CLASSIC = "Mifare Classic";
 static const char *const NFC_FORUM_TYPE_2 = "NFC Forum Type 2";
 static const char *const ERROR = "Error";

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -83,7 +83,11 @@ async def setup_pn532(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
 
-    cg.add(var.set_card_standard(config.get(CONF_CARD_STANDARD, "ISO14443A")))
+    cg.add(
+        var.set_card_standard(
+            config.get(CONF_CARD_STANDARD, CardStandard.CARD_STANDARD_ISO14443A)
+        )
+    )
 
 
 @automation.register_condition(

--- a/esphome/components/pn532/__init__.py
+++ b/esphome/components/pn532/__init__.py
@@ -10,9 +10,16 @@ MULTI_CONF = True
 
 CONF_PN532_ID = "pn532_id"
 CONF_ON_FINISHED_WRITE = "on_finished_write"
+CONF_CARD_STANDARD = "card_standard"
 
 pn532_ns = cg.esphome_ns.namespace("pn532")
 PN532 = pn532_ns.class_("PN532", cg.PollingComponent)
+
+CardStandard = pn532_ns.enum("CardStandard")
+CARD_STANDARD = {
+    "ISO14443A": CardStandard.CARD_STANDARD_ISO14443A,
+    "FELICA": CardStandard.CARD_STANDARD_FELICA,
+}
 
 PN532OnFinishedWriteTrigger = pn532_ns.class_(
     "PN532OnFinishedWriteTrigger", automation.Trigger.template()
@@ -42,6 +49,7 @@ PN532_SCHEMA = cv.Schema(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(nfc.NfcOnTagTrigger),
             }
         ),
+        cv.Optional(CONF_CARD_STANDARD): cv.enum(CARD_STANDARD, upper=True),
     }
 ).extend(cv.polling_component_schema("1s"))
 
@@ -74,6 +82,8 @@ async def setup_pn532(var, config):
     for conf in config.get(CONF_ON_FINISHED_WRITE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
+
+    cg.add(var.set_card_standard(config.get(CONF_CARD_STANDARD, "ISO14443A")))
 
 
 @automation.register_condition(

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -110,11 +110,21 @@ void PN532::update() {
   for (auto *obj : this->binary_sensors_)
     obj->on_scan_end();
 
-  if (!this->write_command_({
-          PN532_COMMAND_INLISTPASSIVETARGET,
-          0x01,  // max 1 card
-          0x00,  // baud rate ISO14443A (106 kbit/s)
-      })) {
+  if (!this->write_command_(this->card_standard_ == CARD_STANDARD_ISO14443A
+                                ? std::vector<uint8_t>({
+                                      PN532_COMMAND_INLISTPASSIVETARGET,
+                                      0x01,  // max 1 card
+                                      0x00,  // baud rate ISO14443A (106 kbit/s)
+                                  })
+                                :  // CARD_STANDARD_FELICA
+                                std::vector<uint8_t>({
+                                    PN532_COMMAND_INLISTPASSIVETARGET,
+                                    0x01,        // max 1 card
+                                    0x01,        // baud rate FeliCa polling (212 kbit/s)
+                                    0x00,        // FELICA_CMD_POLLING
+                                    0x00, 0x03,  // CJRC system code (Suica, PASMO, etc)
+                                    0x00, 0x00,  // request code... no idea
+                                }))) {
     ESP_LOGW(TAG, "Requesting tag read failed!");
     this->status_set_warning();
     return;
@@ -157,11 +167,25 @@ void PN532::loop() {
     return;
   }
 
-  uint8_t nfcid_length = read[5];
-  std::vector<uint8_t> nfcid(read.begin() + 6, read.begin() + 6 + nfcid_length);
-  if (read.size() < 6U + nfcid_length) {
-    // oops, pn532 returned invalid data
-    return;
+  std::vector<uint8_t> nfcid;
+  if (this->card_standard_ == CARD_STANDARD_ISO14443A) {
+    uint8_t nfcid_length = read[5];
+    nfcid.assign(read.begin() + 6, read.begin() + 6 + nfcid_length);
+    if (read.size() < 6U + nfcid_length) {
+      // oops, pn532 returned invalid data
+      return;
+    }
+  } else {
+    uint8_t resp_length = read[1];
+    if (read.size() < 18U) {
+      // oops, pn532 returned invalid data
+      return;
+    }
+    // felica has static 8 byte id lengths
+    nfcid.assign(read.begin() + 4, read.begin() + 4 + 8);
+
+    std::vector<uint8_t> service_data;
+    read_felica_service_(nfcid, {0x090f}, service_data);
   }
 
   bool report = true;
@@ -302,18 +326,24 @@ void PN532::turn_off_rf_() {
 }
 
 std::unique_ptr<nfc::NfcTag> PN532::read_tag_(std::vector<uint8_t> &uid) {
-  uint8_t type = nfc::guess_tag_type(uid.size());
+  if (this->card_standard_ == CARD_STANDARD_ISO14443A) {
+    uint8_t type = nfc::guess_tag_type(uid.size());
 
-  if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
-    ESP_LOGD(TAG, "Mifare classic");
-    return this->read_mifare_classic_tag_(uid);
-  } else if (type == nfc::TAG_TYPE_2) {
-    ESP_LOGD(TAG, "Mifare ultralight");
-    return this->read_mifare_ultralight_tag_(uid);
-  } else if (type == nfc::TAG_TYPE_UNKNOWN) {
-    ESP_LOGV(TAG, "Cannot determine tag type");
-    return make_unique<nfc::NfcTag>(uid);
+    if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
+      ESP_LOGD(TAG, "Mifare classic");
+      return this->read_mifare_classic_tag_(uid);
+    } else if (type == nfc::TAG_TYPE_2) {
+      ESP_LOGD(TAG, "Mifare ultralight");
+      return this->read_mifare_ultralight_tag_(uid);
+    } else if (type == nfc::TAG_TYPE_UNKNOWN) {
+      ESP_LOGV(TAG, "Cannot determine tag type");
+      return make_unique<nfc::NfcTag>(uid);
+    } else {
+      return make_unique<nfc::NfcTag>(uid);
+    }
   } else {
+    // we don't have code to probe tag types for FeliCa cards yet
+    ESP_LOGV(TAG, "Cannot determine tag type");
     return make_unique<nfc::NfcTag>(uid);
   }
 }
@@ -367,6 +397,36 @@ bool PN532::write_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message) {
   }
   ESP_LOGE(TAG, "Unsupported Tag for formatting");
   return false;
+}
+
+// this should probably be under like pn532_felica.cpp or something like that
+bool PN532::read_felica_service_(const std::vector<uint8_t> &uid, const std::vector<uint16_t> &service_code,
+                                 std::vector<uint8_t> &service_data) {
+  std::vector<uint8_t> data({
+      PN532_COMMAND_INDATAEXCHANGE,
+      0x01,  // One card,
+      0x00,  // fill in later with size of data
+      nfc::FELICA_CMD_REQUEST_SERVICE,
+  });
+  data.insert(data.end(), uid.begin(), uid.end());
+  data.push_back(service_code.size());
+  for (auto i = service_code.begin(); i != service_code.end(); i++) {
+    data.push_back(*i & 0xff);
+    data.push_back((*i >> 8) & 0xff);
+  }
+  data[2] = data.size() - 2;
+
+  if (!this->write_command_(service_data)) {
+    ESP_LOGE(TAG, "Error writing request service");
+    return false;
+  }
+
+  if (!this->read_response(PN532_COMMAND_INDATAEXCHANGE, data)) {
+    ESP_LOGE(TAG, "Error reading request service");
+    return false;
+  }
+
+  return true;
 }
 
 float PN532::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -19,10 +19,14 @@ static const uint8_t PN532_COMMAND_INDATAEXCHANGE = 0x40;
 static const uint8_t PN532_COMMAND_INLISTPASSIVETARGET = 0x4A;
 static const uint8_t PN532_COMMAND_POWERDOWN = 0x16;
 
+enum CardStandard { CARD_STANDARD_ISO14443A = 0, CARD_STANDARD_FELICA };
+
 class PN532BinarySensor;
 
 class PN532 : public PollingComponent {
  public:
+  void set_card_standard(const CardStandard card_standard) { this->card_standard_ = card_standard; }
+
   void setup() override;
 
   void dump_config() override;
@@ -82,6 +86,9 @@ class PN532 : public PollingComponent {
   bool write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
   bool clean_mifare_ultralight_();
 
+  bool read_felica_service_(const std::vector<uint8_t> &uid, const std::vector<uint16_t> &service_code,
+                            std::vector<uint8_t> &service_data);
+
   bool updates_enabled_{true};
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;
@@ -89,6 +96,8 @@ class PN532 : public PollingComponent {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
   std::vector<uint8_t> current_uid_;
   nfc::NdefMessage *next_task_message_to_write_;
+  CardStandard card_standard_{CARD_STANDARD_ISO14443A};
+
   enum NfcTask {
     READ = 0,
     CLEAN,


### PR DESCRIPTION
hey all-- before i got too deep in this change i wanted to see if this might be something you folks would be interested in merging? if so, i would add tests, docs, and some more cleanups.

# What does this implement/fix?

    adds a component configuration that lets you set the card standard to
    poll for. the default is to poll for ISO14443A, which is what the component
    currently does.
    
    the FeliCa standard is used in asian transit systems. if you, for example,
    have an iphone loaded with a japanese Suica card with the express transit
    option enabled, you can tap your phone to the reader without unlocking it to
    trigger the `on_tag` event.

    if you don't have a Suica card, but want to experiment with it, you can purchase
    one in the apple wallet app.

    i was hoping to get this working with my local san francisco Clipper card in the
    apple wallet too but didn't have much luck figuring out how to get the phone to
    trigger selecting it automatically.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
pn532_spi:
  cs_pin: GPIO15
  update_interval: 1s
  card_standard: FELICA
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


cc @tracestep @kbx81 @jesserockz @OttoWinter 