### PR TITLE
Change device name in MQTT discovery messages to friendly names

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -134,7 +134,7 @@ bool MQTTComponent::send_discovery_() {
 
         JsonObject device_info = root.createNestedObject(MQTT_DEVICE);
         device_info[MQTT_DEVICE_IDENTIFIERS] = get_mac_address();
-        device_info[MQTT_DEVICE_NAME] = node_name;
+        device_info[MQTT_DEVICE_NAME] = App.get_friendly_name();
         device_info[MQTT_DEVICE_SW_VERSION] = "esphome v" ESPHOME_VERSION " " + App.get_compilation_time();
         device_info[MQTT_DEVICE_MODEL] = ESPHOME_BOARD;
         device_info[MQTT_DEVICE_MANUFACTURER] = "espressif";

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -132,9 +132,14 @@ bool MQTTComponent::send_discovery_() {
         if (discovery_info.object_id_generator == MQTT_DEVICE_NAME_OBJECT_ID_GENERATOR)
           root[MQTT_OBJECT_ID] = node_name + "_" + this->get_default_object_id_();
 
+        std::string node_friendly_name = App.get_friendly_name();
+        if (node_friendly_name.empty()) {
+          node_friendly_name = node_name;
+        }
+
         JsonObject device_info = root.createNestedObject(MQTT_DEVICE);
         device_info[MQTT_DEVICE_IDENTIFIERS] = get_mac_address();
-        device_info[MQTT_DEVICE_NAME] = App.get_friendly_name();
+        device_info[MQTT_DEVICE_NAME] = node_friendly_name;
         device_info[MQTT_DEVICE_SW_VERSION] = "esphome v" ESPHOME_VERSION " " + App.get_compilation_time();
         device_info[MQTT_DEVICE_MODEL] = ESPHOME_BOARD;
         device_info[MQTT_DEVICE_MANUFACTURER] = "espressif";


### PR DESCRIPTION
# What does this implement/fix?

For users using solely MQTT integration and not API connection to Home Assistant, latest change https://github.com/home-assistant/core/pull/95159 of naming schemes made entity names look somewhat robot-ish (i.e. `plant1 Moisture` instead of `Plant 1 Moisture`) due to the `name` field in discovery messages using plain (domain) name instead of friendly name.

I've made a change to use the friendly name instead of qualified name, **but** I'm neither familiar with this part of ESPHome/Home Assistant MQTT interworking nor I feel like I have a comprehensive test suite for that change (I'm only using ESPHome on like 6 devices), so if anyone has a more comprehensive test suite for that - feedback would be more than welcome.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [maybe] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
esphome:
  friendly_name: "CO2 Office"
  name: "co2_office"
mqtt:
  broker: "mqtt"
  discovery: true
  discovery_unique_id_generator: "mac"
uart:
  baud_rate: 9600
  rx_pin: 26
  tx_pin: 25
sensor:
  - co2:
      id: "co2"
      name: "sensor" # This is a bad name for this example but it's something I'm actually using
    platform: "senseair"
    update_interval: "15s"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [not really applicable IMHO] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [not applicable] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
