### PR TITLE
Add `libfreetype-dev` Debian package for armv7 Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,8 @@ RUN \
           python3-dev=3.9.2-3 \
           zlib1g-dev=1:1.2.11.dfsg-2+deb11u2 \
           libjpeg-dev=1:2.0.6-4 \
-          libcairo2=1.16.0-5; \
+          libcairo2=1.16.0-5 \
+          libfreetype-dev=2.10.4+dfsg-1+deb11u1; \
     fi; \
     rm -rf \
         /tmp/* \


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds the `libfreetype-dev` Debian package to the ARMv7 Docker build. This is necessary so that truetype fonts can be  loaded.

In https://github.com/esphome/esphome/pull/5074, the `python-pil` Debian package was removed in favor of installing `pillow` from `requirements_optional.txt`. However, that led to a bug starting in https://github.com/esphome/esphome/releases/tag/2023.8.0b1 where users of the armv7 Docker build were unable to load truetype fonts and got the following error when attempting to compile the firmware:

```
ERROR Could not load truetype file /config/esphome/arial.ttf: cannot import name '_imagingft' from 'PIL' (/usr/local/lib/python3.9/dist-packages/PIL/init.py)
```

This can be fixed by installing the `libfreetype-dev` Debian package to the base Docker image.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4781

<!-- **Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> -->

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: "esphome"
  friendly_name: ESPHome

esp32:
  board: esp32dev
  framework:
    type: arduino

# Enable logging
logger:

# Enable Home Assistant API
api:

ota:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

captive_portal:

spi:
  clk_pin: GPIO18
  mosi_pin: GPIO19

display:
  - platform: st7789v
    model: TTGO TDisplay 135x240
    backlight_pin: GPIO4
    cs_pin: GPIO5
    dc_pin: GPIO16
    reset_pin: GPIO23
    update_interval: 1s
    lambda: |-
      it.print(0, 0, id(font1), "Hello World!");
      it.image(0, 50, id(my_image));

font:
  - file: "arial.ttf"
    id: font1
    size: 20

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
