### PR TITLE
Feat/component poller suspend

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -13,7 +13,6 @@ from esphome.const import (
     CONF_TIME,
     CONF_UPDATE_INTERVAL,
 )
-from esphome.core import TimePeriod
 from esphome.schema_extractors import SCHEMA_EXTRACT, schema_extractor
 from esphome.util import Registry
 
@@ -333,7 +332,7 @@ async def component_suspend_action_to_code(config, action_id, template_arg, args
 )
 async def component_resume_action_to_code(config, action_id, template_arg, args):
     comp = await cg.get_variable(config[CONF_ID])
-    var = cg.new_Pvariable(action_id, template_arg, comp);
+    var = cg.new_Pvariable(action_id, template_arg, comp)
     if CONF_UPDATE_INTERVAL in config:
         cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
     return var

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -326,7 +326,9 @@ async def component_suspend_action_to_code(config, action_id, template_arg, args
     maybe_simple_id(
         {
             cv.Required(CONF_ID): cv.use_id(cg.PollingComponent),
-            cv.Optional(CONF_UPDATE_INTERVAL): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_UPDATE_INTERVAL): cv.templatable(
+                cv.positive_time_period_milliseconds
+            ),
         }
     ),
 )

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -69,6 +69,8 @@ WhileAction = cg.esphome_ns.class_("WhileAction", Action)
 RepeatAction = cg.esphome_ns.class_("RepeatAction", Action)
 WaitUntilAction = cg.esphome_ns.class_("WaitUntilAction", Action, cg.Component)
 UpdateComponentAction = cg.esphome_ns.class_("UpdateComponentAction", Action)
+SuspendComponentAction = cg.esphome_ns.class_("SuspendComponentAction", Action)
+ResumeComponentAction = cg.esphome_ns.class_("ResumeComponentAction", Action)
 Automation = cg.esphome_ns.class_("Automation")
 
 LambdaCondition = cg.esphome_ns.class_("LambdaCondition", Condition)
@@ -301,7 +303,7 @@ async def lambda_action_to_code(config, action_id, template_arg, args):
 
 @register_action(
     "component.suspend",
-    UpdateComponentAction,
+    SuspendComponentAction,
     maybe_simple_id(
         {
             cv.Required(CONF_ID): cv.use_id(cg.PollingComponent),
@@ -311,7 +313,7 @@ async def lambda_action_to_code(config, action_id, template_arg, args):
 
 @register_action(
     "component.resume",
-    UpdateComponentAction,
+    ResumeComponentAction,
     maybe_simple_id(
         {
             cv.Required(CONF_ID): cv.use_id(cg.PollingComponent),

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -298,6 +298,26 @@ async def lambda_action_to_code(config, action_id, template_arg, args):
         }
     ),
 )
+
+@register_action(
+    "component.suspend",
+    UpdateComponentAction,
+    maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(cg.PollingComponent),
+        }
+    ),
+)
+
+@register_action(
+    "component.resume",
+    UpdateComponentAction,
+    maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(cg.PollingComponent),
+        }
+    ),
+)
 async def component_update_action_to_code(config, action_id, template_arg, args):
     comp = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, comp)

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -336,7 +336,8 @@ async def component_resume_action_to_code(config, action_id, template_arg, args)
     comp = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, comp)
     if CONF_UPDATE_INTERVAL in config:
-        cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
+        template_ = await cg.templatable(config[CONF_UPDATE_INTERVAL], args, int)
+        cg.add(var.set_update_interval(template_))
     return var
 
 

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -300,7 +300,6 @@ async def lambda_action_to_code(config, action_id, template_arg, args):
         }
     ),
 )
-
 @register_action(
     "component.suspend",
     SuspendComponentAction,
@@ -310,7 +309,6 @@ async def lambda_action_to_code(config, action_id, template_arg, args):
         }
     ),
 )
-
 @register_action(
     "component.resume",
     ResumeComponentAction,

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -330,4 +330,32 @@ template<typename... Ts> class UpdateComponentAction : public Action<Ts...> {
   PollingComponent *component_;
 };
 
+template<typename... Ts> class SuspendComponentAction : public Action<Ts...> {
+ public:
+  SuspendComponentAction(PollingComponent *component) : component_(component) {}
+
+  void play(Ts... x) override {
+    if (!this->component_->is_ready())
+      return;
+    this->component_->stopPoller();
+  }
+
+ protected:
+  PollingComponent *component_;
+};
+
+template<typename... Ts> class ResumeComponentAction : public Action<Ts...> {
+ public:
+  ResumeComponentAction(PollingComponent *component) : component_(component) {}
+
+  void play(Ts... x) override {
+    if (!this->component_->is_ready())
+      return;
+    this->component_->startPoller();
+  }
+
+ protected:
+  PollingComponent *component_;
+};
+
 }  // namespace esphome

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -337,7 +337,7 @@ template<typename... Ts> class SuspendComponentAction : public Action<Ts...> {
   void play(Ts... x) override {
     if (!this->component_->is_ready())
       return;
-    this->component_->stopPoller();
+    this->component_->stop_poller();
   }
 
  protected:
@@ -351,7 +351,7 @@ template<typename... Ts> class ResumeComponentAction : public Action<Ts...> {
   void play(Ts... x) override {
     if (!this->component_->is_ready())
       return;
-    this->component_->startPoller();
+    this->component_->start_poller();
   }
 
  protected:

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -350,22 +350,12 @@ template<typename... Ts> class ResumeComponentAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(uint32_t, update_interval)
 
   void play(Ts... x) override {
-    if (this->update_interval_.has_value()) {
-      ESP_LOGW("automation", "has update interval %u", this->update_interval_.value());
-    } else {
-      ESP_LOGW("automation", "no update interval");
-    }
-
     if (!this->component_->is_ready()) {
-      ESP_LOGW("automation", "Component not ready");
       return;
     }
     optional<uint32_t> update_interval = this->update_interval_.optional_value(x...);
     if (update_interval.has_value()) {
-      ESP_LOGW("automation", "No update Interval %u", update_interval.value());
       this->component_->set_update_interval(update_interval.value());
-    } else {
-      ESP_LOGW("automation", "No update Interval");
     }
     this->component_->start_poller();
   }

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -347,10 +347,26 @@ template<typename... Ts> class SuspendComponentAction : public Action<Ts...> {
 template<typename... Ts> class ResumeComponentAction : public Action<Ts...> {
  public:
   ResumeComponentAction(PollingComponent *component) : component_(component) {}
+  TEMPLATABLE_VALUE(uint32_t, update_interval)
 
   void play(Ts... x) override {
-    if (!this->component_->is_ready())
+    if (this->update_interval_.has_value()) {
+      ESP_LOGW("automation", "has update interval %u", this->update_interval_.value());
+    } else {
+      ESP_LOGW("automation", "no update interval");
+    }
+
+    if (!this->component_->is_ready()) {
+      ESP_LOGW("automation", "Component not ready");
       return;
+    }
+    optional<uint32_t> update_interval = this->update_interval_.optional_value(x...);
+    if (update_interval.has_value()) {
+      ESP_LOGW("automation", "No update Interval %u", update_interval.value());
+      this->component_->set_update_interval(update_interval.value());
+    } else {
+      ESP_LOGW("automation", "No update Interval");
+    }
     this->component_->start_poller();
   }
 

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -189,7 +189,7 @@ void PollingComponent::call_setup() {
   this->setup();
 
   // init the poller
-  this->startPoller();
+  this->start_poller();
 }
 
 void PollingComponent::start_poller() {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -188,8 +188,18 @@ void PollingComponent::call_setup() {
   // Let the polling component subclass setup their HW.
   this->setup();
 
+  // init the poller
+  this->startPoller();
+}
+
+void PollingComponent::start_poller() {
   // Register interval.
   this->set_interval("update", this->get_update_interval(), [this]() { this->update(); });
+}
+
+void PollingComponent::stop_poller() {
+  // Clear the interval to suspend component
+  this->cancel_interval("update");
 }
 
 uint32_t PollingComponent::get_update_interval() const { return this->update_interval_; }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -307,7 +307,7 @@ class PollingComponent : public Component {
 
   /// Get the update interval in ms of this sensor
   virtual uint32_t get_update_interval() const;
-  
+
   // Start the poller, used for component.suspend
   void start_poller();
 

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -307,6 +307,12 @@ class PollingComponent : public Component {
 
   /// Get the update interval in ms of this sensor
   virtual uint32_t get_update_interval() const;
+  
+  // Start the poller, used for component.suspend
+  void start_poller();
+
+  // Stop the poller, used for component.suspend
+  void stop_poller();
 
  protected:
   uint32_t update_interval_;

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -3578,6 +3578,10 @@ button:
       - component.resume:
           id: myteleinfo
           update_interval: 2s
+      - delay: 20s
+      - component.resume:
+          id: myteleinfo
+          update_interval: !lambda return 2500;
   - platform: ld2410
     factory_reset:
       name: "factory reset"

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -3566,6 +3566,14 @@ button:
     name: Midea Power Inverse
     on_press:
       midea_ac.power_toggle:
+  - platform: template
+    name: Poller component suspend test
+    on_press:
+      - component.suspend: myteleinfo
+      - delay: 20s
+      - component.update: myteleinfo
+      - delay: 20s
+      - component.resume: myteleinfo
   - platform: ld2410
     factory_reset:
       name: "factory reset"

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -3574,6 +3574,10 @@ button:
       - component.update: myteleinfo
       - delay: 20s
       - component.resume: myteleinfo
+      - delay: 20s
+      - component.resume:
+          id: myteleinfo
+          update_interval: 2s
   - platform: ld2410
     factory_reset:
       name: "factory reset"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This pr aims at allowing suspend / resume of polling component update, this is mainly in place to help out with "slow component" when managing audio interractions.

PS: Took a bit of time to understand how to start the version of my pull request, tested and it does work as i expected

Tested on a D1 Mini & and C3 Pico

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2301

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3205

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: test
  friendly_name: test
  platformio_options:
    board_build.flash_mode: dio
  on_boot:
    then:
      - logger.log: Wait
      - delay: 10s
      - component.suspend: adc_pin_3
      - logger.log: Stopped
      - delay: 10s
      - logger.log: Resume
      - component.resume: adc_pin_3
      - delay: 10s
      - logger.log: Stop 2
      - component.suspend: adc_pin_3
      - delay: 10s
      - logger.log: Start Slow
      - component.resume:
          id: adc_pin_3
          update_interval: 10s


esp32:
  board: lolin_c3_mini
  framework:
    type: esp-idf

# Enable logging
logger:
  level: VERBOSE
  hardware_uart: USB_SERIAL_JTAG

sensor:
  - platform: adc
    pin: GPIO3
    name: "Test 1"
    update_interval: 2s
    id: adc_pin_3

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
