### PR TITLE
time: Make std::string version of strftime() avoid runaway memory allocations

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -49,6 +49,11 @@ std::string ESPTime::strftime(const std::string &format) {
   struct tm c_tm = this->to_c_tm();
   size_t len = ::strftime(&timestr[0], timestr.size(), format.c_str(), &c_tm);
   while (len == 0) {
+    if (timestr.size() >= 128) {
+      // strftime has failed for reasons unrelated to the size of the buffer
+      // so return a formatting error
+      return "ERROR";
+    }
     timestr.resize(timestr.size() * 2);
     len = ::strftime(&timestr[0], timestr.size(), format.c_str(), &c_tm);
   }

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -45,6 +45,10 @@ struct ESPTime {
    *
    * @warning This method uses dynamically allocated strings which can cause heap fragmentation with some
    * microcontrollers.
+   *
+   * @warning This method can return "ERROR" when the underlying strftime() call fails, e.g. when the
+   * format string contains unsupported specifiers or when the format string doesn't produce any
+   * output.
    */
   std::string strftime(const std::string &format);
 


### PR DESCRIPTION
# What does this implement/fix?

`ESPTime::strftime()` can crash due to a memory allocation failure if the supplied format string contains unsupported specifiers (in particular '%s' when using the ESP-IDF framework) or if the format string does not produce any output.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml` to reproduce the problem (works with Arduino framework, crashes with ESP-IDF framework):
```yaml
time:
  - id: _time
    platform: sntp
    servers:
      - <IP address of NTP server>
    timezone: EST5EDT,M3.2.0,M11.1.0
    on_time_sync:
      - logger.log:
          format: "%s"
          args:
            - id(_time).now().strftime("%s").c_str()
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
