### PR TITLE
Fix dashboard download for ESP32 variants

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -540,7 +540,10 @@ class DownloadListRequestHandler(BaseHandler):
             self.send_error(404)
             return
 
-        from esphome.components.esp32 import get_download_types as esp32_types
+        from esphome.components.esp32 import (
+            get_download_types as esp32_types,
+            VARIANTS as ESP32_VARIANTS,
+        )
         from esphome.components.esp8266 import get_download_types as esp8266_types
         from esphome.components.rp2040 import get_download_types as rp2040_types
         from esphome.components.libretiny import get_download_types as libretiny_types
@@ -551,7 +554,7 @@ class DownloadListRequestHandler(BaseHandler):
             downloads = rp2040_types(storage_json)
         elif platform == const.PLATFORM_ESP8266:
             downloads = esp8266_types(storage_json)
-        elif platform == const.PLATFORM_ESP32:
+        elif platform.upper() in ESP32_VARIANTS:
             downloads = esp32_types(storage_json)
         elif platform == const.PLATFORM_BK72XX:
             downloads = libretiny_types(storage_json)


### PR DESCRIPTION
# What does this implement/fix?

The dashboard requests binary download list by ESP32 variant:
```py
        hardware = esph.target_platform.upper()
        if esph.is_esp32:
            from esphome.components import esp32

            hardware = esp32.get_esp32_variant(esph)
        return StorageJSON(
....
            target_platform=hardware,
....
```
instead of the platform component name. This produces an error in the dashboard.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
