### PR TITLE
Tweak Color init because IDF 5+

### DIFF
--- a/esphome/components/color/__init__.py
+++ b/esphome/components/color/__init__.py
@@ -82,5 +82,5 @@ async def to_code(config):
 
     cg.new_variable(
         config[CONF_ID],
-        cg.StructInitializer(ColorStruct, ("r", r), ("g", g), ("b", b), ("w", w)),
+        cg.ArrayInitializer(r, g, b, w),
     )


### PR DESCRIPTION
# What does this implement/fix?

Quick and dirty fix for `Color` initialization to mitigate a compilation error when building with IDF 5+:

```
src/main.cpp:4248:3: error: designated initializers cannot be used with a non-aggregate type 'esphome::Color'
 4248 |   };
      |   ^
src/main.cpp:4248:3: error: no matching function for call to 'esphome::Color::Color(<brace-enclosed initializer list>)'
```

Changes:

```c
  kbx_red = Color{
    .r = 255,
    .g = 0,
    .b = 0,
    .w = 0,
  };
```

...to:

```c
kbx_red = { 255, 0, 0, 0 };
```

...which seems to make the compiler happier and does not break Arduino builds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
