### PR TITLE
esp32: Extra build customization

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -152,21 +152,24 @@ def add_idf_component(
             KEY_SUBMODULES: submodules,
         }
 
+
 def add_extra_script(stage: str, filename: str, path: str):
     """Add an extra script to the project."""
     key = f"{stage}:{filename}"
     if add_extra_build_file(filename, path):
         cg.add_platformio_option("extra_scripts", [key])
 
+
 def add_extra_build_file(filename: str, path: str) -> bool:
     """Add an extra build file to the project."""
     if filename not in CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES]:
         CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES][filename] = {
             KEY_NAME: filename,
-            KEY_PATH: path
+            KEY_PATH: path,
         }
         return True
     return False
+
 
 def _format_framework_arduino_version(ver: cv.Version) -> str:
     # format the given arduino (https://github.com/espressif/arduino-esp32/releases) version to
@@ -392,7 +395,11 @@ async def to_code(config):
     conf = config[CONF_FRAMEWORK]
     cg.add_platformio_option("platform", conf[CONF_PLATFORM_VERSION])
 
-    add_extra_script("post", "post_build2.py", os.path.join(os.path.dirname(__file__), "post_build.py.script"))
+    add_extra_script(
+        "post",
+        "post_build2.py",
+        os.path.join(os.path.dirname(__file__), "post_build.py.script"),
+    )
 
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_platformio_option("framework", "espidf")
@@ -612,7 +619,7 @@ def copy_files():
 
             mkdir_p(CORE.relative_build_path(os.path.dirname(file[KEY_NAME])))
             with open(CORE.relative_build_path(file[KEY_NAME]), "wb") as f:
-                f.write(requests.get(file[KEY_PATH]).content)
+                f.write(requests.get(file[KEY_PATH], timeout=30).content)
         else:
             copy_file_if_changed(
                 file[KEY_PATH],

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -22,6 +22,7 @@ from esphome.const import (
     CONF_IGNORE_EFUSE_MAC_CRC,
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
+    KEY_NAME,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     TYPE_GIT,
@@ -37,6 +38,7 @@ from .const import (  # noqa
     KEY_BOARD,
     KEY_COMPONENTS,
     KEY_ESP32,
+    KEY_EXTRA_BUILD_FILES,
     KEY_PATH,
     KEY_REF,
     KEY_REFRESH,
@@ -73,6 +75,8 @@ def set_core_data(config):
     )
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]
     CORE.data[KEY_ESP32][KEY_VARIANT] = config[CONF_VARIANT]
+    CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES] = {}
+
     return config
 
 
@@ -148,6 +152,21 @@ def add_idf_component(
             KEY_SUBMODULES: submodules,
         }
 
+def add_extra_script(stage: str, filename: str, path: str):
+    """Add an extra script to the project."""
+    key = f"{stage}:{filename}"
+    if add_extra_build_file(filename, path):
+        cg.add_platformio_option("extra_scripts", [key])
+
+def add_extra_build_file(filename: str, path: str) -> bool:
+    """Add an extra build file to the project."""
+    if filename not in CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES]:
+        CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES][filename] = {
+            KEY_NAME: filename,
+            KEY_PATH: path
+        }
+        return True
+    return False
 
 def _format_framework_arduino_version(ver: cv.Version) -> str:
     # format the given arduino (https://github.com/espressif/arduino-esp32/releases) version to
@@ -373,7 +392,7 @@ async def to_code(config):
     conf = config[CONF_FRAMEWORK]
     cg.add_platformio_option("platform", conf[CONF_PLATFORM_VERSION])
 
-    cg.add_platformio_option("extra_scripts", ["post:post_build.py"])
+    add_extra_script("post", "post_build2.py", os.path.join(os.path.dirname(__file__), "post_build.py.script"))
 
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_platformio_option("framework", "espidf")
@@ -587,9 +606,15 @@ def copy_files():
                         ignore_dangling_symlinks=True,
                     )
 
-    dir = os.path.dirname(__file__)
-    post_build_file = os.path.join(dir, "post_build.py.script")
-    copy_file_if_changed(
-        post_build_file,
-        CORE.relative_build_path("post_build.py"),
-    )
+    for _, file in CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES].items():
+        if file[KEY_PATH].startswith("http"):
+            import requests
+
+            mkdir_p(CORE.relative_build_path(os.path.dirname(file[KEY_NAME])))
+            with open(CORE.relative_build_path(file[KEY_NAME]), "wb") as f:
+                f.write(requests.get(file[KEY_PATH]).content)
+        else:
+            copy_file_if_changed(
+                file[KEY_PATH],
+                CORE.relative_build_path(file[KEY_NAME]),
+            )

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -10,6 +10,7 @@ KEY_REF = "ref"
 KEY_REFRESH = "refresh"
 KEY_PATH = "path"
 KEY_SUBMODULES = "submodules"
+KEY_EXTRA_BUILD_FILES = "extra_build_files"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32S2 = "ESP32S2"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Add option for components to create `extra_scripts` and add arbitrary files to the build folder

This adds 2 functions:
- `esp32.add_extra_script`
- `esp32.add_extra_build_file`

`add_extra_script` adds the file to the build folder and adds a platformio.ini line under `extra_scripts` to execute said script pre/post compile time.

`add_extra_build_file` just adds any file to the generated project folder, such as those extra scripts above.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
