### PR TITLE
Add shelly-dimmer-stm32 51.7 to known versions

### DIFF
--- a/esphome/components/shelly_dimmer/light.py
+++ b/esphome/components/shelly_dimmer/light.py
@@ -57,6 +57,10 @@ KNOWN_FIRMWARE = {
         "https://github.com/jamesturton/shelly-dimmer-stm32/releases/download/v51.6/shelly-dimmer-stm32_v51.6.bin",
         "eda483e111c914723a33f5088f1397d5c0b19333db4a88dc965636b976c16c36",
     ),
+    "51.7": (
+        "https://github.com/jamesturton/shelly-dimmer-stm32/releases/download/v51.7/shelly-dimmer-stm32_v51.7.bin",
+        "7a20f1c967c469917368a79bc56498009045237080408cef7190743e08031889",
+    ),
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

This version removes support for no-neutral setups in favor of fixing flickering some users have experienced.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
