### PR TITLE
Remove support for ESP-IDF version < 4

### DIFF
--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -12,12 +12,8 @@
 #include <esp_heap_caps.h>
 #include <esp_system.h>
 
-#if ESP_IDF_VERSION_MAJOR >= 4
 #include <esp32/rom/rtc.h>
 #include <esp_chip_info.h>
-#else
-#include <rom/rtc.h>
-#endif
 
 #endif  // USE_ESP32
 

--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -10,9 +10,7 @@
 #include <esp_timer.h>
 #include <soc/rtc.h>
 
-#if ESP_IDF_VERSION_MAJOR >= 4
 #include <hal/cpu_hal.h>
-#endif
 
 #ifdef USE_ARDUINO
 #include <esp32-hal.h>
@@ -55,15 +53,7 @@ void arch_init() {
 void IRAM_ATTR HOT arch_feed_wdt() { esp_task_wdt_reset(); }
 
 uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
-uint32_t arch_get_cpu_cycle_count() {
-#if ESP_IDF_VERSION_MAJOR >= 4
-  return cpu_hal_get_cycle_count();
-#else
-  uint32_t ccount;
-  __asm__ __volatile__("esync; rsr %0,ccount" : "=a"(ccount));
-  return ccount;
-#endif
-}
+uint32_t arch_get_cpu_cycle_count() { return cpu_hal_get_cycle_count(); }
 uint32_t arch_get_cpu_freq_hz() { return rtc_clk_apb_freq_get(); }
 
 #ifdef USE_ESP_IDF

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -8,11 +8,7 @@
 
 #include <vector>
 
-#if ESP_IDF_VERSION_MAJOR >= 4
 #include <driver/touch_sensor.h>
-#else
-#include <driver/touch_pad.h>
-#endif
 
 namespace esphome {
 namespace esp32_touch {

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -87,25 +87,7 @@ class BSDSocketImpl : public Socket {
   int listen(int backlog) override { return ::listen(fd_, backlog); }
   ssize_t read(void *buf, size_t len) override { return ::read(fd_, buf, len); }
   ssize_t readv(const struct iovec *iov, int iovcnt) override {
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR < 4
-    // esp-idf v3 doesn't have readv, emulate it
-    ssize_t ret = 0;
-    for (int i = 0; i < iovcnt; i++) {
-      ssize_t err = this->read(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len);
-      if (err == -1) {
-        if (ret != 0) {
-          // if we already read some don't return an error
-          break;
-        }
-        return err;
-      }
-      ret += err;
-      if (err != iov[i].iov_len)
-        break;
-    }
-    return ret;
-#elif defined(USE_ESP32)
-    // ESP-IDF v4 only has symbol lwip_readv
+#if defined(USE_ESP32)
     return ::lwip_readv(fd_, iov, iovcnt);
 #else
     return ::readv(fd_, iov, iovcnt);
@@ -114,26 +96,7 @@ class BSDSocketImpl : public Socket {
   ssize_t write(const void *buf, size_t len) override { return ::write(fd_, buf, len); }
   ssize_t send(void *buf, size_t len, int flags) { return ::send(fd_, buf, len, flags); }
   ssize_t writev(const struct iovec *iov, int iovcnt) override {
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR < 4
-    // esp-idf v3 doesn't have writev, emulate it
-    ssize_t ret = 0;
-    for (int i = 0; i < iovcnt; i++) {
-      ssize_t err =
-          this->send(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len, i == iovcnt - 1 ? 0 : MSG_MORE);
-      if (err == -1) {
-        if (ret != 0) {
-          // if we already wrote some don't return an error
-          break;
-        }
-        return err;
-      }
-      ret += err;
-      if (err != iov[i].iov_len)
-        break;
-    }
-    return ret;
-#elif defined(USE_ESP32)
-    // ESP-IDF v4 only has symbol lwip_writev
+#if defined(USE_ESP32)
     return ::lwip_writev(fd_, iov, iovcnt);
 #else
     return ::writev(fd_, iov, iovcnt);

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -324,11 +324,7 @@ class WiFiComponent : public Component {
 #endif
 
 #ifdef USE_ESP32_FRAMEWORK_ARDUINO
-#if ESP_IDF_VERSION_MAJOR >= 4
   void wifi_event_callback_(arduino_event_id_t event, arduino_event_info_t info);
-#else
-  void wifi_event_callback_(system_event_id_t event, system_event_info_t info);
-#endif
   void wifi_scan_done_callback_();
 #endif
 #ifdef USE_ESP_IDF

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -203,12 +203,10 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   // Units: AP beacon intervals. Defaults to 3 if set to 0.
   conf.sta.listen_interval = 0;
 
-#if ESP_IDF_VERSION_MAJOR >= 4
   // Protected Management Frame
   // Device will prefer to connect in PMF mode if other device also advertises PMF capability.
   conf.sta.pmf_cfg.capable = true;
   conf.sta.pmf_cfg.required = false;
-#endif
 
   // note, we do our own filtering
   // The minimum rssi to accept in the fast scan mode
@@ -314,11 +312,7 @@ const char *get_auth_mode_str(uint8_t mode) {
   }
 }
 
-#if ESP_IDF_VERSION_MAJOR >= 4
 using esphome_ip4_addr_t = esp_ip4_addr_t;
-#else
-using esphome_ip4_addr_t = ip4_addr_t;
-#endif
 
 std::string format_ip4_addr(const esphome_ip4_addr_t &ip) {
   char buf[20];
@@ -404,8 +398,6 @@ const char *get_disconnect_reason_str(uint8_t reason) {
   }
 }
 
-#if ESP_IDF_VERSION_MAJOR >= 4
-
 #define ESPHOME_EVENT_ID_WIFI_READY ARDUINO_EVENT_WIFI_READY
 #define ESPHOME_EVENT_ID_WIFI_SCAN_DONE ARDUINO_EVENT_WIFI_SCAN_DONE
 #define ESPHOME_EVENT_ID_WIFI_STA_START ARDUINO_EVENT_WIFI_STA_START
@@ -426,28 +418,6 @@ const char *get_disconnect_reason_str(uint8_t reason) {
 using esphome_wifi_event_id_t = arduino_event_id_t;
 using esphome_wifi_event_info_t = arduino_event_info_t;
 
-#else  // ESP_IDF_VERSION_MAJOR >= 4
-
-#define ESPHOME_EVENT_ID_WIFI_READY SYSTEM_EVENT_WIFI_READY
-#define ESPHOME_EVENT_ID_WIFI_SCAN_DONE SYSTEM_EVENT_SCAN_DONE
-#define ESPHOME_EVENT_ID_WIFI_STA_START SYSTEM_EVENT_STA_START
-#define ESPHOME_EVENT_ID_WIFI_STA_STOP SYSTEM_EVENT_STA_STOP
-#define ESPHOME_EVENT_ID_WIFI_STA_CONNECTED SYSTEM_EVENT_STA_CONNECTED
-#define ESPHOME_EVENT_ID_WIFI_STA_DISCONNECTED SYSTEM_EVENT_STA_DISCONNECTED
-#define ESPHOME_EVENT_ID_WIFI_STA_AUTHMODE_CHANGE SYSTEM_EVENT_STA_AUTHMODE_CHANGE
-#define ESPHOME_EVENT_ID_WIFI_STA_GOT_IP SYSTEM_EVENT_STA_GOT_IP
-#define ESPHOME_EVENT_ID_WIFI_STA_LOST_IP SYSTEM_EVENT_STA_LOST_IP
-#define ESPHOME_EVENT_ID_WIFI_AP_START SYSTEM_EVENT_AP_START
-#define ESPHOME_EVENT_ID_WIFI_AP_STOP SYSTEM_EVENT_AP_STOP
-#define ESPHOME_EVENT_ID_WIFI_AP_STACONNECTED SYSTEM_EVENT_AP_STACONNECTED
-#define ESPHOME_EVENT_ID_WIFI_AP_STADISCONNECTED SYSTEM_EVENT_AP_STADISCONNECTED
-#define ESPHOME_EVENT_ID_WIFI_AP_STAIPASSIGNED SYSTEM_EVENT_AP_STAIPASSIGNED
-#define ESPHOME_EVENT_ID_WIFI_AP_PROBEREQRECVED SYSTEM_EVENT_AP_PROBEREQRECVED
-using esphome_wifi_event_id_t = system_event_id_t;
-using esphome_wifi_event_info_t = system_event_info_t;
-
-#endif  // !(ESP_IDF_VERSION_MAJOR >= 4)
-
 void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_wifi_event_info_t info) {
   switch (event) {
     case ESPHOME_EVENT_ID_WIFI_READY: {
@@ -455,11 +425,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_SCAN_DONE: {
-#if ESP_IDF_VERSION_MAJOR >= 4
       auto it = info.wifi_scan_done;
-#else
-      auto it = info.scan_done;
-#endif
       ESP_LOGV(TAG, "Event: WiFi Scan Done status=%u number=%u scan_id=%u", it.status, it.number, it.scan_id);
 
       this->wifi_scan_done_callback_();
@@ -475,11 +441,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_CONNECTED: {
-#if ESP_IDF_VERSION_MAJOR >= 4
       auto it = info.wifi_sta_connected;
-#else
-      auto it = info.connected;
-#endif
       char buf[33];
       memcpy(buf, it.ssid, it.ssid_len);
       buf[it.ssid_len] = '\0';
@@ -492,11 +454,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_DISCONNECTED: {
-#if ESP_IDF_VERSION_MAJOR >= 4
       auto it = info.wifi_sta_disconnected;
-#else
-      auto it = info.disconnected;
-#endif
       char buf[33];
       memcpy(buf, it.ssid, it.ssid_len);
       buf[it.ssid_len] = '\0';
@@ -522,11 +480,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_AUTHMODE_CHANGE: {
-#if ESP_IDF_VERSION_MAJOR >= 4
       auto it = info.wifi_sta_authmode_change;
-#else
-      auto it = info.auth_change;
-#endif
       ESP_LOGV(TAG, "Event: Authmode Change old=%s new=%s", get_auth_mode_str(it.old_mode),
                get_auth_mode_str(it.new_mode));
       // Mitigate CVE-2020-12638
@@ -570,24 +524,14 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_AP_STACONNECTED: {
-#if ESP_IDF_VERSION_MAJOR >= 4
       auto it = info.wifi_sta_connected;
       auto &mac = it.bssid;
-#else
-      auto it = info.sta_connected;
-      auto &mac = it.mac;
-#endif
       ESP_LOGV(TAG, "Event: AP client connected MAC=%s", format_mac_addr(mac).c_str());
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_AP_STADISCONNECTED: {
-#if ESP_IDF_VERSION_MAJOR >= 4
       auto it = info.wifi_sta_disconnected;
       auto &mac = it.bssid;
-#else
-      auto it = info.sta_disconnected;
-      auto &mac = it.mac;
-#endif
       ESP_LOGV(TAG, "Event: AP client disconnected MAC=%s", format_mac_addr(mac).c_str());
       break;
     }
@@ -596,11 +540,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_AP_PROBEREQRECVED: {
-#if ESP_IDF_VERSION_MAJOR >= 4
       auto it = info.wifi_ap_probereqrecved;
-#else
-      auto it = info.ap_probereqrecved;
-#endif
       ESP_LOGVV(TAG, "Event: AP receive Probe Request MAC=%s RSSI=%d", format_mac_addr(it.mac).c_str(), it.rssi);
       break;
     }
@@ -742,10 +682,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
     strncpy(reinterpret_cast<char *>(conf.ap.password), ap.get_password().c_str(), sizeof(conf.ap.ssid));
   }
 
-#if ESP_IDF_VERSION_MAJOR >= 4
-  // pairwise cipher of SoftAP, group cipher will be derived using this.
   conf.ap.pairwise_cipher = WIFI_CIPHER_TYPE_CCMP;
-#endif
 
   esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &conf);
   if (err != ESP_OK) {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -312,12 +312,10 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   // Units: AP beacon intervals. Defaults to 3 if set to 0.
   conf.sta.listen_interval = 0;
 
-#if ESP_IDF_VERSION_MAJOR >= 4
   // Protected Management Frame
   // Device will prefer to connect in PMF mode if other device also advertises PMF capability.
   conf.sta.pmf_cfg.capable = true;
   conf.sta.pmf_cfg.required = false;
-#endif
 
   // note, we do our own filtering
   // The minimum rssi to accept in the fast scan mode
@@ -838,10 +836,8 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
     strncpy(reinterpret_cast<char *>(conf.ap.password), ap.get_password().c_str(), sizeof(conf.ap.password));
   }
 
-#if ESP_IDF_VERSION_MAJOR >= 4
   // pairwise cipher of SoftAP, group cipher will be derived using this.
   conf.ap.pairwise_cipher = WIFI_CIPHER_TYPE_CCMP;
-#endif
 
   esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &conf);
   if (err != ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF version 3.x is EOL and version 5 is around the corner, so there is no need for a version lower than 4.x

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
