### PR TITLE
Improved compensation sgp30

### DIFF
--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -181,9 +181,14 @@ void SGP30Component::send_env_data_() {
     ESP_LOGD(TAG, "External compensation data received: Temperature %0.2f°C", temperature);
   }
 
-  float absolute_humidity =
-      216.7f * (((humidity / 100) * 6.112f * std::exp((17.62f * temperature) / (243.12f + temperature))) /
-                (273.15f + temperature));
+  float absolute_humidity;
+  if (temperature < 0) {
+    absolute_humidity = 216.67f * ((humidity * 0.061121f * std::exp((23.036f - temperature/333.7f) * (temperature / (279.82f + temperature)))) /
+                                  (273.15f + temperature));
+  } else {
+    absolute_humidity = 216.67f * ((humidity * 0.061121f * std::exp((18.678f - temperature/234.5f) * (temperature / (257.14f + temperature)))) /
+                                  (273.15f + temperature));
+  }
   uint8_t humidity_full = uint8_t(std::floor(absolute_humidity));
   uint8_t humidity_dec = uint8_t(std::floor((absolute_humidity - std::floor(absolute_humidity)) * 256));
   ESP_LOGD(TAG, "Calculated Absolute humidity: %0.3f g/m³ (0x%04X)", absolute_humidity,

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -183,11 +183,15 @@ void SGP30Component::send_env_data_() {
 
   float absolute_humidity;
   if (temperature < 0) {
-    absolute_humidity = 216.67f * ((humidity * 0.061121f * std::exp((23.036f - temperature/333.7f) * (temperature / (279.82f + temperature)))) /
-                                  (273.15f + temperature));
+    absolute_humidity =
+        216.67f *
+        ((humidity * 0.061121f * std::exp((23.036f - temperature / 333.7f) * (temperature / (279.82f + temperature)))) /
+         (273.15f + temperature));
   } else {
-    absolute_humidity = 216.67f * ((humidity * 0.061121f * std::exp((18.678f - temperature/234.5f) * (temperature / (257.14f + temperature)))) /
-                                  (273.15f + temperature));
+    absolute_humidity =
+        216.67f *
+        ((humidity * 0.061121f * std::exp((18.678f - temperature / 234.5f) * (temperature / (257.14f + temperature)))) /
+         (273.15f + temperature));
   }
   uint8_t humidity_full = uint8_t(std::floor(absolute_humidity));
   uint8_t humidity_dec = uint8_t(std::floor((absolute_humidity - std::floor(absolute_humidity)) * 256));


### PR DESCRIPTION
# What does this implement/fix?

Improved humidity compensation using Arden Buck equation to calculate the water mass in the air. The original equation works great for small RH changes but struggle for >10% RH changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:


```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
