### PR TITLE
debug: add ESP32-C6 support

### DIFF
--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -17,6 +17,8 @@
 #include <esp32/rom/rtc.h>
 #elif defined(USE_ESP32_VARIANT_ESP32C3)
 #include <esp32c3/rom/rtc.h>
+#elif defined(USE_ESP32_VARIANT_ESP32C6)
+#include <esp32c6/rom/rtc.h>
 #elif defined(USE_ESP32_VARIANT_ESP32S2)
 #include <esp32s2/rom/rtc.h>
 #elif defined(USE_ESP32_VARIANT_ESP32S3)
@@ -119,6 +121,8 @@ void DebugComponent::dump_config() {
   model = "ESP32";
 #elif defined(USE_ESP32_VARIANT_ESP32C3)
   model = "ESP32-C3";
+#elif defined(USE_ESP32_VARIANT_ESP32C6)
+  model = "ESP32-C6";
 #elif defined(USE_ESP32_VARIANT_ESP32S2)
   model = "ESP32-S2";
 #elif defined(USE_ESP32_VARIANT_ESP32S3)
@@ -202,9 +206,11 @@ void DebugComponent::dump_config() {
     case RTCWDT_SYS_RESET:
       reset_reason = "RTC Watch Dog Reset Digital Core";
       break;
+#if !defined(USE_ESP32_VARIANT_ESP32C6)
     case INTRUSION_RESET:
       reset_reason = "Intrusion Reset CPU";
       break;
+#endif
 #if defined(USE_ESP32_VARIANT_ESP32)
     case TGWDT_CPU_RESET:
       reset_reason = "Timer Group Reset CPU";


### PR DESCRIPTION
# What does this implement/fix?

Add ESP32-C6 support to the debug component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
---
esphome:
  name: "esp32c6-test"

esp32:
  board: esp32-c6-devkitc-1
  variant: ESP32C6
  framework:
    platform_version: https://github.com/stintel/platform-espressif32#esp32-c6-test
    type: esp-idf
    version: 5.1.1

debug:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
