### PR TITLE
Do not enable SHT3x heater by default. Fixes #4886.

### DIFF
--- a/esphome/components/sht3xd/sensor.py
+++ b/esphome/components/sht3xd/sensor.py
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_HEATER_ENABLED, default=True): cv.boolean,
+            cv.Optional(CONF_HEATER_ENABLED, default=False): cv.boolean,
         },
     )
     .extend(cv.polling_component_schema("60s"))


### PR DESCRIPTION
# What does this implement/fix?

The SHT sensor heater is for special use and defaulting them to on breaks the vast majority of prior configs and seems quite surprising. This appears to have been an inadvertent side effect of PR #5161.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4886

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
