### PR TITLE
SX1509 component 

### DIFF
--- a/esphome/components/sx1509/binary_sensor/__init__.py
+++ b/esphome/components/sx1509/binary_sensor/__init__.py
@@ -14,8 +14,8 @@ SX1509BinarySensor = sx1509_ns.class_("SX1509BinarySensor", binary_sensor.Binary
 CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(SX1509BinarySensor).extend(
     {
         cv.GenerateID(CONF_SX1509_ID): cv.use_id(SX1509Component),
-        cv.Required(CONF_ROW): cv.int_range(min=0, max=4),
-        cv.Required(CONF_COL): cv.int_range(min=0, max=4),
+        cv.Required(CONF_ROW): cv.int_range(min=0, max=7),
+        cv.Required(CONF_COL): cv.int_range(min=0, max=7),
     }
 )
 


### PR DESCRIPTION
# What does this implement/fix?

It fixes sx1509 change of getting 64 inputs, using matrix switches, as showed in esphome's sx1509 features page.
As it was only allows a 5x5 matrix (0-4 x 0-4)

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3099

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x ] ESP32
- [ ] ESP32 IDF
- [x ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--

-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
