### PR TITLE
Pull PollingComponent up from individual display drivers to Display.

### DIFF
--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -10,7 +10,7 @@
 namespace esphome {
 namespace addressable_light {
 
-class AddressableLightDisplay : public display::DisplayBuffer, public PollingComponent {
+class AddressableLightDisplay : public display::DisplayBuffer {
  public:
   light::AddressableLight *get_light() const { return this->light_; }
 

--- a/esphome/components/addressable_light/display.py
+++ b/esphome/components/addressable_light/display.py
@@ -45,7 +45,6 @@ async def to_code(config):
     cg.add(var.set_height(config[CONF_HEIGHT]))
     cg.add(var.set_light(wrapped_light))
 
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     if pixel_mapper := config.get(CONF_PIXEL_MAPPER):

--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -58,7 +58,7 @@ BASIC_DISPLAY_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_LAMBDA): cv.lambda_,
     }
-)
+).extend(cv.polling_component_schema("1s"))
 
 FULL_DISPLAY_SCHEMA = BASIC_DISPLAY_SCHEMA.extend(
     {
@@ -116,6 +116,7 @@ async def setup_display_core_(var, config):
 
 
 async def register_display(var, config):
+    await cg.register_component(var, config)
     await setup_display_core_(var, config)
 
 

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -163,7 +163,7 @@ class BaseFont {
   virtual void measure(const char *str, int *width, int *x_offset, int *baseline, int *height) = 0;
 };
 
-class Display {
+class Display : public PollingComponent {
  public:
   /// Fill the entire screen with the given color.
   virtual void fill(Color color);

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -114,7 +114,6 @@ async def to_code(config):
     rhs = MODELS[config[CONF_MODEL]].new()
     var = cg.Pvariable(config[CONF_ID], rhs)
 
-    await cg.register_component(var, config)
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -19,8 +19,7 @@ enum ILI9XXXColorMode {
 #define ILI9XXXDisplay_DATA_RATE spi::DATA_RATE_40MHZ
 #endif  // ILI9XXXDisplay_DATA_RATE
 
-class ILI9XXXDisplay : public PollingComponent,
-                       public display::DisplayBuffer,
+class ILI9XXXDisplay : public display::DisplayBuffer,
                        public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                              spi::CLOCK_PHASE_LEADING, ILI9XXXDisplay_DATA_RATE> {
  public:

--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -110,7 +110,6 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    await cg.register_component(var, config)
     await display.register_display(var, config)
     await i2c.register_i2c_device(var, config)
 

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -17,7 +17,7 @@ enum InkplateModel : uint8_t {
   INKPLATE_6_V2 = 3,
 };
 
-class Inkplate6 : public PollingComponent, public display::DisplayBuffer, public i2c::I2CDevice {
+class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
  public:
   const uint8_t LUT2[16] = {0xAA, 0xA9, 0xA6, 0xA5, 0x9A, 0x99, 0x96, 0x95,
                             0x6A, 0x69, 0x66, 0x65, 0x5A, 0x59, 0x56, 0x55};

--- a/esphome/components/lcd_base/__init__.py
+++ b/esphome/components/lcd_base/__init__.py
@@ -52,7 +52,6 @@ LCD_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
 
 
 async def setup_lcd_display(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
     cg.add(var.set_dimensions(config[CONF_DIMENSIONS][0], config[CONF_DIMENSIONS][1]))
     if CONF_USER_CHARACTERS in config:

--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -29,7 +29,6 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
     await display.register_display(var, config)
 

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -39,7 +39,7 @@ CHIP_MODES = {
 
 max7219_ns = cg.esphome_ns.namespace("max7219digit")
 MAX7219Component = max7219_ns.class_(
-    "MAX7219Component", cg.PollingComponent, spi.SPIDevice, display.DisplayBuffer
+    "MAX7219Component", spi.SPIDevice, display.DisplayBuffer
 )
 MAX7219ComponentRef = MAX7219Component.operator("ref")
 
@@ -78,7 +78,6 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
     await display.register_display(var, config)
 

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -39,7 +39,7 @@ CHIP_MODES = {
 
 max7219_ns = cg.esphome_ns.namespace("max7219digit")
 MAX7219Component = max7219_ns.class_(
-    "MAX7219Component", spi.SPIDevice, display.DisplayBuffer
+    "MAX7219Component", spi.SPIDevice, display.DisplayBuffer, cg.PollingComponent
 )
 MAX7219ComponentRef = MAX7219Component.operator("ref")
 

--- a/esphome/components/max7219digit/max7219digit.h
+++ b/esphome/components/max7219digit/max7219digit.h
@@ -25,8 +25,7 @@ class MAX7219Component;
 
 using max7219_writer_t = std::function<void(MAX7219Component &)>;
 
-class MAX7219Component : public PollingComponent,
-                         public display::DisplayBuffer,
+class MAX7219Component : public display::DisplayBuffer,
                          public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                                spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
  public:

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -69,7 +69,6 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
     if CONF_BRIGHTNESS in config:

--- a/esphome/components/pcd8544/display.py
+++ b/esphome/components/pcd8544/display.py
@@ -39,7 +39,6 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    await cg.register_component(var, config)
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
 

--- a/esphome/components/pcd8544/pcd_8544.h
+++ b/esphome/components/pcd8544/pcd_8544.h
@@ -7,8 +7,7 @@
 namespace esphome {
 namespace pcd8544 {
 
-class PCD8544 : public PollingComponent,
-                public display::DisplayBuffer,
+class PCD8544 : public display::DisplayBuffer,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
                                       spi::DATA_RATE_8MHZ> {
  public:

--- a/esphome/components/pvvx_mithermometer/display/__init__.py
+++ b/esphome/components/pvvx_mithermometer/display/__init__.py
@@ -38,7 +38,6 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await display.register_display(var, config)
     await ble_client.register_ble_node(var, config)
     cg.add(var.set_disconnect_delay(config[CONF_DISCONNECT_DELAY].total_milliseconds))

--- a/esphome/components/ssd1306_base/__init__.py
+++ b/esphome/components/ssd1306_base/__init__.py
@@ -71,7 +71,6 @@ SSD1306_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 
 async def setup_ssd1306(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cg.add(var.set_model(config[CONF_MODEL]))

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -23,7 +23,7 @@ enum SSD1306Model {
   SSD1305_MODEL_128_64,
 };
 
-class SSD1306 : public PollingComponent, public display::DisplayBuffer {
+class SSD1306 : public display::DisplayBuffer {
  public:
   void setup() override;
 

--- a/esphome/components/ssd1322_base/__init__.py
+++ b/esphome/components/ssd1322_base/__init__.py
@@ -33,7 +33,6 @@ SSD1322_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 
 async def setup_ssd1322(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cg.add(var.set_model(config[CONF_MODEL]))

--- a/esphome/components/ssd1322_base/ssd1322_base.h
+++ b/esphome/components/ssd1322_base/ssd1322_base.h
@@ -11,7 +11,7 @@ enum SSD1322Model {
   SSD1322_MODEL_256_64 = 0,
 };
 
-class SSD1322 : public PollingComponent, public display::DisplayBuffer {
+class SSD1322 : public display::DisplayBuffer {
  public:
   void setup() override;
 

--- a/esphome/components/ssd1325_base/__init__.py
+++ b/esphome/components/ssd1325_base/__init__.py
@@ -37,7 +37,6 @@ SSD1325_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 
 async def setup_ssd1325(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cg.add(var.set_model(config[CONF_MODEL]))

--- a/esphome/components/ssd1325_base/ssd1325_base.h
+++ b/esphome/components/ssd1325_base/ssd1325_base.h
@@ -15,7 +15,7 @@ enum SSD1325Model {
   SSD1327_MODEL_128_128,
 };
 
-class SSD1325 : public PollingComponent, public display::DisplayBuffer {
+class SSD1325 : public display::DisplayBuffer {
  public:
   void setup() override;
 

--- a/esphome/components/ssd1327_base/__init__.py
+++ b/esphome/components/ssd1327_base/__init__.py
@@ -26,7 +26,6 @@ SSD1327_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 
 async def setup_ssd1327(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cg.add(var.set_model(config[CONF_MODEL]))

--- a/esphome/components/ssd1327_base/ssd1327_base.h
+++ b/esphome/components/ssd1327_base/ssd1327_base.h
@@ -11,7 +11,7 @@ enum SSD1327Model {
   SSD1327_MODEL_128_128 = 0,
 };
 
-class SSD1327 : public PollingComponent, public display::DisplayBuffer {
+class SSD1327 : public display::DisplayBuffer {
  public:
   void setup() override;
 

--- a/esphome/components/ssd1331_base/__init__.py
+++ b/esphome/components/ssd1331_base/__init__.py
@@ -18,7 +18,6 @@ SSD1331_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 
 async def setup_ssd1331(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     if CONF_RESET_PIN in config:

--- a/esphome/components/ssd1331_base/ssd1331_base.h
+++ b/esphome/components/ssd1331_base/ssd1331_base.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace ssd1331_base {
 
-class SSD1331 : public PollingComponent, public display::DisplayBuffer {
+class SSD1331 : public display::DisplayBuffer {
  public:
   void setup() override;
 

--- a/esphome/components/ssd1351_base/__init__.py
+++ b/esphome/components/ssd1351_base/__init__.py
@@ -27,7 +27,6 @@ SSD1351_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 
 async def setup_ssd1351(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cg.add(var.set_model(config[CONF_MODEL]))

--- a/esphome/components/ssd1351_base/ssd1351_base.h
+++ b/esphome/components/ssd1351_base/ssd1351_base.h
@@ -12,7 +12,7 @@ enum SSD1351Model {
   SSD1351_MODEL_128_128,
 };
 
-class SSD1351 : public PollingComponent, public display::DisplayBuffer {
+class SSD1351 : public display::DisplayBuffer {
  public:
   void setup() override;
 

--- a/esphome/components/st7735/display.py
+++ b/esphome/components/st7735/display.py
@@ -69,7 +69,6 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def setup_st7735(var, config):
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     if CONF_RESET_PIN in config:

--- a/esphome/components/st7735/st7735.h
+++ b/esphome/components/st7735/st7735.h
@@ -32,8 +32,7 @@ enum ST7735Model {
   ST7735_INITR_18REDTAB = INITR_18REDTAB
 };
 
-class ST7735 : public PollingComponent,
-               public display::DisplayBuffer,
+class ST7735 : public display::DisplayBuffer,
                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                      spi::DATA_RATE_8MHZ> {
  public:

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -155,7 +155,6 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
 

--- a/esphome/components/st7789v/st7789v.h
+++ b/esphome/components/st7789v/st7789v.h
@@ -107,8 +107,7 @@ static const uint8_t ST7789_MADCTL_GS = 0x01;
 
 static const uint8_t ST7789_MADCTL_COLOR_ORDER = ST7789_MADCTL_BGR;
 
-class ST7789V : public PollingComponent,
-                public display::DisplayBuffer,
+class ST7789V : public display::DisplayBuffer,
                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                       spi::DATA_RATE_20MHZ> {
  public:

--- a/esphome/components/st7920/display.py
+++ b/esphome/components/st7920/display.py
@@ -28,7 +28,6 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
 
     if CONF_LAMBDA in config:

--- a/esphome/components/st7920/st7920.h
+++ b/esphome/components/st7920/st7920.h
@@ -11,8 +11,7 @@ class ST7920;
 
 using st7920_writer_t = std::function<void(ST7920 &)>;
 
-class ST7920 : public PollingComponent,
-               public display::DisplayBuffer,
+class ST7920 : public display::DisplayBuffer,
                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
                                      spi::DATA_RATE_200KHZ> {
  public:

--- a/esphome/components/tm1621/display.py
+++ b/esphome/components/tm1621/display.py
@@ -28,7 +28,6 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cs = await cg.gpio_pin_expression(config[CONF_CS_PIN])

--- a/esphome/components/tm1637/display.py
+++ b/esphome/components/tm1637/display.py
@@ -34,7 +34,6 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     clk = await cg.gpio_pin_expression(config[CONF_CLK_PIN])

--- a/esphome/components/tm1638/display.py
+++ b/esphome/components/tm1638/display.py
@@ -33,7 +33,6 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     await display.register_display(var, config)
 
     clk = await cg.gpio_pin_expression(config[CONF_CLK_PIN])

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -148,7 +148,6 @@ async def to_code(config):
     else:
         raise NotImplementedError()
 
-    await cg.register_component(var, config)
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -7,8 +7,7 @@
 namespace esphome {
 namespace waveshare_epaper {
 
-class WaveshareEPaper : public PollingComponent,
-                        public display::DisplayBuffer,
+class WaveshareEPaper : public display::DisplayBuffer,
                         public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                               spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_2MHZ> {
  public:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Refactor the display drivers so `PollingComponent` is automatically inherited.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
