### PR TITLE
Use gzip compression for the web server component's static resources

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -110,7 +110,9 @@ def build_index_html(config) -> str:
     return html
 
 
-def add_resource_as_progmem(resource_name: str, content: str, compress: bool = True) -> None:
+def add_resource_as_progmem(
+    resource_name: str, content: str, compress: bool = True
+) -> None:
     """Add a resource to progmem."""
     content_encoded = content.encode("utf-8")
     if compress:

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -1,3 +1,4 @@
+import gzip
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import web_server_base
@@ -112,6 +113,7 @@ def build_index_html(config) -> str:
 def add_resource_as_progmem(resource_name: str, content: str) -> None:
     """Add a resource to progmem."""
     content_encoded = content.encode("utf-8")
+    content_encoded = gzip.compress(content_encoded)
     content_encoded_size = len(content_encoded)
     bytes_as_int = ", ".join(str(x) for x in content_encoded)
     uint8_t = f"const uint8_t ESPHOME_WEBSERVER_{resource_name}[{content_encoded_size}] PROGMEM = {{{bytes_as_int}}}"

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -110,10 +110,11 @@ def build_index_html(config) -> str:
     return html
 
 
-def add_resource_as_progmem(resource_name: str, content: str) -> None:
+def add_resource_as_progmem(resource_name: str, content: str, compress: bool = True) -> None:
     """Add a resource to progmem."""
     content_encoded = content.encode("utf-8")
-    content_encoded = gzip.compress(content_encoded)
+    if compress:
+        content_encoded = gzip.compress(content_encoded)
     content_encoded_size = len(content_encoded)
     bytes_as_int = ", ".join(str(x) for x in content_encoded)
     uint8_t = f"const uint8_t ESPHOME_WEBSERVER_{resource_name}[{content_encoded_size}] PROGMEM = {{{bytes_as_int}}}"
@@ -139,7 +140,8 @@ async def to_code(config):
     cg.add_define("USE_WEBSERVER_PORT", config[CONF_PORT])
     cg.add_define("USE_WEBSERVER_VERSION", version)
     if version == 2:
-        add_resource_as_progmem("INDEX_HTML", build_index_html(config))
+        # Don't compress the index HTML as the data sizes are almost the same.
+        add_resource_as_progmem("INDEX_HTML", build_index_html(config), compress=False)
     else:
         cg.add(var.set_css_url(config[CONF_CSS_URL]))
         cg.add(var.set_js_url(config[CONF_JS_URL]))

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -328,6 +328,7 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response =
       request->beginResponse_P(200, "text/html", ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
+  response->addHeader("Content-Encoding", "gzip");
   request->send(response);
 }
 #endif
@@ -336,6 +337,7 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 void WebServer::handle_css_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response =
       request->beginResponse_P(200, "text/css", ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
+  response->addHeader("Content-Encoding", "gzip");
   request->send(response);
 }
 #endif
@@ -344,6 +346,7 @@ void WebServer::handle_css_request(AsyncWebServerRequest *request) {
 void WebServer::handle_js_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response =
       request->beginResponse_P(200, "text/javascript", ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
+  response->addHeader("Content-Encoding", "gzip");
   request->send(response);
 }
 #endif

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -328,7 +328,7 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response =
       request->beginResponse_P(200, "text/html", ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
-  response->addHeader("Content-Encoding", "gzip");
+  // No gzip header here because the HTML file is so small
   request->send(response);
 }
 #endif

--- a/tests/test3.1.yaml
+++ b/tests/test3.1.yaml
@@ -21,6 +21,10 @@ wifi:
   ssid: "MySSID"
   password: "password1"
 
+web_server:
+  port: 80
+  version: 2
+
 i2c:
   sda: 4
   scl: 5


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Compresses static resources in the web server, encoding with gzip in python's stdlib, and decoding client side using the content-encoding header.

On my computer, it brings the size of the V2 js down to 11320 bytes, from 33.2kb currently.

As far as I know, all common browsers have supported this for 15+ years, and even things like Lynx now have support,
so I do not attempt to inspect request headers, or provide any options to control the behavior, I just assume that it is basically universal.

Edit for transparency: Original PR had one import in the wrong place that my IDE missed, failing pylint, I used force-push to keep history neat.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

I don't believe there is an issue in any repo I can see, but I do see compression mentioned on the roadmap here: https://github.com/esphome/esphome-webserver

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Note: Does not change anything a user should notice.

```yaml
# Example config.yaml
web_server:
  port: 80
  js_include: "./www.js"
  js_url: ""
  version: 2
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
  
Nothing user exposed changed, but perhaps a note should be added somewhere, so people are aware that
serving locally is more practical now?