### PR TITLE
Attempt to fix secret blurring

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -371,7 +371,7 @@ def command_config(args, config):
     # add the console decoration so the front-end can hide the secrets
     if not args.show_secrets:
         output = re.sub(
-            r"(password|key|psk|ssid)\:\s(.*)", r"\1: \\033[5m\2\\033[6m", output
+            r"(password|key|psk|ssid)\: (.+)", r"\1: \\033[5m\2\\033[6m", output
         )
     safe_print(output)
     _LOGGER.info("Configuration is valid!")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The existing secret wrapping also wraps the below `wifi_info` `ssid` child sensor block, causing invalid yaml to be printed from the `config` (validate) command.

This changes it to be a bit more strict and only wrap direct values, not blocks.

```yaml
wifi:
  ap:
    ssid: blah

text_sensor:
  - platform: wifi_info
    ssid:
      name: blah
 ```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
