### PR TITLE
Update radon_eye_listener.cpp

### DIFF
--- a/esphome/components/radon_eye_ble/radon_eye_listener.cpp
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "radon_eye_ble";
 
 bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   if (not device.get_name().empty()) {
-    if (device.get_name().rfind("FR:R20:SN", 0) == 0) {
+    if (device.get_name().rfind("FR:R", 0) == 0) {
       // This is an RD200, I think
       ESP_LOGD(TAG, "Found Radon Eye RD200 device Name: %s (MAC: %s)", device.get_name().c_str(),
                device.address_str().c_str());


### PR DESCRIPTION
New devices identifiers do not start by the hardcoded string. FR:RE222 is the 8-char length string of my devices bought in 2023. This proposal aims at solve the topic by making the detection track devices starting only by FR:R

# What does this implement/fix?
It allows the identification of new devices' names.
<!-- Quick description and explanation of changes -->

## Types of changes

- [ X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
