### PR TITLE
Fix .esphome path when not using envvar

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -558,7 +558,7 @@ class EsphomeCore:
     def data_dir(self):
         if is_ha_addon():
             return os.path.join("/data")
-        if get_str_env("ESPHOME_DATA_DIR", None) is not None:
+        if "ESPHOME_DATA_DIR" in os.environ:
             return get_str_env("ESPHOME_DATA_DIR", None)
         return self.relative_config_path(".esphome")
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

#5417 broke the local .esphome folder as `get_str_env` wraps `None` is a string and then returns `"None"`. This fixes that by checking if the env var is actually present

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
