### PR TITLE
7789 controller fixes take 2

### DIFF
--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -5,6 +5,7 @@ namespace esphome {
 namespace st7789v {
 
 static const char *const TAG = "st7789v";
+static const size_t TEMP_BUFFER_SIZE = 512;
 
 void ST7789V::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SPI ST7789V...");
@@ -205,15 +206,23 @@ void ST7789V::write_display_data() {
   this->dc_pin_->digital_write(true);
 
   if (this->eightbitcolor_) {
+    uint8_t temp_buffer[TEMP_BUFFER_SIZE];
+    size_t temp_index = 0;
     for (int line = 0; line < this->get_buffer_length_(); line = line + this->get_width_internal()) {
       for (int index = 0; index < this->get_width_internal(); ++index) {
         auto color = display::ColorUtil::color_to_565(
             display::ColorUtil::to_color(this->buffer_[index + line], display::ColorOrder::COLOR_ORDER_RGB,
                                          display::ColorBitness::COLOR_BITNESS_332, true));
-        this->write_byte((color >> 8) & 0xff);
-        this->write_byte(color & 0xff);
+        temp_buffer[temp_index++] = (uint8_t) (color >> 8);
+        temp_buffer[temp_index++] = (uint8_t) color;
+        if (temp_index == TEMP_BUFFER_SIZE) {
+          this->write_array(temp_buffer, TEMP_BUFFER_SIZE);
+          temp_index = 0;
+        }
       }
     }
+    if (temp_index != 0)
+      this->write_array(temp_buffer, temp_index);
   } else {
     this->write_array(this->buffer_, this->get_buffer_length_());
   }

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -228,7 +228,7 @@ void ST7789V::init_reset_() {
     delay(1);
     // Trigger Reset
     this->reset_pin_->digital_write(false);
-    delay(10);
+    delay(1);
     // Wake up
     this->reset_pin_->digital_write(true);
   }

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -19,7 +19,6 @@ void ST7789V::setup() {
 
   this->write_command_(ST7789_SLPOUT);  // Sleep out
   delay(120);                           // NOLINT
-  this->write_command_(ST7789_SLPOUT);  //
 
   this->write_command_(ST7789_NORON);  // Normal display mode on
 
@@ -232,6 +231,7 @@ void ST7789V::init_reset_() {
     delay(1);
     // Wake up
     this->reset_pin_->digital_write(true);
+    delay(5);
   }
 }
 

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -5,7 +5,7 @@ namespace esphome {
 namespace st7789v {
 
 static const char *const TAG = "st7789v";
-static const size_t TEMP_BUFFER_SIZE = 512;
+static const size_t TEMP_BUFFER_SIZE = 128;
 
 void ST7789V::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SPI ST7789V...");

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -117,8 +117,8 @@ static const uint8_t ST7789_MADCTL_COLOR_ORDER = ST7789_MADCTL_BGR;
 
 class ST7789V : public PollingComponent,
                 public display::DisplayBuffer,
-                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
-                                      spi::DATA_RATE_10MHZ> {
+                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                                      spi::DATA_RATE_40MHZ> {
  public:
   void set_model(ST7789VModel model);
   void set_dc_pin(GPIOPin *dc_pin) { this->dc_pin_ = dc_pin; }

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -118,7 +118,7 @@ static const uint8_t ST7789_MADCTL_COLOR_ORDER = ST7789_MADCTL_BGR;
 class ST7789V : public PollingComponent,
                 public display::DisplayBuffer,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
-                                      spi::DATA_RATE_40MHZ> {
+                                      spi::DATA_RATE_20MHZ> {
  public:
   void set_model(ST7789VModel model);
   void set_dc_pin(GPIOPin *dc_pin) { this->dc_pin_ = dc_pin; }


### PR DESCRIPTION
# What does this implement/fix?


The 7789 driver was set up to use mode 3 SPI - high clock, trailing edge. The datasheet says it should use mode 0 - low clock, leading edge. Implementing this negates the need for the extra SLPOUT as per the previous PR.

SPI clock has also been bumped to 40 MHz - the datasheet says clock high and low periods are minimum 7ns, which means the maximum clock rate is around 70MHz.

This has been tested against the current dev branch (Arduino only) as well as PR https://github.com/esphome/esphome/pull/5311 (Arduino and ESP-IDF 5.0).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** Relates to: https://github.com/esphome/feature-requests/issues/901


## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: t-embed

esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  framework:
    type: arduino

logger:
api:
ota:
  password: !secret ota_password
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

power_supply:
  - id: power_on
    pin: GPIO46

spi:
  clk_pin: GPIO12
  mosi_pin: GPIO11

display:
  - platform: st7789v
    power_supply: power_on
    model: "Custom"
    eightbitcolor: False
    rotation: 270
    width: 170
    height: 320
    offset_width: 0
    offset_height: 35
    backlight_pin: GPIO15
    cs_pin: GPIO10
    dc_pin: GPIO13
    reset_pin: GPIO9
    id: disp
    lambda: |-
      auto rand_col = Color::random_color();
      it.filled_rectangle(0, 0, it.get_width() - 1, it.get_height() - 1, rand_col);
```

## Checklist:
  - [x] The code change is tested and works locally.


