### PR TITLE
Fix AHT10 / AHT20 communication

### DIFF
--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -42,7 +42,7 @@ void AHT10Component::setup() {
       ESP_LOGCONFIG(TAG, "Setting up AHT10");
   }
 
-  if (this->write(calibrate_cmd, sizeof(AHT10_CALIBRATE_CMD)) != i2c::ERROR_OK) {
+  if (this->write(calibrate_cmd, sizeof(AHT20_CALIBRATE_CMD)) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with AHT10 failed!");
     this->mark_failed();
     return;

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -30,12 +30,17 @@ static const uint8_t AHT10_CAL_ATTEMPTS = 10;
 static const uint8_t AHT10_STATUS_BUSY = 0x80;
 
 void AHT10Component::setup() {
-  const uint8_t *calibrate_cmd = AHT10_CALIBRATE_CMD;
-  if (this->variant_ == "aht20") {
-    calibrate_cmd = AHT20_CALIBRATE_CMD;
+  const uint8_t *calibrate_cmd;
+  switch (this->variant_) {
+    case AHT10Variant::AHT20:
+      calibrate_cmd = AHT20_CALIBRATE_CMD;
+      ESP_LOGCONFIG(TAG, "Setting up AHT20");
+      break;
+    case AHT10Variant::AHT10:
+    default:
+      calibrate_cmd = AHT10_CALIBRATE_CMD;
+      ESP_LOGCONFIG(TAG, "Setting up AHT10");
   }
-
-  ESP_LOGCONFIG(TAG, "Setting up AHT10 (variant: %s)", this->variant_.c_str());
 
   if (this->write(calibrate_cmd, sizeof(AHT10_CALIBRATE_CMD)) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with AHT10 failed!");
@@ -53,7 +58,7 @@ void AHT10Component::setup() {
     }
     ++cal_attempts;
     if (cal_attempts > AHT10_CAL_ATTEMPTS) {
-      ESP_LOGE(TAG, "AHT10 calibration hung!");
+      ESP_LOGE(TAG, "AHT10 calibration timed out!");
       this->mark_failed();
       return;
     }

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -26,11 +26,11 @@ static const uint8_t AHT10_MEASURE_CMD[] = {0xAC, 0x33, 0x00};
 static const uint8_t AHT10_DEFAULT_DELAY = 5;    // ms, for calibration and temperature measurement
 static const uint8_t AHT10_HUMIDITY_DELAY = 30;  // ms
 static const uint8_t AHT10_ATTEMPTS = 3;         // safety margin, normally 3 attempts are enough: 3*30=90ms
-static const uint8_t AHT10_CAL_ATTEMPTS = 10; 
+static const uint8_t AHT10_CAL_ATTEMPTS = 10;
 static const uint8_t AHT10_STATUS_BUSY = 0x80;
 
 void AHT10Component::setup() {
-  const uint8_t * calibrate_cmd = AHT10_CALIBRATE_CMD;
+  const uint8_t *calibrate_cmd = AHT10_CALIBRATE_CMD;
   if (this->variant_ == "aht20") {
     calibrate_cmd = AHT20_CALIBRATE_CMD;
   }
@@ -44,7 +44,7 @@ void AHT10Component::setup() {
   }
   uint8_t data = AHT10_STATUS_BUSY;
   int cal_attempts = 0;
-  while(data & AHT10_STATUS_BUSY) {
+  while (data & AHT10_STATUS_BUSY) {
     delay(AHT10_DEFAULT_DELAY);
     if (this->read(&data, 1) != i2c::ERROR_OK) {
       ESP_LOGE(TAG, "Communication with AHT10 failed!");

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -20,6 +20,7 @@ namespace esphome {
 namespace aht10 {
 
 static const char *const TAG = "aht10";
+static const size_t SIZE_CALIBRATE_CMD = 3;
 static const uint8_t AHT10_CALIBRATE_CMD[] = {0xE1, 0x08, 0x00};
 static const uint8_t AHT20_CALIBRATE_CMD[] = {0xBE, 0x08, 0x00};
 static const uint8_t AHT10_MEASURE_CMD[] = {0xAC, 0x33, 0x00};
@@ -42,7 +43,7 @@ void AHT10Component::setup() {
       ESP_LOGCONFIG(TAG, "Setting up AHT10");
   }
 
-  if (this->write(calibrate_cmd, sizeof(AHT20_CALIBRATE_CMD)) != i2c::ERROR_OK) {
+  if (this->write(calibrate_cmd, SIZE_CALIBRATE_CMD) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with AHT10 failed!");
     this->mark_failed();
     return;

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -20,36 +20,43 @@ namespace esphome {
 namespace aht10 {
 
 static const char *const TAG = "aht10";
-static const uint8_t AHT10_CALIBRATE_CMD[] = {0xE1};
+static const uint8_t AHT10_CALIBRATE_CMD[] = {0xE1, 0x08, 0x00};
+static const uint8_t AHT20_CALIBRATE_CMD[] = {0xBE, 0x08, 0x00};
 static const uint8_t AHT10_MEASURE_CMD[] = {0xAC, 0x33, 0x00};
 static const uint8_t AHT10_DEFAULT_DELAY = 5;    // ms, for calibration and temperature measurement
 static const uint8_t AHT10_HUMIDITY_DELAY = 30;  // ms
 static const uint8_t AHT10_ATTEMPTS = 3;         // safety margin, normally 3 attempts are enough: 3*30=90ms
+static const uint8_t AHT10_CAL_ATTEMPTS = 10; 
+static const uint8_t AHT10_STATUS_BUSY = 0x80;
 
 void AHT10Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AHT10...");
+  const uint8_t * calibrate_cmd = AHT10_CALIBRATE_CMD;
+  if (this->variant_ == "aht20") {
+    calibrate_cmd = AHT20_CALIBRATE_CMD;
+  }
 
-  if (!this->write_bytes(0, AHT10_CALIBRATE_CMD, sizeof(AHT10_CALIBRATE_CMD))) {
+  ESP_LOGCONFIG(TAG, "Setting up AHT10 (variant: %s)", this->variant_.c_str());
+
+  if (this->write(calibrate_cmd, sizeof(AHT10_CALIBRATE_CMD)) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with AHT10 failed!");
     this->mark_failed();
     return;
   }
-  uint8_t data = 0;
-  if (this->write(&data, 1) != i2c::ERROR_OK) {
-    ESP_LOGD(TAG, "Communication with AHT10 failed!");
-    this->mark_failed();
-    return;
-  }
-  delay(AHT10_DEFAULT_DELAY);
-  if (this->read(&data, 1) != i2c::ERROR_OK) {
-    ESP_LOGD(TAG, "Communication with AHT10 failed!");
-    this->mark_failed();
-    return;
-  }
-  if (this->read(&data, 1) != i2c::ERROR_OK) {
-    ESP_LOGD(TAG, "Communication with AHT10 failed!");
-    this->mark_failed();
-    return;
+  uint8_t data = AHT10_STATUS_BUSY;
+  int cal_attempts = 0;
+  while(data & AHT10_STATUS_BUSY) {
+    delay(AHT10_DEFAULT_DELAY);
+    if (this->read(&data, 1) != i2c::ERROR_OK) {
+      ESP_LOGE(TAG, "Communication with AHT10 failed!");
+      this->mark_failed();
+      return;
+    }
+    ++cal_attempts;
+    if (cal_attempts > AHT10_CAL_ATTEMPTS) {
+      ESP_LOGE(TAG, "AHT10 calibration hung!");
+      this->mark_failed();
+      return;
+    }
   }
   if ((data & 0x68) != 0x08) {  // Bit[6:5] = 0b00, NORMAL mode and Bit[3] = 0b1, CALIBRATED
     ESP_LOGE(TAG, "AHT10 calibration failed!");
@@ -61,7 +68,7 @@ void AHT10Component::setup() {
 }
 
 void AHT10Component::update() {
-  if (!this->write_bytes(0, AHT10_MEASURE_CMD, sizeof(AHT10_MEASURE_CMD))) {
+  if (this->write(AHT10_MEASURE_CMD, sizeof(AHT10_MEASURE_CMD)) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with AHT10 failed!");
     this->status_set_warning();
     return;
@@ -88,7 +95,7 @@ void AHT10Component::update() {
         break;
       } else {
         ESP_LOGD(TAG, "ATH10 Unrealistic humidity (0x0), retrying...");
-        if (!this->write_bytes(0, AHT10_MEASURE_CMD, sizeof(AHT10_MEASURE_CMD))) {
+        if (this->write(AHT10_MEASURE_CMD, sizeof(AHT10_MEASURE_CMD)) != i2c::ERROR_OK) {
           ESP_LOGE(TAG, "Communication with AHT10 failed!");
           this->status_set_warning();
           return;

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -25,7 +25,7 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
-  AHT10Variant variant_ = AHT10Variant::AHT10;
+  AHT10Variant variant_{};
 };
 
 }  // namespace aht10

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -13,6 +13,7 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   void update() override;
   void dump_config() override;
   float get_setup_priority() const override;
+  void set_variant(std::string variant) { this->variant_ = variant; }
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
@@ -20,6 +21,7 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
+  std::string variant_ = "aht10";
 };
 
 }  // namespace aht10

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
@@ -13,7 +15,7 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   void update() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  void set_variant(std::string variant) { this->variant_ = variant; }
+  void set_variant(std::string variant) { this->variant_ = std::move(variant); }
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -9,13 +9,15 @@
 namespace esphome {
 namespace aht10 {
 
+enum AHT10Variant { AHT10, AHT20 };
+
 class AHT10Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void update() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  void set_variant(std::string variant) { this->variant_ = std::move(variant); }
+  void set_variant(AHT10Variant variant) { this->variant_ = variant; }
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
@@ -23,7 +25,7 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
-  std::string variant_ = "aht10";
+  AHT10Variant variant_ = AHT10Variant::AHT10;
 };
 
 }  // namespace aht10

--- a/esphome/components/aht10/sensor.py
+++ b/esphome/components/aht10/sensor.py
@@ -10,6 +10,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
+    CONF_VARIANT
 )
 
 DEPENDENCIES = ["i2c"]
@@ -33,6 +34,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_VARIANT): cv.one_of('aht10', 'aht20'),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -44,6 +46,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+    cg.add(var.set_variant(config[CONF_VARIANT]))
 
     if temperature := config.get(CONF_TEMPERATURE):
         sens = await sensor.new_sensor(temperature)

--- a/esphome/components/aht10/sensor.py
+++ b/esphome/components/aht10/sensor.py
@@ -10,7 +10,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
-    CONF_VARIANT
+    CONF_VARIANT,
 )
 
 DEPENDENCIES = ["i2c"]
@@ -34,7 +34,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_VARIANT): cv.one_of('aht10', 'aht20'),
+            cv.Optional(CONF_VARIANT): cv.one_of("aht10", "aht20"),
         }
     )
     .extend(cv.polling_component_schema("60s"))

--- a/esphome/components/aht10/sensor.py
+++ b/esphome/components/aht10/sensor.py
@@ -34,7 +34,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_VARIANT): cv.one_of("aht10", "aht20"),
+            cv.Optional(CONF_VARIANT, "aht10"): cv.one_of("aht10", "aht20"),
         }
     )
     .extend(cv.polling_component_schema("60s"))

--- a/esphome/components/aht10/sensor.py
+++ b/esphome/components/aht10/sensor.py
@@ -18,6 +18,12 @@ DEPENDENCIES = ["i2c"]
 aht10_ns = cg.esphome_ns.namespace("aht10")
 AHT10Component = aht10_ns.class_("AHT10Component", cg.PollingComponent, i2c.I2CDevice)
 
+AHT10Variant = aht10_ns.enum("AHT10Variant")
+AHT10_VARIANTS = {
+    "AHT10": AHT10Variant.AHT10,
+    "AHT20": AHT10Variant.AHT20,
+}
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -34,7 +40,9 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_VARIANT, "aht10"): cv.one_of("aht10", "aht20"),
+            cv.Optional(CONF_VARIANT, default="AHT10"): cv.enum(
+                AHT10_VARIANTS, upper=True
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Fixes communication with AHT20 modules & presumably AHT10 modules (though I don't have an AHT10 to test with). The implementation before this PR sends the messages shown in the scope capture, which include a byte of 0x00 after the device address, which is not what is specified in the [AHT10](https://kaimte.com/upload/attach/20200514/2786ec587a09412dcd95609fe91e00e4.pdf) or [AHT20 datasheet](https://cdn.sparkfun.com/assets/d/2/b/e/d/AHT20.pdf) and results in the AHT20 sending a NACK. So I am not sure how this code was working at all previously?
![image](https://github.com/esphome/esphome/assets/5025185/0d10117e-5210-4d95-8505-fd7c0b7b0631)
This PR corrects that, and allows communication with the module.

In addition the AHT20 datasheet indicates that the calibration/initialisation command is different for the AHT20 compared to the AHT10 module, so a variant config option has been added to allow selection of AHT10 or AHT20 modules. I found that my AHT20 module would not calibrate unless the command specified in the data sheet was used.

AHT20 Datasheet commands
![image](https://github.com/esphome/esphome/assets/5025185/bd63df66-7698-4e65-8a2c-240ccaea6201)

AHT10 Datasheet commands
![image](https://github.com/esphome/esphome/assets/5025185/4d1693f0-ee0f-42a4-946c-e4e560b88556)



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** possibly related https://github.com/esphome/issues/issues/3941

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3221

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
i2c:
  sda: 6
  scl: 7
  scan: false
  id: bus_a
  frequency: 200kHz
    
sensor:
  - platform: aht10
    variant: aht20
    i2c_id: bus_a
    id: aht_20
    address: 0x38
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
![image](https://github.com/esphome/esphome/assets/5025185/3ba96dcc-532e-47b6-b1fb-c172ed350f06)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
