### PR TITLE
Fix cpu_ll_get_cycle_count() deprecated warning

### DIFF
--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -53,7 +53,11 @@ void arch_init() {
 void IRAM_ATTR HOT arch_feed_wdt() { esp_task_wdt_reset(); }
 
 uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
+#if ESP_IDF_VERSION_MAJOR >= 5
+uint32_t arch_get_cpu_cycle_count() { return esp_cpu_get_cycle_count(); }
+#else
 uint32_t arch_get_cpu_cycle_count() { return cpu_hal_get_cycle_count(); }
+#endif
 uint32_t arch_get_cpu_freq_hz() { return rtc_clk_apb_freq_get(); }
 
 #ifdef USE_ESP_IDF


### PR DESCRIPTION
# What does this implement/fix?

When building with IDF 5+:

```
In file included from src/esphome/components/esp32/core.cpp:13:

src/esphome/components/esp32/core.cpp: In function 'uint32_t esphome::arch_get_cpu_cycle_count()':

~/.platformio/packages/framework-espidf/components/esp_hw_support/include/hal/cpu_hal.h:49:63: warning: 'uint32_t cpu_ll_get_cycle_count()' is deprecated [-Wdeprecated-declarations]
   49 | #define cpu_hal_get_cycle_count()       cpu_ll_get_cycle_count()
      |                                         ~~~~~~~~~~~~~~~~~~~~~~^~
src/esphome/components/esp32/core.cpp:56:46: note: in expansion of macro 'cpu_hal_get_cycle_count'
   56 | uint32_t arch_get_cpu_cycle_count() { return cpu_hal_get_cycle_count(); }
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~


In file included from ~/.platformio/packages/framework-espidf/components/esp_hw_support/include/hal/cpu_hal.h:16,
                 from src/esphome/components/esp32/core.cpp:13:
~/.platformio/packages/framework-espidf/components/esp_hw_support/include/hal/cpu_ll.h:28:56: note: declared here
   28 | FORCE_INLINE_ATTR __attribute__((deprecated)) uint32_t cpu_ll_get_cycle_count(void)
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~
```

...this PR fixes this warning.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
