### PR TITLE
Bugfix: disable channels after IO if multiple tca9548a  I2C multiplexers are configured

### DIFF
--- a/esphome/components/tca9548a/__init__.py
+++ b/esphome/components/tca9548a/__init__.py
@@ -11,10 +11,9 @@ tca9548a_ns = cg.esphome_ns.namespace("tca9548a")
 TCA9548AComponent = tca9548a_ns.class_("TCA9548AComponent", cg.Component, i2c.I2CDevice)
 TCA9548AChannel = tca9548a_ns.class_("TCA9548AChannel", i2c.I2CBus)
 
-MULTI_CONF = True
-
 CONF_BUS_ID = "bus_id"
-CONFIG_SCHEMA = (
+
+TCA9548A_COMPONENT_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(TCA9548AComponent),
@@ -31,13 +30,18 @@ CONFIG_SCHEMA = (
     .extend(cv.COMPONENT_SCHEMA)
 )
 
+CONFIG_SCHEMA = cv.ensure_list(TCA9548A_COMPONENT_SCHEMA)
+
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
-    await i2c.register_i2c_device(var, config)
+    for component in config:
+        var = cg.new_Pvariable(component[CONF_ID])
+        await cg.register_component(var, component)
+        await i2c.register_i2c_device(var, component)
 
-    for conf in config[CONF_CHANNELS]:
-        chan = cg.new_Pvariable(conf[CONF_BUS_ID])
-        cg.add(chan.set_parent(var))
-        cg.add(chan.set_channel(conf[CONF_CHANNEL]))
+        # If more than one tca9548a is configured, disable all channels after all IO to avoid address conflicts
+        cg.add(var.set_disable_channels_after_io(len(config) > 1))
+        for conf in component[CONF_CHANNELS]:
+            chan = cg.new_Pvariable(conf[CONF_BUS_ID])
+            cg.add(chan.set_parent(var))
+            cg.add(chan.set_channel(conf[CONF_CHANNEL]))

--- a/esphome/components/tca9548a/__init__.py
+++ b/esphome/components/tca9548a/__init__.py
@@ -11,9 +11,10 @@ tca9548a_ns = cg.esphome_ns.namespace("tca9548a")
 TCA9548AComponent = tca9548a_ns.class_("TCA9548AComponent", cg.Component, i2c.I2CDevice)
 TCA9548AChannel = tca9548a_ns.class_("TCA9548AChannel", i2c.I2CBus)
 
-CONF_BUS_ID = "bus_id"
+MULTI_CONF = True
 
-TCA9548A_COMPONENT_SCHEMA = (
+CONF_BUS_ID = "bus_id"
+CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(TCA9548AComponent),
@@ -30,18 +31,13 @@ TCA9548A_COMPONENT_SCHEMA = (
     .extend(cv.COMPONENT_SCHEMA)
 )
 
-CONFIG_SCHEMA = cv.ensure_list(TCA9548A_COMPONENT_SCHEMA)
-
 
 async def to_code(config):
-    for component in config:
-        var = cg.new_Pvariable(component[CONF_ID])
-        await cg.register_component(var, component)
-        await i2c.register_i2c_device(var, component)
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
 
-        # If more than one tca9548a is configured, disable all channels after all IO to avoid address conflicts
-        cg.add(var.set_disable_channels_after_io(len(config) > 1))
-        for conf in component[CONF_CHANNELS]:
-            chan = cg.new_Pvariable(conf[CONF_BUS_ID])
-            cg.add(chan.set_parent(var))
-            cg.add(chan.set_channel(conf[CONF_CHANNEL]))
+    for conf in config[CONF_CHANNELS]:
+        chan = cg.new_Pvariable(conf[CONF_BUS_ID])
+        cg.add(chan.set_parent(var))
+        cg.add(chan.set_channel(conf[CONF_CHANNEL]))

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -7,23 +7,27 @@ namespace tca9548a {
 static const char *const TAG = "tca9548a";
 
 i2c::ErrorCode TCA9548AChannel::readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) {
-  auto err = parent_->switch_to_channel(channel_);
+  auto err = this->parent_->switch_to_channel(channel_);
   if (err != i2c::ERROR_OK)
     return err;
-  return parent_->bus_->readv(address, buffers, cnt);
+  err = this->parent_->bus_->readv(address, buffers, cnt);
+  this->parent_->disable_all_channels();
+  return err;
 }
 i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) {
-  auto err = parent_->switch_to_channel(channel_);
+  auto err = this->parent_->switch_to_channel(channel_);
   if (err != i2c::ERROR_OK)
     return err;
-  return parent_->bus_->writev(address, buffers, cnt, stop);
+  err = this->parent_->bus_->writev(address, buffers, cnt, stop);
+  this->parent_->disable_all_channels();
+  return err;
 }
 
 void TCA9548AComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TCA9548A...");
   uint8_t status = 0;
   if (this->read(&status, 1) != i2c::ERROR_OK) {
-    ESP_LOGI(TAG, "TCA9548A failed");
+    ESP_LOGE(TAG, "TCA9548A failed");
     this->mark_failed();
     return;
   }
@@ -40,12 +44,21 @@ i2c::ErrorCode TCA9548AComponent::switch_to_channel(uint8_t channel) {
   if (current_channel_ == channel)
     return i2c::ERROR_OK;
 
-  uint8_t channel_val = 1 << channel;
+  uint8_t channel_val = 1 << channel;  // if channel > 7, then channel_val = 0, which disables all channels
   auto err = this->write(&channel_val, 1);
   if (err == i2c::ERROR_OK) {
-    current_channel_ = channel;
+    this->current_channel_ = channel;
   }
   return err;
+}
+
+void TCA9548AComponent::disable_all_channels() {
+  if (this->disable_channels_after_io_) {
+    if (this->switch_to_channel(255) != i2c::ERROR_OK) {
+      this->mark_failed();  // couldn't disable channels, mark entire component failed to avoid future address conflicts
+      ESP_LOGE(TAG, "Failed to disable all channels.");
+    }
+  }
 }
 
 }  // namespace tca9548a

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -44,7 +44,13 @@ i2c::ErrorCode TCA9548AComponent::switch_to_channel(uint8_t channel) {
   if (current_channel_ == channel)
     return i2c::ERROR_OK;
 
-  uint8_t channel_val = 1 << channel;  // if channel > 7, then channel_val = 0, which disables all channels
+  uint8_t channel_val = 0;  // 0 disables all channels
+
+  // If it is a valid channel, shift 1 to the corresponding channel bit to enable it
+  if (channel < 8) {
+    channel_val = 1 << channel;
+  }
+
   auto err = this->write(&channel_val, 1);
   if (err == i2c::ERROR_OK) {
     this->current_channel_ = channel;

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -6,6 +6,8 @@
 namespace esphome {
 namespace tca9548a {
 
+static const uint8_t TCA9548A_DISABLE_CHANNELS_COMMAND = 0x00;
+
 class TCA9548AComponent;
 class TCA9548AChannel : public i2c::I2CBus {
  public:
@@ -27,15 +29,11 @@ class TCA9548AComponent : public Component, public i2c::I2CDevice {
   float get_setup_priority() const override { return setup_priority::IO; }
   void update();
 
-  void set_disable_channels_after_io(bool disable) { this->disable_channels_after_io_ = disable; }
-
   i2c::ErrorCode switch_to_channel(uint8_t channel);
   void disable_all_channels();
 
  protected:
   friend class TCA9548AChannel;
-  uint8_t current_channel_{255};
-  bool disable_channels_after_io_{};  // Disable channels after any IO; use when multiple tca9548a are used
 };
 }  // namespace tca9548a
 }  // namespace esphome

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -27,11 +27,15 @@ class TCA9548AComponent : public Component, public i2c::I2CDevice {
   float get_setup_priority() const override { return setup_priority::IO; }
   void update();
 
+  void set_disable_channels_after_io(bool disable) { this->disable_channels_after_io_ = disable; }
+
   i2c::ErrorCode switch_to_channel(uint8_t channel);
+  void disable_all_channels();
 
  protected:
   friend class TCA9548AChannel;
-  uint8_t current_channel_ = 255;
+  uint8_t current_channel_{255};
+  bool disable_channels_after_io_{};  // Disable channels after any IO; use when multiple tca9548a are used
 };
 }  // namespace tca9548a
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

If there are multiple tca9548a I2C multiplexers configured on the same bus, then there are potential address conflicts. If you have two components with the same address attached to two tca9548a multiplexers, they will both attempt to communicate at the same time. This PR disables all the channels on a tca9548a after any IO if there is more than one multiplexer configured.

I removed the MULTI_CONF option in ``__init__.py``, and used a `cv.ensure_list` to determine if more than tca9548a is configured. If only one tca9548a is configured, then the  component does not disable all channels and matches the current behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

tca9548a:
  - address: 0x70
    id: multiplex0
    i2c_id: direct_bus
    channels:
      - bus_id: multplex0channel0
        channel: 0
  - address: 0x71
    id: multiplex1    
    i2c_id: direct_bus
    channels:
      - bus_id: multplex1channel0
        channel: 0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
