### PR TITLE
mdns: bump IDF mdns component to 1.2.0

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -88,7 +88,7 @@ async def to_code(config):
         add_idf_component(
             name="mdns",
             repo="https://github.com/espressif/esp-protocols.git",
-            ref="mdns-v1.0.9",
+            ref="mdns-v1.2.0",
             path="components/mdns",
         )
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes deadly crash and memory issues.

https://github.com/espressif/esp-protocols/releases/tag/mdns-v1.1.0 https://github.com/espressif/esp-protocols/releases/tag/mdns-v1.2.0

Tested on ESP32-C3 with ESP-IDF 5.0.
Tested on ESP32-C6 with ESP-IDF 5.1.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
esphome:
  name: bug
  platformio_options:
    board_build.flash_mode: dio

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: esp-idf

wifi:
  ssid: !secret ssid_iot
  password: !secret pass_wifi_iot

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
