### PR TITLE
Bump LibreTiny version to 1.4.0

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -168,9 +168,9 @@ def _notify_old_style(config):
 # NOTE: Keep this in mind when updating the recommended version:
 #  * For all constants below, update platformio.ini (in this repo)
 ARDUINO_VERSIONS = {
-    "dev": (cv.Version(0, 0, 0), "https://github.com/kuba2k2/libretiny.git"),
+    "dev": (cv.Version(0, 0, 0), "https://github.com/libretiny-eu/libretiny.git"),
     "latest": (cv.Version(0, 0, 0), None),
-    "recommended": (cv.Version(1, 3, 0), None),
+    "recommended": (cv.Version(1, 4, 0), None),
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

Following [the PlatformIO forum topic](https://community.platformio.org/t/libretiny-platform-version-publish-delay/35596/2), after making appropriate changes the version 1.4.0 has been published today, and is available on PlatformIO registry.

This PR bumps the recommended (or minimal, TBH) version, and updates the `dev` version repository, since it's been moved to the organization account.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4859

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
