### PR TITLE
Fix 24 bit signed integer parsing in sml parser

### DIFF
--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -88,6 +88,12 @@ uint64_t bytes_to_uint(const bytes &buffer) {
   for (auto const value : buffer) {
     val = (val << 8) + value;
   }
+  // Some smart meters send 24 bit signed integers. Sign extend to 64 bit if the 
+  // 24 bit value is negative.
+  if (buffer.size() == 3 && buffer[0] & 0x80)
+  {
+    val |= 0xFFFFFFFFFF000000;
+  }
   return val;
 }
 

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -88,10 +88,9 @@ uint64_t bytes_to_uint(const bytes &buffer) {
   for (auto const value : buffer) {
     val = (val << 8) + value;
   }
-  // Some smart meters send 24 bit signed integers. Sign extend to 64 bit if the 
+  // Some smart meters send 24 bit signed integers. Sign extend to 64 bit if the
   // 24 bit value is negative.
-  if (buffer.size() == 3 && buffer[0] & 0x80)
-  {
+  if (buffer.size() == 3 && buffer[0] & 0x80) {
     val |= 0xFFFFFFFFFF000000;
   }
   return val;


### PR DESCRIPTION
# What does this implement/fix?
It fixes the issue reported https://github.com/esphome/issues/issues/4494 here and which I observed in my setup as well.

The issue is caused by a smart meter sending a 24 bit signed integer value. As the bytes_to_int function only handles 8/16/32/64 bit values, it will default to 64 bits if presented with a 24 bit signed value. Without proper sign extension, this will be interpreted as a (very large) positive number. The bytes_to_uint function was modified to detect if the input is a 24 bit negative integer which is than converted and a proper sign extension to a 64 bit integer is performed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4494

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
