### PR TITLE
Daly bms performance

### DIFF
--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -21,8 +21,8 @@ static const uint8_t DALY_REQUEST_TEMPERATURE = 0x96;
 
 void DalyBmsComponent::setup() {}
 
-// to reflect that 8 requests need to be done to get all data
-void DalyBmsComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval / 8; }
+// to reflect that 7 requests need to be done to get all data
+void DalyBmsComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval / 7; }
 
 void DalyBmsComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Daly BMS:");
@@ -50,13 +50,10 @@ void DalyBmsComponent::update() {
       this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
       break;
     case 6:
-      this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
-      break;
-    case 7:
       this->request_data_(DALY_REQUEST_TEMPERATURE);
       break;
   }
-  this->requestid_ = (this->requestid_ + 1) % 8;
+  this->requestid_ = (this->requestid_ + 1) % 7;
   int available_data = this->available();
   if (available_data >= DALY_FRAME_SIZE) {
     get_battery_level_data_.resize(available_data);

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -31,39 +31,32 @@ void DalyBmsComponent::dump_config() {
 
 void DalyBmsComponent::update() {
   switch(this->requestid) {
-    case 0: 
+    case 0:
       this->request_data_(DALY_REQUEST_BATTERY_LEVEL);
       break;
-    case 1: 
+    case 1:
       this->request_data_(DALY_REQUEST_MIN_MAX_VOLTAGE);
       break;
-    case 2: 
+    case 2:
       this->request_data_(DALY_REQUEST_MIN_MAX_TEMPERATURE);
       break;
-    case 3: 
+    case 3:
       this->request_data_(DALY_REQUEST_MOS);
       break;
-    case 4: 
+    case 4:
       this->request_data_(DALY_REQUEST_STATUS);
       break;
-    case 5: 
+    case 5:
       this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
       break;
-    case 6: 
+    case 6:
       this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
       break;
-    case 7: 
+    case 7:
       this->request_data_(DALY_REQUEST_TEMPERATURE);
       break;
   }
   this->requestid = (this->requestid + 1) % 8;
-  
-  
-  
-  
-  
-  
-
   int available_data = this->available();
   if (available_data >= DALY_FRAME_SIZE) {
     get_battery_level_data.resize(available_data);

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -35,12 +35,12 @@ void DalyBmsComponent::update() {
   this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
   this->request_data_(DALY_REQUEST_TEMPERATURE);
 
-  std::vector<uint8_t> get_battery_level_data;
   int available_data = this->available();
   if (available_data >= DALY_FRAME_SIZE) {
     get_battery_level_data.resize(available_data);
     this->read_array(get_battery_level_data.data(), available_data);
     this->decode_data_(get_battery_level_data);
+    get_battery_level_data.resize(0);
   }
 }
 

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -22,7 +22,7 @@ static const uint8_t DALY_REQUEST_TEMPERATURE = 0x96;
 void DalyBmsComponent::setup() {}
 
 // to reflect that 7 requests need to be done to get all data
-void DalyBmsComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval / 7; }
+void DalyBmsComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval / 8; }
 
 void DalyBmsComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Daly BMS:");
@@ -30,13 +30,39 @@ void DalyBmsComponent::dump_config() {
 }
 
 void DalyBmsComponent::update() {
-  this->request_data_(DALY_REQUEST_BATTERY_LEVEL);
-  this->request_data_(DALY_REQUEST_MIN_MAX_VOLTAGE);
-  this->request_data_(DALY_REQUEST_MIN_MAX_TEMPERATURE);
-  this->request_data_(DALY_REQUEST_MOS);
-  this->request_data_(DALY_REQUEST_STATUS);
-  this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
-  this->request_data_(DALY_REQUEST_TEMPERATURE);
+  switch(this->requestid) {
+    case 0: 
+      this->request_data_(DALY_REQUEST_BATTERY_LEVEL);
+      break;
+    case 1: 
+      this->request_data_(DALY_REQUEST_MIN_MAX_VOLTAGE);
+      break;
+    case 2: 
+      this->request_data_(DALY_REQUEST_MIN_MAX_TEMPERATURE);
+      break;
+    case 3: 
+      this->request_data_(DALY_REQUEST_MOS);
+      break;
+    case 4: 
+      this->request_data_(DALY_REQUEST_STATUS);
+      break;
+    case 5: 
+      this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
+      break;
+    case 6: 
+      this->request_data_(DALY_REQUEST_CELL_VOLTAGE);
+      break;
+    case 7: 
+      this->request_data_(DALY_REQUEST_TEMPERATURE);
+      break;
+  }
+  this->requestid = (this->requestid + 1) % 8;
+  
+  
+  
+  
+  
+  
 
   int available_data = this->available();
   if (available_data >= DALY_FRAME_SIZE) {

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -21,6 +21,9 @@ static const uint8_t DALY_REQUEST_TEMPERATURE = 0x96;
 
 void DalyBmsComponent::setup() {}
 
+// to reflect that 7 requests need to be done to get all data
+void DalyBmsComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval / 7; }
+
 void DalyBmsComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Daly BMS:");
   this->check_uart_settings(9600);

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -30,7 +30,7 @@ void DalyBmsComponent::dump_config() {
 }
 
 void DalyBmsComponent::update() {
-  switch (this->requestid) {
+  switch (this->requestid_) {
     case 0:
       this->request_data_(DALY_REQUEST_BATTERY_LEVEL);
       break;
@@ -56,13 +56,13 @@ void DalyBmsComponent::update() {
       this->request_data_(DALY_REQUEST_TEMPERATURE);
       break;
   }
-  this->requestid = (this->requestid + 1) % 8;
+  this->requestid_ = (this->requestid_ + 1) % 8;
   int available_data = this->available();
   if (available_data >= DALY_FRAME_SIZE) {
-    get_battery_level_data.resize(available_data);
-    this->read_array(get_battery_level_data.data(), available_data);
-    this->decode_data_(get_battery_level_data);
-    get_battery_level_data.resize(0);
+    get_battery_level_data_.resize(available_data);
+    this->read_array(get_battery_level_data_.data(), available_data);
+    this->decode_data_(get_battery_level_data_);
+    get_battery_level_data_.resize(0);
   }
 }
 

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -30,7 +30,7 @@ void DalyBmsComponent::dump_config() {
 }
 
 void DalyBmsComponent::update() {
-  switch(this->requestid) {
+  switch (this->requestid) {
     case 0:
       this->request_data_(DALY_REQUEST_BATTERY_LEVEL);
       break;

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -21,7 +21,7 @@ static const uint8_t DALY_REQUEST_TEMPERATURE = 0x96;
 
 void DalyBmsComponent::setup() {}
 
-// to reflect that 7 requests need to be done to get all data
+// to reflect that 8 requests need to be done to get all data
 void DalyBmsComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval / 8; }
 
 void DalyBmsComponent::dump_config() {

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -14,7 +14,7 @@ namespace daly_bms {
 class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
  public:
   DalyBmsComponent() = default;
-  virtual void set_update_interval(uint32_t update_interval);
+  void set_update_interval(uint32_t update_interval) override;
 
   // SENSORS
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
@@ -78,8 +78,8 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   void request_data_(uint8_t data_id);
   void decode_data_(std::vector<uint8_t> data);
 
-  std::vector<uint8_t> get_battery_level_data;
-  uint8_t requestid = 0;
+  std::vector<uint8_t> get_battery_level_data_;
+  uint8_t requestid_ = 0;
 
   uint8_t addr_;
 

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -77,6 +77,8 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   void request_data_(uint8_t data_id);
   void decode_data_(std::vector<uint8_t> data);
 
+  std::vector<uint8_t> get_battery_level_data;
+
   uint8_t addr_;
 
   sensor::Sensor *voltage_sensor_{nullptr};

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -79,6 +79,7 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   void decode_data_(std::vector<uint8_t> data);
 
   std::vector<uint8_t> get_battery_level_data;
+  uint8_t requestid=0;
 
   uint8_t addr_;
 

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -79,7 +79,7 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   void decode_data_(std::vector<uint8_t> data);
 
   std::vector<uint8_t> get_battery_level_data;
-  uint8_t requestid=0;
+  uint8_t requestid = 0;
 
   uint8_t addr_;
 

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -14,6 +14,7 @@ namespace daly_bms {
 class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
  public:
   DalyBmsComponent() = default;
+  virtual void set_update_interval(uint32_t update_interval);
 
   // SENSORS
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }


### PR DESCRIPTION
# What does this implement/fix?

due to the not optimal performance of sending all 8 requests in on loop the maximum loop time exeeds.
![image](https://github.com/esphome/esphome/assets/36455093/92859945-6702-454d-a7a4-cf79b34c7dbd)

This improvements splits those requests up so that the sending as well as response handling is split up in multiple update-calls.
The loop time is now not warning anymore.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Performance improvement



## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
daly_bms:
  update_interval: 1s
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
