### PR TITLE
Add E-Trailer Gaslevel support to Mopeka Std Check

### DIFF
--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -71,8 +71,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   const auto *mopeka_data = (const mopeka_std_package *) manu_data.data.data();
 
   const u_int8_t hardware_id = mopeka_data->data_1 & 0xCF;
-  if (static_cast<SensorType>(hardware_id) != STANDARD && 
-      static_cast<SensorType>(hardware_id) != XL && 
+  if (static_cast<SensorType>(hardware_id) != STANDARD && static_cast<SensorType>(hardware_id) != XL &&
       static_cast<SensorType>(hardware_id) != ETRAILER) {
     ESP_LOGE(TAG, "[%s] Unsupported Sensor Type (0x%X)", device.address_str().c_str(), hardware_id);
     return false;

--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -71,7 +71,9 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   const auto *mopeka_data = (const mopeka_std_package *) manu_data.data.data();
 
   const u_int8_t hardware_id = mopeka_data->data_1 & 0xCF;
-  if (static_cast<SensorType>(hardware_id) != STANDARD && static_cast<SensorType>(hardware_id) != XL) {
+  if (static_cast<SensorType>(hardware_id) != STANDARD && 
+      static_cast<SensorType>(hardware_id) != XL && 
+      static_cast<SensorType>(hardware_id) != ETRAILER) {
     ESP_LOGE(TAG, "[%s] Unsupported Sensor Type (0x%X)", device.address_str().c_str(), hardware_id);
     return false;
   }

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -14,6 +14,7 @@ namespace mopeka_std_check {
 enum SensorType {
   STANDARD = 0x02,
   XL = 0x03,
+  ETRAILER = 0x46,
 };
 
 // 4 values in one struct so it aligns to 8 byte. One `mopeka_std_values` is 40 bit long.


### PR DESCRIPTION
# What does this implement/fix?

E-Trailer rebrands the Mopeka Std Check for their system but they work as expected
https://support.e-trailer.nl/de/haeufig-gestellte-fragen/#E-Gaslevel
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
