### PR TITLE
LibreTiny: enable MQTT, bump to v1.4.1

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -170,7 +170,7 @@ def _notify_old_style(config):
 ARDUINO_VERSIONS = {
     "dev": (cv.Version(0, 0, 0), "https://github.com/libretiny-eu/libretiny.git"),
     "latest": (cv.Version(0, 0, 0), None),
-    "recommended": (cv.Version(1, 4, 0), None),
+    "recommended": (cv.Version(1, 4, 1), None),
 }
 
 

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -250,7 +250,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     validate_config,
-    cv.only_on(["esp32", "esp8266", "bk72xx", "rtl87xx"]),
+    cv.only_on(["esp32", "esp8266", "bk72xx"]),
 )
 
 
@@ -274,7 +274,7 @@ async def to_code(config):
     # Add required libraries for ESP8266 and LibreTiny
     if CORE.is_esp8266 or CORE.is_libretiny:
         # https://github.com/heman/async-mqtt-client/blob/master/library.json
-        cg.add_library("heman/AsyncMqttClient-esphome", "1.0.0")
+        cg.add_library("heman/AsyncMqttClient-esphome", "2.0.0")
 
     cg.add_define("USE_MQTT")
     cg.add_global(mqtt_ns.using)

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -250,7 +250,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     validate_config,
-    cv.only_on(["esp32", "esp8266"]),
+    cv.only_on(["esp32", "esp8266", "bk72xx", "rtl87xx"]),
 )
 
 
@@ -271,8 +271,8 @@ def exp_mqtt_message(config):
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    # Add required libraries for ESP8266
-    if CORE.is_esp8266:
+    # Add required libraries for ESP8266 and LibreTiny
+    if CORE.is_esp8266 or CORE.is_libretiny:
         # https://github.com/heman/async-mqtt-client/blob/master/library.json
         cg.add_library("heman/AsyncMqttClient-esphome", "1.0.0")
 

--- a/esphome/components/mqtt/mqtt_backend_libretiny.h
+++ b/esphome/components/mqtt/mqtt_backend_libretiny.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#ifdef USE_LIBRETINY
+
+#include "mqtt_backend.h"
+#include <AsyncMqttClient.h>
+
+namespace esphome {
+namespace mqtt {
+
+class MQTTBackendLibreTiny final : public MQTTBackend {
+ public:
+  void set_keep_alive(uint16_t keep_alive) final { mqtt_client_.setKeepAlive(keep_alive); }
+  void set_client_id(const char *client_id) final { mqtt_client_.setClientId(client_id); }
+  void set_clean_session(bool clean_session) final { mqtt_client_.setCleanSession(clean_session); }
+  void set_credentials(const char *username, const char *password) final {
+    mqtt_client_.setCredentials(username, password);
+  }
+  void set_will(const char *topic, uint8_t qos, bool retain, const char *payload) final {
+    mqtt_client_.setWill(topic, qos, retain, payload);
+  }
+  void set_server(network::IPAddress ip, uint16_t port) final {
+    mqtt_client_.setServer(IPAddress(static_cast<uint32_t>(ip)), port);
+  }
+  void set_server(const char *host, uint16_t port) final { mqtt_client_.setServer(host, port); }
+#if ASYNC_TCP_SSL_ENABLED
+  void set_secure(bool secure) { mqtt_client.setSecure(secure); }
+  void add_server_fingerprint(const uint8_t *fingerprint) { mqtt_client.addServerFingerprint(fingerprint); }
+#endif
+
+  void set_on_connect(std::function<on_connect_callback_t> &&callback) final {
+    this->mqtt_client_.onConnect(std::move(callback));
+  }
+  void set_on_disconnect(std::function<on_disconnect_callback_t> &&callback) final {
+    auto async_callback = [callback](AsyncMqttClientDisconnectReason reason) {
+      // int based enum so casting isn't a problem
+      callback(static_cast<MQTTClientDisconnectReason>(reason));
+    };
+    this->mqtt_client_.onDisconnect(std::move(async_callback));
+  }
+  void set_on_subscribe(std::function<on_subscribe_callback_t> &&callback) final {
+    this->mqtt_client_.onSubscribe(std::move(callback));
+  }
+  void set_on_unsubscribe(std::function<on_unsubscribe_callback_t> &&callback) final {
+    this->mqtt_client_.onUnsubscribe(std::move(callback));
+  }
+  void set_on_message(std::function<on_message_callback_t> &&callback) final {
+    auto async_callback = [callback](const char *topic, const char *payload,
+                                     AsyncMqttClientMessageProperties async_properties, size_t len, size_t index,
+                                     size_t total) { callback(topic, payload, len, index, total); };
+    mqtt_client_.onMessage(std::move(async_callback));
+  }
+  void set_on_publish(std::function<on_publish_user_callback_t> &&callback) final {
+    this->mqtt_client_.onPublish(std::move(callback));
+  }
+
+  bool connected() const final { return mqtt_client_.connected(); }
+  void connect() final { mqtt_client_.connect(); }
+  void disconnect() final { mqtt_client_.disconnect(true); }
+  bool subscribe(const char *topic, uint8_t qos) final { return mqtt_client_.subscribe(topic, qos) != 0; }
+  bool unsubscribe(const char *topic) final { return mqtt_client_.unsubscribe(topic) != 0; }
+  bool publish(const char *topic, const char *payload, size_t length, uint8_t qos, bool retain) final {
+    return mqtt_client_.publish(topic, qos, retain, payload, length, false, 0) != 0;
+  }
+  using MQTTBackend::publish;
+
+ protected:
+  AsyncMqttClient mqtt_client_;
+};
+
+}  // namespace mqtt
+}  // namespace esphome
+
+#endif  // defined(USE_LIBRETINY)

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -106,6 +106,9 @@ void MQTTClientComponent::send_device_info_() {
 #ifdef USE_ESP32
         root["platform"] = "ESP32";
 #endif
+#ifdef USE_LIBRETINY
+        root["platform"] = lt_cpu_get_model_name();
+#endif
 
         root["board"] = ESPHOME_BOARD;
 #if defined(USE_WIFI)
@@ -156,7 +159,7 @@ void MQTTClientComponent::start_dnslookup_() {
   this->dns_resolve_error_ = false;
   this->dns_resolved_ = false;
   ip_addr_t addr;
-#ifdef USE_ESP32
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
   err_t err = dns_gethostbyname_addrtype(this->credentials_.address.c_str(), &addr,
                                          MQTTClientComponent::dns_found_callback, this, LWIP_DNS_ADDRTYPE_IPV4);
 #endif

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -13,6 +13,8 @@
 #include "mqtt_backend_esp32.h"
 #elif defined(USE_ESP8266)
 #include "mqtt_backend_esp8266.h"
+#elif defined(USE_LIBRETINY)
+#include "mqtt_backend_libretiny.h"
 #endif
 #include "lwip/ip_addr.h"
 
@@ -300,6 +302,8 @@ class MQTTClientComponent : public Component {
   MQTTBackendESP32 mqtt_backend_;
 #elif defined(USE_ESP8266)
   MQTTBackendESP8266 mqtt_backend_;
+#elif defined(USE_LIBRETINY)
+  MQTTBackendLibreTiny mqtt_backend_;
 #endif
 
   MQTTClientState state_{MQTT_CLIENT_DISCONNECTED};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Enables MQTT on BK72xx using `heman/AsyncMqttClient-esphome`, which contains fixes that makes MQTT work.

The library is updated to v2.0.0.

Also, LibreTiny is updated to the latest v1.4.1.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3202

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
