### PR TITLE
2023.9.0b3

### DIFF
--- a/esphome/components/dallas/sensor.py
+++ b/esphome/components/dallas/sensor.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = cv.All(
     ).extend(
         {
             cv.GenerateID(CONF_DALLAS_ID): cv.use_id(DallasComponent),
-            cv.Optional(CONF_ADDRESS): cv.hex_int,
+            cv.Optional(CONF_ADDRESS): cv.hex_uint64_t,
             cv.Optional(CONF_INDEX): cv.positive_int,
             cv.Optional(CONF_RESOLUTION, default=12): cv.int_range(min=9, max=12),
         }

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -152,6 +152,9 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     cg.add(rp2040_ns.setup_preferences())
 
+    # Allow LDF to properly discover dependency including those in preprocessor
+    # conditionals
+    cg.add_platformio_option("lib_ldf_mode", "chain+")
     cg.add_platformio_option("board", config[CONF_BOARD])
     cg.add_build_flag("-DUSE_RP2040")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -351,6 +351,7 @@ class SPIClient {
       : bit_order_(bit_order), mode_(mode), data_rate_(data_rate) {}
 
   virtual void spi_setup() {
+    esph_log_d("spi_device", "mode %u, data_rate %ukHz", (unsigned) this->mode_, (unsigned) (this->data_rate_ / 1000));
     this->delegate_ = this->parent_->register_device(this, this->mode_, this->bit_order_, this->data_rate_, this->cs_);
   }
 
@@ -398,10 +399,7 @@ class SPIDevice : public SPIClient {
 
   void set_data_rate(uint32_t data_rate) { this->data_rate_ = data_rate; }
 
-  void set_bit_order(SPIBitOrder order) {
-    this->bit_order_ = order;
-    esph_log_d("spi.h", "bit order set to %d", order);
-  }
+  void set_bit_order(SPIBitOrder order) { this->bit_order_ = order; }
 
   void set_mode(SPIMode mode) { this->mode_ = mode; }
 

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -15,6 +15,11 @@ class SPIDelegateHw : public SPIDelegate {
   void begin_transaction() override {
 #ifdef USE_RP2040
     SPISettings const settings(this->data_rate_, static_cast<BitOrder>(this->bit_order_), this->mode_);
+#elif defined(ESP8266)
+    // Arduino ESP8266 library has mangled values for SPI modes :-(
+    auto mode = (this->mode_ & 0x01) + ((this->mode_ & 0x02) << 3);
+    ESP_LOGV(TAG, "8266 mangled SPI mode 0x%X", mode);
+    SPISettings const settings(this->data_rate_, this->bit_order_, mode);
 #else
     SPISettings const settings(this->data_rate_, this->bit_order_, this->mode_);
 #endif

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.9.0b2"
+__version__ = "2023.9.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20230904.0
 aioesphomeapi==15.0.0
-zeroconf==0.108.0
+zeroconf==0.112.0
 
 # esp-idf requires this, but doesn't bundle it by default
 # https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Fix SPI inverted clock on ESP8266 [esphome#5416](https://github.com/esphome/esphome/pull/5416)
- [RP2040W] Fix WiFi bootloop upon LibreTiny support [esphome#5414](https://github.com/esphome/esphome/pull/5414)
- dallas: limit addresses to 64 bits [esphome#5413](https://github.com/esphome/esphome/pull/5413)
- Bump zeroconf from 0.108.0 to 0.112.0 [esphome#5392](https://github.com/esphome/esphome/pull/5392)
