### PR TITLE
support keypads with pulldowns

### DIFF
--- a/esphome/components/matrix_keypad/__init__.py
+++ b/esphome/components/matrix_keypad/__init__.py
@@ -21,6 +21,7 @@ CONF_COLUMNS = "columns"
 CONF_KEYS = "keys"
 CONF_DEBOUNCE_TIME = "debounce_time"
 CONF_HAS_DIODES = "has_diodes"
+CONF_HAS_PULLDOWNS = "has_pulldowns"
 
 
 def check_keys(obj):
@@ -45,6 +46,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_KEYS): cv.string,
             cv.Optional(CONF_DEBOUNCE_TIME, default=1): cv.int_range(min=1, max=100),
             cv.Optional(CONF_HAS_DIODES): cv.boolean,
+            cv.Optional(CONF_HAS_PULLDOWNS): cv.boolean,
         }
     ),
     check_keys,
@@ -69,3 +71,5 @@ async def to_code(config):
     cg.add(var.set_debounce_time(config[CONF_DEBOUNCE_TIME]))
     if CONF_HAS_DIODES in config:
         cg.add(var.set_has_diodes(config[CONF_HAS_DIODES]))
+    if CONF_HAS_PULLDOWNS in config:
+        cg.add(var.set_has_pulldowns(config[CONF_HAS_PULLDOWNS]))

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -11,11 +11,16 @@ void MatrixKeypad::setup() {
     if (!has_diodes_) {
       pin->pin_mode(gpio::FLAG_INPUT);
     } else {
-      pin->digital_write(true);
+      pin->digital_write(!has_pulldowns_);
     }
   }
-  for (auto *pin : this->columns_)
-    pin->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+  for (auto *pin : this->columns_) {
+    if (has_pulldowns_) {
+      pin->pin_mode(gpio::FLAG_INPUT);
+    } else {
+      pin->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+    }
+  }
 }
 
 void MatrixKeypad::loop() {
@@ -28,9 +33,9 @@ void MatrixKeypad::loop() {
   for (auto *row : this->rows_) {
     if (!has_diodes_)
       row->pin_mode(gpio::FLAG_OUTPUT);
-    row->digital_write(false);
+    row->digital_write(has_pulldowns_);
     for (auto *col : this->columns_) {
-      if (!col->digital_read()) {
+      if (col->digital_read() == has_pulldowns_) {
         if (key != -1) {
           error = true;
         } else {
@@ -39,7 +44,7 @@ void MatrixKeypad::loop() {
       }
       pos++;
     }
-    row->digital_write(true);
+    row->digital_write(!has_pulldowns_);
     if (!has_diodes_)
       row->pin_mode(gpio::FLAG_INPUT);
   }

--- a/esphome/components/matrix_keypad/matrix_keypad.h
+++ b/esphome/components/matrix_keypad/matrix_keypad.h
@@ -28,6 +28,7 @@ class MatrixKeypad : public key_provider::KeyProvider, public Component {
   void set_keys(std::string keys) { keys_ = std::move(keys); };
   void set_debounce_time(int debounce_time) { debounce_time_ = debounce_time; };
   void set_has_diodes(int has_diodes) { has_diodes_ = has_diodes; };
+  void set_has_pulldowns(int has_pulldowns) { has_pulldowns_ = has_pulldowns; };
 
   void register_listener(MatrixKeypadListener *listener);
 
@@ -37,6 +38,7 @@ class MatrixKeypad : public key_provider::KeyProvider, public Component {
   std::string keys_;
   int debounce_time_ = 0;
   bool has_diodes_{false};
+  bool has_pulldowns_{false};
   int pressed_key_ = -1;
 
   std::vector<MatrixKeypadListener *> listeners_{};

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -667,6 +667,7 @@ matrix_keypad:
     - pin: 17
     - pin: 16
   keys: "1234"
+  has_pulldowns: true
 
 key_collector:
   - id: reader


### PR DESCRIPTION
# What does this implement/fix?

Small change to support keypads that have hardwired external pulldowns.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3198

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
matrix_keypad:
  id: my_keypad
  ...
  has_pulldowns: true

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
