### PR TITLE
Fix Waveshare 7.5v2 epaper screens are always powered on

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -57,6 +57,9 @@ WaveshareEPaper7P5InBV3 = waveshare_epaper_ns.class_(
 WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2", WaveshareEPaper
 )
+WaveshareEPaper7P5InV2Fixed = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P5InV2Fixed", WaveshareEPaper
+)
 WaveshareEPaper7P5InV2alt = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2alt", WaveshareEPaper
 )
@@ -93,6 +96,7 @@ MODELS = {
     "7.50in-bv3": ("b", WaveshareEPaper7P5InBV3),
     "7.50in-bc": ("b", WaveshareEPaper7P5InBC),
     "7.50inv2": ("b", WaveshareEPaper7P5InV2),
+    "7.50inv2fixed": ("b", WaveshareEPaper7P5InV2Fixed),
     "7.50inv2alt": ("b", WaveshareEPaper7P5InV2alt),
     "7.50in-hd-b": ("b", WaveshareEPaper7P5InHDB),
     "2.13in-ttgo-dke": ("c", WaveshareEPaper2P13InDKE),

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -57,9 +57,6 @@ WaveshareEPaper7P5InBV3 = waveshare_epaper_ns.class_(
 WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2", WaveshareEPaper
 )
-WaveshareEPaper7P5InV2Fixed = waveshare_epaper_ns.class_(
-    "WaveshareEPaper7P5InV2Fixed", WaveshareEPaper
-)
 WaveshareEPaper7P5InV2alt = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2alt", WaveshareEPaper
 )
@@ -96,7 +93,6 @@ MODELS = {
     "7.50in-bv3": ("b", WaveshareEPaper7P5InBV3),
     "7.50in-bc": ("b", WaveshareEPaper7P5InBC),
     "7.50inv2": ("b", WaveshareEPaper7P5InV2),
-    "7.50inv2fixed": ("b", WaveshareEPaper7P5InV2Fixed),
     "7.50inv2alt": ("b", WaveshareEPaper7P5InV2alt),
     "7.50in-hd-b": ("b", WaveshareEPaper7P5InHDB),
     "2.13in-ttgo-dke": ("c", WaveshareEPaper2P13InDKE),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1561,66 +1561,7 @@ void WaveshareEPaper7P5In::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
-void WaveshareEPaper7P5InV2::initialize() {
-  // COMMAND POWER SETTING
-  this->command(0x01);
-  this->data(0x07);
-  this->data(0x07);
-  this->data(0x3f);
-  this->data(0x3f);
-  this->command(0x04);
-
-  delay(100);  // NOLINT
-  this->wait_until_idle_();
-  // COMMAND PANEL SETTING
-  this->command(0x00);
-  this->data(0x1F);
-
-  // COMMAND RESOLUTION SETTING
-  this->command(0x61);
-  this->data(0x03);
-  this->data(0x20);
-  this->data(0x01);
-  this->data(0xE0);
-  // COMMAND ...?
-  this->command(0x15);
-  this->data(0x00);
-  // COMMAND VCOM AND DATA INTERVAL SETTING
-  this->command(0x50);
-  this->data(0x10);
-  this->data(0x07);
-  // COMMAND TCON SETTING
-  this->command(0x60);
-  this->data(0x22);
-}
-void HOT WaveshareEPaper7P5InV2::display() {
-  uint32_t buf_len = this->get_buffer_length_();
-  // COMMAND DATA START TRANSMISSION NEW DATA
-  this->command(0x13);
-  delay(2);
-  for (uint32_t i = 0; i < buf_len; i++) {
-    this->data(~(this->buffer_[i]));
-  }
-
-  // COMMAND DISPLAY REFRESH
-  this->command(0x12);
-  delay(100);  // NOLINT
-  this->wait_until_idle_();
-}
-
-int WaveshareEPaper7P5InV2::get_width_internal() { return 800; }
-int WaveshareEPaper7P5InV2::get_height_internal() { return 480; }
-void WaveshareEPaper7P5InV2::dump_config() {
-  LOG_DISPLAY("", "Waveshare E-Paper", this);
-  ESP_LOGCONFIG(TAG, "  Model: 7.5inV2rev2");
-  LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  LOG_PIN("  DC Pin: ", this->dc_pin_);
-  LOG_PIN("  Busy Pin: ", this->busy_pin_);
-  LOG_UPDATE_INTERVAL(this);
-}
-
-/* 7.50inV2Fixed */
-bool WaveshareEPaper7P5InV2Fixed::wait_until_idle_() {
+bool WaveshareEPaper7P5InV2::wait_until_idle_() {
   if (this->busy_pin_ == nullptr) {
     return true;
   }
@@ -1628,7 +1569,7 @@ bool WaveshareEPaper7P5InV2Fixed::wait_until_idle_() {
   const uint32_t start = millis();
   while (this->busy_pin_->digital_read()) {
     this->command(0x71);
-    if (millis() - start > 10000) {
+    if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
       return false;
     }
@@ -1637,8 +1578,7 @@ bool WaveshareEPaper7P5InV2Fixed::wait_until_idle_() {
   }
   return true;
 }
-void WaveshareEPaper7P5InV2Fixed::initialize() {
-
+void WaveshareEPaper7P5InV2::initialize() {
   // COMMAND POWER SETTING
   this->command(0x01);
   this->data(0x07);
@@ -1647,11 +1587,10 @@ void WaveshareEPaper7P5InV2Fixed::initialize() {
   this->data(0x3f);
 
   //we don't want the display to be powered at this point
-  //this->command(0x04); 
 
   delay(100);  // NOLINT
   this->wait_until_idle_();
-  
+
   // COMMAND VCOM AND DATA INTERVAL SETTING
   this->command(0x50);
   this->data(0x10);
@@ -1677,35 +1616,34 @@ void WaveshareEPaper7P5InV2Fixed::initialize() {
   this->data(0x00);
 
   // COMMAND POWER DRIVER HAT DOWN
-  // This command will turn off booster, controller, source driver, gate driver, VCOM, and 
-  // temperature sensor, but register data will be kept until VDD turned OFF or Deep Sleep Mode. 
+  // This command will turn off booster, controller, source driver, gate driver, VCOM, and
+  // temperature sensor, but register data will be kept until VDD turned OFF or Deep Sleep Mode.
   // Source/Gate/Border/VCOM will be released to floating.
   this->command(0x02);
 }
-
-void HOT WaveshareEPaper7P5InV2Fixed::display() {
+void HOT WaveshareEPaper7P5InV2::display() {
   uint32_t buf_len = this->get_buffer_length_();
 
   // COMMAND POWER ON
   ESP_LOGI(TAG, "Power on the display and hat");
 
-  // This command will turn on booster, controller, regulators, and temperature sensor will be 
-  // activated for one-time sensing before enabling booster. When all voltages are ready, the 
+  // This command will turn on booster, controller, regulators, and temperature sensor will be
+  // activated for one-time sensing before enabling booster. When all voltages are ready, the
   // BUSY_N signal will return to high.
   this->command(0x04);
   delay(200);  // NOLINT
   this->wait_until_idle_();
-  
+
   // COMMAND DATA START TRANSMISSION NEW DATA
   this->command(0x13);
   delay(2);
   for (uint32_t i = 0; i < buf_len; i++) {
     this->data(~(this->buffer_[i]));
   }
-  
+
   delay(100);  // NOLINT
   this->wait_until_idle_();
-  
+
   // COMMAND DISPLAY REFRESH
   this->command(0x12);
   delay(100);  // NOLINT
@@ -1717,11 +1655,12 @@ void HOT WaveshareEPaper7P5InV2Fixed::display() {
   ESP_LOGI(TAG, "After command(0x02) (>> power off)");
 }
 
-int WaveshareEPaper7P5InV2Fixed::get_width_internal() { return 800; }
-int WaveshareEPaper7P5InV2Fixed::get_height_internal() { return 480; }
-void WaveshareEPaper7P5InV2Fixed::dump_config() {
+int WaveshareEPaper7P5InV2::get_width_internal() { return 800; }
+int WaveshareEPaper7P5InV2::get_height_internal() { return 480; }
+uint32_t WaveshareEPaper7P5InV2::idle_timeout_() { return 10000; }
+void WaveshareEPaper7P5InV2::dump_config() {
   LOG_DISPLAY("", "Waveshare E-Paper", this);
-  ESP_LOGCONFIG(TAG, "  Model: 7.5inV2Fixed");
+  ESP_LOGCONFIG(TAG, "  Model: 7.5inV2rev2");
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1586,7 +1586,7 @@ void WaveshareEPaper7P5InV2::initialize() {
   this->data(0x3f);
   this->data(0x3f);
 
-  //we don't want the display to be powered at this point
+  // We don't want the display to be powered at this point
 
   delay(100);  // NOLINT
   this->wait_until_idle_();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1649,10 +1649,10 @@ void HOT WaveshareEPaper7P5InV2::display() {
   delay(100);  // NOLINT
   this->wait_until_idle_();
 
-  ESP_LOGI(TAG, "Before command(0x02) (>> power off)");
+  ESP_LOGV(TAG, "Before command(0x02) (>> power off)");
   this->command(0x02);
   this->wait_until_idle_();
-  ESP_LOGI(TAG, "After command(0x02) (>> power off)");
+  ESP_LOGV(TAG, "After command(0x02) (>> power off)");
 }
 
 int WaveshareEPaper7P5InV2::get_width_internal() { return 800; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -489,7 +489,7 @@ class WaveshareEPaper7P5InV2 : public WaveshareEPaper {
     this->data(0xA5);  // check byte
   }
 
- protected:  
+ protected:
   int get_width_internal() override;
 
   int get_height_internal() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -472,29 +472,6 @@ class WaveshareEPaper7P5InBC : public WaveshareEPaper {
 
 class WaveshareEPaper7P5InV2 : public WaveshareEPaper {
  public:
-  void initialize() override;
-
-  void display() override;
-
-  void dump_config() override;
-
-  void deep_sleep() override {
-    // COMMAND POWER OFF
-    this->command(0x02);
-    this->wait_until_idle_();
-    // COMMAND DEEP SLEEP
-    this->command(0x07);
-    this->data(0xA5);  // check byte
-  }
-
- protected:
-  int get_width_internal() override;
-
-  int get_height_internal() override;
-};
-
-class WaveshareEPaper7P5InV2Fixed : public WaveshareEPaper {
- public:
   bool wait_until_idle_();
 
   void initialize() override;
@@ -512,10 +489,12 @@ class WaveshareEPaper7P5InV2Fixed : public WaveshareEPaper {
     this->data(0xA5);  // check byte
   }
 
- protected:
+ protected:  
   int get_width_internal() override;
 
   int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
 };
 
 class WaveshareEPaper7P5InV2alt : public WaveshareEPaper7P5InV2 {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -493,6 +493,31 @@ class WaveshareEPaper7P5InV2 : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
+class WaveshareEPaper7P5InV2Fixed : public WaveshareEPaper {
+ public:
+  bool wait_until_idle_();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
 class WaveshareEPaper7P5InV2alt : public WaveshareEPaper7P5InV2 {
  public:
   bool wait_until_idle_();


### PR DESCRIPTION
# What does this implement/fix?

As I've stated on [#4739](https://github.com/esphome/issues/issues/4739) Waveshare 7.5v2 displays are always powered on (not asleep) which causes damage to the display over time. Waveshare warns of display damage if the display is left on for an extended period of time.

[Waveshare documentation](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT_(B)_Manual#ESP32.2F8266:~:text=Note%20that%20the%20screen%20cannot%20be%20powered%20on%20for%20a%20long%20time.%20When%20the%20screen%20is%20not%20refreshed%2C%20please%20set%20the%20screen%20to%20sleep%20mode%20or%20power%20off%20it.%20Otherwise%2C%20the%20screen%20will%20remain%20in%20a%20high%20voltage%20state%20for%20a%20long%20time%2C%20which%20will%20damage%20the%20e%2DPaper%20and%20cannot%20be%20repaired!)

~~I've created a new version of the 7.50inv2 display variant that fixes this problem.~~ I've updated the existing code of the 7.50inv2 display variant to fix this problem.

- Turn on display only during refresh
- Fixed the `wait_until_idle_()` function to work properly with Waveshare 7.5v2 screens (Warning: You also need to invert the busy pin in the yaml config!)
- Increased the timeout because the display is slow and needs at least 6 seconds to refresh

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#4739](https://github.com/esphome/issues/issues/4739)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#[3143](https://github.com/esphome/esphome-docs/pull/3143)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: waveshare_epaper
    id: epaper_display
    reset_duration: 2ms
    setup_priority: 1000
    cs_pin: 5
    dc_pin: 0
    busy_pin: 
      number: 15
      inverted: True
    reset_pin: 2
    model: 7.50inv2
    update_interval: never 
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
