### PR TITLE
Implement deep sleep and clear screen on Waveshare 7.5in B V3

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1329,9 +1329,7 @@ void WaveshareEPaper7P5InBV2::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-void WaveshareEPaper7P5InBV3::initialize() {
-  this->init_display_();
-}
+void WaveshareEPaper7P5InBV3::initialize() { this->init_display_(); }
 bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
   if (this->busy_pin_ == nullptr) {
     return true;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1331,7 +1331,7 @@ void WaveshareEPaper7P5InBV2::dump_config() {
 
 void WaveshareEPaper7P5InBV3::initialize() {
   this->init_internal_();
-  this->clear();
+  this->clear_screen();
 }
 bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
   if (this->busy_pin_ == nullptr) {
@@ -1472,22 +1472,24 @@ void HOT WaveshareEPaper7P5InBV3::display() {
   this->wait_until_idle_();
   this->deep_sleep();
 }
-void WaveshareEPaper7P5InBV3::clear() {
-  uint32_t pixsize = this->get_buffer_length_();
-  this->command(0x10);
-  delay(2);
-  for (int count = 0; count < pixsize; count++) {
-    this->data(0x00);
-  }
+void WaveshareEPaper7P5InBV3::clear_screen() {
+  this->clear();
+  this->display();
+  // uint32_t pixsize = this->get_buffer_length_();
+  // this->command(0x10);
+  // delay(2);
+  // for (int count = 0; count < pixsize; count++) {
+  //   this->data(0x00);
+  // }
 
-  this->command(0x13);
-  delay(2);
-  for (int count = 0; count < pixsize; count++) {
-    this->data(0x00);
-  }
+  // this->command(0x13);
+  // delay(2);
+  // for (int count = 0; count < pixsize; count++) {
+  //   this->data(0x00);
+  // }
 
-  this->command(0x12);
-  delay(100);  // NOLINT
+  // this->command(0x12);
+  // delay(100);  // NOLINT
 }
 int WaveshareEPaper7P5InBV3::get_width_internal() { return 800; }
 int WaveshareEPaper7P5InBV3::get_height_internal() { return 480; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1473,7 +1473,7 @@ void HOT WaveshareEPaper7P5InBV3::display() {
   this->deep_sleep();
 }
 void WaveshareEPaper7P5InBV3::clear_screen() {
-  this->clear();
+  this->fill(Color::WHITE);
   this->display();
 }
 int WaveshareEPaper7P5InBV3::get_width_internal() { return 800; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1487,7 +1487,7 @@ void WaveshareEPaper7P5InBV3::clear() {
   }
 
   this->command(0x12);
-  delay(100);
+  delay(100);  // NOLINT
 }
 int WaveshareEPaper7P5InBV3::get_width_internal() { return 800; }
 int WaveshareEPaper7P5InBV3::get_height_internal() { return 480; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1331,7 +1331,6 @@ void WaveshareEPaper7P5InBV2::dump_config() {
 
 void WaveshareEPaper7P5InBV3::initialize() {
   this->init_display_();
-  this->clear_screen();
 }
 bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
   if (this->busy_pin_ == nullptr) {
@@ -1345,6 +1344,7 @@ bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
       ESP_LOGI(TAG, "Timeout while displaying image!");
       return false;
     }
+    App.feed_wdt();
     delay(10);
   }
   delay(200);  // NOLINT
@@ -1471,10 +1471,6 @@ void HOT WaveshareEPaper7P5InBV3::display() {
   delay(100);           // NOLINT
   this->wait_until_idle_();
   this->deep_sleep();
-}
-void WaveshareEPaper7P5InBV3::clear_screen() {
-  this->fill(Color::WHITE);
-  this->display();
 }
 int WaveshareEPaper7P5InBV3::get_width_internal() { return 800; }
 int WaveshareEPaper7P5InBV3::get_height_internal() { return 480; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1475,21 +1475,6 @@ void HOT WaveshareEPaper7P5InBV3::display() {
 void WaveshareEPaper7P5InBV3::clear_screen() {
   this->clear();
   this->display();
-  // uint32_t pixsize = this->get_buffer_length_();
-  // this->command(0x10);
-  // delay(2);
-  // for (int count = 0; count < pixsize; count++) {
-  //   this->data(0x00);
-  // }
-
-  // this->command(0x13);
-  // delay(2);
-  // for (int count = 0; count < pixsize; count++) {
-  //   this->data(0x00);
-  // }
-
-  // this->command(0x12);
-  // delay(100);  // NOLINT
 }
 int WaveshareEPaper7P5InBV3::get_width_internal() { return 800; }
 int WaveshareEPaper7P5InBV3::get_height_internal() { return 480; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1464,7 +1464,7 @@ void HOT WaveshareEPaper7P5InBV3::display() {
   this->command(0x13);  // Start Transmission
   delay(2);
   for (uint32_t i = 0; i < buf_len; i++) {
-    this->data(~(this->buffer_[i]));
+    this->data(this->buffer_[i]);
   }
 
   this->command(0x12);  // Display Refresh

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1330,7 +1330,7 @@ void WaveshareEPaper7P5InBV2::dump_config() {
 }
 
 void WaveshareEPaper7P5InBV3::initialize() {
-  this->init_internal_();
+  this->init_display_();
   this->clear_screen();
 }
 bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
@@ -1350,7 +1350,7 @@ bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
   delay(200);  // NOLINT
   return true;
 };
-void WaveshareEPaper7P5InBV3::init_internal_() {
+void WaveshareEPaper7P5InBV3::init_display_() {
   this->reset_();
 
   // COMMAND POWER SETTING
@@ -1453,7 +1453,7 @@ void WaveshareEPaper7P5InBV3::init_internal_() {
     this->data(lut_bb_7_i_n5_v2[count]);
 };
 void HOT WaveshareEPaper7P5InBV3::display() {
-  this->init_internal_();
+  this->init_display_();
   uint32_t buf_len = this->get_buffer_length_();
 
   this->command(0x10);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1457,7 +1457,7 @@ void HOT WaveshareEPaper7P5InBV3::display() {
   uint32_t buf_len = this->get_buffer_length_();
 
   this->command(0x10);
-  for (uint32_t i = 0; i < 800 * 480 / 8; i++) {
+  for (uint32_t i = 0; i < buf_len; i++) {
     this->data(0xFF);
   }
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1329,6 +1329,10 @@ void WaveshareEPaper7P5InBV2::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
+void WaveshareEPaper7P5InBV3::initialize() {
+  this->init_internal_();
+  this->clear();
+}
 bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
   if (this->busy_pin_ == nullptr) {
     return true;
@@ -1346,7 +1350,7 @@ bool WaveshareEPaper7P5InBV3::wait_until_idle_() {
   delay(200);  // NOLINT
   return true;
 };
-void WaveshareEPaper7P5InBV3::initialize() {
+void WaveshareEPaper7P5InBV3::init_internal_() {
   this->reset_();
 
   // COMMAND POWER SETTING
@@ -1402,8 +1406,6 @@ void WaveshareEPaper7P5InBV3::initialize() {
   this->data(0x00);
   this->data(0x00);
 
-  this->wait_until_idle_();
-
   uint8_t lut_vcom_7_i_n5_v2[] = {
       0x0, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0xF, 0x1, 0xF, 0x1, 0x2, 0x0, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
       0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
@@ -1449,14 +1451,15 @@ void WaveshareEPaper7P5InBV3::initialize() {
   this->command(0x24);  // LUTBB
   for (count = 0; count < 42; count++)
     this->data(lut_bb_7_i_n5_v2[count]);
+};
+void HOT WaveshareEPaper7P5InBV3::display() {
+  this->init_internal_();
+  uint32_t buf_len = this->get_buffer_length_();
 
   this->command(0x10);
   for (uint32_t i = 0; i < 800 * 480 / 8; i++) {
     this->data(0xFF);
   }
-};
-void HOT WaveshareEPaper7P5InBV3::display() {
-  uint32_t buf_len = this->get_buffer_length_();
 
   this->command(0x13);  // Start Transmission
   delay(2);
@@ -1467,6 +1470,24 @@ void HOT WaveshareEPaper7P5InBV3::display() {
   this->command(0x12);  // Display Refresh
   delay(100);           // NOLINT
   this->wait_until_idle_();
+  this->deep_sleep();
+}
+void WaveshareEPaper7P5InBV3::clear() {
+  uint32_t pixsize = this->get_buffer_length_();
+  this->command(0x10);
+  delay(2);
+  for (int count = 0; count < pixsize; count++) {
+    this->data(0x00);
+  }
+
+  this->command(0x13);
+  delay(2);
+  for (int count = 0; count < pixsize; count++) {
+    this->data(0x00);
+  }
+
+  this->command(0x12);
+  delay(100);
 }
 int WaveshareEPaper7P5InBV3::get_width_internal() { return 800; }
 int WaveshareEPaper7P5InBV3::get_height_internal() { return 480; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -448,8 +448,8 @@ class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
     }
   };
 
-  private:
-   void init_internal_();
+ private:
+  void init_internal_();
 };
 
 class WaveshareEPaper7P5InBC : public WaveshareEPaper {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -448,8 +448,7 @@ class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
     }
   };
 
- private:
-  void init_internal_();
+  void init_display_();
 };
 
 class WaveshareEPaper7P5InBC : public WaveshareEPaper {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -430,7 +430,7 @@ class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
     this->data(0xA5);
   }
 
-  void clear();
+  void clear_screen();
 
  protected:
   int get_width_internal() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -430,6 +430,8 @@ class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
     this->data(0xA5);
   }
 
+  void clear();
+
  protected:
   int get_width_internal() override;
 
@@ -445,6 +447,9 @@ class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
       delay(200);  // NOLINT
     }
   };
+
+  private:
+   void init_internal_();
 };
 
 class WaveshareEPaper7P5InBC : public WaveshareEPaper {


### PR DESCRIPTION
# What does this implement/fix?

As stated on [issue 4739](https://github.com/esphome/issues/issues/4739), some of the components used to handle the communication with waveshare displays are leaving the screen always on a high power state.

As stated on the "precautions" section of the [official manufacturer documentation](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT_(B)_Manual#Precautions), and in the [Waveshare 7.5in B Datasheet (p. 35)](https://www.waveshare.com/w/upload/8/8c/7.5inch-e-paper-b-v3-specification.pdf), a normal operation should not leave the screen powered on after an update.

This PR implements a "turn off/deep sleep" command after the screen is updated along with a "reset/turn on" command used whenever the display needs to be refreshed.

Also implemented a `clear_screen()` method that clears the screen on initialization and may be used to clear the screen before storage, as recommended by the manufacturer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes [4739](https://github.com/esphome/issues/issues/4739) on 7.5 in [Waveshare V3 "B" model](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT_(B)_Manual#Introduction)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not Applicable

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
button:
  - platform: template
    name: "Clear Screen"
    on_press:
      - lambda: id(epaper).clear_screen();

font:
  - file:
      type: gfonts
      family: Inter
      weight: 900
    id: font_main_title
    size: 24

spi:
  clk_pin: 13
  mosi_pin: 14
  id: epaper_display

display:
  - platform: waveshare_epaper
    id: epaper
    cs_pin: 15
    dc_pin: 27
    busy_pin: 25
    reset_pin: 26
    model: 7.50in-bV3
    update_interval: 30s
    reset_duration: 2ms
    rotation: 90°
    lambda: |-
      it.filled_circle(240, 200, 50);
      it.print(240, 400, id(font_main_title), TextAlign::CENTER, "HELLO WORLD!");
      it.filled_circle(240, 600, 50);
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
