### PR TITLE
Add missing `on_(arming|pending|armed_home|armed_night|armed_away|disarmed)` triggers to alarm_control_panel

### DIFF
--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -21,6 +21,7 @@ CONF_ON_PENDING = "on_pending"
 CONF_ON_ARMED_HOME = "on_armed_home"
 CONF_ON_ARMED_NIGHT = "on_armed_night"
 CONF_ON_ARMED_AWAY = "on_armed_away"
+CONF_ON_DISARMED = "on_disarmed"
 
 alarm_control_panel_ns = cg.esphome_ns.namespace("alarm_control_panel")
 AlarmControlPanel = alarm_control_panel_ns.class_("AlarmControlPanel", cg.EntityBase)
@@ -48,6 +49,9 @@ ArmedNightTrigger = alarm_control_panel_ns.class_(
 )
 ArmedAwayTrigger = alarm_control_panel_ns.class_(
     "ArmedAwayTrigger", automation.Trigger.template()
+)
+DisarmedTrigger = alarm_control_panel_ns.class_(
+    "DisarmedTrigger", automation.Trigger.template()
 )
 ArmAwayAction = alarm_control_panel_ns.class_("ArmAwayAction", automation.Action)
 ArmHomeAction = alarm_control_panel_ns.class_("ArmHomeAction", automation.Action)
@@ -97,6 +101,11 @@ ALARM_CONTROL_PANEL_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmedAwayTrigger),
             }
         ),
+        cv.Optional(CONF_ON_DISARMED): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DisarmedTrigger),
+            }
+        ),
         cv.Optional(CONF_ON_CLEARED): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ClearedTrigger),
@@ -140,6 +149,9 @@ async def setup_alarm_control_panel_core_(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_ARMED_AWAY, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_DISARMED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_CLEARED, []):

--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -20,6 +20,7 @@ CONF_ON_ARMING = "on_arming"
 CONF_ON_PENDING = "on_pending"
 CONF_ON_ARMED_HOME = "on_armed_home"
 CONF_ON_ARMED_NIGHT = "on_armed_night"
+CONF_ON_ARMED_AWAY = "on_armed_away"
 
 alarm_control_panel_ns = cg.esphome_ns.namespace("alarm_control_panel")
 AlarmControlPanel = alarm_control_panel_ns.class_("AlarmControlPanel", cg.EntityBase)
@@ -44,6 +45,9 @@ ArmedHomeTrigger = alarm_control_panel_ns.class_(
 )
 ArmedNightTrigger = alarm_control_panel_ns.class_(
     "ArmedNightTrigger", automation.Trigger.template()
+)
+ArmedAwayTrigger = alarm_control_panel_ns.class_(
+    "ArmedAwayTrigger", automation.Trigger.template()
 )
 ArmAwayAction = alarm_control_panel_ns.class_("ArmAwayAction", automation.Action)
 ArmHomeAction = alarm_control_panel_ns.class_("ArmHomeAction", automation.Action)
@@ -88,6 +92,11 @@ ALARM_CONTROL_PANEL_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmedNightTrigger),
             }
         ),
+        cv.Optional(CONF_ON_ARMED_AWAY): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmedAwayTrigger),
+            }
+        ),
         cv.Optional(CONF_ON_CLEARED): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ClearedTrigger),
@@ -128,6 +137,9 @@ async def setup_alarm_control_panel_core_(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_ARMED_NIGHT, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_ARMED_AWAY, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_CLEARED, []):

--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -17,6 +17,7 @@ IS_PLATFORM_COMPONENT = True
 CONF_ON_TRIGGERED = "on_triggered"
 CONF_ON_CLEARED = "on_cleared"
 CONF_ON_ARMING = "on_arming"
+CONF_ON_PENDING = "on_pending"
 
 alarm_control_panel_ns = cg.esphome_ns.namespace("alarm_control_panel")
 AlarmControlPanel = alarm_control_panel_ns.class_("AlarmControlPanel", cg.EntityBase)
@@ -32,6 +33,9 @@ ClearedTrigger = alarm_control_panel_ns.class_(
 )
 ArmingTrigger = alarm_control_panel_ns.class_(
     "ArmingTrigger", automation.Trigger.template()
+)
+PendingTrigger = alarm_control_panel_ns.class_(
+    "PendingTrigger", automation.Trigger.template()
 )
 ArmAwayAction = alarm_control_panel_ns.class_("ArmAwayAction", automation.Action)
 ArmHomeAction = alarm_control_panel_ns.class_("ArmHomeAction", automation.Action)
@@ -59,6 +63,11 @@ ALARM_CONTROL_PANEL_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
         cv.Optional(CONF_ON_ARMING): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmingTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_PENDING): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PendingTrigger),
             }
         ),
         cv.Optional(CONF_ON_CLEARED): automation.validate_automation(
@@ -92,6 +101,9 @@ async def setup_alarm_control_panel_core_(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_ARMING, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_PENDING, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_CLEARED, []):

--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -19,6 +19,7 @@ CONF_ON_CLEARED = "on_cleared"
 CONF_ON_ARMING = "on_arming"
 CONF_ON_PENDING = "on_pending"
 CONF_ON_ARMED_HOME = "on_armed_home"
+CONF_ON_ARMED_NIGHT = "on_armed_night"
 
 alarm_control_panel_ns = cg.esphome_ns.namespace("alarm_control_panel")
 AlarmControlPanel = alarm_control_panel_ns.class_("AlarmControlPanel", cg.EntityBase)
@@ -40,6 +41,9 @@ PendingTrigger = alarm_control_panel_ns.class_(
 )
 ArmedHomeTrigger = alarm_control_panel_ns.class_(
     "ArmedHomeTrigger", automation.Trigger.template()
+)
+ArmedNightTrigger = alarm_control_panel_ns.class_(
+    "ArmedNightTrigger", automation.Trigger.template()
 )
 ArmAwayAction = alarm_control_panel_ns.class_("ArmAwayAction", automation.Action)
 ArmHomeAction = alarm_control_panel_ns.class_("ArmHomeAction", automation.Action)
@@ -79,6 +83,11 @@ ALARM_CONTROL_PANEL_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmedHomeTrigger),
             }
         ),
+        cv.Optional(CONF_ON_ARMED_NIGHT): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmedNightTrigger),
+            }
+        ),
         cv.Optional(CONF_ON_CLEARED): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ClearedTrigger),
@@ -116,6 +125,9 @@ async def setup_alarm_control_panel_core_(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_ARMED_HOME, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_ARMED_NIGHT, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_CLEARED, []):

--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -18,6 +18,7 @@ CONF_ON_TRIGGERED = "on_triggered"
 CONF_ON_CLEARED = "on_cleared"
 CONF_ON_ARMING = "on_arming"
 CONF_ON_PENDING = "on_pending"
+CONF_ON_ARMED_HOME = "on_armed_home"
 
 alarm_control_panel_ns = cg.esphome_ns.namespace("alarm_control_panel")
 AlarmControlPanel = alarm_control_panel_ns.class_("AlarmControlPanel", cg.EntityBase)
@@ -36,6 +37,9 @@ ArmingTrigger = alarm_control_panel_ns.class_(
 )
 PendingTrigger = alarm_control_panel_ns.class_(
     "PendingTrigger", automation.Trigger.template()
+)
+ArmedHomeTrigger = alarm_control_panel_ns.class_(
+    "ArmedHomeTrigger", automation.Trigger.template()
 )
 ArmAwayAction = alarm_control_panel_ns.class_("ArmAwayAction", automation.Action)
 ArmHomeAction = alarm_control_panel_ns.class_("ArmHomeAction", automation.Action)
@@ -68,6 +72,11 @@ ALARM_CONTROL_PANEL_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
         cv.Optional(CONF_ON_PENDING): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PendingTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_ARMED_HOME): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmedHomeTrigger),
             }
         ),
         cv.Optional(CONF_ON_CLEARED): automation.validate_automation(
@@ -104,6 +113,9 @@ async def setup_alarm_control_panel_core_(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_PENDING, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_ARMED_HOME, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_CLEARED, []):

--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -16,6 +16,7 @@ IS_PLATFORM_COMPONENT = True
 
 CONF_ON_TRIGGERED = "on_triggered"
 CONF_ON_CLEARED = "on_cleared"
+CONF_ON_ARMING = "on_arming"
 
 alarm_control_panel_ns = cg.esphome_ns.namespace("alarm_control_panel")
 AlarmControlPanel = alarm_control_panel_ns.class_("AlarmControlPanel", cg.EntityBase)
@@ -28,6 +29,9 @@ TriggeredTrigger = alarm_control_panel_ns.class_(
 )
 ClearedTrigger = alarm_control_panel_ns.class_(
     "ClearedTrigger", automation.Trigger.template()
+)
+ArmingTrigger = alarm_control_panel_ns.class_(
+    "ArmingTrigger", automation.Trigger.template()
 )
 ArmAwayAction = alarm_control_panel_ns.class_("ArmAwayAction", automation.Action)
 ArmHomeAction = alarm_control_panel_ns.class_("ArmHomeAction", automation.Action)
@@ -50,6 +54,11 @@ ALARM_CONTROL_PANEL_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
         cv.Optional(CONF_ON_TRIGGERED): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(TriggeredTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_ARMING): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ArmingTrigger),
             }
         ),
         cv.Optional(CONF_ON_CLEARED): automation.validate_automation(
@@ -80,6 +89,9 @@ async def setup_alarm_control_panel_core_(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_TRIGGERED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_ARMING, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
     for conf in config.get(CONF_ON_CLEARED, []):

--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -52,6 +52,9 @@ void AlarmControlPanel::publish_state(AlarmControlPanelState state) {
     else if (state == ACP_STATE_ARMED_AWAY) {
       this->armed_away_callback_.call();
     }
+    else if (state == ACP_STATE_DISARMED) {
+      this->disarmed_callback_.call();
+    }
 
     if (prev_state == ACP_STATE_TRIGGERED) {
       this->cleared_callback_.call();
@@ -89,6 +92,10 @@ void AlarmControlPanel::add_on_armed_away_callback(std::function<void()> &&callb
 
 void AlarmControlPanel::add_on_pending_callback(std::function<void()> &&callback) {
   this->pending_callback_.add(std::move(callback));
+}
+
+void AlarmControlPanel::add_on_disarmed_callback(std::function<void()> &&callback) {
+  this->disarmed_callback_.add(std::move(callback));
 }
 
 void AlarmControlPanel::add_on_cleared_callback(std::function<void()> &&callback) {

--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -36,23 +36,17 @@ void AlarmControlPanel::publish_state(AlarmControlPanelState state) {
     this->state_callback_.call();
     if (state == ACP_STATE_TRIGGERED) {
       this->triggered_callback_.call();
-    }
-    else if (state == ACP_STATE_ARMING) {
+    } else if (state == ACP_STATE_ARMING) {
       this->arming_callback_.call();
-    }
-    else if (state == ACP_STATE_PENDING) {
+    } else if (state == ACP_STATE_PENDING) {
       this->pending_callback_.call();
-    }
-    else if (state == ACP_STATE_ARMED_HOME) {
+    } else if (state == ACP_STATE_ARMED_HOME) {
       this->armed_home_callback_.call();
-    }
-    else if (state == ACP_STATE_ARMED_NIGHT) {
+    } else if (state == ACP_STATE_ARMED_NIGHT) {
       this->armed_night_callback_.call();
-    }
-    else if (state == ACP_STATE_ARMED_AWAY) {
+    } else if (state == ACP_STATE_ARMED_AWAY) {
       this->armed_away_callback_.call();
-    }
-    else if (state == ACP_STATE_DISARMED) {
+    } else if (state == ACP_STATE_DISARMED) {
       this->disarmed_callback_.call();
     }
 

--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -49,6 +49,9 @@ void AlarmControlPanel::publish_state(AlarmControlPanelState state) {
     else if (state == ACP_STATE_ARMED_NIGHT) {
       this->armed_night_callback_.call();
     }
+    else if (state == ACP_STATE_ARMED_AWAY) {
+      this->armed_away_callback_.call();
+    }
 
     if (prev_state == ACP_STATE_TRIGGERED) {
       this->cleared_callback_.call();
@@ -78,6 +81,10 @@ void AlarmControlPanel::add_on_armed_home_callback(std::function<void()> &&callb
 
 void AlarmControlPanel::add_on_armed_night_callback(std::function<void()> &&callback) {
   this->armed_night_callback_.add(std::move(callback));
+}
+
+void AlarmControlPanel::add_on_armed_away_callback(std::function<void()> &&callback) {
+  this->armed_away_callback_.add(std::move(callback));
 }
 
 void AlarmControlPanel::add_on_pending_callback(std::function<void()> &&callback) {

--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -40,6 +40,9 @@ void AlarmControlPanel::publish_state(AlarmControlPanelState state) {
     else if (state == ACP_STATE_ARMING) {
       this->arming_callback_.call();
     }
+    else if (state == ACP_STATE_PENDING) {
+      this->pending_callback_.call();
+    }
     if (prev_state == ACP_STATE_TRIGGERED) {
       this->cleared_callback_.call();
     }
@@ -60,6 +63,10 @@ void AlarmControlPanel::add_on_triggered_callback(std::function<void()> &&callba
 
 void AlarmControlPanel::add_on_arming_callback(std::function<void()> &&callback) {
   this->arming_callback_.add(std::move(callback));
+}
+
+void AlarmControlPanel::add_on_pending_callback(std::function<void()> &&callback) {
+  this->pending_callback_.add(std::move(callback));
 }
 
 void AlarmControlPanel::add_on_cleared_callback(std::function<void()> &&callback) {

--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -43,6 +43,9 @@ void AlarmControlPanel::publish_state(AlarmControlPanelState state) {
     else if (state == ACP_STATE_PENDING) {
       this->pending_callback_.call();
     }
+    else if (state == ACP_STATE_ARMED_HOME) {
+      this->armed_home_callback_.call();
+    }
     if (prev_state == ACP_STATE_TRIGGERED) {
       this->cleared_callback_.call();
     }
@@ -63,6 +66,10 @@ void AlarmControlPanel::add_on_triggered_callback(std::function<void()> &&callba
 
 void AlarmControlPanel::add_on_arming_callback(std::function<void()> &&callback) {
   this->arming_callback_.add(std::move(callback));
+}
+
+void AlarmControlPanel::add_on_armed_home_callback(std::function<void()> &&callback) {
+  this->armed_home_callback_.add(std::move(callback));
 }
 
 void AlarmControlPanel::add_on_pending_callback(std::function<void()> &&callback) {

--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -46,6 +46,10 @@ void AlarmControlPanel::publish_state(AlarmControlPanelState state) {
     else if (state == ACP_STATE_ARMED_HOME) {
       this->armed_home_callback_.call();
     }
+    else if (state == ACP_STATE_ARMED_NIGHT) {
+      this->armed_night_callback_.call();
+    }
+
     if (prev_state == ACP_STATE_TRIGGERED) {
       this->cleared_callback_.call();
     }
@@ -70,6 +74,10 @@ void AlarmControlPanel::add_on_arming_callback(std::function<void()> &&callback)
 
 void AlarmControlPanel::add_on_armed_home_callback(std::function<void()> &&callback) {
   this->armed_home_callback_.add(std::move(callback));
+}
+
+void AlarmControlPanel::add_on_armed_night_callback(std::function<void()> &&callback) {
+  this->armed_night_callback_.add(std::move(callback));
 }
 
 void AlarmControlPanel::add_on_pending_callback(std::function<void()> &&callback) {

--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -37,6 +37,9 @@ void AlarmControlPanel::publish_state(AlarmControlPanelState state) {
     if (state == ACP_STATE_TRIGGERED) {
       this->triggered_callback_.call();
     }
+    else if (state == ACP_STATE_ARMING) {
+      this->arming_callback_.call();
+    }
     if (prev_state == ACP_STATE_TRIGGERED) {
       this->cleared_callback_.call();
     }
@@ -53,6 +56,10 @@ void AlarmControlPanel::add_on_state_callback(std::function<void()> &&callback) 
 
 void AlarmControlPanel::add_on_triggered_callback(std::function<void()> &&callback) {
   this->triggered_callback_.add(std::move(callback));
+}
+
+void AlarmControlPanel::add_on_arming_callback(std::function<void()> &&callback) {
+  this->arming_callback_.add(std::move(callback));
 }
 
 void AlarmControlPanel::add_on_cleared_callback(std::function<void()> &&callback) {

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -47,6 +47,12 @@ class AlarmControlPanel : public EntityBase {
    */
   void add_on_triggered_callback(std::function<void()> &&callback);
 
+  /** Add a callback for when the state of the alarm_control_panel chanes to arming
+   *
+   * @param callback The callback function
+   */
+  void add_on_arming_callback(std::function<void()> &&callback);
+
   /** Add a callback for when the state of the alarm_control_panel clears from triggered
    *
    * @param callback The callback function
@@ -128,6 +134,8 @@ class AlarmControlPanel : public EntityBase {
   CallbackManager<void()> state_callback_{};
   // trigger callback
   CallbackManager<void()> triggered_callback_{};
+  // arming callback
+  CallbackManager<void()> arming_callback_{};
   // clear callback
   CallbackManager<void()> cleared_callback_{};
 };

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -53,6 +53,12 @@ class AlarmControlPanel : public EntityBase {
    */
   void add_on_arming_callback(std::function<void()> &&callback);
 
+  /** Add a callback for when the state of the alarm_control_panel changes to pending
+   *
+   * @param callback The callback function
+   */
+  void add_on_pending_callback(std::function<void()> &&callback);
+
   /** Add a callback for when the state of the alarm_control_panel clears from triggered
    *
    * @param callback The callback function
@@ -136,6 +142,8 @@ class AlarmControlPanel : public EntityBase {
   CallbackManager<void()> triggered_callback_{};
   // arming callback
   CallbackManager<void()> arming_callback_{};
+  // pending callback
+  CallbackManager<void()> pending_callback_{};
   // clear callback
   CallbackManager<void()> cleared_callback_{};
 };

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -71,6 +71,12 @@ class AlarmControlPanel : public EntityBase {
    */
   void add_on_armed_night_callback(std::function<void()> &&callback);
 
+  /** Add a callback for when the state of the alarm_control_panel changes to armed_away
+   *
+   * @param callback The callback function
+   */
+  void add_on_armed_away_callback(std::function<void()> &&callback);
+
   /** Add a callback for when the state of the alarm_control_panel clears from triggered
    *
    * @param callback The callback function
@@ -160,6 +166,8 @@ class AlarmControlPanel : public EntityBase {
   CallbackManager<void()> armed_home_callback_{};
   // armed_night callback
   CallbackManager<void()> armed_night_callback_{};
+  // armed_away callback
+  CallbackManager<void()> armed_away_callback_{};
   // clear callback
   CallbackManager<void()> cleared_callback_{};
 };

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -77,6 +77,12 @@ class AlarmControlPanel : public EntityBase {
    */
   void add_on_armed_away_callback(std::function<void()> &&callback);
 
+  /** Add a callback for when the state of the alarm_control_panel changes to disarmed
+   *
+   * @param callback The callback function
+   */
+  void add_on_disarmed_callback(std::function<void()> &&callback);
+
   /** Add a callback for when the state of the alarm_control_panel clears from triggered
    *
    * @param callback The callback function
@@ -168,6 +174,8 @@ class AlarmControlPanel : public EntityBase {
   CallbackManager<void()> armed_night_callback_{};
   // armed_away callback
   CallbackManager<void()> armed_away_callback_{};
+  // disarmed callback
+  CallbackManager<void()> disarmed_callback_{};
   // clear callback
   CallbackManager<void()> cleared_callback_{};
 };

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -59,6 +59,12 @@ class AlarmControlPanel : public EntityBase {
    */
   void add_on_pending_callback(std::function<void()> &&callback);
 
+  /** Add a callback for when the state of the alarm_control_panel changes to armed_home
+   *
+   * @param callback The callback function
+   */
+  void add_on_armed_home_callback(std::function<void()> &&callback);
+
   /** Add a callback for when the state of the alarm_control_panel clears from triggered
    *
    * @param callback The callback function
@@ -144,6 +150,8 @@ class AlarmControlPanel : public EntityBase {
   CallbackManager<void()> arming_callback_{};
   // pending callback
   CallbackManager<void()> pending_callback_{};
+  // armed_home callback
+  CallbackManager<void()> armed_home_callback_{};
   // clear callback
   CallbackManager<void()> cleared_callback_{};
 };

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -65,6 +65,12 @@ class AlarmControlPanel : public EntityBase {
    */
   void add_on_armed_home_callback(std::function<void()> &&callback);
 
+  /** Add a callback for when the state of the alarm_control_panel changes to armed_night
+   *
+   * @param callback The callback function
+   */
+  void add_on_armed_night_callback(std::function<void()> &&callback);
+
   /** Add a callback for when the state of the alarm_control_panel clears from triggered
    *
    * @param callback The callback function
@@ -152,6 +158,8 @@ class AlarmControlPanel : public EntityBase {
   CallbackManager<void()> pending_callback_{};
   // armed_home callback
   CallbackManager<void()> armed_home_callback_{};
+  // armed_night callback
+  CallbackManager<void()> armed_night_callback_{};
   // clear callback
   CallbackManager<void()> cleared_callback_{};
 };

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -41,6 +41,13 @@ class ArmedHomeTrigger : public Trigger<> {
   }
 };
 
+class ArmedNightTrigger : public Trigger<> {
+ public:
+  explicit ArmedNightTrigger(AlarmControlPanel *alarm_control_panel) {
+    alarm_control_panel->add_on_armed_night_callback([this]() { this->trigger(); });
+  }
+};
+
 class ClearedTrigger : public Trigger<> {
  public:
   explicit ClearedTrigger(AlarmControlPanel *alarm_control_panel) {

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -20,6 +20,13 @@ class TriggeredTrigger : public Trigger<> {
   }
 };
 
+class ArmingTrigger : public Trigger<> {
+ public:
+  explicit ArmingTrigger(AlarmControlPanel *alarm_control_panel) {
+    alarm_control_panel->add_on_arming_callback([this]() { this->trigger(); });
+  }
+};
+
 class ClearedTrigger : public Trigger<> {
  public:
   explicit ClearedTrigger(AlarmControlPanel *alarm_control_panel) {

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -48,6 +48,13 @@ class ArmedNightTrigger : public Trigger<> {
   }
 };
 
+class ArmedAwayTrigger : public Trigger<> {
+ public:
+  explicit ArmedAwayTrigger(AlarmControlPanel *alarm_control_panel) {
+    alarm_control_panel->add_on_armed_away_callback([this]() { this->trigger(); });
+  }
+};
+
 class ClearedTrigger : public Trigger<> {
  public:
   explicit ClearedTrigger(AlarmControlPanel *alarm_control_panel) {

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -34,6 +34,13 @@ class PendingTrigger : public Trigger<> {
   }
 };
 
+class ArmedHomeTrigger : public Trigger<> {
+ public:
+  explicit ArmedHomeTrigger(AlarmControlPanel *alarm_control_panel) {
+    alarm_control_panel->add_on_armed_home_callback([this]() { this->trigger(); });
+  }
+};
+
 class ClearedTrigger : public Trigger<> {
  public:
   explicit ClearedTrigger(AlarmControlPanel *alarm_control_panel) {

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -55,6 +55,13 @@ class ArmedAwayTrigger : public Trigger<> {
   }
 };
 
+class DisarmedTrigger : public Trigger<> {
+ public:
+  explicit DisarmedTrigger(AlarmControlPanel *alarm_control_panel) {
+    alarm_control_panel->add_on_disarmed_callback([this]() { this->trigger(); });
+  }
+};
+
 class ClearedTrigger : public Trigger<> {
  public:
   explicit ClearedTrigger(AlarmControlPanel *alarm_control_panel) {

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -27,6 +27,13 @@ class ArmingTrigger : public Trigger<> {
   }
 };
 
+class PendingTrigger : public Trigger<> {
+ public:
+  explicit PendingTrigger(AlarmControlPanel *alarm_control_panel) {
+    alarm_control_panel->add_on_pending_callback([this]() { this->trigger(); });
+  }
+};
+
 class ClearedTrigger : public Trigger<> {
  public:
   explicit ClearedTrigger(AlarmControlPanel *alarm_control_panel) {

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1239,9 +1239,9 @@ alarm_control_panel:
     on_armed_away:
       then:
         - logger.log: "### ARMED AWAY ###"
-    on_armed_triggered:
+    on_triggered:
       then:
         - logger.log: "### TRIGGERED ###"
-    on_armed_cleared:
+    on_cleared:
       then:
         - logger.log: "### CLEARED ###"

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1206,3 +1206,42 @@ alarm_control_panel:
       then:
         - lambda: !lambda |-
             ESP_LOGD("TEST", "State change %s", alarm_control_panel_state_to_string(id(alarmcontrolpanel1)->get_state()));
+  - platform: template
+    id: alarmcontrolpanel2
+    name: Alarm Panel
+    codes:
+      - "1234"
+    requires_code_to_arm: true
+    arming_home_time: 1s
+    arming_night_time: 1s
+    arming_away_time: 15s
+    pending_time: 15s
+    trigger_time: 30s
+    binary_sensors:
+      - input: bin1
+        bypass_armed_home: true
+        bypass_armed_night: true
+    on_disarmed:
+      then:
+        - logger.log: "### DISARMED ###"
+    on_pending:
+      then:
+        - logger.log: "### PENDING ###"
+    on_arming:
+      then:
+        - logger.log: "### ARMING ###"
+    on_armed_home:
+      then:
+        - logger.log: "### ARMED HOME ###"
+    on_armed_night:
+      then:
+        - logger.log: "### ARMED NIGHT ###"
+    on_armed_away:
+      then:
+        - logger.log: "### ARMED AWAY ###"
+    on_armed_triggered:
+      then:
+        - logger.log: "### TRIGGERED ###"
+    on_armed_cleared:
+      then:
+        - logger.log: "### CLEARED ###"


### PR DESCRIPTION
- Add the `on_arming` trigger to alarm_control_panel component
- Add  the `on_pending` trigger to alarm_control_panel component
- Add the `on_armed_home` trigger to alarm_control_panel component
- Add `on_armed_night` trigger to alarm_control_panel component
- Add `on_armed_away` trigger to alarm_control_panel component
- Add `on_disarmed` trigger to alarm_control_panel component
- Add another alarm control panel to the tests

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3114
## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
