### PR TITLE
Move libcairo to all architectures in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,14 +28,14 @@ RUN \
         git=1:2.30.2-1+deb11u2 \
         curl=7.74.0-1.3+deb11u7 \
         openssh-client=1:8.4p1-5+deb11u1 \
-        python3-cffi=1.14.5-1; \
+        python3-cffi=1.14.5-1 \
+        libcairo2=1.16.0-5; \
     if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
         apt-get install -y --no-install-recommends \
           build-essential=12.9 \
           python3-dev=3.9.2-3 \
           zlib1g-dev=1:1.2.11.dfsg-2+deb11u2 \
           libjpeg-dev=1:2.0.6-4 \
-          libcairo2=1.16.0-5 \
           libfreetype-dev=2.10.4+dfsg-1+deb11u1; \
     fi; \
     rm -rf \


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
It seems that libcairo is required for all architectures when used in containers, I have tested this locally by building the amd64 and armv7 image and compiling a test file.

A further PR will add container image testing to CI to prevent this in the future.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
