### PR TITLE
[RP2040W] Fix WiFi bootloop upon LibreTiny support

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -152,6 +152,9 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     cg.add(rp2040_ns.setup_preferences())
 
+    # Allow LDF to properly discover dependency including those in preprocessor
+    # conditionals
+    cg.add_platformio_option("lib_ldf_mode", "chain+")
     cg.add_platformio_option("board", config[CONF_BOARD])
     cg.add_build_flag("-DUSE_RP2040")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])


### PR DESCRIPTION
# What does this implement/fix?

The changes for LibreTiny support (PR #3509) introduced the regression on RP2040W leading to boot loop connecting to WiFi. The regression manifests itself as device reboots with last logged message being `Connecting to WiFi`, and presumably due to extraneous FreeRTOS dependency.

The fix updates LDF mode from default `chain` (does not support preprocessor conditional) to `chain+` hopefully being a nearest equivalent but with support for those conditionals. While author is not fully comfortable with such broad change it at least fixes the issue and dependency mechanism assumed to be compatible.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#4895](https://github.com/esphome/issues/issues/4895)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
---
rp2040:
  board: rpipicow
  framework:
    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git

esphome:
  name: minimal

logger:
  level: VERY_VERBOSE

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_psk
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
