### PR TITLE
support illuminance for airthings wave plus device

### DIFF
--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -14,8 +14,6 @@ void AirthingsWavePlus::read_sensors(uint8_t *raw_value, uint16_t value_len) {
     ESP_LOGD(TAG, "version = %d", value->version);
 
     if (value->version == 1) {
-      ESP_LOGD(TAG, "ambient light = %d", value->ambientLight);
-
       if (this->humidity_sensor_ != nullptr) {
         this->humidity_sensor_->publish_state(value->humidity / 2.0f);
       }

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -43,6 +43,10 @@ void AirthingsWavePlus::read_sensors(uint8_t *raw_value, uint16_t value_len) {
       if ((this->tvoc_sensor_ != nullptr) && this->is_valid_voc_value_(value->voc)) {
         this->tvoc_sensor_->publish_state(value->voc);
       }
+
+      if (this->illuminance_sensor_ != nullptr) {
+        this->illuminance_sensor_->publish_state(value->ambientLight);
+      }
     } else {
       ESP_LOGE(TAG, "Invalid payload version (%d != 1, newer version or not a Wave Plus?)", value->version);
     }
@@ -68,6 +72,7 @@ void AirthingsWavePlus::dump_config() {
   LOG_SENSOR("  ", "Radon", this->radon_sensor_);
   LOG_SENSOR("  ", "Radon Long Term", this->radon_long_term_sensor_);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
+  LOG_SENSOR("  ", "ILLUMINANCE", this->illuminance_sensor_);
 }
 
 AirthingsWavePlus::AirthingsWavePlus() {

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.cpp
@@ -70,7 +70,7 @@ void AirthingsWavePlus::dump_config() {
   LOG_SENSOR("  ", "Radon", this->radon_sensor_);
   LOG_SENSOR("  ", "Radon Long Term", this->radon_long_term_sensor_);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
-  LOG_SENSOR("  ", "ILLUMINANCE", this->illuminance_sensor_);
+  LOG_SENSOR("  ", "Illuminance", this->illuminance_sensor_);
 }
 
 AirthingsWavePlus::AirthingsWavePlus() {

--- a/esphome/components/airthings_wave_plus/airthings_wave_plus.h
+++ b/esphome/components/airthings_wave_plus/airthings_wave_plus.h
@@ -22,6 +22,7 @@ class AirthingsWavePlus : public airthings_wave_base::AirthingsWaveBase {
   void set_radon(sensor::Sensor *radon) { radon_sensor_ = radon; }
   void set_radon_long_term(sensor::Sensor *radon_long_term) { radon_long_term_sensor_ = radon_long_term; }
   void set_co2(sensor::Sensor *co2) { co2_sensor_ = co2; }
+  void set_illuminance(sensor::Sensor *illuminance) { illuminance_sensor_ = illuminance; }
 
  protected:
   bool is_valid_radon_value_(uint16_t radon);
@@ -32,6 +33,7 @@ class AirthingsWavePlus : public airthings_wave_base::AirthingsWaveBase {
   sensor::Sensor *radon_sensor_{nullptr};
   sensor::Sensor *radon_long_term_sensor_{nullptr};
   sensor::Sensor *co2_sensor_{nullptr};
+  sensor::Sensor *illuminance_sensor_{nullptr};
 
   struct WavePlusReadings {
     uint8_t version;

--- a/esphome/components/airthings_wave_plus/sensor.py
+++ b/esphome/components/airthings_wave_plus/sensor.py
@@ -14,7 +14,7 @@ from esphome.const import (
     UNIT_PARTS_PER_MILLION,
     CONF_ILLUMINANCE,
     UNIT_LUX,
-    DEVICE_CLASS_ILLUMINANCE
+    DEVICE_CLASS_ILLUMINANCE,
 )
 
 DEPENDENCIES = airthings_wave_base.DEPENDENCIES
@@ -53,7 +53,7 @@ CONFIG_SCHEMA = airthings_wave_base.BASE_SCHEMA.extend(
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_ILLUMINANCE,
             state_class=STATE_CLASS_MEASUREMENT,
-        )
+        ),
     }
 )
 

--- a/esphome/components/airthings_wave_plus/sensor.py
+++ b/esphome/components/airthings_wave_plus/sensor.py
@@ -12,6 +12,9 @@ from esphome.const import (
     CONF_CO2,
     UNIT_BECQUEREL_PER_CUBIC_METER,
     UNIT_PARTS_PER_MILLION,
+    CONF_ILLUMINANCE,
+    UNIT_LUX,
+    DEVICE_CLASS_ILLUMINANCE
 )
 
 DEPENDENCIES = airthings_wave_base.DEPENDENCIES
@@ -45,6 +48,12 @@ CONFIG_SCHEMA = airthings_wave_base.BASE_SCHEMA.extend(
             device_class=DEVICE_CLASS_CARBON_DIOXIDE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_ILLUMINANCE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_LUX,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_ILLUMINANCE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
     }
 )
 
@@ -62,3 +71,6 @@ async def to_code(config):
     if config_co2 := config.get(CONF_CO2):
         sens = await sensor.new_sensor(config_co2)
         cg.add(var.set_co2(sens))
+    if config_illuminance := config.get(CONF_ILLUMINANCE):
+        sens = await sensor.new_sensor(config_illuminance)
+        cg.add(var.set_illuminance(sens))


### PR DESCRIPTION
# What does this implement/fix?

Extends the existing airthings wave plus integration to also support illuminance values

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [1935](https://github.com/esphome/feature-requests/issues/1935)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3110

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
sensor:
  - platform: airthings_wave_plus
    name: wave plus
    ble_client_id: airthings01
    illuminance:
      name: "WavePlus ambient light"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
