### PR TITLE
Allow upload command to flash file via serial

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -216,14 +216,16 @@ def compile_program(args, config):
     return 0 if idedata is not None else 1
 
 
-def upload_using_esptool(config, port):
+def upload_using_esptool(config, port, file):
     from esphome import platformio_api
 
     first_baudrate = config[CONF_ESPHOME][CONF_PLATFORMIO_OPTIONS].get(
         "upload_speed", 460800
     )
 
-    def run_esptool(baud_rate):
+    if file is not None:
+        flash_images = [platformio_api.FlashImage(path=file, offset="0x0")]
+    else:
         idedata = platformio_api.get_idedata(config)
 
         firmware_offset = "0x10000" if CORE.is_esp32 else "0x0"
@@ -234,12 +236,13 @@ def upload_using_esptool(config, port):
             *idedata.extra_flash_images,
         ]
 
-        mcu = "esp8266"
-        if CORE.is_esp32:
-            from esphome.components.esp32 import get_esp32_variant
+    mcu = "esp8266"
+    if CORE.is_esp32:
+        from esphome.components.esp32 import get_esp32_variant
 
-            mcu = get_esp32_variant().lower()
+        mcu = get_esp32_variant().lower()
 
+    def run_esptool(baud_rate):
         cmd = [
             "esptool.py",
             "--before",
@@ -281,7 +284,8 @@ def upload_using_esptool(config, port):
 def upload_program(config, args, host):
     if get_port_type(host) == "SERIAL":
         if CORE.target_platform in (PLATFORM_ESP32, PLATFORM_ESP8266):
-            return upload_using_esptool(config, host)
+            file = getattr(args, "file", None)
+            return upload_using_esptool(config, host, file)
 
         if CORE.target_platform in (PLATFORM_RP2040):
             from esphome import platformio_api


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The ESPHome CLI has an `upload` subcommand and previously I added a `--file` flag to allow OTA upload of any binary file. This change allows serial flashing using the same method.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
