### PR TITLE
Disable IPv6 when config explicitly says false

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -118,10 +118,10 @@ void EthernetComponent::setup() {
   ESPHL_ERROR_CHECK(err, "ETH event handler register error");
   err = esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &EthernetComponent::got_ip_event_handler, nullptr);
   ESPHL_ERROR_CHECK(err, "GOT IP event handler register error");
-#if LWIP_IPV6
+#if ENABLE_IPV6
   err = esp_event_handler_register(IP_EVENT, IP_EVENT_GOT_IP6, &EthernetComponent::got_ip6_event_handler, nullptr);
   ESPHL_ERROR_CHECK(err, "GOT IP6 event handler register error");
-#endif /* LWIP_IPV6 */
+#endif /* ENABLE_IPV6 */
 
   /* start Ethernet driver state machine */
   err = esp_eth_start(this->eth_handle_);
@@ -164,7 +164,7 @@ void EthernetComponent::loop() {
         this->state_ = EthernetComponentState::CONNECTING;
         this->start_connect_();
       }
-#if LWIP_IPV6
+#if ENABLE_IPV6
       else if (this->got_ipv6_) {
         esp_ip6_addr_t ip6_addr;
         if (esp_netif_get_ip6_global(this->eth_netif_, &ip6_addr) == 0 &&
@@ -177,7 +177,7 @@ void EthernetComponent::loop() {
 
         this->got_ipv6_ = false;
       }
-#endif /* LWIP_IPV6 */
+#endif /* ENABLE_IPV6 */
       break;
   }
 }
@@ -272,14 +272,14 @@ void EthernetComponent::got_ip_event_handler(void *arg, esp_event_base_t event_b
   ESP_LOGV(TAG, "[Ethernet event] ETH Got IP (num=%" PRId32 ")", event_id);
 }
 
-#if LWIP_IPV6
+#if ENABLE_IPV6
 void EthernetComponent::got_ip6_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
                                               void *event_data) {
   ESP_LOGV(TAG, "[Ethernet event] ETH Got IP6 (num=%d)", event_id);
   global_eth_component->got_ipv6_ = true;
   global_eth_component->ipv6_count_ += 1;
 }
-#endif /* LWIP_IPV6 */
+#endif /* ENABLE_IPV6 */
 
 void EthernetComponent::start_connect_() {
   this->connect_begin_ = millis();
@@ -343,12 +343,12 @@ void EthernetComponent::start_connect_() {
     if (err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STARTED) {
       ESPHL_ERROR_CHECK(err, "DHCPC start error");
     }
-#if LWIP_IPV6
+#if ENABLE_IPV6
     err = esp_netif_create_ip6_linklocal(this->eth_netif_);
     if (err != ESP_OK) {
       ESPHL_ERROR_CHECK(err, "IPv6 local failed");
     }
-#endif /* LWIP_IPV6 */
+#endif /* ENABLE_IPV6 */
   }
 
   this->connect_begin_ = millis();
@@ -376,7 +376,7 @@ void EthernetComponent::dump_connect_params_() {
   ESP_LOGCONFIG(TAG, "  DNS2: %s", network::IPAddress(dns_ip2->addr).str().c_str());
 #endif
 
-#if LWIP_IPV6
+#if ENABLE_IPV6
   if (this->ipv6_count_ > 0) {
     esp_ip6_addr_t ip6_addr;
     esp_netif_get_ip6_linklocal(this->eth_netif_, &ip6_addr);
@@ -387,7 +387,7 @@ void EthernetComponent::dump_connect_params_() {
       ESP_LOGCONFIG(TAG, "IPv6 Addr (Global): " IPV6STR, IPV62STR(ip6_addr));
     }
   }
-#endif /* LWIP_IPV6 */
+#endif /* ENABLE_IPV6 */
 
   esp_err_t err;
 

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -23,9 +23,9 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
-    if CONF_ENABLE_IPV6 in config:
+    if CONF_ENABLE_IPV6 in config and config[CONF_ENABLE_IPV6]:
+        cg.add_define("ENABLE_IPV6", config[CONF_ENABLE_IPV6])
         if CORE.using_esp_idf:
-            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
             add_idf_sdkconfig_option(
                 "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
             )

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -447,9 +447,9 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       buf[it.ssid_len] = '\0';
       ESP_LOGV(TAG, "Event: Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
                format_mac_addr(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
-#if LWIP_IPV6
+#if ENABLE_IPV6
       this->set_timeout(100, [] { WiFi.enableIpV6(); });
-#endif /* LWIP_IPV6 */
+#endif /* ENABLE_IPV6 */
 
       break;
     }
@@ -504,13 +504,13 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       s_sta_connecting = false;
       break;
     }
-#if LWIP_IPV6
+#if ENABLE_IPV6
     case ESPHOME_EVENT_ID_WIFI_STA_GOT_IP6: {
       auto it = info.got_ip6.ip6_info;
       ESP_LOGV(TAG, "Got IPv6 address=" IPV6STR, IPV62STR(it.ip));
       break;
     }
-#endif /* LWIP_IPV6 */
+#endif /* ENABLE_IPV6 */
     case ESPHOME_EVENT_ID_WIFI_STA_LOST_IP: {
       ESP_LOGV(TAG, "Event: Lost IP");
       break;

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -58,9 +58,9 @@ struct IDFWiFiEvent {
     wifi_event_ap_probe_req_rx_t ap_probe_req_rx;
     wifi_event_bss_rssi_low_t bss_rssi_low;
     ip_event_got_ip_t ip_got_ip;
-#if LWIP_IPV6
+#if ENABLE_IPV6
     ip_event_got_ip6_t ip_got_ip6;
-#endif
+#endif /* ENABLE_IPV6 */
     ip_event_ap_staipassigned_t ip_ap_staipassigned;
   } data;
 };
@@ -84,10 +84,10 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
     memcpy(&event.data.sta_disconnected, event_data, sizeof(wifi_event_sta_disconnected_t));
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
     memcpy(&event.data.ip_got_ip, event_data, sizeof(ip_event_got_ip_t));
-#if LWIP_IPV6
+#if ENABLE_IPV6
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_GOT_IP6) {
     memcpy(&event.data.ip_got_ip6, event_data, sizeof(ip_event_got_ip6_t));
-#endif
+#endif /* ENABLE_IPV6 */
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_LOST_IP) {  // NOLINT(bugprone-branch-clone)
     // no data
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_SCAN_DONE) {
@@ -645,18 +645,18 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_STA_GOT_IP) {
     const auto &it = data->data.ip_got_ip;
-#if LWIP_IPV6_AUTOCONFIG
+#if ENABLE_IPV6
     esp_netif_create_ip6_linklocal(s_sta_netif);
-#endif
+#endif /* ENABLE_IPV6 */
     ESP_LOGV(TAG, "Event: Got IP static_ip=%s gateway=%s", format_ip4_addr(it.ip_info.ip).c_str(),
              format_ip4_addr(it.ip_info.gw).c_str());
     s_sta_got_ip = true;
 
-#if LWIP_IPV6
+#if ENABLE_IPV6
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_GOT_IP6) {
     const auto &it = data->data.ip_got_ip6;
     ESP_LOGV(TAG, "Event: Got IPv6 address=%s", format_ip6_addr(it.ip6_info.ip).c_str());
-#endif
+#endif /* ENABLE_IPV6 */
 
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_STA_LOST_IP) {
     ESP_LOGV(TAG, "Event: Lost IP");


### PR DESCRIPTION
# What does this implement/fix?

Forgot to disable IPv6 if `enable_ipv6` is set to false, only when that option was missing.
Seems that ESP-IDF enables LWIP_IPV6 by default, so that define could not be used for enabling IPv6 in ESPHome.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4834

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
network:
  enable_ipv6: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
