### PR TITLE
Add Invert method for SSD1306

### DIFF
--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -132,7 +132,7 @@ void SSD1306::setup() {
   this->command(SSD1306_COMMAND_DISPLAY_ALL_ON_RESUME);
 
   // Inverse display mode (0xA6, 0xA7)
-  this->command(SSD1306_COMMAND_NORMAL_DISPLAY | this->invert_);
+  this->set_invert(this->invert_);
 
   // Disable scrolling mode (0x2E)
   this->command(SSD1306_COMMAND_DEACTIVATE_SCROLL);
@@ -189,6 +189,12 @@ bool SSD1306::is_ssd1305_() const {
 void SSD1306::update() {
   this->do_update_();
   this->display();
+}
+
+void SSD1306::set_invert(bool invert) {
+  this->invert_ = invert;
+  // Inverse display mode (0xA6, 0xA7)
+  this->command(SSD1306_COMMAND_NORMAL_DISPLAY | this->invert_);
 }
 void SSD1306::set_contrast(float contrast) {
   // validation

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -43,6 +43,7 @@ class SSD1306 : public PollingComponent, public display::DisplayBuffer {
   void init_offset_x(uint8_t offset_x) { this->offset_x_ = offset_x; }
   void init_offset_y(uint8_t offset_y) { this->offset_y_ = offset_y; }
   void init_invert(bool invert) { this->invert_ = invert; }
+  void set_invert(bool invert);
   bool is_on();
   void turn_on();
   void turn_off();


### PR DESCRIPTION
# What does this implement/fix?

Request from user to expose invert method to avoid burn out screens

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2341

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
