### PR TITLE
Add support for honeywellabp2 pressure sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -121,6 +121,7 @@ esphome/components/hitachi_ac424/* @sourabhjaiswal
 esphome/components/hm3301/* @freekode
 esphome/components/homeassistant/* @OttoWinter
 esphome/components/honeywellabp/* @RubyBailey
+esphome/components/honeywellabp2_i2c/* @jpfaff
 esphome/components/host/* @esphome/core
 esphome/components/hrxl_maxsonar_wr/* @netmikey
 esphome/components/hte501/* @Stock-M

--- a/esphome/components/honeywellabp2_i2c/__init__.py
+++ b/esphome/components/honeywellabp2_i2c/__init__.py
@@ -1,1 +1,2 @@
 """Support for Honeywell ABP2"""
+CODEOWNERS = ["@jpfaff"]

--- a/esphome/components/honeywellabp2_i2c/__init__.py
+++ b/esphome/components/honeywellabp2_i2c/__init__.py
@@ -1,0 +1,1 @@
+"""Support for Honeywell ABP2"""

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -97,11 +97,11 @@ void HONEYWELLABP2Sensor::dump_config() {
 void HONEYWELLABP2Sensor::set_transfer_function(ABP2TRANFERFUNCTION transfer_function) {
   this->transfer_function_ = transfer_function;
   if (this->transfer_function_ == ABP2_TRANS_FUNC_B) {
-    this->max_count_ = this->max_count_B_;
-    this->min_count_ = this->min_count_B_;
+    this->max_count_ = this->max_count_b_;
+    this->min_count_ = this->min_count_b_;
   } else {
-    this->max_count_ = this->max_count_A_;
-    this->min_count_ = this->min_count_A_;
+    this->max_count_ = this->max_count_a_;
+    this->min_count_ = this->min_count_a_;
   }
 }
 

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace honeywellabp2 {
+namespace honeywellabp2_i2c {
 
 static const uint8_t STATUS_BIT_POWER = 6;
 static const uint8_t STATUS_BIT_BUSY = 5;
@@ -11,9 +11,7 @@ static const uint8_t STATUS_MATH_SAT = 0;
 
 static const char *const TAG = "honeywellabp2";
 
-void HONEYWELLABP2Sensor::setup() {
-  ESP_LOGD(TAG, "Setting up Honeywell ABP2 Sensor ");
-}
+void HONEYWELLABP2Sensor::setup() { ESP_LOGD(TAG, "Setting up Honeywell ABP2 Sensor "); }
 
 void HONEYWELLABP2Sensor::read_sensor_data() {
   if (this->read(raw_data_, 7) != i2c::ERROR_OK) {
@@ -21,10 +19,12 @@ void HONEYWELLABP2Sensor::read_sensor_data() {
     this->mark_failed();
     return;
   }
-  float press_counts = raw_data_[3] + raw_data_[2] * 256 + raw_data_[1] * 65536; // calculate digital pressure counts
-  float temp_counts = raw_data_[6] + raw_data_[5] * 256 + raw_data_[4] * 65536; // calculate digital temperature counts
+  float press_counts = raw_data_[3] + raw_data_[2] * 256 + raw_data_[1] * 65536;  // calculate digital pressure counts
+  float temp_counts = raw_data_[6] + raw_data_[5] * 256 + raw_data_[4] * 65536;  // calculate digital temperature counts
 
-  this->last_pressure_ = ((press_counts - this->min_count_) * (double)(this->max_pressure_ - this->min_pressure_)) / (this->max_count_ - this->min_count_) + this->min_pressure_;
+  this->last_pressure_ = ((press_counts - this->min_count_) * (double) (this->max_pressure_ - this->min_pressure_)) /
+                             (this->max_count_ - this->min_count_) +
+                         this->min_pressure_;
   this->last_temperature_ = (temp_counts * 200 / 16777215) - 50;
 }
 
@@ -56,18 +56,13 @@ void HONEYWELLABP2Sensor::measurement_timeout() {
   this->mark_failed();
 }
 
-float HONEYWELLABP2Sensor::get_pressure() {
-  return this->last_pressure_;
-}
+float HONEYWELLABP2Sensor::get_pressure() { return this->last_pressure_; }
 
-float HONEYWELLABP2Sensor::get_temperature() {
-  return this->last_temperature_;
-}
+float HONEYWELLABP2Sensor::get_temperature() { return this->last_temperature_; }
 
 void HONEYWELLABP2Sensor::loop() {
   if (this->measurement_running_) {
     if (this->is_measurement_ready()) {
-
       this->cancel_timeout("meas_timeout");
 
       this->read_sensor_data();
@@ -110,5 +105,5 @@ void HONEYWELLABP2Sensor::set_transfer_function(ABP2TRANFERFUNCTION transfer_fun
   }
 }
 
-}  // namespace honeywellabp2
+}  // namespace honeywellabp2_i2c
 }  // namespace esphome

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -9,18 +9,18 @@ static const char *const TAG = "honeywellabp2";
 void HONEYWELLABP2Sensor::setup() {
   ESP_LOGD(TAG, "Setting up Honeywell ABP2 Sensor ");
   // Call request once
-  read_sensor();
+  this->read_sensor();
 }
 
 void HONEYWELLABP2Sensor::read_sensor() {
-  if (write(i2c_cmd_, 3)) {
-    mark_failed();
+  if (this->write(i2c_cmd_, 3)) {
+    this->mark_failed();
     return;
   }
   // Wait for request to complete
   delay(10);
-  if (!read(raw_data_, 7)) {
-    mark_failed();
+  if (!this->read(raw_data_, 7)) {
+    this->mark_failed();
     return;
   }
 }
@@ -28,39 +28,42 @@ void HONEYWELLABP2Sensor::read_sensor() {
 void HONEYWELLABP2Sensor::update() {
   ESP_LOGV(TAG, "Update Honeywell ABP2 Sensor");
   
-  read_sensor();
+  this->read_sensor();
   
   double press_counts = raw_data_[3] + raw_data_[2] * 256 + raw_data_[1] * 65536; // calculate digital pressure counts
   double temp_counts = raw_data_[6] + raw_data_[5] * 256 + raw_data_[4] * 65536; // calculate digital temperature counts
   
   if (pressure_sensor_ != nullptr) {
-    float pressure = ((press_counts - min_count_) * (max_pressure_ - min_pressure_)) / (max_count_ - min_count_) + min_pressure_;
-    pressure_sensor_->publish_state(pressure);
+    float pressure = ((press_counts - this->min_count_) * (double)(this->max_pressure_ - this->min_pressure_)) / (this->max_count_ - this->min_count_) + this->min_pressure_;
+    this->pressure_sensor_->publish_state(pressure);
   }
   if (temperature_sensor_ != nullptr) {
     float temperature = (temp_counts * 200 / 16777215) - 50;
-    temperature_sensor_->publish_state(temperature);
+    this->temperature_sensor_->publish_state(temperature);
   }
 }
 
 void HONEYWELLABP2Sensor::dump_config() {
-  //  LOG_SENSOR("", "HONEYWELLABP2", this);
-  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f", min_pressure_);
-  ESP_LOGCONFIG(TAG, "  Max Pressure Range: %0.1f", max_pressure_);
+  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f", this->min_pressure_);
+  ESP_LOGCONFIG(TAG, "  Max Pressure Range: %0.1f", this->max_pressure_);
+  if (this->transfer_function_ == ABP2_TRANS_FUNC_A) {
+    ESP_LOGCONFIG(TAG, "  Transfer function A");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Transfer function B");
+  }
   LOG_UPDATE_INTERVAL(this);
 }
 
 void HONEYWELLABP2Sensor::set_transfer_function(ABP2TRANFERFUNCTION transfer_function) {
-  transfer_function_ = transfer_function;
-  if (transfer_function_ == ABP2_TRANS_FUNC_B) {
-    max_count_ = max_count_B_;
-    min_count_ = min_count_B_;
-  }
-  else {
-    max_count_ = max_count_A_;
-    min_count_ = min_count_A_;
+  this->transfer_function_ = transfer_function;
+  if (this->transfer_function_ == ABP2_TRANS_FUNC_B) {
+    this->max_count_ = this->max_count_B_;
+    this->min_count_ = this->min_count_B_;
+  } else {
+    this->max_count_ = this->max_count_A_;
+    this->min_count_ = this->min_count_A_;
   }
 }
 
-}  // namespace honeywellabp
+}  // namespace honeywellabp2
 }  // namespace esphome

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -1,0 +1,66 @@
+#include "honeywellabp2.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace honeywellabp2 {
+
+static const char *const TAG = "honeywellabp2";
+
+void HONEYWELLABP2Sensor::setup() {
+  ESP_LOGD(TAG, "Setting up Honeywell ABP2 Sensor ");
+  // Call request once
+  read_sensor();
+}
+
+void HONEYWELLABP2Sensor::read_sensor() {
+  if (write(i2c_cmd_, 3)) {
+    mark_failed();
+    return;
+  }
+  // Wait for request to complete
+  delay(10);
+  if (!read(raw_data_, 7)) {
+    mark_failed();
+    return;
+  }
+}
+
+void HONEYWELLABP2Sensor::update() {
+  ESP_LOGV(TAG, "Update Honeywell ABP2 Sensor");
+  
+  read_sensor();
+  
+  double press_counts = raw_data_[3] + raw_data_[2] * 256 + raw_data_[1] * 65536; // calculate digital pressure counts
+  double temp_counts = raw_data_[6] + raw_data_[5] * 256 + raw_data_[4] * 65536; // calculate digital temperature counts
+  
+  if (pressure_sensor_ != nullptr) {
+    float pressure = ((press_counts - min_count_) * (max_pressure_ - min_pressure_)) / (max_count_ - min_count_) + min_pressure_;
+    pressure_sensor_->publish_state(pressure);
+  }
+  if (temperature_sensor_ != nullptr) {
+    float temperature = (temp_counts * 200 / 16777215) - 50;
+    temperature_sensor_->publish_state(temperature);
+  }
+}
+
+void HONEYWELLABP2Sensor::dump_config() {
+  //  LOG_SENSOR("", "HONEYWELLABP2", this);
+  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f", min_pressure_);
+  ESP_LOGCONFIG(TAG, "  Max Pressure Range: %0.1f", max_pressure_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void HONEYWELLABP2Sensor::set_transfer_function(ABP2TRANFERFUNCTION transfer_function) {
+  transfer_function_ = transfer_function;
+  if (transfer_function_ == ABP2_TRANS_FUNC_B) {
+    max_count_ = max_count_B_;
+    min_count_ = min_count_B_;
+  }
+  else {
+    max_count_ = max_count_A_;
+    min_count_ = min_count_A_;
+  }
+}
+
+}  // namespace honeywellabp
+}  // namespace esphome

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -1,0 +1,51 @@
+// for Honeywell ABP sensor
+// adapting code from https://github.com/vwls/Honeywell_pressure_sensors
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace honeywellabp2 {
+  
+enum ABP2TRANFERFUNCTION { ABP2_TRANS_FUNC_A = 0, ABP2_TRANS_FUNC_B = 1};
+
+class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void setup() override;
+  void update() override;
+  float get_setup_priority() const override { return setup_priority::LATE; };
+  void dump_config() override;
+  
+  void read_sensor();
+  
+  void set_min_pressure(float min_pressure) {min_pressure_ = min_pressure;};
+  void set_max_pressure(float max_pressure) {max_pressure_ = max_pressure;};
+  void set_transfer_function(ABP2TRANFERFUNCTION transfer_function);
+
+ protected:
+  float min_pressure_ = 0.0;
+  float max_pressure_ = 0.0;
+  ABP2TRANFERFUNCTION transfer_function_ = ABP2_TRANS_FUNC_A;
+  
+  sensor::Sensor *pressure_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+  
+  const double max_count_A_ = 15099494.4; // (90% of 2^24 counts or 0xE66666)
+  const double min_count_A_ = 1677721.6; // (10% of 2^24 counts or 0x19999A)
+  const double max_count_B_ = 11744051.2; // (70% of 2^24 counts or 0xB33333)
+  const double min_count_B_ = 5033164.8; // (30% of 2^24 counts or 0x4CCCCC)
+  
+  double max_count_;
+  double min_count_;
+  
+  uint8_t raw_data_[7]; // holds output data
+  uint8_t i2c_cmd_[3] = {0xAA, 0x00, 0x00}; // command to be sent
+};
+
+}  // namespace honeywellabp2
+}  // namespace esphome

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -14,8 +14,8 @@ enum ABP2TRANFERFUNCTION { ABP2_TRANS_FUNC_A = 0, ABP2_TRANS_FUNC_B = 1};
 
 class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
  public:
-  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
-  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { this->pressure_sensor_ = pressure_sensor; };
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { this->temperature_sensor_ = temperature_sensor; };
   void setup() override;
   void update() override;
   float get_setup_priority() const override { return setup_priority::LATE; };
@@ -23,8 +23,8 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   
   void read_sensor();
   
-  void set_min_pressure(float min_pressure) {min_pressure_ = min_pressure;};
-  void set_max_pressure(float max_pressure) {max_pressure_ = max_pressure;};
+  void set_min_pressure(float min_pressure) {this->min_pressure_ = min_pressure;};
+  void set_max_pressure(float max_pressure) {this->max_pressure_ = max_pressure;};
   void set_transfer_function(ABP2TRANFERFUNCTION transfer_function);
 
  protected:
@@ -35,13 +35,13 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *pressure_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
   
-  const double max_count_A_ = 15099494.4; // (90% of 2^24 counts or 0xE66666)
-  const double min_count_A_ = 1677721.6; // (10% of 2^24 counts or 0x19999A)
-  const double max_count_B_ = 11744051.2; // (70% of 2^24 counts or 0xB33333)
-  const double min_count_B_ = 5033164.8; // (30% of 2^24 counts or 0x4CCCCC)
+  const float max_count_A_ = 15099494.4; // (90% of 2^24 counts or 0xE66666)
+  const float min_count_A_ = 1677721.6; // (10% of 2^24 counts or 0x19999A)
+  const float max_count_B_ = 11744051.2; // (70% of 2^24 counts or 0xB33333)
+  const float min_count_B_ = 5033164.8; // (30% of 2^24 counts or 0x4CCCCC)
   
-  double max_count_;
-  double min_count_;
+  float max_count_;
+  float min_count_;
   
   uint8_t raw_data_[7]; // holds output data
   uint8_t i2c_cmd_[3] = {0xAA, 0x00, 0x00}; // command to be sent

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -8,9 +8,9 @@
 #include "esphome/core/component.h"
 
 namespace esphome {
-namespace honeywellabp2 {
-  
-enum ABP2TRANFERFUNCTION { ABP2_TRANS_FUNC_A = 0, ABP2_TRANS_FUNC_B = 1};
+namespace honeywellabp2_i2c {
+
+enum ABP2TRANFERFUNCTION { ABP2_TRANS_FUNC_A = 0, ABP2_TRANS_FUNC_B = 1 };
 
 class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -21,41 +21,41 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; };
   void dump_config() override;
-  
+
   void read_sensor_data();
   void start_measurement();
   bool is_measurement_ready();
   void measurement_timeout();
-  
+
   float get_pressure();
   float get_temperature();
-  
-  void set_min_pressure(float min_pressure) {this->min_pressure_ = min_pressure;};
-  void set_max_pressure(float max_pressure) {this->max_pressure_ = max_pressure;};
+
+  void set_min_pressure(float min_pressure) { this->min_pressure_ = min_pressure; };
+  void set_max_pressure(float max_pressure) { this->max_pressure_ = max_pressure; };
   void set_transfer_function(ABP2TRANFERFUNCTION transfer_function);
 
  protected:
   float min_pressure_ = 0.0;
   float max_pressure_ = 0.0;
   ABP2TRANFERFUNCTION transfer_function_ = ABP2_TRANS_FUNC_A;
-  
+
   sensor::Sensor *pressure_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
-  
-  const float max_count_A_ = 15099494.4; // (90% of 2^24 counts or 0xE66666)
-  const float min_count_A_ = 1677721.6; // (10% of 2^24 counts or 0x19999A)
-  const float max_count_B_ = 11744051.2; // (70% of 2^24 counts or 0xB33333)
-  const float min_count_B_ = 5033164.8; // (30% of 2^24 counts or 0x4CCCCC)
-  
+
+  const float max_count_A_ = 15099494.4;  // (90% of 2^24 counts or 0xE66666)
+  const float min_count_A_ = 1677721.6;   // (10% of 2^24 counts or 0x19999A)
+  const float max_count_B_ = 11744051.2;  // (70% of 2^24 counts or 0xB33333)
+  const float min_count_B_ = 5033164.8;   // (30% of 2^24 counts or 0x4CCCCC)
+
   float max_count_;
   float min_count_;
   bool measurement_running_ = false;
-  
-  uint8_t raw_data_[7]; // holds output data
-  uint8_t i2c_cmd_[3] = {0xAA, 0x00, 0x00}; // command to be sent
+
+  uint8_t raw_data_[7];                      // holds output data
+  uint8_t i2c_cmd_[3] = {0xAA, 0x00, 0x00};  // command to be sent
   float last_pressure_;
   float last_temperature_;
 };
 
-}  // namespace honeywellabp2
+}  // namespace honeywellabp2_i2c
 }  // namespace esphome

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -42,10 +42,10 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *pressure_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
 
-  const float max_count_A_ = 15099494.4;  // (90% of 2^24 counts or 0xE66666)
-  const float min_count_A_ = 1677721.6;   // (10% of 2^24 counts or 0x19999A)
-  const float max_count_B_ = 11744051.2;  // (70% of 2^24 counts or 0xB33333)
-  const float min_count_B_ = 5033164.8;   // (30% of 2^24 counts or 0x4CCCCC)
+  const float max_count_a_ = 15099494.4;  // (90% of 2^24 counts or 0xE66666)
+  const float min_count_a_ = 1677721.6;   // (10% of 2^24 counts or 0x19999A)
+  const float max_count_b_ = 11744051.2;  // (70% of 2^24 counts or 0xB33333)
+  const float min_count_b_ = 5033164.8;   // (30% of 2^24 counts or 0x4CCCCC)
 
   float max_count_;
   float min_count_;

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -19,7 +19,7 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void loop() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::LATE; };
+  float get_setup_priority() const override { return setup_priority::DATA; };
   void dump_config() override;
   
   void read_sensor_data();

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -22,6 +22,8 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   
   void read_sensor();
+  float get_pressure();
+  float get_temperature();
   
   void set_min_pressure(float min_pressure) {this->min_pressure_ = min_pressure;};
   void set_max_pressure(float max_pressure) {this->max_pressure_ = max_pressure;};
@@ -45,6 +47,8 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   
   uint8_t raw_data_[7]; // holds output data
   uint8_t i2c_cmd_[3] = {0xAA, 0x00, 0x00}; // command to be sent
+  float last_pressure_;
+  float last_temperature_;
 };
 
 }  // namespace honeywellabp2

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -17,11 +17,16 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   void set_pressure_sensor(sensor::Sensor *pressure_sensor) { this->pressure_sensor_ = pressure_sensor; };
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { this->temperature_sensor_ = temperature_sensor; };
   void setup() override;
+  void loop() override;
   void update() override;
   float get_setup_priority() const override { return setup_priority::LATE; };
   void dump_config() override;
   
-  void read_sensor();
+  void read_sensor_data();
+  void start_measurement();
+  bool is_measurement_ready();
+  void measurement_timeout();
+  
   float get_pressure();
   float get_temperature();
   
@@ -44,6 +49,7 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   
   float max_count_;
   float min_count_;
+  bool measurement_running_ = false;
   
   uint8_t raw_data_[7]; // holds output data
   uint8_t i2c_cmd_[3] = {0xAA, 0x00, 0x00}; // command to be sent

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -16,7 +16,6 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_pressure_sensor(sensor::Sensor *pressure_sensor) { this->pressure_sensor_ = pressure_sensor; };
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { this->temperature_sensor_ = temperature_sensor; };
-  void setup() override;
   void loop() override;
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; };

--- a/esphome/components/honeywellabp2_i2c/sensor.py
+++ b/esphome/components/honeywellabp2_i2c/sensor.py
@@ -19,7 +19,7 @@ honeywellabp2_ns = cg.esphome_ns.namespace("honeywellabp2")
 CONF_MIN_PRESSURE = "min_pressure"
 CONF_MAX_PRESSURE = "max_pressure"
 TRANSFER_FUNCTION = "transfer_function"
-ABP2TRANFERFUNCTION = honeywellabp2_ns.enum("SHT4XPRECISION")
+ABP2TRANFERFUNCTION = honeywellabp2_ns.enum("ABP2TRANFERFUNCTION")
 TRANS_FUNC_OPTIONS = {
     "A": ABP2TRANFERFUNCTION.ABP2_TRANS_FUNC_A,
     "B": ABP2TRANFERFUNCTION.ABP2_TRANS_FUNC_B,

--- a/esphome/components/honeywellabp2_i2c/sensor.py
+++ b/esphome/components/honeywellabp2_i2c/sensor.py
@@ -1,0 +1,77 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.components import i2c
+from esphome.const import (
+    CONF_ID,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+)
+
+DEPENDENCIES = ["i2c"]
+
+honeywellabp2_ns = cg.esphome_ns.namespace("honeywellabp2")
+
+CONF_MIN_PRESSURE = "min_pressure"
+CONF_MAX_PRESSURE = "max_pressure"
+TRANSFER_FUNCTION = "transfer_function"
+ABP2TRANFERFUNCTION = honeywellabp2_ns.enum("SHT4XPRECISION")
+TRANS_FUNC_OPTIONS = {
+    "A": ABP2TRANFERFUNCTION.ABP2_TRANS_FUNC_A,
+    "B": ABP2TRANFERFUNCTION.ABP2_TRANS_FUNC_B,
+}
+
+HONEYWELLABP2Sensor = honeywellabp2_ns.class_(
+    "HONEYWELLABP2Sensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(HONEYWELLABP2Sensor),
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+                unit_of_measurement="Pa",
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_PRESSURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_MIN_PRESSURE): cv.float_,
+                    cv.Required(CONF_MAX_PRESSURE): cv.float_,
+                    cv.Required(TRANSFER_FUNCTION): cv.enum(TRANS_FUNC_OPTIONS),
+                }
+            ),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x28))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_PRESSURE in config:
+        conf = config[CONF_PRESSURE]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_pressure_sensor(sens))
+        cg.add(var.set_min_pressure(conf[CONF_MIN_PRESSURE]))
+        cg.add(var.set_max_pressure(conf[CONF_MAX_PRESSURE]))
+        cg.add(var.set_transfer_function(conf[TRANSFER_FUNCTION]))
+
+    if CONF_TEMPERATURE in config:
+        conf = config[CONF_TEMPERATURE]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_temperature_sensor(sens))

--- a/esphome/components/honeywellabp2_i2c/sensor.py
+++ b/esphome/components/honeywellabp2_i2c/sensor.py
@@ -14,7 +14,7 @@ from esphome.const import (
 
 DEPENDENCIES = ["i2c"]
 
-honeywellabp2_ns = cg.esphome_ns.namespace("honeywellabp2")
+honeywellabp2_ns = cg.esphome_ns.namespace("honeywellabp2_i2c")
 
 CONF_MIN_PRESSURE = "min_pressure"
 CONF_MAX_PRESSURE = "max_pressure"

--- a/esphome/components/honeywellabp2_i2c/sensor.py
+++ b/esphome/components/honeywellabp2_i2c/sensor.py
@@ -63,15 +63,13 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_PRESSURE in config:
-        conf = config[CONF_PRESSURE]
-        sens = await sensor.new_sensor(conf)
+    if pressure_config := config.get(CONF_PRESSURE):
+        sens = await sensor.new_sensor(pressure_config)
         cg.add(var.set_pressure_sensor(sens))
-        cg.add(var.set_min_pressure(conf[CONF_MIN_PRESSURE]))
-        cg.add(var.set_max_pressure(conf[CONF_MAX_PRESSURE]))
-        cg.add(var.set_transfer_function(conf[TRANSFER_FUNCTION]))
+        cg.add(var.set_min_pressure(pressure_config[CONF_MIN_PRESSURE]))
+        cg.add(var.set_max_pressure(pressure_config[CONF_MAX_PRESSURE]))
+        cg.add(var.set_transfer_function(pressure_config[TRANSFER_FUNCTION]))
 
-    if CONF_TEMPERATURE in config:
-        conf = config[CONF_TEMPERATURE]
-        sens = await sensor.new_sensor(conf)
+    if temperature_config := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature_config)
         cg.add(var.set_temperature_sensor(sens))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -760,6 +760,16 @@ sensor:
     temperature:
       name: Honeywell temperature
     cs_pin: GPIO5
+  - platform: honeywellabp2_i2c
+    pressure:
+      name: Honeywell2 pressure
+      min_pressure: 0
+      max_pressure: 16000
+      transfer_function: A
+    temperature:
+      name: Honeywell temperature
+    i2c_id: i2c_bus
+    address: 0x28
   - platform: hte501
     temperature:
       name: Office Temperature 2


### PR DESCRIPTION
# What does this implement/fix?

Adding honeywellabp2 pressure sensor component

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3204

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: honeywellabp2_i2c
    id: abp2
    update_interval: never
    pressure:
      name: "Honeywell2 pressure"
      unit_of_measurement: "Pa"
      min_pressure: 0
      max_pressure: 16000
      transfer_function: "A"
      id: abp2_pressure
      accuracy_decimals: 2
    temperature:
      name: "Honeywell temperature"
      id: abp2_temperature
      accuracy_decimals: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
