### PR TITLE
fix to PR # 3887 MQTT connection not using discovery: false

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -66,25 +66,28 @@ void MQTTClientComponent::setup() {
   }
 #endif
 
-  this->subscribe(
-      "esphome/discover", [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); },
-      2);
+  if (this->is_discovery_enabled()) {
+    this->subscribe(
+        "esphome/discover", [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); },
+        2);
 
-  std::string topic = "esphome/ping/";
-  topic.append(App.get_name());
-  this->subscribe(
-      topic, [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); }, 2);
+    std::string topic = "esphome/ping/";
+    topic.append(App.get_name());
+    this->subscribe(
+        topic, [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); }, 2);
+  }
 
   this->last_connected_ = millis();
   this->start_dnslookup_();
 }
 
 void MQTTClientComponent::send_device_info_() {
-  if (!this->is_connected()) {
+  if (!this->is_connected() or !this->is_discovery_enabled()) {
     return;
   }
   std::string topic = "esphome/discover/";
   topic.append(App.get_name());
+
   this->publish_json(
       topic,
       [](JsonObject root) {


### PR DESCRIPTION
# What does this implement/fix?
<!-- Quick description and explanation of changes -->

Setting
```
discovery: false
```
will make MQTT client go silent with any discovery info forced by PR3887. This will allow using external MQTT brokers like io.adafruit which enforces specific topic names


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/4703

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
mqtt:
  broker: 192.168.0.99
  username: devel
  password: anypass
  discovery: false
  birth_message:
  will_message:
  log_topic:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
