### PR TITLE
add value option to timeout filter

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -23,6 +23,7 @@ from esphome.const import (
     CONF_SEND_EVERY,
     CONF_SEND_FIRST_AT,
     CONF_STATE_CLASS,
+    CONF_TIMEOUT,
     CONF_TO,
     CONF_TRIGGER_ID,
     CONF_TYPE,
@@ -543,11 +544,18 @@ async def heartbeat_filter_to_code(config, filter_id):
     return var
 
 
-@FILTER_REGISTRY.register(
-    "timeout", TimeoutFilter, cv.positive_time_period_milliseconds
+TIMEOUT_SCHEMA = cv.maybe_simple_value(
+    {
+        cv.Required(CONF_TIMEOUT): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_VALUE, default="nan"): cv.float_,
+    },
+    key=CONF_TIMEOUT,
 )
+
+
+@FILTER_REGISTRY.register("timeout", TimeoutFilter, TIMEOUT_SCHEMA)
 async def timeout_filter_to_code(config, filter_id):
-    var = cg.new_Pvariable(filter_id, config)
+    var = cg.new_Pvariable(filter_id, config[CONF_TIMEOUT], config[CONF_VALUE])
     await cg.register_component(var, {})
     return var
 

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -375,13 +375,13 @@ void OrFilter::initialize(Sensor *parent, Filter *next) {
 
 // TimeoutFilter
 optional<float> TimeoutFilter::new_value(float value) {
-  this->set_timeout("timeout", this->time_period_, [this]() { this->output(NAN); });
+  this->set_timeout("timeout", this->time_period_, [this]() { this->output(this->value_); });
   this->output(value);
 
   return {};
 }
 
-TimeoutFilter::TimeoutFilter(uint32_t time_period) : time_period_(time_period) {}
+TimeoutFilter::TimeoutFilter(uint32_t time_period, float new_value) : time_period_(time_period), value_(new_value) {}
 float TimeoutFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 // DebounceFilter

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -315,7 +315,8 @@ class ThrottleFilter : public Filter {
 
 class TimeoutFilter : public Filter, public Component {
  public:
-  explicit TimeoutFilter(uint32_t time_period);
+  explicit TimeoutFilter(uint32_t time_period, float new_value);
+  void set_value(float new_value) { this->value_ = new_value; }
 
   optional<float> new_value(float value) override;
 
@@ -323,6 +324,7 @@ class TimeoutFilter : public Filter, public Component {
 
  protected:
   uint32_t time_period_;
+  float value_;
 };
 
 class DebounceFilter : public Filter, public Component {

--- a/tests/test3.1.yaml
+++ b/tests/test3.1.yaml
@@ -87,6 +87,9 @@ sensor:
       - throttle: 100ms
       - debounce: 500s
       - timeout: 10min
+      - timeout:
+          timeout: 10min
+          value: 0
       - calibrate_linear:
           method: exact
           datapoints:


### PR DESCRIPTION
# What does this implement/fix?

Adds an option to set the value that will be sent after the timeout.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3115

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
