### PR TITLE
SPI fixes for buggy components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -270,7 +270,7 @@ esphome/components/sn74hc165/* @jesserockz
 esphome/components/socket/* @esphome/core
 esphome/components/sonoff_d1/* @anatoly-savchenkov
 esphome/components/speaker/* @jesserockz
-esphome/components/spi/* @esphome/core
+esphome/components/spi/* @clydebarrow @esphome/core
 esphome/components/spi_device/* @clydebarrow
 esphome/components/spi_led_strip/* @clydebarrow
 esphome/components/sprinkler/* @kbx81

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -219,7 +219,6 @@ uint8_t MAX7219Component::printf(const char *format, ...) {
 void MAX7219Component::set_writer(max7219_writer_t &&writer) { this->writer_ = writer; }
 void MAX7219Component::set_intensity(uint8_t intensity) {
   this->intensity_ = intensity;
-  this->send_to_all_(MAX7219_REGISTER_INTENSITY, this->intensity_);
 }
 void MAX7219Component::set_num_chips(uint8_t num_chips) { this->num_chips_ = num_chips; }
 

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -217,9 +217,7 @@ uint8_t MAX7219Component::printf(const char *format, ...) {
   return 0;
 }
 void MAX7219Component::set_writer(max7219_writer_t &&writer) { this->writer_ = writer; }
-void MAX7219Component::set_intensity(uint8_t intensity) {
-  this->intensity_ = intensity;
-}
+void MAX7219Component::set_intensity(uint8_t intensity) { this->intensity_ = intensity; }
 void MAX7219Component::set_num_chips(uint8_t num_chips) { this->num_chips_ = num_chips; }
 
 uint8_t MAX7219Component::strftime(uint8_t pos, const char *format, ESPTime time) {

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -28,7 +28,7 @@ from esphome.const import (
 )
 from esphome.core import coroutine_with_priority, CORE
 
-CODEOWNERS = ["@esphome/core"]
+CODEOWNERS = ["@esphome/core", "@clydebarrow"]
 spi_ns = cg.esphome_ns.namespace("spi")
 SPIComponent = spi_ns.class_("SPIComponent", cg.Component)
 SPIDevice = spi_ns.class_("SPIDevice")

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -248,6 +248,7 @@ class SPIDelegateDummy : public SPIDelegate {
   SPIDelegateDummy() = default;
 
   uint8_t transfer(uint8_t data) override { return 0; }
+  void end_transaction() override {};
 
   void begin_transaction() override;
 };

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -248,7 +248,7 @@ class SPIDelegateDummy : public SPIDelegate {
   SPIDelegateDummy() = default;
 
   uint8_t transfer(uint8_t data) override { return 0; }
-  void end_transaction() override {};
+  void end_transaction() override{};
 
   void begin_transaction() override;
 };


### PR DESCRIPTION


# What does this implement/fix?

The new SPI code has exposed some bugs in other components, where SPI transactions are attempted before `spi_setup()` has been called. This PR is to fix those.

* MAX7219 - `set_intensity()` tries to send data, but it gets called before `setup()` and thus `spi_setup()`. It's not necessary for this to send since `setup()` sends the intensity anyway.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4915


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
