### PR TITLE
Make string globals persist-able using fixed size allocations

### DIFF
--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -42,11 +42,11 @@ async def to_code(config):
     restore = config[CONF_RESTORE_VALUE]
 
     # Special casing the strings to their own class with a different save/restore mechanism
-    if str(type_) == "std::string":
+    if str(type_) == "std::string" and restore:
         template_args = cg.TemplateArguments(
             type_, config.get(CONF_MAX_RESTORE_DATA_LENGTH, 63) + 1
         )
-        type = RestoringGlobalStringComponent if restore else GlobalsComponent
+        type = RestoringGlobalStringComponent
     else:
         template_args = cg.TemplateArguments(type_)
         type = RestoringGlobalsComponent if restore else GlobalsComponent

--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -15,7 +15,13 @@ CODEOWNERS = ["@esphome/core"]
 globals_ns = cg.esphome_ns.namespace("globals")
 GlobalsComponent = globals_ns.class_("GlobalsComponent", cg.Component)
 RestoringGlobalsComponent = globals_ns.class_("RestoringGlobalsComponent", cg.Component)
+RestoringGlobalStringComponent = globals_ns.class_(
+    "RestoringGlobalStringComponent", cg.Component
+)
 GlobalVarSetAction = globals_ns.class_("GlobalVarSetAction", automation.Action)
+
+CONF_MAX_RESTORE_DATA_LENGTH = "max_restore_data_length"
+
 
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.Schema(
@@ -24,6 +30,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_TYPE): cv.string_strict,
         cv.Optional(CONF_INITIAL_VALUE): cv.string_strict,
         cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+        cv.Optional(CONF_MAX_RESTORE_DATA_LENGTH): cv.int_range(0, 254),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -32,12 +39,19 @@ CONFIG_SCHEMA = cv.Schema(
 @coroutine_with_priority(-100.0)
 async def to_code(config):
     type_ = cg.RawExpression(config[CONF_TYPE])
-    template_args = cg.TemplateArguments(type_)
     restore = config[CONF_RESTORE_VALUE]
 
-    type = RestoringGlobalsComponent if restore else GlobalsComponent
-    res_type = type.template(template_args)
+    # Special casing the strings to their own class with a different save/restore mechanism
+    if str(type_) == "std::string":
+        template_args = cg.TemplateArguments(
+            type_, config.get(CONF_MAX_RESTORE_DATA_LENGTH, 63) + 1
+        )
+        type = RestoringGlobalStringComponent if restore else GlobalsComponent
+    else:
+        template_args = cg.TemplateArguments(type_)
+        type = RestoringGlobalsComponent if restore else GlobalsComponent
 
+    res_type = type.template(template_args)
     initial_value = None
     if CONF_INITIAL_VALUE in config:
         initial_value = cg.RawExpression(config[CONF_INITIAL_VALUE])

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -663,7 +663,11 @@ async def process_lambda(
     :param return_type: The return type of the lambda.
     :return: The generated lambda expression.
     """
-    from esphome.components.globals import GlobalsComponent, RestoringGlobalsComponent
+    from esphome.components.globals import (
+        GlobalsComponent,
+        RestoringGlobalsComponent,
+        RestoringGlobalStringComponent,
+    )
 
     if value is None:
         return
@@ -676,6 +680,7 @@ async def process_lambda(
             and (
                 full_id.type.inherits_from(GlobalsComponent)
                 or full_id.type.inherits_from(RestoringGlobalsComponent)
+                or full_id.type.inherits_from(RestoringGlobalStringComponent)
             )
         ):
             parts[i * 3 + 1] = var.value()

--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -5,6 +5,13 @@ esphome:
   board: nodemcu-32s
   build_path: build/test2
 
+globals:
+  - id: my_global_string
+    type: std::string
+    restore_value: yes
+    max_restore_data_length: 70
+    initial_value: '"DefaultValue"'
+
 substitutions:
   devicename: test2
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This PR enables the restore feature for global variables of type std::string, by adding a new class for the special case.

It allocates a user-configurable fixed-size preference object(Defaulting to 63 characters), with a single length byte, for compatibility with the existing preference backends. Strings too big to fit are simply ignored and not saved.

Edit:  I *think* I have my IDE set up for proper linting!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3151

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
This entry adds text to the variable at every boot,  so you can confirm that it works in the web server.
```yaml
esphome:
  name: test
  on_boot:
    - lambda: 'id(my_global_string2) = ("Blah");'


text_sensor:
  - platform: template
    lambda: "return id(my_global_string2);"
    id: my_global_string_tester

globals:
  - id: my_global_string2
    type: std::string
    restore_value: yes
    initial_value: '"DefaultVal"'
    max_restore_data_length: 22

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
