### PR TITLE
api: Use mac address for entity unique ids

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -161,7 +161,7 @@ void APIConnection::loop() {
 }
 
 std::string get_default_unique_id(const std::string &component_type, EntityBase *entity) {
-  return App.get_name() + component_type + entity->get_object_id();
+  return get_mac_address_pretty() + "-" + component_type + "-" + entity->get_object_id();
 }
 
 DisconnectResponse APIConnection::disconnect(const DisconnectRequest &msg) {
@@ -437,9 +437,7 @@ bool APIConnection::send_sensor_info(sensor::Sensor *sensor) {
   msg.object_id = sensor->get_object_id();
   if (sensor->has_own_name())
     msg.name = sensor->get_name();
-  msg.unique_id = sensor->unique_id();
-  if (msg.unique_id.empty())
-    msg.unique_id = get_default_unique_id("sensor", sensor);
+  msg.unique_id = get_default_unique_id("sensor", sensor);
   msg.icon = sensor->get_icon();
   msg.unit_of_measurement = sensor->get_unit_of_measurement();
   msg.accuracy_decimals = sensor->get_accuracy_decimals();
@@ -505,9 +503,7 @@ bool APIConnection::send_text_sensor_info(text_sensor::TextSensor *text_sensor) 
   msg.key = text_sensor->get_object_id_hash();
   msg.object_id = text_sensor->get_object_id();
   msg.name = text_sensor->get_name();
-  msg.unique_id = text_sensor->unique_id();
-  if (msg.unique_id.empty())
-    msg.unique_id = get_default_unique_id("text_sensor", text_sensor);
+  msg.unique_id = get_default_unique_id("text_sensor", text_sensor);
   msg.icon = text_sensor->get_icon();
   msg.disabled_by_default = text_sensor->is_disabled_by_default();
   msg.entity_category = static_cast<enums::EntityCategory>(text_sensor->get_entity_category());


### PR DESCRIPTION
# Draft 

Drafted until Home Assistant is released with migration code so that this does not duplicate all the entities.


# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This changes the `object_id` that Api clients can use as the unique_id for an entity. 
This is a breaking change, but a migration on the Home Assistant side will attempt to make it as non-breaking as possible.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2365

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
