### PR TITLE
Add MAX7321 I/O Expander

### DIFF
--- a/esphome/components/max7321/__init__.py
+++ b/esphome/components/max7321/__init__.py
@@ -1,0 +1,90 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins, automation
+from esphome.components import i2c
+from esphome.const import (
+    CONF_ID,
+    CONF_NUMBER,
+    CONF_MODE,
+    CONF_INVERTED,
+    CONF_INPUT,
+    CONF_OUTPUT,
+    CONF_PULLUP,
+)
+
+# code heavily inspired by looping40
+CODEOWNERS = ["@sqozz"]
+
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+
+
+max7321_ns = cg.esphome_ns.namespace("max7321")
+
+MAX7321 = max7321_ns.class_("MAX7321", cg.Component, i2c.I2CDevice)
+MAX7321GPIOPin = max7321_ns.class_("MAX7321GPIOPin", cg.GPIOPin)
+
+# Actions
+SetCurrentGlobalAction = max7321_ns.class_("SetCurrentGlobalAction", automation.Action)
+SetCurrentModeAction = max7321_ns.class_("SetCurrentModeAction", automation.Action)
+
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.declare_id(MAX7321),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x40))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+
+def validate_mode(value):
+    if not (value[CONF_INPUT] or value[CONF_OUTPUT]):
+        raise cv.Invalid("Mode must be either input or output")
+    if value[CONF_INPUT] and value[CONF_OUTPUT]:
+        raise cv.Invalid("Mode must be either input or output")
+    if value[CONF_PULLUP] and not value[CONF_INPUT]:
+        raise cv.Invalid("Pullup only available with input")
+    return value
+
+
+CONF_MAX7321 = "max7321"
+
+MAX7321_PIN_SCHEMA = cv.All(
+    {
+        cv.GenerateID(): cv.declare_id(MAX7321GPIOPin),
+        cv.Required(CONF_MAX7321): cv.use_id(MAX7321),
+        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=7),
+        cv.Optional(CONF_MODE, default={}): cv.All(
+            {
+                cv.Optional(CONF_INPUT, default=False): cv.boolean,
+                cv.Optional(CONF_PULLUP, default=False): cv.boolean,
+                cv.Optional(CONF_OUTPUT, default=False): cv.boolean,
+            },
+            validate_mode,
+        ),
+        cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+    }
+)
+
+
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_MAX7321, MAX7321_PIN_SCHEMA)
+async def max7321_pin_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    parent = await cg.get_variable(config[CONF_MAX7321])
+
+    cg.add(var.set_parent(parent))
+
+    num = config[CONF_NUMBER]
+    cg.add(var.set_pin(num))
+    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
+    return var

--- a/esphome/components/max7321/max7321.cpp
+++ b/esphome/components/max7321/max7321.cpp
@@ -1,0 +1,78 @@
+#include "max7321.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace max7321 {
+
+static const char *const TAG = "max7321";
+
+/**************************************
+ *    MAX7321                         *
+ **************************************/
+void MAX7321::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up MAX7321...");
+  uint8_t configuration;
+  if (!this->read_bytes_raw(&configuration, 1)) {
+    this->mark_failed();
+    return;
+  }
+}
+
+bool MAX7321::digital_read(uint8_t pin) {
+  uint8_t value = 0;
+  this->read_bytes_raw(&value, 1);
+  return (value & (1 << pin));
+}
+
+void MAX7321::digital_write(uint8_t pin, bool value) {
+  uint8_t configuration;
+  this->read_bytes_raw(&configuration, 1);
+  if (value) {
+    configuration |= (1 << pin);
+  } else {
+    configuration &= ~(1 << pin);
+  }
+  this->write_(configuration);
+}
+
+void MAX7321::pin_mode(uint8_t pin, gpio::Flags flags) {
+  uint8_t configuration;
+  this->read_bytes_raw(&configuration, 1);
+
+  if (flags == gpio::FLAG_INPUT) {
+    configuration |= (1 << pin);
+  } else if (flags == gpio::FLAG_OUTPUT) {
+    configuration &= ~(1 << pin);
+  }
+}
+
+bool MAX7321::write_(uint8_t value) {
+  if (this->is_failed())
+    return false;
+
+  if (this->write(&value, 1) == 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void MAX7321::dump_config() {
+  ESP_LOGCONFIG(TAG, "MAX7321");
+}
+
+/**************************************
+ *    MAX7321GPIOPin                  *
+ **************************************/
+void MAX7321GPIOPin::setup() { pin_mode(flags_); }
+void MAX7321GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->pin_, flags); }
+bool MAX7321GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
+void MAX7321GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
+std::string MAX7321GPIOPin::dump_summary() const {
+  char buffer[32];
+  snprintf(buffer, sizeof(buffer), "%u via MAX7321", pin_);
+  return buffer;
+}
+
+}  // namespace max7321
+}  // namespace esphome

--- a/esphome/components/max7321/max7321.h
+++ b/esphome/components/max7321/max7321.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace max7321 {
+
+/// Range for MAX7321 pins
+enum MAX7321GPIORange : uint8_t {
+  MAX7321_MIN = 0,
+  MAX7321_MAX = 7,
+};
+
+class MAX7321 : public Component, public i2c::I2CDevice {
+ public:
+  MAX7321() = default;
+
+  void setup() override;
+
+  bool digital_read(uint8_t pin);
+  void digital_write(uint8_t pin, bool value);
+  void pin_mode(uint8_t pin, gpio::Flags flags);
+
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  void dump_config() override;
+
+ protected:
+  bool write_(uint8_t value);
+};
+
+class MAX7321GPIOPin : public GPIOPin {
+ public:
+  void setup() override;
+  void pin_mode(gpio::Flags flags) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+  std::string dump_summary() const override;
+
+  void set_parent(MAX7321 *parent) { parent_ = parent; }
+  void set_pin(uint8_t pin) { pin_ = pin; }
+  void set_inverted(bool inverted) { inverted_ = inverted; }
+  void set_flags(gpio::Flags flags) { flags_ = flags; }
+
+ protected:
+  MAX7321 *parent_;
+  uint8_t pin_;
+  bool inverted_;
+  gpio::Flags flags_;
+};
+
+}  // namespace max7321
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

A component to make use of the MAX7321 I²C Port Expander IC (https://www.analog.com/media/en/technical-documentation/data-sheets/MAX7321.pdf). This was mainly done to better support the flow3r badge (https://flow3r.garden/) from the CCCamp2023 event within esphome. The code is based on the existing [MAX6956 component](https://esphome.io/components/max6956) and I'm mainly looking for feedback before implementing the needed documentation changes. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation:** ~esphome/esphome-docs#<esphome-docs PR number goes here>~ not done yet

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
max7321:
  - id: max7321_1
    address: 0x6D
    i2c_id: i2c_bus

binary_sensor:
  - platform: gpio
    id: "max1_pin1"
    name: "SW1_R"
    pin:
      max7321: max7321_1
      number: 0
      mode:
        input: true

switch:
  - platform: gpio
    name: "LED Power Enable"
    id: led_power_en
    pin:
      max7321: max7321_1
      number: 1
      mode:
        output: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
