### PR TITLE
Add optional bindkey parameter to LYWSD02

### DIFF
--- a/esphome/components/xiaomi_lywsd02/sensor.py
+++ b/esphome/components/xiaomi_lywsd02/sensor.py
@@ -14,6 +14,7 @@ from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_BATTERY,
     CONF_ID,
+    CONF_BINDKEY,
 )
 
 DEPENDENCIES = ["esp32_ble_tracker"]
@@ -29,6 +30,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(XiaomiLYWSD02),
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
+            cv.Optional(CONF_BINDKEY): cv.bind_key,
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
@@ -61,6 +63,8 @@ async def to_code(config):
     await esp32_ble_tracker.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
+    if CONF_BINDKEY in config:
+        cg.add(var.set_bindkey(config[CONF_BINDKEY]))
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])

--- a/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.h
+++ b/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.h
@@ -13,6 +13,7 @@ namespace xiaomi_lywsd02 {
 class XiaomiLYWSD02 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
+  void set_bindkey(const std::string &bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
@@ -24,6 +25,7 @@ class XiaomiLYWSD02 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
 
  protected:
   uint64_t address_;
+  uint8_t bindkey_[16];
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};
   sensor::Sensor *battery_level_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Newer models of the Xiaomi Mijia LYWSD02 clock using firmware 2.0.1 or newer require a bindkey to read the data from the device.

I have tried adding a custom component based on the LYWSD02 code and include a bindkey, however, I couldn't read the data from the device.

Accessing the device and setting the time manually works without a bindkey, for example.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4364

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3119

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
    sensor:
      - platform: xiaomi_lywsd02
        mac_address: "3F:5B:7D:82:58:4E"
        bindkey: "eef418daf699a0c188f3bfd17e4565d9"
        temperature:
          name: "LYWSD02 Temperature"
        humidity:
          name: "LYWSD02 Humidity"
        battery_level:
          name: "LYWSD02 Battery Level"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
