### PR TITLE
Fix typo in documentation

### DIFF
--- a/esphome/components/pmsa003i/pmsa003i.h
+++ b/esphome/components/pmsa003i/pmsa003i.h
@@ -17,12 +17,12 @@ struct PM25AQIData {
   uint16_t pm10_env,        ///< Environmental PM1.0
       pm25_env,             ///< Environmental PM2.5
       pm100_env;            ///< Environmental PM10.0
-  uint16_t particles_03um,  ///< 0.3um Particle Count
-      particles_05um,       ///< 0.5um Particle Count
-      particles_10um,       ///< 1.0um Particle Count
-      particles_25um,       ///< 2.5um Particle Count
-      particles_50um,       ///< 5.0um Particle Count
-      particles_100um;      ///< 10.0um Particle Count
+  uint16_t particles_03um,  ///> 0.3um Particle Count
+      particles_05um,       ///> 0.5um Particle Count
+      particles_10um,       ///> 1.0um Particle Count
+      particles_25um,       ///> 2.5um Particle Count
+      particles_50um,       ///> 5.0um Particle Count
+      particles_100um;      ///> 10.0um Particle Count
   uint16_t unused;          ///< Unused
   uint16_t checksum;        ///< Packet checksum
 };


### PR DESCRIPTION
# What does this implement/fix?

Fix typos in documentation. 
See this related PR:
https://github.com/esphome/esphome-docs/pull/3207

The documentation says specifically the PMC (particulate matter counts) refer to counts of particles greater than a given size. 

https://esphome.io/components/sensor/pmsa003i.html:
"Count of particles with diameter > 1 um in 0.1 L of air" 
But the code documentation is wrong

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
