### PR TITLE
Climate preset fix

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -986,6 +986,7 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
       // Fire any preset changed trigger if defined
       Trigger<> *trig = this->preset_change_trigger_;
       assert(trig != nullptr);
+      this->preset = preset;
       trig->trigger();
 
       this->refresh();

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1011,6 +1011,7 @@ void ThermostatClimate::change_custom_preset_(const std::string &custom_preset) 
       // Fire any preset changed trigger if defined
       Trigger<> *trig = this->preset_change_trigger_;
       assert(trig != nullptr);
+      this->custom_preset = custom_preset;
       trig->trigger();
 
       this->refresh();


### PR DESCRIPTION
# What does this implement/fix?

Set the new preset before calling the preset_change trigger.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4134

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
climate:
  - platform: thermostat
    id: heater
    name: $name
    sensor: sensor_temperature

    heat_deadband: "0.5 °C"
    heat_overrun: "0.5 °C"
    min_heating_run_time: 1s
    min_heating_off_time: 1s
    min_idle_time: 1s

    visual:
      min_temperature: ${min_temp} °C
      max_temperature: ${max_temp} °C
      temperature_step: ${inc_temp} °C

    heat_action:
      - switch.turn_on: heater_switch
    idle_action:
      - switch.turn_off: heater_switch

    heat_mode:
      - switch.turn_on: fan_switch
    off_mode:
      - switch.turn_off: fan_switch

    preset_change:
      - lambda: |-
          std::string preset_name = id(heater).preset.value();
          ESP_LOGD("preset_change", "Name: %s", preset_name.c_str());
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
