### PR TITLE
esp32_ble_beacon: enable CONFIG_BT_BLE_42_FEATURES_SUPPORTED

### DIFF
--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -72,3 +72,4 @@ async def to_code(config):
 
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
+        add_idf_sdkconfig_option("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)


### PR DESCRIPTION

# What does this implement/fix?

ESP-IDF does not enable CONFIG_BT_BLE_42_FEATURES_SUPPORTED by default for the ESP32-C3 and ESP32-S3. This causes the following linker error with esp32_ble_beacon:

```
/config/.esphome/platformio/packages/toolchain-riscv32-esp@11.2.0+2022r1/bin/../lib/gcc/riscv32-esp-elf/11.2.0/../../../../riscv32-esp-elf/bin/ld: .pioenvs/bug/src/esphome/components/esp32_ble_beacon/esp32_ble_beacon.o: in function `esphome::esp32_ble_beacon::ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t, esp_ble_gap_cb_param_t*)':
/config/.esphome/build/bug/src/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp:164: undefined reference to `esp_ble_gap_start_advertising'
/config/.esphome/platformio/packages/toolchain-riscv32-esp@11.2.0+2022r1/bin/../lib/gcc/riscv32-esp-elf/11.2.0/../../../../riscv32-esp-elf/bin/ld: .pioenvs/bug/src/esphome/components/esp32_ble_beacon/esp32_ble_beacon.o: in function `esphome::esp32_ble_beacon::ESP32BLEBeacon::ble_setup()':
/config/.esphome/build/bug/src/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp:151: undefined reference to `esp_ble_gap_config_adv_data_raw'

```
Enable CONFIG_BT_BLE_42_FEATURES_SUPPORTED to fix this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
esphome:
  name:  bug
  platformio_options:
    board_build.flash_mode: dio

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: esp-idf

wifi:
  ssid: !secret ssid_iot
  password: !secret pass_wifi_iot

esp32_ble_beacon:
  type: iBeacon
  uuid: 3e52cf0d-5ead-48eb-b49c-73efd03e8770
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
