### PR TITLE
Wireguard keepalive remove uint16 type

### DIFF
--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -60,7 +60,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_PEER_ALLOWED_IPS, default=["0.0.0.0/0"]): cv.ensure_list(
             _cidr_network
         ),
-        cv.Optional(CONF_PEER_PERSISTENT_KEEPALIVE, default=0): cv.All(
+        cv.Optional(CONF_PEER_PERSISTENT_KEEPALIVE, default="0s"): cv.All(
             cv.positive_time_period_seconds,
             cv.Range(max=TimePeriod(seconds=65535)),
         ),

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_REBOOT_TIMEOUT,
 )
 from esphome.components import time
+from esphome.core import TimePeriod
 
 CONF_NETMASK = "netmask"
 CONF_PRIVATE_KEY = "private_key"
@@ -59,9 +60,10 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_PEER_ALLOWED_IPS, default=["0.0.0.0/0"]): cv.ensure_list(
             _cidr_network
         ),
-        cv.Optional(
-            CONF_PEER_PERSISTENT_KEEPALIVE, default="0s"
-        ): cv.positive_time_period_seconds,
+        cv.Optional(CONF_PEER_PERSISTENT_KEEPALIVE, default=0): cv.All(
+            cv.positive_time_period_seconds,
+            cv.Range(max=TimePeriod(seconds=65535)),
+        ),
         cv.Optional(
             CONF_REBOOT_TIMEOUT, default="15min"
         ): cv.positive_time_period_milliseconds,

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -59,10 +59,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_PEER_ALLOWED_IPS, default=["0.0.0.0/0"]): cv.ensure_list(
             _cidr_network
         ),
-        cv.Optional(CONF_PEER_PERSISTENT_KEEPALIVE, default=0): cv.Any(
-            cv.positive_time_period_seconds,
-            cv.uint16_t,
-        ),
+        cv.Optional(
+            CONF_PEER_PERSISTENT_KEEPALIVE, default="0s"
+        ): cv.positive_time_period_seconds,
         cv.Optional(
             CONF_REBOOT_TIMEOUT, default="15min"
         ): cv.positive_time_period_milliseconds,


### PR DESCRIPTION
# What does this implement/fix?

Remove unnecessary any type.

If this really needed for any reason? This seems to be the first component trying to do this, I have an assertion fail on the `build_language_schema.py` which was solved by just removing this type. Seems redundant at first glance but might be there for a reason?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
