### PR TITLE
Ci find YAML tests dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out code from GitHub
-      uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.0.0
       - name: Find all YAML test files
         id: set-matrix
         run: echo "::set-output name=matrix::$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
         uses: actions/checkout@v4.0.0
       - name: Find all YAML test files
         id: set-matrix
-        run: echo "::set-output name=matrix::$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')"
+        run: echo "matrix=$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   compile-tests:
     name: Run YAML test ${{ matrix.file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,17 @@ jobs:
         run: script/ci-suggest-changes
         if: always()
 
+  compile-tests-list:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4
+      - name: Find all YAML test files
+        id: set-matrix
+        run: echo "::set-output name=matrix::$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')"
+
   compile-tests:
     name: Run YAML test ${{ matrix.file }}
     runs-on: ubuntu-latest
@@ -228,11 +239,12 @@ jobs:
       - pytest
       - pyupgrade
       - yamllint
+      - compile-tests-list
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
-        file: [1, 2, 3, 3.1, 4, 5, 6, 7, 8]
+        file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
@@ -241,10 +253,10 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run esphome compile tests/test${{ matrix.file }}.yaml
+      - name: Run esphome compile ${{ matrix.file }}
         run: |
           . venv/bin/activate
-          esphome compile tests/test${{ matrix.file }}.yaml
+          esphome compile ${{ matrix.file }}
 
   clang-tidy:
     name: ${{ matrix.name }}


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
The CI pipeline finds all `tests/test*.yaml` files automatically and includes them in the pipeline.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
