### PR TITLE
Resolve offline ESPs in dashboard when using ESPHOME_DASHBOARD_USE_PING=true

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -868,7 +868,6 @@ class PingStatusThread(threading.Thread):
                 entries = _list_dashboard_entries()
                 queue = collections.deque()
                 for entry in entries:
-
                     if entry.address is None:
                         PING_RESULT[entry.filename] = None
                         continue

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -868,8 +868,6 @@ class PingStatusThread(threading.Thread):
                 entries = _list_dashboard_entries()
                 queue = collections.deque()
                 for entry in entries:
-                    if entry.no_mdns is True:
-                        continue
 
                     if entry.address is None:
                         PING_RESULT[entry.filename] = None


### PR DESCRIPTION
# What does this implement/fix?

Starting with 2023.7.0 all ESPs with `mdns.disabled: true` were offline in the dashboard on containers using `ESPHOME_DASHBOARD_USE_PING=true` even though they functioned correctly otherwise. Installed 2023.8.1 and the issue was still present. 

With ssieb's help, found these two lines that appeared to be causing the issue. Removed them on my local container and ESPs using are now correctly found to be online. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4732

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): no documentation changes necessary

## Test Environment
Container

- [X] ESP32 IDF


## Example entry for `config.yaml`:
mdns:
  disabled: true

## Checklist:
  - [X] The code change is tested and works locally.

