### PR TITLE
Only run ci-docker when ci-docker workflow changes

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -8,7 +8,7 @@ on:
     branches: [dev, beta, release]
     paths:
       - "docker/**"
-      - ".github/workflows/**"
+      - ".github/workflows/ci-docker.yml"
       - "requirements*.txt"
       - "platformio.ini"
       - "script/platformio_install_deps.py"
@@ -16,7 +16,7 @@ on:
   pull_request:
     paths:
       - "docker/**"
-      - ".github/workflows/**"
+      - ".github/workflows/ci-docker.yml"
       - "requirements*.txt"
       - "platformio.ini"
       - "script/platformio_install_deps.py"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This just stops unnecessary runs of building the image when other workflow files have changed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
