### PR TITLE
Added a Hybrid Shift Register Component

### DIFF
--- a/esphome/components/hybridshiftreg/__init__.py
+++ b/esphome/components/hybridshiftreg/__init__.py
@@ -1,0 +1,92 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.const import (
+    CONF_ID,
+    CONF_MODE,
+    CONF_NUMBER,
+    CONF_INVERTED,
+    CONF_CLOCK_PIN,
+    CONF_OUTPUT,
+    CONF_INPUT,
+    CONF_ALLOW_OTHER_USES,
+)
+
+DEPENDENCIES = []
+MULTI_CONF = True
+
+hybridshift_ns = cg.esphome_ns.namespace("hybridshiftreg")
+
+HybridShiftComponent = hybridshift_ns.class_("HybridShiftComponent", cg.Component)
+HybridShiftGPIOPin = hybridshift_ns.class_(
+    "HybridShiftGPIOPin", cg.GPIOPin, cg.Parented.template(HybridShiftComponent)
+)
+
+CONF_HYBRIDSHIFTREG = "hybridshiftreg"
+CONF_DATA_OUT_PIN = "data_out_pin"
+CONF_DATA_IN_PIN = "data_in_pin"
+CONF_INH_LATCH_PIN = "inh_latch_pin"
+CONF_LOAD_OE_PIN = "load_oe_pin"
+CONF_SR_COUNT = "sr_count"
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.declare_id(HybridShiftComponent),
+        cv.Required(CONF_DATA_OUT_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_DATA_IN_PIN): pins.gpio_input_pin_schema,
+        cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_INH_LATCH_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_LOAD_OE_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_SR_COUNT, default=1): cv.int_range(min=1, max=256),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    data_out_pin = await cg.gpio_pin_expression(config[CONF_DATA_OUT_PIN])
+    cg.add(var.set_data_out_pin(data_out_pin))
+    data_in_pin = await cg.gpio_pin_expression(config[CONF_DATA_IN_PIN])
+    cg.add(var.set_data_in_pin(data_in_pin))
+    clock_pin = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
+    cg.add(var.set_clock_pin(clock_pin))
+    inh_latch_pin = await cg.gpio_pin_expression(config[CONF_INH_LATCH_PIN])
+    cg.add(var.set_inh_latch_pin(inh_latch_pin))
+    oe_pin = await cg.gpio_pin_expression(config[CONF_LOAD_OE_PIN])
+    cg.add(var.set_load_oe_pin(oe_pin))
+    cg.add(var.set_sr_count(config[CONF_SR_COUNT]))
+
+
+def _validate_output_mode(value):
+    return True
+
+
+SN74HC595_PIN_SCHEMA = cv.All(
+    {
+        cv.GenerateID(): cv.declare_id(HybridShiftGPIOPin),
+        cv.Required(CONF_HYBRIDSHIFTREG): cv.use_id(HybridShiftComponent),
+        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=2048, max_included=False),
+        cv.Optional(CONF_ALLOW_OTHER_USES, default=True): cv.boolean,
+        cv.Optional(CONF_MODE, default={}): cv.All(
+            {
+                cv.Optional(CONF_OUTPUT, default=True): cv.All(
+                    cv.boolean, _validate_output_mode
+                ),
+                cv.Optional(CONF_INPUT, default=False): cv.All(
+                    cv.boolean, _validate_output_mode
+                ),
+            },
+        ),
+        cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+    }
+)
+
+
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_HYBRIDSHIFTREG, SN74HC595_PIN_SCHEMA)
+async def hybridshift_pin_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_parented(var, config[CONF_HYBRIDSHIFTREG])
+
+    cg.add(var.set_pin(config[CONF_NUMBER]))
+    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    return var

--- a/esphome/components/hybridshiftreg/hybridshiftreg.cpp
+++ b/esphome/components/hybridshiftreg/hybridshiftreg.cpp
@@ -1,0 +1,83 @@
+#include "hybridshiftreg.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace hybridshiftreg {
+
+static const char *const TAG = "hybridshiftreg";
+
+void HybridShiftComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up HybridShiftRegister...");
+
+  this->load_oe_pin_->setup();
+  this->load_oe_pin_->digital_write(true);
+
+  // initialize output pins
+  this->clock_pin_->setup();
+  this->data_out_pin_->setup();
+  this->data_in_pin_->setup();
+  this->inh_latch_pin_->setup();
+  this->clock_pin_->digital_write(false);
+  this->data_out_pin_->digital_write(false);
+  this->inh_latch_pin_->digital_write(false);
+
+  // send state to shift register
+  this->read_write_gpio_();
+}
+
+void HybridShiftComponent::dump_config() { ESP_LOGCONFIG(TAG, "HybridShiftRegister:"); }
+
+void HybridShiftComponent::digital_write_(uint16_t pin, bool value) {
+  if (pin >= this->sr_count_ * 8) {
+    ESP_LOGE(TAG, "Pin %u is out of range! Maximum pin number with %u chips in series is %u", pin, this->sr_count_,
+             (this->sr_count_ * 8) - 1);
+    return;
+  }
+  this->output_bits_[pin] = value;
+}
+
+bool HybridShiftComponent::digital_read_(uint16_t pin) {
+  if (pin >= this->sr_count_ * 8) {
+    ESP_LOGE(TAG, "Pin %u is out of range! Maximum pin number with %u chips in series is %u", pin, this->sr_count_,
+             (this->sr_count_ * 8) - 1);
+    return false;
+  }
+  return this->input_bits_[pin];
+}
+
+void HybridShiftComponent::loop() { this->read_write_gpio_(); }
+
+void HybridShiftComponent::read_write_gpio_() {
+  for (uint8_t i = 0; i < this->sr_count_; i++) {
+    for (uint8_t j = 0; j < 8; j++) {
+      this->data_out_pin_->digital_write(output_bits_[(i * 8) + (7 - j)]);
+      this->input_bits_[(i * 8) + (7 - j)] = this->data_in_pin_->digital_read();
+
+      this->clock_pin_->digital_write(true);
+      delayMicroseconds(10);
+      this->clock_pin_->digital_write(false);
+      delayMicroseconds(10);
+    }
+  }
+
+  // pulse latch to activate new values
+  this->inh_latch_pin_->digital_write(true);
+  this->inh_latch_pin_->digital_write(false);
+
+  this->load_oe_pin_->digital_write(false);
+}
+
+float HybridShiftComponent::get_setup_priority() const { return setup_priority::IO; }
+
+void HybridShiftGPIOPin::digital_write(bool value) {
+  this->parent_->digital_write_(this->pin_, value != this->inverted_);
+}
+bool HybridShiftGPIOPin::digital_read() { return this->parent_->digital_read_(this->pin_) != this->inverted_; }
+std::string HybridShiftGPIOPin::dump_summary() const {
+  char buffer[32];
+  snprintf(buffer, sizeof(buffer), "%u via HybridShiftReg", pin_);
+  return buffer;
+}
+
+}  // namespace hybridshiftreg
+}  // namespace esphome

--- a/esphome/components/hybridshiftreg/hybridshiftreg.h
+++ b/esphome/components/hybridshiftreg/hybridshiftreg.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+
+#include <vector>
+
+namespace esphome {
+namespace hybridshiftreg {
+
+class HybridShiftComponent : public Component {
+ public:
+  HybridShiftComponent() = default;
+
+  void setup() override;
+  void loop() override;
+  float get_setup_priority() const override;
+  void dump_config() override;
+
+  void set_data_out_pin(GPIOPin *pin) { data_out_pin_ = pin; }
+  void set_data_in_pin(GPIOPin *pin) { data_in_pin_ = pin; }
+  void set_clock_pin(GPIOPin *pin) { clock_pin_ = pin; }
+  void set_inh_latch_pin(GPIOPin *pin) { inh_latch_pin_ = pin; }
+  void set_load_oe_pin(GPIOPin *pin) { load_oe_pin_ = pin; }
+  void set_sr_count(uint8_t count) {
+    sr_count_ = count;
+    this->output_bits_.resize(count * 8);
+    this->input_bits_.resize(count * 8);
+  }
+
+ protected:
+  friend class HybridShiftGPIOPin;
+  void digital_write_(uint16_t pin, bool value);
+  bool digital_read_(uint16_t pin);
+  void read_write_gpio_();
+
+  GPIOPin *data_out_pin_;
+  GPIOPin *data_in_pin_;
+  GPIOPin *clock_pin_;
+  GPIOPin *inh_latch_pin_;
+  GPIOPin *load_oe_pin_;
+  uint8_t sr_count_;
+  std::vector<bool> output_bits_;
+  std::vector<bool> input_bits_;
+};
+
+/// Helper class to expose a HybridShiftRegister pin as an internal input/output GPIO pin.
+class HybridShiftGPIOPin : public GPIOPin, public Parented<HybridShiftComponent> {
+ public:
+  void setup() override {}
+  void pin_mode(gpio::Flags flags) override {}
+  bool digital_read() override;
+  void digital_write(bool value) override;
+  std::string dump_summary() const override;
+
+  void set_pin(uint16_t pin) { pin_ = pin; }
+  void set_inverted(bool inverted) { inverted_ = inverted; }
+
+ protected:
+  uint16_t pin_;
+  bool inverted_;
+};
+
+}  // namespace hybridshiftreg
+}  // namespace esphome

--- a/tests/components/hybridshiftreg/test.esp32-ard.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-ard.yaml
@@ -3,7 +3,7 @@ hybridshiftreg:
   data_out_pin: 13
   data_in_pin: 16
   clock_pin: 14
-  inh_latch_pin: 15
+  inh_latch_pin: 12
   load_oe_pin: 32
   sr_count: 1
 

--- a/tests/components/hybridshiftreg/test.esp32-ard.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-ard.yaml
@@ -1,0 +1,15 @@
+hybridshiftreg:
+  id: hybridshiftreg_hub
+  data_out_pin: 13
+  data_in_pin: 16
+  clock_pin: 14
+  inh_latch_pin: 15
+  load_oe_pin: 32
+  sr_count: 1
+
+binary_sensor:
+  - platform: gpio
+    id: hybridshiftreg_pin_0
+    pin:
+      hybridshiftreg: hybridshiftreg_hub
+      number: 0

--- a/tests/components/hybridshiftreg/test.esp32-c3-ard.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-c3-ard.yaml
@@ -3,7 +3,7 @@ hybridshiftreg:
   data_out_pin: 13
   data_in_pin: 16
   clock_pin: 14
-  inh_latch_pin: 15
+  inh_latch_pin: 12
   load_oe_pin: 32
   sr_count: 1
 

--- a/tests/components/hybridshiftreg/test.esp32-c3-ard.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-c3-ard.yaml
@@ -1,0 +1,15 @@
+hybridshiftreg:
+  id: hybridshiftreg_hub
+  data_out_pin: 13
+  data_in_pin: 16
+  clock_pin: 14
+  inh_latch_pin: 15
+  load_oe_pin: 32
+  sr_count: 1
+
+binary_sensor:
+  - platform: gpio
+    id: hybridshiftreg_pin_0
+    pin:
+      hybridshiftreg: hybridshiftreg_hub
+      number: 0

--- a/tests/components/hybridshiftreg/test.esp32-c3-idf.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-c3-idf.yaml
@@ -3,7 +3,7 @@ hybridshiftreg:
   data_out_pin: 13
   data_in_pin: 16
   clock_pin: 14
-  inh_latch_pin: 15
+  inh_latch_pin: 12
   load_oe_pin: 32
   sr_count: 1
 

--- a/tests/components/hybridshiftreg/test.esp32-c3-idf.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-c3-idf.yaml
@@ -1,0 +1,15 @@
+hybridshiftreg:
+  id: hybridshiftreg_hub
+  data_out_pin: 13
+  data_in_pin: 16
+  clock_pin: 14
+  inh_latch_pin: 15
+  load_oe_pin: 32
+  sr_count: 1
+
+binary_sensor:
+  - platform: gpio
+    id: hybridshiftreg_pin_0
+    pin:
+      hybridshiftreg: hybridshiftreg_hub
+      number: 0

--- a/tests/components/hybridshiftreg/test.esp32-idf.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-idf.yaml
@@ -3,7 +3,7 @@ hybridshiftreg:
   data_out_pin: 13
   data_in_pin: 16
   clock_pin: 14
-  inh_latch_pin: 15
+  inh_latch_pin: 12
   load_oe_pin: 32
   sr_count: 1
 

--- a/tests/components/hybridshiftreg/test.esp32-idf.yaml
+++ b/tests/components/hybridshiftreg/test.esp32-idf.yaml
@@ -1,0 +1,15 @@
+hybridshiftreg:
+  id: hybridshiftreg_hub
+  data_out_pin: 13
+  data_in_pin: 16
+  clock_pin: 14
+  inh_latch_pin: 15
+  load_oe_pin: 32
+  sr_count: 1
+
+binary_sensor:
+  - platform: gpio
+    id: hybridshiftreg_pin_0
+    pin:
+      hybridshiftreg: hybridshiftreg_hub
+      number: 0

--- a/tests/components/hybridshiftreg/test.esp8266-ard.yaml
+++ b/tests/components/hybridshiftreg/test.esp8266-ard.yaml
@@ -3,7 +3,7 @@ hybridshiftreg:
   data_out_pin: 13
   data_in_pin: 16
   clock_pin: 14
-  inh_latch_pin: 15
+  inh_latch_pin: 12
   load_oe_pin: 32
   sr_count: 1
 

--- a/tests/components/hybridshiftreg/test.esp8266-ard.yaml
+++ b/tests/components/hybridshiftreg/test.esp8266-ard.yaml
@@ -1,0 +1,15 @@
+hybridshiftreg:
+  id: hybridshiftreg_hub
+  data_out_pin: 13
+  data_in_pin: 16
+  clock_pin: 14
+  inh_latch_pin: 15
+  load_oe_pin: 32
+  sr_count: 1
+
+binary_sensor:
+  - platform: gpio
+    id: hybridshiftreg_pin_0
+    pin:
+      hybridshiftreg: hybridshiftreg_hub
+      number: 0

--- a/tests/components/hybridshiftreg/test.rp2040-ard.yaml
+++ b/tests/components/hybridshiftreg/test.rp2040-ard.yaml
@@ -3,7 +3,7 @@ hybridshiftreg:
   data_out_pin: 13
   data_in_pin: 16
   clock_pin: 14
-  inh_latch_pin: 15
+  inh_latch_pin: 12
   load_oe_pin: 32
   sr_count: 1
 

--- a/tests/components/hybridshiftreg/test.rp2040-ard.yaml
+++ b/tests/components/hybridshiftreg/test.rp2040-ard.yaml
@@ -1,0 +1,15 @@
+hybridshiftreg:
+  id: hybridshiftreg_hub
+  data_out_pin: 13
+  data_in_pin: 16
+  clock_pin: 14
+  inh_latch_pin: 15
+  load_oe_pin: 32
+  sr_count: 1
+
+binary_sensor:
+  - platform: gpio
+    id: hybridshiftreg_pin_0
+    pin:
+      hybridshiftreg: hybridshiftreg_hub
+      number: 0


### PR DESCRIPTION
Hybrid Shift Register compnent is a combination of SN74HC565 and SN74HC165 Components providing I/O operation.

# What does this implement/fix?
This component i wrote to add support of some Chinese ESP32 boards. I've got dtWonder 8 Channel relay board which also has 8 Inputs.
Interesting thing is how Chinese team solved issue with lack of GPIO pins. They used typical shift registers, but connected
together in a "mixed mode". And this PR adds this variation to ESPHome.

What is "mixed mode"? Mixed mode is a combination of SN74HC565 and SN74HC165, which are sharing most of its pins.
It uses both type shift registers, but all pins except serial data pins are connected together to save GPIOs: 
- SH/LD  on 165  and OE on 565
- CLK INH on 165 and RCLK on 565
- CLK on 165 and SCLK on 565

In this mode Q7 and SER pins needs to be connected separately, so using only 5 pins we're able to provide full Input and Output for max of 1024 pins.

## Types of changes

- [  ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [  ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

Not yet done, but i will create one if we initially accept to add this to core.

## Test Environment

- [X] ESP32
- [  ] ESP32 IDF
- [  ] ESP8266
- [  ] RP2040

## Example entry for `config.yaml`:
```yaml
hybridshiftreg:
  - id: 'hybridshiftreg_hub'
    data_out_pin: GPIO13
    data_in_pin: GPIO16
    clock_pin: GPIO14
    inh_latch_pin: GPIO15
    load_oe_pin: GPIO32
    sr_count: 1
binary_sensor:
  - platform: gpio
    name: "SN74HC165 Pin #0"
    pin:
      hybridshiftreg: hybridshiftreg_hub
      # Use pin number 0
      number: 0
      inverted: false
   ....
  - platform: gpio
    name: "SN74HC165 Pin #8"
    pin:
      hybridshiftreg: hybridshiftreg_hub
      # Use pin number 8
      number: 8
      inverted: false
switch:
  - platform: gpio
    name: "SN74HC595 Pin #0"
    pin:
      hybridshiftreg: hybridshiftreg_hub
      # Use pin number 0
      number: 0
      inverted: false
   ...
  - platform: gpio
    name: "SN74HC595 Pin #8"
    pin:
      hybridshiftreg: hybridshiftreg_hub
      # Use pin number 0
      number: 8
      inverted: false

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [  ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
