### PR TITLE
dallas: limit addresses to 64 bits

### DIFF
--- a/esphome/components/dallas/sensor.py
+++ b/esphome/components/dallas/sensor.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = cv.All(
     ).extend(
         {
             cv.GenerateID(CONF_DALLAS_ID): cv.use_id(DallasComponent),
-            cv.Optional(CONF_ADDRESS): cv.hex_int,
+            cv.Optional(CONF_ADDRESS): cv.hex_uint64_t,
             cv.Optional(CONF_INDEX): cv.positive_int,
             cv.Optional(CONF_RESOLUTION, default=12): cv.int_range(min=9, max=12),
         }


### PR DESCRIPTION
# What does this implement/fix?

Limits dallas temperature sensor address to 64 bits.
Currently, all bits that exceed this limit is silently dropped, causing unexpected behavior for users moving from Arduino where address is given as an array, which drops bytes on the other end of the address.

 https://discord.com/channels/429907082951524364/1154371632731799603

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Invalid

dallas:
  pin: 2

sensor:
  - id: ds_temp
    platform: dallas
    address: 0xcd3ce1045784a128067925
```

```yaml
# Valid

dallas:
  pin: 2

sensor:
  - id: ds_temp
    platform: dallas
    address: 0xcd3ce1045784a128
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
