### PR TITLE
Add extra SLPOUT for waking up some ST7789 chips

### DIFF
--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -19,6 +19,7 @@ void ST7789V::setup() {
 
   this->write_command_(ST7789_SLPOUT);  // Sleep out
   delay(120);                           // NOLINT
+  this->write_command_(ST7789_SLPOUT);  //
 
   this->write_command_(ST7789_NORON);  // Normal display mode on
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The ST7789 in the [Lilygo T-Embed board](https://github.com/Xinyuan-LilyGO/T-Embed) seems to need an extra wakeup (SLPOUT) command. This should not affect other boards, as the datasheet says "This command has no effect when module is already in sleep out mode".

This has been tested against the current dev branch (Arduino only) as well as PR https://github.com/esphome/esphome/pull/5311 (Arduino and ESP-IDF 5.0).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** Relates to: https://github.com/esphome/feature-requests/issues/901


## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: t-embed

esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  framework:
    type: arduino

logger:
api:
ota:
  password: !secret ota_password
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

power_supply:
  - id: power_on
    pin: GPIO46

spi:
  clk_pin: GPIO12
  mosi_pin: GPIO11

display:
  - platform: st7789v
    power_supply: power_on
    model: "Custom"
    eightbitcolor: False
    rotation: 270
    width: 170
    height: 320
    offset_width: 0
    offset_height: 35
    backlight_pin: GPIO15
    cs_pin: GPIO10
    dc_pin: GPIO13
    reset_pin: GPIO9
    id: disp
    lambda: |-
      auto rand_col = Color::random_color();
      it.filled_rectangle(0, 0, it.get_width() - 1, it.get_height() - 1, rand_col);
```

## Checklist:
  - [x] The code change is tested and works locally.

