### PR TITLE
remote_base: change dumpers log level

### DIFF
--- a/esphome/components/remote_base/aeha_protocol.cpp
+++ b/esphome/components/remote_base/aeha_protocol.cpp
@@ -96,7 +96,7 @@ std::string AEHAProtocol::format_data_(const std::vector<uint8_t> &data) {
 
 void AEHAProtocol::dump(const AEHAData &data) {
   auto data_str = format_data_(data.data);
-  ESP_LOGD(TAG, "Received AEHA: address=0x%04X, data=[%s]", data.address, data_str.c_str());
+  ESP_LOGI(TAG, "Received AEHA: address=0x%04X, data=[%s]", data.address, data_str.c_str());
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/canalsat_protocol.cpp
+++ b/esphome/components/remote_base/canalsat_protocol.cpp
@@ -96,10 +96,10 @@ optional<CanalSatData> CanalSatBaseProtocol::decode(RemoteReceiveData src) {
 
 void CanalSatBaseProtocol::dump(const CanalSatData &data) {
   if (this->tag_ == CANALSATLD_TAG) {
-    ESP_LOGD(this->tag_, "Received CanalSatLD: device=0x%02X, address=0x%02X, command=0x%02X, repeat=0x%X", data.device,
+    ESP_LOGI(this->tag_, "Received CanalSatLD: device=0x%02X, address=0x%02X, command=0x%02X, repeat=0x%X", data.device,
              data.address, data.command, data.repeat);
   } else {
-    ESP_LOGD(this->tag_, "Received CanalSat: device=0x%02X, address=0x%02X, command=0x%02X, repeat=0x%X", data.device,
+    ESP_LOGI(this->tag_, "Received CanalSat: device=0x%02X, address=0x%02X, command=0x%02X, repeat=0x%X", data.device,
              data.address, data.command, data.repeat);
   }
 }

--- a/esphome/components/remote_base/coolix_protocol.cpp
+++ b/esphome/components/remote_base/coolix_protocol.cpp
@@ -101,11 +101,11 @@ optional<CoolixData> CoolixProtocol::decode(RemoteReceiveData data) {
 
 void CoolixProtocol::dump(const CoolixData &data) {
   if (data.is_strict()) {
-    ESP_LOGD(TAG, "Received Coolix: 0x%06X", data.first);
+    ESP_LOGI(TAG, "Received Coolix: 0x%06X", data.first);
   } else if (data.has_second()) {
-    ESP_LOGD(TAG, "Received unstrict Coolix: [0x%06X, 0x%06X]", data.first, data.second);
+    ESP_LOGI(TAG, "Received unstrict Coolix: [0x%06X, 0x%06X]", data.first, data.second);
   } else {
-    ESP_LOGD(TAG, "Received unstrict Coolix: [0x%06X]", data.first);
+    ESP_LOGI(TAG, "Received unstrict Coolix: [0x%06X]", data.first);
   }
 }
 

--- a/esphome/components/remote_base/dish_protocol.cpp
+++ b/esphome/components/remote_base/dish_protocol.cpp
@@ -87,7 +87,7 @@ optional<DishData> DishProtocol::decode(RemoteReceiveData src) {
 }
 
 void DishProtocol::dump(const DishData &data) {
-  ESP_LOGD(TAG, "Received Dish: address=0x%02X, command=0x%02X", data.address, data.command);
+  ESP_LOGI(TAG, "Received Dish: address=0x%02X, command=0x%02X", data.address, data.command);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -205,7 +205,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
   return out;
 }
 void DraytonProtocol::dump(const DraytonData &data) {
-  ESP_LOGD(TAG, "Received Drayton: address=0x%04X (0x%04x), channel=0x%03x command=0x%03X", data.address,
+  ESP_LOGI(TAG, "Received Drayton: address=0x%04X (0x%04x), channel=0x%03x command=0x%03X", data.address,
            ((data.address << 1) & 0xffff), data.channel, data.command);
 }
 

--- a/esphome/components/remote_base/jvc_protocol.cpp
+++ b/esphome/components/remote_base/jvc_protocol.cpp
@@ -46,7 +46,7 @@ optional<JVCData> JVCProtocol::decode(RemoteReceiveData src) {
   }
   return out;
 }
-void JVCProtocol::dump(const JVCData &data) { ESP_LOGD(TAG, "Received JVC: data=0x%04X", data.data); }
+void JVCProtocol::dump(const JVCData &data) { ESP_LOGI(TAG, "Received JVC: data=0x%04X", data.data); }
 
 }  // namespace remote_base
 }  // namespace esphome

--- a/esphome/components/remote_base/lg_protocol.cpp
+++ b/esphome/components/remote_base/lg_protocol.cpp
@@ -51,7 +51,7 @@ optional<LGData> LGProtocol::decode(RemoteReceiveData src) {
   return out;
 }
 void LGProtocol::dump(const LGData &data) {
-  ESP_LOGD(TAG, "Received LG: data=0x%08X, nbits=%d", data.data, data.nbits);
+  ESP_LOGI(TAG, "Received LG: data=0x%08X, nbits=%d", data.data, data.nbits);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/magiquest_protocol.cpp
+++ b/esphome/components/remote_base/magiquest_protocol.cpp
@@ -76,7 +76,7 @@ optional<MagiQuestData> MagiQuestProtocol::decode(RemoteReceiveData src) {
   return data;
 }
 void MagiQuestProtocol::dump(const MagiQuestData &data) {
-  ESP_LOGD(TAG, "Received MagiQuest: wand_id=0x%08X, magnitude=0x%04X", data.wand_id, data.magnitude);
+  ESP_LOGI(TAG, "Received MagiQuest: wand_id=0x%08X, magnitude=0x%04X", data.wand_id, data.magnitude);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/midea_protocol.cpp
+++ b/esphome/components/remote_base/midea_protocol.cpp
@@ -70,7 +70,7 @@ optional<MideaData> MideaProtocol::decode(RemoteReceiveData src) {
   return {};
 }
 
-void MideaProtocol::dump(const MideaData &data) { ESP_LOGD(TAG, "Received Midea: %s", data.to_string().c_str()); }
+void MideaProtocol::dump(const MideaData &data) { ESP_LOGI(TAG, "Received Midea: %s", data.to_string().c_str()); }
 
 }  // namespace remote_base
 }  // namespace esphome

--- a/esphome/components/remote_base/nec_protocol.cpp
+++ b/esphome/components/remote_base/nec_protocol.cpp
@@ -67,7 +67,7 @@ optional<NECData> NECProtocol::decode(RemoteReceiveData src) {
   return data;
 }
 void NECProtocol::dump(const NECData &data) {
-  ESP_LOGD(TAG, "Received NEC: address=0x%04X, command=0x%04X", data.address, data.command);
+  ESP_LOGI(TAG, "Received NEC: address=0x%04X, command=0x%04X", data.address, data.command);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/nexa_protocol.cpp
+++ b/esphome/components/remote_base/nexa_protocol.cpp
@@ -232,7 +232,7 @@ optional<NexaData> NexaProtocol::decode(RemoteReceiveData src) {
 }
 
 void NexaProtocol::dump(const NexaData &data) {
-  ESP_LOGD(TAG, "Received NEXA: device=0x%04X group=%d state=%d channel=%d level=%d", data.device, data.group,
+  ESP_LOGI(TAG, "Received NEXA: device=0x%04X group=%d state=%d channel=%d level=%d", data.device, data.group,
            data.state, data.channel, data.level);
 }
 

--- a/esphome/components/remote_base/panasonic_protocol.cpp
+++ b/esphome/components/remote_base/panasonic_protocol.cpp
@@ -67,7 +67,7 @@ optional<PanasonicData> PanasonicProtocol::decode(RemoteReceiveData src) {
   return out;
 }
 void PanasonicProtocol::dump(const PanasonicData &data) {
-  ESP_LOGD(TAG, "Received Panasonic: address=0x%04X, command=0x%08X", data.address, data.command);
+  ESP_LOGI(TAG, "Received Panasonic: address=0x%04X, command=0x%08X", data.address, data.command);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/pioneer_protocol.cpp
+++ b/esphome/components/remote_base/pioneer_protocol.cpp
@@ -146,9 +146,9 @@ optional<PioneerData> PioneerProtocol::decode(RemoteReceiveData src) {
 }
 void PioneerProtocol::dump(const PioneerData &data) {
   if (data.rc_code_2 == 0) {
-    ESP_LOGD(TAG, "Received Pioneer: rc_code_X=0x%04X", data.rc_code_1);
+    ESP_LOGI(TAG, "Received Pioneer: rc_code_X=0x%04X", data.rc_code_1);
   } else {
-    ESP_LOGD(TAG, "Received Pioneer: rc_code_1=0x%04X, rc_code_2=0x%04X", data.rc_code_1, data.rc_code_2);
+    ESP_LOGI(TAG, "Received Pioneer: rc_code_1=0x%04X, rc_code_2=0x%04X", data.rc_code_1, data.rc_code_2);
   }
 }
 

--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -234,9 +234,9 @@ void ProntoProtocol::dump(const ProntoData &data) {
     first = data.data.substr(0, 229);
     rest = data.data.substr(230);
   }
-  ESP_LOGD(TAG, "Received Pronto: data=%s", first.c_str());
+  ESP_LOGI(TAG, "Received Pronto: data=%s", first.c_str());
   if (!rest.empty()) {
-    ESP_LOGD(TAG, "%s", rest.c_str());
+    ESP_LOGI(TAG, "%s", rest.c_str());
   }
 }
 

--- a/esphome/components/remote_base/raw_protocol.cpp
+++ b/esphome/components/remote_base/raw_protocol.cpp
@@ -25,7 +25,7 @@ bool RawDumper::dump(RemoteReceiveData src) {
     if (written < 0 || written >= int(remaining_length)) {
       // write failed, flush...
       buffer[buffer_offset] = '\0';
-      ESP_LOGD(TAG, "%s", buffer);
+      ESP_LOGI(TAG, "%s", buffer);
       buffer_offset = 0;
       written = sprintf(buffer, "  ");
       if (i + 1 < src.size()) {
@@ -38,7 +38,7 @@ bool RawDumper::dump(RemoteReceiveData src) {
     buffer_offset += written;
   }
   if (buffer_offset != 0) {
-    ESP_LOGD(TAG, "%s", buffer);
+    ESP_LOGI(TAG, "%s", buffer);
   }
   return true;
 }

--- a/esphome/components/remote_base/rc5_protocol.cpp
+++ b/esphome/components/remote_base/rc5_protocol.cpp
@@ -83,7 +83,7 @@ optional<RC5Data> RC5Protocol::decode(RemoteReceiveData src) {
   return out;
 }
 void RC5Protocol::dump(const RC5Data &data) {
-  ESP_LOGD(TAG, "Received RC5: address=0x%02X, command=0x%02X", data.address, data.command);
+  ESP_LOGI(TAG, "Received RC5: address=0x%02X, command=0x%02X", data.address, data.command);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/rc6_protocol.cpp
+++ b/esphome/components/remote_base/rc6_protocol.cpp
@@ -173,7 +173,7 @@ optional<RC6Data> RC6Protocol::decode(RemoteReceiveData src) {
 }
 
 void RC6Protocol::dump(const RC6Data &data) {
-  ESP_LOGD(RC6_TAG, "Received RC6: mode=0x%X, address=0x%02X, command=0x%02X, toggle=0x%X", data.mode, data.address,
+  ESP_LOGI(RC6_TAG, "Received RC6: mode=0x%X, address=0x%02X, command=0x%02X, toggle=0x%X", data.mode, data.address,
            data.command, data.toggle);
 }
 

--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -258,7 +258,7 @@ bool RCSwitchDumper::dump(RemoteReceiveData src) {
         buffer[j] = (out_data & ((uint64_t) 1 << (out_nbits - j - 1))) ? '1' : '0';
 
       buffer[out_nbits] = '\0';
-      ESP_LOGD(TAG, "Received RCSwitch Raw: protocol=%u data='%s'", i, buffer);
+      ESP_LOGI(TAG, "Received RCSwitch Raw: protocol=%u data='%s'", i, buffer);
 
       // only send first decoded protocol
       return true;

--- a/esphome/components/remote_base/samsung36_protocol.cpp
+++ b/esphome/components/remote_base/samsung36_protocol.cpp
@@ -96,7 +96,7 @@ optional<Samsung36Data> Samsung36Protocol::decode(RemoteReceiveData src) {
   return out;
 }
 void Samsung36Protocol::dump(const Samsung36Data &data) {
-  ESP_LOGD(TAG, "Received Samsung36: address=0x%04X, command=0x%08X", data.address, data.command);
+  ESP_LOGI(TAG, "Received Samsung36: address=0x%04X, command=0x%08X", data.address, data.command);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/samsung_protocol.cpp
+++ b/esphome/components/remote_base/samsung_protocol.cpp
@@ -58,7 +58,7 @@ optional<SamsungData> SamsungProtocol::decode(RemoteReceiveData src) {
   return out;
 }
 void SamsungProtocol::dump(const SamsungData &data) {
-  ESP_LOGD(TAG, "Received Samsung: data=0x%" PRIX64 ", nbits=%d", data.data, data.nbits);
+  ESP_LOGI(TAG, "Received Samsung: data=0x%" PRIX64 ", nbits=%d", data.data, data.nbits);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/sony_protocol.cpp
+++ b/esphome/components/remote_base/sony_protocol.cpp
@@ -62,7 +62,7 @@ optional<SonyData> SonyProtocol::decode(RemoteReceiveData src) {
   return out;
 }
 void SonyProtocol::dump(const SonyData &data) {
-  ESP_LOGD(TAG, "Received Sony: data=0x%08X, nbits=%d", data.data, data.nbits);
+  ESP_LOGI(TAG, "Received Sony: data=0x%08X, nbits=%d", data.data, data.nbits);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/toshiba_ac_protocol.cpp
+++ b/esphome/components/remote_base/toshiba_ac_protocol.cpp
@@ -105,9 +105,9 @@ optional<ToshibaAcData> ToshibaAcProtocol::decode(RemoteReceiveData src) {
 
 void ToshibaAcProtocol::dump(const ToshibaAcData &data) {
   if (data.rc_code_2 != 0) {
-    ESP_LOGD(TAG, "Received Toshiba AC: rc_code_1=0x%" PRIX64 ", rc_code_2=0x%" PRIX64, data.rc_code_1, data.rc_code_2);
+    ESP_LOGI(TAG, "Received Toshiba AC: rc_code_1=0x%" PRIX64 ", rc_code_2=0x%" PRIX64, data.rc_code_1, data.rc_code_2);
   } else {
-    ESP_LOGD(TAG, "Received Toshiba AC: rc_code_1=0x%" PRIX64, data.rc_code_1);
+    ESP_LOGI(TAG, "Received Toshiba AC: rc_code_1=0x%" PRIX64, data.rc_code_1);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR lowers the logging level for dumpers, since logging is its job.

Causes:
1. If the user adds a `dumper` to his config, then he expects to see it in the log not only in `debug` mode.
2. Separates dumper logs from other debug information, including color.
3. Helps to remind the user to exclude dumpers from the config if the log level is downgraded to `INFO`. This will eliminate unnecessary decoding that does not result in any logging output.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
