### PR TITLE
Introduce cv.temperature_delta and fix problematic thermostat configuration behavior

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -591,11 +591,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.temperature,
             cv.Optional(
                 CONF_SET_POINT_MINIMUM_DIFFERENTIAL, default=0.5
-            ): cv.temperature,
-            cv.Optional(CONF_COOL_DEADBAND, default=0.5): cv.temperature,
-            cv.Optional(CONF_COOL_OVERRUN, default=0.5): cv.temperature,
-            cv.Optional(CONF_HEAT_DEADBAND, default=0.5): cv.temperature,
-            cv.Optional(CONF_HEAT_OVERRUN, default=0.5): cv.temperature,
+            ): cv.temperature_delta,
+            cv.Optional(CONF_COOL_DEADBAND, default=0.5): cv.temperature_delta,
+            cv.Optional(CONF_COOL_OVERRUN, default=0.5): cv.temperature_delta,
+            cv.Optional(CONF_HEAT_DEADBAND, default=0.5): cv.temperature_delta,
+            cv.Optional(CONF_HEAT_OVERRUN, default=0.5): cv.temperature_delta,
             cv.Optional(CONF_MAX_COOLING_RUN_TIME): cv.positive_time_period_seconds,
             cv.Optional(CONF_MAX_HEATING_RUN_TIME): cv.positive_time_period_seconds,
             cv.Optional(CONF_MIN_COOLING_OFF_TIME): cv.positive_time_period_seconds,
@@ -608,8 +608,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MIN_HEATING_OFF_TIME): cv.positive_time_period_seconds,
             cv.Optional(CONF_MIN_HEATING_RUN_TIME): cv.positive_time_period_seconds,
             cv.Required(CONF_MIN_IDLE_TIME): cv.positive_time_period_seconds,
-            cv.Optional(CONF_SUPPLEMENTAL_COOLING_DELTA): cv.temperature,
-            cv.Optional(CONF_SUPPLEMENTAL_HEATING_DELTA): cv.temperature,
+            cv.Optional(CONF_SUPPLEMENTAL_COOLING_DELTA): cv.temperature_delta,
+            cv.Optional(CONF_SUPPLEMENTAL_HEATING_DELTA): cv.temperature_delta,
             cv.Optional(
                 CONF_FAN_ONLY_ACTION_USES_FAN_MODE_TIMER, default=False
             ): cv.boolean,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -929,6 +929,28 @@ def temperature(value):
     raise err
 
 
+def temperature_delta(value):
+    err = None
+    try:
+        return _temperature_c(value)
+    except Invalid as orig_err:
+        err = orig_err
+
+    try:
+        kelvin = _temperature_k(value)
+        return kelvin - 273.15
+    except Invalid:
+        pass
+
+    try:
+        fahrenheit = _temperature_f(value)
+        return (fahrenheit) * (5 / 9)
+    except Invalid:
+        pass
+
+    raise err
+
+
 _color_temperature_mireds = float_with_unit("Color Temperature", r"(mireds|Mireds)")
 _color_temperature_kelvin = float_with_unit("Color Temperature", r"(K|Kelvin)")
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -937,14 +937,13 @@ def temperature_delta(value):
         err = orig_err
 
     try:
-        kelvin = _temperature_k(value)
-        return kelvin - 273.15
+        return _temperature_k(value)
     except Invalid:
         pass
 
     try:
         fahrenheit = _temperature_f(value)
-        return (fahrenheit) * (5 / 9)
+        return fahrenheit * (5 / 9)
     except Invalid:
         pass
 


### PR DESCRIPTION
# What does this implement/fix?

Implements cv.temperature_delta which only applies scaling for Fahrenheit, and does not apply the 32 degree Fahrenheit offset or the 273.15 Kelvin offset.

This fixes an issue with the thermostat component, where if you attempt to use a Fahrenheit value for a delta or offset configuration variable it will create a nonsensical configuration. For example `supplemental_heating_delta: 5 °F` is currently evaluated as `supplemental_heating_delta: -15.0`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
