### PR TITLE
Migrate dashboard json files to /data folder instead of wiping out

### DIFF
--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -42,7 +42,12 @@ fi
 mkdir -p "${pio_cache_base}"
 
 if bashio::fs.directory_exists '/config/esphome/.esphome'; then
-    bashio::log.info "Removing old .esphome directory..."
+    bashio::log.info "Migrating old .esphome directory..."
+    if bashio::fs.file_exists '/config/esphome/.esphome/esphome.json'; then
+        mv /config/esphome/.esphome/esphome.json /data/esphome.json
+    fi
+    mkdir -p "/data/storage"
+    mv /config/esphome/.esphome/*.json /data/storage/ || true
     rm -rf /config/esphome/.esphome
 fi
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

#5374 altered the HA add-on version of ESPHome to delete the existing .esphome folder and start generating the files in `/data`.
This caused issues with the dashboard either showing every device as new, or losing the update available for every device as it no longer knew which firmware was on the devices.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4912

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
