### PR TITLE
fix midea: undo approved PR#4053

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1488,11 +1488,9 @@ MideaData, MideaBinarySensor, MideaTrigger, MideaAction, MideaDumper = declare_p
 MideaAction = ns.class_("MideaAction", RemoteTransmitterActionBase)
 MIDEA_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_CODE): cv.templatable(
-            cv.All(
-                [cv.Any(cv.hex_uint8_t, cv.uint8_t)],
-                cv.Length(min=5, max=5),
-            )
+        cv.Required(CONF_CODE): cv.All(
+            [cv.Any(cv.hex_uint8_t, cv.uint8_t)],
+            cv.Length(min=5, max=5),
         ),
     }
 )
@@ -1519,12 +1517,10 @@ def midea_dumper(var, config):
     MIDEA_SCHEMA,
 )
 async def midea_action(var, config, args):
-    code_ = config[CONF_CODE]
-    if cg.is_template(code_):
-        template_ = await cg.templatable(code_, args, cg.std_vector.template(cg.uint8))
-        cg.add(var.set_code_template(template_))
-    else:
-        cg.add(var.set_code_static(code_))
+    template_ = await cg.templatable(
+        config[CONF_CODE], args, cg.std_vector.template(cg.uint8)
+    )
+    cg.add(var.set_code(template_))
 
 
 # AEHA

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <array>
+#include <vector>
+
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "remote_base.h"
-#include <array>
-#include <utility>
-#include <vector>
 
 namespace esphome {
 namespace remote_base {
@@ -84,23 +84,12 @@ using MideaDumper = RemoteReceiverDumper<MideaProtocol, MideaData>;
 
 template<typename... Ts> class MideaAction : public RemoteTransmitterActionBase<Ts...> {
   TEMPLATABLE_VALUE(std::vector<uint8_t>, code)
-  void set_code_static(std::vector<uint8_t> code) { code_static_ = std::move(code); }
-  void set_code_template(std::function<std::vector<uint8_t>(Ts...)> func) { this->code_func_ = func; }
 
   void encode(RemoteTransmitData *dst, Ts... x) override {
-    MideaData data;
-    if (!this->code_static_.empty()) {
-      data = MideaData(this->code_static_);
-    } else {
-      data = MideaData(this->code_func_(x...));
-    }
+    MideaData data(this->code_.value(x...));
     data.finalize();
     MideaProtocol().encode(dst, data);
   }
-
- protected:
-  std::function<std::vector<uint8_t>(Ts...)> code_func_{};
-  std::vector<uint8_t> code_static_{};
 };
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -84,6 +84,7 @@ using MideaDumper = RemoteReceiverDumper<MideaProtocol, MideaData>;
 
 template<typename... Ts> class MideaAction : public RemoteTransmitterActionBase<Ts...> {
   TEMPLATABLE_VALUE(std::vector<uint8_t>, code)
+  void set_code(std::initializer_list<uint8_t> code) { this->code_ = code; }
 
   void encode(RemoteTransmitData *dst, Ts... x) override {
     MideaData data(this->code_.value(x...));

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2334,9 +2334,7 @@ switch:
       - remote_transmitter.transmit_midea:
           code: [0xA2, 0x08, 0xFF, 0xFF, 0xFF]
       - remote_transmitter.transmit_midea:
-          code: !lambda |-
-            const uint8_t tmp = static_cast<uint8_t>(id(pulse_meter_sensor).state) + 1;
-            return {0xA4, 0x82, 0x48, 0x7F, tmp};
+          code: !lambda "return {0xA2, 0x08, 0xFF, 0xFF, 0xFF};"
   - platform: gpio
     name: "MCP23S08 Pin #0"
     pin:

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2333,6 +2333,10 @@ switch:
           second: !lambda "return 0xB21F98;"
       - remote_transmitter.transmit_midea:
           code: [0xA2, 0x08, 0xFF, 0xFF, 0xFF]
+      - remote_transmitter.transmit_midea:
+          code: !lambda |-
+            const uint8_t tmp = static_cast<uint8_t>(id(pulse_meter_sensor).state) + 1;
+            return {0xA4, 0x82, 0x48, 0x7F, tmp};
   - platform: gpio
     name: "MCP23S08 Pin #0"
     pin:


### PR DESCRIPTION
(cherry picked from commit 069f20fa06c50aaf4d79d392fc941880ce5a36fa)

# What does this implement/fix?

Cancels almost all approved [PR#4053](https://github.com/esphome/esphome/pull/4053). To use a lambda, it was only necessary to process it with `cg.templatable`, and not write so much unnecessary code. This PR actually optimizes and puts things in order in the code. Everything is checked - the code works.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
