### PR TITLE
Attempt to fix rp2040 adc with vcc

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -5,10 +5,7 @@ from esphome.const import CONF_ANALOG, CONF_INPUT
 
 from esphome.core import CORE
 from esphome.components.esp32 import get_esp32_variant
-from esphome.const import (
-    PLATFORM_ESP8266,
-    PLATFORM_RP2040,
-)
+from esphome.const import PLATFORM_ESP8266
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
     VARIANT_ESP32C2,
@@ -147,7 +144,9 @@ ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
 
 def validate_adc_pin(value):
     if str(value).upper() == "VCC":
-        return cv.only_on([PLATFORM_ESP8266, PLATFORM_RP2040])("VCC")
+        if CORE.is_rp2040:
+            return pins.internal_gpio_input_pin_schema(29)
+        return cv.only_on([PLATFORM_ESP8266])("VCC")
 
     if str(value).upper() == "TEMPERATURE":
         return cv.only_on_rp2040("TEMPERATURE")

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -255,26 +255,26 @@ float ADCSensor::sample() {
     return raw * 3.3f / 4096.0f;
   } else {
     uint8_t pin = this->pin_->get_pin();
-    if (pin == PICO_VSYS_PIN) {
 #ifdef CYW43_USES_VSYS_PIN
+    if (pin == PICO_VSYS_PIN) {
       // Measuring VSYS on Raspberry Pico W needs to be wrapped with
       // `cyw43_thread_enter()`/`cyw43_thread_exit()` as discussed in
       // https://github.com/raspberrypi/pico-sdk/issues/1222, since Wifi chip and
       // VSYS ADC both share GPIO29
       cyw43_thread_enter();
-#endif  // CYW43_USES_VSYS_PIN
     }
+#endif  // CYW43_USES_VSYS_PIN
 
     adc_gpio_init(pin);
     adc_select_input(pin - 26);
 
     int32_t raw = adc_read();
 
-    if (pin == PICO_VSYS_PIN) {
 #ifdef CYW43_USES_VSYS_PIN
+    if (pin == PICO_VSYS_PIN) {
       cyw43_thread_exit();
-#endif  // CYW43_USES_VSYS_PIN
     }
+#endif  // CYW43_USES_VSYS_PIN
 
     if (output_raw_) {
       return raw;

--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -1,6 +1,6 @@
 #include "adc_sensor.h"
-#include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
 
 #ifdef USE_ESP8266
 #ifdef USE_ADC_SENSOR_VCC
@@ -246,45 +246,42 @@ float ADCSensor::sample() {
     adc_set_temp_sensor_enabled(true);
     delay(1);
     adc_select_input(4);
+
+    int32_t raw = adc_read();
+    adc_set_temp_sensor_enabled(false);
+    if (this->output_raw_) {
+      return raw;
+    }
+    return raw * 3.3f / 4096.0f;
   } else {
-    uint8_t pin;
-#ifdef USE_ADC_SENSOR_VCC
+    uint8_t pin = this->pin_->get_pin();
+    if (pin == PICO_VSYS_PIN) {
 #ifdef CYW43_USES_VSYS_PIN
-    // Measuring VSYS on Raspberry Pico W needs to be wrapped with
-    // `cyw43_thread_enter()`/`cyw43_thread_exit()` as discussed in
-    // https://github.com/raspberrypi/pico-sdk/issues/1222, since Wifi chip and
-    // VSYS ADC both share GPIO29
-    cyw43_thread_enter();
+      // Measuring VSYS on Raspberry Pico W needs to be wrapped with
+      // `cyw43_thread_enter()`/`cyw43_thread_exit()` as discussed in
+      // https://github.com/raspberrypi/pico-sdk/issues/1222, since Wifi chip and
+      // VSYS ADC both share GPIO29
+      cyw43_thread_enter();
 #endif  // CYW43_USES_VSYS_PIN
-    pin = PICO_VSYS_PIN;
-#else
-    pin = this->pin_->get_pin();
-#endif  // USE_ADC_SENSOR_VCC
+    }
 
     adc_gpio_init(pin);
     adc_select_input(pin - 26);
-  }
 
-  int32_t raw = adc_read();
-  if (this->is_temperature_) {
-    adc_set_temp_sensor_enabled(false);
-  } else {
-#ifdef USE_ADC_SENSOR_VCC
+    int32_t raw = adc_read();
+
+    if (pin == PICO_VSYS_PIN) {
 #ifdef CYW43_USES_VSYS_PIN
-    cyw43_thread_exit();
+      cyw43_thread_exit();
 #endif  // CYW43_USES_VSYS_PIN
-#endif  // USE_ADC_SENSOR_VCC
-  }
+    }
 
-  if (output_raw_) {
-    return raw;
+    if (output_raw_) {
+      return raw;
+    }
+    float coeff = pin == PICO_VSYS_PIN ? 3.0 : 1.0;
+    return raw * 3.3f / 4096.0f * coeff;
   }
-  float coeff = 1.0;
-#ifdef USE_ADC_SENSOR_VCC
-  // As per Raspberry Pico (W) datasheet (section 2.1) the VSYS/3 is measured
-  coeff = 3.0;
-#endif  // USE_ADC_SENSOR_VCC
-  return raw * 3.3f / 4096.0f * coeff;
 }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
https://github.com/esphome/esphome/pull/5335 introduced allowing the VCC adc sensor on rp2040, but broke regular adc when you wanted to use a gpio adc pin **and** the vcc adc reading together.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
