### PR TITLE
Fix SPI inverted clock on ESP8266

### DIFF
--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -351,6 +351,7 @@ class SPIClient {
       : bit_order_(bit_order), mode_(mode), data_rate_(data_rate) {}
 
   virtual void spi_setup() {
+    esph_log_d("spi_device", "mode %u, data_rate %ukHz", (unsigned) this->mode_, (unsigned) (this->data_rate_ / 1000));
     this->delegate_ = this->parent_->register_device(this, this->mode_, this->bit_order_, this->data_rate_, this->cs_);
   }
 
@@ -398,10 +399,7 @@ class SPIDevice : public SPIClient {
 
   void set_data_rate(uint32_t data_rate) { this->data_rate_ = data_rate; }
 
-  void set_bit_order(SPIBitOrder order) {
-    this->bit_order_ = order;
-    esph_log_d("spi.h", "bit order set to %d", order);
-  }
+  void set_bit_order(SPIBitOrder order) { this->bit_order_ = order; }
 
   void set_mode(SPIMode mode) { this->mode_ = mode; }
 

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -15,6 +15,11 @@ class SPIDelegateHw : public SPIDelegate {
   void begin_transaction() override {
 #ifdef USE_RP2040
     SPISettings const settings(this->data_rate_, static_cast<BitOrder>(this->bit_order_), this->mode_);
+#elif defined(ESP8266)
+    // Arduino ESP8266 library has mangled values for SPI modes :-(
+    auto mode = (this->mode_ & 0x01) + ((this->mode_ & 0x02) << 3);
+    ESP_LOGV(TAG, "8266 mangled SPI mode 0x%X", mode);
+    SPISettings const settings(this->data_rate_, this->bit_order_, mode);
 #else
     SPISettings const settings(this->data_rate_, this->bit_order_, this->mode_);
 #endif
@@ -55,8 +60,6 @@ class SPIBusHw : public SPIBus {
  public:
   SPIBusHw(GPIOPin *clk, GPIOPin *sdo, GPIOPin *sdi, SPIInterface channel) : SPIBus(clk, sdo, sdi), channel_(channel) {
 #ifdef USE_ESP8266
-    clk->setup();
-    clk->digital_write(true);
     channel->pins(Utility::get_pin_no(clk), Utility::get_pin_no(sdi), Utility::get_pin_no(sdo), -1);
     channel->begin();
 #endif  // USE_ESP8266

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -55,6 +55,8 @@ class SPIBusHw : public SPIBus {
  public:
   SPIBusHw(GPIOPin *clk, GPIOPin *sdo, GPIOPin *sdi, SPIInterface channel) : SPIBus(clk, sdo, sdi), channel_(channel) {
 #ifdef USE_ESP8266
+    clk->setup();
+    clk->digital_write(true);
     channel->pins(Utility::get_pin_no(clk), Utility::get_pin_no(sdi), Utility::get_pin_no(sdo), -1);
     channel->begin();
 #endif  // USE_ESP8266


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes wrong SPI clock polarity on ESP8266.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4902

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

