### PR TITLE
Change haier from AUTO to HEAT_COOL

### DIFF
--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -89,7 +89,7 @@ SUPPORTED_SWING_MODES_OPTIONS = {
 
 SUPPORTED_CLIMATE_MODES_OPTIONS = {
     "OFF": ClimateMode.CLIMATE_MODE_OFF,  # always available
-    "AUTO": ClimateMode.CLIMATE_MODE_AUTO,  # always available
+    "HEAT_COOL": ClimateMode.CLIMATE_MODE_HEAT_COOL,  # always available
     "COOL": ClimateMode.CLIMATE_MODE_COOL,
     "HEAT": ClimateMode.CLIMATE_MODE_HEAT,
     "DRY": ClimateMode.CLIMATE_MODE_DRY,

--- a/esphome/components/haier/haier_base.cpp
+++ b/esphome/components/haier/haier_base.cpp
@@ -171,8 +171,8 @@ void HaierClimateBase::set_answer_timeout(uint32_t timeout) {
 
 void HaierClimateBase::set_supported_modes(const std::set<climate::ClimateMode> &modes) {
   this->traits_.set_supported_modes(modes);
-  this->traits_.add_supported_mode(climate::CLIMATE_MODE_OFF);   // Always available
-  this->traits_.add_supported_mode(climate::CLIMATE_MODE_AUTO);  // Always available
+  this->traits_.add_supported_mode(climate::CLIMATE_MODE_OFF);        // Always available
+  this->traits_.add_supported_mode(climate::CLIMATE_MODE_HEAT_COOL);  // Always available
 }
 
 void HaierClimateBase::set_supported_presets(const std::set<climate::ClimatePreset> &presets) {

--- a/esphome/components/haier/haier_base.cpp
+++ b/esphome/components/haier/haier_base.cpp
@@ -72,7 +72,7 @@ HaierClimateBase::HaierClimateBase()
   this->traits_ = climate::ClimateTraits();
   this->traits_.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT,
                                      climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY,
-                                     climate::CLIMATE_MODE_AUTO});
+                                     climate::CLIMATE_MODE_HEAT_COOL});
   this->traits_.set_supported_fan_modes(
       {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH});
   this->traits_.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH,

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -458,7 +458,7 @@ haier_protocol::HaierMessage HonClimate::get_control_message() {
         case CLIMATE_MODE_OFF:
           out_data->ac_power = 0;
           break;
-        case CLIMATE_MODE_AUTO:
+        case CLIMATE_MODE_HEAT_COOL:
           out_data->ac_power = 1;
           out_data->ac_mode = (uint8_t) hon_protocol::ConditioningMode::AUTO;
           out_data->fan_mode = this->other_modes_fan_speed_;
@@ -758,7 +758,7 @@ haier_protocol::HandlerError HonClimate::process_status_message_(const uint8_t *
           this->mode = CLIMATE_MODE_FAN_ONLY;
           break;
         case (uint8_t) hon_protocol::ConditioningMode::AUTO:
-          this->mode = CLIMATE_MODE_AUTO;
+          this->mode = CLIMATE_MODE_HEAT_COOL;
           break;
       }
     }

--- a/esphome/components/haier/smartair2_climate.cpp
+++ b/esphome/components/haier/smartair2_climate.cpp
@@ -270,7 +270,7 @@ haier_protocol::HaierMessage Smartair2Climate::get_control_message() {
           out_data->ac_power = 0;
           break;
 
-        case CLIMATE_MODE_AUTO:
+        case CLIMATE_MODE_HEAT_COOL:
           out_data->ac_power = 1;
           out_data->ac_mode = (uint8_t) smartair2_protocol::ConditioningMode::AUTO;
           out_data->fan_mode = this->other_modes_fan_speed_;
@@ -487,7 +487,7 @@ haier_protocol::HandlerError Smartair2Climate::process_status_message_(const uin
           this->mode = CLIMATE_MODE_FAN_ONLY;
           break;
         case (uint8_t) smartair2_protocol::ConditioningMode::AUTO:
-          this->mode = CLIMATE_MODE_AUTO;
+          this->mode = CLIMATE_MODE_HEAT_COOL;
           break;
       }
     }

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -957,7 +957,7 @@ climate:
       temperature_step: 1 °C
     supported_modes:
     - 'OFF'
-    - AUTO
+    - HEAT_COOL
     - COOL
     - HEAT
     - DRY


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

As per https://developers.home-assistant.io/docs/core/entity/climate#hvac-modes

`AUTO` is for when "The device is set to a schedule, learned behavior, AI."

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
