### PR TITLE
Debug component: add free PSRAM sensor

### DIFF
--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -143,6 +143,10 @@ void DebugComponent::dump_config() {
     features += "BT,";
     info.features &= ~CHIP_FEATURE_BT;
   }
+  if (info.features & CHIP_FEATURE_EMB_PSRAM) {
+    features += "EMB_PSRAM,";
+    info.features &= ~CHIP_FEATURE_EMB_PSRAM;
+  }
   if (info.features)
     features += "Other:" + format_hex(info.features);
   ESP_LOGD(TAG, "Chip: Model=%s, Features=%s Cores=%u, Revision=%u", model, features.c_str(), info.cores,
@@ -398,6 +402,12 @@ void DebugComponent::update() {
     this->loop_time_sensor_->publish_state(this->max_loop_time_);
     this->max_loop_time_ = 0;
   }
+
+#ifdef USE_ESP32
+  if (this->psram_sensor_ != nullptr) {
+    this->psram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+  }
+#endif  // USE_ESP32
 #endif  // USE_SENSOR
 }
 

--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -33,6 +33,9 @@ class DebugComponent : public PollingComponent {
   void set_fragmentation_sensor(sensor::Sensor *fragmentation_sensor) { fragmentation_sensor_ = fragmentation_sensor; }
 #endif
   void set_loop_time_sensor(sensor::Sensor *loop_time_sensor) { loop_time_sensor_ = loop_time_sensor; }
+#ifdef USE_ESP32
+  void set_psram_sensor(sensor::Sensor *psram_sensor) { this->psram_sensor_ = psram_sensor; }
+#endif  // USE_ESP32
 #endif  // USE_SENSOR
  protected:
   uint32_t free_heap_{};
@@ -47,6 +50,9 @@ class DebugComponent : public PollingComponent {
   sensor::Sensor *fragmentation_sensor_{nullptr};
 #endif
   sensor::Sensor *loop_time_sensor_{nullptr};
+#ifdef USE_ESP32
+  sensor::Sensor *psram_sensor_{nullptr};
+#endif  // USE_ESP32
 #endif  // USE_SENSOR
 
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -17,6 +17,8 @@ from . import CONF_DEBUG_ID, DebugComponent
 
 DEPENDENCIES = ["debug"]
 
+CONF_PSRAM = "psram"
+
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_DEBUG_ID): cv.use_id(DebugComponent),
     cv.Optional(CONF_FREE): sensor.sensor_schema(
@@ -47,24 +49,37 @@ CONFIG_SCHEMA = {
         accuracy_decimals=0,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    cv.Optional(CONF_PSRAM): cv.All(
+        cv.only_on_esp32,
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_BYTES,
+            icon=ICON_COUNTER,
+            accuracy_decimals=0,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    ),
 }
 
 
 async def to_code(config):
     debug_component = await cg.get_variable(config[CONF_DEBUG_ID])
 
-    if CONF_FREE in config:
-        sens = await sensor.new_sensor(config[CONF_FREE])
+    if free_conf := config.get(CONF_FREE):
+        sens = await sensor.new_sensor(free_conf)
         cg.add(debug_component.set_free_sensor(sens))
 
-    if CONF_BLOCK in config:
-        sens = await sensor.new_sensor(config[CONF_BLOCK])
+    if block_conf := config.get(CONF_BLOCK):
+        sens = await sensor.new_sensor(block_conf)
         cg.add(debug_component.set_block_sensor(sens))
 
-    if CONF_FRAGMENTATION in config:
-        sens = await sensor.new_sensor(config[CONF_FRAGMENTATION])
+    if fragmentation_conf := config.get(CONF_FRAGMENTATION):
+        sens = await sensor.new_sensor(fragmentation_conf)
         cg.add(debug_component.set_fragmentation_sensor(sens))
 
-    if CONF_LOOP_TIME in config:
-        sens = await sensor.new_sensor(config[CONF_LOOP_TIME])
+    if loop_time_conf := config.get(CONF_LOOP_TIME):
+        sens = await sensor.new_sensor(loop_time_conf)
         cg.add(debug_component.set_loop_time_sensor(sens))
+
+    if psram_conf := config.get(CONF_PSRAM):
+        sens = await sensor.new_sensor(psram_conf)
+        cg.add(debug_component.set_psram_sensor(sens))

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -51,6 +51,7 @@ CONFIG_SCHEMA = {
     ),
     cv.Optional(CONF_PSRAM): cv.All(
         cv.only_on_esp32,
+        cv.requires_component("psram"),
         sensor.sensor_schema(
             unit_of_measurement=UNIT_BYTES,
             icon=ICON_COUNTER,

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1448,6 +1448,15 @@ sensor:
     pressure:
       name: "BMP581 Pressure"
       oversampling: 128x
+  - platform: debug
+    free:
+      name: "Heap Free"
+    block:
+      name: "Heap Max Block"
+    loop_time:
+      name: "Loop Time"
+    psram:
+      name: "PSRAM Free"
 
 esp32_touch:
   setup_mode: false
@@ -3447,7 +3456,6 @@ number:
         name: g8 move threshold
       still_threshold:
         name: g8 still threshold
-
 
 select:
   - platform: template

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -28,6 +28,8 @@ ota:
 
 logger:
 
+debug:
+
 uart:
   - id: uart_1
     tx_pin: 1
@@ -524,6 +526,16 @@ sensor:
       name: Heat Quantity
     time:
       name: System Time
+
+  - platform: debug
+    free:
+      name: "Heap Free"
+    block:
+      name: "Heap Max Block"
+    loop_time:
+      name: "Loop Time"
+    psram:
+      name: "PSRAM Free"
 
   - platform: vbus
     model: custom

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -30,6 +30,8 @@ logger:
 
 debug:
 
+psram:
+
 uart:
   - id: uart_1
     tx_pin: 1

--- a/tests/test8.yaml
+++ b/tests/test8.yaml
@@ -16,6 +16,8 @@ logger:
 
 debug:
 
+psram:
+
 light:
   - platform: neopixelbus
     type: GRB

--- a/tests/test8.yaml
+++ b/tests/test8.yaml
@@ -14,6 +14,8 @@ esphome:
 
 logger:
 
+debug:
+
 light:
   - platform: neopixelbus
     type: GRB
@@ -50,3 +52,14 @@ binary_sensor:
   - platform: tt21100
     name: Home Button
     index: 1
+
+sensor:
+  - platform: debug
+    free:
+      name: "Heap Free"
+    block:
+      name: "Max Block Free"
+    loop_time:
+      name: "Loop Time"
+    psram:
+      name: "PSRAM Free"


### PR DESCRIPTION
# What does this implement/fix?

Adds a free PSRAM sensor to the ``debug`` component, as suggested by @martijnbuts in a comment on a recent PR. Additionally, it checks for the ``CHIP_FEATURE_EMB_PSRAM`` bit in the ``esp_chip_info_t`` variable in ``dump_config()``. Note, this appears to not be consistently set for all chips with psram in the esp-idf code. Finally, I added the sensors to several test cases.

I have tested these changes on an ESP32 with PSRAM, without PSRAM, and an ESP32-S3 with PSRAM, and all report as expected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3160

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
