### PR TITLE
2023.8.3

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -371,7 +371,7 @@ def command_config(args, config):
     # add the console decoration so the front-end can hide the secrets
     if not args.show_secrets:
         output = re.sub(
-            r"(password|key|psk|ssid)\:\s(.*)", r"\1: \\033[5m\2\\033[6m", output
+            r"(password|key|psk|ssid)\: (.+)", r"\1: \\033[5m\2\\033[6m", output
         )
     safe_print(output)
     _LOGGER.info("Configuration is valid!")

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -66,25 +66,28 @@ void MQTTClientComponent::setup() {
   }
 #endif
 
-  this->subscribe(
-      "esphome/discover", [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); },
-      2);
+  if (this->is_discovery_enabled()) {
+    this->subscribe(
+        "esphome/discover", [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); },
+        2);
 
-  std::string topic = "esphome/ping/";
-  topic.append(App.get_name());
-  this->subscribe(
-      topic, [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); }, 2);
+    std::string topic = "esphome/ping/";
+    topic.append(App.get_name());
+    this->subscribe(
+        topic, [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); }, 2);
+  }
 
   this->last_connected_ = millis();
   this->start_dnslookup_();
 }
 
 void MQTTClientComponent::send_device_info_() {
-  if (!this->is_connected()) {
+  if (!this->is_connected() or !this->is_discovery_enabled()) {
     return;
   }
   std::string topic = "esphome/discover/";
   topic.append(App.get_name());
+
   this->publish_json(
       topic,
       [](JsonObject root) {

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -769,7 +769,7 @@ uint8_t Pipsolar::check_incoming_length_(uint8_t length) {
 
 uint8_t Pipsolar::check_incoming_crc_() {
   uint16_t crc16;
-  crc16 = crc16be(read_buffer_, read_pos_ - 3);
+  crc16 = this->pipsolar_crc_(read_buffer_, read_pos_ - 3);
   ESP_LOGD(TAG, "checking crc on incoming message");
   if (((uint8_t) ((crc16) >> 8)) == read_buffer_[read_pos_ - 3] &&
       ((uint8_t) ((crc16) &0xff)) == read_buffer_[read_pos_ - 2]) {
@@ -798,7 +798,7 @@ uint8_t Pipsolar::send_next_command_() {
     this->command_start_millis_ = millis();
     this->empty_uart_buffer_();
     this->read_pos_ = 0;
-    crc16 = crc16be(byte_command, length);
+    crc16 = this->pipsolar_crc_(byte_command, length);
     this->write_str(command);
     // checksum
     this->write(((uint8_t) ((crc16) >> 8)));   // highbyte
@@ -825,8 +825,8 @@ void Pipsolar::send_next_poll_() {
   this->command_start_millis_ = millis();
   this->empty_uart_buffer_();
   this->read_pos_ = 0;
-  crc16 = crc16be(this->used_polling_commands_[this->last_polling_command_].command,
-                  this->used_polling_commands_[this->last_polling_command_].length);
+  crc16 = this->pipsolar_crc_(this->used_polling_commands_[this->last_polling_command_].command,
+                              this->used_polling_commands_[this->last_polling_command_].length);
   this->write_array(this->used_polling_commands_[this->last_polling_command_].command,
                     this->used_polling_commands_[this->last_polling_command_].length);
   // checksum
@@ -891,6 +891,18 @@ void Pipsolar::add_polling_command_(const char *command, ENUMPollingCommand poll
       return;
     }
   }
+}
+
+uint16_t Pipsolar::pipsolar_crc_(uint8_t *msg, uint8_t len) {
+  uint16_t crc = crc16be(msg, len);
+  uint8_t crc_low = crc & 0xff;
+  uint8_t crc_high = crc >> 8;
+  if (crc_low == 0x28 || crc_low == 0x0d || crc_low == 0x0a)
+    crc_low++;
+  if (crc_high == 0x28 || crc_high == 0x0d || crc_high == 0x0a)
+    crc_high++;
+  crc = (crc_high << 8) | crc_low;
+  return crc;
 }
 
 }  // namespace pipsolar

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -193,7 +193,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   void empty_uart_buffer_();
   uint8_t check_incoming_crc_();
   uint8_t check_incoming_length_(uint8_t length);
-  uint16_t cal_crc_half_(uint8_t *msg, uint8_t len);
+  uint16_t pipsolar_crc_(uint8_t *msg, uint8_t len);
   uint8_t send_next_command_();
   void send_next_poll_();
   void queue_command_(const char *command, uint8_t length);

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -7,23 +7,27 @@ namespace tca9548a {
 static const char *const TAG = "tca9548a";
 
 i2c::ErrorCode TCA9548AChannel::readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) {
-  auto err = parent_->switch_to_channel(channel_);
+  auto err = this->parent_->switch_to_channel(channel_);
   if (err != i2c::ERROR_OK)
     return err;
-  return parent_->bus_->readv(address, buffers, cnt);
+  err = this->parent_->bus_->readv(address, buffers, cnt);
+  this->parent_->disable_all_channels();
+  return err;
 }
 i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) {
-  auto err = parent_->switch_to_channel(channel_);
+  auto err = this->parent_->switch_to_channel(channel_);
   if (err != i2c::ERROR_OK)
     return err;
-  return parent_->bus_->writev(address, buffers, cnt, stop);
+  err = this->parent_->bus_->writev(address, buffers, cnt, stop);
+  this->parent_->disable_all_channels();
+  return err;
 }
 
 void TCA9548AComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TCA9548A...");
   uint8_t status = 0;
   if (this->read(&status, 1) != i2c::ERROR_OK) {
-    ESP_LOGI(TAG, "TCA9548A failed");
+    ESP_LOGE(TAG, "TCA9548A failed");
     this->mark_failed();
     return;
   }
@@ -37,15 +41,16 @@ void TCA9548AComponent::dump_config() {
 i2c::ErrorCode TCA9548AComponent::switch_to_channel(uint8_t channel) {
   if (this->is_failed())
     return i2c::ERROR_NOT_INITIALIZED;
-  if (current_channel_ == channel)
-    return i2c::ERROR_OK;
 
   uint8_t channel_val = 1 << channel;
-  auto err = this->write(&channel_val, 1);
-  if (err == i2c::ERROR_OK) {
-    current_channel_ = channel;
+  return this->write(&channel_val, 1);
+}
+
+void TCA9548AComponent::disable_all_channels() {
+  if (this->write(&TCA9548A_DISABLE_CHANNELS_COMMAND, 1) != i2c::ERROR_OK) {
+    ESP_LOGE(TAG, "Failed to disable all channels.");
+    this->status_set_error();  // couldn't disable channels, set error status
   }
-  return err;
 }
 
 }  // namespace tca9548a

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -6,6 +6,8 @@
 namespace esphome {
 namespace tca9548a {
 
+static const uint8_t TCA9548A_DISABLE_CHANNELS_COMMAND = 0x00;
+
 class TCA9548AComponent;
 class TCA9548AChannel : public i2c::I2CBus {
  public:
@@ -28,10 +30,10 @@ class TCA9548AComponent : public Component, public i2c::I2CDevice {
   void update();
 
   i2c::ErrorCode switch_to_channel(uint8_t channel);
+  void disable_all_channels();
 
  protected:
   friend class TCA9548AChannel;
-  uint8_t current_channel_ = 255;
 };
 }  // namespace tca9548a
 }  // namespace esphome

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -591,11 +591,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.temperature,
             cv.Optional(
                 CONF_SET_POINT_MINIMUM_DIFFERENTIAL, default=0.5
-            ): cv.temperature,
-            cv.Optional(CONF_COOL_DEADBAND, default=0.5): cv.temperature,
-            cv.Optional(CONF_COOL_OVERRUN, default=0.5): cv.temperature,
-            cv.Optional(CONF_HEAT_DEADBAND, default=0.5): cv.temperature,
-            cv.Optional(CONF_HEAT_OVERRUN, default=0.5): cv.temperature,
+            ): cv.temperature_delta,
+            cv.Optional(CONF_COOL_DEADBAND, default=0.5): cv.temperature_delta,
+            cv.Optional(CONF_COOL_OVERRUN, default=0.5): cv.temperature_delta,
+            cv.Optional(CONF_HEAT_DEADBAND, default=0.5): cv.temperature_delta,
+            cv.Optional(CONF_HEAT_OVERRUN, default=0.5): cv.temperature_delta,
             cv.Optional(CONF_MAX_COOLING_RUN_TIME): cv.positive_time_period_seconds,
             cv.Optional(CONF_MAX_HEATING_RUN_TIME): cv.positive_time_period_seconds,
             cv.Optional(CONF_MIN_COOLING_OFF_TIME): cv.positive_time_period_seconds,
@@ -608,8 +608,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MIN_HEATING_OFF_TIME): cv.positive_time_period_seconds,
             cv.Optional(CONF_MIN_HEATING_RUN_TIME): cv.positive_time_period_seconds,
             cv.Required(CONF_MIN_IDLE_TIME): cv.positive_time_period_seconds,
-            cv.Optional(CONF_SUPPLEMENTAL_COOLING_DELTA): cv.temperature,
-            cv.Optional(CONF_SUPPLEMENTAL_HEATING_DELTA): cv.temperature,
+            cv.Optional(CONF_SUPPLEMENTAL_COOLING_DELTA): cv.temperature_delta,
+            cv.Optional(CONF_SUPPLEMENTAL_HEATING_DELTA): cv.temperature_delta,
             cv.Optional(
                 CONF_FAN_ONLY_ACTION_USES_FAN_MODE_TIMER, default=False
             ): cv.boolean,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -929,6 +929,27 @@ def temperature(value):
     raise err
 
 
+def temperature_delta(value):
+    err = None
+    try:
+        return _temperature_c(value)
+    except Invalid as orig_err:
+        err = orig_err
+
+    try:
+        return _temperature_k(value)
+    except Invalid:
+        pass
+
+    try:
+        fahrenheit = _temperature_f(value)
+        return fahrenheit * (5 / 9)
+    except Invalid:
+        pass
+
+    raise err
+
+
 _color_temperature_mireds = float_with_unit("Color Temperature", r"(mireds|Mireds)")
 _color_temperature_kelvin = float_with_unit("Color Temperature", r"(K|Kelvin)")
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.8.2"
+__version__ = "2023.8.3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Introduce cv.temperature_delta and fix problematic thermostat configuration behavior [esphome#5297](https://github.com/esphome/esphome/pull/5297)
- fix to PR # 3887 MQTT connection not using discovery: false [esphome#5275](https://github.com/esphome/esphome/pull/5275)
- Attempt to fix secret blurring [esphome#5326](https://github.com/esphome/esphome/pull/5326)
- Bugfix: disable channels after IO if multiple tca9548a  I2C multiplexers are configured [esphome#5317](https://github.com/esphome/esphome/pull/5317)
- Fix checksum calculation for pipsolar [esphome#5299](https://github.com/esphome/esphome/pull/5299)
