### PR TITLE
Add manufacturer data config to BLE server

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -87,7 +87,7 @@ esphome/components/ens210/* @itn3rd77
 esphome/components/esp32/* @esphome/core
 esphome/components/esp32_ble/* @jesserockz
 esphome/components/esp32_ble_client/* @jesserockz
-esphome/components/esp32_ble_server/* @jesserockz
+esphome/components/esp32_ble_server/* @clydebarrow @jesserockz
 esphome/components/esp32_camera_web_server/* @ayufan
 esphome/components/esp32_can/* @Sympatron
 esphome/components/esp32_improv/* @jesserockz

--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -43,7 +43,7 @@ void BLEAdvertising::remove_service_uuid(ESPBTUUID uuid) {
 }
 
 void BLEAdvertising::set_manufacturer_data(const std::vector<uint8_t> &data) {
-  if(this->advertising_data_.p_manufacturer_data != nullptr)
+  if (this->advertising_data_.p_manufacturer_data != nullptr)
     delete[] this->advertising_data_.p_manufacturer_data;
   this->advertising_data_.manufacturer_len = data.size();
   if (data.size() == 0)
@@ -87,7 +87,7 @@ void BLEAdvertising::start() {
     this->scan_response_data_.set_scan_rsp = true;
     this->scan_response_data_.include_name = true;
     this->scan_response_data_.include_txpower = true;
-    this->scan_response_data_.min_interval = 0;   // don't repeat this data
+    this->scan_response_data_.min_interval = 0;
     this->scan_response_data_.max_interval = 0;
     this->scan_response_data_.manufacturer_len = 0;
     this->scan_response_data_.appearance = 0;

--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -42,9 +42,17 @@ void BLEAdvertising::remove_service_uuid(ESPBTUUID uuid) {
                                  this->advertising_uuids_.end());
 }
 
-void BLEAdvertising::set_manufacturer_data(uint8_t *data, uint16_t size) {
-  this->advertising_data_.p_manufacturer_data = data;
-  this->advertising_data_.manufacturer_len = size;
+void BLEAdvertising::set_manufacturer_data(const std::vector<uint8_t> &data) {
+  if(this->advertising_data_.p_manufacturer_data != nullptr)
+    delete[] this->advertising_data_.p_manufacturer_data;
+  this->advertising_data_.manufacturer_len = data.size();
+  if (data.size() == 0)
+    this->advertising_data_.p_manufacturer_data = nullptr;
+  else {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    this->advertising_data_.p_manufacturer_data = new uint8_t[data.size()];
+    memcpy(this->advertising_data_.p_manufacturer_data, data.data(), data.size());
+  }
 }
 
 void BLEAdvertising::start() {
@@ -74,16 +82,21 @@ void BLEAdvertising::start() {
     return;
   }
 
-  memcpy(&this->scan_response_data_, &this->advertising_data_, sizeof(esp_ble_adv_data_t));
-  this->scan_response_data_.set_scan_rsp = true;
-  this->scan_response_data_.include_name = true;
-  this->scan_response_data_.include_txpower = true;
-  this->scan_response_data_.appearance = 0;
-  this->scan_response_data_.flag = 0;
-  err = esp_ble_gap_config_adv_data(&this->scan_response_data_);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_ble_gap_config_adv_data failed (Scan response): %d", err);
-    return;
+  if (this->scan_response_) {
+    memcpy(&this->scan_response_data_, &this->advertising_data_, sizeof(esp_ble_adv_data_t));
+    this->scan_response_data_.set_scan_rsp = true;
+    this->scan_response_data_.include_name = true;
+    this->scan_response_data_.include_txpower = true;
+    this->scan_response_data_.min_interval = 0;   // don't repeat this data
+    this->scan_response_data_.max_interval = 0;
+    this->scan_response_data_.manufacturer_len = 0;
+    this->scan_response_data_.appearance = 0;
+    this->scan_response_data_.flag = 0;
+    err = esp_ble_gap_config_adv_data(&this->scan_response_data_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_ble_gap_config_adv_data failed (Scan response): %d", err);
+      return;
+    }
   }
 
   if (this->advertising_data_.service_uuid_len > 0) {

--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -43,12 +43,10 @@ void BLEAdvertising::remove_service_uuid(ESPBTUUID uuid) {
 }
 
 void BLEAdvertising::set_manufacturer_data(const std::vector<uint8_t> &data) {
-  if (this->advertising_data_.p_manufacturer_data != nullptr)
-    delete[] this->advertising_data_.p_manufacturer_data;
+  delete[] this->advertising_data_.p_manufacturer_data;
+  this->advertising_data_.p_manufacturer_data = nullptr;
   this->advertising_data_.manufacturer_len = data.size();
-  if (data.size() == 0)
-    this->advertising_data_.p_manufacturer_data = nullptr;
-  else {
+  if (!data.empty()) {
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     this->advertising_data_.p_manufacturer_data = new uint8_t[data.size()];
     memcpy(this->advertising_data_.p_manufacturer_data, data.data(), data.size());

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -20,7 +20,7 @@ class BLEAdvertising {
   void remove_service_uuid(ESPBTUUID uuid);
   void set_scan_response(bool scan_response) { this->scan_response_ = scan_response; }
   void set_min_preferred_interval(uint16_t interval) { this->advertising_data_.min_interval = interval; }
-  void set_manufacturer_data(uint8_t *data, uint16_t size);
+  void set_manufacturer_data(const std::vector<uint8_t> &data);
 
   void start();
   void stop();

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -6,7 +6,7 @@ from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
 
 AUTO_LOAD = ["esp32_ble"]
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@clydebarrow"]
 CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["esp32"]
 
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(BLEServer),
         cv.GenerateID(esp32_ble.CONF_BLE_ID): cv.use_id(esp32_ble.ESP32BLE),
         cv.Optional(CONF_MANUFACTURER, default="ESPHome"): cv.string,
-        cv.Optional(CONF_MANUFACTURER_DATA): cv.ensure_list(cv.hex_uint8_t),
+        cv.Optional(CONF_MANUFACTURER_DATA): cv.Schema([cv.hex_uint8_t]),
         cv.Optional(CONF_MODEL): cv.string,
     }
 ).extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -11,6 +11,7 @@ CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["esp32"]
 
 CONF_MANUFACTURER = "manufacturer"
+CONF_MANUFACTURER_DATA = "manufacturer_data"
 
 esp32_ble_server_ns = cg.esphome_ns.namespace("esp32_ble_server")
 BLEServer = esp32_ble_server_ns.class_(
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(BLEServer),
         cv.GenerateID(esp32_ble.CONF_BLE_ID): cv.use_id(esp32_ble.ESP32BLE),
         cv.Optional(CONF_MANUFACTURER, default="ESPHome"): cv.string,
+        cv.Optional(CONF_MANUFACTURER_DATA): cv.ensure_list(cv.hex_uint8_t),
         cv.Optional(CONF_MODEL): cv.string,
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -42,6 +44,8 @@ async def to_code(config):
     cg.add(var.set_parent(parent))
 
     cg.add(var.set_manufacturer(config[CONF_MANUFACTURER]))
+    if CONF_MANUFACTURER_DATA in config:
+        cg.add(var.set_manufacturer_data(config[CONF_MANUFACTURER_DATA]))
     if CONF_MODEL in config:
         cg.add(var.set_model(config[CONF_MODEL]))
     cg.add_define("USE_ESP32_BLE_SERVER")

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -68,12 +68,20 @@ void BLEServer::loop() {
       if (this->device_information_service_->is_running()) {
         this->state_ = RUNNING;
         this->can_proceed_ = true;
+        this->restart_advertising_();
         ESP_LOGD(TAG, "BLE server setup successfully");
       } else if (!this->device_information_service_->is_starting()) {
         this->device_information_service_->start();
       }
       break;
     }
+  }
+}
+
+void BLEServer::restart_advertising_() {
+  if (this->state_ == RUNNING) {
+    esp32_ble::global_ble->get_advertising()->set_manufacturer_data(this->manufacturer_data_);
+    esp32_ble::global_ble->get_advertising()->start();
   }
 }
 

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -45,6 +45,9 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
 
   void set_manufacturer(const std::string &manufacturer) { this->manufacturer_ = manufacturer; }
   void set_model(const std::string &model) { this->model_ = model; }
+  void set_manufacturer_data(const std::vector<uint8_t> &data) {
+    esp32_ble::global_ble->get_advertising()->set_manufacturer_data(buffer.data, buffer.size());
+  }
 
   std::shared_ptr<BLEService> create_service(const uint8_t *uuid, bool advertise = false);
   std::shared_ptr<BLEService> create_service(uint16_t uuid, bool advertise = false);

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -46,7 +46,8 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
   void set_manufacturer(const std::string &manufacturer) { this->manufacturer_ = manufacturer; }
   void set_model(const std::string &model) { this->model_ = model; }
   void set_manufacturer_data(const std::vector<uint8_t> &data) {
-    esp32_ble::global_ble->get_advertising()->set_manufacturer_data(buffer.data, buffer.size());
+    this->manufacturer_data_ = data;
+    this->restart_advertising_();
   }
 
   std::shared_ptr<BLEService> create_service(const uint8_t *uuid, bool advertise = false);
@@ -66,6 +67,7 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
 
  protected:
   bool create_device_characteristics_();
+  void restart_advertising_();
 
   void add_client_(uint16_t conn_id, void *client) {
     this->clients_.insert(std::pair<uint16_t, void *>(conn_id, client));
@@ -76,6 +78,7 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
 
   std::string manufacturer_;
   optional<std::string> model_;
+  std::vector<uint8_t> manufacturer_data_;
   esp_gatt_if_t gatts_if_{0};
   bool registered_{false};
 

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -768,3 +768,8 @@ switch:
           characteristic_uuid: 6490FAFE-0734-732C-8705-91B653A081FC
           value: !lambda |-
             return {0x13, 0x37};
+
+
+esp32_ble_server:
+  id: ble
+  manufacturer_data: [0x72, 0x4, 0x00, 0x23]

--- a/tests/test6.yaml
+++ b/tests/test6.yaml
@@ -60,7 +60,3 @@ switch:
 sensor:
   - platform: internal_temperature
     name: Internal Temperature
-
-esp32_ble_server:
-  id: ble
-  manufacturer_data: [0x72, 0x4, 0x00, 0x23]

--- a/tests/test6.yaml
+++ b/tests/test6.yaml
@@ -60,3 +60,7 @@ switch:
 sensor:
   - platform: internal_temperature
     name: Internal Temperature
+
+esp32_ble_server:
+  id: ble
+  manufacturer_data: [0x72, 0x4, 0x00, 0x23]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

A new config item has been added to the `ble_server` component. This allows the manufacturer-specific data in an advertising packet to be specified.

In addition some changes have been made in the BLE code to remove duplicate data from the scan response packets.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3125

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esp32_ble_server:
  id: ble
  manufacturer_data: [0x72, 0x4, 0x00, 0x23]

time:
  - platform: sntp
    id: sntp_time
    on_time:
    - seconds: 0,30
      then:
        - lambda: |-
            uint32_t now = id(sntp_time).now().timestamp;
            uint8_t first = now & 0xFF;
            id(ble).set_manufacturer_data({ 0x72, 4, first});
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
