### PR TITLE
ledc: check SOC_LEDC_SUPPORT_APB_CLOCK

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -17,7 +17,11 @@
 #define CLOCK_FREQUENCY 40e6f
 #endif
 #else
+#ifdef SOC_LEDC_SUPPORT_APB_CLOCK
 #define DEFAULT_CLK LEDC_USE_APB_CLK
+#else
+#define DEFAULT_CLK LEDC_AUTO_CLK
+#endif
 #endif
 
 static const uint8_t SETUP_ATTEMPT_COUNT_MAX = 5;


### PR DESCRIPTION
# What does this implement/fix?

Check if SOC_LEDC_SUPPORT_APB_CLOCK is defined instead of hardcoding the default clock source for the LEDC peripheral to APB_CLOCK.

Fixes the following compile error on boards that don't have SOC_LEDC_SUPPORT_APB_CLOCK (like the ESP32-H2 or ESP32-C6).

```
src/esphome/components/ledc/ledc_output.cpp: In function 'esp_err_t esphome::ledc::configure_timer_frequency(ledc_mode_t, ledc_timer_t, ledc_channel_t, uint8_t, uint8_t&, float)': src/esphome/components/ledc/ledc_output.cpp:20:21: error: 'LEDC_USE_APB_CLK' was not declared in this scope; did you mean 'LEDC_USE_XTAL_CLK'?
   20 | #define DEFAULT_CLK LEDC_USE_APB_CLK
      |                     ^~~~~~~~~~~~~~~~
src/esphome/components/ledc/ledc_output.cpp:76:24: note: in expansion of macro 'DEFAULT_CLK'
   76 |   timer_conf.clk_cfg = DEFAULT_CLK;
      |                        ^~~~~~~~~~~

```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
---
esphome:
  name: "esp32c6-test2"

esp32:
  board: esp32-c6-devkitc-1
  framework:
    platform_version: https://github.com/stintel/platform-espressif32#esp32-c6-test
    type: esp-idf
    version: 5.1.0

wifi:
  ssid: !secret ssid_iot
  password: !secret pass_wifi_iot

fan:
  - platform: speed
    output: id_fan_out
    name: "fan speed"
    id: id_fan
    speed_count: 80
    
output:
  - platform: ledc
    pin: GPIO7
    id: id_fan_out
    frequency: 25000Hz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
