### PR TITLE
ESP32-C6-DevKitC-1 support

### DIFF
--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -1,4 +1,10 @@
-from .const import VARIANT_ESP32, VARIANT_ESP32S2, VARIANT_ESP32C3, VARIANT_ESP32S3
+from .const import (
+    VARIANT_ESP32,
+    VARIANT_ESP32C3,
+    VARIANT_ESP32C6,
+    VARIANT_ESP32S2,
+    VARIANT_ESP32S3,
+)
 
 ESP32_BASE_PINS = {
     "TX": 1,
@@ -1284,6 +1290,10 @@ BOARDS = {
     "esp32-c3-m1i-kit": {
         "name": "Ai-Thinker ESP-C3-M1-I-Kit",
         "variant": VARIANT_ESP32C3,
+    },
+    "esp32-c6-devkitc-1": {
+        "name": "Espressif ESP32-C6-DevKitC-1",
+        "variant": VARIANT_ESP32C6,
     },
     "esp32cam": {
         "name": "AI Thinker ESP32-CAM",

--- a/platformio.ini
+++ b/platformio.ini
@@ -258,6 +258,24 @@ build_flags =
     ${flags:clangtidy.build_flags}
     -DUSE_ESP32_VARIANT_ESP32C3
 
+;;;;;;;; ESP32-C6 ;;;;;;;;
+
+[env:esp32c6-idf]
+extends = common:esp32-idf
+board = esp32-c6-devkitc-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32c6-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:runtime.build_flags}
+
+[env:esp32c6-idf-tidy]
+extends = common:esp32-idf
+board = esp32-c6-devkitc-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32c6-idf-tidy
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:clangtidy.build_flags}
+
 ;;;;;;;; ESP32-S2 ;;;;;;;;
 
 [env:esp32s2-arduino]


### PR DESCRIPTION
# What does this implement/fix?

Add ESP32-C6-DevKitC-1 support.

Compiled-tested OK:
- api
- bluetooth_proxy
- esp32_ble_beacon
- esp32_ble_tracker
- i2c
- logger
- mqtt
- output
- sensor
  - scd4x
  - sps30
- switch
- wifi
- wifi_signal

Observations:
- fan causes Guru Meditation Error: Core  0 panic'ed (Illegal instruction)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [<link to issue>](https://github.com/esphome/feature-requests/issues/2176)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
---
esphome:
  name: "esp32c6-test"

esp32:
  board: esp32-c6-devkitc-1
  variant: ESP32C6
  framework:
    platform_version: https://github.com/stintel/platform-espressif32#esp32-c6-test
    type: esp-idf
    version: 5.1.0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
