### PR TITLE
Fix legacy zeroconf record update method

### DIFF
--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -41,7 +41,7 @@ class HostResolver(RecordUpdateListener):
         for record_update in records:
             record, _ = record_update
             if record is None:
-                return
+                continue
             if record.type == _TYPE_A:
                 assert isinstance(record, DNSAddress)
                 if record.name == self.name:

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -1,19 +1,19 @@
+import logging
 import socket
 import threading
 import time
-from typing import Optional
-import logging
 from dataclasses import dataclass
+from typing import Optional
 
 from zeroconf import (
     DNSAddress,
     DNSOutgoing,
-    DNSRecord,
     DNSQuestion,
+    RecordUpdate,
     RecordUpdateListener,
-    Zeroconf,
     ServiceBrowser,
     ServiceStateChange,
+    Zeroconf,
     current_time_millis,
 )
 
@@ -24,17 +24,28 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class HostResolver(RecordUpdateListener):
+    """Resolve a host name to an IP address."""
+
     def __init__(self, name: str):
         self.name = name
         self.address: Optional[bytes] = None
 
-    def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
-        if record is None:
-            return
-        if record.type == _TYPE_A:
-            assert isinstance(record, DNSAddress)
-            if record.name == self.name:
-                self.address = record.address
+    def async_update_records(
+        self, zc: Zeroconf, now: float, records: list[RecordUpdate]
+    ) -> None:
+        """Update multiple records in one shot.
+
+        This will run in zeroconf's event loop thread so it
+        must be thread-safe.
+        """
+        for record_update in records:
+            record, _ = record_update
+            if record is None:
+                return
+            if record.type == _TYPE_A:
+                assert isinstance(record, DNSAddress)
+                if record.name == self.name:
+                    self.address = record.address
 
     def request(self, zc: Zeroconf, timeout: float) -> bool:
         now = time.time()


### PR DESCRIPTION
# What does this implement/fix?

The first step of removing the legacy `update_record` in https://github.com/python-zeroconf/python-zeroconf/pull/1231 will be in zeroconf 0.82

This prepares ESPHome for this as its been deprecated for a few years and this one was missed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
