### PR TITLE
Remove Wi-Fi dependency from Midea component

### DIFF
--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -35,7 +35,7 @@ from esphome.components.climate import (
 )
 
 CODEOWNERS = ["@dudanov"]
-DEPENDENCIES = ["climate", "uart", "wifi"]
+DEPENDENCIES = ["climate", "uart"]
 AUTO_LOAD = ["sensor"]
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
 CONF_POWER_USAGE = "power_usage"


### PR DESCRIPTION
# What does this implement/fix?

While the commonly used Midea USB dongles ([IoT Uni Dongle](https://github.com/dudanov/iot-uni-dongle) or [Midea SLWF-01pro](https://smartlight.me/smart-home-devices/wifi-devices/wifi-dongle-air-conditioners-midea-idea-electrolux-for-home-assistant)) do require Wi-Fi, the Midea component itself has no reason to be dependent on Wi-Fi. 

This dependency prevents the use of ethernet with a Midea device, as the Wi-Fi component and ethernet component cannot be used at the same time. This pull request removes this unneeded dependency.

This change was tested working locally on a WT32-ETH01 ESP32.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
