### PR TITLE
Added Handling for Nack "file not found"

### DIFF
--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -101,6 +101,10 @@ void DFPlayer::loop() {
             ESP_LOGV(TAG, "Nack");
             this->ack_set_is_playing_ = false;
             this->ack_reset_is_playing_ = false;
+            if (argument == 6) {
+              ESP_LOGV(TAG, "File not found");
+              this->is_playing_  = false;
+            }
           case 0x41:
             ESP_LOGV(TAG, "Ack ok");
             this->is_playing_ |= this->ack_set_is_playing_;

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -103,7 +103,7 @@ void DFPlayer::loop() {
             this->ack_reset_is_playing_ = false;
             if (argument == 6) {
               ESP_LOGV(TAG, "File not found");
-              this->is_playing_  = false;
+              this->is_playing_ = false;
             }
           case 0x41:
             ESP_LOGV(TAG, "Ack ok");

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -105,6 +105,7 @@ void DFPlayer::loop() {
               ESP_LOGV(TAG, "File not found");
               this->is_playing_ = false;
             }
+            break;
           case 0x41:
             ESP_LOGV(TAG, "Ack ok");
             this->is_playing_ |= this->ack_set_is_playing_;


### PR DESCRIPTION
If DFPlayer sends NACK witch argument 0x06 indicating that the file was not found, still the component stays in is_playing =true state. This fixes this faulty behavior, however might not be the cleanest solution.

# What does this implement/fix?

If NACK is received with "File not found errorcode 0x06" the is_playing state is set to false.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).