### PR TITLE
PWM Output on RP2040 for high frequencies

### DIFF
--- a/esphome/components/rp2040_pwm/rp2040_pwm.cpp
+++ b/esphome/components/rp2040_pwm/rp2040_pwm.cpp
@@ -27,8 +27,12 @@ void RP2040PWM::setup_pwm_() {
 
   uint32_t clock = clock_get_hz(clk_sys);
   float divider = ceil(clock / (4096 * this->frequency_)) / 16.0f;
+  if (divider < 1.0f) {
+    divider = 1.0f;
+  }
   uint16_t wrap = clock / divider / this->frequency_ - 1;
   this->wrap_ = wrap;
+  ESP_LOGD(TAG, "divider=%.5f, wrap=%d, clock=%d", divider, wrap, clock);
 
   pwm_config_set_clkdiv(&config, divider);
   pwm_config_set_wrap(&config, wrap);


### PR DESCRIPTION
# What does this implement/fix?

For frequencies above ~2030 Hz clock divider was set below 1, what does not make sense (we cannot speed up the clock (-: ).

Now in that case we set divider to 1 and set lower wrap value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue:** fixes [4679](https://github.com/esphome/issues/issues/4679)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [X] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
