### PR TITLE
Update PSRAM config params for IDF4+

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -21,7 +21,8 @@ async def to_code(config):
         cg.add_build_flag("-DBOARD_HAS_PSRAM")
 
     if CORE.using_esp_idf:
-        add_idf_sdkconfig_option("CONFIG_ESP32_SPIRAM_SUPPORT", True)
+        add_idf_sdkconfig_option("CONFIG_SPIRAM", True)
+        add_idf_sdkconfig_option("CONFIG_SPIRAM_USE", True)
         add_idf_sdkconfig_option("CONFIG_SPIRAM_USE_CAPS_ALLOC", True)
         add_idf_sdkconfig_option("CONFIG_SPIRAM_IGNORE_NOTFOUND", True)
 

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
 from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
@@ -21,6 +21,9 @@ async def to_code(config):
         cg.add_build_flag("-DBOARD_HAS_PSRAM")
 
     if CORE.using_esp_idf:
+        add_idf_sdkconfig_option(
+            f"CONFIG_{get_esp32_variant().upper()}_SPIRAM_SUPPORT", True
+        )
         add_idf_sdkconfig_option("CONFIG_SPIRAM", True)
         add_idf_sdkconfig_option("CONFIG_SPIRAM_USE", True)
         add_idf_sdkconfig_option("CONFIG_SPIRAM_USE_CAPS_ALLOC", True)


### PR DESCRIPTION
# What does this implement/fix?

Minor change to update IDF configuration params when PSRAM is enabled. Based on [this](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/kconfig.html#config-spiram).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP32-S2 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
