### PR TITLE
Tweak Improv serial to build in IDF 5

### DIFF
--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -48,7 +48,7 @@ uint8_t ImprovSerialComponent::read_byte_() {
   this->hw_serial_->readBytes(&data, 1);
 #endif
 #ifdef USE_ESP_IDF
-  uart_read_bytes(this->uart_num_, &data, 1, 20 / portTICK_RATE_MS);
+  uart_read_bytes(this->uart_num_, &data, 1, 20 / portTICK_PERIOD_MS);
 #endif
   return data;
 }


### PR DESCRIPTION
# What does this implement/fix?

I discovered that `improv_serial` won't compile under IDF 5. This tweak fixes that (and it still builds in Arduino & IDF 4).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
