### PR TITLE
2023.8.0b4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,8 @@ RUN \
           python3-dev=3.9.2-3 \
           zlib1g-dev=1:1.2.11.dfsg-2+deb11u2 \
           libjpeg-dev=1:2.0.6-4 \
-          libcairo2=1.16.0-5; \
+          libcairo2=1.16.0-5 \
+          libfreetype-dev=2.10.4+dfsg-1+deb11u1; \
     fi; \
     rm -rf \
         /tmp/* \

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -486,7 +486,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       ESP_LOGV(TAG, "Event: Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
                format_mac_addr(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
 #if LWIP_IPV6
-      WiFi.enableIpV6();
+      this->set_timeout(100, [] { WiFi.enableIpV6(); });
 #endif /* LWIP_IPV6 */
 
       break;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.8.0b3"
+__version__ = "2023.8.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ esptool==4.6.2
 click==8.1.6
 esphome-dashboard==20230711.0
 aioesphomeapi==15.0.0
-zeroconf==0.74.0
+zeroconf==0.80.0
 
 # esp-idf requires this, but doesn't bundle it by default
 # https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Add `libfreetype-dev` Debian package for armv7 Docker builds [esphome#5262](https://github.com/esphome/esphome/pull/5262)
- Add delay before enabling ipv6 [esphome#5256](https://github.com/esphome/esphome/pull/5256)
- Bump zeroconf from 0.74.0 to 0.80.0 [esphome#5260](https://github.com/esphome/esphome/pull/5260)
