### PR TITLE
Fix repeat.count = 0 case

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -249,7 +249,11 @@ template<typename... Ts> class RepeatAction : public Action<Ts...> {
   void play_complex(Ts... x) override {
     this->num_running_++;
     this->var_ = std::make_tuple(x...);
-    this->then_.play(0, x...);
+    if (this->count_.value(x...) > 0) {
+      this->then_.play(0, x...);
+    } else {
+      this->play_next_tuple_(this->var_);
+    }
   }
 
   void play(Ts... x) override { /* ignore - see play_complex */

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -566,7 +566,7 @@ script:
   - id: zero_repeat_test
     then:
       - repeat:
-          count: 0
+          count: !lambda "return 0;"
           then:
             - logger.log: shouldn't see mee!
 

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -563,6 +563,13 @@ script:
           then:
             - logger.log: looping!
 
+  - id: zero_repeat_test
+    then:
+      - repeat:
+          count: 0
+          then:
+            - logger.log: shouldn't see mee!
+
 switch:
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_test


### PR DESCRIPTION
# What does this implement/fix?

repeat.count = 0 right now acts the same as repeat.count = 1, which should not be the case.
There are plenty of instances when a lambda returning 0 should mean the code needs to be skipped.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
