### PR TITLE
Make ESPHome data dir configurable

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -558,7 +558,7 @@ class EsphomeCore:
     def data_dir(self):
         if is_ha_addon():
             return os.path.join("/data")
-        elif get_str_env('ESPHOME_DATA_DIR', None) is not None:
+        if get_str_env('ESPHOME_DATA_DIR', None) is not None:
             return get_str_env('ESPHOME_DATA_DIR', None)
         return self.relative_config_path(".esphome")
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -21,7 +21,7 @@ from esphome.coroutine import FakeEventLoop as _FakeEventLoop
 
 # pylint: disable=unused-import
 from esphome.coroutine import coroutine, coroutine_with_priority  # noqa
-from esphome.helpers import ensure_unique_string, is_ha_addon
+from esphome.helpers import ensure_unique_string, get_str_env, is_ha_addon
 from esphome.util import OrderedDict
 
 if TYPE_CHECKING:
@@ -558,6 +558,8 @@ class EsphomeCore:
     def data_dir(self):
         if is_ha_addon():
             return os.path.join("/data")
+        elif get_str_env('ESPHOME_DATA_DIR', None) is not None:
+            return get_str_env('ESPHOME_DATA_DIR', None)
         return self.relative_config_path(".esphome")
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -558,8 +558,8 @@ class EsphomeCore:
     def data_dir(self):
         if is_ha_addon():
             return os.path.join("/data")
-        if get_str_env('ESPHOME_DATA_DIR', None) is not None:
-            return get_str_env('ESPHOME_DATA_DIR', None)
+        if get_str_env("ESPHOME_DATA_DIR", None) is not None:
+            return get_str_env("ESPHOME_DATA_DIR", None)
         return self.relative_config_path(".esphome")
 
     @property


### PR DESCRIPTION
With this change, the ESPHOME_DATA_DIR environment variable overrides the 'data directory' (i.e., the '.esphome' directory).

In my particular case, this is intended to allow me to store my ESPHome configurations on (slow) network storage, but have ESPHome do its compilation on (fast) volatile storage - e.g. in /tmp or similar.

# What does this implement/fix?

Allows the '.esphome' data directory to be overridden with an environment variable (ESPHOME_DATA_DIR).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

Related issue or feature (if applicable): N/A

Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): None right now

## Test Environment

N/A

## Example entry for config.yaml:
N/A

## Checklist:
  - [YES] The code change is tested and works locally - tested in Docker container
  - [NO] Tests have been added to verify that the new code works (under tests/ folder). - not sure if there's a sensible test to write here

If user exposed functionality or configuration variables are added/changed:
  - [NO] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).