### PR TITLE
i2c: fix build on ESP-IDF >= 5.1

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -15,8 +15,13 @@ static const char *const TAG = "i2c.idf";
 
 void IDFI2CBus::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2C bus...");
-  static i2c_port_t next_port = 0;
-  port_ = next_port++;
+  static i2c_port_t next_port = I2C_NUM_0;
+  port_ = next_port;
+#if I2C_NUM_MAX > 1
+  next_port = (next_port == I2C_NUM_0) ? I2C_NUM_1 : I2C_NUM_MAX;
+#else
+  next_port = I2C_NUM_MAX;
+#endif
 
   recover_();
 

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -23,11 +23,11 @@ void IDFI2CBus::setup() {
   next_port = I2C_NUM_MAX;
 #endif
 
-if (port_ == I2C_NUM_MAX) {
-  ESP_LOGE(TAG, "Too many I2C buses configured");
-  this->mark_failed();
-  return;
-}
+  if (port_ == I2C_NUM_MAX) {
+    ESP_LOGE(TAG, "Too many I2C buses configured");
+    this->mark_failed();
+    return;
+  }
 
   recover_();
 

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -23,6 +23,12 @@ void IDFI2CBus::setup() {
   next_port = I2C_NUM_MAX;
 #endif
 
+if (port_ == I2C_NUM_MAX) {
+  ESP_LOGE(TAG, "Too many I2C buses configured");
+  this->mark_failed();
+  return;
+}
+
   recover_();
 
   i2c_config_t conf{};


### PR DESCRIPTION
# What does this implement/fix?

As of version 5.1, i2c_port_t is an enum.

Compile error before this change:

```
src/esphome/components/i2c/i2c_bus_esp_idf.cpp:18:33: error: invalid conversion from 'int' to 'i2c_port_t' [-fpermissive]
   18 |   static i2c_port_t next_port = 0;
      |                                 ^
      |                                 |
      |                                 int
src/esphome/components/i2c/i2c_bus_esp_idf.cpp:19:20: error: no 'operator++(int)' declared for postfix '++' [-fpermissive]
   19 |   port_ = next_port++;
      |           ~~~~~~~~~^~
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
esphome:
  name: bug

esp32:
  board: esp32-c3-devkitm-1
  framework:
    platform_version: https://github.com/platformio/platform-espressif32
    type: esp-idf
    version: 5.1.0

i2c:
  sda: 4
  scl: 5

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
