### PR TITLE
Fix RC Switch protocol not transmitting correctly via IR

### DIFF
--- a/esphome/components/remote_base/rc_switch_protocol.cpp
+++ b/esphome/components/remote_base/rc_switch_protocol.cpp
@@ -54,7 +54,7 @@ void RCSwitchBase::sync(RemoteTransmitData *dst) const {
   }
 }
 void RCSwitchBase::transmit(RemoteTransmitData *dst, uint64_t code, uint8_t len) const {
-  dst->set_carrier_frequency(0);
+  dst->set_carrier_frequency(38000);
   this->sync(dst);
   for (int16_t i = len - 1; i >= 0; i--) {
     if (code & ((uint64_t) 1 << i)) {


### PR DESCRIPTION
# What does this implement/fix?

Enables the use of RC Switch protocol with IR Remote transmitters, by setting the carrier frequency to 38kHz.

The RC Switch protocol can be used for both RF and IR remotes. RF Remotes don't require generating a carrier signal, so, as pointed out in the [remote transmitter configuration variables docs](https://esphome.io/components/remote_transmitter#configuration-variables), that carrier frequency can be nullified by setting the duty cycle to 100%.

Since this protocol is also used with IR devices, a 50% duty cycle should still result in a carrier frequency being generated. Therefore, this sets the frequency to 38kHz in the protocol implementation, allowing the user to cancel it out in YAML config.

When this carrier frequency is left to 0, then even with the duty cycle set to 50%, infrared transmitters don't include the carrier, and thus de-modulators don't pick up the signal at all.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#2044](https://github.com/esphome/issues/issues/2044)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a, docs already say to use `carrier_duty_cycle: 100%` for RF transmitters.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
remote_transmitter:
  pin:
    number: GPIO13
  carrier_duty_percent: 50%

button:
  - platform: template
    name: "Power"
    on_press:
      remote_transmitter.transmit_rc_switch_raw:
        # Reverse engineered protocol for
        # Dreo Solaris Slim H3 Space Heater remote
        code: '10110000001'
        protocol:
          pulse_length: 60
          sync: [24, 4]
          zero: [8, 20]
          one: [23, 5]
        repeat:
          times: 5
          wait_time: 8ms
# Other buttons omitted for brevity
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
